### PR TITLE
fix: restore --campaign value space-separated syntax for intent add

### DIFF
--- a/cmd/camp/args_normalize.go
+++ b/cmd/camp/args_normalize.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"strings"
+)
+
+// optionalValueFlags are long/short flag tokens whose flag definitions set
+// NoOptDefVal so that a bare occurrence (no value) falls back to a sentinel
+// default — see cmd/camp/intent/add.go. Cobra's pflag library refuses to
+// consume the next space-separated argument as the value for these flags,
+// which means users who run `--campaign foo "title"` end up with "foo"
+// treated as a positional argument instead of the flag's value.
+//
+// normalizeOptionalValueFlagArgs rewrites the space-separated form to the
+// `--flag=value` form before cobra ever sees os.Args, so the standard
+// Unix convention (`--flag value`) works as expected while the bare-flag
+// picker UX is preserved.
+//
+// Keep this list in sync with every flag that sets NoOptDefVal.
+var optionalValueFlags = map[string]struct{}{
+	"--campaign": {},
+	"-c":         {},
+}
+
+// normalizeOptionalValueFlagArgs rewrites `--flag value` to `--flag=value`
+// for flags listed in optionalValueFlags, returning a new slice. Bare
+// occurrences (last arg, or followed by another flag starting with `-`)
+// are left untouched so the NoOptDefVal sentinel still fires.
+//
+// Tokens after a standalone `--` separator are treated as positionals and
+// not rewritten.
+func normalizeOptionalValueFlagArgs(args []string) []string {
+	out := make([]string, 0, len(args))
+	sawDoubleDash := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		if sawDoubleDash {
+			out = append(out, arg)
+			continue
+		}
+		if arg == "--" {
+			sawDoubleDash = true
+			out = append(out, arg)
+			continue
+		}
+
+		// Skip `--flag=value` forms — already glued.
+		if strings.Contains(arg, "=") {
+			out = append(out, arg)
+			continue
+		}
+
+		if _, ok := optionalValueFlags[arg]; !ok {
+			out = append(out, arg)
+			continue
+		}
+
+		// Flag is in our set. Look at the next token to decide whether to glue.
+		next := ""
+		hasNext := i+1 < len(args)
+		if hasNext {
+			next = args[i+1]
+		}
+
+		// Bare flag cases — keep the flag as-is and let NoOptDefVal apply.
+		//   - last argument
+		//   - next token is another flag (starts with `-`, or is the `--` separator)
+		if !hasNext || strings.HasPrefix(next, "-") {
+			out = append(out, arg)
+			continue
+		}
+
+		// Glue: `--flag value` → `--flag=value`.
+		out = append(out, arg+"="+next)
+		i++
+	}
+	return out
+}

