### PR TITLE
fix: filter untracked source paths from dungeon crawl commit scope

### DIFF
--- a/cmd/camp/dungeon_crawl.go
+++ b/cmd/camp/dungeon_crawl.go
@@ -153,9 +153,9 @@ func commitCrawlChanges(ctx context.Context, cfg *config.CampaignConfig, campaig
 
 	files := []string{relDungeon}
 
-	// For triage moves, stage source deletions and include specific
-	// source paths in the commit scope. Avoids using relCwd which
-	// would be "." at campaign root, capturing unrelated changes.
+	// For triage moves, include source deletions in the commit scope.
+	// Only include paths git actually tracks to avoid "pathspec did not
+	// match" errors when the parent directory was renamed or never committed.
 	if triage != nil && triage.HasMoves() {
 		var sourcePaths []string
 		for _, names := range triage.MovedItems {
@@ -164,10 +164,16 @@ func commitCrawlChanges(ctx context.Context, cfg *config.CampaignConfig, campaig
 			}
 		}
 		if len(sourcePaths) > 0 {
-			if err := git.StageTrackedChanges(ctx, campaignRoot, sourcePaths...); err != nil {
-				fmt.Printf("%s Warning: could not stage source deletions: %v\n", ui.InfoIcon(), err)
+			tracked, filterErr := git.FilterTracked(ctx, campaignRoot, sourcePaths)
+			if filterErr != nil {
+				fmt.Printf("%s Warning: could not check tracked paths: %v\n", ui.InfoIcon(), filterErr)
 			}
-			files = append(files, sourcePaths...)
+			if len(tracked) > 0 {
+				if err := git.StageTrackedChanges(ctx, campaignRoot, tracked...); err != nil {
+					fmt.Printf("%s Warning: could not stage source deletions: %v\n", ui.InfoIcon(), err)
+				}
+				files = append(files, tracked...)
+			}
 		}
 	}
 

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -194,6 +194,54 @@ func StageTrackedChanges(ctx context.Context, repoPath string, paths ...string) 
 	})
 }
 
