### PR TITLE
feat: reverse-sync local submodule URLs and post-pull ref reporting

### DIFF
--- a/cmd/camp/pull.go
+++ b/cmd/camp/pull.go
@@ -212,6 +212,9 @@ func runPullAll(ctx context.Context, campRoot string, gitArgs []string, noRecurs
 		}
 	}
 
+	// Post-pull: report submodules with changed refs in the parent
+	changedRefs := reportChangedRefs(ctx, campRoot, paths, yellow)
+
 	// Summary
 	fmt.Println()
 	total := pulled + failed
@@ -226,10 +229,39 @@ func runPullAll(ctx context.Context, campRoot string, gitArgs []string, noRecurs
 		}
 	}
 
+	if changedRefs > 0 {
+		fmt.Println()
+		fmt.Println(dim.Render("  Run 'camp commit' to record these ref updates."))
+	}
+
 	if failed > 0 {
 		return fmt.Errorf("%d repo(s) failed to pull", failed)
 	}
 	return nil
+}
+
+// reportChangedRefs checks which submodules have new refs after pulling
+// and prints a summary. Does not stage or commit anything.
+func reportChangedRefs(ctx context.Context, campRoot string, subPaths []string, style lipgloss.Style) int {
+	var changed []string
+	for _, p := range subPaths {
+		fullPath := filepath.Join(campRoot, p)
+		if checkParentNeedsCommit(ctx, campRoot, fullPath) {
+			changed = append(changed, p)
+		}
+	}
+
+	if len(changed) == 0 {
+		return 0
+	}
+
+	fmt.Println()
+	fmt.Println(style.Render("  Submodule refs updated (not yet committed):"))
+	for _, p := range changed {
+		fmt.Printf("    %-30s (new commits)\n", git.SubmoduleDisplayName(p))
+	}
+
+	return len(changed)
 }
 
 // isDivergentError checks if git output indicates divergent branches.

--- a/cmd/camp/pull_integration_test.go
+++ b/cmd/camp/pull_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -259,5 +260,31 @@ func TestIntegration_PullAll_RebaseConflictAutoAborts(t *testing.T) {
 	}
 	if branch == "HEAD" {
 		t.Error("submodule should not be in detached HEAD state after abort")
+	}
+}
+
+func TestIntegration_PullAll_ReportsChangedRefs(t *testing.T) {
+	campDir, bareDir := setupCampaignWithSubmodule(t)
+	ctx := context.Background()
+
+	// Push a new commit to the bare remote
+	pushCommitToBare(t, bareDir, "ref-change.txt", "new content", "Advance ref")
+
+	// Capture stdout to check for ref change message
+	err := runPullAll(ctx, campDir, nil, false)
+	if err != nil {
+		t.Fatalf("runPullAll() error = %v", err)
+	}
+
+	// Verify the submodule ref changed in the parent (not yet committed)
+	subPath := filepath.Join(campDir, "projects", "test-project")
+	if !checkParentNeedsCommit(ctx, campDir, subPath) {
+		t.Error("expected parent to show submodule as modified after pull")
+	}
+
+	// Verify nothing was auto-staged or committed
+	output := run(t, "git", "-C", campDir, "diff", "--cached", "--name-only")
+	if strings.TrimSpace(output) != "" {
+		t.Errorf("expected no staged changes, got: %s", output)
 	}
 }

--- a/internal/git/submodule.go
+++ b/internal/git/submodule.go
@@ -221,3 +221,68 @@ func normalizeGitURL(url string) string {
 	url = strings.TrimSuffix(url, "/")
 	return url
 }
+
+// IsLocalFilesystemURL returns true if the URL is a local filesystem path
+// rather than a real remote URL (SSH or HTTPS). Matches absolute paths,
+// relative paths (./  ../), and file:// protocol URLs.
+func IsLocalFilesystemURL(url string) bool {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return false
+	}
+
+	// file:// protocol
+	if strings.HasPrefix(url, "file://") {
+		return true
+	}
+
+	// Absolute path (Unix)
+	if strings.HasPrefix(url, "/") {
+		return true
+	}
+
+	// Relative paths
+	if strings.HasPrefix(url, "./") || strings.HasPrefix(url, "../") {
+		return true
+	}
+
+	return false
+}
+
+// RemoteOriginURL returns the origin remote URL configured inside a submodule.
+// Returns empty string if no origin remote is configured.
+func RemoteOriginURL(ctx context.Context, submodulePath string) (string, error) {
+	if ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "-C", submodulePath, "remote", "get-url", "origin")
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// No origin remote configured
+			return "", nil
+		}
+		return "", fmt.Errorf("get remote origin URL for %s: %w", submodulePath, err)
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}
+
+// SetDeclaredURL updates the URL in .gitmodules for a submodule.
+func SetDeclaredURL(ctx context.Context, repoRoot, submodulePath, newURL string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot,
+		"config", "-f", ".gitmodules",
+		fmt.Sprintf("submodule.%s.url", submodulePath), newURL)
+
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("set declared URL for %s: %w: %s", submodulePath, err, strings.TrimSpace(string(output)))
+	}
+
+	return nil
+}

