### PR TITLE
Remove dead alpha-stable migration code from release.just

### DIFF
--- a/.justfiles/release.just
+++ b/.justfiles/release.just
@@ -16,17 +16,7 @@ dev level="":
     latest=$(git tag -l "v*-dev.*" --sort=-version:refname | head -1)
 
     if [ -z "$latest" ]; then
-        # No dev tags — migrate from alpha-stable or start fresh
-        alpha=$(git tag -l "v*-alpha-stable" --sort=-version:refname | head -1)
-        if [ -n "$alpha" ]; then
-            nums="${alpha#v}"
-            nums="${nums%-alpha-stable}"
-            IFS='.' read -r major minor patch <<< "$nums"
-            minor=$((minor + 1))
-            patch=0
-        else
-            major=0; minor=1; patch=0
-        fi
+        major=0; minor=1; patch=0
         new="v${major}.${minor}.${patch}-dev.1"
     else
         # Parse: v0.2.0-dev.3


### PR DESCRIPTION
## Summary
- Removed dead alpha-stable tag migration fallback from `dev` recipe in `release.just`
- Alpha-stable tags were already deleted; this code was unreachable

## Test plan
- [x] `just release current` still works correctly
- [x] `just release dev` fallback starts at v0.1.0-dev.1 when no dev tags exist