### PR TITLE
fix: guard camp init --repair against subdirectory execution

### DIFF
--- a/cmd/camp/init.go
+++ b/cmd/camp/init.go
@@ -103,20 +103,9 @@ func runInit(cmd *cobra.Command, args []string) error {
 	// Early detection: error if already inside a campaign
 	existingRoot, _ := campaign.Detect(ctx, dir)
 	if existingRoot != "" {
-		absDir, _ := filepath.Abs(dir)
-		absRoot, _ := filepath.Abs(existingRoot)
-
 		if repair {
-			// Repair mode: must be AT the campaign root, not inside a subdirectory
-			if absDir != absRoot {
-				cfg, _ := config.LoadCampaignConfig(ctx, existingRoot)
-				name := filepath.Base(existingRoot)
-				if cfg != nil && cfg.Name != "" {
-					name = cfg.Name
-				}
-				return fmt.Errorf("cannot repair from here — inside campaign '%s' at %s\n       Run repair from the campaign root: cd %s && camp init --repair", name, existingRoot, existingRoot)
-			}
-			// At campaign root — proceed with repair
+			// Repair mode: use the detected campaign root regardless of where we are
+			dir = existingRoot
 		} else if !dryRun {
 			cfg, _ := config.LoadCampaignConfig(ctx, existingRoot)
 			name := filepath.Base(existingRoot)


### PR DESCRIPTION
## Summary

- `camp init --repair` bypassed campaign detection, allowing it to scaffold a new campaign inside any subdirectory of an existing campaign
- This caused the camp CLI repo itself (a submodule inside `obey-campaign`) to get polluted with 60+ campaign scaffold files (`.campaign/`, `workflow/`, `festivals/`, `ai_docs/`, etc.)
- Now `--repair` detects the campaign root via `campaign.Detect()` and redirects to it — works from anywhere inside the campaign, same as `cgo` does

## Root Cause

The early detection check at `init.go:103` was completely skipped when `repair=true`:

```go
if !repair && !dryRun {  // repair bypassed this entirely
    existingRoot, _ := campaign.Detect(ctx, dir)
    ...
}
```

## Fix

When `--repair` is used and we detect an existing campaign, set `dir` to the detected campaign root. This is a 2-line change — the detection now always runs, and repair simply redirects to the right place.

## Test plan

- [x] `just build` compiles cleanly
- [x] `just test unit` — all 1676 tests pass
- [ ] Manual: `camp init --repair` from a submodule repairs the parent campaign root
- [ ] Manual: `camp init --repair` from campaign root still works as before