### PR TITLE
Exclude submodule refs from campaign root commits

### DIFF
--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -119,8 +119,15 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	// Stage if requested
 	if commitAll {
 		fmt.Println(ui.Info("Staging changes..."))
-		if err := executor.StageAll(ctx); err != nil {
-			return fmt.Errorf("failed to stage: %w", err)
+		if target.IsSubmodule {
+			if err := executor.StageAll(ctx); err != nil {
+				return fmt.Errorf("failed to stage: %w", err)
+			}
+		} else {
+			// Campaign root: exclude submodule refs from staging
+			if err := executor.StageAllExcludingSubmodules(ctx); err != nil {
+				return fmt.Errorf("failed to stage: %w", err)
+			}
 		}
 	}
 

--- a/cmd/camp/project_commit.go
+++ b/cmd/camp/project_commit.go
@@ -46,7 +46,7 @@ func init() {
 	projectCommitCmd.Flags().StringVarP(&projectCommitMessage, "message", "m", "", "Commit message (required)")
 	projectCommitCmd.Flags().BoolVarP(&projectCommitAll, "all", "a", true, "Stage all changes")
 	projectCommitCmd.Flags().BoolVar(&projectCommitAmend, "amend", false, "Amend the previous commit")
-	projectCommitCmd.Flags().BoolVar(&projectCommitSync, "sync", true, "Auto-commit submodule ref in campaign root")
+	projectCommitCmd.Flags().BoolVar(&projectCommitSync, "sync", false, "Commit submodule ref update in campaign root")
 
 	projectCommitCmd.RegisterFlagCompletionFunc("project", completeProjectName)
 

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -171,6 +171,54 @@ func StageFiles(ctx context.Context, repoPath string, files ...string) error {
 	return Stage(ctx, repoPath, files)
 }
 
+// StageAllExcluding stages all changes then unstages the specified paths.
+// This is used to exclude certain paths (like submodule refs) from broad staging.
+func StageAllExcluding(ctx context.Context, repoPath string, excludePaths []string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	if err := StageAll(ctx, repoPath); err != nil {
+		return err
+	}
+
+	if len(excludePaths) == 0 {
+		return nil
+	}
+
+	// Unstage the excluded paths via git reset HEAD --
+	args := []string{"-C", repoPath, "reset", "HEAD", "--"}
+	args = append(args, excludePaths...)
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// If reset fails because the paths aren't staged, that's fine
+		outStr := strings.TrimSpace(string(output))
+		if strings.Contains(outStr, "did not match any file") {
+			return nil
+		}
+		return fmt.Errorf("git reset HEAD failed: %s: %w", outStr, err)
+	}
+
+	return nil
+}
+
+// StageAllExcludingSubmodules stages all changes but excludes submodule ref updates.
+// It reads submodule paths from .gitmodules and unstages them after a broad stage.
+func StageAllExcludingSubmodules(ctx context.Context, repoPath string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	paths, err := ListSubmodulePaths(ctx, repoPath)
+	if err != nil {
+		return fmt.Errorf("list submodule paths: %w", err)
+	}
+
+	return StageAllExcluding(ctx, repoPath, paths)
+}
+
 // HasStagedChanges checks if there are any staged changes ready to commit.
 func HasStagedChanges(ctx context.Context, repoPath string) (bool, error) {
 	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "diff", "--cached", "--quiet")

--- a/internal/git/executor.go
+++ b/internal/git/executor.go
@@ -22,6 +22,9 @@ type GitExecutor interface {
 	// StageAll stages all changes
 	StageAll(ctx context.Context) error
 
+	// StageAllExcludingSubmodules stages all changes but excludes submodule refs
+	StageAllExcludingSubmodules(ctx context.Context) error
+
 	// HasChanges returns true if there are uncommitted changes
 	HasChanges(ctx context.Context) (bool, error)
 
@@ -161,6 +164,14 @@ func (e *Executor) Stage(ctx context.Context, files []string) error {
 // StageAll stages all changes.
 func (e *Executor) StageAll(ctx context.Context) error {
 	return e.Stage(ctx, nil)
+}
+
+// StageAllExcludingSubmodules stages all changes but excludes submodule ref updates.
+func (e *Executor) StageAllExcludingSubmodules(ctx context.Context) error {
+	if e.config.Verbose {
+		e.logger.Debug("staging all excluding submodules", "path", e.path)
+	}
+	return StageAllExcludingSubmodules(ctx, e.path)
 }
 
 // HasChanges returns true if there are uncommitted changes.

--- a/internal/git/executor_test.go
+++ b/internal/git/executor_test.go
@@ -299,6 +299,10 @@ func (m *MockExecutor) StageAll(ctx context.Context) error {
 	return m.ReturnError
 }
 
+func (m *MockExecutor) StageAllExcludingSubmodules(ctx context.Context) error {
+	return m.ReturnError
+}
+
 func (m *MockExecutor) HasChanges(ctx context.Context) (bool, error) {
 	return m.ChangesExist, m.ReturnError
 }

--- a/pkg/commitkit/commitkit.go
+++ b/pkg/commitkit/commitkit.go
@@ -122,6 +122,17 @@ func CommitAll(ctx context.Context, repoPath, message string) error {
 	return git.CommitAll(ctx, repoPath, message)
 }
 
+// StageAllExcludingSubmodules stages all changes but excludes submodule ref
+// updates. Reads submodule paths from .gitmodules and unstages them after
+// a broad stage. Use this instead of StageAll when committing at a campaign
+// root to prevent submodule refs from polluting commits.
+func StageAllExcludingSubmodules(ctx context.Context, repoPath string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return git.StageAllExcludingSubmodules(ctx, repoPath)
+}
+
 // ShortHash returns the short commit hash of HEAD in the repository at repoPath.
 func ShortHash(ctx context.Context, repoPath string) (string, error) {
 	if ctx.Err() != nil {


### PR DESCRIPTION
## Summary

- Add `StageAllExcluding` and `StageAllExcludingSubmodules` to `internal/git/commit.go` — stages everything then unstages submodule paths via `git reset HEAD --`
- Add `Executor.StageAllExcludingSubmodules` to `executor.go` and the `GitExecutor` interface
- `camp commit` at campaign root now uses `StageAllExcludingSubmodules` instead of `StageAll`, preventing submodule refs from polluting commits
- `camp project commit` defaults `--sync=false` — ref syncing is now opt-in (`--sync`) instead of opt-out
- `commitkit.StageAllExcludingSubmodules` exposed as public API for `fest commit` and external tools

## Why

Submodule refs are local machine state. When `git add .` stages them alongside actual content, it creates merge conflicts across machines on the least important data (refs) blocking the most important data (festivals, docs, workflow).

## Test plan

- [x] `just build` compiles cleanly
- [x] All 1685 unit tests pass
- [x] All 66 integration tests pass
- [ ] Manual: `camp commit -m "test"` at campaign root only stages campaign content, not `projects/*`
- [ ] Manual: `camp project commit -m "test"` no longer auto-syncs ref (new default)
- [ ] Manual: `camp project commit --sync -m "test"` syncs when explicitly requested