### PR TITLE
feat: add linked project support via symlinks

### DIFF
--- a/cmd/camp/project/add.go
+++ b/cmd/camp/project/add.go
@@ -25,13 +25,22 @@ Source can be:
   - SSH URL:   git@github.com:org/repo.git
   - HTTPS URL: https://github.com/org/repo.git
   - Local path (with --local): ./existing-repo
+  - Local path (with --link):  ~/code/my-project
+
+The --link flag creates a symlink to an external directory instead of
+cloning. This is useful for projects already on your machine that you
+want to include in the campaign without copying. Linked projects can
+be git repos or plain directories. The symlink and metadata are
+machine-local and won't be committed to the campaign repo.
 
 Examples:
   camp project add git@github.com:org/api.git           # Add remote repo
   camp project add https://github.com/org/web.git       # Add via HTTPS
-  camp project add --local ./my-repo --name my-project  # Add existing local repo
+  camp project add --local ./my-repo --name my-project  # Add existing local repo as submodule
+  camp project add --link ~/code/my-app                 # Link external project
+  camp project add --link ~/code/my-app --name app      # Link with custom name
   camp project add git@github.com:org/api.git --name backend  # Custom name`,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	RunE: runProjectAdd,
 }
 
@@ -40,17 +49,18 @@ func init() {
 
 	projectAddCmd.Flags().StringP("name", "n", "", "Override project name (defaults to repo name)")
 	projectAddCmd.Flags().StringP("path", "p", "", "Override destination path (defaults to projects/<name>)")
-	projectAddCmd.Flags().StringP("local", "l", "", "Add existing local repository instead of cloning")
+	projectAddCmd.Flags().StringP("local", "l", "", "Add existing local repository as submodule (clones into campaign)")
+	projectAddCmd.Flags().String("link", "", "Link an external directory via symlink (no cloning, machine-local)")
 	projectAddCmd.Flags().Bool("no-commit", false, "Skip automatic git commit")
 }
 
 func runProjectAdd(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	source := args[0]
 
 	name, _ := cmd.Flags().GetString("name")
 	path, _ := cmd.Flags().GetString("path")
 	local, _ := cmd.Flags().GetString("local")
+	link, _ := cmd.Flags().GetString("link")
 	noCommit, _ := cmd.Flags().GetBool("no-commit")
 
 	// Detect campaign root
@@ -58,6 +68,41 @@ func runProjectAdd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Handle --link: create symlink to external project
+	if link != "" {
+		linkOpts := projectsvc.LinkOptions{
+			Name: name,
+			Path: path,
+		}
+		linkResult, err := projectsvc.AddLinked(ctx, root, link, linkOpts)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("%s %s\n", ui.SuccessIcon(), ui.Success("Linked project: "+linkResult.Name))
+		fmt.Println()
+		fmt.Println(ui.KeyValue("  Path:", linkResult.Path))
+		fmt.Println(ui.KeyValue("  Source:", linkResult.Source))
+		if linkResult.Type != "" {
+			fmt.Println(ui.KeyValue("  Type:", linkResult.Type))
+		}
+		if linkResult.IsGit {
+			fmt.Println(ui.KeyValue("  Git:", "yes"))
+		} else {
+			fmt.Println(ui.KeyValue("  Git:", "no (non-git directory)"))
+		}
+		fmt.Println()
+		fmt.Println(ui.Dim("  Linked projects are machine-local and not committed to the campaign repo."))
+		return nil
+	}
+
+	// Require source arg for non-link add
+	if len(args) == 0 {
+		return fmt.Errorf("source URL is required\n" +
+			"Hint: Provide a git URL, or use --link to symlink an existing directory")
+	}
+	source := args[0]
 
 	opts := projectsvc.AddOptions{
 		Name:  name,

--- a/cmd/camp/project/remove.go
+++ b/cmd/camp/project/remove.go
@@ -88,6 +88,9 @@ func runProjectRemove(cmd *cobra.Command, args []string) error {
 		fmt.Println(ui.Warning("Dry run - would remove:"))
 		fmt.Println()
 		fmt.Println(ui.KeyValue("  Project:", result.Name))
+		if result.LinkRemoved {
+			fmt.Printf("    %s Remove linked project symlink and manifest entry\n", ui.BulletIcon())
+		}
 		if result.SubmoduleRemoved {
 			fmt.Printf("    %s Remove from git submodule tracking\n", ui.BulletIcon())
 		}
@@ -101,6 +104,9 @@ func runProjectRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("%s %s\n", ui.SuccessIcon(), ui.Success("Removed project: "+result.Name))
+	if result.LinkRemoved {
+		fmt.Printf("  %s Linked project unlinked (original files untouched)\n", ui.SuccessIcon())
+	}
 	if result.SubmoduleRemoved {
 		fmt.Printf("  %s Submodule unregistered\n", ui.SuccessIcon())
 	}
@@ -111,8 +117,9 @@ func runProjectRemove(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  %s Worktrees deleted\n", ui.SuccessIcon())
 	}
 
-	// Auto-commit if not disabled and not a dry run
-	if !noCommit && !dryRun {
+	// Auto-commit if not disabled, not a dry run, and not a linked project
+	// (linked project removal doesn't change tracked files)
+	if !noCommit && !dryRun && !result.LinkRemoved {
 		cfg, _ := config.LoadCampaignConfig(ctx, root)
 		campaignID := ""
 		if cfg != nil {

--- a/internal/project/link.go
+++ b/internal/project/link.go
@@ -1,0 +1,263 @@
+package project
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// LinkOptions configures how a local project is linked into the campaign.
+type LinkOptions struct {
+	// Name overrides the project name (defaults to directory basename).
+	Name string
+	// Path overrides the destination path (defaults to projects/<name>).
+	Path string
+}
+
+// LinkResult contains information about the linked project.
+type LinkResult struct {
+	// Name is the project name.
+	Name string
+	// Path is the relative path from campaign root (symlink location).
+	Path string
+	// Source is the original absolute path.
+	Source string
+	// Type is the detected project type.
+	Type string
+	// IsGit indicates whether the linked project is a git repository.
+	IsGit bool
+}
+
+// AddLinked links an external directory into the campaign via symlink.
+// The project can be a git repo or a plain directory. The symlink is created
+// inside projects/ and the project is recorded in the linked projects manifest.
+// A .gitignore entry is added so git does not track the symlink.
+func AddLinked(ctx context.Context, campaignRoot, localPath string, opts LinkOptions) (*LinkResult, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	// Resolve to absolute path
+	absLocal, err := filepath.Abs(localPath)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "failed to resolve local path")
+	}
+
+	// Verify the path exists and is a directory
+	info, err := os.Stat(absLocal)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("path does not exist: %s", localPath)
+		}
+		return nil, camperrors.Wrapf(err, "cannot access %s", localPath)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("path is not a directory: %s", localPath)
+	}
+
+	// Determine project name
+	name := opts.Name
+	if name == "" {
+		name = filepath.Base(absLocal)
+	}
+	if err := ValidateProjectName(name); err != nil {
+		return nil, err
+	}
+
+	// Determine destination path
+	destPath := opts.Path
+	if destPath == "" {
+		destPath = filepath.Join("projects", name)
+	}
+
+	fullPath := filepath.Join(campaignRoot, destPath)
+
+	// Check if already exists
+	if _, err := os.Lstat(fullPath); err == nil {
+		return nil, &ErrProjectExists{Name: name, Path: destPath}
+	}
+
+	// Check if it's a git repo
+	isGit := isGitRepo(absLocal)
+
+	// Determine source type
+	source := SourceLinked
+	if !isGit {
+		source = SourceLinkedNonGit
+	}
+
+	// Ensure parent directory exists
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		return nil, camperrors.Wrapf(err, "create parent directory")
+	}
+
+	// Create the symlink (absolute path for reliability)
+	if err := os.Symlink(absLocal, fullPath); err != nil {
+		return nil, camperrors.Wrapf(err, "create symlink")
+	}
+
+	// Add to manifest
+	entry := LinkedProjectEntry{
+		Source:  source,
+		AbsPath: absLocal,
+		IsGit:  isGit,
+		AddedAt: time.Now(),
+	}
+	if err := AddToManifest(campaignRoot, name, entry); err != nil {
+		// Clean up symlink on manifest failure
+		os.Remove(fullPath)
+		return nil, camperrors.Wrapf(err, "record linked project")
+	}
+
+	// Add gitignore entry so the campaign repo doesn't track the symlink
+	if err := addGitignoreEntry(campaignRoot, destPath); err != nil {
+		// Non-fatal - warn but continue
+		fmt.Fprintf(os.Stderr, "Warning: could not add .gitignore entry: %v\n", err)
+	}
+
+	// Detect project type
+	projectType := detectProjectType(absLocal)
+
+	return &LinkResult{
+		Name:   name,
+		Path:   destPath,
+		Source: absLocal,
+		Type:   projectType,
+		IsGit:  isGit,
+	}, nil
+}
+
+// UnlinkProject removes a linked project's symlink and manifest entry.
+// Returns true if the project was a linked project that was unlinked.
+func UnlinkProject(ctx context.Context, campaignRoot, name string) (bool, error) {
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+
+	isLinked, _, err := IsLinkedProject(campaignRoot, name)
+	if err != nil {
+		return false, err
+	}
+	if !isLinked {
+		return false, nil
+	}
+
+	projectPath := filepath.Join(campaignRoot, "projects", name)
+
+	// Verify it's actually a symlink before removing
+	info, err := os.Lstat(projectPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Symlink already gone, just clean up manifest
+			RemoveFromManifest(campaignRoot, name)
+			return true, nil
+		}
+		return false, camperrors.Wrapf(err, "check linked project")
+	}
+
+	if info.Mode()&os.ModeSymlink != 0 {
+		if err := os.Remove(projectPath); err != nil {
+			return false, camperrors.Wrapf(err, "remove symlink")
+		}
+	}
+
+	// Remove from manifest
+	if _, err := RemoveFromManifest(campaignRoot, name); err != nil {
+		return false, err
+	}
+
+	// Remove gitignore entry
+	destPath := filepath.Join("projects", name)
+	if err := removeGitignoreEntry(campaignRoot, destPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not remove .gitignore entry: %v\n", err)
+	}
+
+	return true, nil
+}
+
+// isGitRepo checks whether a directory contains a .git directory or file.
+func isGitRepo(path string) bool {
+	_, err := os.Stat(filepath.Join(path, ".git"))
+	return err == nil
+}
+
+// addGitignoreEntry appends a path to the campaign root's .gitignore
+// if it's not already present.
+func addGitignoreEntry(campaignRoot, entry string) error {
+	gitignorePath := filepath.Join(campaignRoot, ".gitignore")
+
+	// Normalize to forward slashes for gitignore compatibility
+	entry = filepath.ToSlash(entry)
+
+	// Check if entry already exists
+	existing, err := os.ReadFile(gitignorePath)
+	if err == nil {
+		for _, line := range strings.Split(string(existing), "\n") {
+			if strings.TrimSpace(line) == entry {
+				return nil // Already present
+			}
+		}
+	}
+
+	// Append entry
+	f, err := os.OpenFile(gitignorePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Add a newline before if the file doesn't end with one
+	if len(existing) > 0 && existing[len(existing)-1] != '\n' {
+		if _, err := f.WriteString("\n"); err != nil {
+			return err
+		}
+	}
+
+	// Add comment on first linked project entry
+	if !strings.Contains(string(existing), "# Linked projects") {
+		if _, err := f.WriteString("\n# Linked projects (machine-local symlinks)\n"); err != nil {
+			return err
+		}
+	}
+
+	_, err = f.WriteString(entry + "\n")
+	return err
+}
+
+// removeGitignoreEntry removes a path from the campaign root's .gitignore.
+func removeGitignoreEntry(campaignRoot, entry string) error {
+	gitignorePath := filepath.Join(campaignRoot, ".gitignore")
+
+	entry = filepath.ToSlash(entry)
+
+	data, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	var lines []string
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) != entry {
+			lines = append(lines, line)
+		}
+	}
+
+	// Clean up empty "Linked projects" comment section if no linked entries remain
+	result := strings.Join(lines, "\n")
+	if !strings.Contains(result, "projects/") {
+		result = strings.Replace(result, "\n# Linked projects (machine-local symlinks)\n", "", 1)
+	}
+
+	return os.WriteFile(gitignorePath, []byte(result), 0644)
+}

