### PR TITLE
feat(pull): add --default-branch flag to camp pull all

### DIFF
--- a/cmd/camp/project_prune.go
+++ b/cmd/camp/project_prune.go
@@ -67,7 +67,7 @@ var (
 func init() {
 	projectPruneCmd.Flags().StringVarP(&pruneProjectFlag, "project", "p", "", "Project name (auto-detected from cwd)")
 	projectPruneCmd.Flags().BoolVarP(&pruneDryRun, "dry-run", "n", false, "Preview without deleting")
-	projectPruneCmd.Flags().BoolVarP(&pruneForce, "force", "f", false, "Skip confirmation prompt for local deletion")
+	projectPruneCmd.Flags().BoolVarP(&pruneForce, "force", "f", false, "Skip local branch deletion confirmation")
 	projectPruneCmd.Flags().BoolVar(&pruneRemote, "remote", false, "Also prune stale remote tracking refs")
 	projectPruneCmd.Flags().BoolVar(&pruneRemoteDelete, "remote-delete", false, "Also delete merged branches on origin (destructive)")
 
@@ -146,10 +146,26 @@ func executePrune(ctx context.Context, name, path string, opts PruneOptions) pro
 		return pr
 	}
 
-	// Confirmation for local deletion (unless dry-run or force)
-	if len(merged) > 0 && !opts.DryRun && !opts.Force {
+	deleteLocalBranches(ctx, path, merged, opts, &pr)
+
+	// Remote branch deletion uses the original merged list intentionally —
+	// remote branches should be cleaned up regardless of local deletion outcome.
+	deleteRemoteBranches(ctx, path, merged, opts, &pr)
+
+	pruneTrackingRefs(ctx, path, opts, &pr)
+
+	return pr
+}
+
+// deleteLocalBranches handles confirmation and deletion of locally merged branches.
+func deleteLocalBranches(ctx context.Context, path string, merged []string, opts PruneOptions, pr *projectPruneResult) {
+	if len(merged) == 0 {
+		return
+	}
+
+	if !opts.DryRun && !opts.Force {
 		fmt.Printf("\n%s Will delete %d merged branch(es) in %s:\n",
-			ui.WarningIcon(), len(merged), ui.Value(name))
+			ui.WarningIcon(), len(merged), ui.Value(pr.Name))
 		for _, b := range merged {
 			fmt.Printf("  %s %s\n", ui.Dim("-"), b)
 		}
@@ -164,11 +180,10 @@ func executePrune(ctx context.Context, name, path string, opts PruneOptions) pro
 					Detail: "cancelled by user",
 				})
 			}
-			return pr
+			return
 		}
 	}
 
-	// Delete merged branches locally
 	for _, branch := range merged {
 		if opts.DryRun {
 			pr.Results = append(pr.Results, pruneResult{
@@ -191,77 +206,86 @@ func executePrune(ctx context.Context, name, path string, opts PruneOptions) pro
 			})
 		}
 	}
+}
 