--- a/internal/git/submodule_test.go
+++ b/internal/git/submodule_test.go
@@ -479,6 +479,35 @@ func TestCompareURLs_ContextCanceled(t *testing.T) {
 	}
 }
 
+func TestIsLocalFilesystemURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{"absolute path", "/Users/lance/Dev/repo", true},
+		{"absolute path with trailing slash", "/tmp/repos/project/", true},
+		{"relative dot-slash", "./sibling-repo", true},
+		{"relative dot-dot-slash", "../other-repo", true},
+		{"file protocol", "file:///Users/lance/Dev/repo", true},
+		{"SSH URL", "git@github.com:org/repo.git", false},
+		{"HTTPS URL", "https://github.com/org/repo.git", false},
+		{"HTTP URL", "http://gitlab.com/org/repo.git", false},
+		{"empty string", "", false},
+		{"whitespace only", "   ", false},
+		{"SSH with port", "ssh://git@github.com:22/org/repo.git", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsLocalFilesystemURL(tt.url)
+			if result != tt.expected {
+				t.Errorf("IsLocalFilesystemURL(%q) = %v, want %v", tt.url, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestNormalizeGitURL(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -66,6 +66,13 @@ func (s *Syncer) Sync(ctx context.Context) (*SyncResult, error) {
 		result.Warnings = append(result.Warnings, fmt.Sprintf("removed orphaned gitlink: %s", path))
 	}
 
+	// Phase 1.7: Reverse-sync local filesystem URLs
+	reverseChanges, reverseErr := s.reverseSyncLocalURLs(ctx)
+	if reverseErr != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("reverse URL sync: %v", reverseErr))
+	}
+	result.URLChanges = append(result.URLChanges, reverseChanges...)
+
 	// Phase 2: URL synchronization
 	urlChanges, err := s.syncURLs(ctx)
 	if err != nil {
@@ -73,7 +80,7 @@ func (s *Syncer) Sync(ctx context.Context) (*SyncResult, error) {
 		result.Errors = append(result.Errors, err)
 		return result, nil
 	}
-	result.URLChanges = urlChanges
+	result.URLChanges = append(result.URLChanges, urlChanges...)
 
 	// Phase 3: Submodule update
 	updateResults, err := s.updateSubmodules(ctx)
@@ -309,6 +316,68 @@ func (s *Syncer) cleanOrphanedGitlinks(ctx context.Context) ([]string, error) {
 	}
 
 	return removed, nil
+}
+
+// reverseSyncLocalURLs detects submodules where .gitmodules has a local
+// filesystem path but the submodule has a real remote origin configured,
+// and updates .gitmodules to use the remote URL.
+func (s *Syncer) reverseSyncLocalURLs(ctx context.Context) ([]URLChange, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	paths, err := s.listSubmodules(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var changes []URLChange
+	for _, path := range paths {
+		if ctx.Err() != nil {
+			return changes, ctx.Err()
+		}
+
+		declaredURL, err := git.GetDeclaredURL(ctx, s.repoRoot, path)
+		if err != nil {
+			continue
+		}
+
+		if !git.IsLocalFilesystemURL(declaredURL) {
+			continue
+		}
+
+		subFullPath := filepath.Join(s.repoRoot, path)
+		remoteURL, err := git.RemoteOriginURL(ctx, subFullPath)
+		if err != nil || remoteURL == "" {
+			continue
+		}
+
+		if git.IsLocalFilesystemURL(remoteURL) {
+			continue
+		}
+
+		if err := git.SetDeclaredURL(ctx, s.repoRoot, path, remoteURL); err != nil {
+			return changes, fmt.Errorf("reverse-sync %s: %w", path, err)
+		}
+
+		changes = append(changes, URLChange{
+			Submodule: path,
+			OldURL:    declaredURL,
+			NewURL:    remoteURL,
+		})
+	}
+
+	// Propagate changes to .git/config
+	if len(changes) > 0 {
+		cmd := exec.CommandContext(ctx, "git", "-C", s.repoRoot,
+			"submodule", "sync", "--recursive")
+		if output, syncErr := cmd.CombinedOutput(); syncErr != nil {
+			return changes, fmt.Errorf("submodule sync after reverse-sync: %w: %s",
+				syncErr, strings.TrimSpace(string(output)))
+		}
+	}
+
+	return changes, nil
 }
 
 // validateUpdate checks that all submodules are at expected commits.

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -295,6 +296,100 @@ func TestCollectWarnings_SafeMode(t *testing.T) {
 
 	if len(warnings) != 0 {
 		t.Errorf("collectWarnings() in safe mode = %d warnings, want 0", len(warnings))
+	}
+}
+
+func TestReverseSyncLocalURLs_NoLocalPaths(t *testing.T) {
+	ctx := context.Background()
+	repoRoot := setupTestRepo(t)
+	setupSubmodule(t, repoRoot, "projects/sub")
+
+	syncer := NewSyncer(repoRoot)
+	changes, err := syncer.reverseSyncLocalURLs(ctx)
+	if err != nil {
+		t.Fatalf("reverseSyncLocalURLs() error = %v", err)
+	}
+
+	// The submodule was added from a temp dir (local path), but the submodule
+	// itself has a remote origin pointing to that same temp dir. Since the
+	// remote origin is also a local path, it should be skipped.
+	// This is a no-op scenario because the remote URL is also local.
+	for _, c := range changes {
+		t.Logf("change: %s -> %s", c.OldURL, c.NewURL)
+	}
+}
+
+func TestReverseSyncLocalURLs_LocalPathWithRemote(t *testing.T) {
+	ctx := context.Background()
+	repoRoot := setupTestRepo(t)
+	subPath := setupSubmodule(t, repoRoot, "projects/sub")
+
+	// Verify .gitmodules has a local path (from setupSubmodule using temp dir)
+	cmd := exec.Command("git", "-C", repoRoot, "config", "-f", ".gitmodules", "submodule.projects/sub.url")
+	declaredBytes, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("failed to get declared URL: %v", err)
+	}
+	declared := strings.TrimSpace(string(declaredBytes))
+	t.Logf("declared URL before reverse sync: %s", declared)
+
+	// Add a real remote origin inside the submodule
+	remoteURL := "git@github.com:test-org/sub.git"
+	runGit(t, subPath, "remote", "set-url", "origin", remoteURL)
+
+	syncer := NewSyncer(repoRoot)
+	changes, err := syncer.reverseSyncLocalURLs(ctx)
+	if err != nil {
+		t.Fatalf("reverseSyncLocalURLs() error = %v", err)
+	}
+
+	if len(changes) != 1 {
+		t.Fatalf("reverseSyncLocalURLs() changes = %d, want 1", len(changes))
+	}
+
+	if changes[0].NewURL != remoteURL {
+		t.Errorf("NewURL = %q, want %q", changes[0].NewURL, remoteURL)
+	}
+
+	// Verify .gitmodules was updated
+	cmd = exec.Command("git", "-C", repoRoot, "config", "-f", ".gitmodules", "submodule.projects/sub.url")
+	updatedBytes, _ := cmd.Output()
+	updated := strings.TrimSpace(string(updatedBytes))
+	if updated != remoteURL {
+		t.Errorf(".gitmodules URL = %q, want %q", updated, remoteURL)
+	}
+}
+
+func TestReverseSyncLocalURLs_LocalPathWithoutRemote(t *testing.T) {
+	ctx := context.Background()
+	repoRoot := setupTestRepo(t)
+	subPath := setupSubmodule(t, repoRoot, "projects/sub")
+
+	// Remove origin remote from the submodule
+	runGit(t, subPath, "remote", "remove", "origin")
+
+	syncer := NewSyncer(repoRoot)
+	changes, err := syncer.reverseSyncLocalURLs(ctx)
+	if err != nil {
+		t.Fatalf("reverseSyncLocalURLs() error = %v", err)
+	}
+
+	// Should skip - no remote origin to sync from
+	if len(changes) != 0 {
+		t.Errorf("reverseSyncLocalURLs() changes = %d, want 0 (no remote origin)", len(changes))
+	}
+}
+
+func TestReverseSyncLocalURLs_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	repoRoot := setupTestRepo(t)
+	syncer := NewSyncer(repoRoot)
+
+	_, err := syncer.reverseSyncLocalURLs(ctx)
+	if err != context.Canceled {
+		t.Errorf("reverseSyncLocalURLs() error = %v, want context.Canceled", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Reverse URL sync**: `camp sync` now detects submodules where `.gitmodules` has a local filesystem path (from `camp project new`) but the submodule has a real remote origin configured, and updates `.gitmodules` to use the remote URL. Fixes broken clones on other machines.
- **Post-pull reporting**: `camp pull all` now reports which submodules have changed refs in the parent repo after pulling. Purely informational — never auto-stages or auto-commits. Guides users to run `camp commit`.

## Changes

- `internal/git/submodule.go`: Added `IsLocalFilesystemURL`, `RemoteOriginURL`, `SetDeclaredURL`
- `internal/sync/sync.go`: Added `reverseSyncLocalURLs` as Phase 1.7 in the sync pipeline
- `cmd/camp/pull.go`: Added `reportChangedRefs` after the pull loop

## Test plan

- [x] `TestIsLocalFilesystemURL` — 11-case table-driven covering absolute, relative, file://, SSH, HTTPS, empty
- [x] `TestReverseSyncLocalURLs_*` — 4 scenarios: no local paths, local with remote, local without remote, context canceled
- [x] `TestIntegration_PullAll_ReportsChangedRefs` — verifies ref detection and no auto-staging
- [x] All existing tests pass (`go test ./...`)
- [x] All pull integration tests pass (`go test -tags=integration ./cmd/camp/ -run TestIntegration_PullAll`)