--- a/internal/project/list.go
+++ b/internal/project/list.go
@@ -12,10 +12,17 @@ import (
 
 // List returns all projects in the campaign's projects directory.
 // It identifies git repositories, detects their project type, and expands
-// repos with .gitmodules into root + submodule entries.
+// repos with .gitmodules into root + submodule entries. Symlinked directories
+// (linked projects) are included and annotated with their source type.
 func List(ctx context.Context, campaignRoot string) ([]Project, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
+	}
+
+	// Load linked project manifest for source annotation
+	manifest, _ := LoadManifest(campaignRoot)
+	if manifest == nil {
+		manifest = &LinkedProjectManifest{Projects: make(map[string]LinkedProjectEntry)}
 	}
 
 	projectsDir := filepath.Join(campaignRoot, "projects")
@@ -34,11 +41,29 @@ func List(ctx context.Context, campaignRoot string) ([]Project, error) {
 			return nil, ctx.Err()
 		}
 
-		if !entry.IsDir() {
+		name := entry.Name()
+		projectPath := filepath.Join(projectsDir, name)
+
+		// Check if this is a symlink (linked project)
+		if entry.Type()&os.ModeSymlink != 0 {
+			// Resolve symlink target to check if it's valid
+			resolved, err := filepath.EvalSymlinks(projectPath)
+			if err != nil {
+				// Broken symlink — skip
+				continue
+			}
+			info, err := os.Stat(resolved)
+			if err != nil || !info.IsDir() {
+				continue
+			}
+
+			projects = append(projects, resolveLinkedProject(ctx, name, resolved, manifest)...)
 			continue
 		}
 
-		projectPath := filepath.Join(projectsDir, entry.Name())
+		if !entry.IsDir() {
+			continue
+		}
 
 		// Check if it's a git repo (has .git file or directory)
 		gitPath := filepath.Join(projectPath, ".git")
@@ -46,12 +71,85 @@ func List(ctx context.Context, campaignRoot string) ([]Project, error) {
 			continue
 		}
 
-		projects = append(projects, resolveProject(ctx, entry.Name(), projectPath)...)
+		resolved := resolveProject(ctx, name, projectPath)
+		// Annotate submodule source type
+		for i := range resolved {
+			resolved[i].Source = SourceSubmodule
+		}
+		projects = append(projects, resolved...)
 	}
 
 	projects = deduplicateByRemoteURL(ctx, campaignRoot, projects)
 
 	return projects, nil
+}
+
+// resolveLinkedProject returns Project entries for a symlinked directory.
+// It handles both git and non-git linked projects.
+func resolveLinkedProject(ctx context.Context, name, resolvedPath string, manifest *LinkedProjectManifest) []Project {
+	entry, inManifest := manifest.Projects[name]
+
+	isGit := isGitRepo(resolvedPath)
+
+	source := SourceLinked
+	if !isGit {
+		source = SourceLinkedNonGit
+	}
+	// Trust manifest source if available
+	if inManifest {
+		source = entry.Source
+	}
+
+	linkedPath := resolvedPath
+	if inManifest {
+		linkedPath = entry.AbsPath
+	}
+
+	url := ""
+	if isGit {
+		url = getGitRemoteURL(ctx, resolvedPath)
+	}
+
+	relPath := filepath.Join("projects", name)
+
+	// For git repos, check for monorepo expansion
+	if isGit {
+		submodulePaths, _ := git.ListSubmodulePaths(ctx, resolvedPath)
+		if len(submodulePaths) > 0 {
+			expanded := make([]Project, 0, len(submodulePaths)+1)
+			expanded = append(expanded, Project{
+				Name:        name,
+				Path:        relPath,
+				Type:        detectProjectType(resolvedPath),
+				URL:         url,
+				Source:      source,
+				LinkedPath:  linkedPath,
+				ExcludeDirs: submodulePaths,
+			})
+			for _, subPath := range submodulePaths {
+				subFullPath := filepath.Join(resolvedPath, subPath)
+				expanded = append(expanded, Project{
+					Name:         name + "@" + subPath,
+					Path:         filepath.Join(relPath, subPath),
+					Type:         detectProjectType(subFullPath),
+					URL:          url,
+					Source:       source,
+					LinkedPath:   linkedPath,
+					MonorepoRoot: relPath,
+				})
+			}
+			return expanded
+		}
+	}
+
+	return []Project{{
+		Name:       name,
+		Path:       relPath,
+		Type:       detectProjectType(resolvedPath),
+		URL:        url,
+		Source:     source,
+		LinkedPath: linkedPath,
+	}}
 }
 
 // resolveProject returns one or more Project entries for a discovered git repo.

