### PR TITLE
fix(nav): invalidate worktree index cache on topology changes

### DIFF
--- a/internal/nav/index/cache.go
+++ b/internal/nav/index/cache.go
@@ -138,6 +138,33 @@ func IsStale(idx *Index, campaignRoot string) bool {
 		return true
 	}
 
+	// Check worktree topology changes. Worktree add/remove operations mutate:
+	// 1) projects/worktrees/ when projects are added/removed
+	// 2) projects/worktrees/<project>/ when worktree dirs are added/removed
+	//
+	// We intentionally avoid checking individual worktree directories, so regular
+	// file edits inside a worktree do not invalidate the navigation cache.
+	worktreesDir := filepath.Join(projectsDir, "worktrees")
+	info, err = os.Stat(worktreesDir)
+	if err == nil && info.ModTime().After(idx.BuildTime) {
+		return true
+	}
+	if err == nil && info.IsDir() {
+		projectDirs, readErr := os.ReadDir(worktreesDir)
+		if readErr == nil {
+			for _, entry := range projectDirs {
+				if !entry.IsDir() {
+					continue
+				}
+				projectDirPath := filepath.Join(worktreesDir, entry.Name())
+				projectInfo, statErr := os.Stat(projectDirPath)
+				if statErr == nil && projectInfo.ModTime().After(idx.BuildTime) {
+					return true
+				}
+			}
+		}
+	}
+
 	return false
 }
 

--- a/internal/nav/index/cache_test.go
+++ b/internal/nav/index/cache_test.go
@@ -493,6 +493,63 @@ func TestIsStale_ProjectsDirDoesNotExist(t *testing.T) {
 	}
 }
 
+func TestIsStale_WorktreesDirChanged(t *testing.T) {
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+
+	worktreesDir := filepath.Join(root, "projects", "worktrees")
+	if err := os.MkdirAll(worktreesDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := &Index{
+		BuildTime: time.Now().Add(-1 * time.Hour),
+		Version:   IndexVersion,
+	}
+
+	now := time.Now()
+	if err := os.Chtimes(worktreesDir, now, now); err != nil {
+		t.Fatal(err)
+	}
+
+	if !IsStale(idx, root) {
+		t.Error("Index should be stale when projects/worktrees/ directory is newer")
+	}
+}
+
+func TestIsStale_WorktreeProjectDirChanged(t *testing.T) {
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+
+	worktreesDir := filepath.Join(root, "projects", "worktrees")
+	projectDir := filepath.Join(worktreesDir, "camp")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	buildTime := time.Now().Add(-1 * time.Hour)
+	idx := &Index{
+		BuildTime: buildTime,
+		Version:   IndexVersion,
+	}
+
+	// Keep projects/worktrees older than the index build time so this test
+	// specifically validates per-project worktree directory invalidation.
+	older := buildTime.Add(-1 * time.Minute)
+	if err := os.Chtimes(worktreesDir, older, older); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	if err := os.Chtimes(projectDir, now, now); err != nil {
+		t.Fatal(err)
+	}
+
+	if !IsStale(idx, root) {
+		t.Error("Index should be stale when projects/worktrees/<project>/ is newer")
+	}
+}
+
 // Benchmarks
 
 func BenchmarkLoad(b *testing.B) {


### PR DESCRIPTION
## Summary
- invalidate nav index cache when `projects/worktrees/` changes
- invalidate cache when `projects/worktrees/<project>/` changes (worktree add/remove)
- add regression tests for both invalidation paths

## Why
`cgo wt` completion and navigation could use stale worktree index entries after worktree directories changed, causing missing new worktrees or stale paths that fail on `cd`.

## Validation
- `go test ./internal/nav/index ./internal/complete`

Closes #130