+// FilterTracked returns only the paths from the input that git currently tracks.
+// For directories, a path is considered tracked if any file under it is in the index.
+// Useful for filtering commit scopes to avoid "pathspec did not match" errors.
+func FilterTracked(ctx context.Context, repoPath string, paths []string) ([]string, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+
+	args := []string{"-C", repoPath, "ls-files", "--"}
+	args = append(args, paths...)
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, camperrors.NewGit("ls-files", "", "", strings.TrimSpace(string(output)), err)
+	}
+
+	raw := strings.TrimSpace(string(output))
+	if raw == "" {
+		return nil, nil
+	}
+
+	// Build a set of tracked file paths returned by git
+	trackedFiles := strings.Split(raw, "\n")
+	trackedSet := make(map[string]bool, len(trackedFiles))
+	for _, f := range trackedFiles {
+		trackedSet[f] = true
+	}
+
+	var result []string
+	for _, p := range paths {
+		// Exact match (file path)
+		if trackedSet[p] {
+			result = append(result, p)
+			continue
+		}
+		// Directory match: check if any tracked file has this prefix
+		prefix := p + "/"
+		for t := range trackedSet {
+			if strings.HasPrefix(t, prefix) {
+				result = append(result, p)
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
 // StageFiles stages specific files.
 func StageFiles(ctx context.Context, repoPath string, files ...string) error {
 	if len(files) == 0 {

--- a/internal/git/commit_test.go
+++ b/internal/git/commit_test.go
@@ -602,6 +602,117 @@ func TestStageAllExcluding_MultipleExclusions(t *testing.T) {
 	}
 }
 
+func TestFilterTracked(t *testing.T) {
+	t.Run("empty paths", func(t *testing.T) {
+		tmpDir := initTestRepo(t)
+		ctx := context.Background()
+		result, err := FilterTracked(ctx, tmpDir, nil)
+		if err != nil {
+			t.Fatalf("FilterTracked() error = %v", err)
+		}
+		if result != nil {
+			t.Errorf("FilterTracked() = %v, want nil", result)
+		}
+	})
+
+	t.Run("tracked file returned", func(t *testing.T) {
+		tmpDir := initTestRepo(t)
+		os.WriteFile(filepath.Join(tmpDir, "a.txt"), []byte("a"), 0644)
+		exec.Command("git", "-C", tmpDir, "add", "a.txt").Run()
+		exec.Command("git", "-C", tmpDir, "commit", "-m", "init").Run()
+
+		ctx := context.Background()
+		result, err := FilterTracked(ctx, tmpDir, []string{"a.txt"})
+		if err != nil {
+			t.Fatalf("FilterTracked() error = %v", err)
+		}
+		if len(result) != 1 || result[0] != "a.txt" {
+			t.Errorf("FilterTracked() = %v, want [a.txt]", result)
+		}
+	})
+
+	t.Run("untracked file excluded", func(t *testing.T) {
+		tmpDir := initTestRepo(t)
+		os.WriteFile(filepath.Join(tmpDir, "a.txt"), []byte("a"), 0644)
+		exec.Command("git", "-C", tmpDir, "add", "a.txt").Run()
+		exec.Command("git", "-C", tmpDir, "commit", "-m", "init").Run()
+		os.WriteFile(filepath.Join(tmpDir, "b.txt"), []byte("b"), 0644)
+
+		ctx := context.Background()
+		result, err := FilterTracked(ctx, tmpDir, []string{"a.txt", "b.txt"})
+		if err != nil {
+			t.Fatalf("FilterTracked() error = %v", err)
+		}
+		if len(result) != 1 || result[0] != "a.txt" {
+			t.Errorf("FilterTracked() = %v, want [a.txt]", result)
+		}
+	})
+
+	t.Run("nonexistent path excluded", func(t *testing.T) {
+		tmpDir := initTestRepo(t)
+		os.WriteFile(filepath.Join(tmpDir, "a.txt"), []byte("a"), 0644)
+		exec.Command("git", "-C", tmpDir, "add", "a.txt").Run()
+		exec.Command("git", "-C", tmpDir, "commit", "-m", "init").Run()
+
+		ctx := context.Background()
+		result, err := FilterTracked(ctx, tmpDir, []string{"a.txt", "nonexistent.txt"})
+		if err != nil {
+			t.Fatalf("FilterTracked() error = %v", err)
+		}
+		if len(result) != 1 || result[0] != "a.txt" {
+			t.Errorf("FilterTracked() = %v, want [a.txt]", result)
+		}
+	})
+
+	t.Run("directory with tracked files", func(t *testing.T) {
+		tmpDir := initTestRepo(t)
+		os.MkdirAll(filepath.Join(tmpDir, "subdir"), 0755)
+		os.WriteFile(filepath.Join(tmpDir, "subdir", "file.txt"), []byte("content"), 0644)
+		exec.Command("git", "-C", tmpDir, "add", ".").Run()
+		exec.Command("git", "-C", tmpDir, "commit", "-m", "init").Run()
+
+		ctx := context.Background()
+		result, err := FilterTracked(ctx, tmpDir, []string{"subdir"})
+		if err != nil {
+			t.Fatalf("FilterTracked() error = %v", err)
+		}
+		if len(result) != 1 || result[0] != "subdir" {
+			t.Errorf("FilterTracked() = %v, want [subdir]", result)
+		}
+	})
+
+	t.Run("renamed directory not tracked", func(t *testing.T) {
+		tmpDir := initTestRepo(t)
+		os.MkdirAll(filepath.Join(tmpDir, "old-name"), 0755)
+		os.WriteFile(filepath.Join(tmpDir, "old-name", "file.txt"), []byte("content"), 0644)
+		exec.Command("git", "-C", tmpDir, "add", ".").Run()
+		exec.Command("git", "-C", tmpDir, "commit", "-m", "init").Run()
+
+		// Rename without telling git
+		os.Rename(filepath.Join(tmpDir, "old-name"), filepath.Join(tmpDir, "new-name"))
+
+		ctx := context.Background()
+		result, err := FilterTracked(ctx, tmpDir, []string{"new-name"})
+		if err != nil {
+			t.Fatalf("FilterTracked() error = %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("FilterTracked() = %v, want empty (new-name was never tracked)", result)
+		}
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		tmpDir := initTestRepo(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := FilterTracked(ctx, tmpDir, []string{"anything"})
+		if err == nil {
+			t.Error("Expected error for cancelled context")
+		}
+	})
+}
+
 func TestStage_WithStaleLock(t *testing.T) {
 	tmpDir := initTestRepo(t)
 


### PR DESCRIPTION
## Summary

- Adds `FilterTracked()` to `internal/git` — uses `git ls-files` to identify which paths are actually in the index, supporting both files and directories
- Filters source paths in `commitCrawlChanges()` before staging and committing, so untracked/renamed paths are silently excluded rather than causing the entire commit to fail

## Problem

When a directory is renamed before running `camp dungeon crawl`, source paths may never have been tracked under their current name. Including these in the commit file list causes `git add` to fail with "pathspec did not match", which prevents even the valid dungeon additions from being committed.

Identified during staff review of PR #137.

## Changed Files

- `internal/git/commit.go` — Add `FilterTracked()` function
- `internal/git/commit_test.go` — 7 test cases including renamed-directory scenario
- `cmd/camp/dungeon_crawl.go` — Filter source paths through `FilterTracked` before staging

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./internal/git/...` passes (all existing + 7 new tests)
- [x] New test covers exact bug scenario: directory renamed, new name not tracked → filtered out
- [ ] Manual: rename a tracked directory, run `camp dungeon crawl`, triage items → commit should succeed for dungeon additions

Fixes #138