### PR TITLE
Add release next alias to camp release recipes

### DIFF
--- a/.justfiles/release.just
+++ b/.justfiles/release.just
@@ -136,3 +136,8 @@ current:
 [no-cd]
 tags:
     @git tag -l "v*" --sort=-version:refname
+
+# Bump version, tag, and push (aliases to dev channel bump)
+[no-cd]
+next level="":
+    @just --justfile {{source_file()}} dev {{level}}


### PR DESCRIPTION
## Summary
- add `just release next [level]` to `camp` release recipes
- make it behave like `fest` by providing a quick alias for dev-channel bump/tag/push

## Behavior
- `just release next` -> equivalent to `just release dev`
- `just release next patch|minor|major` -> equivalent to `just release dev patch|minor|major`

## Validation
- `just --list --justfile .justfiles/release.just` shows `next level=""`
