### PR TITLE
Fix shell completion and cache staleness detection

### DIFF
--- a/cmd/camp/root.go
+++ b/cmd/camp/root.go
@@ -24,7 +24,12 @@ var rootCmd = &cobra.Command{
 	Short:   "Campaign management CLI for multi-project AI workspaces",
 	Version: fmt.Sprintf("%s (built %s, commit %s)", version.Version, version.BuildDate, version.Commit),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		// Wire up the no-color flag
+		// Skip color detection for completion commands to avoid
+		// termenv interfering with zsh's completion state machine.
+		if cmd.Name() == "complete" {
+			ui.SetNoColor(true)
+			return
+		}
 		ui.SetNoColor(noColor)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/complete/complete.go
+++ b/internal/complete/complete.go
@@ -19,8 +19,8 @@ type RichCategoryGroup struct {
 }
 
 // Timeout is the maximum time to spend generating completions.
-// Shell completion should be fast to feel responsive.
-const Timeout = 50 * time.Millisecond
+// 200ms allows room for cold-start index rebuilds while staying responsive.
+const Timeout = 200 * time.Millisecond
 
 // Generate returns completion candidates for the given args.
 // It uses a timeout to ensure shell responsiveness.

--- a/internal/nav/index/cache.go
+++ b/internal/nav/index/cache.go
@@ -96,10 +96,25 @@ func IsFresh(idx *Index) bool {
 }
 
 // IsStale checks if the cache should be rebuilt.
-// Returns true if the cache is nil, too old, or if project configuration changed.
+// Returns true if the cache is nil, too old, if the index version changed,
+// if the camp binary was rebuilt, or if project configuration changed.
 func IsStale(idx *Index, campaignRoot string) bool {
 	if !IsFresh(idx) {
 		return true
+	}
+
+	// Cache is stale if index version changed (format migration)
+	if idx.Version != IndexVersion {
+		return true
+	}
+
+	// Cache is stale if camp binary was rebuilt since cache was built
+	campBin, err := os.Executable()
+	if err == nil {
+		info, err := os.Stat(campBin)
+		if err == nil && info.ModTime().After(idx.BuildTime) {
+			return true
+		}
 	}
 
 	// Check if .gitmodules changed (projects added/removed via submodules)

--- a/internal/nav/index/cache_test.go
+++ b/internal/nav/index/cache_test.go
@@ -188,10 +188,50 @@ func TestIsStale(t *testing.T) {
 	root := t.TempDir()
 	root, _ = filepath.EvalSymlinks(root)
 
-	// Fresh index, no trigger files
-	idx := &Index{BuildTime: time.Now()}
+	// Fresh index with current version, no trigger files
+	idx := &Index{BuildTime: time.Now(), Version: IndexVersion}
 	if IsStale(idx, root) {
 		t.Error("Fresh index should not be stale")
+	}
+}
+
+func TestIsStale_VersionMismatch(t *testing.T) {
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+
+	// Fresh index but with old version
+	idx := &Index{BuildTime: time.Now(), Version: IndexVersion - 1}
+	if !IsStale(idx, root) {
+		t.Error("Index with old version should be stale")
+	}
+}
+
+func TestIsStale_BinaryRebuilt(t *testing.T) {
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+
+	// Index built in the past, binary is newer
+	idx := &Index{
+		BuildTime: time.Now().Add(-1 * time.Hour),
+		Version:   IndexVersion,
+	}
+
+	// The running binary's mod time is likely after an hour ago,
+	// so this should detect staleness from the binary check.
+	campBin, err := os.Executable()
+	if err != nil {
+		t.Skip("cannot determine executable path")
+	}
+	info, err := os.Stat(campBin)
+	if err != nil {
+		t.Skip("cannot stat executable")
+	}
+
+	// Only assert stale if the binary is actually newer than build time
+	if info.ModTime().After(idx.BuildTime) {
+		if !IsStale(idx, root) {
+			t.Error("Index should be stale when binary is newer")
+		}
 	}
 }
 

--- a/internal/nav/index/target.go
+++ b/internal/nav/index/target.go
@@ -100,7 +100,8 @@ type Index struct {
 }
 
 // IndexVersion is the current index format version.
-const IndexVersion = 1
+// Bump when the target format changes to invalidate stale caches.
+const IndexVersion = 2
 
 // NewIndex creates a new empty index for a campaign root.
 func NewIndex(campaignRoot string) *Index {

--- a/internal/shell/zsh.go
+++ b/internal/shell/zsh.go
@@ -94,9 +94,9 @@ _cgo() {
     # Get completions with descriptions (name\tpath format)
     while IFS=$'\t' read -r name path; do
       [[ -n "$name" ]] && completions+=("$name:$path")
-    done < <(camp complete --described "$category" "$query" 2>/dev/null)
+    done < <(command camp complete --described "$category" "$query" 2>/dev/null)
 
-    _describe 'target' completions
+    (( ${#completions} )) && _describe 'target' completions
   fi
 }
 compdef _cgo cgo


### PR DESCRIPTION
## Summary

- Fix zsh completion breaking shell state by skipping termenv color detection for completion commands
- Use `command camp` in zsh completion function to bypass aliases/functions that could interfere
- Guard `_describe` call to avoid zsh errors when completions array is empty
- Increase completion timeout from 50ms to 200ms to accommodate cold-start index rebuilds
- Add cache staleness detection for index version changes and binary rebuilds
- Bump `IndexVersion` to 2 to invalidate stale caches from the format change

## Test plan

- [ ] `cgo <tab>` completes without corrupting zsh state
- [ ] Cold-start completions return results within the 200ms timeout
- [ ] Rebuilding camp binary invalidates the navigation cache on next use
- [ ] Index version mismatch triggers cache rebuild
- [ ] `TestIsStale_VersionMismatch` and `TestIsStale_BinaryRebuilt` pass