### PR TITLE
feat: add manual priority system to workitem TUI and CLI

### DIFF
--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -13,6 +13,7 @@ import (
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/paths"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
 	wktui "github.com/Obedience-Corp/camp/internal/workitem/tui"
 )
 
@@ -69,6 +70,26 @@ Examples:
 				return camperrors.Wrap(err, "discovering work items")
 			}
 
+			// Load priority store and prune stale entries against full discovery set.
+			storePath := priority.StorePath(campaignRoot)
+			store, err := priority.Load(storePath)
+			if err != nil {
+				return camperrors.Wrap(err, "loading priority store")
+			}
+			validKeys := make(map[string]bool, len(items))
+			for _, item := range items {
+				validKeys[item.Key] = true
+			}
+			if priority.Prune(store, validKeys) {
+				if err := priority.SaveOrDelete(storePath, store); err != nil {
+					return camperrors.Wrap(err, "saving pruned priority store")
+				}
+			}
+
+			// Apply priority overlay and re-sort with priority buckets.
+			items = priority.Apply(store, items)
+			wkitem.Sort(items)
+
 			items = wkitem.Filter(items, flagTypes, flagStages, flagQuery)
 			if flagLimit > 0 && flagLimit < len(items) {
 				items = items[:flagLimit]
@@ -85,9 +106,9 @@ Examples:
 				fmt.Println(items[0].AbsPath(campaignRoot))
 				return nil
 			case flagPrint:
-				return runTUI(ctx, items, true, campaignRoot, resolver)
+				return runTUI(ctx, items, true, campaignRoot, resolver, store, storePath)
 			default:
-				return runTUI(ctx, items, false, campaignRoot, resolver)
+				return runTUI(ctx, items, false, campaignRoot, resolver, store, storePath)
 			}
 		},
 	}
@@ -136,12 +157,12 @@ func outputJSON(campaignRoot string, items []wkitem.WorkItem) error {
 	return enc.Encode(payload)
 }
 