-	// Remote branch deletion — separate confirmation gate (irreversible)
-	if opts.RemoteDelete && len(merged) > 0 {
-		if opts.DryRun {
-			for _, branch := range merged {
-				pr.Results = append(pr.Results, pruneResult{
-					Branch: "origin/" + branch,
-					Status: pruneStatusWouldDelete,
-					Detail: "remote",
-				})
-			}
-		} else {
-			// Always confirm remote deletion independently — --force only covers local
-			fmt.Printf("\n%s Will DELETE %d branch(es) from origin (irreversible):\n",
-				ui.WarningIcon(), len(merged))
-			for _, b := range merged {
-				fmt.Printf("  %s origin/%s\n", ui.Dim("-"), b)
-			}
-			fmt.Print("\nDelete from remote? [y/N] ")
-			var answer string
-			fmt.Scanln(&answer)
-			if strings.HasPrefix(strings.ToLower(answer), "y") {
-				for _, branch := range merged {
-					if err := git.DeleteRemoteBranch(ctx, path, branch); err != nil {
-						pr.Results = append(pr.Results, pruneResult{
-							Branch: "origin/" + branch,
-							Status: pruneStatusError,
-							Detail: err.Error(),
-						})
-					} else {
-						pr.Results = append(pr.Results, pruneResult{
-							Branch: "origin/" + branch,
-							Status: pruneStatusDeleted,
-							Detail: "remote",
-						})
-					}
-				}
-			} else {
-				for _, branch := range merged {
-					pr.Results = append(pr.Results, pruneResult{
-						Branch: "origin/" + branch,
-						Status: pruneStatusSkipped,
-						Detail: "remote deletion cancelled",
-					})
-				}
-			}
-		}
+// deleteRemoteBranches handles confirmation and deletion of merged branches on origin.
+func deleteRemoteBranches(ctx context.Context, path string, merged []string, opts PruneOptions, pr *projectPruneResult) {
+	if !opts.RemoteDelete || len(merged) == 0 {
+		return
 	}
 
-	// Prune stale remote tracking refs
-	if opts.Remote {
-		if opts.DryRun {
+	if opts.DryRun {
+		for _, branch := range merged {
 			pr.Results = append(pr.Results, pruneResult{
-				Branch: "(remote tracking refs)",
-				Status: pruneStatusWouldPrune,
+				Branch: "origin/" + branch,
+				Status: pruneStatusWouldDelete,
+				Detail: "remote",
+			})
+		}
+		return
+	}
+
+	// Always confirm remote deletion independently — --force only covers local
+	fmt.Printf("\n%s Will DELETE %d branch(es) from origin (irreversible):\n",
+		ui.WarningIcon(), len(merged))
+	for _, b := range merged {
+		fmt.Printf("  %s origin/%s\n", ui.Dim("-"), b)
+	}
+	fmt.Print("\nDelete from remote? [y/N] ")
+	var answer string
+	fmt.Scanln(&answer)
+	if !strings.HasPrefix(strings.ToLower(answer), "y") {
+		for _, branch := range merged {
+			pr.Results = append(pr.Results, pruneResult{
+				Branch: "origin/" + branch,
+				Status: pruneStatusSkipped,
+				Detail: "remote deletion cancelled",
+			})
+		}
+		return
+	}
+
+	for _, branch := range merged {
+		if err := git.DeleteRemoteBranch(ctx, path, branch); err != nil {
+			pr.Results = append(pr.Results, pruneResult{
+				Branch: "origin/" + branch,
+				Status: pruneStatusError,
+				Detail: err.Error(),
 			})
 		} else {
-			count, err := git.PruneRemote(ctx, path)
-			if err != nil {
-				pr.Results = append(pr.Results, pruneResult{
-					Branch: "(remote tracking refs)",
-					Status: pruneStatusError,
-					Detail: err.Error(),
-				})
-			} else {
-				pr.Pruned = count
-			}
+			pr.Results = append(pr.Results, pruneResult{
+				Branch: "origin/" + branch,
+				Status: pruneStatusDeleted,
+				Detail: "remote",
+			})
 		}
 	}
+}
 
-	return pr
+// pruneTrackingRefs handles pruning of stale remote tracking refs.
+func pruneTrackingRefs(ctx context.Context, path string, opts PruneOptions, pr *projectPruneResult) {
+	if !opts.Remote {
+		return
+	}
+
+	if opts.DryRun {
+		pr.Results = append(pr.Results, pruneResult{
+			Branch: "(remote tracking refs)",
+			Status: pruneStatusWouldPrune,
+		})
+		return
+	}
+
+	count, err := git.PruneRemote(ctx, path)
+	if err != nil {
+		pr.Results = append(pr.Results, pruneResult{
+			Branch: "(remote tracking refs)",
+			Status: pruneStatusError,
+			Detail: err.Error(),
+		})
+	} else {
+		pr.Pruned = count
+	}
 }
 
 // Package-level styles for prune output — allocated once.
@@ -287,52 +311,13 @@ func renderPruneResult(pr projectPruneResult) {
 	fmt.Printf("\n%s %s\n", ui.Subheader("Project:"), ui.Value(pr.Name))
 
 	if len(pr.Results) > 0 {
-		headers := []string{"BRANCH", "STATUS", "DETAIL"}
-		var rows [][]string
-
-		for _, r := range pr.Results {
-			var statusStr string
-			switch r.Status {
-			case pruneStatusDeleted:
-				statusStr = pruneStyleGreen.Render(string(r.Status))
-			case pruneStatusWouldDelete, pruneStatusWouldPrune:
-				statusStr = pruneStyleYellow.Render(string(r.Status))
-			case pruneStatusSkipped:
-				statusStr = pruneStyleDim.Render(string(r.Status))
-			case pruneStatusError:
-				statusStr = pruneStyleRed.Render(string(r.Status))
-			default:
-				statusStr = string(r.Status)
-			}
-
-			detail := r.Detail
-			if detail == "" {
-				detail = "-"
-			}
-
-			rows = append(rows, []string{r.Branch, statusStr, detail})
-		}
-
-		t := table.New().
-			Border(lipgloss.ASCIIBorder()).
-			BorderStyle(lipgloss.NewStyle().Foreground(ui.DimColor)).
-			Headers(headers...).
-			Rows(rows...).
-			StyleFunc(func(row, col int) lipgloss.Style {
-				if row == table.HeaderRow {
-					return pruneStyleHeader
-				}
-				return lipgloss.NewStyle()
-			})
-
-		fmt.Println(t)
+		fmt.Println(buildPruneTable(pr.Results))
 	}
 
 	if pr.Pruned > 0 {
 		fmt.Printf("%s Pruned %d stale remote tracking ref(s)\n", ui.SuccessIcon(), pr.Pruned)
 	}
 
-	// Summary line
 	deleted := 0
 	for _, r := range pr.Results {
 		if r.Status == pruneStatusDeleted {
@@ -342,4 +327,45 @@ func renderPruneResult(pr projectPruneResult) {
 	if deleted > 0 {
 		fmt.Printf("\n%s Pruned %d branch(es)\n", ui.SuccessIcon(), deleted)
 	}
+}
+
+// buildPruneTable constructs the lipgloss table for prune results.
+func buildPruneTable(results []pruneResult) *table.Table {
+	headers := []string{"BRANCH", "STATUS", "DETAIL"}
+	var rows [][]string
+
+	for _, r := range results {
+		var statusStr string
+		switch r.Status {
+		case pruneStatusDeleted:
+			statusStr = pruneStyleGreen.Render(string(r.Status))
+		case pruneStatusWouldDelete, pruneStatusWouldPrune:
+			statusStr = pruneStyleYellow.Render(string(r.Status))
+		case pruneStatusSkipped:
+			statusStr = pruneStyleDim.Render(string(r.Status))
+		case pruneStatusError:
+			statusStr = pruneStyleRed.Render(string(r.Status))
+		default:
+			statusStr = string(r.Status)
+		}
+
+		detail := r.Detail
+		if detail == "" {
+			detail = "-"
+		}
+
+		rows = append(rows, []string{r.Branch, statusStr, detail})
+	}
+
+	return table.New().
+		Border(lipgloss.ASCIIBorder()).
+		BorderStyle(lipgloss.NewStyle().Foreground(ui.DimColor)).
+		Headers(headers...).
+		Rows(rows...).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return pruneStyleHeader
+			}
+			return lipgloss.NewStyle()
+		})
 }

--- a/cmd/camp/pull.go
+++ b/cmd/camp/pull.go
@@ -90,6 +90,12 @@ func runPull(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// PullAllOptions holds configuration for pull-all operations.
+type PullAllOptions struct {
+	NoRecurse     bool
+	DefaultBranch bool
+}
+
 // pullTarget holds information about a repo to potentially pull.
 type pullTarget struct {
 	name   string
@@ -98,10 +104,27 @@ type pullTarget struct {
 	isRoot bool // campaign root repo (skip recursive submodule fetch)
 }
 
+// checkoutDefaultIfNeeded switches a submodule to its default branch when
+// --default-branch is active and the submodule is on detached HEAD or has no
+// upstream tracking. Returns the original branch name before any switch.
+// If the checkout fails, it appends to errs and returns skip=true.
+func checkoutDefaultIfNeeded(ctx context.Context, t *pullTarget) (originalBranch string, switched bool, err error) {
+	originalBranch = t.branch
+
+	if t.branch != "" && t.branch != "HEAD" {
+		return originalBranch, false, nil
+	}
+
+	branch, err := git.CheckoutDefaultBranch(ctx, t.path)
+	if err != nil {
+		return originalBranch, false, err
+	}
+	t.branch = branch
+	return originalBranch, true, nil
+}
+
 // runPullAll discovers all submodules + campaign root, and pulls them.
-// When useDefault is true, submodules on detached HEAD or without upstream
-// are switched to their remote's default branch before pulling.
-func runPullAll(ctx context.Context, campRoot string, gitArgs []string, noRecurse, useDefault bool) error {
+func runPullAll(ctx context.Context, campRoot string, gitArgs []string, opts PullAllOptions) error {
 	green := lipgloss.NewStyle().Foreground(ui.SuccessColor)
 	yellow := lipgloss.NewStyle().Foreground(ui.WarningColor)
 	red := lipgloss.NewStyle().Foreground(ui.ErrorColor)
@@ -110,25 +133,181 @@ func runPullAll(ctx context.Context, campRoot string, gitArgs []string, noRecurs
 	fmt.Println(ui.Info("Pulling all repos..."))
 	fmt.Println()
 
-	// Discover submodules (including nested monorepo submodules)
-	var (
-		paths []string
-		err   error
-	)
-	if noRecurse {
-		paths, err = git.ListSubmodulePathsFiltered(ctx, campRoot, "projects/")
-	} else {
-		paths, err = git.ListSubmodulePathsRecursive(ctx, campRoot, "projects/")
-	}
+	paths, err := discoverSubmodules(ctx, campRoot, opts.NoRecurse)
 	if err != nil {
-		return fmt.Errorf("failed to list submodules: %w", err)
+		return err
 	}
 
-	// Build target list: campaign root first, then submodules
+	targets := buildPullTargets(ctx, campRoot, paths)
+
+	var pulled, skipped, failed int
+	var errors []string
+
+	for i := range targets {
+		t := &targets[i]
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		result := pullSingleTarget(ctx, t, gitArgs, opts, dim, green, yellow, red)
+		switch result.outcome {
+		case pullOutcomePulled:
+			pulled++
+		case pullOutcomeSkipped:
+			skipped++
+		case pullOutcomeFailed:
+			failed++
+			errors = append(errors, result.errMsg)
+		}
+	}
+
+	changedRefs := reportChangedRefs(ctx, campRoot, paths, yellow)
+	printPullSummary(pulled, failed, changedRefs, errors, green, yellow, red, dim)
+
+	if failed > 0 {
+		return fmt.Errorf("%d repo(s) failed to pull", failed)
+	}
+	return nil
+}
+
+type pullOutcome int
+
+const (
+	pullOutcomePulled pullOutcome = iota
+	pullOutcomeSkipped
+	pullOutcomeFailed
+)
+
+type pullResult struct {
+	outcome pullOutcome
+	errMsg  string
+}
+
+// pullSingleTarget handles the checkout-if-needed, upstream check, and pull
+// for a single target. Returns the outcome and optional error message.
+func pullSingleTarget(
+	ctx context.Context,
+	t *pullTarget,
+	gitArgs []string,
+	opts PullAllOptions,
+	dim, green, yellow, red lipgloss.Style,
+) pullResult {
+	originalBranch := t.branch
+
+	// Handle detached HEAD
+	if t.branch == "" || t.branch == "HEAD" {
+		if opts.DefaultBranch && !t.isRoot {
+			if _, _, err := checkoutDefaultIfNeeded(ctx, t); err != nil {
+				fmt.Printf("  %-30s %s\n", t.name, yellow.Render("detached HEAD (checkout failed)"))
+				return pullResult{outcome: pullOutcomeSkipped}
+			}
+		} else {
+			fmt.Printf("  %-30s %s\n", t.name, yellow.Render("detached HEAD"))
+			return pullResult{outcome: pullOutcomeSkipped}
+		}
+	}
+
+	// Check upstream tracking
+	if _, err := gitOutput(ctx, t.path, "rev-parse", "--abbrev-ref", "@{upstream}"); err != nil {
+		if opts.DefaultBranch && !t.isRoot {
+			branch, checkoutErr := git.CheckoutDefaultBranch(ctx, t.path)
+			if checkoutErr != nil {
+				fmt.Printf("  %-30s %s\n", t.name, yellow.Render("no upstream (checkout failed)"))
+				return pullResult{outcome: pullOutcomeSkipped}
+			}
+			if t.branch != branch {
+				t.branch = branch
+			}
+			// Re-check upstream after checkout
+			if _, err := gitOutput(ctx, t.path, "rev-parse", "--abbrev-ref", "@{upstream}"); err != nil {
+				fmt.Printf("  %-30s %s\n", t.name, yellow.Render("no upstream"))
+				return pullResult{outcome: pullOutcomeSkipped}
+			}
+		} else {
+			fmt.Printf("  %-30s %s\n", t.name, yellow.Render("no upstream"))
+			return pullResult{outcome: pullOutcomeSkipped}
+		}
+	}
+
+	// Print progress line
+	if originalBranch != "" && originalBranch != "HEAD" && originalBranch != t.branch {
+		fmt.Printf("  %-30s %s  %s  pulling... ",
+			t.name, dim.Render(t.branch),
+			dim.Render(fmt.Sprintf("(was %s)", originalBranch)))
+	} else {
+		fmt.Printf("  %-30s %s  pulling... ",
+			t.name, dim.Render(t.branch))
+	}
+
+	// Execute pull
+	pullArgs := []string{"-C", t.path, "pull"}
+	if t.isRoot {
+		pullArgs = append(pullArgs, "--no-recurse-submodules")
+	}
+	pullArgs = append(pullArgs, gitArgs...)
+	gitCmd := exec.CommandContext(ctx, "git", pullArgs...)
+	output, err := gitCmd.CombinedOutput()
+	if err != nil {
+		return handlePullError(ctx, t, output, err, red)
+	}
+
+	outStr := strings.TrimSpace(string(output))
+	if strings.Contains(outStr, "Already up to date") {
+		fmt.Println(dim.Render("up-to-date"))
+		return pullResult{outcome: pullOutcomeSkipped}
+	}
+	fmt.Println(green.Render("done"))
+	return pullResult{outcome: pullOutcomePulled}
+}
+
+// handlePullError processes a failed git pull, aborting any in-progress rebase.
+func handlePullError(ctx context.Context, t *pullTarget, output []byte, err error, red lipgloss.Style) pullResult {
+	if isRebaseInProgress(ctx, t.path) {
+		_ = abortRebase(ctx, t.path)
+		fmt.Println(red.Render("conflict (aborted rebase)"))
+		return pullResult{
+			outcome: pullOutcomeFailed,
+			errMsg:  fmt.Sprintf("  %s: rebase conflict (try: camp pull -p %s --no-rebase)", t.name, t.name),
+		}
+	}
+
+	fmt.Println(red.Render("failed"))
+	errMsg := strings.TrimSpace(string(output))
+	if isDivergentError(errMsg) {
+		errMsg = "branches diverged (try: camp pull all --ff-only, --rebase, or resolve manually)"
+	} else if errMsg == "" {
+		errMsg = err.Error()
+	}
+	return pullResult{
+		outcome: pullOutcomeFailed,
+		errMsg:  fmt.Sprintf("  %s: %s", t.name, errMsg),
+	}
+}
+
+// discoverSubmodules lists submodule paths, optionally filtering to top-level only.
+func discoverSubmodules(ctx context.Context, campRoot string, noRecurse bool) ([]string, error) {
+	if noRecurse {
+		paths, err := git.ListSubmodulePathsFiltered(ctx, campRoot, "projects/")
+		if err != nil {
+			return nil, fmt.Errorf("failed to list submodules: %w", err)
+		}
+		return paths, nil
+	}
+	paths, err := git.ListSubmodulePathsRecursive(ctx, campRoot, "projects/")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list submodules: %w", err)
+	}
+	return paths, nil
+}
+
+// buildPullTargets constructs the target list: campaign root first, then submodules.
+func buildPullTargets(ctx context.Context, campRoot string, paths []string) []pullTarget {
 	targets := make([]pullTarget, 0, len(paths)+1)
+	rootBranch, _ := gitOutput(ctx, campRoot, "rev-parse", "--abbrev-ref", "HEAD")
 	targets = append(targets, pullTarget{
 		name:   "campaign root",
 		path:   campRoot,
+		branch: rootBranch,
 		isRoot: true,
 	})
 	for _, p := range paths {
@@ -140,135 +319,11 @@ func runPullAll(ctx context.Context, campRoot string, gitArgs []string, noRecurs
 			branch: branch,
 		})
 	}
+	return targets
+}
 
-	// Get campaign root branch
-	targets[0].branch, _ = gitOutput(ctx, campRoot, "rev-parse", "--abbrev-ref", "HEAD")
-
-	// Pull each target
-	var pulled, skipped, failed int
-	var errors []string
-
-	for i := range targets {
-		t := &targets[i]
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
-
-		originalBranch := t.branch
-
-		// Skip detached HEAD (or checkout default branch if --default-branch)
-		if t.branch == "" || t.branch == "HEAD" {
-			if useDefault && !t.isRoot {
-				branch, err := git.DetectDefaultBranch(ctx, t.path)
-				if err != nil {
-					fmt.Printf("  %-30s %s\n", t.name, yellow.Render("detached HEAD (no default found)"))
-					skipped++
-					continue
-				}
-				cmd := exec.CommandContext(ctx, "git", "-C", t.path, "checkout", branch)
-				if out, err := cmd.CombinedOutput(); err != nil {
-					fmt.Printf("  %-30s %s\n", t.name, red.Render(fmt.Sprintf("checkout %s failed", branch)))
-					errors = append(errors, fmt.Sprintf("  %s: checkout %s: %s", t.name, branch, strings.TrimSpace(string(out))))
-					failed++
-					continue
-				}
-				t.branch = branch
-			} else {
-				fmt.Printf("  %-30s %s\n", t.name, yellow.Render("detached HEAD"))
-				skipped++
-				continue
-			}
-		}
-
-		// Skip repos with no upstream tracking (or checkout default branch if --default-branch)
-		if _, err := gitOutput(ctx, t.path, "rev-parse", "--abbrev-ref", "@{upstream}"); err != nil {
-			if useDefault && !t.isRoot {
-				branch, err := git.DetectDefaultBranch(ctx, t.path)
-				if err != nil {
-					fmt.Printf("  %-30s %s\n", t.name, yellow.Render("no upstream (no default found)"))
-					skipped++
-					continue
-				}
-				if t.branch != branch {
-					cmd := exec.CommandContext(ctx, "git", "-C", t.path, "checkout", branch)
-					if out, err := cmd.CombinedOutput(); err != nil {
-						fmt.Printf("  %-30s %s\n", t.name, red.Render(fmt.Sprintf("checkout %s failed", branch)))
-						errors = append(errors, fmt.Sprintf("  %s: checkout %s: %s", t.name, branch, strings.TrimSpace(string(out))))
-						failed++
-						continue
-					}
-					t.branch = branch
-				}
-				// Re-check upstream after checkout; skip if still missing
-				if _, err := gitOutput(ctx, t.path, "rev-parse", "--abbrev-ref", "@{upstream}"); err != nil {
-					fmt.Printf("  %-30s %s\n", t.name, yellow.Render("no upstream"))
-					skipped++
-					continue
-				}
-			} else {
-				fmt.Printf("  %-30s %s\n", t.name, yellow.Render("no upstream"))
-				skipped++
-				continue
-			}
-		}
-
-		if originalBranch != "" && originalBranch != "HEAD" && originalBranch != t.branch {
-			fmt.Printf("  %-30s %s  %s  pulling... ",
-				t.name, dim.Render(t.branch),
-				dim.Render(fmt.Sprintf("(was %s)", originalBranch)))
-		} else {
-			fmt.Printf("  %-30s %s  pulling... ",
-				t.name, dim.Render(t.branch))
-		}
-
-		pullArgs := []string{"-C", t.path, "pull"}
-		if t.isRoot {
-			// Campaign root: skip recursive submodule fetch since we pull
-			// each submodule individually. Prevents failures from stale
-			// submodule refs that no longer exist on their remotes.
-			pullArgs = append(pullArgs, "--no-recurse-submodules")
-		}
-		pullArgs = append(pullArgs, gitArgs...)
-		gitCmd := exec.CommandContext(ctx, "git", pullArgs...)
-		output, err := gitCmd.CombinedOutput()
-		if err != nil {
-			// If a rebase failed mid-way, abort it so the repo isn't left
-			// in a broken state. We can't stop to resolve during a batch.
-			if isRebaseInProgress(ctx, t.path) {
-				_ = abortRebase(ctx, t.path)
-				fmt.Println(red.Render("conflict (aborted rebase)"))
-				errors = append(errors, fmt.Sprintf("  %s: rebase conflict (try: camp pull -p %s --no-rebase)", t.name, t.name))
-				failed++
-				continue
-			}
-
-			fmt.Println(red.Render("failed"))
-			errMsg := strings.TrimSpace(string(output))
-			if isDivergentError(errMsg) {
-				errMsg = "branches diverged (try: camp pull all --ff-only, --rebase, or resolve manually)"
-			} else if errMsg == "" {
-				errMsg = err.Error()
-			}
-			errors = append(errors, fmt.Sprintf("  %s: %s", t.name, errMsg))
-			failed++
-			continue
-		}
-
-		// Check if anything was actually pulled
-		outStr := strings.TrimSpace(string(output))
-		if strings.Contains(outStr, "Already up to date") {
-			fmt.Println(dim.Render("up-to-date"))
-			skipped++
-		} else {
-			fmt.Println(green.Render("done"))
-			pulled++
-		}
-	}
-
-	// Post-pull: report submodules with changed refs in the parent
-	changedRefs := reportChangedRefs(ctx, campRoot, paths, yellow)
-
-	// Summary
+// printPullSummary outputs the final pull-all summary.
+func printPullSummary(pulled, failed, changedRefs int, errors []string, green, yellow, red, dim lipgloss.Style) {
 	fmt.Println()
 	total := pulled + failed
 	if total == 0 {
@@ -286,11 +341,6 @@ func runPullAll(ctx context.Context, campRoot string, gitArgs []string, noRecurs
 		fmt.Println()
 		fmt.Println(dim.Render("  Run 'camp commit' to record these ref updates."))
 	}
-
-	if failed > 0 {
-		return fmt.Errorf("%d repo(s) failed to pull", failed)
-	}
-	return nil
 }
 
 // reportChangedRefs checks which submodules have new refs after pulling

--- a/cmd/camp/pull_all.go
+++ b/cmd/camp/pull_all.go
@@ -45,26 +45,12 @@ func runPullAllCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Extract camp-specific flags before passing remaining args to git.
-	var noRecurse bool
-	args, noRecurse = extractNoRecurse(args)
+	var noRecurse, useDefault bool
+	args, noRecurse = extractFlag(args, "--no-recurse")
+	args, useDefault = extractFlag(args, "--default-branch")
 
-	var useDefault bool
-	args, useDefault = extractDefaultBranch(args)
-
-	return runPullAll(ctx, campRoot, args, noRecurse, useDefault)
-}
-
-// extractDefaultBranch removes --default-branch from args and returns the
-// filtered args plus whether the flag was present.
-func extractDefaultBranch(args []string) ([]string, bool) {
-	var filtered []string
-	var found bool
-	for _, a := range args {
-		if a == "--default-branch" {
-			found = true
-			continue
-		}
-		filtered = append(filtered, a)
-	}
-	return filtered, found
+	return runPullAll(ctx, campRoot, args, PullAllOptions{
+		NoRecurse:     noRecurse,
+		DefaultBranch: useDefault,
+	})
 }

--- a/cmd/camp/push_all.go
+++ b/cmd/camp/push_all.go
@@ -42,19 +42,20 @@ func runPushAllCmd(cmd *cobra.Command, args []string) error {
 
 	// Extract --no-recurse before passing remaining args to git.
 	var noRecurse bool
-	args, noRecurse = extractNoRecurse(args)
+	args, noRecurse = extractFlag(args, "--no-recurse")
 
 	return runPushAll(ctx, campRoot, args, noRecurse)
 }
 
-// extractNoRecurse removes --no-recurse from args and returns the filtered
+// extractFlag removes a camp-specific flag from args and returns the filtered
 // args plus whether the flag was present. Used by commands with
-// DisableFlagParsing that need to intercept camp-specific flags.
-func extractNoRecurse(args []string) ([]string, bool) {
+// DisableFlagParsing that need to intercept camp-specific flags before passing
+// remaining args through to git.
+func extractFlag(args []string, flag string) ([]string, bool) {
 	var filtered []string
 	var found bool
 	for _, a := range args {
-		if a == "--no-recurse" {
+		if a == flag {
 			found = true
 			continue
 		}


### PR DESCRIPTION
## Summary

- Adds `--default-branch` flag to `camp pull all` that auto-checkouts each submodule's default branch before pulling
- Solves the "I just sat down at another machine" problem where submodules are stuck on stale feature branches whose remote tracking branch was deleted (merged & cleaned up)
- Shows `(was <branch>)` indicator in output when a branch checkout occurs

## How it works

1. Extracts `--default-branch` flag using the same pattern as `--no-recurse` (manual extraction since `DisableFlagParsing: true`)
2. For detached HEAD submodules: detects default branch via `git.DetectDefaultBranch()` and checks it out
3. For submodules with no upstream tracking: checks out default branch and re-verifies upstream before pulling
4. Campaign root is never auto-switched (only submodules)

## Test plan

- [x] `just build` compiles without errors
- [x] `just test all` — all 66 integration tests pass
- [ ] Manual: checkout a submodule to a stale branch, run `camp pull all --default-branch`, verify switch + pull
- [ ] Manual: verify `camp pull all` without the flag behaves unchanged
- [ ] Manual: verify `camp pull all --default-branch --rebase` passes git flags through correctly