### PR TITLE
feat: multi-channel release recipes (dev + stable)

### DIFF
--- a/.justfiles/release.just
+++ b/.justfiles/release.just
@@ -1,25 +1,84 @@
 # Release and versioning recipes
+# Two channels: dev (pre-release) and stable (public)
 
 # Show available release commands (default)
 [private]
 default:
     @just --list --unsorted --justfile {{source_file()}}
 
-# Bump version, tag, and push (patch|minor|major)
+# Create a dev pre-release tag (bumps dev counter, or pass patch|minor|major to bump base version)
 [no-cd]
-next level="patch":
+dev level="":
     #!/usr/bin/env bash
     set -euo pipefail
-    suffix="alpha-stable"
-    level="{{level}}"
 
-    latest=$(git tag -l "v*-${suffix}" --sort=-version:refname | head -1)
+    level="{{level}}"
+    latest=$(git tag -l "v*-dev.*" --sort=-version:refname | head -1)
 
     if [ -z "$latest" ]; then
-        new="v0.1.0-${suffix}"
+        # No dev tags — migrate from alpha-stable or start fresh
+        alpha=$(git tag -l "v*-alpha-stable" --sort=-version:refname | head -1)
+        if [ -n "$alpha" ]; then
+            nums="${alpha#v}"
+            nums="${nums%-alpha-stable}"
+            IFS='.' read -r major minor patch <<< "$nums"
+            minor=$((minor + 1))
+            patch=0
+        else
+            major=0; minor=1; patch=0
+        fi
+        new="v${major}.${minor}.${patch}-dev.1"
+    else
+        # Parse: v0.2.0-dev.3
+        base="${latest%-dev.*}"
+        dev_num="${latest##*-dev.}"
+        nums="${base#v}"
+        IFS='.' read -r major minor patch <<< "$nums"
+
+        if [ -z "$level" ]; then
+            # Just bump dev counter
+            dev_num=$((dev_num + 1))
+            new="v${major}.${minor}.${patch}-dev.${dev_num}"
+        else
+            # Bump base version, reset dev counter
+            case "$level" in
+                major) major=$((major + 1)); minor=0; patch=0 ;;
+                minor) minor=$((minor + 1)); patch=0 ;;
+                patch) patch=$((patch + 1)) ;;
+                *) echo "Unknown level: $level (use patch, minor, or major)"; exit 1 ;;
+            esac
+            new="v${major}.${minor}.${patch}-dev.1"
+        fi
+    fi
+
+    echo "Creating dev release: $new"
+    git tag -a "$new" -m "$new"
+    git push origin "$new"
+    gh release create "$new" --title "$new" --generate-notes --prerelease
+    echo "Released $new"
+
+# Create a stable release tag (patch|minor|major)
+[no-cd]
+stable level="patch":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    level="{{level}}"
+
+    # Find latest stable tag (no pre-release suffix — matches vX.Y.Z exactly)
+    latest=$(git tag -l --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+
+    if [ -z "$latest" ]; then
+        # No stable tags — derive from latest dev tag base or start fresh
+        dev=$(git tag -l "v*-dev.*" --sort=-version:refname | head -1)
+        if [ -n "$dev" ]; then
+            base="${dev%-dev.*}"
+            new="$base"
+        else
+            new="v0.2.0"
+        fi
     else
         nums="${latest#v}"
-        nums="${nums%-${suffix}}"
         IFS='.' read -r major minor patch <<< "$nums"
 
         case "$level" in
@@ -28,27 +87,52 @@ next level="patch":
             patch) patch=$((patch + 1)) ;;
             *) echo "Unknown level: $level (use patch, minor, or major)"; exit 1 ;;
         esac
-        new="v${major}.${minor}.${patch}-${suffix}"
+        new="v${major}.${minor}.${patch}"
     fi
 
+    echo "Creating stable release: $new"
     git tag -a "$new" -m "$new"
     git push origin "$new"
-    gh release create "$new" --title "$new" --generate-notes --prerelease
+    gh release create "$new" --title "$new" --generate-notes --latest
     echo "Released $new"
 
-# Show current version tag
+# Promote latest dev version to stable (strips -dev.N suffix)
+[no-cd]
+promote:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    latest_dev=$(git tag -l "v*-dev.*" --sort=-version:refname | head -1)
+    if [ -z "$latest_dev" ]; then
+        echo "No dev tags found. Create one first with: just release dev"
+        exit 1
+    fi
+
+    # Extract base version
+    base="${latest_dev%-dev.*}"
+
+    # Check if stable already exists
+    if git tag -l "$base" | grep -q .; then
+        echo "Stable tag $base already exists"
+        exit 1
+    fi
+
+    echo "Promoting $latest_dev -> $base"
+    git tag -a "$base" -m "Promote $latest_dev to stable $base"
+    git push origin "$base"
+    gh release create "$base" --title "$base" --generate-notes --latest
+    echo "Released $base"
+
+# Show current version for each channel
 [no-cd]
 current:
     #!/usr/bin/env bash
-    set -euo pipefail
-    latest=$(git tag -l "v*-alpha-stable" --sort=-version:refname | head -1)
-    if [ -z "$latest" ]; then
-        echo "No releases yet"
-    else
-        echo "$latest"
-    fi
+    dev=$(git tag -l "v*-dev.*" --sort=-version:refname | head -1)
+    stable=$(git tag -l --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+    echo "dev:    ${dev:-none}"
+    echo "stable: ${stable:-none}"
 
 # List all release tags
 [no-cd]
 tags:
-    @git tag -l "v*-alpha-stable" --sort=-version:refname
+    @git tag -l "v*" --sort=-version:refname


### PR DESCRIPTION
## Summary
- Replace `alpha-stable` versioning with two-channel release pattern
- `just release dev` for pre-release dev tags (`v0.x.y-dev.N`)
- `just release stable` for public releases (`v0.x.y`)
- `just release promote` to promote latest dev to stable
- `just release current` to show versions per channel
- Auto-migrates from existing `alpha-stable` tags on first run

## Test plan
- [ ] `just release current` shows `none` for both channels
- [ ] `just release tags` lists existing alpha-stable tags
- [ ] `just release dev` creates `v0.2.0-dev.1` (migrated from `v0.1.3-alpha-stable`)
- [ ] `just release dev` again creates `v0.2.0-dev.2`
- [ ] `just release promote` creates `v0.2.0` stable
- [ ] `just release stable` creates `v0.2.1`