### PR TITLE
[OBEY-CAMPAIGN-8deed8b4] Fix init --repair

### DIFF
--- a/internal/scaffold/repair.go
+++ b/internal/scaffold/repair.go
@@ -201,10 +201,12 @@ func computeJumpsChanges(ctx context.Context, absDir string, plan *RepairPlan) e
 		merged.Shortcuts[k] = v
 	}
 
-	// Identify user-defined shortcuts (source != "auto" or source empty on legacy entries).
+	// Identify user-defined shortcuts — only show truly user-defined ones.
+	// Default shortcuts that already exist and match are silently kept.
+	defShortcuts := config.DefaultNavigationShortcuts()
 	for _, key := range sortedKeys(existing.Shortcuts) {
 		sc := existing.Shortcuts[key]
-		if isUserDefined(sc) {
+		if isUserDefined(sc, key, defShortcuts) {
 			plan.Changes = append(plan.Changes, RepairChange{
 				Type:        RepairPreserve,
 				Category:    "shortcut",
@@ -255,9 +257,24 @@ func computeMiscFileChanges(absDir string, plan *RepairPlan) {
 }
 
 // isUserDefined returns true if a shortcut was added by the user (not auto-generated).
-// Legacy entries without a Source field are treated as user-defined (safe default).
-func isUserDefined(sc config.ShortcutConfig) bool {
-	return sc.Source != config.ShortcutSourceAuto
+// Legacy entries (empty Source) are checked against known defaults before being classified.
+func isUserDefined(sc config.ShortcutConfig, key string, defaults map[string]config.ShortcutConfig) bool {
+	if sc.Source == config.ShortcutSourceAuto {
+		return false
+	}
+	if sc.Source == config.ShortcutSourceUser {
+		return true
+	}
+	// Legacy (empty Source): check if it matches a known default
+	if def, ok := defaults[key]; ok {
+		return !shortcutMatchesDefault(sc, def)
+	}
+	return true // Unknown shortcut with no source → treat as user-defined
+}
+
+// shortcutMatchesDefault returns true if a shortcut matches a default by path and concept.
+func shortcutMatchesDefault(sc, def config.ShortcutConfig) bool {
+	return sc.Path == def.Path && sc.Concept == def.Concept
 }
 
 // computeMigrationChanges walks the campaign tree looking for directories

--- a/internal/scaffold/repair_test.go
+++ b/internal/scaffold/repair_test.go
@@ -69,22 +69,26 @@ func TestRepairPlan_HasChanges(t *testing.T) {
 }
 
 func TestIsUserDefined(t *testing.T) {
+	defaults := config.DefaultNavigationShortcuts()
+
 	tests := []struct {
-		name   string
-		source string
-		want   bool
+		name string
+		sc   config.ShortcutConfig
+		key  string
+		want bool
 	}{
-		{name: "auto source is not user-defined", source: config.ShortcutSourceAuto, want: false},
-		{name: "user source is user-defined", source: config.ShortcutSourceUser, want: true},
-		{name: "empty source is user-defined (legacy)", source: "", want: true},
-		{name: "unknown source is user-defined", source: "custom", want: true},
+		{name: "auto source is not user-defined", sc: config.ShortcutConfig{Source: config.ShortcutSourceAuto}, key: "p", want: false},
+		{name: "user source is user-defined", sc: config.ShortcutConfig{Source: config.ShortcutSourceUser}, key: "x", want: true},
+		{name: "empty source matching default is not user-defined", sc: config.ShortcutConfig{Path: "projects/", Concept: "project"}, key: "p", want: false},
+		{name: "empty source not matching any default is user-defined", sc: config.ShortcutConfig{Path: "custom/"}, key: "z", want: true},
+		{name: "empty source with default key but different path is user-defined", sc: config.ShortcutConfig{Path: "my-projects/"}, key: "p", want: true},
+		{name: "unknown source is user-defined", sc: config.ShortcutConfig{Source: "custom"}, key: "x", want: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc := config.ShortcutConfig{Source: tt.source}
-			if got := isUserDefined(sc); got != tt.want {
-				t.Errorf("isUserDefined(source=%q) = %v, want %v", tt.source, got, tt.want)
+			if got := isUserDefined(tt.sc, tt.key, defaults); got != tt.want {
+				t.Errorf("isUserDefined(key=%q, source=%q) = %v, want %v", tt.key, tt.sc.Source, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Improves `camp init --repair` output quality by reducing noisy shortcut preservation entries.

Specifically, legacy shortcuts with empty `source` are no longer automatically treated as user-defined when they match known defaults. This keeps the repair plan focused on meaningful changes.

## Problem

`init --repair` previously classified all legacy shortcuts (empty `source`) as user-defined, which caused default shortcuts to be listed as preserved even when they were just legacy auto/default entries. That made repair output noisy and less actionable.

## What Changed

- Updated shortcut classification logic in `internal/scaffold/repair.go`:
  - `isUserDefined` now accepts `(shortcut, key, defaults)`
  - Legacy entries are checked against default shortcut definitions before being marked user-defined
  - Added `shortcutMatchesDefault` helper (path + concept match)
- `computeJumpsChanges` now uses default shortcut map to classify legacy entries more accurately
- Expanded tests in `internal/scaffold/repair_test.go`:
  - legacy default match is **not** user-defined
  - legacy unknown key remains user-defined
  - legacy default key with different path remains user-defined

## Behavior Impact

Before:
- Legacy default shortcuts (empty `source`) appeared as preserved user shortcuts.

After:
- Legacy shortcuts that match defaults are silently treated as defaults.
- Only true user/custom shortcuts are shown as preserved.

This is a UX/reporting improvement for repair planning; existing shortcuts are still merged/preserved as before.

## Changed Files

- `internal/scaffold/repair.go`
- `internal/scaffold/repair_test.go`

## Test Plan

- [x] `go test ./internal/scaffold/...`
- [x] `go test ./cmd/camp -run 'TestInit|TestRepair|TestScaffold' -count=1`