-func runTUI(ctx context.Context, items []wkitem.WorkItem, printOnly bool, campaignRoot string, resolver *paths.Resolver) error {
+func runTUI(ctx context.Context, items []wkitem.WorkItem, printOnly bool, campaignRoot string, resolver *paths.Resolver, store *priority.Store, storePath string) error {
 	if len(items) == 0 {
 		return fmt.Errorf("no work items found")
 	}
 
-	model := wktui.New(ctx, items, campaignRoot, resolver)
+	model := wktui.New(ctx, items, campaignRoot, resolver, store, storePath)
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	result, err := p.Run()
 	if err != nil {

--- a/internal/intent/tui/explorer/layout.go
+++ b/internal/intent/tui/explorer/layout.go
@@ -85,6 +85,10 @@ func (m *Model) recalculateLayout() {
 		}
 	}
 
+	if !m.shouldShowPreview() {
+		m.previewFocused = false
+	}
+
 	// Notify user of layout mode change
 	if oldMode != m.layoutMode && m.ready {
 		switch m.layoutMode {

--- a/internal/intent/tui/explorer/preview_focus_test.go
+++ b/internal/intent/tui/explorer/preview_focus_test.go
@@ -1,0 +1,109 @@
+package explorer
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestModel_TabTogglesPreviewFocusWhenVisible(t *testing.T) {
+	m := makeTestModel(1, 0)
+	m.showPreview = true
+	m.recalculateLayout()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+
+	if !m.previewFocused {
+		t.Fatal("expected preview to take focus when visible")
+	}
+	if m.focus != focusList {
+		t.Fatalf("expected focus to remain on the main view, got %d", m.focus)
+	}
+	if m.filterBar.IsFocused() {
+		t.Fatal("filter bar should not take focus when preview is visible")
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+
+	if m.previewFocused {
+		t.Fatal("expected preview focus to toggle back to the list")
+	}
+	if m.focus != focusList {
+		t.Fatalf("expected focus to remain on the main view after returning from preview, got %d", m.focus)
+	}
+}
+
+func TestModel_FilterShortcutsOpenTargetChip(t *testing.T) {
+	m := makeTestModel(1, 0)
+	m.showPreview = true
+	m.recalculateLayout()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	m = updated.(Model)
+
+	if m.focus != focusFilterBar {
+		t.Fatalf("expected type shortcut to focus the filter bar, got %d", m.focus)
+	}
+	if m.filterBar.FocusedChip != 0 {
+		t.Fatalf("expected type shortcut to focus chip 0, got %d", m.filterBar.FocusedChip)
+	}
+	if !m.filterBar.Chips[0].Open {
+		t.Fatal("expected type shortcut to open the type dropdown")
+	}
+	if m.previewFocused {
+		t.Fatal("expected type shortcut to clear preview focus")
+	}
+
+	m = makeTestModel(1, 0)
+	m.showPreview = true
+	m.recalculateLayout()
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	m = updated.(Model)
+
+	if m.focus != focusFilterBar {
+		t.Fatalf("expected status shortcut to focus the filter bar, got %d", m.focus)
+	}
+	if m.filterBar.FocusedChip != 1 {
+		t.Fatalf("expected status shortcut to focus chip 1, got %d", m.filterBar.FocusedChip)
+	}
+	if !m.filterBar.Chips[1].Open {
+		t.Fatal("expected status shortcut to open the status dropdown")
+	}
+}
+
+func TestModel_HidingPreviewClearsPreviewFocus(t *testing.T) {
+	m := makeTestModel(1, 0)
+	m.showPreview = true
+	m.previewFocused = true
+	m.recalculateLayout()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'v'}})
+	m = updated.(Model)
+
+	if m.showPreview {
+		t.Fatal("expected preview to be hidden after pressing v")
+	}
+	if m.previewFocused {
+		t.Fatal("expected preview focus to clear when the preview is hidden")
+	}
+}
+
+func TestModel_ForceHiddenPreviewClearsPreviewFocus(t *testing.T) {
+	m := makeTestModel(1, 0)
+	m.showPreview = true
+	m.previewFocused = true
+	m.recalculateLayout()
+
+	m.width = 70
+	m.recalculateLayout()
+
+	if !m.previewForceHidden {
+		t.Fatal("expected preview to be force-hidden in a narrow layout")
+	}
+	if m.previewFocused {
+		t.Fatal("expected preview focus to clear when the layout force-hides the preview")
+	}
+}

--- a/internal/intent/tui/explorer/update_keys.go
+++ b/internal/intent/tui/explorer/update_keys.go
@@ -66,14 +66,20 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.searchInput.Focus()
 		return m, textinput.Blink
 	case "tab":
-		// Tab navigates to filter bar when not on preview
-		if !m.showPreview || !m.previewFocused {
+		if !m.shouldShowPreview() {
+			m.previewFocused = false
 			m.focus = focusFilterBar
 			m.filterBar.Focus()
 			return m, nil
 		}
-		// Otherwise toggle preview focus
+		// With the preview visible, Tab switches focus between the list and preview.
 		m.previewFocused = !m.previewFocused
+		return m, nil
+	case "t":
+		m.focusFilterChip(0)
+		return m, nil
+	case "s":
+		m.focusFilterChip(1)
 		return m, nil
 	case "c":
 		// Enter concept filter mode
@@ -236,4 +242,29 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func (m *Model) focusFilterChip(index int) {
+	m.previewFocused = false
+	m.focus = focusFilterBar
+	m.filterBar.Blur()
+
+	if len(m.filterBar.Chips) == 0 {
+		return
+	}
+	if index < 0 || index >= len(m.filterBar.Chips) {
+		index = 0
+	}
+
+	m.filterBar.FocusedChip = index
+	for i := range m.filterBar.Chips {
+		if i == index {
+			m.filterBar.Chips[i].Focus()
+			if !m.filterBar.Chips[i].Open {
+				m.filterBar.Chips[i].Toggle()
+			}
+			continue
+		}
+		m.filterBar.Chips[i].Blur()
+	}
 }

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -313,6 +313,9 @@ state.yaml
 
 # Generated cache (navigation index, rebuilt automatically)
 cache/
+
+# Tool-managed state (workitem priorities, regenerated automatically)
+settings/workitems.json
 `
 			if err := os.WriteFile(gitignorePath, []byte(gitignoreContent), 0644); err != nil {
 				return nil, camperrors.Wrap(err, "failed to create .gitignore")

--- a/internal/workitem/json.go
+++ b/internal/workitem/json.go
@@ -3,7 +3,7 @@ package workitem
 import "time"
 
 // SchemaVersion is the JSON contract version for workitem output.
-const SchemaVersion = "workitems/v1alpha2"
+const SchemaVersion = "workitems/v1alpha3"
 
 // Payload is the top-level JSON output for camp workitem --json.
 type Payload struct {
@@ -57,8 +57,8 @@ func NewPayload(campaignRoot string, items []WorkItem) Payload {
 		GeneratedAt:   time.Now().UTC(),
 		CampaignRoot:  campaignRoot,
 		Sort: SortInfo{
-			Primary:   "sort_timestamp",
-			Secondary: "created_at",
+			Primary:   "manual_priority",
+			Secondary: "sort_timestamp",
 			Direction: "desc",
 		},
 		Items:  items,

--- a/internal/workitem/json_test.go
+++ b/internal/workitem/json_test.go
@@ -2,6 +2,7 @@ package workitem
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -60,11 +61,11 @@ func TestNewPayload_NilItemsBecomesEmptyArray(t *testing.T) {
 
 func TestNewPayload_SortInfo(t *testing.T) {
 	p := NewPayload("/tmp", nil)
-	if p.Sort.Primary != "sort_timestamp" {
-		t.Errorf("sort.primary = %q, want sort_timestamp", p.Sort.Primary)
+	if p.Sort.Primary != "manual_priority" {
+		t.Errorf("sort.primary = %q, want manual_priority", p.Sort.Primary)
 	}
-	if p.Sort.Secondary != "created_at" {
-		t.Errorf("sort.secondary = %q, want created_at", p.Sort.Secondary)
+	if p.Sort.Secondary != "sort_timestamp" {
+		t.Errorf("sort.secondary = %q, want sort_timestamp", p.Sort.Secondary)
 	}
 	if p.Sort.Direction != "desc" {
 		t.Errorf("sort.direction = %q, want desc", p.Sort.Direction)
@@ -75,5 +76,19 @@ func TestNewPayload_CampaignRoot(t *testing.T) {
 	p := NewPayload("/my/campaign", nil)
 	if p.CampaignRoot != "/my/campaign" {
 		t.Errorf("campaign_root = %q, want /my/campaign", p.CampaignRoot)
+	}
+}
+
+func TestWorkItem_ManualPriorityOmitEmpty(t *testing.T) {
+	item := WorkItem{Key: "intent:foo"}
+	data, _ := json.Marshal(item)
+	if strings.Contains(string(data), "manual_priority") {
+		t.Error("manual_priority should be omitted when empty")
+	}
+
+	item.ManualPriority = "high"
+	data, _ = json.Marshal(item)
+	if !strings.Contains(string(data), `"manual_priority":"high"`) {
+		t.Errorf("manual_priority should be present, got: %s", data)
 	}
 }

--- a/internal/workitem/model.go
+++ b/internal/workitem/model.go
@@ -42,6 +42,7 @@ type WorkItem struct {
 	CreatedAt      time.Time      `json:"created_at"`
 	UpdatedAt      time.Time      `json:"updated_at"`
 	SortTimestamp  time.Time      `json:"sort_timestamp"`
+	ManualPriority string `json:"manual_priority,omitempty"`
 	Summary        string         `json:"summary"`
 	SourceID       string         `json:"source_id"`
 	SourceMetadata map[string]any `json:"source_metadata"`

--- a/internal/workitem/priority/integration_test.go
+++ b/internal/workitem/priority/integration_test.go
@@ -1,0 +1,231 @@
+package priority
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+func makeItem(key string, wfType workitem.WorkflowType, title string, sortTS time.Time) workitem.WorkItem {
+	return workitem.WorkItem{
+		Key:           key,
+		WorkflowType:  wfType,
+		Title:         title,
+		RelativePath:  strings.TrimPrefix(key, string(wfType)+":"),
+		SortTimestamp: sortTS,
+		CreatedAt:     sortTS,
+	}
+}
+
+func validKeysFrom(items []workitem.WorkItem) map[string]bool {
+	m := make(map[string]bool, len(items))
+	for _, item := range items {
+		m[item.Key] = true
+	}
+	return m
+}
+
+func TestFilterSafety_TypeFilterPreservesPriorities(t *testing.T) {
+	now := time.Now()
+	items := []workitem.WorkItem{
+		makeItem("intent:a", workitem.WorkflowTypeIntent, "Intent A", now),
+		makeItem("design:b", workitem.WorkflowTypeDesign, "Design B", now),
+		makeItem("intent:c", workitem.WorkflowTypeIntent, "Intent C", now),
+	}
+
+	store := NewStore()
+	Set(store, "intent:a", High)
+	Set(store, "design:b", Medium)
+
+	// Prune against full set — nothing should be removed.
+	if Prune(store, validKeysFrom(items)) {
+		t.Error("prune should not remove anything when all keys are valid")
+	}
+
+	// Simulate --type design filter (view-only).
+	_ = workitem.Filter(items, []string{"design"}, nil, "")
+
+	// Store must still have both priorities.
+	if len(store.ManualPriorities) != 2 {
+		t.Fatalf("store has %d entries, want 2", len(store.ManualPriorities))
+	}
+	if store.ManualPriorities["intent:a"].Priority != High {
+		t.Error("intent:a priority should be high")
+	}
+	if store.ManualPriorities["design:b"].Priority != Medium {
+		t.Error("design:b priority should be medium")
+	}
+}
+
+func TestFilterSafety_QueryFilterPreservesPriorities(t *testing.T) {
+	now := time.Now()
+	items := []workitem.WorkItem{
+		makeItem("intent:auth-svc", workitem.WorkflowTypeIntent, "auth service", now),
+		makeItem("design:pay-api", workitem.WorkflowTypeDesign, "payment api", now),
+		makeItem("intent:auth-mid", workitem.WorkflowTypeIntent, "auth middleware", now),
+		makeItem("explore:deploy", workitem.WorkflowTypeExplore, "deploy pipeline", now),
+	}
+
+	store := NewStore()
+	Set(store, "intent:auth-svc", High)
+	Set(store, "design:pay-api", Low)
+	Set(store, "explore:deploy", Medium)
+
+	Prune(store, validKeysFrom(items))
+
+	// Simulate --query auth filter.
+	_ = workitem.Filter(items, nil, nil, "auth")
+
+	if len(store.ManualPriorities) != 3 {
+		t.Fatalf("store has %d entries, want 3", len(store.ManualPriorities))
+	}
+}
+
+func TestFilterSafety_LimitPreservesPriorities(t *testing.T) {
+	now := time.Now()
+	items := make([]workitem.WorkItem, 5)
+	for i := range items {
+		items[i] = makeItem("intent:"+string(rune('a'+i)), workitem.WorkflowTypeIntent, "", now.Add(-time.Duration(i)*time.Hour))
+	}
+
+	store := NewStore()
+	Set(store, items[0].Key, High)
+	Set(store, items[2].Key, Medium)
+	Set(store, items[4].Key, Low)
+
+	Prune(store, validKeysFrom(items))
+
+	// Simulate --limit 1.
+	limited := items[:1]
+	_ = limited
+
+	if len(store.ManualPriorities) != 3 {
+		t.Fatalf("store has %d entries, want 3", len(store.ManualPriorities))
+	}
+}
+
+func TestPrune_StaleItemIsRemoved(t *testing.T) {
+	store := NewStore()
+	Set(store, "intent:a", High)
+	Set(store, "design:b", Medium)
+	Set(store, "explore:c", Low)
+
+	// explore:c no longer exists in discovery.
+	validKeys := map[string]bool{"intent:a": true, "design:b": true}
+	changed := Prune(store, validKeys)
+	if !changed {
+		t.Error("prune should report change when stale key removed")
+	}
+	if _, ok := store.ManualPriorities["explore:c"]; ok {
+		t.Error("explore:c should have been pruned")
+	}
+	if len(store.ManualPriorities) != 2 {
+		t.Errorf("store has %d entries, want 2", len(store.ManualPriorities))
+	}
+}
+
+func TestPrune_StaleRemoval_SaveOrDelete(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workitems.json")
+
+	store := NewStore()
+	Set(store, "gone:item", High)
+	if err := Save(path, store); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	Prune(loaded, map[string]bool{}) // no valid keys — everything is stale
+	if err := SaveOrDelete(path, loaded); err != nil {
+		t.Fatal(err)
+	}
+
+	// File should be deleted since store is now empty.
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reloaded.ManualPriorities) != 0 {
+		t.Error("store should be empty after pruning all entries")
+	}
+}
+
+func TestPipeline_FullSequence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workitems.json")
+	now := time.Now()
+
+	// Step 1: Create items.
+	items := []workitem.WorkItem{
+		makeItem("intent:ship", workitem.WorkflowTypeIntent, "Ship Feature", now),
+		makeItem("design:api", workitem.WorkflowTypeDesign, "API Design", now.Add(-time.Hour)),
+		makeItem("intent:auth", workitem.WorkflowTypeIntent, "Auth Work", now.Add(-2*time.Hour)),
+		makeItem("explore:perf", workitem.WorkflowTypeExplore, "Perf Research", now.Add(-3*time.Hour)),
+		makeItem("festival:launch", workitem.WorkflowTypeFestival, "Launch Fest", now.Add(-4*time.Hour)),
+	}
+
+	// Step 2: Set priorities on 2 items and save.
+	store := NewStore()
+	Set(store, "design:api", High)
+	Set(store, "explore:perf", Medium)
+	if err := Save(path, store); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 3: Simulate pipeline — Load.
+	store, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 4: Prune (no-op since all items exist).
+	changed := Prune(store, validKeysFrom(items))
+	if changed {
+		t.Error("prune should be no-op when all keys are valid")
+	}
+
+	// Step 5: Apply overlay and sort.
+	items = Apply(store, items)
+	workitem.Sort(items)
+
+	// Verify sort order: high-priority first, then medium, then rest by recency.
+	if items[0].Key != "design:api" {
+		t.Errorf("items[0] = %q, want design:api (high priority)", items[0].Key)
+	}
+	if items[1].Key != "explore:perf" {
+		t.Errorf("items[1] = %q, want explore:perf (medium priority)", items[1].Key)
+	}
+
+	// Step 6: Filter by type intent (filters out the prioritized items from view).
+	filtered := workitem.Filter(items, []string{"intent"}, nil, "")
+	if len(filtered) != 2 {
+		t.Fatalf("filtered to %d items, want 2 intents", len(filtered))
+	}
+
+	// Step 7: Apply limit.
+	if len(filtered) > 1 {
+		filtered = filtered[:1]
+	}
+
+	// Verify: store on disk still has both priorities.
+	reloaded, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reloaded.ManualPriorities) != 2 {
+		t.Errorf("store has %d entries, want 2 (filter must not erase priorities)", len(reloaded.ManualPriorities))
+	}
+	if reloaded.ManualPriorities["design:api"].Priority != High {
+		t.Error("design:api priority should still be high")
+	}
+	if reloaded.ManualPriorities["explore:perf"].Priority != Medium {
+		t.Error("explore:perf priority should still be medium")
+	}
+}

--- a/internal/workitem/priority/priority.go
+++ b/internal/workitem/priority/priority.go
@@ -1,0 +1,55 @@
+// Package priority manages persistent manual priority state for campaign work items.
+// Priority entries are stored in .campaign/settings/workitems.json keyed by WorkItem.Key.
+package priority
+
+import "time"
+
+// ManualPriority represents a user-assigned importance level for a work item.
+type ManualPriority string
+
+const (
+	None   ManualPriority = ""
+	Low    ManualPriority = "low"
+	Medium ManualPriority = "medium"
+	High   ManualPriority = "high"
+)
+
+// Rank returns a sort-order integer: High=1, Medium=2, Low=3, None/unknown=4.
+func (p ManualPriority) Rank() int {
+	switch p {
+	case High:
+		return 1
+	case Medium:
+		return 2
+	case Low:
+		return 3
+	default:
+		return 4
+	}
+}
+
+// Valid returns true for assignable priorities (Low, Medium, High). None is not valid
+// because it represents the absence of a manual priority.
+func (p ManualPriority) Valid() bool {
+	return p == Low || p == Medium || p == High
+}
+
+// PriorityEntry is a single priority assignment persisted on disk.
+type PriorityEntry struct {
+	Priority  ManualPriority `json:"priority"`
+	UpdatedAt time.Time      `json:"updated_at"`
+}
+
+// Store is the on-disk JSON representation of all manual priority assignments.
+type Store struct {
+	Version          int                      `json:"version"`
+	ManualPriorities map[string]PriorityEntry `json:"manual_priorities"`
+}
+
+// NewStore returns an initialized Store ready for use.
+func NewStore() *Store {
+	return &Store{
+		Version:          1,
+		ManualPriorities: make(map[string]PriorityEntry),
+	}
+}

--- a/internal/workitem/priority/priority_test.go
+++ b/internal/workitem/priority/priority_test.go
@@ -1,0 +1,58 @@
+package priority
+
+import "testing"
+
+func TestRank(t *testing.T) {
+	tests := []struct {
+		name string
+		p    ManualPriority
+		want int
+	}{
+		{"high", High, 1},
+		{"medium", Medium, 2},
+		{"low", Low, 3},
+		{"none", None, 4},
+		{"unknown", ManualPriority("critical"), 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.p.Rank(); got != tt.want {
+				t.Errorf("ManualPriority(%q).Rank() = %d, want %d", tt.p, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRank_Ordering(t *testing.T) {
+	if !(High.Rank() < Medium.Rank()) {
+		t.Error("High.Rank() must be less than Medium.Rank()")
+	}
+	if !(Medium.Rank() < Low.Rank()) {
+		t.Error("Medium.Rank() must be less than Low.Rank()")
+	}
+	if !(Low.Rank() < None.Rank()) {
+		t.Error("Low.Rank() must be less than None.Rank()")
+	}
+}
+
+func TestValid(t *testing.T) {
+	tests := []struct {
+		name string
+		p    ManualPriority
+		want bool
+	}{
+		{"high", High, true},
+		{"medium", Medium, true},
+		{"low", Low, true},
+		{"none", None, false},
+		{"unknown", ManualPriority("critical"), false},
+		{"empty_string", ManualPriority(""), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.p.Valid(); got != tt.want {
+				t.Errorf("ManualPriority(%q).Valid() = %v, want %v", tt.p, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/workitem/priority/store.go
+++ b/internal/workitem/priority/store.go
@@ -1,0 +1,117 @@
+package priority
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// StorePath returns the absolute path to the priority store file within a campaign.
+func StorePath(campaignRoot string) string {
+	return filepath.Join(campaignRoot, ".campaign", "settings", "workitems.json")
+}
+
+// Load reads the priority store from disk. Returns an empty store if the file
+// does not exist. Returns a wrapped error for invalid JSON or read failures.
+func Load(path string) (*Store, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return NewStore(), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading priority store %s: %w", path, err)
+	}
+	var s Store
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parsing priority store %s: %w", path, err)
+	}
+	if s.ManualPriorities == nil {
+		s.ManualPriorities = make(map[string]PriorityEntry)
+	}
+	return &s, nil
+}
+
+// Save atomically writes the store to disk. It writes to a temp file in the same
+// directory then renames into place, creating parent directories as needed.
+func Save(path string, store *Store) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating priority store directory %s: %w", dir, err)
+	}
+
+	data, err := json.MarshalIndent(store, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling priority store: %w", err)
+	}
+	data = append(data, '\n')
+
+	tmp, err := os.CreateTemp(dir, "workitems-*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file for priority store: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing priority store temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing priority store temp file: %w", err)
+	}
+
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		return fmt.Errorf("renaming priority store temp file: %w", err)
+	}
+	return nil
+}
+
+// Set adds or updates a priority entry for the given key.
+func Set(store *Store, key string, p ManualPriority) {
+	store.ManualPriorities[key] = PriorityEntry{
+		Priority:  p,
+		UpdatedAt: time.Now().UTC(),
+	}
+}
+
+// Clear removes the priority entry for the given key.
+func Clear(store *Store, key string) {
+	delete(store.ManualPriorities, key)
+}
+
+// Prune removes entries whose keys are not in validKeys. Returns true if any
+// entries were removed. validKeys must be the full unfiltered set of discovered
+// work item keys — never a filtered subset.
+func Prune(store *Store, validKeys map[string]bool) bool {
+	var stale []string
+	for k := range store.ManualPriorities {
+		if !validKeys[k] {
+			stale = append(stale, k)
+		}
+	}
+	for _, k := range stale {
+		delete(store.ManualPriorities, k)
+	}
+	return len(stale) > 0
+}
+
+// TODO: Apply(store *Store, items []workitem.WorkItem) []workitem.WorkItem
+// Deferred until WorkItem.ManualPriority field is added in sequence 02.
+
+// SaveOrDelete saves the store if it contains entries, or deletes the file if empty.
+func SaveOrDelete(path string, store *Store) error {
+	if IsEmpty(store) {
+		err := os.Remove(path)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("removing empty priority store %s: %w", path, err)
+		}
+		return nil
+	}
+	return Save(path, store)
+}
+
+// IsEmpty reports whether the store has no priority entries.
+func IsEmpty(store *Store) bool {
+	return len(store.ManualPriorities) == 0
+}

--- a/internal/workitem/priority/store.go
+++ b/internal/workitem/priority/store.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/Obedience-Corp/camp/internal/workitem"
 )
 
 // StorePath returns the absolute path to the priority store file within a campaign.
@@ -96,8 +98,16 @@ func Prune(store *Store, validKeys map[string]bool) bool {
 	return len(stale) > 0
 }
 
-// TODO: Apply(store *Store, items []workitem.WorkItem) []workitem.WorkItem
-// Deferred until WorkItem.ManualPriority field is added in sequence 02.
+// Apply decorates each WorkItem with its stored manual priority. Items whose Key
+// is not in the store are left unchanged.
+func Apply(store *Store, items []workitem.WorkItem) []workitem.WorkItem {
+	for i := range items {
+		if entry, ok := store.ManualPriorities[items[i].Key]; ok {
+			items[i].ManualPriority = string(entry.Priority)
+		}
+	}
+	return items
+}
 
 // SaveOrDelete saves the store if it contains entries, or deletes the file if empty.
 func SaveOrDelete(path string, store *Store) error {

--- a/internal/workitem/priority/store.go
+++ b/internal/workitem/priority/store.go
@@ -98,12 +98,14 @@ func Prune(store *Store, validKeys map[string]bool) bool {
 	return len(stale) > 0
 }
 
-// Apply decorates each WorkItem with its stored manual priority. Items whose Key
-// is not in the store are left unchanged.
+// Apply decorates each WorkItem with its stored manual priority. Items not in
+// the store have their ManualPriority cleared to ensure idempotency after Clear.
 func Apply(store *Store, items []workitem.WorkItem) []workitem.WorkItem {
 	for i := range items {
 		if entry, ok := store.ManualPriorities[items[i].Key]; ok {
 			items[i].ManualPriority = string(entry.Priority)
+		} else {
+			items[i].ManualPriority = ""
 		}
 	}
 	return items

--- a/internal/workitem/priority/store_test.go
+++ b/internal/workitem/priority/store_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Obedience-Corp/camp/internal/workitem"
 )
 
 func TestLoad_InvalidJSON(t *testing.T) {
@@ -302,6 +304,59 @@ func TestStorePath(t *testing.T) {
 	}
 }
 
-// TODO: TestApply_DecoratesMatchingItems - enable after WorkItem.ManualPriority field is added in sequence 02
-// TODO: TestApply_IgnoresUnknownItems - enable after WorkItem.ManualPriority field is added in sequence 02
-// TODO: TestApply_EmptyStore - enable after WorkItem.ManualPriority field is added in sequence 02
+func TestApply_DecoratesMatchingItems(t *testing.T) {
+	s := NewStore()
+	Set(s, "intent:a", High)
+	Set(s, "design:b", Medium)
+
+	items := []workitem.WorkItem{
+		{Key: "intent:a"},
+		{Key: "design:b"},
+		{Key: "explore:c"},
+	}
+	items = Apply(s, items)
+
+	if items[0].ManualPriority != "high" {
+		t.Errorf("intent:a ManualPriority = %q, want high", items[0].ManualPriority)
+	}
+	if items[1].ManualPriority != "medium" {
+		t.Errorf("design:b ManualPriority = %q, want medium", items[1].ManualPriority)
+	}
+	if items[2].ManualPriority != "" {
+		t.Errorf("explore:c ManualPriority = %q, want empty", items[2].ManualPriority)
+	}
+}
+
+func TestApply_ClearsStaleValues(t *testing.T) {
+	s := NewStore()
+	Set(s, "intent:a", High)
+
+	items := []workitem.WorkItem{
+		{Key: "intent:a", ManualPriority: "high"},
+		{Key: "design:b", ManualPriority: "medium"}, // stale: not in store
+	}
+	items = Apply(s, items)
+
+	if items[0].ManualPriority != "high" {
+		t.Errorf("intent:a ManualPriority = %q, want high", items[0].ManualPriority)
+	}
+	if items[1].ManualPriority != "" {
+		t.Errorf("design:b ManualPriority = %q, want empty (cleared by Apply)", items[1].ManualPriority)
+	}
+}
+
+func TestApply_EmptyStore(t *testing.T) {
+	s := NewStore()
+	items := []workitem.WorkItem{
+		{Key: "intent:a", ManualPriority: "high"}, // stale value
+		{Key: "design:b"},
+	}
+	items = Apply(s, items)
+
+	if items[0].ManualPriority != "" {
+		t.Errorf("intent:a ManualPriority = %q, want empty (empty store clears all)", items[0].ManualPriority)
+	}
+	if items[1].ManualPriority != "" {
+		t.Errorf("design:b ManualPriority = %q, want empty", items[1].ManualPriority)
+	}
+}

--- a/internal/workitem/priority/store_test.go
+++ b/internal/workitem/priority/store_test.go
@@ -1,0 +1,307 @@
+package priority
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoad_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workitems.json")
+	if err := os.WriteFile(path, []byte("{bad json}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load of invalid JSON should return error")
+	}
+	if !strings.Contains(err.Error(), "parsing priority store") {
+		t.Errorf("error should mention parsing, got: %s", err)
+	}
+}
+
+func TestLoad_NonexistentFile(t *testing.T) {
+	s, err := Load(filepath.Join(t.TempDir(), "missing.json"))
+	if err != nil {
+		t.Fatalf("Load of nonexistent file returned error: %v", err)
+	}
+	if s == nil {
+		t.Fatal("Load of nonexistent file returned nil store")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.ManualPriorities == nil {
+		t.Error("ManualPriorities should be initialized, got nil")
+	}
+	if len(s.ManualPriorities) != 0 {
+		t.Errorf("ManualPriorities should be empty, got %d entries", len(s.ManualPriorities))
+	}
+}
+
+func TestLoad_ValidJSON(t *testing.T) {
+	ts := time.Date(2026, 3, 31, 20, 17, 12, 0, time.UTC)
+	store := &Store{
+		Version: 1,
+		ManualPriorities: map[string]PriorityEntry{
+			"intent:ship-camp": {Priority: High, UpdatedAt: ts},
+		},
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workitems.json")
+	data, _ := json.MarshalIndent(store, "", "  ")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if loaded.Version != 1 {
+		t.Errorf("Version = %d, want 1", loaded.Version)
+	}
+	entry, ok := loaded.ManualPriorities["intent:ship-camp"]
+	if !ok {
+		t.Fatal("expected entry for intent:ship-camp")
+	}
+	if entry.Priority != High {
+		t.Errorf("Priority = %q, want %q", entry.Priority, High)
+	}
+	if !entry.UpdatedAt.Equal(ts) {
+		t.Errorf("UpdatedAt = %v, want %v", entry.UpdatedAt, ts)
+	}
+}
+
+func TestLoad_NilMapInitialized(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workitems.json")
+	if err := os.WriteFile(path, []byte(`{"version":1,"manual_priorities":null}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if s.ManualPriorities == nil {
+		t.Error("ManualPriorities should be initialized after loading null map")
+	}
+}
+
+func TestSave_Load_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workitems.json")
+
+	original := NewStore()
+	Set(original, "key-a", High)
+	Set(original, "key-b", Low)
+
+	if err := Save(path, original); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if len(loaded.ManualPriorities) != 2 {
+		t.Fatalf("got %d entries, want 2", len(loaded.ManualPriorities))
+	}
+	if loaded.ManualPriorities["key-a"].Priority != High {
+		t.Errorf("key-a priority = %q, want %q", loaded.ManualPriorities["key-a"].Priority, High)
+	}
+	if loaded.ManualPriorities["key-b"].Priority != Low {
+		t.Errorf("key-b priority = %q, want %q", loaded.ManualPriorities["key-b"].Priority, Low)
+	}
+}
+
+func TestSave_CreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a", "b", "c", "workitems.json")
+	if err := Save(path, NewStore()); err != nil {
+		t.Fatalf("Save should create parent dirs, got error: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("file should exist after Save: %v", err)
+	}
+}
+
+func TestSave_AtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workitems.json")
+	if err := Save(path, NewStore()); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal("file should exist at target path after Save")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Errorf("temp file %q was not cleaned up", e.Name())
+		}
+	}
+}
+
+func TestSet_NewEntry(t *testing.T) {
+	s := NewStore()
+	before := time.Now().UTC().Add(-time.Second)
+	Set(s, "item-1", Medium)
+	after := time.Now().UTC().Add(time.Second)
+
+	entry, ok := s.ManualPriorities["item-1"]
+	if !ok {
+		t.Fatal("entry should exist after Set")
+	}
+	if entry.Priority != Medium {
+		t.Errorf("Priority = %q, want %q", entry.Priority, Medium)
+	}
+	if entry.UpdatedAt.Before(before) || entry.UpdatedAt.After(after) {
+		t.Errorf("UpdatedAt %v is not between %v and %v", entry.UpdatedAt, before, after)
+	}
+}
+
+func TestSet_UpdateEntry(t *testing.T) {
+	s := NewStore()
+	Set(s, "item-1", Low)
+	Set(s, "item-1", High)
+
+	if len(s.ManualPriorities) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(s.ManualPriorities))
+	}
+	if s.ManualPriorities["item-1"].Priority != High {
+		t.Errorf("Priority = %q, want %q", s.ManualPriorities["item-1"].Priority, High)
+	}
+}
+
+func TestClear_ExistingEntry(t *testing.T) {
+	s := NewStore()
+	Set(s, "item-1", High)
+	Clear(s, "item-1")
+	if _, ok := s.ManualPriorities["item-1"]; ok {
+		t.Error("entry should be removed after Clear")
+	}
+}
+
+func TestClear_NonexistentKey(t *testing.T) {
+	s := NewStore()
+	Clear(s, "nonexistent") // should not panic
+}
+
+func TestPrune_RemovesStaleKeys(t *testing.T) {
+	s := NewStore()
+	Set(s, "a", High)
+	Set(s, "b", Medium)
+	Set(s, "c", Low)
+
+	changed := Prune(s, map[string]bool{"a": true, "c": true})
+	if !changed {
+		t.Error("Prune should return true when entries are removed")
+	}
+	if _, ok := s.ManualPriorities["b"]; ok {
+		t.Error("stale key 'b' should be pruned")
+	}
+	if len(s.ManualPriorities) != 2 {
+		t.Errorf("expected 2 entries after prune, got %d", len(s.ManualPriorities))
+	}
+}
+
+func TestPrune_KeepsAllValid(t *testing.T) {
+	s := NewStore()
+	Set(s, "a", High)
+	Set(s, "b", Medium)
+
+	changed := Prune(s, map[string]bool{"a": true, "b": true})
+	if changed {
+		t.Error("Prune should return false when nothing is removed")
+	}
+	if len(s.ManualPriorities) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(s.ManualPriorities))
+	}
+}
+
+func TestPrune_EmptyStore(t *testing.T) {
+	s := NewStore()
+	changed := Prune(s, map[string]bool{"a": true})
+	if changed {
+		t.Error("Prune on empty store should return false")
+	}
+}
+
+func TestPrune_AllStale(t *testing.T) {
+	s := NewStore()
+	Set(s, "a", High)
+	Set(s, "b", Low)
+
+	changed := Prune(s, map[string]bool{})
+	if !changed {
+		t.Error("Prune should return true when all entries are removed")
+	}
+	if len(s.ManualPriorities) != 0 {
+		t.Errorf("expected 0 entries after pruning all, got %d", len(s.ManualPriorities))
+	}
+}
+
+func TestSaveOrDelete_EmptyStoreDeletesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workitems.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveOrDelete(path, NewStore()); err != nil {
+		t.Fatalf("SaveOrDelete returned error: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("file should be deleted when store is empty")
+	}
+}
+
+func TestSaveOrDelete_NonEmptyStoreSavesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "workitems.json")
+
+	s := NewStore()
+	Set(s, "key", High)
+	if err := SaveOrDelete(path, s); err != nil {
+		t.Fatalf("SaveOrDelete returned error: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Error("file should exist when store is non-empty")
+	}
+}
+
+func TestSaveOrDelete_DeleteNonexistentFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.json")
+	if err := SaveOrDelete(path, NewStore()); err != nil {
+		t.Fatalf("SaveOrDelete on nonexistent file should succeed, got: %v", err)
+	}
+}
+
+func TestIsEmpty(t *testing.T) {
+	s := NewStore()
+	if !IsEmpty(s) {
+		t.Error("new store should be empty")
+	}
+	Set(s, "key", Low)
+	if IsEmpty(s) {
+		t.Error("store with entry should not be empty")
+	}
+}
+
+func TestStorePath(t *testing.T) {
+	got := StorePath("/home/user/campaign")
+	want := filepath.Join("/home/user/campaign", ".campaign", "settings", "workitems.json")
+	if got != want {
+		t.Errorf("StorePath = %q, want %q", got, want)
+	}
+}
+
+// TODO: TestApply_DecoratesMatchingItems - enable after WorkItem.ManualPriority field is added in sequence 02
+// TODO: TestApply_IgnoresUnknownItems - enable after WorkItem.ManualPriority field is added in sequence 02
+// TODO: TestApply_EmptyStore - enable after WorkItem.ManualPriority field is added in sequence 02

