### PR TITLE
[OBEY-CAMPAIGN-8deed8b4] fix(pins): resolve symlinks in unpin, migrat…

### DIFF
--- a/cmd/camp/go.go
+++ b/cmd/camp/go.go
@@ -543,6 +543,7 @@ func formatConfigShortcuts(shortcuts map[string]config.ShortcutConfig) string {
 
 // resolvePin checks if the query matches a pin name and returns its absolute path.
 func resolvePin(campaignRoot, query string) (string, bool) {
+	migratePinsIfNeeded(campaignRoot)
 	storePath := config.PinsConfigPath(campaignRoot)
 	store := pins.NewStore(storePath)
 	if err := store.Load(); err != nil {
@@ -552,9 +553,9 @@ func resolvePin(campaignRoot, query string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	// Pins are stored as campaign-root-relative paths
+	// After migration all paths should be relative; reject any remaining absolute paths
 	if filepath.IsAbs(pin.Path) {
-		return pin.Path, true
+		return "", false
 	}
 	return filepath.Join(campaignRoot, pin.Path), true
 }

--- a/cmd/camp/pins.go
+++ b/cmd/camp/pins.go
@@ -203,6 +203,10 @@ func runUnpin(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return camperrors.Wrap(err, "get working directory")
 		}
+		cwd, err = filepath.EvalSymlinks(cwd)
+		if err != nil {
+			return camperrors.Wrap(err, "resolve symlinks for working directory")
+		}
 		relCwd, err := filepath.Rel(campaignRoot, cwd)
 		if err != nil {
 			return camperrors.Wrap(err, "compute relative path")

--- a/internal/pins/pins.go
+++ b/internal/pins/pins.go
@@ -158,19 +158,39 @@ func (s *Store) Toggle(name, path string) ToggleResult {
 // paths. Pins outside the campaign root are dropped. Returns true if any
 // pins were converted or removed.
 func (s *Store) MigrateAbsoluteToRelative(root string) bool {
+	// Canonicalize root so comparison is consistent even if caller
+	// passes a non-symlink-resolved path.
+	if r, err := filepath.EvalSymlinks(root); err == nil {
+		root = r
+	}
+
 	changed := false
 	for i := len(s.pins) - 1; i >= 0; i-- {
 		p := s.pins[i]
 		if filepath.IsAbs(p.Path) {
-			// Canonicalize to match the symlink-resolved root
+			// Try symlink-resolved path first, fall back to cleaned original
+			// (handles deleted directories whose symlink can't be resolved)
 			resolved := p.Path
 			if r, err := filepath.EvalSymlinks(p.Path); err == nil {
 				resolved = r
 			}
+
 			rel, err := filepath.Rel(root, resolved)
 			if err == nil && rel != ".." && !strings.HasPrefix(rel, "../") {
 				s.pins[i].Path = rel
 				changed = true
+			} else if resolved != p.Path {
+				// EvalSymlinks changed the path but Rel failed — try with
+				// the original cleaned path in case the resolved form
+				// diverged (e.g. /tmp vs /private/tmp on macOS for deleted dirs)
+				rel2, err2 := filepath.Rel(root, filepath.Clean(p.Path))
+				if err2 == nil && rel2 != ".." && !strings.HasPrefix(rel2, "../") {
+					s.pins[i].Path = rel2
+					changed = true
+				} else {
+					s.pins = append(s.pins[:i], s.pins[i+1:]...)
+					changed = true
+				}
 			} else {
 				// External pin — remove from list
 				s.pins = append(s.pins[:i], s.pins[i+1:]...)


### PR DESCRIPTION
…e, and resolvePin

- resolvePin: call migratePinsIfNeeded before loading, reject remaining absolute paths instead of returning them
- runUnpin no-arg: EvalSymlinks on cwd before Rel against canonical root
- MigrateAbsoluteToRelative: canonicalize root, fall back to cleaned original path when EvalSymlinks fails on deleted directories