### PR TITLE
feat(commitkit): expose lock-aware git operations as public API

### DIFF
--- a/pkg/commitkit/commitkit.go
+++ b/pkg/commitkit/commitkit.go
@@ -2,6 +2,9 @@
 // operations. It wraps camp's internal git and campaign packages so that
 // external tools (e.g. fest) can import them without depending on internal
 // implementation paths.
+//
+// All staging and commit operations use automatic lock retry with stale
+// lock cleanup, making them resilient to index.lock contention.
 package commitkit
 
 import (
@@ -14,6 +17,17 @@ import (
 	"github.com/obediencecorp/camp/internal/config"
 	"github.com/obediencecorp/camp/internal/git"
 )
+
+// ErrNoChanges is returned when there are no changes to commit.
+var ErrNoChanges = git.ErrNoChanges
+
+// CommitOptions configures a commit operation.
+type CommitOptions struct {
+	Message    string
+	Amend      bool
+	AllowEmpty bool
+	Author     string // Optional: "Name <email>"
+}
 
 // FormatCampaignTag returns the "[OBEY-CAMPAIGN-{id}]" prefix string.
 // Truncates campaignID to 8 characters. Returns empty string if campaignID
@@ -56,6 +70,71 @@ func LoadCampaignID(ctx context.Context, campaignRoot string) (string, error) {
 	return cfg.ID, nil
 }
 
+// StageAll stages all changes in the repository at repoPath.
+// Uses automatic lock retry with stale lock cleanup.
+func StageAll(ctx context.Context, repoPath string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return git.StageAll(ctx, repoPath)
+}
+
+// StageFiles stages specific files in the repository at repoPath.
+// Uses automatic lock retry with stale lock cleanup.
+func StageFiles(ctx context.Context, repoPath string, files ...string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return git.StageFiles(ctx, repoPath, files...)
+}
+
+// HasStagedChanges reports whether there are staged changes ready to commit
+// in the repository at repoPath.
+func HasStagedChanges(ctx context.Context, repoPath string) (bool, error) {
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	return git.HasStagedChanges(ctx, repoPath)
+}
+
+// Commit creates a git commit in the repository at repoPath.
+// Uses automatic lock retry with stale lock cleanup.
+// Returns ErrNoChanges if there is nothing to commit.
+func Commit(ctx context.Context, repoPath string, opts CommitOptions) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return git.Commit(ctx, repoPath, &git.CommitOptions{
+		Message:    opts.Message,
+		Amend:      opts.Amend,
+		AllowEmpty: opts.AllowEmpty,
+		Author:     opts.Author,
+	})
+}
+
+// CommitAll stages all changes and commits them with the given message.
+// Returns ErrNoChanges if there is nothing to commit.
+// Uses automatic lock retry with stale lock cleanup.
+func CommitAll(ctx context.Context, repoPath, message string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return git.CommitAll(ctx, repoPath, message)
+}
+
+// ShortHash returns the short commit hash of HEAD in the repository at repoPath.
+func ShortHash(ctx context.Context, repoPath string) (string, error) {
+	if ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "--short", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("commitkit: rev-parse --short HEAD: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // SyncSubmoduleRef stages the updated submodule pointer for projectRelPath
 // inside the campaign root and commits it with a campaign-tagged message.
 // projectRelPath is the path to the submodule relative to campaignRoot
@@ -63,32 +142,32 @@ func LoadCampaignID(ctx context.Context, campaignRoot string) (string, error) {
 //
 // It is a no-op and returns nil when the submodule pointer has not changed
 // (git reports nothing to commit).
+//
+// Uses automatic lock retry with stale lock cleanup.
 func SyncSubmoduleRef(ctx context.Context, campaignRoot, projectRelPath, campaignID string) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
 
 	// Stage only the submodule ref — not the entire working tree.
-	stageCmd := exec.CommandContext(ctx, "git", "-C", campaignRoot, "add", projectRelPath)
-	if out, err := stageCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("commitkit: stage submodule %s: %s: %w",
-			projectRelPath, strings.TrimSpace(string(out)), err)
+	if err := git.StageFiles(ctx, campaignRoot, projectRelPath); err != nil {
+		return fmt.Errorf("commitkit: stage submodule %s: %w", projectRelPath, err)
 	}
 
 	// Check whether there is actually something staged before committing.
-	diffCmd := exec.CommandContext(ctx, "git", "-C", campaignRoot, "diff", "--cached", "--quiet")
-	if err := diffCmd.Run(); err == nil {
-		// Exit 0 means no staged changes — nothing to commit.
-		return nil
+	hasChanges, err := git.HasStagedChanges(ctx, campaignRoot)
+	if err != nil {
+		return fmt.Errorf("commitkit: check staged changes: %w", err)
+	}
+	if !hasChanges {
+		return nil // No-op: submodule pointer hasn't changed.
 	}
 
 	msg := git.PrependCampaignTag(campaignID,
 		fmt.Sprintf("sync submodule ref: %s", projectRelPath))
 
-	commitCmd := exec.CommandContext(ctx, "git", "-C", campaignRoot, "commit", "-m", msg)
-	if out, err := commitCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("commitkit: commit submodule ref for %s: %s: %w",
-			projectRelPath, strings.TrimSpace(string(out)), err)
+	if err := git.Commit(ctx, campaignRoot, &git.CommitOptions{Message: msg}); err != nil {
+		return fmt.Errorf("commitkit: commit submodule ref for %s: %w", projectRelPath, err)
 	}
 
 	return nil

--- a/pkg/commitkit/commitkit_test.go
+++ b/pkg/commitkit/commitkit_test.go
@@ -2,6 +2,7 @@ package commitkit_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -307,5 +308,335 @@ func TestSyncSubmoduleRef(t *testing.T) {
 		err := commitkit.SyncSubmoduleRef(ctx, parent, "sub", "testid")
 		require.Error(t, err)
 		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// StageAll
+// ---------------------------------------------------------------------------
+
+func TestStageAll(t *testing.T) {
+	t.Run("stages new and modified files", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		// Create a new file.
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "new.txt"), []byte("hello\n"), 0644))
+
+		err := commitkit.StageAll(context.Background(), dir)
+		require.NoError(t, err)
+
+		has, err := commitkit.HasStagedChanges(context.Background(), dir)
+		require.NoError(t, err)
+		assert.True(t, has)
+	})
+
+	t.Run("stages deletions", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		// Delete the README that was committed in makeGitRepo.
+		require.NoError(t, os.Remove(filepath.Join(dir, "README.md")))
+
+		err := commitkit.StageAll(context.Background(), dir)
+		require.NoError(t, err)
+
+		has, err := commitkit.HasStagedChanges(context.Background(), dir)
+		require.NoError(t, err)
+		assert.True(t, has)
+	})
+
+	t.Run("no-op on clean repo", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		err := commitkit.StageAll(context.Background(), dir)
+		require.NoError(t, err)
+
+		has, err := commitkit.HasStagedChanges(context.Background(), dir)
+		require.NoError(t, err)
+		assert.False(t, has)
+	})
+
+	t.Run("returns error on cancelled context", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := commitkit.StageAll(ctx, dir)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("succeeds with stale lock file", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "new.txt"), []byte("data\n"), 0644))
+
+		// Create a stale lock (no process holding it).
+		lockPath := filepath.Join(dir, ".git", "index.lock")
+		require.NoError(t, os.WriteFile(lockPath, []byte{}, 0644))
+
+		err := commitkit.StageAll(context.Background(), dir)
+		require.NoError(t, err)
+
+		// Lock should have been cleaned up.
+		_, err = os.Stat(lockPath)
+		assert.True(t, os.IsNotExist(err), "stale lock should be removed")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// StageFiles
+// ---------------------------------------------------------------------------
+
+func TestStageFiles(t *testing.T) {
+	t.Run("stages specific file only", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a\n"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("b\n"), 0644))
+
+		err := commitkit.StageFiles(context.Background(), dir, "a.txt")
+		require.NoError(t, err)
+
+		// Verify only a.txt is staged by checking diff output.
+		out, err := exec.Command("git", "-C", dir, "diff", "--cached", "--name-only").Output()
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "a.txt")
+		assert.NotContains(t, string(out), "b.txt")
+	})
+
+	t.Run("returns error on cancelled context", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := commitkit.StageFiles(ctx, dir, "file.txt")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// HasStagedChanges
+// ---------------------------------------------------------------------------
+
+func TestHasStagedChanges(t *testing.T) {
+	t.Run("returns false on clean repo", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		has, err := commitkit.HasStagedChanges(context.Background(), dir)
+		require.NoError(t, err)
+		assert.False(t, has)
+	})
+
+	t.Run("returns true with staged changes", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "new.txt"), []byte("hello\n"), 0644))
+		_, err := exec.Command("git", "-C", dir, "add", "new.txt").CombinedOutput()
+		require.NoError(t, err)
+
+		has, err := commitkit.HasStagedChanges(context.Background(), dir)
+		require.NoError(t, err)
+		assert.True(t, has)
+	})
+
+	t.Run("returns false with only unstaged changes", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		// Modify existing file without staging.
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("modified\n"), 0644))
+
+		has, err := commitkit.HasStagedChanges(context.Background(), dir)
+		require.NoError(t, err)
+		assert.False(t, has)
+	})
+
+	t.Run("returns error on cancelled context", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := commitkit.HasStagedChanges(ctx, dir)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Commit
+// ---------------------------------------------------------------------------
+
+func TestCommit(t *testing.T) {
+	t.Run("commits staged changes", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("content\n"), 0644))
+		require.NoError(t, commitkit.StageAll(context.Background(), dir))
+
+		err := commitkit.Commit(context.Background(), dir, commitkit.CommitOptions{
+			Message: "test commit",
+		})
+		require.NoError(t, err)
+
+		// Verify the commit message.
+		out, err := exec.Command("git", "-C", dir, "log", "--oneline", "-1").Output()
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "test commit")
+	})
+
+	t.Run("returns ErrNoChanges when nothing staged", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		err := commitkit.Commit(context.Background(), dir, commitkit.CommitOptions{
+			Message: "empty",
+		})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, commitkit.ErrNoChanges))
+	})
+
+	t.Run("succeeds with stale lock file", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("data\n"), 0644))
+		require.NoError(t, commitkit.StageAll(context.Background(), dir))
+
+		// Create a stale lock (no process holding it).
+		lockPath := filepath.Join(dir, ".git", "index.lock")
+		require.NoError(t, os.WriteFile(lockPath, []byte{}, 0644))
+
+		err := commitkit.Commit(context.Background(), dir, commitkit.CommitOptions{
+			Message: "commit with lock",
+		})
+		require.NoError(t, err)
+
+		// Lock should have been cleaned up.
+		_, err = os.Stat(lockPath)
+		assert.True(t, os.IsNotExist(err), "stale lock should be removed")
+	})
+
+	t.Run("returns error on cancelled context", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := commitkit.Commit(ctx, dir, commitkit.CommitOptions{Message: "msg"})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// CommitAll
+// ---------------------------------------------------------------------------
+
+func TestCommitAll(t *testing.T) {
+	t.Run("stages and commits all changes", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("aaa\n"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("bbb\n"), 0644))
+
+		err := commitkit.CommitAll(context.Background(), dir, "commit all test")
+		require.NoError(t, err)
+
+		// Verify the commit.
+		out, err := exec.Command("git", "-C", dir, "log", "--oneline", "-1").Output()
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "commit all test")
+
+		// Verify clean working tree.
+		has, err := commitkit.HasStagedChanges(context.Background(), dir)
+		require.NoError(t, err)
+		assert.False(t, has)
+	})
+
+	t.Run("returns ErrNoChanges on clean repo", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		err := commitkit.CommitAll(context.Background(), dir, "nothing here")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, commitkit.ErrNoChanges))
+	})
+
+	t.Run("returns error on cancelled context", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := commitkit.CommitAll(ctx, dir, "msg")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ShortHash
+// ---------------------------------------------------------------------------
+
+func TestShortHash(t *testing.T) {
+	t.Run("returns non-empty hash", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		hash, err := commitkit.ShortHash(context.Background(), dir)
+		require.NoError(t, err)
+		assert.NotEmpty(t, hash)
+		// Short hashes are typically 7 chars.
+		assert.GreaterOrEqual(t, len(hash), 7)
+	})
+
+	t.Run("hash changes after new commit", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		hash1, err := commitkit.ShortHash(context.Background(), dir)
+		require.NoError(t, err)
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "new.txt"), []byte("data\n"), 0644))
+		require.NoError(t, commitkit.CommitAll(context.Background(), dir, "second commit"))
+
+		hash2, err := commitkit.ShortHash(context.Background(), dir)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, hash1, hash2)
+	})
+
+	t.Run("returns error on cancelled context", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := commitkit.ShortHash(ctx, dir)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ErrNoChanges sentinel
+// ---------------------------------------------------------------------------
+
+func TestErrNoChanges(t *testing.T) {
+	t.Run("is compatible with errors.Is", func(t *testing.T) {
+		assert.True(t, errors.Is(commitkit.ErrNoChanges, commitkit.ErrNoChanges))
 	})
 }


### PR DESCRIPTION
## Summary

- **Expands commitkit's public API** to expose camp's internal lock-aware git operations, enabling external tools (like fest) to benefit from automatic `index.lock` retry and stale lock cleanup
- **Adds 7 new public functions**: `StageAll`, `StageFiles`, `HasStagedChanges`, `Commit`, `CommitAll`, `ShortHash`, plus `CommitOptions` type and `ErrNoChanges` sentinel
- **Refactors `SyncSubmoduleRef`** to use lock-aware internals instead of raw `exec.CommandContext` calls

## Context

Fest's `autoCommitStatusChange()` was using raw git commands (`exec.CommandContext`) for staging and committing during festival status transitions. When an `index.lock` file existed (stale or otherwise), these operations failed immediately with no retry.

Camp already had sophisticated lock handling in `internal/git/`:
- **Cycle-based retry** with configurable attempts per cycle and backoff between cycles
- **Stale lock detection** via `fuser`/`lsof` to check if the holding process still exists
- **Safe lock removal** with double-check staleness verification before deletion
- **Error classification** that distinguishes lock errors from other git failures

However, none of this was exposed through `pkg/commitkit/`. This PR bridges that gap.

## New Public API

| Function | Description |
|---|---|
| `StageAll(ctx, repoPath)` | Stage all changes with lock retry |
| `StageFiles(ctx, repoPath, files...)` | Stage specific files with lock retry |
| `HasStagedChanges(ctx, repoPath)` | Check for staged changes |
| `Commit(ctx, repoPath, opts)` | Commit with lock retry and stale cleanup |
| `CommitAll(ctx, repoPath, message)` | Stage all + commit with lock retry |
| `ShortHash(ctx, repoPath)` | Get HEAD short hash |
| `CommitOptions` | Public commit configuration struct |
| `ErrNoChanges` | Sentinel for "nothing to commit" |

## SyncSubmoduleRef Fix

The existing `SyncSubmoduleRef` was also using raw git commands. Now uses:
- `git.StageFiles()` instead of `exec git add`
- `git.HasStagedChanges()` instead of `exec git diff --cached --quiet`
- `git.Commit()` instead of `exec git commit`

## Test Plan

- [x] 18 new tests added covering all new functions
- [x] Stale lock recovery tests (create orphaned lock, verify operations succeed after cleanup)
- [x] Context cancellation tests for every function
- [x] `ErrNoChanges` sentinel compatibility test
- [x] Existing SyncSubmoduleRef tests still pass
- [x] `go build ./...` clean
- [x] `go test ./pkg/commitkit/` — all 30 tests pass