### PR TITLE
Fix dungeon crawl showing hidden files in triage

### DIFF
--- a/internal/dungeon/service.go
+++ b/internal/dungeon/service.go
@@ -211,6 +211,11 @@ func (s *Service) ListItems(ctx context.Context) ([]DungeonItem, error) {
 			continue
 		}
 
+		// Skip hidden files
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
 		info, err := entry.Info()
 		if err != nil {
 			continue // Skip entries we can't stat


### PR DESCRIPTION
## Summary
- `ListItems()` in the dungeon service was not filtering hidden files (`.` prefix), causing `.gitkeep` and other dotfiles to appear in the crawl output
- Added hidden file check matching the existing pattern already used in `ListParentItems()`

## Test plan
- [x] `just build` passes
- [x] `just test all` passes (1559/1559)
- [ ] Manual: run `camp dungeon crawl` in a directory with `.gitkeep` in the dungeon — it should no longer appear