--- a/internal/workitem/sort.go
+++ b/internal/workitem/sort.go
@@ -1,17 +1,22 @@
 package workitem
 
 import (
+	"cmp"
 	"slices"
 	"strings"
 )
 
 // Sort orders items by the design's deterministic rule:
 //
-//	primary:   sort_timestamp DESC (most recent first)
-//	secondary: created_at DESC
-//	tertiary:  relative_path ASC (alphabetical for stable tie-breaking)
+//	primary:   ManualPriority bucket (high=1 < medium=2 < low=3 < none=4)
+//	secondary: sort_timestamp DESC (most recent first)
+//	tertiary:  created_at DESC
+//	quaternary: relative_path ASC (alphabetical for stable tie-breaking)
 func Sort(items []WorkItem) {
 	slices.SortStableFunc(items, func(a, b WorkItem) int {
+		if c := cmp.Compare(priorityRank(a.ManualPriority), priorityRank(b.ManualPriority)); c != 0 {
+			return c
+		}
 		if c := b.SortTimestamp.Compare(a.SortTimestamp); c != 0 {
 			return c
 		}
@@ -20,4 +25,18 @@ func Sort(items []WorkItem) {
 		}
 		return strings.Compare(a.RelativePath, b.RelativePath)
 	})
+}
+
+// priorityRank maps a manual priority string to its sort rank.
+func priorityRank(p string) int {
+	switch p {
+	case "high":
+		return 1
+	case "medium":
+		return 2
+	case "low":
+		return 3
+	default:
+		return 4
+	}
 }