--- a/internal/project/manifest.go
+++ b/internal/project/manifest.go
@@ -1,0 +1,141 @@
+package project
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// LinkedProjectManifest stores metadata about projects linked into the campaign
+// via symlinks rather than git submodules. This file is machine-local and
+// should be gitignored.
+type LinkedProjectManifest struct {
+	Projects map[string]LinkedProjectEntry `json:"projects"`
+}
+
+// LinkedProjectEntry records how a linked project was added.
+type LinkedProjectEntry struct {
+	// Source is the project source type (SourceLinked or SourceLinkedNonGit).
+	Source string `json:"source"`
+	// AbsPath is the absolute path to the original project on disk.
+	AbsPath string `json:"abs_path"`
+	// IsGit indicates whether the linked project is a git repository.
+	IsGit bool `json:"is_git"`
+	// AddedAt is the timestamp when the project was linked.
+	AddedAt time.Time `json:"added_at"`
+}
+
+const linkedProjectsFile = "linked-projects.json"
+
+// manifestPath returns the path to the linked projects manifest.
+func manifestPath(campaignRoot string) string {
+	return filepath.Join(campaignRoot, ".campaign", linkedProjectsFile)
+}
+
+var manifestMu sync.Mutex
+
+// LoadManifest reads the linked projects manifest from disk.
+// Returns an empty manifest if the file doesn't exist.
+func LoadManifest(campaignRoot string) (*LinkedProjectManifest, error) {
+	path := manifestPath(campaignRoot)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &LinkedProjectManifest{
+				Projects: make(map[string]LinkedProjectEntry),
+			}, nil
+		}
+		return nil, camperrors.Wrapf(err, "read linked projects manifest")
+	}
+
+	var m LinkedProjectManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, camperrors.Wrapf(err, "parse linked projects manifest")
+	}
+
+	if m.Projects == nil {
+		m.Projects = make(map[string]LinkedProjectEntry)
+	}
+
+	return &m, nil
+}
+
+// SaveManifest writes the linked projects manifest to disk atomically.
+func SaveManifest(campaignRoot string, m *LinkedProjectManifest) error {
+	manifestMu.Lock()
+	defer manifestMu.Unlock()
+
+	path := manifestPath(campaignRoot)
+
+	// Ensure .campaign directory exists
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return camperrors.Wrapf(err, "create .campaign directory")
+	}
+
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return camperrors.Wrapf(err, "marshal linked projects manifest")
+	}
+	data = append(data, '\n')
+
+	// Write atomically via temp file
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return camperrors.Wrapf(err, "write linked projects manifest")
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return camperrors.Wrapf(err, "rename linked projects manifest")
+	}
+
+	return nil
+}
+
+// AddToManifest adds a linked project entry and saves the manifest.
+func AddToManifest(campaignRoot, name string, entry LinkedProjectEntry) error {
+	m, err := LoadManifest(campaignRoot)
+	if err != nil {
+		return err
+	}
+
+	m.Projects[name] = entry
+
+	return SaveManifest(campaignRoot, m)
+}
+
+// RemoveFromManifest removes a linked project entry and saves the manifest.
+// Returns true if the entry existed.
+func RemoveFromManifest(campaignRoot, name string) (bool, error) {
+	m, err := LoadManifest(campaignRoot)
+	if err != nil {
+		return false, err
+	}
+
+	if _, exists := m.Projects[name]; !exists {
+		return false, nil
+	}
+
+	delete(m.Projects, name)
+
+	return true, SaveManifest(campaignRoot, m)
+}
+
+// IsLinkedProject checks whether a project name is in the linked manifest.
+func IsLinkedProject(campaignRoot, name string) (bool, *LinkedProjectEntry, error) {
+	m, err := LoadManifest(campaignRoot)
+	if err != nil {
+		return false, nil, err
+	}
+
+	entry, exists := m.Projects[name]
+	if !exists {
+		return false, nil, nil
+	}
+
+	return true, &entry, nil
+}

