### PR TITLE
feat: make camp switch agent-friendly

### DIFF
--- a/cmd/camp/manifest_test.go
+++ b/cmd/camp/manifest_test.go
@@ -112,6 +112,7 @@ func TestManifestCommand_AllCommandsHaveAnnotations(t *testing.T) {
 		"dungeon list": true,
 		"dungeon move": true,
 		"flow add":     true,
+		"switch":       true,
 	}
 
 	for _, cmd := range manifest.Commands {

--- a/cmd/camp/switch.go
+++ b/cmd/camp/switch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/nav/fuzzy"
+	"github.com/Obedience-Corp/camp/internal/nav/tui"
 )
 
 var switchCmd = &cobra.Command{
@@ -37,8 +38,8 @@ The --print flag outputs just the path for shell integration:
 	Aliases: []string{"sw"},
 	Args:    cobra.MaximumNArgs(1),
 	Annotations: map[string]string{
-		"agent_allowed": "false",
-		"agent_reason":  "Interactive campaign picker — sandbox escape vector",
+		"agent_allowed": "true",
+		"agent_reason":  "Agents use: camp switch <name> --print",
 		"interactive":   "true",
 	},
 	RunE: runSwitch,
@@ -102,6 +103,9 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 		}
 		selected = c
 	} else {
+		if !tui.IsTerminal() {
+			return fmt.Errorf("campaign name required in non-interactive mode\n       Usage: camp switch <name> --print")
+		}
 		c, err := pickCampaign(cmd, reg)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary

- Flip `agent_allowed` to `true` on the `switch` command so agents can use `camp switch <name> --print` to resolve campaign paths
- Add a `tui.IsTerminal()` guard before launching the fuzzyfinder picker — returns a clear error with usage hint when no campaign name is provided in non-interactive mode
- Add `switch` to the agent-allowed allowlist in manifest tests

## Test plan

- [x] `go build ./cmd/camp/` compiles
- [x] `go test ./cmd/camp/ -run TestManifest -v` — all 5 manifest tests pass
- [ ] `camp switch obey-campaign --print` outputs path
- [ ] `echo "" | camp switch --print` returns error: "campaign name required in non-interactive mode"
- [ ] `camp __manifest | jq '.commands[] | select(.path=="switch")'` shows `agent_allowed: true`