### PR TITLE
Fix integration tests: required flags and disable caching

### DIFF
--- a/internal/buildutil/tasks/integration.go
+++ b/internal/buildutil/tasks/integration.go
@@ -105,15 +105,14 @@ func Integration(verbose bool) error {
 		var testsPassed, testsFailed int
 		var failedTests []string
 
-		// Docker environment variables for Colima/testcontainers compatibility
+		// Disable ryuk reaper for Colima compatibility (testcontainers auto-detects DOCKER_HOST)
 		dockerEnv := append(os.Environ(),
-			"DOCKER_HOST=unix://"+os.Getenv("HOME")+"/.colima/default/docker.sock",
 			"TESTCONTAINERS_RYUK_DISABLED=true",
 		)
 
 		if verbose {
 			// In verbose mode, show output directly
-			cmd := exec.Command("go", "test", "-v", "-tags", "integration", "-timeout", "2m", "./"+suite)
+			cmd := exec.Command("go", "test", "-count=1", "-v", "-tags", "integration", "-timeout", "2m", "./"+suite)
 			cmd.Env = dockerEnv
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
@@ -121,7 +120,7 @@ func Integration(verbose bool) error {
 			pass = cmd.Run() == nil
 		} else {
 			// Run with -json for real-time progress
-			cmd := exec.Command("go", "test", "-json", "-tags", "integration", "-timeout", "2m", "./"+suite)
+			cmd := exec.Command("go", "test", "-count=1", "-json", "-tags", "integration", "-timeout", "2m", "./"+suite)
 			cmd.Env = dockerEnv
 			stdout, err := cmd.StdoutPipe()
 			if err != nil {

--- a/internal/buildutil/tasks/test.go
+++ b/internal/buildutil/tasks/test.go
@@ -60,7 +60,7 @@ func Test(verbose bool) error {
 		start := time.Now()
 
 		// Run with -json to get detailed test counts
-		cmd := exec.Command("go", "test", "-json", "-short", "-timeout", "30s", pkg)
+		cmd := exec.Command("go", "test", "-count=1", "-json", "-short", "-timeout", "30s", pkg)
 		output, _ := cmd.Output()
 		duration := time.Since(start)
 

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -279,7 +279,7 @@ func (tc *TestContainer) RunCampInDir(dir string, args ...string) (string, error
 
 // InitCampaign creates a new campaign via camp init and initializes it as a git repo
 func (tc *TestContainer) InitCampaign(path, name, campType string) (string, error) {
-	args := []string{"init", path, "--name", name}
+	args := []string{"init", path, "--name", name, "-d", "Test campaign", "-m", "Test mission"}
 	if campType != "" {
 		args = append(args, "--type", campType)
 	}

--- a/tests/integration/init_test.go
+++ b/tests/integration/init_test.go
@@ -137,7 +137,7 @@ func TestInit_InvalidType(t *testing.T) {
 	tc := GetSharedContainer(t)
 
 	// Try to initialize with invalid type
-	output, err := tc.RunCamp("init", "/campaigns/test-invalid", "--name", "test-invalid", "--type", "invalid-type")
+	output, err := tc.RunCamp("init", "/campaigns/test-invalid", "--name", "test-invalid", "-d", "Test", "-m", "Test", "--type", "invalid-type")
 	require.Error(t, err, "camp init should fail with invalid type")
 	assert.Contains(t, strings.ToLower(output), "invalid", "error should mention invalid type")
 }
@@ -146,7 +146,7 @@ func TestInit_MissingName(t *testing.T) {
 	tc := GetSharedContainer(t)
 
 	// Try to initialize without name - should use directory name
-	output, err := tc.RunCamp("init", "/campaigns/auto-named-campaign")
+	output, err := tc.RunCamp("init", "/campaigns/auto-named-campaign", "-d", "Test", "-m", "Test")
 	require.NoError(t, err, "camp init without name should succeed (uses dir name)")
 	assert.Contains(t, output, "Campaign Initialized")
 


### PR DESCRIPTION
- Add -d and -m flags to integration test helpers (required for camp init)
- Disable test caching with -count=1 for reliable test runs
- Remove broken DOCKER_HOST override (testcontainers auto-detects)