### PR TITLE
Fix author count deduplication for same-email identities

### DIFF
--- a/internal/leverage/authors.go
+++ b/internal/leverage/authors.go
@@ -218,9 +218,39 @@ func blameFile(ctx context.Context, dir, file string, accum map[string]*authorAc
 	return nil
 }
 
+// unionFind implements a simple union-find (disjoint set) for author deduplication.
+type unionFind struct {
+	parent []int
+}
+
+func newUnionFind(n int) *unionFind {
+	p := make([]int, n)
+	for i := range p {
+		p[i] = i
+	}
+	return &unionFind{parent: p}
+}
+
+func (uf *unionFind) find(x int) int {
+	for uf.parent[x] != x {
+		uf.parent[x] = uf.parent[uf.parent[x]] // path compression
+		x = uf.parent[x]
+	}
+	return x
+}
+
+func (uf *unionFind) union(x, y int) {
+	rx, ry := uf.find(x), uf.find(y)
+	if rx != ry {
+		uf.parent[rx] = ry
+	}
+}
+
 // CountAuthors returns the number of distinct human authors for a git repo.
 // Uses git shortlog for speed (no blame needed). Filters bot accounts and
-// deduplicates email aliases (same name = 1 person). Returns minimum 1.
+// deduplicates identities sharing either a normalized name or an email address,
+// with transitive merging (A shares name with B, B shares email with C → all
+// one person). Returns minimum 1.
 func CountAuthors(ctx context.Context, gitDir string) (int, error) {
 	if err := ctx.Err(); err != nil {
 		return 0, err
@@ -232,8 +262,12 @@ func CountAuthors(ctx context.Context, gitDir string) (int, error) {
 		return 1, nil // fallback: assume 1 author
 	}
 
-	// Parse "  123\tName <email>" lines
-	names := make(map[string]bool)
+	// Collect all (name, email) identity pairs from shortlog.
+	type identity struct {
+		name  string
+		email string
+	}
+	var ids []identity
 	scanner := bufio.NewScanner(strings.NewReader(string(out)))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -247,24 +281,53 @@ func CountAuthors(ctx context.Context, gitDir string) (int, error) {
 			continue
 		}
 
-		nameEmail := strings.TrimSpace(parts[1])
-		name, email := parseNameEmail(nameEmail)
-
+		name, email := parseNameEmail(strings.TrimSpace(parts[1]))
 		if isBotEmail(email) {
 			continue
 		}
 
-		// Deduplicate by normalized name
 		normName := normalizeName(name)
-		if normName != "" {
-			names[normName] = true
+		if normName == "" {
+			continue
+		}
+
+		ids = append(ids, identity{
+			name:  normName,
+			email: strings.ToLower(strings.TrimSpace(email)),
+		})
+	}
+
+	if len(ids) == 0 {
+		return 1, nil
+	}
+
+	// Union-find: merge identities sharing either name or email.
+	uf := newUnionFind(len(ids))
+	nameFirst := make(map[string]int)  // normalized name → first index
+	emailFirst := make(map[string]int) // email → first index
+
+	for i, id := range ids {
+		if prev, ok := nameFirst[id.name]; ok {
+			uf.union(i, prev)
+		} else {
+			nameFirst[id.name] = i
+		}
+		if id.email != "" {
+			if prev, ok := emailFirst[id.email]; ok {
+				uf.union(i, prev)
+			} else {
+				emailFirst[id.email] = i
+			}
 		}
 	}
 
-	if len(names) == 0 {
-		return 1, nil
+	// Count distinct roots.
+	roots := make(map[int]bool)
+	for i := range ids {
+		roots[uf.find(i)] = true
 	}
-	return len(names), nil
+
+	return len(roots), nil
 }
 
 // AuthorHasCommits returns true if the given author email has commits in the repo.

--- a/internal/leverage/authors_test.go
+++ b/internal/leverage/authors_test.go
@@ -258,6 +258,41 @@ func TestCountAuthors_DeduplicatesSameName(t *testing.T) {
 	}
 }
 
+func TestCountAuthors_SameEmailDifferentNames(t *testing.T) {
+	dir := initGitRepo(t)
+	// Same email, different display names (the real-world bug)
+	commitFile(t, dir, "a.go", "package a\n", "lancekrogers", "lancekrogers@gmail.com")
+	commitFile(t, dir, "b.go", "package b\n", "Lance Rogers", "lancekrogers@gmail.com")
+
+	count, err := CountAuthors(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("CountAuthors: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1 (same email, different display names)", count)
+	}
+}
+
+func TestCountAuthors_TransitiveMerge(t *testing.T) {
+	dir := initGitRepo(t)
+	// A shares name with B (both "Alice"), B shares email with C
+	// A: "Alice" <alice@work.com>
+	// B: "Alice" <alice@personal.com>
+	// C: "A. Smith" <alice@personal.com>
+	// All three should merge to 1 person via transitive chain.
+	commitFile(t, dir, "a.go", "package a\n", "Alice", "alice@work.com")
+	commitFile(t, dir, "b.go", "package b\n", "Alice", "alice@personal.com")
+	commitFile(t, dir, "c.go", "package c\n", "A. Smith", "alice@personal.com")
+
+	count, err := CountAuthors(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("CountAuthors: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1 (transitive merge: name→name→email)", count)
+	}
+}
+
 func TestCountAuthors_FiltersBots(t *testing.T) {
 	dir := initGitRepo(t)
 	commitFile(t, dir, "a.go", "package a\n", "Alice", "alice@example.com")


### PR DESCRIPTION
## Summary
- **Fix**: `CountAuthors` was reporting 2 authors when the same person had commits under different display names (e.g. `lancekrogers` vs `Lance Rogers`) but the same email address
- **Root cause**: Deduplication used normalized name only, ignoring email entirely
- **Solution**: Replace the name-only map with a union-find that merges identities sharing either a normalized name or an email, with transitive merging support

## Test plan
- [x] `TestCountAuthors_SameEmailDifferentNames` — same email, different display names → count 1
- [x] `TestCountAuthors_TransitiveMerge` — A shares name with B, B shares email with C → count 1
- [x] All existing `CountAuthors` tests pass (no regressions)
- [x] Full leverage test suite passes (120 tests)
- [ ] Run `camp leverage --json` and confirm `author_count: 1` across projects