### PR TITLE
feat: add camp project prune command

### DIFF
--- a/cmd/camp/project_prune.go
+++ b/cmd/camp/project_prune.go
@@ -15,6 +15,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// pruneStatus represents the outcome of a single branch prune operation.
+type pruneStatus string
+
+const (
+	pruneStatusDeleted     pruneStatus = "deleted"
+	pruneStatusWouldDelete pruneStatus = "would delete"
+	pruneStatusSkipped     pruneStatus = "skipped"
+	pruneStatusError       pruneStatus = "error"
+	pruneStatusWouldPrune  pruneStatus = "would prune"
+)
+
+// PruneOptions holds configuration for a prune operation.
+type PruneOptions struct {
+	DryRun       bool
+	Force        bool
+	Remote       bool
+	RemoteDelete bool
+}
+
 var projectPruneCmd = &cobra.Command{
 	Use:   "prune [project-name]",
 	Short: "Delete merged branches in a project",
@@ -38,7 +57,7 @@ Examples:
 }
 
 var (
-	pruneProject      string
+	pruneProjectFlag  string
 	pruneDryRun       bool
 	pruneForce        bool
 	pruneRemote       bool
@@ -46,9 +65,9 @@ var (
 )
 
 func init() {
-	projectPruneCmd.Flags().StringVarP(&pruneProject, "project", "p", "", "Project name (auto-detected from cwd)")
+	projectPruneCmd.Flags().StringVarP(&pruneProjectFlag, "project", "p", "", "Project name (auto-detected from cwd)")
 	projectPruneCmd.Flags().BoolVarP(&pruneDryRun, "dry-run", "n", false, "Preview without deleting")
-	projectPruneCmd.Flags().BoolVarP(&pruneForce, "force", "f", false, "Skip confirmation prompt")
+	projectPruneCmd.Flags().BoolVarP(&pruneForce, "force", "f", false, "Skip confirmation prompt for local deletion")
 	projectPruneCmd.Flags().BoolVar(&pruneRemote, "remote", false, "Also prune stale remote tracking refs")
 	projectPruneCmd.Flags().BoolVar(&pruneRemoteDelete, "remote-delete", false, "Also delete merged branches on origin (destructive)")
 
@@ -60,8 +79,8 @@ func init() {
 // pruneResult holds the outcome for a single branch.
 type pruneResult struct {
 	Branch string
-	Status string // "deleted", "would delete", "skipped", "error"
-	Detail string // error message or reason for skip
+	Status pruneStatus
+	Detail string
 }
 
 // projectPruneResult holds all results for a single project.
@@ -73,6 +92,16 @@ type projectPruneResult struct {
 	Error   string
 }
 
+// pruneOptionsFromFlags constructs PruneOptions from the package-level flag vars.
+func pruneOptionsFromFlags() PruneOptions {
+	return PruneOptions{
+		DryRun:       pruneDryRun,
+		Force:        pruneForce,
+		Remote:       pruneRemote,
+		RemoteDelete: pruneRemoteDelete,
+	}
+}
+
 func runProjectPrune(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
@@ -82,7 +111,7 @@ func runProjectPrune(cmd *cobra.Command, args []string) error {
 	}
 
 	// Resolve project: positional arg > flag > cwd
-	projectName := pruneProject
+	projectName := pruneProjectFlag
 	if len(args) > 0 {
 		projectName = args[0]
 	}
@@ -96,16 +125,15 @@ func runProjectPrune(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	pr := pruneProject_(ctx, result.Name, result.Path)
+	pr := executePrune(ctx, result.Name, result.Path, pruneOptionsFromFlags())
 
 	renderPruneResult(pr)
 
 	return nil
 }
 
-// pruneProject_ executes the prune logic for a single project.
-// It respects the package-level flag variables (pruneDryRun, pruneForce, etc.).
-func pruneProject_(ctx context.Context, name, path string) projectPruneResult {
+// executePrune runs the prune logic for a single project.
+func executePrune(ctx context.Context, name, path string, opts PruneOptions) projectPruneResult {
 	pr := projectPruneResult{Name: name, Path: path}
 
 	merged, err := git.MergedBranches(ctx, path)
@@ -114,12 +142,12 @@ func pruneProject_(ctx context.Context, name, path string) projectPruneResult {
 		return pr
 	}
 
-	if len(merged) == 0 && !pruneRemote {
+	if len(merged) == 0 && !opts.Remote {
 		return pr
 	}
 
-	// Confirmation (unless dry-run or force)
-	if len(merged) > 0 && !pruneDryRun && !pruneForce {
+	// Confirmation for local deletion (unless dry-run or force)
+	if len(merged) > 0 && !opts.DryRun && !opts.Force {
 		fmt.Printf("\n%s Will delete %d merged branch(es) in %s:\n",
 			ui.WarningIcon(), len(merged), ui.Value(name))
 		for _, b := range merged {
@@ -132,7 +160,7 @@ func pruneProject_(ctx context.Context, name, path string) projectPruneResult {
 			for _, b := range merged {
 				pr.Results = append(pr.Results, pruneResult{
 					Branch: b,
-					Status: "skipped",
+					Status: pruneStatusSkipped,
 					Detail: "cancelled by user",
 				})
 			}
@@ -140,12 +168,12 @@ func pruneProject_(ctx context.Context, name, path string) projectPruneResult {
 		}
 	}
 
-	// Delete merged branches
+	// Delete merged branches locally
 	for _, branch := range merged {
-		if pruneDryRun {
+		if opts.DryRun {
 			pr.Results = append(pr.Results, pruneResult{
 				Branch: branch,
-				Status: "would delete",
+				Status: pruneStatusWouldDelete,
 			})
 			continue
 		}
@@ -153,58 +181,78 @@ func pruneProject_(ctx context.Context, name, path string) projectPruneResult {
 		if err := git.DeleteBranch(ctx, path, branch); err != nil {
 			pr.Results = append(pr.Results, pruneResult{
 				Branch: branch,
-				Status: "error",
+				Status: pruneStatusError,
 				Detail: err.Error(),
 			})
 		} else {
 			pr.Results = append(pr.Results, pruneResult{
 				Branch: branch,
-				Status: "deleted",
+				Status: pruneStatusDeleted,
 			})
 		}
 	}
 
-	// Delete remote branches if requested
-	if pruneRemoteDelete {
-		for _, branch := range merged {
-			if pruneDryRun {
+	// Remote branch deletion — separate confirmation gate (irreversible)
+	if opts.RemoteDelete && len(merged) > 0 {
+		if opts.DryRun {
+			for _, branch := range merged {
 				pr.Results = append(pr.Results, pruneResult{
 					Branch: "origin/" + branch,
-					Status: "would delete",
+					Status: pruneStatusWouldDelete,
 					Detail: "remote",
 				})
-				continue
 			}
-
-			if err := git.DeleteRemoteBranch(ctx, path, branch); err != nil {
-				pr.Results = append(pr.Results, pruneResult{
-					Branch: "origin/" + branch,
-					Status: "error",
-					Detail: err.Error(),
-				})
+		} else {
+			// Always confirm remote deletion independently — --force only covers local
+			fmt.Printf("\n%s Will DELETE %d branch(es) from origin (irreversible):\n",
+				ui.WarningIcon(), len(merged))
+			for _, b := range merged {
+				fmt.Printf("  %s origin/%s\n", ui.Dim("-"), b)
+			}
+			fmt.Print("\nDelete from remote? [y/N] ")
+			var answer string
+			fmt.Scanln(&answer)
+			if strings.HasPrefix(strings.ToLower(answer), "y") {
+				for _, branch := range merged {
+					if err := git.DeleteRemoteBranch(ctx, path, branch); err != nil {
+						pr.Results = append(pr.Results, pruneResult{
+							Branch: "origin/" + branch,
+							Status: pruneStatusError,
+							Detail: err.Error(),
+						})
+					} else {
+						pr.Results = append(pr.Results, pruneResult{
+							Branch: "origin/" + branch,
+							Status: pruneStatusDeleted,
+							Detail: "remote",
+						})
+					}
+				}
 			} else {
-				pr.Results = append(pr.Results, pruneResult{
-					Branch: "origin/" + branch,
-					Status: "deleted",
-					Detail: "remote",
-				})
+				for _, branch := range merged {
+					pr.Results = append(pr.Results, pruneResult{
+						Branch: "origin/" + branch,
+						Status: pruneStatusSkipped,
+						Detail: "remote deletion cancelled",
+					})
+				}
 			}
 		}
 	}
 
 	// Prune stale remote tracking refs
-	if pruneRemote {
-		if pruneDryRun {
+	if opts.Remote {
+		if opts.DryRun {
 			pr.Results = append(pr.Results, pruneResult{
 				Branch: "(remote tracking refs)",
-				Status: "would prune",
+				Status: pruneStatusWouldPrune,
 			})
 		} else {
 			count, err := git.PruneRemote(ctx, path)
 			if err != nil {
 				pr.Results = append(pr.Results, pruneResult{
 					Branch: "(remote tracking refs)",
-					Status: "error",
+					Status: pruneStatusError,
 					Detail: err.Error(),
 				})
 			} else {
@@ -216,13 +264,16 @@ func pruneProject_(ctx context.Context, name, path string) projectPruneResult {
 	return pr
 }
 
-func renderPruneResult(pr projectPruneResult) {
-	green := lipgloss.NewStyle().Foreground(ui.SuccessColor)
-	red := lipgloss.NewStyle().Foreground(ui.ErrorColor)
-	yellow := lipgloss.NewStyle().Foreground(ui.WarningColor)
-	dim := lipgloss.NewStyle().Foreground(ui.DimColor)
-	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(ui.BrightColor)
+// Package-level styles for prune output — allocated once.
+var (
+	pruneStyleGreen  = lipgloss.NewStyle().Foreground(ui.SuccessColor)
+	pruneStyleRed    = lipgloss.NewStyle().Foreground(ui.ErrorColor)
+	pruneStyleYellow = lipgloss.NewStyle().Foreground(ui.WarningColor)
+	pruneStyleDim    = lipgloss.NewStyle().Foreground(ui.DimColor)
+	pruneStyleHeader = lipgloss.NewStyle().Bold(true).Foreground(ui.BrightColor)
+)
 
+func renderPruneResult(pr projectPruneResult) {
 	if pr.Error != "" {
 		fmt.Printf("%s %s: %s\n", ui.ErrorIcon(), pr.Name, ui.Error(pr.Error))
 		return
@@ -242,16 +293,16 @@ func renderPruneResult(pr projectPruneResult) {
 		for _, r := range pr.Results {
 			var statusStr string
 			switch r.Status {
-			case "deleted":
-				statusStr = green.Render(r.Status)
-			case "would delete", "would prune":
-				statusStr = yellow.Render(r.Status)
-			case "skipped":
-				statusStr = dim.Render(r.Status)
-			case "error":
-				statusStr = red.Render(r.Status)
+			case pruneStatusDeleted:
+				statusStr = pruneStyleGreen.Render(string(r.Status))
+			case pruneStatusWouldDelete, pruneStatusWouldPrune:
+				statusStr = pruneStyleYellow.Render(string(r.Status))
+			case pruneStatusSkipped:
+				statusStr = pruneStyleDim.Render(string(r.Status))
+			case pruneStatusError:
+				statusStr = pruneStyleRed.Render(string(r.Status))
 			default:
-				statusStr = r.Status
+				statusStr = string(r.Status)
 			}
 
 			detail := r.Detail
@@ -269,7 +320,7 @@ func renderPruneResult(pr projectPruneResult) {
 			Rows(rows...).
 			StyleFunc(func(row, col int) lipgloss.Style {
 				if row == table.HeaderRow {
-					return headerStyle
+					return pruneStyleHeader
 				}
 				return lipgloss.NewStyle()
 			})
@@ -284,7 +335,7 @@ func renderPruneResult(pr projectPruneResult) {
 	// Summary line
 	deleted := 0
 	for _, r := range pr.Results {
-		if r.Status == "deleted" {
+		if r.Status == pruneStatusDeleted {
 			deleted++
 		}
 	}

--- a/cmd/camp/project_prune_all.go
+++ b/cmd/camp/project_prune_all.go
@@ -48,6 +48,8 @@ func runProjectPruneAll(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
+	opts := pruneOptionsFromFlags()
+
 	var results []projectPruneResult
 	totalDeleted := 0
 	totalWouldDelete := 0
@@ -57,14 +59,14 @@ func runProjectPruneAll(cmd *cobra.Command, _ []string) error {
 		fullPath := filepath.Join(campRoot, p)
 		name := git.SubmoduleDisplayName(p)
 
-		pr := pruneProject_(ctx, name, fullPath)
+		pr := executePrune(ctx, name, fullPath, opts)
 		results = append(results, pr)
 
 		for _, r := range pr.Results {
 			switch r.Status {
-			case "deleted":
+			case pruneStatusDeleted:
 				totalDeleted++
-			case "would delete":
+			case pruneStatusWouldDelete:
 				totalWouldDelete++
 			}
 		}
@@ -84,7 +86,7 @@ func runProjectPruneAll(cmd *cobra.Command, _ []string) error {
 	// Summary
 	fmt.Println()
 	fmt.Println(ui.Separator(50))
-	if pruneDryRun {
+	if opts.DryRun {
 		fmt.Printf("%s Would prune %d branch(es) across %d project(s)\n",
 			ui.InfoIcon(), totalWouldDelete, projectsWithWork)
 	} else if totalDeleted > 0 {

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -15,7 +15,7 @@ func UnmergedBranchCount(ctx context.Context, repoPath string) int {
 		return 0
 	}
 
-	defaultBranch := DefaultBranch(ctx, repoPath)
+	defaultBranch := defaultBranchLocal(ctx, repoPath)
 	if defaultBranch == "" {
 		return 0
 	}
@@ -43,7 +43,32 @@ func UnmergedBranchCount(ctx context.Context, repoPath string) int {
 	return count
 }
 
+// defaultBranchLocal determines the default branch using local-only heuristics
+// (no network calls). Used by latency-sensitive paths like status displays.
+func defaultBranchLocal(ctx context.Context, repoPath string) string {
+	if ctx.Err() != nil {
+		return ""
+	}
+
+	if branch := symbolicRefOriginHead(ctx, repoPath); branch != "" {
+		return branch
+	}
+
+	for _, candidate := range []string{"main", "master"} {
+		cmd := exec.CommandContext(ctx, "git", "-C", repoPath,
+			"rev-parse", "--verify", "--quiet", candidate)
+		if cmd.Run() == nil {
+			return candidate
+		}
+	}
+
+	return ""
+}
+
 // DefaultBranch determines the remote's default branch for a repository.
+// This may make a one-time network call if the local symbolic-ref cache
+// is not set. Use defaultBranchLocal for latency-sensitive paths.
+//
 // Strategy:
 //  1. Check local symbolic-ref cache of origin/HEAD
 //  2. If not set, run git remote set-head origin --auto (one-time network fetch)
@@ -166,7 +191,7 @@ func DeleteBranch(ctx context.Context, repoPath, branch string) error {
 		"branch", "-d", branch)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("delete branch %s: %s", branch, strings.TrimSpace(string(output)))
+		return fmt.Errorf("delete branch %s: %w: %s", branch, err, strings.TrimSpace(string(output)))
 	}
 	return nil
 }
@@ -182,7 +207,7 @@ func PruneRemote(ctx context.Context, repoPath string) (int, error) {
 		"remote", "prune", "origin")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return 0, fmt.Errorf("prune remote: %s", strings.TrimSpace(string(output)))
+		return 0, fmt.Errorf("prune remote: %w: %s", err, strings.TrimSpace(string(output)))
 	}
 
 	// Count pruned lines (lines containing " * [pruned]")
@@ -206,7 +231,7 @@ func DeleteRemoteBranch(ctx context.Context, repoPath, branch string) error {
 		"push", "origin", "--delete", branch)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("delete remote branch %s: %s", branch, strings.TrimSpace(string(output)))
+		return fmt.Errorf("delete remote branch %s: %w: %s", branch, err, strings.TrimSpace(string(output)))
 	}
 	return nil
 }

--- a/internal/git/branches_test.go
+++ b/internal/git/branches_test.go
@@ -377,3 +377,30 @@ func TestDeleteBranch_UnmergedFails(t *testing.T) {
 		t.Fatal("expected error deleting unmerged branch with -d, got nil")
 	}
 }
+
+func TestDeleteBranch_CancelledContext(t *testing.T) {
+	dir := initBranchTestRepo(t, "main")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := DeleteBranch(ctx, dir, "any-branch")
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+}
+
+func TestMergedBranches_CancelledContext(t *testing.T) {
+	dir := initBranchTestRepo(t, "main")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	branches, err := MergedBranches(ctx, dir)
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+	if branches != nil {
+		t.Fatalf("expected nil branches for cancelled context, got %v", branches)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `camp project prune [project-name]` command to delete local branches merged into the default branch
- Adds `camp project prune all` subcommand to prune across every project submodule
- Extends `internal/git/branches.go` with `DefaultBranch`, `CurrentBranch`, `MergedBranches`, `DeleteBranch`, `PruneRemote`, and `DeleteRemoteBranch` functions
- Fixes `DefaultBranch` fallback to exclude `develop` (only `main`/`master`)

## Flags

- `--dry-run` / `-n` — preview without deleting
- `--force` / `-f` — skip confirmation prompt
- `--remote` — prune stale remote tracking refs
- `--remote-delete` — delete merged branches on origin (destructive)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass (19 branch tests, full suite green)
- [ ] Manual: `camp project prune --dry-run` lists merged branches
- [ ] Manual: `camp project prune` deletes with confirmation, default/current protected
- [ ] Manual: `camp project prune all --dry-run` shows all projects
- [ ] Manual: `camp project prune --remote` prunes stale tracking refs