--- a/internal/project/output.go
+++ b/internal/project/output.go
@@ -34,23 +34,60 @@ func formatTable(w io.Writer, projects []Project) error {
 	if len(projects) == 0 {
 		fmt.Fprintln(w, ui.Warning("No projects found."))
 		fmt.Fprintln(w)
-		fmt.Fprintf(w, "Add one with: %s\n", ui.Accent("camp project add <url>"))
+		fmt.Fprintf(w, "Add one with: %s or %s\n",
+			ui.Accent("camp project add <url>"),
+			ui.Accent("camp project add --link <path>"))
 		return nil
 	}
 
+	// Check if any linked projects exist to decide whether to show SOURCE column
+	hasLinked := false
+	for _, p := range projects {
+		if p.Source == SourceLinked || p.Source == SourceLinkedNonGit {
+			hasLinked = true
+			break
+		}
+	}
+
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, "%s\t%s\t%s\n", ui.Label("NAME"), ui.Label("PATH"), ui.Label("TYPE"))
+	if hasLinked {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", ui.Label("NAME"), ui.Label("PATH"), ui.Label("TYPE"), ui.Label("SOURCE"))
+	} else {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", ui.Label("NAME"), ui.Label("PATH"), ui.Label("TYPE"))
+	}
 	for _, p := range projects {
 		projectType := p.Type
 		if projectType == "" {
 			projectType = "-"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%s\n",
-			ui.Value(p.Name),
-			ui.Dim(p.Path),
-			getProjectTypeStyled(projectType))
+		if hasLinked {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+				ui.Value(p.Name),
+				ui.Dim(p.Path),
+				getProjectTypeStyled(projectType),
+				getSourceStyled(p.Source))
+		} else {
+			fmt.Fprintf(tw, "%s\t%s\t%s\n",
+				ui.Value(p.Name),
+				ui.Dim(p.Path),
+				getProjectTypeStyled(projectType))
+		}
 	}
 	return tw.Flush()