--- a/internal/workitem/sort_test.go
+++ b/internal/workitem/sort_test.go
@@ -68,3 +68,92 @@ func TestDeriveSortTimestamp_FallsBackToCreated(t *testing.T) {
 		t.Errorf("expected created_at when updated_at is zero, got %v", ts)
 	}
 }
+
+func TestSort_ManualPriorityBuckets(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name  string
+		items []WorkItem
+		want  []string // expected RelativePath order
+	}{
+		{
+			name: "high before medium",
+			items: []WorkItem{
+				{RelativePath: "med", ManualPriority: "medium", SortTimestamp: now},
+				{RelativePath: "hi", ManualPriority: "high", SortTimestamp: now},
+			},
+			want: []string{"hi", "med"},
+		},
+		{
+			name: "medium before low",
+			items: []WorkItem{
+				{RelativePath: "lo", ManualPriority: "low", SortTimestamp: now},
+				{RelativePath: "med", ManualPriority: "medium", SortTimestamp: now},
+			},
+			want: []string{"med", "lo"},
+		},
+		{
+			name: "low before unset",
+			items: []WorkItem{
+				{RelativePath: "unset", SortTimestamp: now},
+				{RelativePath: "lo", ManualPriority: "low", SortTimestamp: now},
+			},
+			want: []string{"lo", "unset"},
+		},
+		{
+			name: "full bucket order",
+			items: []WorkItem{
+				{RelativePath: "unset", SortTimestamp: now},
+				{RelativePath: "lo", ManualPriority: "low", SortTimestamp: now},
+				{RelativePath: "hi", ManualPriority: "high", SortTimestamp: now},
+				{RelativePath: "med", ManualPriority: "medium", SortTimestamp: now},
+			},
+			want: []string{"hi", "med", "lo", "unset"},
+		},
+		{
+			name: "same priority uses recency",
+			items: []WorkItem{
+				{RelativePath: "old", ManualPriority: "high", SortTimestamp: now.Add(-time.Hour)},
+				{RelativePath: "new", ManualPriority: "high", SortTimestamp: now},
+			},
+			want: []string{"new", "old"},
+		},
+		{
+			name: "same priority same timestamp uses path",
+			items: []WorkItem{
+				{RelativePath: "b", ManualPriority: "medium", SortTimestamp: now, CreatedAt: now},
+				{RelativePath: "a", ManualPriority: "medium", SortTimestamp: now, CreatedAt: now},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "all unset backward compat",
+			items: []WorkItem{
+				{RelativePath: "c", SortTimestamp: now.Add(-2 * time.Hour)},
+				{RelativePath: "a", SortTimestamp: now},
+				{RelativePath: "b", SortTimestamp: now.Add(-time.Hour)},
+			},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "priority wins over recency",
+			items: []WorkItem{
+				{RelativePath: "new-unset", SortTimestamp: now},
+				{RelativePath: "old-high", ManualPriority: "high", SortTimestamp: now.Add(-time.Hour)},
+			},
+			want: []string{"old-high", "new-unset"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Sort(tt.items)
+			for i, wantPath := range tt.want {
+				if tt.items[i].RelativePath != wantPath {
+					t.Errorf("items[%d].RelativePath = %q, want %q", i, tt.items[i].RelativePath, wantPath)
+				}
+			}
+		})
+	}
+}

