### PR TITLE
Fix campaign leverage double-counting authors across repos

### DIFF
--- a/cmd/camp/leverage.go
+++ b/cmd/camp/leverage.go
@@ -258,6 +258,19 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 	// Aggregate campaign-wide totals
 	agg := leverage.AggregateScores(scores, effectivePeople, elapsed)
 
+	// Override with deduplicated campaign-wide actual person-months.
+	// AggregateScores naively sums per-project ActualPersonMonths, which
+	// double-counts authors who contribute across multiple repos.
+	// CampaignActualPersonMonths merges authors by name across all git dirs.
+	if authorFilter == "" && peopleOverride == 0 {
+		campaignPM, pmErr := leverage.CampaignActualPersonMonths(ctx, resolved)
+		if pmErr == nil && campaignPM > 0 {
+			estPM := agg.EstimatedPeople * agg.EstimatedMonths
+			agg.ActualPersonMonths = campaignPM
+			agg.FullLeverage = estPM / campaignPM
+		}
+	}
+
 	// Compute recent leverage from snapshots
 	store := leverage.NewFileSnapshotStore(leverage.DefaultSnapshotDir(setup.Root))
 	week7, has7 := leverage.RecentLeverage(ctx, store, scores, effectivePeople, now.AddDate(0, 0, -7))

--- a/internal/leverage/authors.go
+++ b/internal/leverage/authors.go
@@ -216,32 +216,30 @@ func AuthorDateRange(ctx context.Context, gitDir, authorEmail string) (first, la
 	return first, last, nil
 }
 