+}
+
+// getSourceStyled returns styled source type text.
+func getSourceStyled(source string) string {
+	switch source {
+	case SourceSubmodule:
+		return ui.Dim("submodule")
+	case SourceLinked:
+		return ui.ColoredText("linked", ui.SuccessColor)
+	case SourceLinkedNonGit:
+		return ui.ColoredText("linked (non-git)", ui.WarningColor)
+	default:
+		return ui.Dim("submodule")
+	}
 }
 
 // getProjectTypeStyled returns styled project type text.

--- a/internal/project/remove.go
+++ b/internal/project/remove.go
@@ -36,6 +36,8 @@ type RemoveResult struct {
 	Path string
 	// SubmoduleRemoved indicates if git submodule was deinitialized.
 	SubmoduleRemoved bool
+	// LinkRemoved indicates if a linked project symlink was removed.
+	LinkRemoved bool
 	// FilesDeleted indicates if project files were deleted.
 	FilesDeleted bool
 	// WorktreeDeleted indicates if worktree directory was deleted.
@@ -93,11 +95,22 @@ func Remove(ctx context.Context, campaignRoot, name string, opts RemoveOptions) 
 		Path: projectPath,
 	}
 
+	// Check if this is a linked project (symlink)
+	isLinked, _, linkedErr := IsLinkedProject(campaignRoot, name)
+	if linkedErr != nil {
+		return nil, linkedErr
+	}
+
 	// Dry run just reports what would happen
 	if opts.DryRun {
-		addStep(result, "would deinit and remove submodule from git tracking")
-		result.SubmoduleRemoved = true
-		if opts.Delete {
+		if isLinked {
+			addStep(result, "would remove linked project symlink and manifest entry")
+			result.LinkRemoved = true
+		} else {
+			addStep(result, "would deinit and remove submodule from git tracking")
+			result.SubmoduleRemoved = true
+		}
+		if opts.Delete && !isLinked {
 			addStep(result, fmt.Sprintf("would delete project directory %s", projectPath))
 			result.FilesDeleted = true
 			worktreePath := campaignProjectWorktreePath(ctx, campaignRoot, name)
@@ -105,6 +118,19 @@ func Remove(ctx context.Context, campaignRoot, name string, opts RemoveOptions) 
 				addStep(result, fmt.Sprintf("would delete worktree directory %s", worktreePath))
 				result.WorktreeDeleted = true
 			}
+		}
+		return result, nil
+	}
+
+	// Handle linked project removal
+	if isLinked {
+		unlinked, err := UnlinkProject(ctx, campaignRoot, name)
+		if err != nil {
+			return nil, camperrors.Wrap(err, "failed to unlink project")
+		}
+		if unlinked {
+			addStep(result, "symlink removed and manifest entry cleaned up")
+			result.LinkRemoved = true
 		}
 		return result, nil
 	}