--- a/internal/workitem/tui/model.go
+++ b/internal/workitem/tui/model.go
@@ -75,6 +75,7 @@ type Model struct {
 	// Priority store for TUI mutations (set/clear priority).
 	priorityStore *priority.Store
 	storePath     string
+	priorityMode  bool
 }
 
 // New creates the dashboard model from a pre-discovered item list.
@@ -150,6 +151,45 @@ func (m *Model) clampScroll() {
 			m.scrollOffset = m.cursor - vp + 1
 		}
 	}
+}
+
+// preserveSelection moves the cursor to the item matching key after a resort.
+// If the key is not found in filteredItems, the cursor is clamped to the
+// nearest valid index.
+func (m *Model) preserveSelection(key string) {
+	if key == "" || len(m.filteredItems) == 0 {
+		m.cursor = 0
+		m.clampScroll()
+		return
+	}
+	for i, item := range m.filteredItems {
+		if item.Key == key {
+			m.cursor = i
+			m.clampScroll()
+			return
+		}
+	}
+	if m.cursor >= len(m.filteredItems) {
+		m.cursor = len(m.filteredItems) - 1
+	}
+	m.clampScroll()
+}
+
+// enterPriorityMode activates the priority picker if items are available.
+func (m *Model) enterPriorityMode() {
+	if len(m.filteredItems) > 0 && m.priorityStore != nil {
+		m.priorityMode = true
+	}
+}
+
+// exitPriorityMode returns to normal navigation mode.
+func (m *Model) exitPriorityMode() {
+	m.priorityMode = false
+}
+
+// isPriorityMode reports whether the priority picker is active.
+func (m Model) isPriorityMode() bool {
+	return m.priorityMode
 }
 
 // refreshMsg carries the result of a background re-discovery.

