### PR TITLE
Default to --rebase for camp pull commands

### DIFF
--- a/cmd/camp/pull.go
+++ b/cmd/camp/pull.go
@@ -64,6 +64,13 @@ func runPull(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, ui.Info(fmt.Sprintf("Submodule: %s", target.Name)))
 	}
 
+	// Default to --rebase when no pull strategy is specified.
+	// Campaigns are often worked on across multiple machines, making
+	// divergent branches common. Rebase keeps history linear.
+	if !git.HasPullStrategyFlag(gitArgs) {
+		gitArgs = append([]string{"--rebase"}, gitArgs...)
+	}
+
 	fullArgs := append([]string{"-C", target.Path, "pull"}, gitArgs...)
 	gitCmd := exec.CommandContext(ctx, "git", fullArgs...)
 	gitCmd.Stdout = os.Stdout
@@ -90,6 +97,11 @@ func runPullAll(ctx context.Context, campRoot string, gitArgs []string) error {
 
 	fmt.Println(ui.Info("Pulling all repos..."))
 	fmt.Println()
+
+	// Default to --rebase when no pull strategy is specified.
+	if !git.HasPullStrategyFlag(gitArgs) {
+		gitArgs = append([]string{"--rebase"}, gitArgs...)
+	}
 
 	// Discover submodules
 	paths, err := git.ListSubmodulePathsFiltered(ctx, campRoot, "projects/")
@@ -156,7 +168,9 @@ func runPullAll(ctx context.Context, campRoot string, gitArgs []string) error {
 		if err != nil {
 			fmt.Println(red.Render("failed"))
 			errMsg := strings.TrimSpace(string(output))
-			if errMsg == "" {
+			if isDivergentError(errMsg) {
+				errMsg = "branches diverged (try: camp pull all --rebase or resolve manually)"
+			} else if errMsg == "" {
 				errMsg = err.Error()
 			}
 			errors = append(errors, fmt.Sprintf("  %s: %s", t.name, errMsg))
@@ -193,4 +207,11 @@ func runPullAll(ctx context.Context, campRoot string, gitArgs []string) error {
 		return fmt.Errorf("%d repo(s) failed to pull", failed)
 	}
 	return nil
+}
+
+// isDivergentError checks if git output indicates divergent branches.
+func isDivergentError(output string) bool {
+	lower := strings.ToLower(output)
+	return strings.Contains(lower, "divergent branches") ||
+		strings.Contains(lower, "need to specify how to reconcile")
 }

--- a/cmd/camp/pull_integration_test.go
+++ b/cmd/camp/pull_integration_test.go
@@ -130,6 +130,57 @@ func TestIntegration_PullAll_ContextCancellation(t *testing.T) {
 	}
 }
 
+func TestIntegration_PullAll_DivergentBranchesRebase(t *testing.T) {
+	campDir, bareDir := setupCampaignWithSubmodule(t)
+	ctx := context.Background()
+
+	// Push a new commit to the bare remote (creates remote-only change)
+	pushCommitToBare(t, bareDir, "remote.txt", "remote content", "Remote commit")
+
+	// Create a local commit in the submodule (creates divergence)
+	subDir := filepath.Join(campDir, "projects", "test-project")
+	os.WriteFile(filepath.Join(subDir, "local.txt"), []byte("local content"), 0644)
+	run(t, "git", "-C", subDir, "add", ".")
+	run(t, "git", "-C", subDir, "commit", "-m", "Local commit")
+
+	// Default pull (no flags) should succeed via rebase
+	err := runPullAll(ctx, campDir, nil)
+	if err != nil {
+		t.Fatalf("runPullAll() should succeed with default rebase on divergent branches: %v", err)
+	}
+
+	// Verify both files exist (remote pulled + local preserved)
+	remoteFile := filepath.Join(subDir, "remote.txt")
+	if _, err := os.Stat(remoteFile); os.IsNotExist(err) {
+		t.Error("remote.txt was not pulled")
+	}
+	localFile := filepath.Join(subDir, "local.txt")
+	if _, err := os.Stat(localFile); os.IsNotExist(err) {
+		t.Error("local.txt was lost after rebase")
+	}
+}
+
+func TestIntegration_PullAll_ExplicitFfOnlyOverride(t *testing.T) {
+	campDir, bareDir := setupCampaignWithSubmodule(t)
+	ctx := context.Background()
+
+	// Push a new commit to remote
+	pushCommitToBare(t, bareDir, "remote.txt", "remote content", "Remote commit")
+
+	// Create local divergence
+	subDir := filepath.Join(campDir, "projects", "test-project")
+	os.WriteFile(filepath.Join(subDir, "local.txt"), []byte("local content"), 0644)
+	run(t, "git", "-C", subDir, "add", ".")
+	run(t, "git", "-C", subDir, "commit", "-m", "Local commit")
+
+	// Explicit --ff-only should fail on divergent branches
+	// (proves user flags override the default --rebase)
+	err := runPullAll(ctx, campDir, []string{"--ff-only"})
+	if err == nil {
+		t.Fatal("runPullAll(--ff-only) should fail with divergent branches")
+	}
+}
+
 func TestIntegration_PullAll_PassesThroughGitFlags(t *testing.T) {
 	campDir, bareDir := setupCampaignWithSubmodule(t)
 	ctx := context.Background()

--- a/internal/git/resolve.go
+++ b/internal/git/resolve.go
@@ -96,6 +96,18 @@ func resolveFromCwd(_ context.Context, campaignRoot string) (*TargetResult, erro
 	}, nil
 }
 
+// HasPullStrategyFlag reports whether gitArgs contains a pull reconciliation
+// strategy flag (--rebase, --no-rebase, --ff-only, --ff, --no-ff).
+func HasPullStrategyFlag(gitArgs []string) bool {
+	for _, arg := range gitArgs {
+		switch arg {
+		case "--rebase", "--no-rebase", "--ff-only", "--ff", "--no-ff":
+			return true
+		}
+	}
+	return false
+}
+
 // ExtractSubFlags extracts --sub and --project/-p flags from a raw args slice.
 // Returns the remaining args (to pass to git) and the flag values.
 // This is used by commands with DisableFlagParsing that need to extract

--- a/internal/git/resolve_test.go
+++ b/internal/git/resolve_test.go
@@ -190,6 +190,32 @@ func TestExtractSubFlags_ProjectAtEnd(t *testing.T) {
 	}
 }
 
+func TestHasPullStrategyFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"nil args", nil, false},
+		{"empty args", []string{}, false},
+		{"unrelated flags", []string{"--verbose", "-q"}, false},
+		{"rebase", []string{"--rebase"}, true},
+		{"no-rebase", []string{"--no-rebase"}, true},
+		{"ff-only", []string{"--ff-only"}, true},
+		{"ff", []string{"--ff"}, true},
+		{"no-ff", []string{"--no-ff"}, true},
+		{"strategy mixed with others", []string{"--verbose", "--rebase", "-q"}, true},
+		{"prefix should not match", []string{"--rebase-merges"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := HasPullStrategyFlag(tt.args); got != tt.want {
+				t.Errorf("HasPullStrategyFlag(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
 func initGitRepo(t *testing.T, dir string) {
 	t.Helper()
 	cmd := exec.Command("git", "init", dir)


### PR DESCRIPTION
## Summary
- Both `camp pull` and `camp pull all` now default to `--rebase` when no pull strategy flag is specified
- Prevents the confusing "need to specify how to reconcile divergent branches" git error that occurs when working across multiple machines
- User-provided flags (`--ff-only`, `--no-rebase`, etc.) still override the default
- Improved error messages for divergent branches in `pull all` — replaces raw git hint blocks with actionable guidance

## Changes
- **`internal/git/resolve.go`** — Added `HasPullStrategyFlag()` helper to detect existing strategy flags
- **`cmd/camp/pull.go`** — Default `--rebase` in `runPull` and `runPullAll`, added `isDivergentError` helper
- **Integration tests** — 2 new tests: divergent branches auto-resolved via rebase, explicit `--ff-only` override

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `TestHasPullStrategyFlag` — 10 table-driven cases pass
- [x] All 8 pull integration tests pass (6 existing + 2 new)
- [ ] Manual: `camp pull all` on campaign with divergent root succeeds