### PR TITLE
Exclude submodule refs from campaign root staging

### DIFF
--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -21,6 +21,10 @@ var commitCmd = &cobra.Command{
 Automatically stages all changes and creates a commit. Handles
 stale lock files from crashed processes.
 
+At the campaign root, submodule ref changes (projects/*) are excluded
+from staging by default to prevent accidental ref conflicts across
+machines. Use --include-refs to stage them explicitly.
+
 Use --sub to commit in the submodule detected from your current directory.
 Use -p/--project to commit in a specific project (e.g., -p projects/camp).
 
@@ -28,17 +32,19 @@ Examples:
   camp commit -m "Add new feature"
   camp commit --amend -m "Fix typo"
   camp commit -a -m "Stage and commit all"
+  camp commit --include-refs -m "Sync all submodule refs"
   camp commit --sub -m "Commit in current submodule"
   camp commit -p projects/camp -m "Commit in camp project"`,
 	RunE: runCommit,
 }
 
 var (
-	commitMessage string
-	commitAll     bool
-	commitAmend   bool
-	commitSub     bool
-	commitProject string
+	commitMessage     string
+	commitAll         bool
+	commitAmend       bool
+	commitSub         bool
+	commitProject     string
+	commitIncludeRefs bool
 )
 
 func init() {
@@ -47,6 +53,7 @@ func init() {
 	commitCmd.Flags().BoolVar(&commitAmend, "amend", false, "Amend the previous commit")
 	commitCmd.Flags().BoolVar(&commitSub, "sub", false, "Operate on the submodule detected from current directory")
 	commitCmd.Flags().StringVarP(&commitProject, "project", "p", "", "Operate on a specific project/submodule path")
+	commitCmd.Flags().BoolVar(&commitIncludeRefs, "include-refs", false, "Include submodule ref changes when staging at campaign root")
 
 	rootCmd.AddCommand(commitCmd)
 	commitCmd.GroupID = "git"
@@ -119,8 +126,20 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	// Stage if requested
 	if commitAll {
 		fmt.Println(ui.Info("Staging changes..."))
-		if err := executor.StageAll(ctx); err != nil {
-			return fmt.Errorf("failed to stage: %w", err)
+		if target.IsSubmodule || commitIncludeRefs {
+			if err := executor.StageAll(ctx); err != nil {
+				return fmt.Errorf("failed to stage: %w", err)
+			}
+		} else {
+			// Campaign root: exclude submodule refs to prevent accidental
+			// ref changes from polluting content commits.
+			paths, pathErr := git.ListSubmodulePaths(ctx, target.Path)
+			if pathErr != nil {
+				return fmt.Errorf("failed to list submodules: %w", pathErr)
+			}
+			if err := git.StageAllExcluding(ctx, target.Path, paths); err != nil {
+				return fmt.Errorf("failed to stage: %w", err)
+			}
 		}
 	}
 

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -171,6 +171,24 @@ func StageFiles(ctx context.Context, repoPath string, files ...string) error {
 	return Stage(ctx, repoPath, files)
 }
 
+// StageAllExcluding stages all changes except paths matching the given exclusions.
+// Uses git pathspec exclusion (`:!path`) for atomic single-operation staging.
+func StageAllExcluding(ctx context.Context, repoPath string, excludePaths []string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	if len(excludePaths) == 0 {
+		return StageAll(ctx, repoPath)
+	}
+
+	files := []string{"--", "."}
+	for _, p := range excludePaths {
+		files = append(files, ":!"+p)
+	}
+	return Stage(ctx, repoPath, files)
+}
+
 // HasStagedChanges checks if there are any staged changes ready to commit.
 func HasStagedChanges(ctx context.Context, repoPath string) (bool, error) {
 	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "diff", "--cached", "--quiet")

--- a/internal/git/commit_test.go
+++ b/internal/git/commit_test.go
@@ -485,6 +485,123 @@ func TestIsLockError(t *testing.T) {
 	})
 }
 
+func TestStageAllExcluding_ExcludesPaths(t *testing.T) {
+	tmpDir := initTestRepo(t)
+
+	// Create files in different directories
+	os.MkdirAll(filepath.Join(tmpDir, "projects", "camp"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "festivals"), 0755)
+	os.WriteFile(filepath.Join(tmpDir, "festivals", "plan.md"), []byte("plan"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "projects", "camp", "main.go"), []byte("package main"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "README.md"), []byte("readme"), 0644)
+
+	ctx := context.Background()
+	err := StageAllExcluding(ctx, tmpDir, []string{"projects/camp"})
+	if err != nil {
+		t.Fatalf("StageAllExcluding() error = %v", err)
+	}
+
+	// Check what's staged
+	cmd := exec.Command("git", "-C", tmpDir, "diff", "--cached", "--name-only")
+	output, _ := cmd.Output()
+	staged := strings.TrimSpace(string(output))
+
+	if !strings.Contains(staged, "festivals/plan.md") {
+		t.Error("Expected festivals/plan.md to be staged")
+	}
+	if !strings.Contains(staged, "README.md") {
+		t.Error("Expected README.md to be staged")
+	}
+	if strings.Contains(staged, "projects/camp") {
+		t.Error("Expected projects/camp to be excluded from staging")
+	}
+}
+
+func TestStageAllExcluding_NoExclusions(t *testing.T) {
+	tmpDir := initTestRepo(t)
+
+	os.WriteFile(filepath.Join(tmpDir, "test.txt"), []byte("content"), 0644)
+
+	ctx := context.Background()
+	err := StageAllExcluding(ctx, tmpDir, nil)
+	if err != nil {
+		t.Fatalf("StageAllExcluding() with nil exclusions error = %v", err)
+	}
+
+	hasStaged, err := HasStagedChanges(ctx, tmpDir)
+	if err != nil {
+		t.Fatalf("HasStagedChanges() error = %v", err)
+	}
+	if !hasStaged {
+		t.Error("Expected staged changes when no exclusions provided")
+	}
+}
+
+func TestStageAllExcluding_EmptyExclusions(t *testing.T) {
+	tmpDir := initTestRepo(t)
+
+	os.WriteFile(filepath.Join(tmpDir, "test.txt"), []byte("content"), 0644)
+
+	ctx := context.Background()
+	err := StageAllExcluding(ctx, tmpDir, []string{})
+	if err != nil {
+		t.Fatalf("StageAllExcluding() with empty exclusions error = %v", err)
+	}
+
+	hasStaged, err := HasStagedChanges(ctx, tmpDir)
+	if err != nil {
+		t.Fatalf("HasStagedChanges() error = %v", err)
+	}
+	if !hasStaged {
+		t.Error("Expected staged changes when empty exclusions provided")
+	}
+}
+
+func TestStageAllExcluding_CancelledContext(t *testing.T) {
+	tmpDir := initTestRepo(t)
+	os.WriteFile(filepath.Join(tmpDir, "test.txt"), []byte("content"), 0644)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := StageAllExcluding(ctx, tmpDir, []string{"some/path"})
+	if err == nil {
+		t.Error("Expected error for cancelled context")
+	}
+}
+
+func TestStageAllExcluding_MultipleExclusions(t *testing.T) {
+	tmpDir := initTestRepo(t)
+
+	// Create files in multiple directories
+	os.MkdirAll(filepath.Join(tmpDir, "projects", "alpha"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "projects", "beta"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "docs"), 0755)
+	os.WriteFile(filepath.Join(tmpDir, "projects", "alpha", "go.mod"), []byte("module alpha"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "projects", "beta", "go.mod"), []byte("module beta"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "docs", "guide.md"), []byte("guide"), 0644)
+
+	ctx := context.Background()
+	err := StageAllExcluding(ctx, tmpDir, []string{"projects/alpha", "projects/beta"})
+	if err != nil {
+		t.Fatalf("StageAllExcluding() error = %v", err)
+	}
+
+	cmd := exec.Command("git", "-C", tmpDir, "diff", "--cached", "--name-only")
+	output, _ := cmd.Output()
+	staged := strings.TrimSpace(string(output))
+
+	if !strings.Contains(staged, "docs/guide.md") {
+		t.Error("Expected docs/guide.md to be staged")
+	}
+	if strings.Contains(staged, "projects/alpha") {
+		t.Error("Expected projects/alpha to be excluded")
+	}
+	if strings.Contains(staged, "projects/beta") {
+		t.Error("Expected projects/beta to be excluded")
+	}
+}
+
 func TestStage_WithStaleLock(t *testing.T) {
 	tmpDir := initTestRepo(t)
 


### PR DESCRIPTION
## Summary

- `camp commit` at campaign root now excludes submodule ref changes (`projects/*`) from staging by default
- Uses git pathspec exclusion (`:!path`) — a single atomic `git add` operation, no stage-then-unstage
- Adds `--include-refs` flag to explicitly include submodule refs when needed
- **Does NOT change** `camp project commit --sync` default — auto-sync remains `true`

## Why

Submodule refs change frequently and independently on different machines. When `git add .` stages them alongside actual campaign content (festivals, docs, workflow), it creates merge conflicts on the least important data (refs) blocking the most important data (content).

This replaces #100 which was closed because it:
1. Flipped `--sync` default (silent breaking change)
2. Used fragile stage-then-unstage approach (non-atomic)
3. Together with the sync change, orphaned submodule refs entirely

## Workflow after this change

| Command | Behavior |
|---------|----------|
| `camp commit -m "update festival"` | Stages campaign content only, excludes refs |
| `camp commit --include-refs -m "sync refs"` | Stages everything including refs |
| `camp project commit -m "feature"` | Commits in project, auto-syncs that project's ref (unchanged) |

## Test plan

- [x] `just build` compiles cleanly
- [x] All 1691 unit tests pass (5 new tests for `StageAllExcluding`)
- [x] All 66 integration tests pass
- [ ] Manual: `camp commit -m "test"` at campaign root excludes `projects/*`
- [ ] Manual: `camp commit --include-refs -m "test"` stages everything
- [ ] Manual: `camp project commit -m "test"` still auto-syncs ref