### PR TITLE
Add vim count motions and line numbers to intent explorer

### DIFF
--- a/internal/intent/tui/explorer/model.go
+++ b/internal/intent/tui/explorer/model.go
@@ -117,6 +117,10 @@ type Model struct {
 	scrollOffset int // First visible line in the list
 	listHeight   int // Number of visible lines in the list area
 
+	// Vim-style count prefix (e.g., "5j" moves 5 lines)
+	countBuffer int    // Accumulated digit count (0 = no count entered)
+	pendingKey  string // For multi-key sequences like "gg"
+
 	// Multi-select mode for gather
 	multiSelectMode bool
 	selectedIntents map[string]bool // intent ID -> selected

--- a/internal/intent/tui/explorer/navigation.go
+++ b/internal/intent/tui/explorer/navigation.go
@@ -166,6 +166,34 @@ func (m *Model) moveToNextGroup() {
 	}
 }
 
+// jumpToVisualLine moves cursor to visual line n (0-indexed).
+// Used by Ngg to jump to a specific line number.
+func (m *Model) jumpToVisualLine(targetLine int) {
+	line := 0
+	for gi, group := range m.groups {
+		if line == targetLine {
+			m.cursorGroup = gi
+			m.cursorItem = -1
+			m.ensureCursorVisible()
+			return
+		}
+		line++
+		if group.Expanded {
+			for ii := range group.Intents {
+				if line == targetLine {
+					m.cursorGroup = gi
+					m.cursorItem = ii
+					m.ensureCursorVisible()
+					return
+				}
+				line++
+			}
+		}
+	}
+	// Past the end — jump to bottom
+	m.jumpToBottom()
+}
+
 // handleSelect handles Enter/Space key - toggle group or open viewer on item.
 func (m *Model) handleSelect() {
 	if len(m.groups) == 0 {

--- a/internal/intent/tui/explorer/render.go
+++ b/internal/intent/tui/explorer/render.go
@@ -296,9 +296,17 @@ func (m *Model) buildMainView() string {
 		listWidth = max(listWidth, 40)
 	}
 
-	titleWidth := listWidth - 35
+	// Estimate gutter width for line numbers (based on total visual lines)
+	totalVisual := m.totalVisualLines()
+	if totalVisual < 1 {
+		totalVisual = 1
+	}
+	gutterWidth := len(fmt.Sprintf("%d", totalVisual))
+	gutterSpace := gutterWidth + 1 // number + space
+
+	titleWidth := listWidth - 35 - gutterSpace
 	if m.layoutMode == layoutNarrow {
-		titleWidth = m.width - 28
+		titleWidth = m.width - 28 - gutterSpace
 	}
 	titleWidth = max(titleWidth, 20)
 
@@ -346,6 +354,12 @@ func (m *Model) buildMainView() string {
 				listLines = append(listLines, m.renderIntentRow(i, isSelected, titleWidth))
 			}
 		}
+	}
+
+	// Step 6b: Prepend line numbers (1-indexed, right-aligned)
+	for i, line := range listLines {
+		num := fmt.Sprintf("%*d", gutterWidth, i+1)
+		listLines[i] = tui.LineNumberStyle.Render(num) + " " + line
 	}
 
 	// Step 7: Apply scroll windowing (use local scrollOffset — View() is a value

