### PR TITLE
fix: Windows cross-compilation for TermWidth and git locks

### DIFF
--- a/internal/buildutil/ui/ansi.go
+++ b/internal/buildutil/ui/ansi.go
@@ -1,13 +1,9 @@
-// internal/buildutil/ui/ansi.go
 package ui
 
 import (
-	"fmt"
 	"os"
 	"strings"
-	"syscall"
 	"unicode/utf8"
-	"unsafe"
 )
 
 var noColor bool
@@ -44,47 +40,6 @@ func isatty() bool {
 		return false
 	}
 	return fi.Mode()&os.ModeCharDevice != 0
-}
-
-// TIOCGWINSZ is the ioctl command to get window size (macOS/Darwin)
-const TIOCGWINSZ = 0x40087468
-
-// TermWidth returns the terminal width
-func TermWidth() int {
-	if cols := os.Getenv("COLUMNS"); cols != "" {
-		var width int
-		fmt.Sscanf(cols, "%d", &width)
-		if width > 0 {
-			return width
-		}
-	}
-
-	type winsize struct {
-		Row    uint16
-		Col    uint16
-		Xpixel uint16
-		Ypixel uint16
-	}
-	ws := &winsize{}
-
-	_, _, err := syscall.Syscall(syscall.SYS_IOCTL,
-		uintptr(os.Stdout.Fd()),
-		uintptr(TIOCGWINSZ),
-		uintptr(unsafe.Pointer(ws)),
-	)
-
-	if (err != 0 || ws.Col == 0) && isatty() {
-		_, _, err = syscall.Syscall(syscall.SYS_IOCTL,
-			uintptr(os.Stderr.Fd()),
-			uintptr(TIOCGWINSZ),
-			uintptr(unsafe.Pointer(ws)),
-		)
-	}
-
-	if err != 0 || ws.Col == 0 {
-		return 80
-	}
-	return int(ws.Col)
 }
 
 // Center centers text to given width

--- a/internal/buildutil/ui/ansi_unix.go
+++ b/internal/buildutil/ui/ansi_unix.go
@@ -1,0 +1,51 @@
+//go:build unix
+
+package ui
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// TIOCGWINSZ is the ioctl command to get window size (macOS/Darwin)
+const TIOCGWINSZ = 0x40087468
+
+// TermWidth returns the terminal width
+func TermWidth() int {
+	if cols := os.Getenv("COLUMNS"); cols != "" {
+		var width int
+		fmt.Sscanf(cols, "%d", &width)
+		if width > 0 {
+			return width
+		}
+	}
+
+	type winsize struct {
+		Row    uint16
+		Col    uint16
+		Xpixel uint16
+		Ypixel uint16
+	}
+	ws := &winsize{}
+
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL,
+		uintptr(os.Stdout.Fd()),
+		uintptr(TIOCGWINSZ),
+		uintptr(unsafe.Pointer(ws)),
+	)
+
+	if (err != 0 || ws.Col == 0) && isatty() {
+		_, _, err = syscall.Syscall(syscall.SYS_IOCTL,
+			uintptr(os.Stderr.Fd()),
+			uintptr(TIOCGWINSZ),
+			uintptr(unsafe.Pointer(ws)),
+		)
+	}
+
+	if err != 0 || ws.Col == 0 {
+		return 80
+	}
+	return int(ws.Col)
+}

--- a/internal/buildutil/ui/ansi_windows.go
+++ b/internal/buildutil/ui/ansi_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package ui
+
+import (
+	"fmt"
+	"os"
+)
+
+// TermWidth returns the terminal width.
+// On Windows, it reads the COLUMNS environment variable or falls back to 80.
+func TermWidth() int {
+	if cols := os.Getenv("COLUMNS"); cols != "" {
+		var width int
+		fmt.Sscanf(cols, "%d", &width)
+		if width > 0 {
+			return width
+		}
+	}
+	return 80
+}


### PR DESCRIPTION
## Summary

- Split `internal/buildutil/ui/ansi.go` into platform-specific files to fix `syscall.SYS_IOCTL` undefined on Windows:
  - `ansi.go` — platform-agnostic ANSI utilities (no syscall/unsafe imports)
  - `ansi_unix.go` — `TermWidth()` with ioctl implementation (`//go:build unix`)
  - `ansi_windows.go` — `TermWidth()` with `COLUMNS` env fallback (`//go:build windows`)
- `lock_windows.go` (already on develop) provides no-op stubs for `RemovalResult`, `CleanStaleLocks`, `WaitForLockRelease`, and `LockInfo`

## Test plan

- [x] `GOOS=windows GOARCH=amd64 go build ./...` passes
- [x] `GOOS=linux GOARCH=amd64 go build ./...` passes
- [x] Native darwin build passes
- [x] `go test ./internal/git/... ./internal/buildutil/ui/...` passes