### PR TITLE
Fix flaky integration tests with sync in Reset()

### DIFF
--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -198,12 +198,15 @@ func runCommand(cmd string) error {
 
 // Reset clears container state between tests.
 // This removes all test artifacts while keeping the container and binary intact.
+// The trailing `sync` ensures filesystem buffers are flushed before the next test
+// begins — required for consistency on macOS/Colima where Docker exec runs through
+// a virtualization layer (overlayfs in a Linux VM).
 func (tc *TestContainer) Reset() error {
 	// Remove all test artifacts and recreate clean directories
 	exitCode, _, err := tc.container.Exec(tc.ctx, []string{
 		"sh", "-c",
 		"rm -rf /test /campaigns /root/.config/camp /root/.camp 2>/dev/null; " +
-			"mkdir -p /test /campaigns /root/.config/camp",
+			"mkdir -p /test /campaigns /root/.config/camp; sync",
 	})
 	if err != nil {
 		return fmt.Errorf("failed to reset container: %w", err)


### PR DESCRIPTION
## Summary

- Adds `sync` to the shell command in `Reset()` in `tests/integration/helpers.go`
- On macOS/Colima, Docker exec runs through a virtualization layer (overlayfs in a Linux VM) where filesystem operations can return before writes are fully consistent
- `sync` blocks until all dirty filesystem buffers are flushed, providing a kernel-level consistency guarantee before the next test begins

## Test plan

- [ ] Run integration tests multiple times to confirm flaky failures no longer reproduce
- [ ] Verify no measurable regression in test suite runtime (~50-200ms overhead per `Reset()` call)