--- a/internal/intent/tui/explorer/update.go
+++ b/internal/intent/tui/explorer/update.go
@@ -341,7 +341,41 @@ func (m Model) updateViewer(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 // updateNormal handles navigation mode keys.
 func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
+	key := msg.String()
+
+	// Accumulate digit count prefix (vim-style: 5j, 12gg, etc.)
+	if len(key) == 1 && key[0] >= '1' && key[0] <= '9' {
+		m.countBuffer = m.countBuffer*10 + int(key[0]-'0')
+		return m, nil
+	}
+	if len(key) == 1 && key[0] == '0' && m.countBuffer > 0 {
+		m.countBuffer = m.countBuffer * 10
+		return m, nil
+	}
+
+	// Retrieve and reset count (defaults to 1)
+	count := m.countBuffer
+	if count == 0 {
+		count = 1
+	}
+	m.countBuffer = 0
+
+	// Handle pending "g" key (for gg / Ngg)
+	if m.pendingKey == "g" {
+		m.pendingKey = ""
+		if key == "g" {
+			if count > 1 {
+				m.jumpToVisualLine(count - 1) // Ngg: 1-indexed → 0-indexed
+			} else {
+				m.jumpToTop()
+			}
+			m.updatePreviewForSelection()
+			return m, nil
+		}
+		// Not "g" — fall through to normal handling
+	}
+
+	switch key {
 	case "q", "ctrl+c":
 		m.quitting = true
 		return m, tea.Quit
@@ -449,21 +483,19 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "j", "down":
 		if m.previewFocused && m.showPreview {
-			// Scroll preview down
 			var cmd tea.Cmd
 			m.previewPane, cmd = m.previewPane.Update(msg)
 			return m, cmd
 		}
-		m.moveCursorDown()
+		m.moveCursorDownN(count)
 		m.updatePreviewForSelection()
 	case "k", "up":
 		if m.previewFocused && m.showPreview {
-			// Scroll preview up
 			var cmd tea.Cmd
 			m.previewPane, cmd = m.previewPane.Update(msg)
 			return m, cmd
 		}
-		m.moveCursorUp()
+		m.moveCursorUpN(count)
 		m.updatePreviewForSelection()
 	case "ctrl+d":
 		if m.previewFocused && m.showPreview {
@@ -471,7 +503,6 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.previewPane, cmd = m.previewPane.Update(msg)
 			return m, cmd
 		}
-		// Half-page down in list
 		halfPage := max(m.listHeight/2, 1)
 		m.moveCursorDownN(halfPage)
 		m.updatePreviewForSelection()
@@ -481,7 +512,6 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.previewPane, cmd = m.previewPane.Update(msg)
 			return m, cmd
 		}
-		// Half-page up in list
 		halfPage := max(m.listHeight/2, 1)
 		m.moveCursorUpN(halfPage)
 		m.updatePreviewForSelection()
@@ -491,17 +521,26 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.previewPane, cmd = m.previewPane.Update(msg)
 			return m, cmd
 		}
-		// Jump to top of list
-		m.jumpToTop()
-		m.updatePreviewForSelection()
+		// Set pending key — wait for second "g" to form "gg"
+		// Count is saved in countBuffer (already reset above, but the
+		// pending-g handler reads count which was captured before reset)
+		m.pendingKey = "g"
+		// Restore count so the pending handler can use it
+		if count > 1 {
+			m.countBuffer = count
+		}
+		return m, nil
 	case "G":
 		if m.previewFocused && m.showPreview {
 			var cmd tea.Cmd
 			m.previewPane, cmd = m.previewPane.Update(msg)
 			return m, cmd
 		}
-		// Jump to bottom of list
-		m.jumpToBottom()
+		if count > 1 {
+			m.jumpToVisualLine(count - 1) // NG: jump to line N
+		} else {
+			m.jumpToBottom()
+		}
 		m.updatePreviewForSelection()
 	case "enter":
 		m.handleSelect()

--- a/internal/intent/tui/styles.go
+++ b/internal/intent/tui/styles.go
@@ -141,6 +141,10 @@ var (
 	CheckboxUncheckedStyle = lipgloss.NewStyle().
 				Foreground(pal.TextMuted)
 
+	// Line numbers in explorer list
+	LineNumberStyle = lipgloss.NewStyle().
+			Foreground(pal.TextMuted)
+
 	// Selection count badge
 	SelectionCountStyle = lipgloss.NewStyle().
 				Background(pal.Accent).


### PR DESCRIPTION
- Digit prefix support: 5j/3k moves N lines, 12gg jumps to line 12
- Line numbers displayed in gutter (1-indexed, right-aligned, muted)
- jumpToVisualLine(n) helper for Ngg and NG navigation
- Count buffer with pending key support for multi-key sequences (gg)