--- a/internal/project/resolve.go
+++ b/internal/project/resolve.go
@@ -74,24 +74,46 @@ func ResolveFromCwd(ctx context.Context, campRoot string) (*ResolveResult, error
 		return nil, camperrors.Wrap(err, "failed to get working directory")
 	}
 
-	projectRoot, isSubmodule, err := git.FindProjectRootWithType(cwd)
-	if err != nil {
-		return nil, camperrors.Wrap(err, "not inside a project directory")
-	}
-
-	// Resolve symlinks for reliable comparison (e.g., macOS /var → /private/var)
-	resolvedRoot, _ := filepath.EvalSymlinks(projectRoot)
+	// Resolve symlinks in cwd so we can match against both symlink and target paths
+	resolvedCwd, _ := filepath.EvalSymlinks(cwd)
 	resolvedCamp, _ := filepath.EvalSymlinks(campRoot)
-	if resolvedRoot == resolvedCamp || projectRoot == campRoot {
-		return nil, errors.New("you're in the campaign root, not a project\nUse 'camp commit' for campaign-level commits")
-	}
 
-	// Look up the project in the dynamic list
+	// Look up the project in the dynamic list first — this covers linked projects
+	// (symlinks) which may not have a .git directory at all.
 	projects, listErr := List(ctx, campRoot)
 	if listErr != nil {
 		return nil, camperrors.Wrap(listErr, "failed to list projects")
 	}
 
