### PR TITLE
Fix camp pull rebase conflict handling

### DIFF
--- a/cmd/camp/pull.go
+++ b/cmd/camp/pull.go
@@ -27,14 +27,16 @@ Use --sub to pull the submodule detected from your current directory.
 Use --project/-p to pull a specific project.
 Use 'camp pull all' to pull all repos with upstream tracking.
 
+Any git pull flags are passed through (e.g. --rebase, --ff-only).
+
 Examples:
-  camp pull                    # Pull current branch
+  camp pull                    # Pull current branch (merge)
   camp pull --rebase           # Pull with rebase
   camp pull --ff-only          # Fast-forward only
   camp pull --sub              # Pull current submodule
   camp pull -p projects/camp   # Pull camp project
   camp pull all                # Pull all repos
-  camp pull all --rebase       # Pull all repos with rebase`,
+  camp pull all --ff-only      # Pull all repos, fast-forward only`,
 	RunE:               runPull,
 	DisableFlagParsing: true,
 }
@@ -62,13 +64,6 @@ func runPull(cmd *cobra.Command, args []string) error {
 
 	if target.IsSubmodule {
 		fmt.Fprintln(os.Stderr, ui.Info(fmt.Sprintf("Submodule: %s", target.Name)))
-	}
-
-	// Default to --rebase when no pull strategy is specified.
-	// Campaigns are often worked on across multiple machines, making
-	// divergent branches common. Rebase keeps history linear.
-	if !git.HasPullStrategyFlag(gitArgs) {
-		gitArgs = append([]string{"--rebase"}, gitArgs...)
 	}
 
 	fullArgs := append([]string{"-C", target.Path, "pull"}, gitArgs...)
@@ -112,11 +107,6 @@ func runPullAll(ctx context.Context, campRoot string, gitArgs []string) error {
 
 	fmt.Println(ui.Info("Pulling all repos..."))
 	fmt.Println()
-
-	// Default to --rebase when no pull strategy is specified.
-	if !git.HasPullStrategyFlag(gitArgs) {
-		gitArgs = append([]string{"--rebase"}, gitArgs...)
-	}
 
 	// Discover submodules
 	paths, err := git.ListSubmodulePathsFiltered(ctx, campRoot, "projects/")
@@ -194,7 +184,7 @@ func runPullAll(ctx context.Context, campRoot string, gitArgs []string) error {
 			fmt.Println(red.Render("failed"))
 			errMsg := strings.TrimSpace(string(output))
 			if isDivergentError(errMsg) {
-				errMsg = "branches diverged (try: camp pull all --rebase or resolve manually)"
+				errMsg = "branches diverged (try: camp pull all --ff-only, --rebase, or resolve manually)"
 			} else if errMsg == "" {
 				errMsg = err.Error()
 			}

--- a/cmd/camp/pull_integration_test.go
+++ b/cmd/camp/pull_integration_test.go
@@ -143,10 +143,10 @@ func TestIntegration_PullAll_DivergentBranchesRebase(t *testing.T) {
 	run(t, "git", "-C", subDir, "add", ".")
 	run(t, "git", "-C", subDir, "commit", "-m", "Local commit")
 
-	// Default pull (no flags) should succeed via rebase
-	err := runPullAll(ctx, campDir, nil)
+	// Explicit --rebase should succeed on divergent branches
+	err := runPullAll(ctx, campDir, []string{"--rebase"})
 	if err != nil {
-		t.Fatalf("runPullAll() should succeed with default rebase on divergent branches: %v", err)
+		t.Fatalf("runPullAll(--rebase) should succeed on divergent branches: %v", err)
 	}
 
 	// Verify both files exist (remote pulled + local preserved)
@@ -157,6 +157,27 @@ func TestIntegration_PullAll_DivergentBranchesRebase(t *testing.T) {
 	localFile := filepath.Join(subDir, "local.txt")
 	if _, err := os.Stat(localFile); os.IsNotExist(err) {
 		t.Error("local.txt was lost after rebase")
+	}
+}
+
+func TestIntegration_PullAll_DivergentBranchesDefaultFails(t *testing.T) {
+	campDir, bareDir := setupCampaignWithSubmodule(t)
+	ctx := context.Background()
+
+	// Push a new commit to the bare remote (creates remote-only change)
+	pushCommitToBare(t, bareDir, "remote.txt", "remote content", "Remote commit")
+
+	// Create a local commit in the submodule (creates divergence)
+	subDir := filepath.Join(campDir, "projects", "test-project")
+	os.WriteFile(filepath.Join(subDir, "local.txt"), []byte("local content"), 0644)
+	run(t, "git", "-C", subDir, "add", ".")
+	run(t, "git", "-C", subDir, "commit", "-m", "Local commit")
+
+	// Default pull (no strategy) should fail on divergent branches
+	// (git requires the user to specify a reconciliation strategy)
+	err := runPullAll(ctx, campDir, nil)
+	if err == nil {
+		t.Fatal("runPullAll() should fail with divergent branches and no strategy")
 	}
 }
 
@@ -174,7 +195,6 @@ func TestIntegration_PullAll_ExplicitFfOnlyOverride(t *testing.T) {
 	run(t, "git", "-C", subDir, "commit", "-m", "Local commit")
 
 	// Explicit --ff-only should fail on divergent branches
-	// (proves user flags override the default --rebase)
 	err := runPullAll(ctx, campDir, []string{"--ff-only"})
 	if err == nil {
 		t.Fatal("runPullAll(--ff-only) should fail with divergent branches")
@@ -221,8 +241,8 @@ func TestIntegration_PullAll_RebaseConflictAutoAborts(t *testing.T) {
 	run(t, "git", "-C", subDir, "add", ".")
 	run(t, "git", "-C", subDir, "commit", "-m", "Local change to README")
 
-	// Pull should fail on the submodule (rebase conflict) but auto-abort
-	err := runPullAll(ctx, campDir, nil)
+	// Pull with --rebase should fail on the submodule (conflict) but auto-abort
+	err := runPullAll(ctx, campDir, []string{"--rebase"})
 	if err == nil {
 		t.Fatal("expected error from rebase conflict, got nil")
 	}


### PR DESCRIPTION
Auto-abort failed rebases in pull all so repos aren't left in broken state. Suppress cobra's misleading usage output on git errors in single pull and show recovery guidance instead.