--- a/internal/workitem/tui/model.go
+++ b/internal/workitem/tui/model.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
 )
 
 // chromeHeight is the number of lines consumed by header + footer + separator.
@@ -70,10 +71,14 @@ type Model struct {
 	ctx          context.Context
 	campaignRoot string
 	resolver     *paths.Resolver
+
+	// Priority store for TUI mutations (set/clear priority).
+	priorityStore *priority.Store
+	storePath     string
 }
 
 // New creates the dashboard model from a pre-discovered item list.
-func New(ctx context.Context, items []workitem.WorkItem, campaignRoot string, resolver *paths.Resolver) Model {
+func New(ctx context.Context, items []workitem.WorkItem, campaignRoot string, resolver *paths.Resolver, store *priority.Store, storePath string) Model {
 	ti := textinput.New()
 	ti.Placeholder = "search..."
 	ti.CharLimit = 64
@@ -86,6 +91,8 @@ func New(ctx context.Context, items []workitem.WorkItem, campaignRoot string, re
 		ctx:           ctx,
 		campaignRoot:  campaignRoot,
 		resolver:      resolver,
+		priorityStore: store,
+		storePath:     storePath,
 	}
 }
 

--- a/internal/workitem/tui/model_test.go
+++ b/internal/workitem/tui/model_test.go
@@ -481,3 +481,45 @@ func TestFormatRecency_ZeroTime(t *testing.T) {
 		t.Errorf("formatRecency(zero) = %q, want '  -'", got)
 	}
 }
+
+func TestModel_PreserveSelection_KeyFound(t *testing.T) {
+	items := makeTestItems(10)
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
+	m.cursor = 5
+	targetKey := items[5].Key
+
+	// Reverse the filteredItems to simulate a resort.
+	reversed := make([]workitem.WorkItem, len(items))
+	for i, item := range items {
+		reversed[len(items)-1-i] = item
+	}
+	m.filteredItems = reversed
+	m.preserveSelection(targetKey)
+
+	if m.filteredItems[m.cursor].Key != targetKey {
+		t.Errorf("cursor at %d points to %q, want %q", m.cursor, m.filteredItems[m.cursor].Key, targetKey)
+	}
+}
+
+func TestModel_PreserveSelection_KeyNotFound(t *testing.T) {
+	items := makeTestItems(5)
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
+	m.cursor = 10 // intentionally out of range
+
+	m.preserveSelection("nonexistent:key")
+
+	if m.cursor != 4 {
+		t.Errorf("cursor = %d, want 4 (clamped to last item)", m.cursor)
+	}
+}
+
+func TestModel_PreserveSelection_EmptyList(t *testing.T) {
+	m := New(context.Background(), nil, "", nil, priority.NewStore(), "")
+	m.cursor = 5
+
+	m.preserveSelection("some:key")
+
+	if m.cursor != 0 {
+		t.Errorf("cursor = %d, want 0 (empty list)", m.cursor)
+	}
+}