+	for _, proj := range projects {
+		projPath := filepath.Join(campRoot, proj.Path)
+		resolvedProj, _ := filepath.EvalSymlinks(projPath)
+
+		// Check if cwd is the project root or inside it
+		if isPathWithin(resolvedCwd, resolvedProj) || isPathWithin(cwd, projPath) {
+			return &ResolveResult{Name: proj.Name, Path: resolvedProj}, nil
+		}
+
+		// For linked projects, also check against the linked target path
+		if proj.LinkedPath != "" {
+			if isPathWithin(resolvedCwd, proj.LinkedPath) {
+				return &ResolveResult{Name: proj.Name, Path: proj.LinkedPath}, nil
+			}
+		}
+	}
+
+	// Fall back to git-based detection for submodules
+	projectRoot, isSubmodule, err := git.FindProjectRootWithType(cwd)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "not inside a project directory")
+	}
+
+	resolvedRoot, _ := filepath.EvalSymlinks(projectRoot)
+	if resolvedRoot == resolvedCamp || projectRoot == campRoot {
+		return nil, errors.New("you're in the campaign root, not a project\nUse 'camp commit' for campaign-level commits")
+	}
+
+	// Check again against the list with the git-detected root
 	for _, proj := range projects {
 		projPath := filepath.Join(campRoot, proj.Path)
 		resolvedProj, _ := filepath.EvalSymlinks(projPath)
@@ -111,6 +133,18 @@ func ResolveFromCwd(ctx context.Context, campRoot string) (*ResolveResult, error
 		CampRoot: campRoot,
 		Projects: projects,
 	}
+}
+
+// isPathWithin returns true if child is equal to or a subdirectory of parent.
+func isPathWithin(child, parent string) bool {
+	if child == parent {
+		return true
+	}
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != ".."
 }
 
 // nameFromPath extracts a project name from its absolute path relative to

