### PR TITLE
Replace fmt.Errorf with structured errors in git/commit

### DIFF
--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -91,7 +91,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	// Find campaign root
 	campRoot, err := campaign.DetectCached(ctx)
 	if err != nil {
-		return fmt.Errorf("not in a campaign: %w", err)
+		return err
 	}
 
 	// Resolve target repository
@@ -119,7 +119,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("prompt failed: %w", promptErr)
 		}
 		if message == "" {
-			return fmt.Errorf("commit cancelled")
+			return git.ErrCommitCancelled
 		}
 	}
 
@@ -128,17 +128,17 @@ func runCommit(cmd *cobra.Command, args []string) error {
 		fmt.Println(ui.Info("Staging changes..."))
 		if target.IsSubmodule || commitIncludeRefs {
 			if err := executor.StageAll(ctx); err != nil {
-				return fmt.Errorf("failed to stage: %w", err)
+				return err
 			}
 		} else {
 			// Campaign root: exclude submodule refs to prevent accidental
 			// ref changes from polluting content commits.
 			paths, pathErr := git.ListSubmodulePaths(ctx, target.Path)
 			if pathErr != nil {
-				return fmt.Errorf("failed to list submodules: %w", pathErr)
+				return pathErr
 			}
 			if err := git.StageAllExcluding(ctx, target.Path, paths); err != nil {
-				return fmt.Errorf("failed to stage: %w", err)
+				return err
 			}
 		}
 	}
@@ -173,7 +173,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 			fmt.Println(ui.Success("Nothing to commit"))
 			return nil
 		}
-		return fmt.Errorf("commit failed: %w", err)
+		return err
 	}
 
 	fmt.Println(ui.Success("Changes committed successfully"))

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -3,7 +3,6 @@ package git
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -19,7 +18,7 @@ type CommitOptions struct {
 // Validate checks if options are valid.
 func (o *CommitOptions) Validate() error {
 	if o.Message == "" && !o.Amend {
-		return fmt.Errorf("commit message is required")
+		return ErrCommitMessageRequired
 	}
 	return nil
 }
@@ -27,7 +26,7 @@ func (o *CommitOptions) Validate() error {
 // Commit creates a git commit with automatic lock handling.
 func Commit(ctx context.Context, repoPath string, opts *CommitOptions) error {
 	if opts == nil {
-		return fmt.Errorf("commit options required")
+		return ErrCommitOptionsRequired
 	}
 	if err := opts.Validate(); err != nil {
 		return err
@@ -73,10 +72,12 @@ func executeCommit(ctx context.Context, repoPath string, opts *CommitOptions) er
 				Err:  err,
 			}
 		default:
-			return fmt.Errorf("git commit failed (type=%s): %s: %w",
-				errType.String(),
-				strings.TrimSpace(string(output)),
-				err)
+			return &GitOpError{
+				Op:      "commit",
+				ErrType: errType,
+				Detail:  strings.TrimSpace(string(output)),
+				Cause:   err,
+			}
 		}
 	}
 
@@ -93,7 +94,7 @@ func isLockError(err error) bool {
 func CommitAll(ctx context.Context, repoPath, message string) error {
 	// Stage all changes first
 	if err := StageAll(ctx, repoPath); err != nil {
-		return fmt.Errorf("failed to stage changes: %w", err)
+		return err
 	}
 
 	// Check if there's anything to commit
@@ -149,10 +150,12 @@ func executeStage(ctx context.Context, repoPath string, files []string) error {
 			}
 		}
 
-		return fmt.Errorf("git add failed (type=%s): %s: %w",
-			errType.String(),
-			strings.TrimSpace(string(output)),
-			err)
+		return &GitOpError{
+			Op:      "add",
+			ErrType: errType,
+			Detail:  strings.TrimSpace(string(output)),
+			Cause:   err,
+		}
 	}
 
 	return nil
@@ -166,7 +169,7 @@ func StageAll(ctx context.Context, repoPath string) error {
 // StageFiles stages specific files.
 func StageFiles(ctx context.Context, repoPath string, files ...string) error {
 	if len(files) == 0 {
-		return fmt.Errorf("no files specified for staging in %s", repoPath)
+		return ErrNoFilesSpecified
 	}
 	return Stage(ctx, repoPath, files)
 }
@@ -201,7 +204,7 @@ func HasStagedChanges(ctx context.Context, repoPath string) (bool, error) {
 				return true, nil
 			}
 		}
-		return false, fmt.Errorf("git diff --cached failed: %w", err)
+		return false, &GitOpError{Op: "diff --cached", Cause: err}
 	}
 
 	// Exit code 0 means no differences (nothing staged)
