### PR TITLE
Leverage score improvements: styling, recent leverage, monorepo fix

### DIFF
--- a/internal/project/list.go
+++ b/internal/project/list.go
@@ -86,7 +86,7 @@ func resolveProject(ctx context.Context, name, projectPath string) []Project {
 		expanded := make([]Project, 0, len(subprojects))
 		for _, sub := range subprojects {
 			expanded = append(expanded, Project{
-				Name:         name + "/" + sub.name,
+				Name:         name + "@" + sub.name,
 				Path:         filepath.Join(relPath, sub.name),
 				Type:         sub.projectType,
 				URL:          url,

--- a/internal/project/list_test.go
+++ b/internal/project/list_test.go
@@ -264,7 +264,7 @@ func TestList_MonorepoExpansion(t *testing.T) {
 	}
 
 	// Verify subprojects
-	for _, name := range []string{"my-monorepo/service-a", "my-monorepo/service-b", "my-monorepo/rust-lib"} {
+	for _, name := range []string{"my-monorepo@service-a", "my-monorepo@service-b", "my-monorepo@rust-lib"} {
 		p, ok := projectMap[name]
 		if !ok {
 			t.Errorf("missing expected subproject %q", name)
@@ -276,10 +276,10 @@ func TestList_MonorepoExpansion(t *testing.T) {
 	}
 
 	// Verify types
-	if p := projectMap["my-monorepo/service-a"]; p.Type != TypeGo {
+	if p := projectMap["my-monorepo@service-a"]; p.Type != TypeGo {
 		t.Errorf("service-a type = %q, want %q", p.Type, TypeGo)
 	}
-	if p := projectMap["my-monorepo/rust-lib"]; p.Type != TypeRust {
+	if p := projectMap["my-monorepo@rust-lib"]; p.Type != TypeRust {
 		t.Errorf("rust-lib type = %q, want %q", p.Type, TypeRust)
 	}
 }

--- a/internal/project/types.go
+++ b/internal/project/types.go
@@ -2,7 +2,7 @@ package project
 
 // Project represents a project within a campaign.
 type Project struct {
-	// Name is the project directory name (e.g., "obey-platform-monorepo/obey").
+	// Name is the project directory name (e.g., "obey-platform-monorepo@obey").
 	Name string
 	// Path is the relative path from campaign root.
 	Path string


### PR DESCRIPTION
## Summary

- **Styled leverage output** with lipgloss — tables, borders, and colored headers for readability
- **Recent leverage** — added 7-day and 30-day leverage trends to the header display
- **Actual months from git** — per-project actual months derived from git history, person-months in aggregate view
- **Monorepo name fix** — switched monorepo subproject separator from `/` to `@` (e.g. `hermes@common`) to fix `camp leverage backfill` failing on campaigns with monorepo subprojects

## Key changes

- `cmd/camp/leverage.go` — redesigned output with lipgloss styling, recent leverage section
- `cmd/camp/leverage_history.go` — styled history views with lipgloss
- `internal/leverage/history.go` — 7-day and 30-day recent leverage computation
- `internal/leverage/score.go` — actual months from git log
- `internal/project/list.go` — use `@` separator for monorepo subproject names instead of `/`

## Test plan

- [x] `just test all` — 1415 unit tests pass
- [x] `just test integration` — 66/66 integration tests pass
- [x] `just build && just install` — binary compiles and installs cleanly
- [x] `camp leverage backfill` succeeds on campaigns with monorepo subprojects