--- a/internal/project/types.go
+++ b/internal/project/types.go
@@ -10,6 +10,12 @@ type Project struct {
 	Type string
 	// URL is the git remote origin URL.
 	URL string
+	// Source indicates how the project was added to the campaign.
+	// One of SourceSubmodule, SourceLinked, or SourceLinkedNonGit.
+	Source string
+	// LinkedPath is the absolute path to the original project on disk.
+	// Only set when Source is SourceLinked or SourceLinkedNonGit.
+	LinkedPath string
 	// MonorepoRoot is the relative path to the parent monorepo, set when this
 	// project is a subproject expanded from a monorepo. Empty for standalone projects.
 	MonorepoRoot string
@@ -25,4 +31,14 @@ const (
 	TypeTypeScript = "typescript"
 	TypePython     = "python"
 	TypeUnknown    = ""
+)
+
+// Project source constants indicate how a project was added.
+const (
+	// SourceSubmodule is a project added as a git submodule (default).
+	SourceSubmodule = "submodule"
+	// SourceLinked is a git project symlinked from an external path.
+	SourceLinked = "linked"
+	// SourceLinkedNonGit is a non-git project symlinked from an external path.
+	SourceLinkedNonGit = "linked-non-git"
 )

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -311,6 +311,9 @@ state.yaml
 
 # Generated cache (navigation index, rebuilt automatically)
 cache/
+
+# Linked project registry (machine-local symlink metadata)
+linked-projects.json
 `
 			if err := os.WriteFile(gitignorePath, []byte(gitignoreContent), 0644); err != nil {
 				return nil, camperrors.Wrap(err, "failed to create .gitignore")


### PR DESCRIPTION
## Summary

Add support for linking external local projects into campaigns via symlinks, complementing the existing git submodule approach. This is a draft/starting point — several areas need further work before merge.

## Design Rationale

### Why this is needed

Campaigns are git monorepos where projects are added as submodules. This works well for portability but creates friction for a common use case: **users who already have projects cloned elsewhere on their machine**. Today they must either:

1. Re-clone into the campaign as a submodule (duplicating the repo)
2. Use `--local` which still clones and bakes an absolute path into `.gitmodules` (non-portable anyway)

Based on feedback, most users care more about "all my projects in one place that works" than strict git portability. They want to point their campaign at existing work, not reorganize their filesystem.

### Why symlinks

Symlinks are the simplest solution that gives filesystem transparency:
- `cd projects/my-app` just works — editors, tools, scripts all see real files
- `camp project list` finds them via `os.ReadDir`
- Git commands work inside the symlink target if it's a git repo
- No special mount permissions needed (unlike bind mounts)

The trade-off is they're not portable across machines, which is acceptable since that's the explicit contract: linked projects are local conveniences, submodules are for portability.

### No manifest — symlinks are the source of truth

~~The initial implementation included a `.campaign/linked-projects.json` manifest.~~ After discussion, this was identified as redundant. Everything the manifest stored is derivable from the filesystem at runtime:

- **Is it linked?** → `os.Lstat()` checks if entry in `projects/` is a symlink
- **Where does it point?** → `os.Readlink()` gives the target path
- **Is it a git repo?** → `os.Stat(target + "/.git")`

The manifest should be removed from this PR. The symlinks themselves are the source of truth for the campaign→project direction. For the reverse direction (project→campaign), see the `.camp` marker file discussion below.

### Architecture: two-way linking without a manifest

The linking relationship is established by two lightweight markers:

1. **Symlink in `projects/`** → the campaign knows about the project
2. **`.camp` file in the project directory** → the project knows about the campaign

No manifest, no duplicated state. Each side of the relationship is stored exactly once, at the location that needs it.

## What this PR implements (code changes)

- `Source` and `LinkedPath` fields on `Project` type with `submodule`, `linked`, `linked-non-git` constants
- ~~`.campaign/linked-projects.json` manifest~~ (to be removed — see above)
- `AddLinked()` / `UnlinkProject()` functions (`link.go`)
- `List()` updated to follow symlinks and annotate source type
- `Remove()` detects linked projects and unlinks cleanly (original files untouched)
- `ResolveFromCwd()` checks project list before git fallback (handles non-git linked projects)
- Table output shows `SOURCE` column when linked projects exist
- `--link` flag on `camp project add` CLI command

## What still needs to be done

See comments below for detailed discussion of:
1. Removing the manifest and using filesystem detection instead
2. All `camp project` subcommands that need linked project support
3. `.camp` marker file for campaign context detection (critical)
4. Fuzzy navigation (`cgo`/`camp go`) fixes

https://claude.ai/code/session_01MM4k12uBDhiw5sLHVzZV44