@@ -219,7 +222,7 @@ func HasUnstagedChanges(ctx context.Context, repoPath string) (bool, error) {
 				return true, nil
 			}
 		}
-		return false, fmt.Errorf("git diff failed: %w", err)
+		return false, &GitOpError{Op: "diff", Cause: err}
 	}
 
 	return false, nil
@@ -231,7 +234,7 @@ func HasUntrackedFiles(ctx context.Context, repoPath string) (bool, error) {
 	output, err := cmd.Output()
 
 	if err != nil {
-		return false, fmt.Errorf("git ls-files failed: %w", err)
+		return false, &GitOpError{Op: "ls-files", Cause: err}
 	}
 
 	return len(strings.TrimSpace(string(output))) > 0, nil

--- a/internal/git/errors.go
+++ b/internal/git/errors.go
@@ -76,6 +76,31 @@ func (e *LockError) Unwrap() error {
 	return e.Err
 }
 
+// GitOpError wraps errors from git command execution with structured context.
+type GitOpError struct {
+	// Op is the git operation that failed (e.g., "commit", "add", "diff").
+	Op string
+	// ErrType is the classified error type from git stderr.
+	ErrType GitErrorType
+	// Detail is the trimmed git stderr output.
+	Detail string
+	// Cause is the underlying exec error.
+	Cause error
+}
+
+// Error implements the error interface.
+func (e *GitOpError) Error() string {
+	if e.Detail != "" {
+		return fmt.Sprintf("git %s failed (%s): %s", e.Op, e.ErrType.String(), e.Detail)
+	}
+	return fmt.Sprintf("git %s failed (%s)", e.Op, e.ErrType.String())
+}
+
+// Unwrap returns the underlying error for errors.Is/As support.
+func (e *GitOpError) Unwrap() error {
+	return e.Cause
+}
+
 // Sentinel errors for common git error cases.
 var (
 	// ErrLockActive indicates a lock file is held by a running process.
@@ -119,6 +144,24 @@ var (
 
 	// ErrOrphanedGitlink indicates a gitlink exists in the index but has no entry in .gitmodules.
 	ErrOrphanedGitlink = errors.New("orphaned gitlink in index")
+
+	// ErrStage indicates a staging (git add) operation failed.
+	ErrStage = errors.New("staging failed")
+
+	// ErrCommitFailed indicates a git commit operation failed.
+	ErrCommitFailed = errors.New("commit failed")
+
+	// ErrCommitCancelled indicates the user cancelled the commit.
+	ErrCommitCancelled = errors.New("commit cancelled")
+
+	// ErrCommitOptionsRequired indicates nil commit options were provided.
+	ErrCommitOptionsRequired = errors.New("commit options required")
+
+	// ErrCommitMessageRequired indicates a commit message was not provided.
+	ErrCommitMessageRequired = errors.New("commit message is required")
+
+	// ErrNoFilesSpecified indicates an empty file list was provided for staging.
+	ErrNoFilesSpecified = errors.New("no files specified for staging")
 )
 
 // ClassifyGitError determines the error type from git stderr output.

--- a/internal/git/errors_test.go
+++ b/internal/git/errors_test.go
@@ -223,6 +223,12 @@ func TestSentinelErrors(t *testing.T) {
 		ErrLockRemovalFailed,
 		ErrNotRepository,
 		ErrNoChanges,
+		ErrStage,
+		ErrCommitFailed,
+		ErrCommitCancelled,
+		ErrCommitOptionsRequired,
+		ErrCommitMessageRequired,
+		ErrNoFilesSpecified,
 	}
 
 	for i, err1 := range sentinels {
@@ -231,5 +237,84 @@ func TestSentinelErrors(t *testing.T) {
 				t.Errorf("sentinel errors should be distinct: %v == %v", err1, err2)
 			}
 		}
+	}
+}
+
+func TestGitOpError_Error(t *testing.T) {
+	tests := []struct {
+		name    string
+		opErr   *GitOpError
+		wantMsg string
+	}{
+		{
+			name: "with detail",
+			opErr: &GitOpError{
+				Op:      "commit",
+				ErrType: GitErrorUnknown,
+				Detail:  "some git output",
+				Cause:   errors.New("exit status 1"),
+			},
+			wantMsg: "git commit failed (unknown): some git output",
+		},
+		{
+			name: "without detail",
+			opErr: &GitOpError{
+				Op:      "add",
+				ErrType: GitErrorPermission,
+				Cause:   errors.New("exit status 128"),
+			},
+			wantMsg: "git add failed (permission)",
+		},
+		{
+			name: "lock type with detail",
+			opErr: &GitOpError{
+				Op:      "diff --cached",
+				ErrType: GitErrorLock,
+				Detail:  "index.lock exists",
+				Cause:   errors.New("exit status 128"),
+			},
+			wantMsg: "git diff --cached failed (lock): index.lock exists",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.opErr.Error()
+			if got != tt.wantMsg {
+				t.Errorf("GitOpError.Error() = %q, want %q", got, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestGitOpError_Unwrap(t *testing.T) {
+	underlying := errors.New("exit status 1")
+	opErr := &GitOpError{
+		Op:    "commit",
+		Cause: underlying,
+	}
+
+	if !errors.Is(opErr, underlying) {
+		t.Error("GitOpError.Unwrap() should allow errors.Is to find underlying error")
+	}
+}
+
+func TestGitOpError_As(t *testing.T) {
+	opErr := &GitOpError{
+		Op:      "add",
+		ErrType: GitErrorPermission,
+		Detail:  "permission denied",
+		Cause:   errors.New("exit status 128"),
+	}
+
+	var target *GitOpError
+	if !errors.As(opErr, &target) {
+		t.Fatal("errors.As should match *GitOpError")
+	}
+	if target.Op != "add" {
+		t.Errorf("GitOpError.Op = %q, want %q", target.Op, "add")
+	}
+	if target.ErrType != GitErrorPermission {
+		t.Errorf("GitOpError.ErrType = %v, want %v", target.ErrType, GitErrorPermission)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `GitOpError` structured error type to `internal/git/errors.go` following the existing `SyncError`/`SubmoduleError` pattern from other packages
- Adds sentinel errors (`ErrStage`, `ErrCommitFailed`, `ErrCommitCancelled`, `ErrCommitOptionsRequired`, `ErrCommitMessageRequired`, `ErrNoFilesSpecified`) for programmatic error checking
- Replaces all `fmt.Errorf` calls in `internal/git/commit.go` with sentinel errors and `GitOpError` structured types
- Removes redundant error wrapping in `cmd/camp/commit.go` — the git package now returns descriptive `GitOpError` types, so double-wrapping with `"failed to stage: git add failed (...): ..."` is eliminated
- Includes table-driven tests for `GitOpError.Error()`, `Unwrap()`, and `errors.As`

## Motivation

PR #101 introduced `fmt.Errorf` wrapping that violated the project's error handling conventions. The root CLAUDE.md specifies "Never use `fmt.Errorf` in production code" and the project has an established pattern of sentinel errors + structured error types per package.

## Changes

| File | Change |
|------|--------|
| `internal/git/errors.go` | Add `GitOpError` type + 6 sentinel errors |
| `internal/git/errors_test.go` | Add tests for `GitOpError` + expanded sentinel distinctness test |
| `internal/git/commit.go` | Replace all `fmt.Errorf` → sentinels/`GitOpError` (removes `fmt` import) |
| `cmd/camp/commit.go` | Remove redundant wrapping, use `git.ErrCommitCancelled` sentinel |

## Test plan
- [x] `go build ./...` — clean compilation
- [x] `go test ./...` — all tests pass (0 failures)
- [x] `just lint` — clean
- [x] New `GitOpError` tests pass (Error, Unwrap, As)
- [x] Expanded sentinel distinctness test covers new errors