### PR TITLE
fix: replace language marker monorepo detection with .gitmodules, fix SIGSEGV in integration tests

### DIFF
--- a/cmd/camp/go.go
+++ b/cmd/camp/go.go
@@ -131,7 +131,7 @@ func runGo(cmd *cobra.Command, args []string) error {
 					return err
 				}
 				if execResult.ExitCode != 0 {
-					os.Exit(execResult.ExitCode)
+					return &CommandExitError{Code: execResult.ExitCode}
 				}
 				return nil
 			}
@@ -152,9 +152,8 @@ func runGo(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		// Exit with the command's exit code
 		if execResult.ExitCode != 0 {
-			os.Exit(execResult.ExitCode)
+			return &CommandExitError{Code: execResult.ExitCode}
 		}
 		return nil
 	}
@@ -327,9 +326,8 @@ func handleCustomNavShortcut(ctx context.Context, sc config.ShortcutConfig, camp
 		if err != nil {
 			return err
 		}
-		// Exit with the command's exit code
 		if execResult.ExitCode != 0 {
-			os.Exit(execResult.ExitCode)
+			return &CommandExitError{Code: execResult.ExitCode}
 		}
 		return nil
 	}

--- a/cmd/camp/leverage.go
+++ b/cmd/camp/leverage.go
@@ -90,7 +90,7 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		result, err := runner.Run(ctx, proj.SCCDir)
+		result, err := runner.Run(ctx, proj.SCCDir, proj.ExcludeDirs)
 		if err != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: skipping %s: %v\n", proj.Name, err)
 			continue

--- a/cmd/camp/leverage_snapshot.go
+++ b/cmd/camp/leverage_snapshot.go
@@ -76,7 +76,7 @@ func runLeverageSnapshot(cmd *cobra.Command, args []string) error {
 		}
 
 		// Run scc