--- a/cmd/camp/args_normalize_test.go
+++ b/cmd/camp/args_normalize_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeOptionalValueFlagArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "space-separated long flag gets glued",
+			in:   []string{"intent", "add", "--campaign", "dest", "Title"},
+			want: []string{"intent", "add", "--campaign=dest", "Title"},
+		},
+		{
+			name: "space-separated short flag gets glued",
+			in:   []string{"intent", "add", "-c", "dest", "Title"},
+			want: []string{"intent", "add", "-c=dest", "Title"},
+		},
+		{
+			name: "already glued long flag left alone",
+			in:   []string{"intent", "add", "--campaign=dest", "Title"},
+			want: []string{"intent", "add", "--campaign=dest", "Title"},
+		},
+		{
+			name: "already glued short flag left alone",
+			in:   []string{"intent", "add", "-c=dest", "Title"},
+			want: []string{"intent", "add", "-c=dest", "Title"},
+		},
+		{
+			name: "bare long flag at end of args stays bare for NoOptDefVal",
+			in:   []string{"intent", "add", "--campaign"},
+			want: []string{"intent", "add", "--campaign"},
+		},
+		{
+			name: "bare long flag followed by another flag stays bare",
+			in:   []string{"intent", "add", "--campaign", "--no-commit"},
+			want: []string{"intent", "add", "--campaign", "--no-commit"},
+		},
+		{
+			name: "bare short flag followed by long flag stays bare",
+			in:   []string{"intent", "add", "-c", "--no-commit"},
+			want: []string{"intent", "add", "-c", "--no-commit"},
+		},
+		{
+			name: "flag followed by `--` stays bare",
+			in:   []string{"intent", "add", "--campaign", "--", "Title"},
+			want: []string{"intent", "add", "--campaign", "--", "Title"},
+		},
+		{
+			name: "token after `--` separator is never rewritten",
+			in:   []string{"intent", "add", "--", "--campaign", "dest"},
+			want: []string{"intent", "add", "--", "--campaign", "dest"},
+		},
+		{
+			name: "unrelated flags untouched",
+			in:   []string{"intent", "add", "--no-commit", "Title", "--type", "feature"},
+			want: []string{"intent", "add", "--no-commit", "Title", "--type", "feature"},
+		},
+		{
+			name: "end-to-end test invocation",
+			in:   []string{"intent", "add", "--campaign", "intent-target-dest", "Targeted Intent", "--no-commit"},
+			want: []string{"intent", "add", "--campaign=intent-target-dest", "Targeted Intent", "--no-commit"},
+		},
+		{
+			name: "empty args",
+			in:   []string{},
+			want: []string{},
+		},
+		{
+			name: "no optional-value flags present",
+			in:   []string{"project", "list"},
+			want: []string{"project", "list"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeOptionalValueFlagArgs(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("normalizeOptionalValueFlagArgs(%v)\n  got:  %v\n  want: %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/camp/args_normalize_test.go
+++ b/cmd/camp/args_normalize_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"reflect"
 	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func TestNormalizeOptionalValueFlagArgs(t *testing.T) {
@@ -85,5 +88,73 @@ func TestNormalizeOptionalValueFlagArgs(t *testing.T) {
 				t.Errorf("normalizeOptionalValueFlagArgs(%v)\n  got:  %v\n  want: %v", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestOptionalValueFlagsCoverNoOptDefValFlags guards against silent drift
+// between the hand-maintained optionalValueFlags map and the set of
+// non-bool flags with NoOptDefVal set across the cobra command tree.
+//
+// pflag auto-assigns NoOptDefVal="true" on every bool flag (so bare
+// --verbose means --verbose=true); those are a built-in pflag mechanism,
+// not the "optional string value" pattern the preprocessor targets and
+// they are excluded from this check.
+//
+// For non-bool flags, NoOptDefVal is the deliberate "bare flag means
+// sentinel default" pattern — see cmd/camp/intent/add.go for the only
+// current example. Without this guard, someone adding a second such flag
+// would reintroduce the original bug: `--flag value` never consumes the
+// space-separated token, leaving `value` as a stray positional argument.
+//
+// If this test fails, add every reported flag token to optionalValueFlags
+// in cmd/camp/args_normalize.go.
+func TestOptionalValueFlagsCoverNoOptDefValFlags(t *testing.T) {
+	var missing []string
+	seen := map[string]struct{}{}
+
+	check := func(f *pflag.Flag) {
+		if f.NoOptDefVal == "" {
+			return
+		}
+		// Bool flags get NoOptDefVal="true" automatically from pflag and
+		// must not be rewritten to `--flag=value` (which would fail bool
+		// parsing on anything that isn't a bool literal). Skip them.
+		if f.Value.Type() == "bool" {
+			return
+		}
+		long := "--" + f.Name
+		if _, ok := seen[long]; !ok {
+			seen[long] = struct{}{}
+			if _, ok := optionalValueFlags[long]; !ok {
+				missing = append(missing, long)
+			}
+		}
+		if f.Shorthand != "" {
+			short := "-" + f.Shorthand
+			if _, ok := seen[short]; !ok {
+				seen[short] = struct{}{}
+				if _, ok := optionalValueFlags[short]; !ok {
+					missing = append(missing, short)
+				}
+			}
+		}
+	}
+
+	var walk func(cmd *cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		cmd.PersistentFlags().VisitAll(check)
+		cmd.Flags().VisitAll(check)
+		for _, child := range cmd.Commands() {
+			walk(child)
+		}
+	}
+	walk(rootCmd)
+
+	if len(missing) > 0 {
+		t.Errorf(
+			"non-bool flags with NoOptDefVal set but missing from optionalValueFlags in cmd/camp/args_normalize.go:\n  %v\n\n"+
+				"Add each token to the optionalValueFlags map so space-separated `--flag value` parses correctly.",
+			missing,
+		)
 	}
 }

--- a/cmd/camp/root.go
+++ b/cmd/camp/root.go
@@ -56,6 +56,13 @@ func Execute() error {
 	// Expand shortcuts before command execution
 	expandShortcuts()
 
+	// Rewrite `--flag value` → `--flag=value` for optional-value flags (those
+	// with NoOptDefVal set on their pflag definition). Without this, cobra's
+	// pflag library never consumes the space-separated next token, which
+	// makes `camp intent add --campaign <name> "Title"` misparse <name> as a
+	// positional arg.
+	os.Args = normalizeOptionalValueFlagArgs(os.Args)
+
 	// Try git-style plugin dispatch for unknown subcommands.
 	// A camp-<name> binary on PATH becomes "camp <name> [args...]".
 	if err := dispatchPlugin(); err != nil {

--- a/tests/integration/intent_add_target_test.go
+++ b/tests/integration/intent_add_target_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -43,4 +44,74 @@ func TestIntentAdd_TargetCampaignWritesToSelectedRoot(t *testing.T) {
 	currentLS, err := execLS(tc, "/campaigns/intent-target-current/.campaign/intents/inbox")
 	require.NoError(t, err)
 	assert.True(t, strings.TrimSpace(currentLS) == "", "current campaign inbox should remain empty")
+}
+
+// TestIntentAdd_TargetCampaignFlagForms verifies that all four valid
+// invocation forms of the --campaign flag route the intent to the target
+// campaign end-to-end through cobra. The normalizer is unit-tested in
+// cmd/camp/args_normalize_test.go, but cobra's parsing pipeline is
+// exercised here so a future pflag upgrade or cobra version bump that
+// changes optional-value semantics will be caught.
+//
+// Forms covered:
+//   --campaign <name>   long, space-separated  (the original bug)
+//   --campaign=<name>   long, equals-attached
+//   -c <name>           short, space-separated
+//   -c=<name>           short, equals-attached
+func TestIntentAdd_TargetCampaignFlagForms(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	const sourceCampaign = "/campaigns/intent-forms-source"
+	_, err := tc.InitCampaign(sourceCampaign, "intent-forms-source", "product")
+	require.NoError(t, err)
+
+	cases := []struct {
+		name         string
+		targetSuffix string   // appended to form the unique target campaign name
+		flagArgs     []string // arg tokens that go between `intent add` and the title
+	}{
+		{"long-space", "long-space", []string{"--campaign", "intent-forms-dest-long-space"}},
+		{"long-equals", "long-equals", []string{"--campaign=intent-forms-dest-long-equals"}},
+		{"short-space", "short-space", []string{"-c", "intent-forms-dest-short-space"}},
+		{"short-equals", "short-equals", []string{"-c=intent-forms-dest-short-equals"}},
+	}
+
+	for _, tc2 := range cases {
+		tc2 := tc2
+		t.Run(tc2.name, func(t *testing.T) {
+			targetName := "intent-forms-dest-" + tc2.targetSuffix
+			targetPath := "/campaigns/" + targetName
+			targetInbox := targetPath + "/.campaign/intents/inbox"
+
+			_, err := tc.InitCampaign(targetPath, targetName, "product")
+			require.NoError(t, err)
+
+			title := fmt.Sprintf("Title for %s form", tc2.name)
+			args := append([]string{"intent", "add"}, tc2.flagArgs...)
+			args = append(args, title, "--no-commit")
+
+			output, err := tc.RunCampInDir(sourceCampaign, args...)
+			require.NoError(t, err, "camp intent add (%s form) should succeed", tc2.name)
+			assert.Contains(t, output, targetInbox+"/",
+				"intent should be created in target campaign %q (%s form)", targetName, tc2.name)
+
+			targetLS, err := execLS(tc, targetInbox)
+			require.NoError(t, err)
+			targetFiles := strings.Fields(strings.TrimSpace(targetLS))
+			assert.Len(t, targetFiles, 1,
+				"target campaign %q should have exactly one intent after the %s invocation", targetName, tc2.name)
+		})
+	}
+
+	// After all four forms, the source campaign's inbox must still be empty
+	// (or not yet created). None of the forms should have leaked an intent
+	// into the wrong campaign.
+	sourceInbox := sourceCampaign + "/.campaign/intents/inbox"
+	sourceInboxExists, err := tc.CheckDirExists(sourceInbox)
+	require.NoError(t, err)
+	if sourceInboxExists {
+		sourceLS, err := execLS(tc, sourceInbox)
+		require.NoError(t, err)
+		assert.Empty(t, strings.TrimSpace(sourceLS), "source campaign inbox must remain empty across all forms")
+	}
 }


### PR DESCRIPTION
## Summary

The integration test `TestIntentAdd_TargetCampaignWritesToSelectedRoot` was failing on `lr/develop` with:

\`\`\`
camp exited with code 1: Error: accepts at most 1 arg(s), received 2
\`\`\`

## Root cause

`#206` added a bare-flag interactive picker for `--campaign` by setting `NoOptDefVal` on the flag. Cobra's pflag library treats a flag with `NoOptDefVal` as "optional-value": the value must be attached with `=`, and space-separated `--campaign value` **never consumes the next token**. So:

\`\`\`
camp intent add --campaign intent-target-dest "Targeted Intent" --no-commit
\`\`\`

parsed as: `--campaign` (uses sentinel), plus positionals `["intent-target-dest", "Targeted Intent"]` → two positionals violates `MaximumNArgs(1)`.

The test was written in `2c04f84` (Mar 16) before `NoOptDefVal` was added in `5f90da0` / `ff83a1a`. The regression wasn't caught when `#206` merged.

## Fix

Preprocess `os.Args` in `Execute()` before cobra parses, rewriting `--campaign value` → `--campaign=value` (and `-c value` → `-c=value`) when the next token is not a flag. Bare `--campaign` (end-of-args or followed by another flag) is left untouched so the `NoOptDefVal` sentinel still fires and the bare-flag picker UX from #206 is preserved.

Result — all three UX contracts now hold simultaneously:
- \`--campaign foo\` / \`-c foo\` (space-separated) — value "foo" ✓ **(was broken)**
- \`--campaign=foo\` / \`-c=foo\` (equals form) — value "foo" ✓
- \`--campaign\` / \`-c\` (bare) — interactive picker ✓

## Files

- \`cmd/camp/args_normalize.go\` — new pure function \`normalizeOptionalValueFlagArgs\`
- \`cmd/camp/args_normalize_test.go\` — 13 unit-test cases covering gluing, already-glued, bare-at-end, bare-before-flag, \`--\` separator, and unrelated flags
- \`cmd/camp/root.go\` — wire the normalizer into \`Execute()\`, documented with a comment explaining why it's needed

## Test plan

- [x] \`just test unit\` — 2116 / 2116 pass (63 packages)
- [x] \`just test integration\` — 137 / 137 pass (previously 136/137 with \`TestIntentAdd_TargetCampaignWritesToSelectedRoot\` failing)
- [x] Failing test \`TestIntentAdd_TargetCampaignWritesToSelectedRoot\` runs green in isolation
- [x] New \`TestNormalizeOptionalValueFlagArgs\` table-driven test covers all argument permutations

## Scope

The \`optionalValueFlags\` registry in \`args_normalize.go\` is a one-entry map today (\`--campaign\` / \`-c\`) because that's the only \`NoOptDefVal\` flag in the codebase (confirmed via grep). The comment on the registry notes it should be kept in sync with any future flag that sets \`NoOptDefVal\`.