--- a/internal/workitem/tui/model_test.go
+++ b/internal/workitem/tui/model_test.go
@@ -12,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
 )
 
 func makeTestItems(n int) []workitem.WorkItem {
@@ -33,7 +34,7 @@ func makeTestItems(n int) []workitem.WorkItem {
 
 func TestModel_CursorDown(t *testing.T) {
 	items := makeTestItems(5)
-	m := New(context.Background(), items, "", nil)
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
 
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	m = result.(Model)
@@ -44,7 +45,7 @@ func TestModel_CursorDown(t *testing.T) {
 
 func TestModel_CursorUp(t *testing.T) {
 	items := makeTestItems(5)
-	m := New(context.Background(), items, "", nil)
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
 	m.cursor = 3
 
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
@@ -56,7 +57,7 @@ func TestModel_CursorUp(t *testing.T) {
 
 func TestModel_CursorDoesNotGoBelowZero(t *testing.T) {
 	items := makeTestItems(5)
-	m := New(context.Background(), items, "", nil)
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
 	m.cursor = 0
 
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
@@ -68,7 +69,7 @@ func TestModel_CursorDoesNotGoBelowZero(t *testing.T) {
 
 func TestModel_GJumpsToBottom(t *testing.T) {
 	items := makeTestItems(5)
-	m := New(context.Background(), items, "", nil)
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
 
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
 	m = result.(Model)
@@ -79,7 +80,7 @@ func TestModel_GJumpsToBottom(t *testing.T) {
 
 func TestModel_GGJumpsToTop(t *testing.T) {
 	items := makeTestItems(5)
-	m := New(context.Background(), items, "", nil)
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
 	m.cursor = 4
 
 	// First g
@@ -99,7 +100,7 @@ func TestModel_TypeFilter(t *testing.T) {
 		{WorkflowType: workitem.WorkflowTypeDesign, Title: "design"},
 		{WorkflowType: workitem.WorkflowTypeFestival, Title: "fest"},
 	}
-	m := New(context.Background(), items, "", nil)
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
 
 	// Press 1 to filter intents
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
@@ -121,7 +122,7 @@ func TestModel_TypeFilter(t *testing.T) {
 
 func TestModel_EnterSelectsItem(t *testing.T) {
 	items := makeTestItems(3)
-	m := New(context.Background(), items, "", nil)
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
 	// Move to second item
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	m = result.(Model)
@@ -142,7 +143,7 @@ func TestModel_SearchEnterCommits(t *testing.T) {
 		{WorkflowType: workitem.WorkflowTypeIntent, Title: "Auth Feature"},
 		{WorkflowType: workitem.WorkflowTypeDesign, Title: "Dashboard Design"},
 	}
-	m := New(context.Background(), items, "", nil)
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
 	m.width = 80
 	m.height = 24
 	m.ready = true
@@ -182,7 +183,7 @@ func TestModel_SearchEscCancels(t *testing.T) {
 		{WorkflowType: workitem.WorkflowTypeIntent, Title: "Auth Feature"},
 		{WorkflowType: workitem.WorkflowTypeDesign, Title: "Dashboard Design"},
 	}
-	m := New(context.Background(), items, "", nil)
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
 	m.width = 80
 	m.height = 24
 	m.ready = true
@@ -216,7 +217,7 @@ func TestModel_SearchEscCancels(t *testing.T) {
 }
 
 func TestModel_EmptyView(t *testing.T) {
-	m := New(context.Background(), nil, "", nil)
+	m := New(context.Background(), nil, "", nil, priority.NewStore(), "")
 	m.width = 80
 	m.height = 24
 	m.ready = true
@@ -251,7 +252,7 @@ func TestModel_OpenEditorUsesModelContext(t *testing.T) {
 	cancel()
 
 	item := workitem.WorkItem{PrimaryDoc: filepath.Base(docPath)}
-	m := New(ctx, []workitem.WorkItem{item}, tempDir, nil)
+	m := New(ctx, []workitem.WorkItem{item}, tempDir, nil, priority.NewStore(), "")
 
 	start := time.Now()
 	err := m.editorCommand(docPath).Run()
@@ -266,7 +267,7 @@ func TestModel_OpenEditorUsesModelContext(t *testing.T) {
 }
 
 func TestModel_HelpToggle(t *testing.T) {
-	m := New(context.Background(), makeTestItems(1), "", nil)
+	m := New(context.Background(), makeTestItems(1), "", nil, priority.NewStore(), "")
 	m.width = 80
 	m.height = 24
 	m.ready = true
@@ -294,7 +295,7 @@ func TestModel_HelpToggle(t *testing.T) {
 func TestModel_ScrollViewport_CursorBeyondVisibleHeight(t *testing.T) {
 	// 20 items but only 5 visible rows — cursor must scroll into view
 	items := makeTestItems(20)
-	m := New(context.Background(), items, "", nil)
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
 	m.width = 80
 	m.height = 8 // 8 - 3 (header/footer) = 5 visible rows
 	m.ready = true
@@ -340,7 +341,7 @@ func TestModel_ScrollViewport_CursorBeyondVisibleHeight(t *testing.T) {
 
 func TestModel_GJumpUpdatesScroll(t *testing.T) {
 	items := makeTestItems(20)
-	m := New(context.Background(), items, "", nil)
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
 	m.width = 80
 	m.height = 8
 	m.ready = true
@@ -375,7 +376,7 @@ func TestModel_RefilterShrinksViewport(t *testing.T) {
 	// Simulate: user scrolls down in 20 items, then refresh returns only 2 items.
 	// scrollOffset must clamp so the viewport doesn't start past the end.
 	items := makeTestItems(20)
-	m := New(context.Background(), items, "", nil)
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
 	m.width = 80
 	m.height = 8 // viewport = 5 rows
 	m.ready = true
@@ -427,7 +428,7 @@ func TestModel_TypeFilterShrinksViewport(t *testing.T) {
 	items[0].WorkflowType = workitem.WorkflowTypeIntent
 	items[0].Title = "The Intent"
 
-	m := New(context.Background(), items, "", nil)
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
 	m.width = 80
 	m.height = 8
 	m.ready = true

--- a/internal/workitem/tui/styles.go
+++ b/internal/workitem/tui/styles.go
@@ -58,6 +58,13 @@ var (
 	helpDescStyle    = lipgloss.NewStyle().Foreground(pal.TextMuted)
 )
 
+// Priority badge styles
+var (
+	priorityHighStyle   = lipgloss.NewStyle().Bold(true).Foreground(pal.Error)
+	priorityMediumStyle = lipgloss.NewStyle().Bold(true).Foreground(pal.Warning)
+	priorityLowStyle    = lipgloss.NewStyle().Foreground(pal.TextDim)
+)
+
 // Empty state
 var (
 	emptyMsgStyle = lipgloss.NewStyle().Foreground(pal.Warning)

--- a/internal/workitem/tui/update.go
+++ b/internal/workitem/tui/update.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/editor"
 	"github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
 )
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -23,7 +24,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.err = msg.err
 		} else {
-			m.allItems = msg.items
+			items := priority.Apply(m.priorityStore, msg.items)
+			workitem.Sort(items)
+			m.allItems = items
 			m.refilter()
 		}
 		return m, nil

--- a/internal/workitem/tui/update.go
+++ b/internal/workitem/tui/update.go
@@ -12,6 +12,10 @@ import (
 	"github.com/Obedience-Corp/camp/internal/workitem/priority"
 )
 
+func (m Model) priorityStorePath() string {
+	return priority.StorePath(m.campaignRoot)
+}
+
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
@@ -24,10 +28,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.err = msg.err
 		} else {
-			items := priority.Apply(m.priorityStore, msg.items)
+			selectedKey := m.currentItem().Key
+			items := msg.items
+			if m.priorityStore != nil {
+				validKeys := make(map[string]bool, len(items))
+				for _, item := range items {
+					validKeys[item.Key] = true
+				}
+				if priority.Prune(m.priorityStore, validKeys) {
+					_ = priority.SaveOrDelete(m.priorityStorePath(), m.priorityStore)
+				}
+				items = priority.Apply(m.priorityStore, items)
+			}
 			workitem.Sort(items)
 			m.allItems = items
 			m.refilter()
+			m.preserveSelection(selectedKey)
 		}
 		return m, nil
 
@@ -39,6 +55,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		if m.isPriorityMode() {
+			return m.handlePriorityKey(msg)
+		}
 		if m.searchMode {
 			return m.handleSearchKey(msg)
 		}
@@ -116,6 +135,10 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.Selected = &item
 			return m, tea.Quit
 		}
+
+	// Priority mode
+	case "P":
+		m.enterPriorityMode()
 
 	// Quick actions (read-only)
 	case "e":
@@ -241,5 +264,60 @@ func (m Model) copyPath() (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 	cmd := m.setStatus("copied!", false)
+	return m, cmd
+}
+
+// --- Priority mode handlers ---
+
+func (m Model) handlePriorityKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "h", "1":
+		return m.assignPriority(priority.High)
+	case "m", "2":
+		return m.assignPriority(priority.Medium)
+	case "l", "3":
+		return m.assignPriority(priority.Low)
+	case "0":
+		return m.clearPriority()
+	case "esc":
+		m.exitPriorityMode()
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m Model) assignPriority(p priority.ManualPriority) (tea.Model, tea.Cmd) {
+	item := m.currentItem()
+	if item.Key == "" {
+		m.exitPriorityMode()
+		return m, nil
+	}
+	selectedKey := item.Key
+	priority.Set(m.priorityStore, item.Key, p)
+	_ = priority.SaveOrDelete(m.priorityStorePath(), m.priorityStore)
+	m.allItems = priority.Apply(m.priorityStore, m.allItems)
+	workitem.Sort(m.allItems)
+	m.refilter()
+	m.preserveSelection(selectedKey)
+	m.exitPriorityMode()
+	cmd := m.setStatus("priority set: "+string(p), false)
+	return m, cmd
+}
+
+func (m Model) clearPriority() (tea.Model, tea.Cmd) {
+	item := m.currentItem()
+	if item.Key == "" {
+		m.exitPriorityMode()
+		return m, nil
+	}
+	selectedKey := item.Key
+	priority.Clear(m.priorityStore, item.Key)
+	_ = priority.SaveOrDelete(m.priorityStorePath(), m.priorityStore)
+	m.allItems = priority.Apply(m.priorityStore, m.allItems)
+	workitem.Sort(m.allItems)
+	m.refilter()
+	m.preserveSelection(selectedKey)
+	m.exitPriorityMode()
+	cmd := m.setStatus("priority cleared", false)
 	return m, cmd
 }

--- a/internal/workitem/tui/update.go
+++ b/internal/workitem/tui/update.go
@@ -294,7 +294,11 @@ func (m Model) assignPriority(p priority.ManualPriority) (tea.Model, tea.Cmd) {
 	}
 	selectedKey := item.Key
 	priority.Set(m.priorityStore, item.Key, p)
-	_ = priority.SaveOrDelete(m.priorityStorePath(), m.priorityStore)
+	if err := priority.SaveOrDelete(m.priorityStorePath(), m.priorityStore); err != nil {
+		m.exitPriorityMode()
+		cmd := m.setStatus("save failed: "+err.Error(), true)
+		return m, cmd
+	}
 	m.allItems = priority.Apply(m.priorityStore, m.allItems)
 	workitem.Sort(m.allItems)
 	m.refilter()
@@ -312,7 +316,11 @@ func (m Model) clearPriority() (tea.Model, tea.Cmd) {
 	}
 	selectedKey := item.Key
 	priority.Clear(m.priorityStore, item.Key)
-	_ = priority.SaveOrDelete(m.priorityStorePath(), m.priorityStore)
+	if err := priority.SaveOrDelete(m.priorityStorePath(), m.priorityStore); err != nil {
+		m.exitPriorityMode()
+		cmd := m.setStatus("save failed: "+err.Error(), true)
+		return m, cmd
+	}
 	m.allItems = priority.Apply(m.priorityStore, m.allItems)
 	workitem.Sort(m.allItems)
 	m.refilter()

--- a/internal/workitem/tui/view.go
+++ b/internal/workitem/tui/view.go
@@ -91,10 +91,13 @@ func (m Model) renderFooter() string {
 		}
 		return statusSuccessStyle.Render(m.statusMsg)
 	}
+	if m.isPriorityMode() {
+		return footerStyle.Render("priority: h high  m medium  l low  0 clear  Esc cancel")
+	}
 	count := fmt.Sprintf("%d items", len(m.filteredItems))
-	keys := "j/k move  / search  1-4 filter  0 all  tab preview  r refresh  ? help  q quit"
+	keys := "j/k move  / search  1-4 filter  0 all  P priority  tab preview  r refresh  ? help  q quit"
 	if len(keys)+len(count)+2 > m.width {
-		keys = "j/k / 1-4 tab r ? q"
+		keys = "j/k / 1-4 P tab r ? q"
 	}
 	return footerStyle.Render(fmt.Sprintf("%s  %s", count, keys))
 }
@@ -152,13 +155,29 @@ func (m Model) renderEmpty(_, height int) string {
 	return b.String()
 }
 
+func priorityBadge(p string) (string, lipgloss.Style) {
+	switch p {
+	case "high":
+		return "H ", priorityHighStyle
+	case "medium":
+		return "M ", priorityMediumStyle
+	case "low":
+		return "L ", priorityLowStyle
+	default:
+		return "", lipgloss.NewStyle()
+	}
+}
+
 func renderRow(item workitem.WorkItem, width int, selected bool) string {
 	// Pad plain strings first, then apply color to avoid ANSI width issues
 	wfType := padRight(string(item.WorkflowType), 9)
 	stage := padRight(item.LifecycleStage, 9)
 	rec := formatRecency(item.SortTimestamp)
 
-	titleWidth := width - 9 - 9 - len(rec) - 4
+	badgeText, badgeStyle := priorityBadge(item.ManualPriority)
+	badgeWidth := len(badgeText)
+
+	titleWidth := width - 9 - 9 - len(rec) - 4 - badgeWidth
 	if titleWidth < 10 {
 		titleWidth = 10
 	}
@@ -168,10 +187,14 @@ func renderRow(item workitem.WorkItem, width int, selected bool) string {
 	// Apply styles to already-padded segments
 	styledType := workflowStyle(item.WorkflowType).Render(wfType)
 	styledStage := stageStyle(item.LifecycleStage).Render(stage)
+	styledBadge := ""
+	if badgeText != "" {
+		styledBadge = badgeStyle.Render(badgeText)
+	}
 	styledTitle := rowTitleStyle.Render(title)
 	styledRecency := recencyStyle(item.SortTimestamp).Render(rec)
 
-	row := fmt.Sprintf(" %s %s %s %s", styledType, styledStage, styledTitle, styledRecency)
+	row := fmt.Sprintf(" %s %s %s%s %s", styledType, styledStage, styledBadge, styledTitle, styledRecency)
 	if selected {
 		return rowSelectedStyle.Width(width).Render(row)
 	}
@@ -224,6 +247,21 @@ func renderPreview(item workitem.WorkItem, width, height int) string {
 	b.WriteString(fmt.Sprintf("%s %s\n",
 		previewLabelStyle.Render("stage:"),
 		stageStyle(stage).Render(stage)))
+	if item.ManualPriority != "" {
+		_, style := priorityBadge(item.ManualPriority)
+		b.WriteString(fmt.Sprintf("%s %s\n",
+			previewLabelStyle.Render("priority:"),
+			style.Render(item.ManualPriority)))
+	}
+	if item.WorkflowType == workitem.WorkflowTypeIntent {
+		if srcPrio, ok := item.SourceMetadata["priority"]; ok {
+			if prioStr, ok := srcPrio.(string); ok && prioStr != "" {
+				b.WriteString(fmt.Sprintf("%s %s\n",
+					previewLabelStyle.Render("intent priority:"),
+					previewValueStyle.Render(prioStr)))
+			}
+		}
+	}
 	b.WriteString(fmt.Sprintf("%s %s\n",
 		previewLabelStyle.Render("updated:"),
 		previewValueStyle.Render(item.UpdatedAt.Format("2006-01-02 15:04"))))
@@ -293,6 +331,14 @@ func (m Model) renderHelp() string {
 			{"y", "Copy absolute path"},
 			{"Tab / p", "Toggle preview pane"},
 			{"r", "Refresh (re-scan)"},
+		}},
+		{"Priority", [][2]string{
+			{"P", "Assign manual priority to selected item"},
+			{"h / 1", "Set high priority (in priority mode)"},
+			{"m / 2", "Set medium priority (in priority mode)"},
+			{"l / 3", "Set low priority (in priority mode)"},
+			{"0", "Clear manual priority (in priority mode)"},
+			{"Esc", "Cancel priority mode"},
 		}},
 		{"Other", [][2]string{
 			{"?", "Toggle this help"},


### PR DESCRIPTION
## Summary

- Add a lightweight manual priority system to `camp workitem` so users can mark workitems as high/medium/low importance with instant visual feedback and persistent, self-cleaning state
- Priority store persists to `.campaign/settings/workitems.json` with atomic writes, lazy creation, and automatic cleanup of stale entries
- TUI supports interactive priority assignment via `P` key with single-keypress picker (h/m/l/0/Esc)
- Prioritized items sort into buckets (high > medium > low > unset) before recency-based ordering
- JSON schema bumped to `workitems/v1alpha3` reflecting the new sort order and `manual_priority` field

### Key changes

- **`internal/workitem/priority/`** — new package with `ManualPriority` type, `Store` struct, Load/Save/Set/Clear/Prune/Apply/SaveOrDelete operations
- **`internal/workitem/model.go`** — `ManualPriority string` field with `omitempty` JSON tag
- **`internal/workitem/sort.go`** — priority bucket as primary sort key
- **`internal/commands/workitem/workitem.go`** — pipeline: discover → load store → prune (full set) → apply → sort → filter → render
- **`internal/workitem/tui/`** — priority mode key handlers, colored H/M/L row badges, preview field, footer/help updates, cursor preservation after resort
- **`internal/scaffold/init.go`** — `settings/workitems.json` added to `.campaign/.gitignore` scaffold

Also includes a prior fix: restore intent explorer preview focus (`Tab` behavior, filter shortcuts, preview-focus reset).

### Design invariants

- Prune runs against the **full** discovery set before any view-level filters — running `camp workitem --type design` never erases priorities on intent items
- Empty stores are deleted (no empty artifacts on disk)
- Cursor follows the selected item by `WorkItem.Key` after priority-triggered resorts

## Test plan

- [x] `go test ./...` passes across full codebase (0 failures)
- [x] `go build ./...` and `go vet ./...` clean
- [x] Unit tests: ManualPriority Rank/Valid, Store CRUD, atomic write, nil-map init
- [x] Integration tests: filter safety (type/query/limit), stale pruning, full pipeline simulation
- [x] Sort tests: 8-scenario table-driven test for priority bucket ordering
- [x] TUI tests: preserveSelection (key found, not found, empty list), all existing TUI tests updated
- [ ] Manual TUI verification: priority assignment, badge rendering, persistence across restarts