### PR TITLE
Support nested submodules in push/pull/status all

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Without a `default` shortcut, navigation jumps to the project root.
 
 ### Global Config
 
-Located at `~/.config/obey/campaign/config.yaml`:
+Located at `~/.obey/campaign/config.yaml`:
 
 ```yaml
 default_type: product

--- a/cmd/camp/list.go
+++ b/cmd/camp/list.go
@@ -29,7 +29,7 @@ var listCmd = &cobra.Command{
 	Long: `List all campaigns registered in the global registry.
 
 Campaigns are registered when created with 'camp init' or manually
-with 'camp register'. The registry lives at ~/.config/obey/campaign/registry.yaml.
+with 'camp register'. The registry lives at ~/.obey/campaign/registry.yaml.
 
 Output formats:
   table   - Aligned columns with headers (default)

--- a/cmd/camp/pull.go
+++ b/cmd/camp/pull.go
@@ -99,7 +99,7 @@ type pullTarget struct {
 }
 
 // runPullAll discovers all submodules + campaign root, and pulls them.
-func runPullAll(ctx context.Context, campRoot string, gitArgs []string) error {
+func runPullAll(ctx context.Context, campRoot string, gitArgs []string, noRecurse bool) error {
 	green := lipgloss.NewStyle().Foreground(ui.SuccessColor)
 	yellow := lipgloss.NewStyle().Foreground(ui.WarningColor)
 	red := lipgloss.NewStyle().Foreground(ui.ErrorColor)
@@ -108,8 +108,16 @@ func runPullAll(ctx context.Context, campRoot string, gitArgs []string) error {
 	fmt.Println(ui.Info("Pulling all repos..."))
 	fmt.Println()
 
-	// Discover submodules
-	paths, err := git.ListSubmodulePathsFiltered(ctx, campRoot, "projects/")
+	// Discover submodules (including nested monorepo submodules)
+	var (
+		paths []string
+		err   error
+	)
+	if noRecurse {
+		paths, err = git.ListSubmodulePathsFiltered(ctx, campRoot, "projects/")
+	} else {
+		paths, err = git.ListSubmodulePathsRecursive(ctx, campRoot, "projects/")
+	}
 	if err != nil {
 		return fmt.Errorf("failed to list submodules: %w", err)
 	}
@@ -125,7 +133,7 @@ func runPullAll(ctx context.Context, campRoot string, gitArgs []string) error {
 		fullPath := filepath.Join(campRoot, p)
 		branch, _ := gitOutput(ctx, fullPath, "rev-parse", "--abbrev-ref", "HEAD")
 		targets = append(targets, pullTarget{
-			name:   filepath.Base(p),
+			name:   git.SubmoduleDisplayName(p),
 			path:   fullPath,
 			branch: branch,
 		})
@@ -145,19 +153,19 @@ func runPullAll(ctx context.Context, campRoot string, gitArgs []string) error {
 
 		// Skip detached HEAD
 		if t.branch == "" || t.branch == "HEAD" {
-			fmt.Printf("  %-20s %s\n", t.name, yellow.Render("detached HEAD"))
+			fmt.Printf("  %-30s %s\n", t.name, yellow.Render("detached HEAD"))
 			skipped++
 			continue
 		}
 
 		// Skip repos with no upstream tracking
 		if _, err := gitOutput(ctx, t.path, "rev-parse", "--abbrev-ref", "@{upstream}"); err != nil {
-			fmt.Printf("  %-20s %s\n", t.name, yellow.Render("no upstream"))
+			fmt.Printf("  %-30s %s\n", t.name, yellow.Render("no upstream"))
 			skipped++
 			continue
 		}
 
-		fmt.Printf("  %-20s %s  pulling... ",
+		fmt.Printf("  %-30s %s  pulling... ",
 			t.name, dim.Render(t.branch))
 
 		pullArgs := []string{"-C", t.path, "pull"}

--- a/cmd/camp/pull_all.go
+++ b/cmd/camp/pull_all.go
@@ -16,10 +16,14 @@ to git pull for each repo.
 
 Repos in detached HEAD state or without upstream tracking are skipped.
 
+By default, nested submodules (e.g. inside monorepos) are included.
+Use --no-recurse to only pull top-level submodules.
+
 Examples:
   camp pull all              # Pull all repos
   camp pull all --rebase     # Pull all repos with rebase
-  camp pull all --ff-only    # Fast-forward only for all repos`,
+  camp pull all --ff-only    # Fast-forward only for all repos
+  camp pull all --no-recurse # Only top-level submodules`,
 	RunE:               runPullAllCmd,
 	DisableFlagParsing: true,
 }
@@ -36,5 +40,9 @@ func runPullAllCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return runPullAll(ctx, campRoot, args)
+	// Extract --no-recurse before passing remaining args to git.
+	var noRecurse bool
+	args, noRecurse = extractNoRecurse(args)
+
+	return runPullAll(ctx, campRoot, args, noRecurse)
 }

--- a/cmd/camp/pull_integration_test.go
+++ b/cmd/camp/pull_integration_test.go
@@ -61,7 +61,7 @@ func TestIntegration_PullAll_UpToDate(t *testing.T) {
 	ctx := context.Background()
 
 	// Everything is up-to-date, should succeed with no errors
-	err := runPullAll(ctx, campDir, nil)
+	err := runPullAll(ctx, campDir, nil, false)
 	if err != nil {
 		t.Fatalf("runPullAll() error = %v", err)
 	}
@@ -75,7 +75,7 @@ func TestIntegration_PullAll_PullsNewCommits(t *testing.T) {
 	pushCommitToBare(t, bareDir, "new-file.txt", "new content", "Add new file")
 
 	// Pull should succeed
-	err := runPullAll(ctx, campDir, nil)
+	err := runPullAll(ctx, campDir, nil, false)
 	if err != nil {
 		t.Fatalf("runPullAll() error = %v", err)
 	}
@@ -97,7 +97,7 @@ func TestIntegration_PullAll_SkipsDetachedHEAD(t *testing.T) {
 	run(t, "git", "-C", subDir, "checkout", hash[:8])
 
 	// Should succeed (skips detached HEAD, doesn't fail)
-	err := runPullAll(ctx, campDir, nil)
+	err := runPullAll(ctx, campDir, nil, false)
 	if err != nil {
 		t.Fatalf("runPullAll() error = %v", err)
 	}
@@ -112,7 +112,7 @@ func TestIntegration_PullAll_SkipsNoUpstream(t *testing.T) {
 	run(t, "git", "-C", subDir, "checkout", "-b", "local-only")
 
 	// Should succeed (skips no-upstream repos)
-	err := runPullAll(ctx, campDir, nil)
+	err := runPullAll(ctx, campDir, nil, false)
 	if err != nil {
 		t.Fatalf("runPullAll() error = %v", err)
 	}
@@ -124,7 +124,7 @@ func TestIntegration_PullAll_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	err := runPullAll(ctx, campDir, nil)
+	err := runPullAll(ctx, campDir, nil, false)
 	if err == nil {
 		t.Error("expected error from cancelled context, got nil")
 	}
@@ -144,7 +144,7 @@ func TestIntegration_PullAll_DivergentBranchesRebase(t *testing.T) {
 	run(t, "git", "-C", subDir, "commit", "-m", "Local commit")
 
 	// Explicit --rebase should succeed on divergent branches
-	err := runPullAll(ctx, campDir, []string{"--rebase"})
+	err := runPullAll(ctx, campDir, []string{"--rebase"}, false)
 	if err != nil {
 		t.Fatalf("runPullAll(--rebase) should succeed on divergent branches: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestIntegration_PullAll_DivergentBranchesDefaultFails(t *testing.T) {
 
 	// Default pull (no strategy) should fail on divergent branches
 	// (git requires the user to specify a reconciliation strategy)
-	err := runPullAll(ctx, campDir, nil)
+	err := runPullAll(ctx, campDir, nil, false)
 	if err == nil {
 		t.Fatal("runPullAll() should fail with divergent branches and no strategy")
 	}
@@ -195,7 +195,7 @@ func TestIntegration_PullAll_ExplicitFfOnlyOverride(t *testing.T) {
 	run(t, "git", "-C", subDir, "commit", "-m", "Local commit")
 
 	// Explicit --ff-only should fail on divergent branches
-	err := runPullAll(ctx, campDir, []string{"--ff-only"})
+	err := runPullAll(ctx, campDir, []string{"--ff-only"}, false)
 	if err == nil {
 		t.Fatal("runPullAll(--ff-only) should fail with divergent branches")
 	}
@@ -209,7 +209,7 @@ func TestIntegration_PullAll_PassesThroughGitFlags(t *testing.T) {
 	pushCommitToBare(t, bareDir, "ff-file.txt", "ff content", "Fast-forward commit")
 
 	// Pull with --ff-only should succeed (this is a fast-forward)
-	err := runPullAll(ctx, campDir, []string{"--ff-only"})
+	err := runPullAll(ctx, campDir, []string{"--ff-only"}, false)
 	if err != nil {
 		t.Fatalf("runPullAll(--ff-only) error = %v", err)
 	}
@@ -242,7 +242,7 @@ func TestIntegration_PullAll_RebaseConflictAutoAborts(t *testing.T) {
 	run(t, "git", "-C", subDir, "commit", "-m", "Local change to README")
 
 	// Pull with --rebase should fail on the submodule (conflict) but auto-abort
-	err := runPullAll(ctx, campDir, []string{"--rebase"})
+	err := runPullAll(ctx, campDir, []string{"--rebase"}, false)
 	if err == nil {
 		t.Fatal("expected error from rebase conflict, got nil")
 	}

--- a/cmd/camp/push.go
+++ b/cmd/camp/push.go
@@ -83,7 +83,7 @@ type pushTarget struct {
 
 // runPushAll discovers all submodules + campaign root, checks which have
 // unpushed commits, and pushes them.
-func runPushAll(ctx context.Context, campRoot string, gitArgs []string) error {
+func runPushAll(ctx context.Context, campRoot string, gitArgs []string, noRecurse bool) error {
 	green := lipgloss.NewStyle().Foreground(ui.SuccessColor)
 	yellow := lipgloss.NewStyle().Foreground(ui.WarningColor)
 	red := lipgloss.NewStyle().Foreground(ui.ErrorColor)
@@ -92,8 +92,16 @@ func runPushAll(ctx context.Context, campRoot string, gitArgs []string) error {
 	fmt.Println(ui.Info("Pushing all repos with unpushed changes..."))
 	fmt.Println()
 
-	// Discover submodules
-	paths, err := git.ListSubmodulePathsFiltered(ctx, campRoot, "projects/")
+	// Discover submodules (including nested monorepo submodules)
+	var (
+		paths []string
+		err   error
+	)
+	if noRecurse {
+		paths, err = git.ListSubmodulePathsFiltered(ctx, campRoot, "projects/")
+	} else {
+		paths, err = git.ListSubmodulePathsRecursive(ctx, campRoot, "projects/")
+	}
 	if err != nil {
 		return fmt.Errorf("failed to list submodules: %w", err)
 	}
@@ -102,7 +110,7 @@ func runPushAll(ctx context.Context, campRoot string, gitArgs []string) error {
 	targets := make([]pushTarget, 0, len(paths)+1)
 	for _, p := range paths {
 		targets = append(targets, pushTarget{
-			name: filepath.Base(p),
+			name: git.SubmoduleDisplayName(p),
 			path: filepath.Join(campRoot, p),
 		})
 	}
@@ -127,12 +135,12 @@ func runPushAll(ctx context.Context, campRoot string, gitArgs []string) error {
 		}
 
 		if t.ahead <= 0 {
-			fmt.Printf("  %-20s %s\n", t.name, dim.Render("synced"))
+			fmt.Printf("  %-30s %s\n", t.name, dim.Render("synced"))
 			skipped++
 			continue
 		}
 
-		fmt.Printf("  %-20s %s  pushing... ",
+		fmt.Printf("  %-30s %s  pushing... ",
 			t.name, yellow.Render(fmt.Sprintf("↑%d", t.ahead)))
 
 		pushArgs := append([]string{"-C", t.path, "push"}, gitArgs...)

--- a/cmd/camp/push_all.go
+++ b/cmd/camp/push_all.go
@@ -5,6 +5,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var pushAllNoRecurse bool
+
 var pushAllCmd = &cobra.Command{
 	Use:   "all [git push flags]",
 	Short: "Push all repos with unpushed commits",
@@ -14,10 +16,14 @@ Scans all submodules and the campaign root, checks which have commits
 ahead of their upstream, and pushes them. Any extra flags are passed
 through to git push for each repo.
 
+By default, nested submodules (e.g. inside monorepos) are included.
+Use --no-recurse to only push top-level submodules.
+
 Examples:
   camp push all              # Push all repos with unpushed commits
   camp push all --force      # Force push all repos
-  camp push all -u origin    # Push and set upstream for all`,
+  camp push all -u origin    # Push and set upstream for all
+  camp push all --no-recurse # Only top-level submodules`,
 	RunE:               runPushAllCmd,
 	DisableFlagParsing: true,
 }
@@ -34,5 +40,25 @@ func runPushAllCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return runPushAll(ctx, campRoot, args)
+	// Extract --no-recurse before passing remaining args to git.
+	var noRecurse bool
+	args, noRecurse = extractNoRecurse(args)
+
+	return runPushAll(ctx, campRoot, args, noRecurse)
+}
+
+// extractNoRecurse removes --no-recurse from args and returns the filtered
+// args plus whether the flag was present. Used by commands with
+// DisableFlagParsing that need to intercept camp-specific flags.
+func extractNoRecurse(args []string) ([]string, bool) {
+	var filtered []string
+	var found bool
+	for _, a := range args {
+		if a == "--no-recurse" {
+			found = true
+			continue
+		}
+		filtered = append(filtered, a)
+	}
+	return filtered, found
 }

--- a/cmd/camp/register.go
+++ b/cmd/camp/register.go
@@ -18,7 +18,7 @@ var registerCmd = &cobra.Command{
 	Short: "Register campaign in global registry",
 	Long: `Register an existing campaign in the global registry.
 
-This adds the campaign to the registry at ~/.config/obey/campaign/registry.yaml,
+This adds the campaign to the registry at ~/.obey/campaign/registry.yaml,
 enabling it to appear in 'camp list' and be accessible via navigation commands.
 
 Note: 'camp init' automatically registers new campaigns. This command is for

--- a/cmd/camp/registry.go
+++ b/cmd/camp/registry.go
@@ -16,7 +16,7 @@ import (
 var registryCmd = &cobra.Command{
 	Use:   "registry",
 	Short: "Manage the campaign registry",
-	Long: `Manage the campaign registry at ~/.config/obey/campaign/registry.json.
+	Long: `Manage the campaign registry at ~/.obey/campaign/registry.json.
 
 The registry tracks all known campaigns for quick navigation and lookup.
 Use these commands to maintain registry health and resolve issues.

--- a/cmd/camp/root.go
+++ b/cmd/camp/root.go
@@ -174,7 +174,7 @@ func init() {
 	)
 
 	// Global persistent flags
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default: ~/.config/obey/campaign/config.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default: ~/.obey/campaign/config.yaml)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "disable colored output")
 	rootCmd.PersistentFlags().BoolVar(&verbose, "verbose", false, "enable verbose output")
 }

--- a/cmd/camp/status_all.go
+++ b/cmd/camp/status_all.go
@@ -36,15 +36,17 @@ Examples:
 }
 
 var (
-	statusAllJSON    bool
-	statusAllNoCache bool
-	statusAllView    bool
+	statusAllJSON      bool
+	statusAllNoCache   bool
+	statusAllView      bool
+	statusAllNoRecurse bool
 )
 
 func init() {
 	statusAllCmd.Flags().BoolVar(&statusAllJSON, "json", false, "Output as JSON")
 	statusAllCmd.Flags().BoolVar(&statusAllNoCache, "no-cache", false, "Skip cache and refresh")
 	statusAllCmd.Flags().BoolVar(&statusAllView, "view", false, "Open interactive TUI viewer")
+	statusAllCmd.Flags().BoolVar(&statusAllNoRecurse, "no-recurse", false, "Only list top-level submodules")
 
 	statusCmd.AddCommand(statusAllCmd)
 }
@@ -81,8 +83,13 @@ func runStatusAll(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("not in a campaign: %w", err)
 	}
 
-	// Enumerate submodules
-	paths, err := git.ListSubmodulePathsFiltered(ctx, campRoot, "projects/")
+	// Enumerate submodules (including nested monorepo submodules)
+	var paths []string
+	if statusAllNoRecurse {
+		paths, err = git.ListSubmodulePathsFiltered(ctx, campRoot, "projects/")
+	} else {
+		paths, err = git.ListSubmodulePathsRecursive(ctx, campRoot, "projects/")
+	}
 	if err != nil {
 		return fmt.Errorf("failed to list submodules: %w", err)
 	}
@@ -148,7 +155,7 @@ func collectStatuses(ctx context.Context, campRoot string, paths []string) []rep
 
 	for _, p := range paths {
 		fullPath := filepath.Join(campRoot, p)
-		name := filepath.Base(p)
+		name := git.SubmoduleDisplayName(p)
 		status := getRepoStatus(ctx, fullPath, name)
 		status.Path = p
 		statuses = append(statuses, status)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,9 +2,9 @@
 //
 // Camp uses a two-level configuration system:
 //   - Campaign config: .campaign/campaign.yaml in the campaign root
-//   - Global config: ~/.config/obey/campaign/config.yaml for user preferences
+//   - Global config: ~/.obey/campaign/config.yaml for user preferences
 //
-// Additionally, a registry at ~/.config/obey/campaign/registry.yaml tracks
+// Additionally, a registry at ~/.obey/campaign/registry.yaml tracks
 // all known campaigns for quick navigation.
 package config
 

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-// LoadGlobalConfig loads the global configuration from ~/.config/obey/campaign/config.json.
+// LoadGlobalConfig loads the global configuration from ~/.obey/campaign/config.json.
 // Returns default configuration if the file doesn't exist, and auto-creates the file.
 func LoadGlobalConfig(ctx context.Context) (*GlobalConfig, error) {
 	if ctx.Err() != nil {
@@ -42,7 +42,7 @@ func LoadGlobalConfig(ctx context.Context) (*GlobalConfig, error) {
 	return &cfg, nil
 }
 
-// SaveGlobalConfig saves the global configuration to ~/.config/obey/campaign/config.json.
+// SaveGlobalConfig saves the global configuration to ~/.obey/campaign/config.json.
 func SaveGlobalConfig(ctx context.Context, cfg *GlobalConfig) error {
 	if ctx.Err() != nil {
 		return ctx.Err()

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -204,7 +204,7 @@ func TestConfigDir_Default(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "")
 
 	home, _ := os.UserHomeDir()
-	want := filepath.Join(home, ".config", OrgName, AppName)
+	want := filepath.Join(home, ".obey", AppName)
 
 	got := ConfigDir()
 	if got != want {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -18,7 +18,7 @@ func ConfigDir() string {
 		return filepath.Join(xdg, OrgName, AppName)
 	}
 	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".config", OrgName, AppName)
+	return filepath.Join(home, ".obey", AppName)
 }
 
 // GlobalConfigPath returns the path to the global config file.

--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -17,7 +17,7 @@ var ErrMultipleMatches = errors.New("multiple campaigns match that prefix")
 // ErrCampaignNotFound is returned when a campaign cannot be found.
 var ErrCampaignNotFound = errors.New("campaign not found")
 
-// LoadRegistry loads the campaign registry from ~/.config/obey/campaign/registry.json.
+// LoadRegistry loads the campaign registry from ~/.obey/campaign/registry.json.
 // Returns an empty registry if the file doesn't exist.
 func LoadRegistry(ctx context.Context) (*Registry, error) {
 	if ctx.Err() != nil {
@@ -60,7 +60,7 @@ func LoadRegistry(ctx context.Context) (*Registry, error) {
 	return &reg, nil
 }
 
-// SaveRegistry saves the campaign registry to ~/.config/obey/campaign/registry.json.
+// SaveRegistry saves the campaign registry to ~/.obey/campaign/registry.json.
 // Uses atomic write to prevent corruption.
 func SaveRegistry(ctx context.Context, reg *Registry) error {
 	if ctx.Err() != nil {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -258,7 +258,7 @@ type TUIConfig struct {
 	VimMode bool `json:"vim_mode,omitempty" yaml:"vim_mode,omitempty"`
 }
 
-// GlobalConfig represents ~/.config/obey/campaign/config.json configuration.
+// GlobalConfig represents ~/.obey/campaign/config.json configuration.
 // Contains only user preference fields - campaign-specific settings belong elsewhere.
 type GlobalConfig struct {
 	// Editor is the preferred editor command.
@@ -274,7 +274,7 @@ type GlobalConfig struct {
 // RegistryVersion is the current registry format version.
 const RegistryVersion = 2
 
-// Registry represents ~/.config/obey/campaign/registry.json for tracking campaigns.
+// Registry represents ~/.obey/campaign/registry.json for tracking campaigns.
 type Registry struct {
 	// Version is the registry format version.
 	Version int `json:"version" yaml:"version,omitempty"`

--- a/internal/git/submodule_list.go
+++ b/internal/git/submodule_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -55,4 +56,44 @@ func ListSubmodulePathsFiltered(ctx context.Context, repoRoot, prefix string) ([
 		}
 	}
 	return filtered, nil
+}
+
+// ListSubmodulePathsRecursive returns submodule paths matching a prefix,
+// including nested submodules one level deep within monorepos.
+func ListSubmodulePathsRecursive(ctx context.Context, repoRoot, prefix string) ([]string, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	topLevel, err := ListSubmodulePathsFiltered(ctx, repoRoot, prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []string
+	for _, p := range topLevel {
+		result = append(result, p)
+
+		// Check for nested submodules one level deep.
+		nested, err := ListSubmodulePaths(ctx, filepath.Join(repoRoot, p))
+		if err != nil || len(nested) == 0 {
+			continue
+		}
+		for _, n := range nested {
+			result = append(result, filepath.Join(p, n))
+		}
+	}
+
+	return result, nil
+}
+
+// SubmoduleDisplayName returns a concise display name for a submodule path.
+// For nested submodules (3+ path components like "projects/monorepo/child"),
+// it returns "monorepo/child". For top-level submodules it returns the base name.
+func SubmoduleDisplayName(relPath string) string {
+	parts := strings.Split(filepath.ToSlash(relPath), "/")
+	if len(parts) > 2 {
+		return parts[len(parts)-2] + "/" + parts[len(parts)-1]
+	}
+	return filepath.Base(relPath)
 }

--- a/internal/git/submodule_list_test.go
+++ b/internal/git/submodule_list_test.go
@@ -1,0 +1,138 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// setupRepoWithGitmodules creates a git repo with a .gitmodules file
+// listing the given submodule paths.
+func setupRepoWithGitmodules(t *testing.T, subPaths []string) string {
+	t.Helper()
+	dir := t.TempDir()
+	exec.Command("git", "init", dir).Run()
+	exec.Command("git", "-C", dir, "config", "user.email", "test@test.com").Run()
+	exec.Command("git", "-C", dir, "config", "user.name", "Test").Run()
+
+	for _, p := range subPaths {
+		name := filepath.Base(p)
+		exec.Command("git", "-C", dir, "config", "-f", ".gitmodules",
+			"submodule."+name+".path", p).Run()
+		exec.Command("git", "-C", dir, "config", "-f", ".gitmodules",
+			"submodule."+name+".url", "https://example.com/"+name+".git").Run()
+
+		// Create the directory so it looks like a real submodule.
+		os.MkdirAll(filepath.Join(dir, p), 0o755)
+	}
+
+	return dir
+}
+
+func TestListSubmodulePathsRecursive(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a root repo with two top-level submodules.
+	root := setupRepoWithGitmodules(t, []string{
+		"projects/solo-project",
+		"projects/monorepo",
+	})
+
+	// Give the monorepo submodule its own .gitmodules with nested children.
+	monorepoDir := filepath.Join(root, "projects", "monorepo")
+	exec.Command("git", "init", monorepoDir).Run()
+	for _, child := range []string{"child-a", "child-b"} {
+		exec.Command("git", "-C", monorepoDir, "config", "-f", ".gitmodules",
+			"submodule."+child+".path", child).Run()
+		exec.Command("git", "-C", monorepoDir, "config", "-f", ".gitmodules",
+			"submodule."+child+".url", "https://example.com/"+child+".git").Run()
+		os.MkdirAll(filepath.Join(monorepoDir, child), 0o755)
+	}
+
+	paths, err := ListSubmodulePathsRecursive(ctx, root, "projects/")
+	if err != nil {
+		t.Fatalf("ListSubmodulePathsRecursive() error = %v", err)
+	}
+
+	sort.Strings(paths)
+	want := []string{
+		"projects/monorepo",
+		"projects/monorepo/child-a",
+		"projects/monorepo/child-b",
+		"projects/solo-project",
+	}
+	sort.Strings(want)
+
+	if len(paths) != len(want) {
+		t.Fatalf("got %d paths, want %d: %v", len(paths), len(want), paths)
+	}
+	for i := range want {
+		if paths[i] != want[i] {
+			t.Errorf("paths[%d] = %q, want %q", i, paths[i], want[i])
+		}
+	}
+}
+
+func TestListSubmodulePathsRecursive_NoNested(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a root repo with two plain submodules (no nested .gitmodules).
+	root := setupRepoWithGitmodules(t, []string{
+		"projects/alpha",
+		"projects/beta",
+	})
+
+	paths, err := ListSubmodulePathsRecursive(ctx, root, "projects/")
+	if err != nil {
+		t.Fatalf("ListSubmodulePathsRecursive() error = %v", err)
+	}
+
+	sort.Strings(paths)
+	want := []string{"projects/alpha", "projects/beta"}
+
+	if len(paths) != len(want) {
+		t.Fatalf("got %d paths, want %d: %v", len(paths), len(want), paths)
+	}
+	for i := range want {
+		if paths[i] != want[i] {
+			t.Errorf("paths[%d] = %q, want %q", i, paths[i], want[i])
+		}
+	}
+}
+
+func TestListSubmodulePathsRecursive_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := ListSubmodulePathsRecursive(ctx, t.TempDir(), "projects/")
+	if err != context.Canceled {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestSubmoduleDisplayName(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"projects/camp", "camp"},
+		{"projects/obey-platform-monorepo/obey", "obey-platform-monorepo/obey"},
+		{"projects/obey-platform-monorepo/fest", "obey-platform-monorepo/fest"},
+		{"projects/festival/camp", "festival/camp"},
+		{"single", "single"},
+		{"a/b", "b"},
+		{"a/b/c/d", "c/d"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := SubmoduleDisplayName(tt.path)
+			if got != tt.want {
+				t.Errorf("SubmoduleDisplayName(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ListSubmodulePathsRecursive` to discover submodules one level deep inside monorepos (e.g. `obey-platform-monorepo/obey`, `festival/camp`)
- All three `all` commands (`push all`, `pull all`, `status all`) now include nested submodules by default
- Add `SubmoduleDisplayName` for concise nested names (`monorepo/child` instead of just `child`)
- Add `--no-recurse` flag to all three commands as an escape hatch to revert to top-level-only behavior
- Widen name columns from 20 to 30 chars to accommodate nested display names

## Test plan

- [x] `go build ./...` compiles clean
- [x] `go test ./internal/git/` — all tests pass including new recursive discovery and display name tests
- [x] `go test ./cmd/camp/` — all existing tests pass with updated signatures
- [ ] Manual: `camp status all` shows nested submodules (e.g. `obey-platform-monorepo/obey`)
- [ ] Manual: `camp status all --no-recurse` shows only top-level submodules
- [ ] Manual: `camp push all` and `camp pull all` include nested submodules