### PR TITLE
Add markdown syntax highlighting to intent body editor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/obediencecorp/camp
 go 1.25.6
 
 require (
+	github.com/alecthomas/chroma/v2 v2.23.1
 	github.com/charmbracelet/bubbles v0.21.1
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0
@@ -12,6 +13,7 @@ require (
 	github.com/ktr0731/go-fuzzyfinder v0.9.0
 	github.com/lancekrogers/guild-scaffold v0.0.0-20260127172326-92f4536360f3
 	github.com/muesli/termenv v0.16.0
+	github.com/obediencecorp/obey-shared v0.0.0-00010101000000-000000000000
 	github.com/sahilm/fuzzy v0.1.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -25,7 +27,6 @@ require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/alecthomas/chroma/v2 v2.23.1 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect

--- a/internal/intent/tui/add_model.go
+++ b/internal/intent/tui/add_model.go
@@ -106,6 +106,7 @@ func NewIntentAddModel(ctx context.Context, conceptSvc concept.Service, opts Add
 	// Body vim editor
 	vimEd := vim.NewEditor("")
 	vimEd.SetSize(60, 6)
+	vimEd.SetSyntax(vim.NewMarkdownStyler())
 
 	// Find default type index
 	typeIdx := 0

--- a/internal/intent/tui/vim/editor.go
+++ b/internal/intent/tui/vim/editor.go
@@ -14,9 +14,13 @@ type Editor struct {
 	undoStack    *UndoStack
 	width        int
 	height       int
-	scrollOffset int    // First visible line
-	lastChange   string // For . command
+	scrollOffset int            // First visible line
+	lastChange   string         // For . command
+	syntax       *SyntaxStyler  // nil = no highlighting
 }
+
+// SetSyntax enables syntax highlighting for the editor content.
+func (e *Editor) SetSyntax(s *SyntaxStyler) { e.syntax = s }
 
 // NewEditor creates a new vim editor with the given content.
 func NewEditor(content string) *Editor {

--- a/internal/intent/tui/vim/syntax.go
+++ b/internal/intent/tui/vim/syntax.go
@@ -1,0 +1,147 @@
+package vim
+
+import (
+	"crypto/sha256"
+
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/lexers"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/obediencecorp/camp/internal/ui/theme"
+)
+
+// SyntaxStyler tokenizes content and provides per-offset styles for rendering.
+// It caches results and only re-tokenizes when content changes.
+type SyntaxStyler struct {
+	styles   []lipgloss.Style
+	tokens   []chroma.TokenType // parallel to styles, for testing
+	hash     [32]byte           // SHA-256 of last tokenized content
+	valid    bool
+	lexer    chroma.Lexer
+	tokenMap tokenStyleMap
+}
+
+// TokenAt returns the chroma token type at the given byte offset.
+// Returns -1 for out-of-bounds offsets.
+func (s *SyntaxStyler) TokenAt(offset int) chroma.TokenType {
+	if offset < 0 || offset >= len(s.tokens) {
+		return -1
+	}
+	return s.tokens[offset]
+}
+
+// tokenStyleMap holds the lipgloss styles for each chroma token type.
+type tokenStyleMap struct {
+	heading    lipgloss.Style
+	bold       lipgloss.Style
+	italic     lipgloss.Style
+	code       lipgloss.Style
+	link       lipgloss.Style
+	keyword    lipgloss.Style
+	deleted    lipgloss.Style
+	defaultSty lipgloss.Style
+}
+
+// NewMarkdownStyler creates a SyntaxStyler configured for markdown.
+func NewMarkdownStyler() *SyntaxStyler {
+	pal := theme.TUI()
+	return &SyntaxStyler{
+		lexer: lexers.Get("markdown"),
+		tokenMap: tokenStyleMap{
+			heading:    lipgloss.NewStyle().Bold(true).Foreground(pal.Accent),
+			bold:       lipgloss.NewStyle().Bold(true),
+			italic:     lipgloss.NewStyle().Italic(true),
+			code:       lipgloss.NewStyle().Foreground(pal.Success),
+			link:       lipgloss.NewStyle().Foreground(pal.AccentAlt),
+			keyword:    lipgloss.NewStyle().Foreground(pal.Warning),
+			deleted:    lipgloss.NewStyle().Strikethrough(true).Foreground(pal.TextMuted),
+			defaultSty: lipgloss.NewStyle(),
+		},
+	}
+}
+
+// Update re-tokenizes content if it changed since the last call.
+func (s *SyntaxStyler) Update(content string, defaultStyle lipgloss.Style) {
+	h := sha256.Sum256([]byte(content))
+	if s.valid && h == s.hash {
+		return
+	}
+	s.hash = h
+	s.valid = true
+	s.tokenMap.defaultSty = defaultStyle
+	s.tokenize(content)
+}
+
+// StyleAt returns the style for the character at the given byte offset.
+func (s *SyntaxStyler) StyleAt(offset int) lipgloss.Style {
+	if offset < 0 || offset >= len(s.styles) {
+		return s.tokenMap.defaultSty
+	}
+	return s.styles[offset]
+}
+
+// tokenize runs the chroma lexer and builds per-byte style and token slices.
+func (s *SyntaxStyler) tokenize(content string) {
+	n := len(content)
+	s.styles = make([]lipgloss.Style, n)
+	s.tokens = make([]chroma.TokenType, n)
+
+	if s.lexer == nil {
+		for i := range n {
+			s.styles[i] = s.tokenMap.defaultSty
+			s.tokens[i] = chroma.Text
+		}
+		return
+	}
+
+	iter, err := s.lexer.Tokenise(nil, content)
+	if err != nil {
+		for i := range n {
+			s.styles[i] = s.tokenMap.defaultSty
+			s.tokens[i] = chroma.Text
+		}
+		return
+	}
+
+	offset := 0
+	for _, tok := range iter.Tokens() {
+		style := s.styleForToken(tok.Type)
+		for i := range len(tok.Value) {
+			byteOffset := offset + i
+			if byteOffset < n {
+				s.styles[byteOffset] = style
+				s.tokens[byteOffset] = tok.Type
+			}
+		}
+		offset += len(tok.Value)
+	}
+
+	// Fill any remaining positions with default.
+	for i := offset; i < n; i++ {
+		s.styles[i] = s.tokenMap.defaultSty
+		s.tokens[i] = chroma.Text
+	}
+}
+
+// styleForToken maps a chroma token type to a lipgloss style.
+func (s *SyntaxStyler) styleForToken(tt chroma.TokenType) lipgloss.Style {
+	switch tt {
+	case chroma.GenericHeading, chroma.GenericSubheading:
+		return s.tokenMap.heading
+	case chroma.GenericStrong:
+		return s.tokenMap.bold
+	case chroma.GenericEmph:
+		return s.tokenMap.italic
+	case chroma.LiteralStringBacktick, chroma.LiteralString:
+		return s.tokenMap.code
+	case chroma.NameTag, chroma.NameAttribute:
+		return s.tokenMap.link
+	case chroma.Keyword:
+		return s.tokenMap.keyword
+	case chroma.GenericDeleted:
+		return s.tokenMap.deleted
+	case chroma.NameEntity:
+		return s.tokenMap.link
+	default:
+		return s.tokenMap.defaultSty
+	}
+}

--- a/internal/intent/tui/vim/syntax_test.go
+++ b/internal/intent/tui/vim/syntax_test.go
@@ -1,0 +1,159 @@
+package vim
+
+import (
+	"testing"
+
+	"github.com/alecthomas/chroma/v2"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// hasTokenType checks if any byte offset in content has the given token type.
+func hasTokenType(s *SyntaxStyler, content string, tt chroma.TokenType) bool {
+	for i := range len(content) {
+		if s.TokenAt(i) == tt {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSyntaxStyler_EmptyContent(t *testing.T) {
+	s := NewMarkdownStyler()
+	s.Update("", lipgloss.NewStyle())
+
+	if s.TokenAt(0) != -1 {
+		t.Error("expected -1 token for out-of-bounds offset on empty content")
+	}
+}
+
+func TestSyntaxStyler_PlainText(t *testing.T) {
+	s := NewMarkdownStyler()
+	s.Update("hello world", lipgloss.NewStyle())
+
+	// All characters should be Text type.
+	for i := range len("hello world") {
+		if s.TokenAt(i) != chroma.Text {
+			t.Errorf("offset %d: expected Text token, got %d", i, s.TokenAt(i))
+		}
+	}
+}
+
+func TestSyntaxStyler_HeadingStyle(t *testing.T) {
+	s := NewMarkdownStyler()
+	content := "# Hello\n"
+	s.Update(content, lipgloss.NewStyle())
+
+	if !hasTokenType(s, content, chroma.GenericHeading) {
+		t.Error("expected GenericHeading token in '# Hello\\n'")
+	}
+}
+
+func TestSyntaxStyler_SubheadingStyle(t *testing.T) {
+	s := NewMarkdownStyler()
+	content := "## Sub\n"
+	s.Update(content, lipgloss.NewStyle())
+
+	if !hasTokenType(s, content, chroma.GenericSubheading) {
+		t.Error("expected GenericSubheading token in '## Sub\\n'")
+	}
+}
+
+func TestSyntaxStyler_BoldStyle(t *testing.T) {
+	s := NewMarkdownStyler()
+	content := "text **bold** end\n"
+	s.Update(content, lipgloss.NewStyle())
+
+	if !hasTokenType(s, content, chroma.GenericStrong) {
+		t.Error("expected GenericStrong token in 'text **bold** end'")
+	}
+}
+
+func TestSyntaxStyler_ItalicStyle(t *testing.T) {
+	s := NewMarkdownStyler()
+	content := "text *italic* end\n"
+	s.Update(content, lipgloss.NewStyle())
+
+	if !hasTokenType(s, content, chroma.GenericEmph) {
+		t.Error("expected GenericEmph token in 'text *italic* end'")
+	}
+}
+
+func TestSyntaxStyler_InlineCodeStyle(t *testing.T) {
+	s := NewMarkdownStyler()
+	content := "use `code` here"
+	s.Update(content, lipgloss.NewStyle())
+
+	if !hasTokenType(s, content, chroma.LiteralStringBacktick) {
+		t.Error("expected LiteralStringBacktick token for inline `code`")
+	}
+}
+
+func TestSyntaxStyler_LinkStyle(t *testing.T) {
+	s := NewMarkdownStyler()
+	content := "see [link](http://example.com)\n"
+	s.Update(content, lipgloss.NewStyle())
+
+	if !hasTokenType(s, content, chroma.NameTag) {
+		t.Error("expected NameTag token in '[link](url)'")
+	}
+	if !hasTokenType(s, content, chroma.NameAttribute) {
+		t.Error("expected NameAttribute token in '[link](url)'")
+	}
+}
+
+func TestSyntaxStyler_CacheHit(t *testing.T) {
+	s := NewMarkdownStyler()
+	content := "# Cached\n"
+
+	s.Update(content, lipgloss.NewStyle())
+	firstTokens := make([]chroma.TokenType, len(content))
+	for i := range len(content) {
+		firstTokens[i] = s.TokenAt(i)
+	}
+
+	// Update with same content — should be a no-op.
+	s.Update(content, lipgloss.NewStyle())
+	for i := range len(content) {
+		if s.TokenAt(i) != firstTokens[i] {
+			t.Fatalf("cache miss: token changed at offset %d", i)
+		}
+	}
+}
+
+func TestSyntaxStyler_ContentChange(t *testing.T) {
+	s := NewMarkdownStyler()
+
+	s.Update("plain text\n", lipgloss.NewStyle())
+	plainToken := s.TokenAt(0)
+
+	s.Update("# Heading\n", lipgloss.NewStyle())
+	headingToken := s.TokenAt(0)
+
+	if plainToken == headingToken {
+		t.Error("expected different tokens after content change")
+	}
+}
+
+func TestSyntaxStyler_OutOfBounds(t *testing.T) {
+	s := NewMarkdownStyler()
+	s.Update("hi", lipgloss.NewStyle())
+
+	if s.TokenAt(-1) != -1 {
+		t.Error("expected -1 for negative offset")
+	}
+	if s.TokenAt(100) != -1 {
+		t.Error("expected -1 for offset beyond content")
+	}
+}
+
+func TestSyntaxStyler_NilLexer(t *testing.T) {
+	s := &SyntaxStyler{lexer: nil}
+	s.Update("# test", lipgloss.NewStyle())
+
+	// Should not panic; all tokens should be Text.
+	for i := range len("# test") {
+		if s.TokenAt(i) != chroma.Text {
+			t.Errorf("nil lexer: expected Text at offset %d, got %d", i, s.TokenAt(i))
+		}
+	}
+}

--- a/internal/intent/tui/vim/view.go
+++ b/internal/intent/tui/vim/view.go
@@ -40,6 +40,11 @@ func (e *Editor) View(cfg ViewConfig) string {
 	lines := e.buffer.Lines()
 	cursor := e.buffer.Cursor()
 
+	// Update syntax highlighting if enabled.
+	if e.syntax != nil {
+		e.syntax.Update(e.buffer.Content(), cfg.NormalText)
+	}
+
 	// Calculate visible range based on scroll offset
 	startLine := e.scrollOffset
 	endLine := min(startLine+e.height, len(lines))
@@ -132,7 +137,11 @@ func (e *Editor) renderLine(lineIdx int, line string, cursor Position, cfg ViewC
 			// Visual selection
 			result.WriteString(cfg.Selection.Render(char))
 		default:
-			result.WriteString(cfg.NormalText.Render(char))
+			style := cfg.NormalText
+			if e.syntax != nil {
+				style = e.syntax.StyleAt(charOffset)
+			}
+			result.WriteString(style.Render(char))
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Adds live markdown syntax highlighting to the `camp intent add` body vim editor
- Uses chroma's markdown lexer (already in dependency tree via glamour) to tokenize content
- Maps token types to lipgloss styles: headings (bold+accent), bold, italic, inline code (green), links (blue), list markers (orange), strikethrough
- Caches tokenization per content hash — zero cost when content hasn't changed
- Opt-in via `SyntaxStyler` — nil by default, no change to editor behavior unless explicitly enabled

## Changes

| File | What changed |
|------|-------------|
| `vim/syntax.go` (new) | `SyntaxStyler` struct with chroma tokenization, per-byte style array, SHA-256 content caching, token type → lipgloss style mapping |
| `vim/syntax_test.go` (new) | 12 tests covering headings, subheadings, bold, italic, inline code, links, cache hit/miss, content change, out-of-bounds, nil lexer |
| `vim/editor.go` | Added `syntax *SyntaxStyler` field and `SetSyntax()` method |
| `vim/view.go` | `View()` calls `syntax.Update()` before render loop; `renderLine()` uses `syntax.StyleAt()` for default case |
| `add_model.go` | Attaches `NewMarkdownStyler()` to vim editor on init |
| `go.mod` | `chroma/v2` promoted from indirect to direct dependency |

## How it works

The existing character-by-character rendering pipeline (`renderLine()`) already styles each character individually for cursor/selection. This adds a thin layer: when neither cursor nor selection apply, the character gets its syntax-aware style instead of `NormalText`. Cursor and selection styles always take priority.

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `go test ./...` — all tests pass (48 packages, 0 failures)
- [ ] Manual: `camp intent add` → type markdown in body → confirm headings, bold, code get colored
- [ ] Manual: confirm cursor and visual selection still render correctly over highlighted text