-		result, err := runner.Run(ctx, proj.SCCDir)
+		result, err := runner.Run(ctx, proj.SCCDir, proj.ExcludeDirs)
 		if err != nil {
 			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: skipping %s (scc): %v\n", proj.Name, err)
 			continue

--- a/cmd/camp/leverage_test.go
+++ b/cmd/camp/leverage_test.go
@@ -24,7 +24,7 @@ type mockRunner struct {
 	err     error
 }
 
-func (m *mockRunner) Run(ctx context.Context, dir string) (*leverage.SCCResult, error) {
+func (m *mockRunner) Run(ctx context.Context, dir string, excludeDirs []string) (*leverage.SCCResult, error) {
 	if m.err != nil {
 		return nil, m.err
 	}

--- a/cmd/camp/main.go
+++ b/cmd/camp/main.go
@@ -1,12 +1,19 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 )
 
 func main() {
 	if err := Execute(); err != nil {
+		// If a child process exited with a specific code (e.g. camp run),
+		// propagate that code without printing a redundant error message.
+		var exitErr *CommandExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.Code)
+		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/camp/root.go
+++ b/cmd/camp/root.go
@@ -20,9 +20,10 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:     "camp",
-	Short:   "Campaign management CLI for multi-project AI workspaces",
-	Version: fmt.Sprintf("%s (built %s, commit %s)", version.Version, version.BuildDate, version.Commit),
+	Use:           "camp",
+	Short:         "Campaign management CLI for multi-project AI workspaces",
+	Version:       fmt.Sprintf("%s (built %s, commit %s)", version.Version, version.BuildDate, version.Commit),
+	SilenceErrors: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// Skip color detection for completion commands to avoid
 		// termenv interfering with zsh's completion state machine.

--- a/cmd/camp/run.go
+++ b/cmd/camp/run.go
@@ -231,11 +231,24 @@ func executeCommand(ctx context.Context, cmdStr string, workDir string, extraArg
 
 	if err := cmd.Run(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			// Command failed - exit with the same code
-			os.Exit(exitErr.ExitCode())
+			// Propagate the child's exit code through cobra instead of calling
+			// os.Exit() directly. This allows deferred cleanup to run and
+			// prevents stale file handles in shared test containers.
+			return &CommandExitError{Code: exitErr.ExitCode()}
 		}
 		return fmt.Errorf("failed to execute command: %w", err)
 	}
 
 	return nil
+}
+
+// CommandExitError signals that a child process exited with a non-zero code.
+// main.go checks for this and calls os.Exit with the code, keeping cleanup
+// paths intact through cobra's error propagation.
+type CommandExitError struct {
+	Code int
+}
+
+func (e *CommandExitError) Error() string {
+	return fmt.Sprintf("command exited with code %d", e.Code)
 }

--- a/internal/leverage/backfill.go
+++ b/internal/leverage/backfill.go
@@ -240,7 +240,7 @@ func (b *Backfiller) processSample(ctx context.Context, gitDir string, sample Co
 		}
 
 		// Run scc
-		result, err := b.runner.Run(ctx, sccDir)
+		result, err := b.runner.Run(ctx, sccDir, proj.ExcludeDirs)
 		if err != nil {
 			b.warn(proj.Name, dateStr, fmt.Errorf("scc: %w", err))
 			continue

--- a/internal/leverage/backfill_test.go
+++ b/internal/leverage/backfill_test.go
@@ -500,7 +500,7 @@ func TestBackfiller_WarningCallback(t *testing.T) {
 // failingRunner is a Runner that always returns an error.
 type failingRunner struct{}
 
-func (f *failingRunner) Run(_ context.Context, _ string) (*SCCResult, error) {
+func (f *failingRunner) Run(_ context.Context, _ string, _ []string) (*SCCResult, error) {
 	return nil, fmt.Errorf("scc unavailable")
 }
 

--- a/internal/leverage/projects.go
+++ b/internal/leverage/projects.go
@@ -24,6 +24,10 @@ type ResolvedProject struct {
 
 	// InMonorepo marks the project as a subdirectory within a larger git repo.
 	InMonorepo bool
+
+	// ExcludeDirs lists subdirectory names that scc should skip when scanning.
+	// Set on monorepo root entries to prevent double-counting submodule code.
+	ExcludeDirs []string
 }
 
 // ResolveProjects resolves project entries into absolute paths for leverage scoring.
@@ -64,10 +68,11 @@ func resolveFromProjectList(ctx context.Context, campaignRoot string) ([]Resolve
 		}
 
 		resolved = append(resolved, ResolvedProject{
-			Name:       p.Name,
-			SCCDir:     sccDir,
-			GitDir:     gitDir,
-			InMonorepo: inMonorepo,
+			Name:        p.Name,
+			SCCDir:      sccDir,
+			GitDir:      gitDir,
+			InMonorepo:  inMonorepo,
+			ExcludeDirs: p.ExcludeDirs,
 		})
 	}
 

--- a/internal/leverage/projects_test.go
+++ b/internal/leverage/projects_test.go
@@ -2,6 +2,7 @@ package leverage
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -203,7 +204,7 @@ func TestResolveProjects_FallbackMonorepoExpansion(t *testing.T) {
 	root := t.TempDir()
 	root, _ = filepath.EvalSymlinks(root)
 
-	// Create a monorepo with 2+ subprojects so project.List() expands it
+	// Create a repo with .gitmodules listing 2 submodules
 	mono := filepath.Join(root, "projects", "my-mono")
 	if err := os.MkdirAll(mono, 0o755); err != nil {
 		t.Fatal(err)
@@ -213,12 +214,15 @@ func TestResolveProjects_FallbackMonorepoExpansion(t *testing.T) {
 		t.Fatalf("git init failed: %v\n%s", err, out)
 	}
 
-	// Two subprojects with language markers
+	// Write .gitmodules declaring two submodules
+	gitmodules := ""
 	for _, name := range []string{"svc-a", "svc-b"} {
+		gitmodules += fmt.Sprintf("[submodule %q]\n\tpath = %s\n\turl = https://example.com/%s.git\n", name, name, name)
 		sub := filepath.Join(mono, name)
 		os.MkdirAll(sub, 0o755)
 		os.WriteFile(filepath.Join(sub, "go.mod"), []byte("module mono/"+name), 0644)
 	}
+	os.WriteFile(filepath.Join(mono, ".gitmodules"), []byte(gitmodules), 0644)
 
 	cfg := &LeverageConfig{} // empty Projects → fallback to project.List()
 
@@ -227,13 +231,23 @@ func TestResolveProjects_FallbackMonorepoExpansion(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(got) != 2 {
-		t.Fatalf("got %d projects, want 2", len(got))
+	// Expect 3: root entry + 2 submodule entries
+	if len(got) != 3 {
+		names := make([]string, len(got))
+		for i, p := range got {
+			names[i] = p.Name
+		}
+		t.Fatalf("got %d projects %v, want 3 (root + 2 submodules)", len(got), names)
 	}
 
+	// Check submodule entries
 	for _, p := range got {
 		if !p.InMonorepo {
-			t.Errorf("%s: expected InMonorepo = true", p.Name)
+			// Root entry should NOT be InMonorepo
+			if p.Name != "my-mono" {
+				t.Errorf("%s: expected InMonorepo = true", p.Name)
+			}
+			continue
 		}
 		wantGit := filepath.Join(root, "projects", "my-mono")
 		if p.GitDir != wantGit {
@@ -242,6 +256,21 @@ func TestResolveProjects_FallbackMonorepoExpansion(t *testing.T) {
 		if p.SCCDir == p.GitDir {
 			t.Errorf("%s: SCCDir should differ from GitDir for monorepo subproject", p.Name)
 		}
+	}
+
+	// Check root entry has ExcludeDirs
+	rootEntry := got[0] // sorted alphabetically, "my-mono" comes first
+	if rootEntry.Name != "my-mono" {
+		// Find the root entry
+		for _, p := range got {
+			if p.Name == "my-mono" {
+				rootEntry = p
+				break
+			}
+		}
+	}
+	if len(rootEntry.ExcludeDirs) != 2 {
+		t.Errorf("root ExcludeDirs = %v, want 2 entries", rootEntry.ExcludeDirs)
 	}
 }
 

--- a/internal/leverage/scc.go
+++ b/internal/leverage/scc.go
@@ -25,16 +25,22 @@ func NewSCCRunner(cocomoType string) (*SCCRunner, error) {
 }
 
 // Run executes scc on dir and returns the parsed json2 result.
-func (r *SCCRunner) Run(ctx context.Context, dir string) (*SCCResult, error) {
+// excludeDirs specifies subdirectory names to skip (passed as --exclude-dir flags).
+func (r *SCCRunner) Run(ctx context.Context, dir string, excludeDirs []string) (*SCCResult, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
 
-	cmd := exec.CommandContext(ctx, r.binaryPath,
+	args := []string{
 		"--format", FormatJSON2,
 		"--cocomo-project-type", r.cocomoType,
-		dir,
-	)
+	}
+	for _, d := range excludeDirs {
+		args = append(args, "--exclude-dir", d)
+	}
+	args = append(args, dir)
+
+	cmd := exec.CommandContext(ctx, r.binaryPath, args...)
 
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/leverage/scc_test.go
+++ b/internal/leverage/scc_test.go
@@ -12,7 +12,7 @@ type MockRunner struct {
 	Err    error
 }
 
-func (m *MockRunner) Run(ctx context.Context, dir string) (*SCCResult, error) {
+func (m *MockRunner) Run(ctx context.Context, dir string, excludeDirs []string) (*SCCResult, error) {
 	if m.Err != nil {
 		return nil, m.Err
 	}
@@ -35,7 +35,7 @@ func TestMockRunner_Success(t *testing.T) {
 	}
 
 	mock := &MockRunner{Result: expected}
-	result, err := mock.Run(context.Background(), "/any/path")
+	result, err := mock.Run(context.Background(), "/any/path", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestMockRunner_Success(t *testing.T) {
 
 func TestMockRunner_Error(t *testing.T) {
 	mock := &MockRunner{Err: errors.New("scc failed")}
-	result, err := mock.Run(context.Background(), "/any/path")
+	result, err := mock.Run(context.Background(), "/any/path", nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -74,7 +74,7 @@ func TestSCCRunner_Run(t *testing.T) {
 
 	// Run against the camp project itself
 	ctx := context.Background()
-	result, err := runner.Run(ctx, ".")
+	result, err := runner.Run(ctx, ".", nil)
 	if err != nil {
 		t.Fatalf("Run failed: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestSCCRunner_Run_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 
-	_, err = runner.Run(ctx, ".")
+	_, err = runner.Run(ctx, ".", nil)
 	if err == nil {
 		t.Fatal("expected error from cancelled context")
 	}
@@ -112,7 +112,7 @@ func TestSCCRunner_Run_InvalidDir(t *testing.T) {
 	}
 
 	// Run against a nonexistent directory — scc should fail with exit error
-	_, err = runner.Run(context.Background(), "/nonexistent/dir/that/does/not/exist")
+	_, err = runner.Run(context.Background(), "/nonexistent/dir/that/does/not/exist", nil)
 	if err == nil {
 		t.Fatal("expected error for nonexistent directory")
 	}
@@ -126,7 +126,7 @@ func TestSCCRunner_Run_EmptyDir(t *testing.T) {
 
 	// scc on an empty dir produces valid json2 with zero results
 	dir := t.TempDir()
-	result, err := runner.Run(context.Background(), dir)
+	result, err := runner.Run(context.Background(), dir, nil)
 	if err != nil {
 		// Some scc versions may error on empty dirs, which is fine
 		return

--- a/internal/leverage/types.go
+++ b/internal/leverage/types.go
@@ -23,7 +23,7 @@ const (
 // The interface exists so tests can inject a mock without requiring
 // the scc binary to be installed.
 type Runner interface {
-	Run(ctx context.Context, dir string) (*SCCResult, error)
+	Run(ctx context.Context, dir string, excludeDirs []string) (*SCCResult, error)
 }
 
 // SCCResult is the top-level JSON object returned by `scc --format json2`.

--- a/internal/project/list.go
+++ b/internal/project/list.go
@@ -6,33 +6,13 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/obediencecorp/camp/internal/git"
 )
-
-// languageMarkers are files that indicate an independently buildable subproject.
-var languageMarkers = []string{
-	"go.mod",
-	"Cargo.toml",
-	"package.json",
-	"pyproject.toml",
-	"setup.py",
-	"pom.xml",
-	"build.gradle",
-	"mix.exs",
-}
-
-// excludedSubdirs are directories that should never be treated as subprojects.
-var excludedSubdirs = map[string]bool{
-	"vendor":       true,
-	"node_modules": true,
-	".git":         true,
-	"testdata":     true,
-	"test":         true,
-	"tests":        true,
-}
 
 // List returns all projects in the campaign's projects directory.
 // It identifies git repositories, detects their project type, and expands
-// monorepos into individual subproject entries.
+// repos with .gitmodules into root + submodule entries.
 func List(ctx context.Context, campaignRoot string) ([]Project, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
@@ -75,98 +55,46 @@ func List(ctx context.Context, campaignRoot string) ([]Project, error) {
 }
 
 // resolveProject returns one or more Project entries for a discovered git repo.
-// Monorepos with 2+ language-marker subdirectories are expanded into individual
-// subproject entries; standalone projects return a single entry.
+// Repos with .gitmodules are expanded into a root entry plus one entry per
+// submodule. Repos without .gitmodules are treated as standalone.
 func resolveProject(ctx context.Context, name, projectPath string) []Project {
 	url := getGitRemoteURL(ctx, projectPath)
 	relPath := filepath.Join("projects", name)
 
-	subprojects := detectMonorepoSubprojects(projectPath)
-	if len(subprojects) >= 2 {
-		expanded := make([]Project, 0, len(subprojects))
-		for _, sub := range subprojects {
-			expanded = append(expanded, Project{
-				Name:         name + "@" + sub.name,
-				Path:         filepath.Join(relPath, sub.name),
-				Type:         sub.projectType,
-				URL:          url,
-				MonorepoRoot: relPath,
-			})
-		}
-		return expanded
+	submodulePaths, _ := git.ListSubmodulePaths(ctx, projectPath)
+	if len(submodulePaths) == 0 {
+		// Standalone repo — single entry, scc scans entire directory.
+		return []Project{{
+			Name: name,
+			Path: relPath,
+			Type: detectProjectType(projectPath),
+			URL:  url,
+		}}
 	}
 
-	return []Project{{
-		Name: name,
-		Path: relPath,
-		Type: detectProjectType(projectPath),
-		URL:  url,
-	}}
-}
+	// Submodule-based repo — root entry + one entry per submodule.
+	expanded := make([]Project, 0, len(submodulePaths)+1)
 
-type subproject struct {
-	name        string
-	projectType string
-}
+	// Root entry captures root-level code (configs, docs, shared tooling).
+	expanded = append(expanded, Project{
+		Name:        name,
+		Path:        relPath,
+		Type:        detectProjectType(projectPath),
+		URL:         url,
+		ExcludeDirs: submodulePaths,
+	})
 
-// detectMonorepoSubprojects scans immediate subdirectories for language markers.
-// Returns the list of subdirectories that have markers. If fewer than 2 are
-// found, the caller should treat the project as standalone.
-func detectMonorepoSubprojects(projectPath string) []subproject {
-	entries, err := os.ReadDir(projectPath)
-	if err != nil {
-		return nil
+	for _, subPath := range submodulePaths {
+		subFullPath := filepath.Join(projectPath, subPath)
+		expanded = append(expanded, Project{
+			Name:         name + "@" + subPath,
+			Path:         filepath.Join(relPath, subPath),
+			Type:         detectProjectType(subFullPath),
+			URL:          url,
+			MonorepoRoot: relPath,
+		})
 	}
-
-	var subs []subproject
-	for _, entry := range entries {
-		name := entry.Name()
-
-		// Skip non-directories
-		if !entry.IsDir() {
-			continue
-		}
-
-		// Skip excluded directories
-		if excludedSubdirs[name] {
-			continue
-		}
-
-		// Skip hidden and underscore-prefixed directories
-		if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
-			continue
-		}
-
-		// Skip symlinks (avoid double-counting repos tracked independently)
-		info, err := os.Lstat(filepath.Join(projectPath, name))
-		if err != nil {
-			continue
-		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			continue
-		}
-
-		subPath := filepath.Join(projectPath, name)
-		if marker := findLanguageMarker(subPath); marker != "" {
-			subs = append(subs, subproject{
-				name:        name,
-				projectType: detectProjectType(subPath),
-			})
-		}
-	}
-
-	return subs
-}
-
-// findLanguageMarker checks if a directory contains any language project marker.
-// Returns the marker filename if found, empty string otherwise.
-func findLanguageMarker(dir string) string {
-	for _, marker := range languageMarkers {
-		if _, err := os.Stat(filepath.Join(dir, marker)); err == nil {
-			return marker
-		}
-	}
-	return ""
+	return expanded
 }
 
 // detectProjectType attempts to determine the project type based on marker files.

--- a/internal/project/list_test.go
+++ b/internal/project/list_test.go
@@ -2,10 +2,10 @@ package project
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 )
@@ -215,38 +215,40 @@ func TestList_GitSubmodule(t *testing.T) {
 	}
 }
 
-func TestList_MonorepoExpansion(t *testing.T) {
+func TestList_GitmodulesExpansion(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
 
 	projectsDir := filepath.Join(tmpDir, "projects")
 	os.MkdirAll(projectsDir, 0755)
 
-	// Create a monorepo with 3 subprojects
+	// Create a repo with .gitmodules listing 2 submodules
 	mono := filepath.Join(projectsDir, "my-monorepo")
 	os.MkdirAll(mono, 0755)
 	initGitRepo(t, mono)
 
-	// Root go.mod (monorepo root)
+	// Root go.mod
 	os.WriteFile(filepath.Join(mono, "go.mod"), []byte("module mono"), 0644)
 
-	// Subproject 1: Go
+	// .gitmodules declares two submodules
+	writeGitmodules(t, mono, map[string]string{
+		"service-a": "service-a",
+		"service-b": "service-b",
+	})
+
+	// Create submodule directories with language markers
 	sub1 := filepath.Join(mono, "service-a")
 	os.MkdirAll(sub1, 0755)
 	os.WriteFile(filepath.Join(sub1, "go.mod"), []byte("module mono/service-a"), 0644)
 
-	// Subproject 2: Go
 	sub2 := filepath.Join(mono, "service-b")
 	os.MkdirAll(sub2, 0755)
-	os.WriteFile(filepath.Join(sub2, "go.mod"), []byte("module mono/service-b"), 0644)
+	os.WriteFile(filepath.Join(sub2, "Cargo.toml"), []byte("[package]"), 0644)
 
-	// Subproject 3: Rust
-	sub3 := filepath.Join(mono, "rust-lib")
-	os.MkdirAll(sub3, 0755)
-	os.WriteFile(filepath.Join(sub3, "Cargo.toml"), []byte("[package]"), 0644)
-
-	// Non-subproject dir (no marker)
-	os.MkdirAll(filepath.Join(mono, "docs"), 0755)
+	// Non-submodule dir with a language marker (should NOT become a subproject)
+	lib := filepath.Join(mono, "lib")
+	os.MkdirAll(lib, 0755)
+	os.WriteFile(filepath.Join(lib, "go.mod"), []byte("module mono/lib"), 0644)
 
 	ctx := context.Background()
 	projects, err := List(ctx, tmpDir)
@@ -254,8 +256,13 @@ func TestList_MonorepoExpansion(t *testing.T) {
 		t.Fatalf("List() error = %v", err)
 	}
 
+	// Expect: root entry + 2 submodule entries = 3 (NOT lib, it's not in .gitmodules)
 	if len(projects) != 3 {
-		t.Fatalf("List() returned %d projects, want 3", len(projects))
+		names := make([]string, len(projects))
+		for i, p := range projects {
+			names[i] = p.Name
+		}
+		t.Fatalf("List() returned %d projects %v, want 3 (root + 2 submodules)", len(projects), names)
 	}
 
 	projectMap := make(map[string]Project)
@@ -263,8 +270,24 @@ func TestList_MonorepoExpansion(t *testing.T) {
 		projectMap[p.Name] = p
 	}
 
-	// Verify subprojects
-	for _, name := range []string{"my-monorepo@service-a", "my-monorepo@service-b", "my-monorepo@rust-lib"} {
+	// Verify root entry exists
+	root, ok := projectMap["my-monorepo"]
+	if !ok {
+		t.Fatal("missing root entry 'my-monorepo'")
+	}
+	if root.MonorepoRoot != "" {
+		t.Errorf("root MonorepoRoot = %q, want empty", root.MonorepoRoot)
+	}
+	if root.Type != TypeGo {
+		t.Errorf("root type = %q, want %q", root.Type, TypeGo)
+	}
+	// Root entry should carry ExcludeDirs for scc double-count prevention
+	if len(root.ExcludeDirs) != 2 {
+		t.Errorf("root ExcludeDirs = %v, want 2 entries", root.ExcludeDirs)
+	}
+
+	// Verify submodule entries
+	for _, name := range []string{"my-monorepo@service-a", "my-monorepo@service-b"} {
 		p, ok := projectMap[name]
 		if !ok {
 			t.Errorf("missing expected subproject %q", name)
@@ -279,8 +302,64 @@ func TestList_MonorepoExpansion(t *testing.T) {
 	if p := projectMap["my-monorepo@service-a"]; p.Type != TypeGo {
 		t.Errorf("service-a type = %q, want %q", p.Type, TypeGo)
 	}
-	if p := projectMap["my-monorepo@rust-lib"]; p.Type != TypeRust {
-		t.Errorf("rust-lib type = %q, want %q", p.Type, TypeRust)
+	if p := projectMap["my-monorepo@service-b"]; p.Type != TypeRust {
+		t.Errorf("service-b type = %q, want %q", p.Type, TypeRust)
+	}
+
+	// Verify lib is NOT present (it's not in .gitmodules)
+	if _, ok := projectMap["my-monorepo@lib"]; ok {
+		t.Error("lib should not be a subproject — it's not in .gitmodules")
+	}
+}
+
+func TestList_NoGitmodulesStandalone(t *testing.T) {
+	// Regression test: repos without .gitmodules should NEVER be expanded,
+	// even if they have multiple subdirectories with language markers.
+	// This is the hermes bug — language markers caused false monorepo detection.
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	projectsDir := filepath.Join(tmpDir, "projects")
+	os.MkdirAll(projectsDir, 0755)
+
+	// Create a repo that looks like hermes: multiple language-marker subdirs but NO .gitmodules
+	hermes := filepath.Join(projectsDir, "hermes")
+	os.MkdirAll(hermes, 0755)
+	initGitRepo(t, hermes)
+
+	// Root has no marker
+	// common/ and loadtests/ both have package.json
+	common := filepath.Join(hermes, "common")
+	os.MkdirAll(common, 0755)
+	os.WriteFile(filepath.Join(common, "package.json"), []byte("{}"), 0644)
+
+	loadtests := filepath.Join(hermes, "loadtests")
+	os.MkdirAll(loadtests, 0755)
+	os.WriteFile(filepath.Join(loadtests, "package.json"), []byte("{}"), 0644)
+
+	// services/ has no marker (but has real code)
+	os.MkdirAll(filepath.Join(hermes, "services"), 0755)
+
+	ctx := context.Background()
+	projects, err := List(ctx, tmpDir)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	// Should be 1 standalone entry, NOT expanded
+	if len(projects) != 1 {
+		names := make([]string, len(projects))
+		for i, p := range projects {
+			names[i] = p.Name
+		}
+		t.Fatalf("List() returned %d projects %v, want 1 standalone entry (no .gitmodules = no expansion)", len(projects), names)
+	}
+
+	if projects[0].Name != "hermes" {
+		t.Errorf("project name = %q, want %q", projects[0].Name, "hermes")
+	}
+	if projects[0].MonorepoRoot != "" {
+		t.Errorf("MonorepoRoot = %q, want empty (standalone)", projects[0].MonorepoRoot)
 	}
 }
 
@@ -319,29 +398,38 @@ func TestList_StandaloneNotExpanded(t *testing.T) {
 	}
 }
 
-func TestList_MonorepoSkipsSymlinks(t *testing.T) {
+func TestList_GitmodulesSubmoduleDedupAgainstStandalone(t *testing.T) {
+	// When a .gitmodules repo has a submodule named "foo" and there's also
+	// a standalone project named "foo", the submodule entry should be deduped.
 	tmpDir := t.TempDir()
 	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
 
 	projectsDir := filepath.Join(tmpDir, "projects")
 	os.MkdirAll(projectsDir, 0755)
 
-	// Create a monorepo
+	remoteURL := "git@github.com:test/foo.git"
+
+	// Standalone "foo" project
+	foo := filepath.Join(projectsDir, "foo")
+	os.MkdirAll(foo, 0755)
+	initGitRepoWithRemoteAndCommit(t, foo, remoteURL, "standalone foo")
+	os.WriteFile(filepath.Join(foo, "go.mod"), []byte("module foo"), 0644)
+
+	// Monorepo with .gitmodules listing "foo" as a submodule
 	mono := filepath.Join(projectsDir, "mono")
 	os.MkdirAll(mono, 0755)
-	initGitRepo(t, mono)
+	initGitRepoWithRemoteAndCommit(t, mono, "git@github.com:test/mono.git", "mono init")
 
-	// Two real subprojects
-	for _, name := range []string{"svc-a", "svc-b"} {
-		sub := filepath.Join(mono, name)
-		os.MkdirAll(sub, 0755)
-		os.WriteFile(filepath.Join(sub, "go.mod"), []byte("module mono/"+name), 0644)
-	}
+	writeGitmodules(t, mono, map[string]string{
+		"foo": "foo",
+		"bar": "bar",
+	})
 
-	// Symlink subdir (should be skipped)
-	externalDir := t.TempDir()
-	os.WriteFile(filepath.Join(externalDir, "go.mod"), []byte("module external"), 0644)
-	os.Symlink(externalDir, filepath.Join(mono, "linked-sub"))
+	// Create submodule directories
+	os.MkdirAll(filepath.Join(mono, "foo"), 0755)
+	os.WriteFile(filepath.Join(mono, "foo", "go.mod"), []byte("module mono/foo"), 0644)
+	os.MkdirAll(filepath.Join(mono, "bar"), 0755)
+	os.WriteFile(filepath.Join(mono, "bar", "go.mod"), []byte("module mono/bar"), 0644)
 
 	ctx := context.Background()
 	projects, err := List(ctx, tmpDir)
@@ -349,55 +437,29 @@ func TestList_MonorepoSkipsSymlinks(t *testing.T) {
 		t.Fatalf("List() error = %v", err)
 	}
 
-	if len(projects) != 2 {
-		t.Fatalf("List() returned %d projects, want 2 (symlink excluded)", len(projects))
-	}
-
+	projectMap := make(map[string]Project)
 	for _, p := range projects {
-		if strings.Contains(p.Name, "linked-sub") {
-			t.Errorf("symlinked subdirectory should not appear as subproject: %s", p.Name)
-		}
-	}
-}
-
-func TestList_MonorepoSkipsExcludedDirs(t *testing.T) {
-	tmpDir := t.TempDir()
-	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
-
-	projectsDir := filepath.Join(tmpDir, "projects")
-	os.MkdirAll(projectsDir, 0755)
-
-	mono := filepath.Join(projectsDir, "mono")
-	os.MkdirAll(mono, 0755)
-	initGitRepo(t, mono)
-
-	// Two real subprojects
-	for _, name := range []string{"app", "lib"} {
-		sub := filepath.Join(mono, name)
-		os.MkdirAll(sub, 0755)
-		os.WriteFile(filepath.Join(sub, "package.json"), []byte("{}"), 0644)
+		projectMap[p.Name] = p
 	}
 
-	// vendor/ and node_modules/ with markers (should be excluded)
-	for _, excluded := range []string{"vendor", "node_modules", "testdata"} {
-		dir := filepath.Join(mono, excluded)
-		os.MkdirAll(dir, 0755)
-		os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0644)
+	// "foo" standalone should exist
+	if _, ok := projectMap["foo"]; !ok {
+		t.Error("missing standalone 'foo' project")
 	}
 
-	// Hidden dir with marker (should be excluded)
-	hidden := filepath.Join(mono, ".internal")
-	os.MkdirAll(hidden, 0755)
-	os.WriteFile(filepath.Join(hidden, "go.mod"), []byte("module hidden"), 0644)
-
-	ctx := context.Background()
-	projects, err := List(ctx, tmpDir)
-	if err != nil {
-		t.Fatalf("List() error = %v", err)
+	// "mono@foo" should be deduped (standalone "foo" takes precedence)
+	if _, ok := projectMap["mono@foo"]; ok {
+		t.Error("mono@foo should be deduped against standalone 'foo'")
 	}
 
-	if len(projects) != 2 {
-		t.Fatalf("List() returned %d projects, want 2 (excluded dirs filtered)", len(projects))
+	// "mono@bar" should exist (no standalone "bar")
+	if _, ok := projectMap["mono@bar"]; !ok {
+		t.Error("missing mono@bar subproject")
+	}
+
+	// "mono" root entry should exist
+	if _, ok := projectMap["mono"]; !ok {
+		t.Error("missing mono root entry")
 	}
 }
 
@@ -469,6 +531,19 @@ func initGitRepo(t *testing.T, path string) {
 	cmd := exec.Command("git", "init", path)
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("failed to init git repo: %v", err)
+	}
+}
+
+// writeGitmodules writes a .gitmodules file to the given repo path.
+// submodules maps submodule name to relative path.
+func writeGitmodules(t *testing.T, repoPath string, submodules map[string]string) {
+	t.Helper()
+	var content string
+	for name, path := range submodules {
+		content += fmt.Sprintf("[submodule %q]\n\tpath = %s\n\turl = https://example.com/%s.git\n", name, path, name)
+	}
+	if err := os.WriteFile(filepath.Join(repoPath, ".gitmodules"), []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write .gitmodules: %v", err)
 	}
 }
 

--- a/internal/project/types.go
+++ b/internal/project/types.go
@@ -13,6 +13,9 @@ type Project struct {
 	// MonorepoRoot is the relative path to the parent monorepo, set when this
 	// project is a subproject expanded from a monorepo. Empty for standalone projects.
 	MonorepoRoot string
+	// ExcludeDirs lists subdirectory paths that scc should skip when scanning this
+	// project. Set on monorepo root entries to prevent double-counting submodule code.
+	ExcludeDirs []string
 }
 
 // ProjectType constants for common project types.

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -68,18 +69,16 @@ func NewSharedContainer() (*TestContainer, error) {
 		return nil, fmt.Errorf("failed to build camp binary: %w", err)
 	}
 
+	// Start container without bind-mounting the binary. Bind mounts go through
+	// the host's overlayfs (Colima virtualisation layer on macOS) which can
+	// serve stale or corrupted pages after heavy rm -rf / sync cycles, causing
+	// non-deterministic SIGSEGV when the kernel page-faults the binary. Copying
+	// the binary into the container's own writable layer avoids this entirely.
 	req := testcontainers.ContainerRequest{
 		Image:      "alpine:latest",
 		Cmd:        []string{"sleep", "3600"}, // Keep container running
 		WaitingFor: wait.ForExec([]string{"true"}).WithStartupTimeout(30 * time.Second),
 		AutoRemove: true,
-		Mounts: testcontainers.ContainerMounts{
-			{
-				Source:   testcontainers.GenericBindMountSource{HostPath: campBinary},
-				Target:   "/camp",
-				ReadOnly: false,
-			},
-		},
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
@@ -88,6 +87,12 @@ func NewSharedContainer() (*TestContainer, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to start container: %w", err)
+	}
+
+	// Copy camp binary into the container's own filesystem layer (not a bind mount).
+	if err := container.CopyFileToContainer(ctx, campBinary, "/camp", 0o755); err != nil {
+		container.Terminate(ctx)
+		return nil, fmt.Errorf("failed to copy camp binary into container: %w", err)
 	}
 
 	// Install git (required for project operations)
@@ -114,7 +119,7 @@ func NewSharedContainer() (*TestContainer, error) {
 		return nil, fmt.Errorf("failed to configure git name: %w", err)
 	}
 
-	// Check if camp binary exists and make it executable
+	// Verify camp binary was copied correctly
 	exitCode, output, err = container.Exec(ctx, []string{"ls", "-la", "/camp"})
 	if err != nil {
 		container.Terminate(ctx)
@@ -124,18 +129,6 @@ func NewSharedContainer() (*TestContainer, error) {
 		outputBytes, _ := io.ReadAll(output)
 		container.Terminate(ctx)
 		return nil, fmt.Errorf("camp binary not found, ls output: %s", string(outputBytes))
-	}
-
-	// Make camp executable in container
-	exitCode, output, err = container.Exec(ctx, []string{"chmod", "+x", "/camp"})
-	if err != nil {
-		container.Terminate(ctx)
-		return nil, fmt.Errorf("failed to make camp executable: %w", err)
-	}
-	if exitCode != 0 {
-		outputBytes, _ := io.ReadAll(output)
-		container.Terminate(ctx)
-		return nil, fmt.Errorf("chmod failed with exit code %d, output: %s", exitCode, string(outputBytes))
 	}
 
 	// Create initial working directories
@@ -175,8 +168,11 @@ func buildCampBinaryShared() (string, error) {
 
 	binaryPath := filepath.Join(binDir, "camp")
 
-	// Build the binary for Linux (required for Alpine containers)
-	cmd := fmt.Sprintf("cd %s && GOOS=linux GOARCH=amd64 go build -o %s ./cmd/camp", projectRoot, binaryPath)
+	// Build the binary for Linux matching the host architecture.
+	// Using runtime.GOARCH ensures native execution inside Colima's VM
+	// (which matches the host arch). Hardcoding amd64 on an arm64 host
+	// forces QEMU x86 emulation, causing non-deterministic SIGSEGV.
+	cmd := fmt.Sprintf("cd %s && GOOS=linux GOARCH=%s go build -o %s ./cmd/camp", projectRoot, runtime.GOARCH, binaryPath)
 	if err := runCommand(cmd); err != nil {
 		return "", fmt.Errorf("failed to build binary: %w", err)
 	}


### PR DESCRIPTION
## Summary

- **Replace language marker monorepo detection with .gitmodules** — fixes false monorepo expansion (e.g. hermes) and coincidental-only correctness by switching to `git.ListSubmodulePaths()` which parses `.gitmodules` directly. Adds `ExcludeDirs` propagation through scc `--exclude-dir` flags so monorepo root stats exclude submodule directories.

- **Fix non-deterministic SIGSEGV in integration tests** — root cause was `GOARCH=amd64` hardcoded on arm64 host, forcing QEMU x86 emulation which caused random segfaults. Fixed with `runtime.GOARCH`, replaced bind mounts with `CopyFileToContainer` for test binary delivery, and introduced `CommandExitError` to replace `os.Exit()` calls that were untestable.

## Changes

18 files changed, +302/-241

### Monorepo detection
- `internal/project/list.go` — replaced `detectMonorepoSubprojects()` with `git.ListSubmodulePaths()`
- `internal/project/types.go` — added `ExcludeDirs` field to `Project`
- `internal/project/list_test.go` — TDD tests for .gitmodules-based detection
- `internal/leverage/projects.go` — propagate `ExcludeDirs` to `ResolvedProject`
- `internal/leverage/scc.go` — support `--exclude-dir` flags in scc invocation
- Removed dead code: `detectMonorepoSubprojects()`, `subproject` struct, `findLanguageMarker()`, `languageMarkers`, `excludedSubdirs`

### Integration test SIGSEGV fix
- `internal/leverage/integration_test.go` — use `runtime.GOARCH` instead of hardcoded `amd64`
- `internal/leverage/integration_test.go` — use `CopyFileToContainer` instead of bind mount
- Introduced `CommandExitError` replacing direct `os.Exit()` calls

## Test plan

- [x] All unit tests pass (`just test`)
- [x] Integration tests pass on arm64 without SIGSEGV
- [x] Monorepo detection correctly identifies .gitmodules-based repos
- [x] Standalone repos with multiple language markers are NOT falsely expanded