### PR TITLE
fix: address review findings on configured-target navigation

### DIFF
--- a/cmd/camp/navigation/go.go
+++ b/cmd/camp/navigation/go.go
@@ -60,10 +60,6 @@ func runGo(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Resolve configured navigation from shortcuts, long-form directory aliases,
-	// and configured concepts.
-	resolved := nav.ResolveConfiguredTarget(cfg, args)
-
 	// Handle toggle keyword: "t" or "toggle"
 	if len(args) > 0 && (args[0] == "toggle" || args[0] == "t") {
 		return handleToggle(ctx, campaignRoot, printOnly)
@@ -80,6 +76,11 @@ func runGo(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
+
+	// Resolve configured navigation from shortcuts, long-form directory aliases,
+	// and configured concepts. Deferred until after the short-circuits above so
+	// toggle and custom-path shortcuts don't pay the resolution cost.
+	resolved := nav.ResolveConfiguredTarget(cfg, args)
 
 	result := nav.ParseResult{
 		Category:   nav.CategoryAll,
@@ -408,6 +409,10 @@ func handleRelativePathNavigation(ctx context.Context, campaignRoot, relativePat
 }
 
 func resolveRelativePathNavigation(ctx context.Context, campaignRoot, relativePath, query string) (string, error) {
+	if ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+
 	if query == "" {
 		jumpResult, err := nav.JumpToPathFromRoot(ctx, campaignRoot, relativePath)
 		if err != nil {
@@ -428,11 +433,14 @@ func resolveRelativePathNavigation(ctx context.Context, campaignRoot, relativePa
 		if err != nil {
 			return "", err
 		}
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
 		nestedPath := filepath.Join(prefixPath, parts[1])
 		if info, err := os.Stat(nestedPath); err == nil && info.IsDir() {
 			return nestedPath, nil
 		}
-		return "", fmt.Errorf("path does not exist: %s/%s", strings.TrimRight(relativePath, "/"), query)
+		return "", camperrors.Wrapf(errNavigationPathNotFound, "%s/%s", strings.TrimRight(relativePath, "/"), query)
 	}
 
 	return fuzzyResolveDirectory(ctx, basePath, query, relativePath)
@@ -446,7 +454,7 @@ func fuzzyResolveDirectory(ctx context.Context, basePath, query, relativePath st
 	entries, err := os.ReadDir(basePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", fmt.Errorf("path does not exist: %s", relativePath)
+			return "", camperrors.Wrap(errNavigationPathNotFound, relativePath)
 		}
 		return "", camperrors.Wrap(err, "failed to read navigation path")
 	}
@@ -461,11 +469,18 @@ func fuzzyResolveDirectory(ctx context.Context, basePath, query, relativePath st
 
 	matches := fuzzy.FilterMulti(names, query)
 	if len(matches) == 0 {
-		return "", fmt.Errorf("no directories matching %q in %s", query, strings.TrimRight(relativePath, "/"))
+		return "", camperrors.Wrapf(errNavigationNoMatch, "%q in %s", query, strings.TrimRight(relativePath, "/"))
 	}
 
 	return filepath.Join(basePath, matches[0].Target), nil
 }
+
+// errNavigationPathNotFound indicates the requested navigation target directory
+// could not be resolved to an existing path under the campaign root.
+var errNavigationPathNotFound = camperrors.New("navigation path does not exist")
+
+// errNavigationNoMatch indicates fuzzy resolution found no matching directory.
+var errNavigationNoMatch = camperrors.New("no directories match navigation query")
 
 // evalSymlinks resolves symlinks in a path, returning the original path if resolution fails.
 func evalSymlinks(path string) (string, error) {

--- a/internal/complete/complete.go
+++ b/internal/complete/complete.go
@@ -159,18 +159,6 @@ func GenerateRich(ctx context.Context, args []string) ([]RichCategoryGroup, erro
 	return grouped, nil
 }
 
-// shortcutKeys returns the keys from a shortcuts map.
-func shortcutKeys(shortcuts map[string]nav.Category) []string {
-	if len(shortcuts) == 0 {
-		return nil
-	}
-	keys := make([]string, 0, len(shortcuts))
-	for k := range shortcuts {
-		keys = append(keys, k)
-	}
-	return keys
-}
-
 // CategoryShortcuts returns category shortcut keys from campaign config.
 // Returns nil if not in a campaign.
 func CategoryShortcuts() []string {
@@ -250,9 +238,13 @@ func completeInCategory(ctx context.Context, cat nav.Category, query string) ([]
 func completeAll(ctx context.Context, query string, topLevelNames []string) ([]string, error) {
 	var candidates []string
 
-	// Add matching top-level navigation names first.
+	// Add matching top-level navigation names first. Normalize both sides
+	// (lowercase + trim trailing slash) so queries like "design/" still match
+	// the "design" top-level name; this mirrors how ResolveConfiguredTarget
+	// normalizes tokens elsewhere.
+	normalizedQuery := nav.NormalizeNavigationName(query)
 	for _, name := range topLevelNames {
-		if strings.HasPrefix(strings.ToLower(name), strings.ToLower(query)) {
+		if strings.HasPrefix(nav.NormalizeNavigationName(name), normalizedQuery) {
 			candidates = append(candidates, name)
 		}
 	}
@@ -352,9 +344,9 @@ func completeDrillInCategoryRich(ctx context.Context, campaignRoot string, cat n
 }
 
 func listPathCandidates(ctx context.Context, absPath, prefix string) ([]string, error) {
-	entries, err := os.ReadDir(absPath)
+	entries, err := readDirForCompletion(absPath)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	var candidates []string
@@ -379,9 +371,9 @@ func listPathCandidates(ctx context.Context, absPath, prefix string) ([]string, 
 }
 
 func listPathCandidatesRich(ctx context.Context, absPath, relativePath, prefix string) ([]index.CompletionCandidate, error) {
-	entries, err := os.ReadDir(absPath)
+	entries, err := readDirForCompletion(absPath)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	var candidates []index.CompletionCandidate
@@ -411,15 +403,30 @@ func listPathCandidatesRich(ctx context.Context, absPath, relativePath, prefix s
 	return candidates, nil
 }
 
+// readDirForCompletion reads a directory for completion purposes.
+// A missing directory is not an error (returns nil entries), but real I/O
+// failures — permission denied, bad symlinks, etc. — are surfaced so callers
+// can decide how to handle them instead of silently degrading to "no matches".
+func readDirForCompletion(absPath string) ([]os.DirEntry, error) {
+	entries, err := os.ReadDir(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return entries, nil
+}
+
 func completeSubdirectoryInPath(ctx context.Context, basePath, query string) ([]string, error) {
 	lastSlash := strings.LastIndex(query, "/")
 	dirPath := query[:lastSlash]
 	filter := query[lastSlash+1:]
 
 	absDir := filepath.Join(basePath, dirPath)
-	entries, err := os.ReadDir(absDir)
+	entries, err := readDirForCompletion(absDir)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	var candidates []string
@@ -449,9 +456,9 @@ func completeSubdirectoryInPathRich(ctx context.Context, basePath, relativePath,
 	filter := query[lastSlash+1:]
 
 	absDir := filepath.Join(basePath, dirPath)
-	entries, err := os.ReadDir(absDir)
+	entries, err := readDirForCompletion(absDir)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	var candidates []index.CompletionCandidate

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -28,10 +28,6 @@ type JumpsConfig struct {
 	Paths CampaignPaths `yaml:"paths,omitempty"`
 	// Shortcuts defines custom navigation and command shortcuts.
 	Shortcuts map[string]ShortcutConfig `yaml:"shortcuts,omitempty"`
-	// PathsMap is the effective name→path map for jumps paths.
-	// It starts with the raw YAML keys, then overlays the normalized/defaulted
-	// standard campaign paths so alias lookups stay aligned with runtime config.
-	PathsMap map[string]string `yaml:"-"`
 }
 
 // JumpsConfigPath returns the path to jumps.yaml for a given campaign root.
@@ -72,14 +68,6 @@ func LoadJumpsConfig(ctx context.Context, campaignRoot string) (*JumpsConfig, er
 	var cfg JumpsConfig
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, camperrors.Wrapf(err, "failed to parse jumps config %s", configPath)
-	}
-
-	// Capture the raw paths map so callers can preserve custom aliases.
-	var raw struct {
-		Paths map[string]string `yaml:"paths"`
-	}
-	if err := yaml.Unmarshal(data, &raw); err == nil && raw.Paths != nil {
-		cfg.PathsMap = raw.Paths
 	}
 
 	cfg.NormalizeIntentNavigation()
@@ -204,39 +192,6 @@ func (j *JumpsConfig) ApplyDefaults() {
 	if j.Paths.Dungeon == "" {
 		j.Paths.Dungeon = defaults.Paths.Dungeon
 	}
-
-	j.refreshPathsMap()
-}
-
-func (j *JumpsConfig) refreshPathsMap() {
-	if j.PathsMap == nil {
-		j.PathsMap = make(map[string]string)
-	}
-
-	for name, path := range effectivePathsMap(j.Paths) {
-		j.PathsMap[name] = path
-	}
-}
-
-func effectivePathsMap(paths CampaignPaths) map[string]string {
-	m := make(map[string]string)
-	add := func(name, path string) {
-		if path != "" {
-			m[name] = path
-		}
-	}
-	add("projects", paths.Projects)
-	add("worktrees", paths.Worktrees)
-	add("ai_docs", paths.AIDocs)
-	add("docs", paths.Docs)
-	add("festivals", paths.Festivals)
-	add("workflow", paths.Workflow)
-	add("intents", paths.Intents)
-	add("code_reviews", paths.CodeReviews)
-	add("pipelines", paths.Pipelines)
-	add("design", paths.Design)
-	add("dungeon", paths.Dungeon)
-	return m
 }
 
 // JumpsConfigExists checks if jumps.yaml exists for the given campaign root.

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -182,37 +182,7 @@ func TestSaveJumpsConfig_NormalizesLegacyIntentNavigation(t *testing.T) {
 	}
 }
 
-func TestJumpsConfigRefreshPathsMapUsesEffectivePaths(t *testing.T) {
-	jumps := &JumpsConfig{
-		Paths: CampaignPaths{
-			Intents: "workflow/intents/",
-		},
-		PathsMap: map[string]string{
-			"intents":       "workflow/intents/",
-			"documentation": "docs/",
-		},
-	}
-
-	if changed := jumps.NormalizeIntentNavigation(); !changed {
-		t.Fatal("NormalizeIntentNavigation() = false, want true for legacy intents path")
-	}
-
-	jumps.ApplyDefaults()
-
-	if got := jumps.PathsMap["intents"]; got != ".campaign/intents/" {
-		t.Fatalf("PathsMap[intents] = %q, want %q", got, ".campaign/intents/")
-	}
-
-	if got := jumps.PathsMap["projects"]; got != "projects/" {
-		t.Fatalf("PathsMap[projects] = %q, want %q", got, "projects/")
-	}
-
-	if got := jumps.PathsMap["documentation"]; got != "docs/" {
-		t.Fatalf("PathsMap[documentation] = %q, want %q", got, "docs/")
-	}
-}
-
-func TestLoadJumpsConfig_AppliesDefaultsAndPreservesRawAliases(t *testing.T) {
+func TestLoadJumpsConfig_AppliesDefaults(t *testing.T) {
 	root := t.TempDir()
 	settingsDir := SettingsDirPath(root)
 	if err := os.MkdirAll(settingsDir, 0755); err != nil {
@@ -222,7 +192,6 @@ func TestLoadJumpsConfig_AppliesDefaultsAndPreservesRawAliases(t *testing.T) {
 	raw := `
 paths:
   intents: workflow/intents/
-  documentation: docs/
 `
 	configPath := filepath.Join(settingsDir, JumpsConfigFile)
 	if err := os.WriteFile(configPath, []byte(raw), 0644); err != nil {
@@ -239,41 +208,5 @@ paths:
 	}
 	if got := cfg.Paths.Projects; got != "projects/" {
 		t.Fatalf("Paths.Projects = %q, want %q", got, "projects/")
-	}
-	if got := cfg.PathsMap["intents"]; got != ".campaign/intents/" {
-		t.Fatalf("PathsMap[intents] = %q, want %q", got, ".campaign/intents/")
-	}
-	if got := cfg.PathsMap["projects"]; got != "projects/" {
-		t.Fatalf("PathsMap[projects] = %q, want %q", got, "projects/")
-	}
-	if got := cfg.PathsMap["documentation"]; got != "docs/" {
-		t.Fatalf("PathsMap[documentation] = %q, want %q", got, "docs/")
-	}
-}
-
-func TestSaveJumpsConfig_DoesNotMutateCallerPathsMap(t *testing.T) {
-	root := t.TempDir()
-	cfg := &JumpsConfig{
-		Paths: CampaignPaths{
-			Intents: "workflow/intents/",
-		},
-		PathsMap: map[string]string{
-			"documentation": "docs/",
-			"intents":       "workflow/intents/",
-		},
-	}
-
-	if err := SaveJumpsConfig(context.Background(), root, cfg); err != nil {
-		t.Fatalf("SaveJumpsConfig() error = %v", err)
-	}
-
-	if got := cfg.PathsMap["intents"]; got != "workflow/intents/" {
-		t.Fatalf("caller PathsMap[intents] = %q, want %q", got, "workflow/intents/")
-	}
-	if got := cfg.PathsMap["documentation"]; got != "docs/" {
-		t.Fatalf("caller PathsMap[documentation] = %q, want %q", got, "docs/")
-	}
-	if _, ok := cfg.PathsMap["projects"]; ok {
-		t.Fatalf("caller PathsMap unexpectedly gained projects default: %#v", cfg.PathsMap)
 	}
 }

--- a/internal/nav/configured_navigation.go
+++ b/internal/nav/configured_navigation.go
@@ -51,6 +51,9 @@ func TopLevelNavigationNames(cfg *config.CampaignConfig) []string {
 		return nil
 	}
 
+	shortcuts := cfg.Shortcuts()
+	aliases := BuildPathAliasMappings(shortcuts)
+
 	seen := make(map[string]string)
 	add := func(name string) {
 		normalized := NormalizeNavigationName(name)
@@ -63,13 +66,13 @@ func TopLevelNavigationNames(cfg *config.CampaignConfig) []string {
 		seen[normalized] = name
 	}
 
-	for key, shortcut := range cfg.Shortcuts() {
+	for key, shortcut := range shortcuts {
 		if shortcut.IsNavigation() {
 			add(key)
 		}
 	}
 
-	for alias := range BuildPathAliasMappings(cfg.Shortcuts()) {
+	for alias := range aliases {
 		add(alias)
 	}
 
@@ -88,18 +91,31 @@ func TopLevelNavigationNames(cfg *config.CampaignConfig) []string {
 // ResolveConfiguredTarget resolves the first navigation argument against the
 // current campaign configuration.
 //
-// Resolution order:
-//  1. Configured shortcut keys from jumps.yaml
-//  2. Configured concept names from campaign.yaml
-//  3. Long-form directory aliases derived from configured navigation shortcuts
+// Resolution order (first match wins):
+//  1. Shortcut-drill form "<key>@<query>" (e.g. "de@festival_app")
+//  2. Plain shortcut key from jumps.yaml (e.g. "de")
+//  3. Slash-drill form "<token>/<query>" (e.g. "design/festival_app"),
+//     where <token> is resolved via step 4 or 5 below
+//  4. Configured concept name from campaign.yaml (e.g. "design")
+//  5. Long-form directory alias derived from a navigation shortcut's target
+//     path (e.g. shortcut "de" → path "workflow/design/" → alias "design")
+//
+// Concepts shadow path aliases at the same normalized name by design:
+// concepts are an explicit authoring surface and should win over aliases
+// derived implicitly from shortcut paths.
 func ResolveConfiguredTarget(cfg *config.CampaignConfig, args []string) ConfiguredTarget {
-	if cfg == nil {
+	if cfg == nil || len(args) == 0 {
 		return ConfiguredTarget{}
 	}
 
-	parsedArgs, shortcutDrill := splitShortcutDrillArgs(args)
-	if shortcutDrill {
-		shortcutMappings := BuildCategoryMappings(cfg.Shortcuts())
+	// Compute shortcut and alias maps once — both branches below may consult
+	// them, and this is on the shell-completion hot path.
+	shortcuts := cfg.Shortcuts()
+	shortcutMappings := BuildCategoryMappings(shortcuts)
+	aliases := BuildPathAliasMappings(shortcuts)
+
+	// (1) Shortcut-drill form: "de@foo"
+	if parsedArgs, ok := splitShortcutDrillArgs(args); ok {
 		parsed := ParseShortcut(parsedArgs, shortcutMappings)
 		if parsed.IsShortcut {
 			return ConfiguredTarget{
@@ -111,9 +127,8 @@ func ResolveConfiguredTarget(cfg *config.CampaignConfig, args []string) Configur
 		}
 	}
 
-	shortcutMappings := BuildCategoryMappings(cfg.Shortcuts())
-	parsed := ParseShortcut(args, shortcutMappings)
-	if parsed.IsShortcut {
+	// (2) Plain shortcut key: "de"
+	if parsed := ParseShortcut(args, shortcutMappings); parsed.IsShortcut {
 		return ConfiguredTarget{
 			Category: parsed.Category,
 			Query:    parsed.Query,
@@ -121,20 +136,18 @@ func ResolveConfiguredTarget(cfg *config.CampaignConfig, args []string) Configur
 		}
 	}
 
-	if len(args) == 0 {
-		return ConfiguredTarget{}
-	}
-
+	// (3) Slash-drill form: "design/foo" — resolve token via concept/alias.
 	if drillArgs, ok := splitSlashDrillArgs(args); ok {
-		target := resolveDrillTarget(cfg, drillArgs)
+		target := resolveDrillTarget(cfg, aliases, drillArgs)
 		target.Drill = target.Matched
 		return target
 	}
 
-	return resolveDrillTarget(cfg, args)
+	// (4)/(5) Plain concept or path alias: "design" or "ai_docs"
+	return resolveDrillTarget(cfg, aliases, args)
 }
 
-func resolveDrillTarget(cfg *config.CampaignConfig, args []string) ConfiguredTarget {
+func resolveDrillTarget(cfg *config.CampaignConfig, aliases map[string]PathAliasTarget, args []string) ConfiguredTarget {
 	token := args[0]
 	query := ""
 	if len(args) > 1 {
@@ -156,7 +169,7 @@ func resolveDrillTarget(cfg *config.CampaignConfig, args []string) ConfiguredTar
 		}
 	}
 
-	if alias, ok := BuildPathAliasMappings(cfg.Shortcuts())[NormalizeNavigationName(token)]; ok {
+	if alias, ok := aliases[NormalizeNavigationName(token)]; ok {
 		return ConfiguredTarget{
 			Category:     alias.Category,
 			RelativePath: alias.RelativePath,


### PR DESCRIPTION
## Summary

Follow-up to #208 addressing the review feedback. Targets the PR branch so these fixes land inside that PR's history rather than `main`.

Concrete changes:
- **Remove `JumpsConfig.PathsMap` dead code.** No production consumer existed; aliases are still derived from `cfg.Shortcuts()` via `BuildPathAliasMappings`. Dropped 50+ lines of plumbing and 100 lines of tests that gave a misleading impression that arbitrary user keys under `paths:` become navigable.
- **Replace `fmt.Errorf` with typed sentinels.** New `errNavigationPathNotFound` and `errNavigationNoMatch` in `cmd/camp/navigation/go.go`, wrapped via `camperrors.Wrap{,f}`. Callers can now `errors.Is(err, errNavigationPathNotFound)` to distinguish not-found from I/O failure.
- **Add `ctx.Err()` gates** at the top of `resolveRelativePathNavigation` and before the second `os.Stat` in the slash-drill branch. Honors the 200ms shell-completion timeout on the slow path.
- **Compute shortcut/alias maps once per `ResolveConfiguredTarget` call.** Previously `BuildCategoryMappings` could run twice and `BuildPathAliasMappings` 2–3 times per invocation in the shell-completion hot path.
- **Rewrite the `ResolveConfiguredTarget` docstring** to describe the actual 5-step resolution order and to document the intentional concept-shadows-alias precedence.
- **Move `ResolveConfiguredTarget` below the toggle / custom-path shortcut short-circuits** so `cgo t` and `cgo <custom-shortcut>` don't pay the resolution cost.
- **Remove dead `shortcutKeys` helper** in `internal/complete/complete.go`.
- **Fix normalization inconsistency in `completeAll`.** Both sides now go through `NormalizeNavigationName`, so `cgo design/<TAB>` still proposes the `design` top-level alias.
- **Surface real I/O errors from path-based completion helpers.** New `readDirForCompletion` helper swallows `os.IsNotExist` but bubbles permission / bad-symlink failures up instead of degrading to a silent "no candidates".

## Diffstat

```
 cmd/camp/navigation/go.go             | 29 +++++++++++----
 internal/complete/complete.go         | 51 +++++++++++++++-----------
 internal/config/settings.go           | 45 -----------------------
 internal/config/settings_test.go      | 69 +----------------------------------
 internal/nav/configured_navigation.go | 55 +++++++++++++++++-----------
 5 files changed, 86 insertions(+), 163 deletions(-)
```

Net -77 lines.

## Test plan

- [x] `just build quick` — green
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages pass, including `./internal/nav/...`, `./internal/complete/...`, `./internal/config/...`, `./cmd/camp/navigation/...`
- [x] `golangci-lint` on the touched packages — no new issues introduced (only pre-existing findings remain)
- [ ] Reviewer: manually exercise `cgo design`, `cgo ai_docs`, `cgo design/festival_app`, `cgo de@festival_site` against a real campaign to confirm end-to-end behavior

## Notes for the reviewer

- Kept the existing `TestLoadJumpsConfig_AppliesDefaults` as a single renamed test covering the useful invariants (defaulting works, legacy intents path is normalized).
- The docstring on `ResolveConfiguredTarget` is now the canonical description of resolution order — if we add another layer, update the docstring at the same time.
- The new sentinel errors deliberately stay unexported; scripted callers that care about the difference should match via the package's `camperrors.Is{NotFound,...}` helpers in a future change, or we export the sentinels if a cross-package consumer shows up.