### PR TITLE
Fix leverage actual PM collapsing to 0.1 floor

### DIFF
--- a/cmd/camp/leverage_helpers.go
+++ b/cmd/camp/leverage_helpers.go
@@ -52,19 +52,16 @@ func initLeverageSetup(ctx context.Context) (*leverageSetup, error) {
 		cfg = detected
 	}
 
-	// Populate projects from discovery if missing.
-	configCreated := false
-	if len(cfg.Projects) == 0 {
-		if err := leverage.PopulateProjects(ctx, root, cfg); err != nil {
-			return nil, fmt.Errorf("populating projects: %w", err)
-		}
-
-		if err := leverage.SaveConfig(configPath, cfg); err != nil {
-			return nil, fmt.Errorf("saving config: %w", err)
-		}
-
-		configCreated = !configExists
+	// Sync projects from discovery: adds new projects, removes stale entries.
+	if err := leverage.PopulateProjects(ctx, root, cfg); err != nil {
+		return nil, fmt.Errorf("populating projects: %w", err)
 	}
+
+	if err := leverage.SaveConfig(configPath, cfg); err != nil {
+		return nil, fmt.Errorf("saving config: %w", err)
+	}
+
+	configCreated := !configExists
 
 	return &leverageSetup{Root: root, Cfg: cfg, AutoDetected: autoDetected, ConfigCreated: configCreated}, nil
 }

--- a/internal/leverage/blame_cache.go
+++ b/internal/leverage/blame_cache.go
@@ -20,9 +20,15 @@ type BlameCacheEntry struct {
 	CachedAt   time.Time                 `json:"cached_at"`
 	FileBlame  map[string]map[string]int `json:"file_blame"`
 
-	AuthorCount        int                  `json:"author_count"`
-	ActualPM           float64              `json:"actual_person_months"`
-	Authors            []AuthorContribution `json:"authors"`
+	// EmailToName maps author email → display name from git blame output.
+	// Used by RecomputeAggregates to resolve real author names from FileBlame
+	// (which only stores emails as keys). Without this mapping, the name-based
+	// join with git date spans fails and actual PM collapses to the 0.1 floor.
+	EmailToName map[string]string `json:"email_to_name,omitempty"`
+
+	AuthorCount int                  `json:"author_count"`
+	ActualPM    float64              `json:"actual_person_months"`
+	Authors     []AuthorContribution `json:"authors"`
 }
 
 // BlameCache provides three-tier caching for git blame data.
@@ -243,8 +249,16 @@ func (entry *BlameCacheEntry) RecomputeAggregates() {
 			if a, ok := accum[email]; ok {
 				a.lines += lines
 			} else {
+				// Resolve real author name from cached mapping.
+				// Falls back to email for old caches without EmailToName.
+				name := email
+				if entry.EmailToName != nil {
+					if n, ok := entry.EmailToName[email]; ok {
+						name = n
+					}
+				}
 				accum[email] = &authorAccum{
-					name:  email, // best we have from blame cache
+					name:  name,
 					email: email,
 					lines: lines,
 				}
@@ -315,6 +329,14 @@ func PopulateOneProjectCached(ctx context.Context, p *ResolvedProject, cache *Bl
 	p.ActualPersonMonths = totalPM
 	p.Authors = enriched
 
+	// Build email→name mapping from blame contributions for cache persistence.
+	emailToName := make(map[string]string, len(contribs))
+	for _, c := range contribs {
+		if c.Email != "" && c.Name != "" {
+			emailToName[c.Email] = c.Name
+		}
+	}
+
 	// Build and save cache entry.
 	entry := &BlameCacheEntry{
 		Project:     p.Name,
@@ -322,6 +344,7 @@ func PopulateOneProjectCached(ctx context.Context, p *ResolvedProject, cache *Bl
 		SCCDir:      p.SCCDir,
 		CachedAt:    time.Now(),
 		FileBlame:   fileBlame,
+		EmailToName: emailToName,
 		AuthorCount: p.AuthorCount,
 		ActualPM:    totalPM,
 		Authors:     enriched,

--- a/internal/leverage/blame_cache_test.go
+++ b/internal/leverage/blame_cache_test.go
@@ -287,6 +287,58 @@ func TestRecomputeAggregates(t *testing.T) {
 	}
 }
 
+func TestRecomputeAggregates_WithEmailToName(t *testing.T) {
+	entry := &BlameCacheEntry{
+		FileBlame: map[string]map[string]int{
+			"a.go": {"alice@example.com": 10, "bob@example.com": 5},
+			"b.go": {"alice@example.com": 20},
+		},
+		EmailToName: map[string]string{
+			"alice@example.com": "Alice Smith",
+			"bob@example.com":   "Bob Jones",
+		},
+	}
+
+	entry.RecomputeAggregates()
+
+	if len(entry.Authors) != 2 {
+		t.Fatalf("Authors has %d entries, want 2", len(entry.Authors))
+	}
+
+	// Verify names come from EmailToName, not email addresses.
+	for _, a := range entry.Authors {
+		if a.Name == a.Email {
+			t.Errorf("Author name %q should not equal email — EmailToName mapping not applied", a.Name)
+		}
+	}
+	if entry.Authors[0].Name != "Alice Smith" {
+		t.Errorf("Authors[0].Name = %q, want %q", entry.Authors[0].Name, "Alice Smith")
+	}
+	if entry.Authors[1].Name != "Bob Jones" {
+		t.Errorf("Authors[1].Name = %q, want %q", entry.Authors[1].Name, "Bob Jones")
+	}
+}
+
+func TestRecomputeAggregates_NilEmailToName(t *testing.T) {
+	// Backwards compat: old cache files without EmailToName should still work.
+	entry := &BlameCacheEntry{
+		FileBlame: map[string]map[string]int{
+			"a.go": {"alice@example.com": 10},
+		},
+		EmailToName: nil,
+	}
+
+	entry.RecomputeAggregates()
+
+	if len(entry.Authors) != 1 {
+		t.Fatalf("Authors has %d entries, want 1", len(entry.Authors))
+	}
+	// Without mapping, name falls back to email.
+	if entry.Authors[0].Name != "alice@example.com" {
+		t.Errorf("Authors[0].Name = %q, want email fallback", entry.Authors[0].Name)
+	}
+}
+
 func TestRecomputeAggregates_Empty(t *testing.T) {
 	entry := &BlameCacheEntry{
 		FileBlame: map[string]map[string]int{},


### PR DESCRIPTION
## Summary
- **Blame cache name mismatch**: `RecomputeAggregates` used emails as author names, breaking the join with git date spans (keyed by real names). Every author fell to the 0.1 PM floor. Added `EmailToName` mapping to `BlameCacheEntry` so real names persist through cache cycles.
- **Stale config entries**: `initLeverageSetup` only synced projects when config was empty. Removed projects (e.g. `obey-simulator`) persisted and caused scc parse errors. Now always syncs on startup.

**Before**: Campaign actual effort showed 4.8 PM, guild-core showed 0.1 PM
**After**: Campaign actual effort shows 9.3 PM, guild-core shows 7.7 PM

## Test plan
- [x] All existing tests pass
- [x] New tests for `RecomputeAggregates` with/without `EmailToName`
- [x] Backwards compat test for old cache files (nil `EmailToName`)
- [x] End-to-end: cleared cache, rebuilt, verified correct PM values