-// ProjectActualPersonMonths computes total actual person-months for a project
-// by summing each distinct author's active duration (first commit to last commit).
-// This produces an accurate effort measure — an author who committed over 6 months
-// counts as 6 person-months, not N × totalProjectDuration.
-//
-// Authors with a single commit (first == last) are counted as minAuthorMonths
-// to represent their minimal but nonzero contribution.
-func ProjectActualPersonMonths(ctx context.Context, gitDir string) (float64, error) {
-	const minAuthorMonths = 0.1
+// authorDateSpan holds the earliest and latest commit dates for a single author.
+type authorDateSpan struct {
+	earliest time.Time
+	latest   time.Time
+}
 
+// gitDirAuthors enumerates all non-bot authors in a git repo and computes their
+// date ranges. Returns a map keyed by normalized name.
+func gitDirAuthors(ctx context.Context, gitDir string) (map[string]*authorDateSpan, error) {
 	if err := ctx.Err(); err != nil {
-		return 0, err
+		return nil, err
 	}
 
-	// Get all authors via shortlog
 	cmd := exec.CommandContext(ctx, "git", "-C", gitDir, "shortlog", "-sne", "--all")
 	out, err := cmd.Output()
 	if err != nil {
-		return 0, fmt.Errorf("git shortlog: %w", err)
+		return nil, fmt.Errorf("git shortlog: %w", err)
 	}
 
-	// Deduplicate authors by normalized name, keeping all emails per person
+	// Parse shortlog and group emails by normalized name.
 	type authorInfo struct {
 		emails []string
 	}
-	authors := make(map[string]*authorInfo) // key: normalized name
+	byName := make(map[string]*authorInfo)
 	scanner := bufio.NewScanner(strings.NewReader(string(out)))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -260,45 +258,138 @@ func ProjectActualPersonMonths(ctx context.Context, gitDir string) (float64, err
 		if normName == "" {
 			continue
 		}
-		a, ok := authors[normName]
+		a, ok := byName[normName]
 		if !ok {
 			a = &authorInfo{}
-			authors[normName] = a
+			byName[normName] = a
 		}
 		a.emails = append(a.emails, email)
+	}
+
+	// For each person, find earliest/latest across all their emails.
+	result := make(map[string]*authorDateSpan, len(byName))
+	for normName, info := range byName {
+		span := &authorDateSpan{}
+		for _, email := range info.emails {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			first, last, err := AuthorDateRange(ctx, gitDir, email)
+			if err != nil {
+				continue
+			}
+			if span.earliest.IsZero() || first.Before(span.earliest) {
+				span.earliest = first
+			}
+			if span.latest.IsZero() || last.After(span.latest) {
+				span.latest = last
+			}
+		}
+		result[normName] = span
+	}
+
+	return result, nil
+}
+
+// ProjectActualPersonMonths computes total actual person-months for a project
+// by summing each distinct author's active duration (first commit to last commit).
+// This produces an accurate effort measure — an author who committed over 6 months
+// counts as 6 person-months, not N × totalProjectDuration.
+//
+// Authors with a single commit (first == last) are counted as minAuthorMonths
+// to represent their minimal but nonzero contribution.
+func ProjectActualPersonMonths(ctx context.Context, gitDir string) (float64, error) {
+	const minAuthorMonths = 0.1
+
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	authors, err := gitDirAuthors(ctx, gitDir)
+	if err != nil {
+		return minAuthorMonths, nil
 	}
 
 	if len(authors) == 0 {
 		return minAuthorMonths, nil
 	}
 
-	// For each distinct person, find their earliest and latest commit across all emails
 	var totalPM float64
-	for _, info := range authors {
-		var earliest, latest time.Time
-
-		for _, email := range info.emails {
-			if ctx.Err() != nil {
-				return 0, ctx.Err()
-			}
-			first, last, err := AuthorDateRange(ctx, gitDir, email)
-			if err != nil {
-				continue
-			}
-			if earliest.IsZero() || first.Before(earliest) {
-				earliest = first
-			}
-			if latest.IsZero() || last.After(latest) {
-				latest = last
-			}
-		}
-
-		if earliest.IsZero() {
+	for _, span := range authors {
+		if span.earliest.IsZero() {
 			totalPM += minAuthorMonths
 			continue
 		}
+		months := ElapsedMonths(span.earliest, span.latest)
+		if months < minAuthorMonths {
+			months = minAuthorMonths
+		}
+		totalPM += months
+	}
 
-		months := ElapsedMonths(earliest, latest)
+	if totalPM < minAuthorMonths {
+		totalPM = minAuthorMonths
+	}
+	return totalPM, nil
+}
+
+// CampaignActualPersonMonths computes deduplicated campaign-wide actual
+// person-months across multiple projects. Unlike summing ProjectActualPersonMonths
+// per project, this merges authors by normalized name ACROSS git repos, so a
+// single person contributing to 7 repos counts once with their widest date range.
+func CampaignActualPersonMonths(ctx context.Context, projects []ResolvedProject) (float64, error) {
+	const minAuthorMonths = 0.1
+
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	// Deduplicate git dirs (monorepo subprojects share the same GitDir).
+	uniqueGitDirs := make(map[string]bool)
+	for _, p := range projects {
+		uniqueGitDirs[p.GitDir] = true
+	}
+
+	// For each unique git dir, get authors and merge by normalized name
+	// across ALL repos.
+	merged := make(map[string]*authorDateSpan)
+
+	for gitDir := range uniqueGitDirs {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+
+		authors, err := gitDirAuthors(ctx, gitDir)
+		if err != nil {
+			continue
+		}
+
+		for normName, info := range authors {
+			span, ok := merged[normName]
+			if !ok {
+				span = &authorDateSpan{}
+				merged[normName] = span
+			}
+			if span.earliest.IsZero() || info.earliest.Before(span.earliest) {
+				span.earliest = info.earliest
+			}
+			if span.latest.IsZero() || info.latest.After(span.latest) {
+				span.latest = info.latest
+			}
+		}
+	}
+
+	if len(merged) == 0 {
+		return minAuthorMonths, nil
+	}
+
+	var totalPM float64
+	for _, span := range merged {
+		if span.earliest.IsZero() {
+			totalPM += minAuthorMonths
+			continue
+		}
+		months := ElapsedMonths(span.earliest, span.latest)
 		if months < minAuthorMonths {
 			months = minAuthorMonths
 		}

--- a/internal/leverage/authors_test.go
+++ b/internal/leverage/authors_test.go
@@ -525,3 +525,143 @@ func TestBuildContributions_Sorted(t *testing.T) {
 		t.Errorf("percentages sum = %f, want 100.0", totalPct)
 	}
 }
+
+func TestGitDirAuthors(t *testing.T) {
+	dir := initGitRepo(t)
+	commitFileWithDate(t, dir, "a.go", "package a\n", "Alice", "alice@example.com", "2025-01-01T12:00:00+00:00")
+	commitFileWithDate(t, dir, "b.go", "package a\nvar x = 1\n", "Alice", "alice@example.com", "2025-06-01T12:00:00+00:00")
+	commitFileWithDate(t, dir, "c.go", "package a\nvar y = 1\n", "Bob", "bob@example.com", "2025-03-01T12:00:00+00:00")
+
+	authors, err := gitDirAuthors(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("gitDirAuthors: %v", err)
+	}
+
+	if len(authors) != 2 {
+		t.Fatalf("got %d authors, want 2", len(authors))
+	}
+
+	alice, ok := authors["alice"]
+	if !ok {
+		t.Fatal("missing alice")
+	}
+	if alice.earliest.IsZero() || alice.latest.IsZero() {
+		t.Error("alice dates should be non-zero")
+	}
+
+	bob, ok := authors["bob"]
+	if !ok {
+		t.Fatal("missing bob")
+	}
+	if bob.earliest.IsZero() {
+		t.Error("bob earliest should be non-zero")
+	}
+}
+
+func TestCampaignActualPersonMonths_DeduplicatesAcrossRepos(t *testing.T) {
+	ctx := context.Background()
+
+	repo1 := initGitRepo(t)
+	repo2 := initGitRepo(t)
+
+	// Alice commits to repo1: Jan - Sep (8 months)
+	commitFileWithDate(t, repo1, "a.go", "package a\n", "Alice", "alice@example.com", "2025-01-01T12:00:00+00:00")
+	commitFileWithDate(t, repo1, "b.go", "package a\nvar x = 1\n", "Alice", "alice@example.com", "2025-09-01T12:00:00+00:00")
+
+	// Alice also commits to repo2: Mar - Jul (within the same span)
+	commitFileWithDate(t, repo2, "c.go", "package b\n", "Alice", "alice@example.com", "2025-03-01T12:00:00+00:00")
+	commitFileWithDate(t, repo2, "d.go", "package b\nvar y = 1\n", "Alice", "alice@example.com", "2025-07-01T12:00:00+00:00")
+
+	projects := []ResolvedProject{
+		{Name: "project1", GitDir: repo1, SCCDir: repo1},
+		{Name: "project2", GitDir: repo2, SCCDir: repo2},
+	}
+
+	campaignPM, err := CampaignActualPersonMonths(ctx, projects)
+	if err != nil {
+		t.Fatalf("CampaignActualPersonMonths: %v", err)
+	}
+
+	// Alice's campaign span is Jan-Sep = ~8 months, NOT repo1(8) + repo2(4) = 12
+	if campaignPM < 7.5 || campaignPM > 9.0 {
+		t.Errorf("campaignPM = %.2f, want ~8.0 (deduplicated across repos)", campaignPM)
+	}
+
+	// Must be less than naive sum of per-project PMs
+	pm1, _ := ProjectActualPersonMonths(ctx, repo1)
+	pm2, _ := ProjectActualPersonMonths(ctx, repo2)
+	naiveSum := pm1 + pm2
+	if campaignPM >= naiveSum {
+		t.Errorf("campaign PM (%.2f) should be less than naive sum (%.2f)", campaignPM, naiveSum)
+	}
+}
+
+func TestCampaignActualPersonMonths_DeduplicatesMonorepo(t *testing.T) {
+	ctx := context.Background()
+
+	// Single repo, two subprojects pointing to same GitDir
+	repo := initGitRepo(t)
+	commitFileWithDate(t, repo, "a.go", "package a\n", "Alice", "alice@example.com", "2025-01-01T12:00:00+00:00")
+	commitFileWithDate(t, repo, "b.go", "package a\nvar x = 1\n", "Alice", "alice@example.com", "2025-07-01T12:00:00+00:00")
+
+	projects := []ResolvedProject{
+		{Name: "sub1", GitDir: repo, SCCDir: repo + "/sub1", InMonorepo: true},
+		{Name: "sub2", GitDir: repo, SCCDir: repo + "/sub2", InMonorepo: true},
+	}
+
+	campaignPM, err := CampaignActualPersonMonths(ctx, projects)
+	if err != nil {
+		t.Fatalf("CampaignActualPersonMonths: %v", err)
+	}
+
+	// Single author, ~6 months. Should NOT be doubled.
+	singlePM, _ := ProjectActualPersonMonths(ctx, repo)
+	if math.Abs(campaignPM-singlePM) > 0.5 {
+		t.Errorf("campaignPM = %.2f, singlePM = %.2f; monorepo should not double-count", campaignPM, singlePM)
+	}
+}
+
+func TestCampaignActualPersonMonths_MultipleAuthors(t *testing.T) {
+	ctx := context.Background()
+
+	repo1 := initGitRepo(t)
+	repo2 := initGitRepo(t)
+
+	// Alice in repo1: Jan-Sep (~8 months)
+	commitFileWithDate(t, repo1, "a1.go", "package a\n", "Alice", "alice@example.com", "2025-01-01T12:00:00+00:00")
+	commitFileWithDate(t, repo1, "a2.go", "package a\nvar x = 1\n", "Alice", "alice@example.com", "2025-09-01T12:00:00+00:00")
+
+	// Bob in repo1: Jan-Mar (~2 months)
+	commitFileWithDate(t, repo1, "b1.go", "package a\nvar y = 1\n", "Bob", "bob@example.com", "2025-01-15T12:00:00+00:00")
+	commitFileWithDate(t, repo1, "b2.go", "package a\nvar z = 1\n", "Bob", "bob@example.com", "2025-03-15T12:00:00+00:00")
+
+	// Alice in repo2: Mar-Jul (within her repo1 span)
+	commitFileWithDate(t, repo2, "c1.go", "package b\n", "Alice", "alice@example.com", "2025-03-01T12:00:00+00:00")
+	commitFileWithDate(t, repo2, "c2.go", "package b\nvar w = 1\n", "Alice", "alice@example.com", "2025-07-01T12:00:00+00:00")
+
+	projects := []ResolvedProject{
+		{Name: "project1", GitDir: repo1, SCCDir: repo1},
+		{Name: "project2", GitDir: repo2, SCCDir: repo2},
+	}
+
+	campaignPM, err := CampaignActualPersonMonths(ctx, projects)
+	if err != nil {
+		t.Fatalf("CampaignActualPersonMonths: %v", err)
+	}
+
+	// Alice ~8 months (Jan-Sep), Bob ~2 months (Jan-Mar) = ~10 PM
+	if campaignPM < 9.0 || campaignPM > 11.0 {
+		t.Errorf("campaignPM = %.2f, want ~10 (Alice 8 + Bob 2)", campaignPM)
+	}
+}
+
+func TestCampaignActualPersonMonths_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	projects := []ResolvedProject{{Name: "p", GitDir: "/tmp/nonexistent"}}
+	_, err := CampaignActualPersonMonths(ctx, projects)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}


### PR DESCRIPTION
## Summary

- **Bug**: `AggregateScores()` summed per-project `ActualPersonMonths`, double-counting the same author across multiple repos (e.g., one author active 8 months in 7 repos → 56 PM instead of 8)
- **Fix**: Added `CampaignActualPersonMonths()` which deduplicates authors by normalized name across all git repos and deduplicates `GitDir` values for monorepo subprojects before computing campaign-wide actual effort
- Extracted `gitDirAuthors()` helper from `ProjectActualPersonMonths()` for reuse, reducing duplication

## Test plan

- [x] All existing leverage tests pass (100 tests in `internal/leverage/`)
- [x] All leverage command tests pass (`cmd/camp/`)
- [x] 5 new tests: `gitDirAuthors` helper, cross-repo dedup, monorepo dedup, multi-author, context cancellation
- [ ] Run `camp leverage` on a real campaign to verify "Actual Effort" drops from inflated values back to accurate range
- [ ] Run `camp leverage --author <email>` to verify personal leverage is unaffected