### PR TITLE
feat: programmatic CLI parity for intent add and edit

### DIFF
--- a/cmd/camp/intent/add.go
+++ b/cmd/camp/intent/add.go
@@ -44,6 +44,16 @@ Fast capture is optimized for speed - ideas are saved immediately.
 Use --full when you want to add a body description in the form.
 Use --edit when you need the complete template in your editor.
 
+PROGRAMMATIC (agent) FLAGS:
+  --body              Set intent body from a literal string
+  --body-file         Read intent body from a file (- for stdin)
+  --concept           Set the concept field (e.g., "projects/camp")
+  --author            Override the default author attribution
+
+  --body and --body-file are mutually exclusive.
+  --full + body flags is a usage error.
+  --edit + body flags pre-fills the editor template.
+
 Examples:
   camp intent add "Add dark mode"        Ultra-fast capture
   camp intent add -c obey-campaign "Add dark mode"
@@ -51,7 +61,10 @@ Examples:
   camp intent add --campaign             Pick a target campaign interactively
   camp intent add --full                 Full TUI (includes body)
   camp intent add -e "Complex feature"   Deep capture with editor
-  camp intent add -t feature "New API"   Set type explicitly`,
+  camp intent add -t feature "New API"   Set type explicitly
+  camp intent add "Fix login" --body "The login page returns 500"
+  camp intent add "Migrate DB" --body-file spec.md --concept projects/camp
+  echo "body" | camp intent add "Idea" --body-file -`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runIntentAdd,
 }
@@ -66,6 +79,12 @@ func init() {
 	flags.StringP("campaign", "c", "", "Target campaign by name or ID; omit value to pick interactively")
 	flags.Bool("no-commit", false, "Don't create a git commit")
 	flags.Lookup("campaign").NoOptDefVal = noOptCampaign
+
+	// Programmatic (agent) flags
+	flags.String("body", "", "Set intent body as a literal string")
+	flags.String("body-file", "", "Read intent body from file (- for stdin, 10 MiB cap)")
+	flags.String("concept", "", "Set the concept field (e.g., projects/camp)")
+	flags.String("author", "", "Override the default author attribution")
 }
 
 func runIntentAdd(cmd *cobra.Command, args []string) error {
@@ -77,6 +96,19 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 	fullMode, _ := cmd.Flags().GetBool("full")
 	targetCampaign, _ := cmd.Flags().GetString("campaign")
 	noCommit, _ := cmd.Flags().GetBool("no-commit")
+	conceptFlag, _ := cmd.Flags().GetString("concept")
+	authorFlag, _ := cmd.Flags().GetString("author")
+
+	// Resolve body from --body / --body-file (mutual exclusivity checked inside)
+	body, bodySet, err := resolveBody(cmd)
+	if err != nil {
+		return err
+	}
+
+	// --full + body flags = usage error (body in TUI conflicts with programmatic body)
+	if fullMode && bodySet {
+		return fmt.Errorf("--full and --body/--body-file are mutually exclusive")
+	}
 
 	campaignResolver := newIntentAddCampaignResolver(cmd.ErrOrStderr())
 	cfg, campaignRoot, err := campaignResolver.resolve(ctx, targetCampaign, cmd.Flags().Changed("campaign"))
@@ -96,15 +128,26 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "ensuring intent directories")
 	}
 
-	// Ultra-fast path: title provided as argument (non-TUI = agent author)
+	// Determine if any programmatic flags were used (signals agent/CLI path)
+	hasProgrammaticFlags := bodySet || cmd.Flags().Changed("concept") || cmd.Flags().Changed("author")
+
+	// Ultra-fast path: title provided as argument
 	if len(args) > 0 {
-		opts := intent.CreateOptions{
-			Title:  args[0],
-			Type:   intent.Type(intentType),
-			Author: "agent",
+		// Default author for CLI-with-title is "agent", but --author overrides
+		author := "agent"
+		if cmd.Flags().Changed("author") {
+			author = authorFlag
 		}
 
-		// Deep capture overrides ultra-fast
+		opts := intent.CreateOptions{
+			Title:   args[0],
+			Type:    intent.Type(intentType),
+			Author:  author,
+			Body:    body,
+			Concept: conceptFlag,
+		}
+
+		// Deep capture overrides ultra-fast; body flags pre-fill the template
 		if useEditor {
 			return runDeepCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, opts)
 		}
@@ -112,10 +155,18 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 		return runFastCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, opts)
 	}
 
-	// TUI path: use git config author (human)
-	author := git.GetUserName(ctx)
+	// No title argument: non-TTY requires a title (can't launch TUI)
+	if !navtui.IsTerminal() && !hasProgrammaticFlags {
+		return fmt.Errorf("title argument required in non-interactive mode\n       Usage: camp intent add <title> [flags]")
+	}
 
-	// Build navigation shortcuts map (key → path) for @ completion
+	// TUI path: use git config author (human), unless --author overrides
+	author := git.GetUserName(ctx)
+	if cmd.Flags().Changed("author") {
+		author = authorFlag
+	}
+
+	// Build navigation shortcuts map (key -> path) for @ completion
 	shortcuts := make(map[string]string)
 	for key, sc := range cfg.Shortcuts() {
 		if sc.HasPath() {

--- a/cmd/camp/intent/add.go
+++ b/cmd/camp/intent/add.go
@@ -128,9 +128,6 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "ensuring intent directories")
 	}
 
-	// Determine if any programmatic flags were used (signals agent/CLI path)
-	hasProgrammaticFlags := bodySet || cmd.Flags().Changed("concept") || cmd.Flags().Changed("author")
-
 	// Ultra-fast path: title provided as argument
 	if len(args) > 0 {
 		// Default author for CLI-with-title is "agent", but --author overrides
@@ -155,8 +152,10 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 		return runFastCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, opts)
 	}
 
-	// No title argument: non-TTY requires a title (can't launch TUI)
-	if !navtui.IsTerminal() && !hasProgrammaticFlags {
+	// No title argument: non-TTY always requires a title (can't launch TUI)
+	// Programmatic flags like --body/--concept/--author supplement a title,
+	// they don't replace it.
+	if !navtui.IsTerminal() {
 		return fmt.Errorf("title argument required in non-interactive mode\n       Usage: camp intent add <title> [flags]")
 	}
 

--- a/cmd/camp/intent/add_flags_test.go
+++ b/cmd/camp/intent/add_flags_test.go
@@ -1,0 +1,199 @@
+package intent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	intentcore "github.com/Obedience-Corp/camp/internal/intent"
+	"github.com/Obedience-Corp/camp/internal/paths"
+)
+
+// setupAddFlagsTest creates a campaign root and returns the service, path resolver,
+// and config needed to test add flows end-to-end.
+func setupAddFlagsTest(t *testing.T) (*intentcore.IntentService, string, *config.CampaignConfig, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	cfg := &config.CampaignConfig{
+		ID:        "test-id",
+		Name:      "test-campaign",
+		Type:      config.CampaignTypeProduct,
+		CreatedAt: time.Now(),
+	}
+	ctx := context.Background()
+	if err := config.SaveCampaignConfig(ctx, root, cfg); err != nil {
+		t.Fatalf("SaveCampaignConfig: %v", err)
+	}
+	jumps := config.DefaultJumpsConfig()
+	if err := config.SaveJumpsConfig(ctx, root, &jumps); err != nil {
+		t.Fatalf("SaveJumpsConfig: %v", err)
+	}
+
+	resolver := paths.NewResolverFromConfig(root, cfg)
+	svc := intentcore.NewIntentService(root, resolver.Intents())
+	if err := svc.EnsureDirectories(ctx); err != nil {
+		t.Fatalf("EnsureDirectories: %v", err)
+	}
+
+	return svc, resolver.Intents(), cfg, root
+}
+
+func TestIntentAdd_WithBody(t *testing.T) {
+	svc, intentsDir, cfg, root := setupAddFlagsTest(t)
+
+	err := runFastCapture(context.Background(), svc, intentsDir, cfg, root, true, intentcore.CreateOptions{
+		Title:  "Test with body",
+		Type:   intentcore.TypeIdea,
+		Author: "agent",
+		Body:   "This is the body content",
+	})
+	if err != nil {
+		t.Fatalf("runFastCapture: %v", err)
+	}
+
+	// Verify the intent was created with the body
+	inbox := filepath.Join(intentsDir, "inbox")
+	entries, err := os.ReadDir(inbox)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("inbox entries = %d, want 1", len(entries))
+	}
+
+	content, err := os.ReadFile(filepath.Join(inbox, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(content), "This is the body content") {
+		t.Fatalf("body not found in content: %s", content)
+	}
+}
+
+func TestIntentAdd_WithConcept(t *testing.T) {
+	svc, intentsDir, cfg, root := setupAddFlagsTest(t)
+
+	err := runFastCapture(context.Background(), svc, intentsDir, cfg, root, true, intentcore.CreateOptions{
+		Title:   "Test with concept",
+		Type:    intentcore.TypeFeature,
+		Author:  "agent",
+		Concept: "projects/camp",
+	})
+	if err != nil {
+		t.Fatalf("runFastCapture: %v", err)
+	}
+
+	inbox := filepath.Join(intentsDir, "inbox")
+	entries, err := os.ReadDir(inbox)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("inbox entries = %d, want 1", len(entries))
+	}
+
+	content, err := os.ReadFile(filepath.Join(inbox, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(content), "concept: projects/camp") {
+		t.Fatalf("concept not found in content: %s", content)
+	}
+}
+
+func TestIntentAdd_WithCustomAuthor(t *testing.T) {
+	svc, intentsDir, cfg, root := setupAddFlagsTest(t)
+
+	err := runFastCapture(context.Background(), svc, intentsDir, cfg, root, true, intentcore.CreateOptions{
+		Title:  "Test custom author",
+		Type:   intentcore.TypeIdea,
+		Author: "lance",
+	})
+	if err != nil {
+		t.Fatalf("runFastCapture: %v", err)
+	}
+
+	inbox := filepath.Join(intentsDir, "inbox")
+	entries, err := os.ReadDir(inbox)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(inbox, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(content), "author: lance") {
+		t.Fatalf("custom author not found in content: %s", content)
+	}
+}
+
+func TestIntentAdd_WithBodyFile(t *testing.T) {
+	svc, intentsDir, cfg, root := setupAddFlagsTest(t)
+
+	// Create a body file
+	bodyFile := filepath.Join(t.TempDir(), "body.md")
+	if err := os.WriteFile(bodyFile, []byte("Body from file\nwith multiple lines"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Read the body file content (simulating what resolveBody does)
+	bodyContent, err := readBodySource(bodyFile)
+	if err != nil {
+		t.Fatalf("readBodySource: %v", err)
+	}
+
+	err = runFastCapture(context.Background(), svc, intentsDir, cfg, root, true, intentcore.CreateOptions{
+		Title:  "Test body file",
+		Type:   intentcore.TypeIdea,
+		Author: "agent",
+		Body:   bodyContent,
+	})
+	if err != nil {
+		t.Fatalf("runFastCapture: %v", err)
+	}
+
+	inbox := filepath.Join(intentsDir, "inbox")
+	entries, err := os.ReadDir(inbox)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(inbox, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(content), "Body from file") {
+		t.Fatalf("body file content not found: %s", content)
+	}
+}
+
+func TestIntentAdd_FullAndBodyMutualExclusivity(t *testing.T) {
+	// This tests the flag validation logic, not the full command
+	cmd := newTestCmd()
+	cmd.Flags().BoolP("full", "f", false, "")
+
+	if err := cmd.Flags().Set("full", "true"); err != nil {
+		t.Fatalf("Set(full) error: %v", err)
+	}
+	if err := cmd.Flags().Set("body", "some body"); err != nil {
+		t.Fatalf("Set(body) error: %v", err)
+	}
+
+	fullMode, _ := cmd.Flags().GetBool("full")
+	_, bodySet, err := resolveBody(cmd)
+	if err != nil {
+		t.Fatalf("resolveBody error: %v", err)
+	}
+
+	if fullMode && bodySet {
+		// This is the expected condition - would produce an error in runIntentAdd
+		return
+	}
+	t.Fatal("expected full + body to be detected as mutually exclusive")
+}

--- a/cmd/camp/intent/body.go
+++ b/cmd/camp/intent/body.go
@@ -1,0 +1,73 @@
+package intent
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// maxBodyFileSize is the maximum allowed size when reading body from a file or
+// stdin (10 MiB). This prevents accidental pipe of huge files into intent body.
+const maxBodyFileSize = 10 << 20 // 10 MiB
+
+// resolveBody inspects --body and --body-file on cmd and returns the resolved
+// body text. The second return value indicates whether any body flag was set.
+//
+// Mutual exclusivity: setting both --body and --body-file is a usage error.
+// --body-file "-" reads from stdin with a 10 MiB cap.
+func resolveBody(cmd *cobra.Command) (string, bool, error) {
+	bodySet := cmd.Flags().Changed("body")
+	bodyFileSet := cmd.Flags().Changed("body-file")
+
+	if bodySet && bodyFileSet {
+		return "", false, fmt.Errorf("--body and --body-file are mutually exclusive")
+	}
+
+	if bodySet {
+		body, _ := cmd.Flags().GetString("body")
+		return body, true, nil
+	}
+
+	if bodyFileSet {
+		path, _ := cmd.Flags().GetString("body-file")
+		content, err := readBodySource(path)
+		if err != nil {
+			return "", false, err
+		}
+		return content, true, nil
+	}
+
+	return "", false, nil
+}
+
+// readBodySource reads body content from a file path or stdin (when path is "-").
+// Enforces a 10 MiB size cap on input.
+func readBodySource(path string) (string, error) {
+	var r io.Reader
+
+	if path == "-" {
+		r = os.Stdin
+	} else {
+		f, err := os.Open(path)
+		if err != nil {
+			return "", camperrors.Wrapf(camperrors.ErrInvalidInput, "opening body file %q: %v", path, err)
+		}
+		defer f.Close()
+		r = f
+	}
+
+	limited := io.LimitReader(r, maxBodyFileSize+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return "", camperrors.Wrap(err, "reading body input")
+	}
+	if len(data) > maxBodyFileSize {
+		return "", fmt.Errorf("body input exceeds maximum size of 10 MiB")
+	}
+
+	return string(data), nil
+}

--- a/cmd/camp/intent/body_test.go
+++ b/cmd/camp/intent/body_test.go
@@ -1,0 +1,166 @@
+package intent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newTestCmd returns a cobra.Command with body/body-file flags registered,
+// ready for unit-testing resolveBody.
+func newTestCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "test",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	cmd.Flags().String("body", "", "")
+	cmd.Flags().String("body-file", "", "")
+	return cmd
+}
+
+func TestResolveBody_NoFlags(t *testing.T) {
+	cmd := newTestCmd()
+	body, set, err := resolveBody(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if set {
+		t.Fatal("expected set=false when no flags provided")
+	}
+	if body != "" {
+		t.Fatalf("expected empty body, got %q", body)
+	}
+}
+
+func TestResolveBody_BodyFlag(t *testing.T) {
+	cmd := newTestCmd()
+	if err := cmd.Flags().Set("body", "hello world"); err != nil {
+		t.Fatalf("Set(body) error: %v", err)
+	}
+
+	body, set, err := resolveBody(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !set {
+		t.Fatal("expected set=true when --body provided")
+	}
+	if body != "hello world" {
+		t.Fatalf("body = %q, want %q", body, "hello world")
+	}
+}
+
+func TestResolveBody_BodyFileFlag(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "body.txt")
+	if err := os.WriteFile(tmp, []byte("from file"), 0644); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	cmd := newTestCmd()
+	if err := cmd.Flags().Set("body-file", tmp); err != nil {
+		t.Fatalf("Set(body-file) error: %v", err)
+	}
+
+	body, set, err := resolveBody(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !set {
+		t.Fatal("expected set=true when --body-file provided")
+	}
+	if body != "from file" {
+		t.Fatalf("body = %q, want %q", body, "from file")
+	}
+}
+
+func TestResolveBody_MutualExclusivity(t *testing.T) {
+	cmd := newTestCmd()
+	if err := cmd.Flags().Set("body", "literal"); err != nil {
+		t.Fatalf("Set(body) error: %v", err)
+	}
+	if err := cmd.Flags().Set("body-file", "some.txt"); err != nil {
+		t.Fatalf("Set(body-file) error: %v", err)
+	}
+
+	_, _, err := resolveBody(cmd)
+	if err == nil {
+		t.Fatal("expected error for mutually exclusive flags")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestResolveBody_BodyFileMissing(t *testing.T) {
+	cmd := newTestCmd()
+	if err := cmd.Flags().Set("body-file", "/nonexistent/path/to/file.txt"); err != nil {
+		t.Fatalf("Set(body-file) error: %v", err)
+	}
+
+	_, _, err := resolveBody(cmd)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestResolveBody_EmptyBodyFlag(t *testing.T) {
+	cmd := newTestCmd()
+	// Explicitly set --body to empty string (distinct from "not set")
+	if err := cmd.Flags().Set("body", ""); err != nil {
+		t.Fatalf("Set(body) error: %v", err)
+	}
+
+	body, set, err := resolveBody(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !set {
+		t.Fatal("expected set=true when --body explicitly provided (even empty)")
+	}
+	if body != "" {
+		t.Fatalf("body = %q, want empty", body)
+	}
+}
+
+func TestReadBodySource_SizeLimit(t *testing.T) {
+	// Create a file just over the size limit
+	tmp := filepath.Join(t.TempDir(), "large.txt")
+	data := make([]byte, maxBodyFileSize+1)
+	for i := range data {
+		data[i] = 'x'
+	}
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	_, err := readBodySource(tmp)
+	if err == nil {
+		t.Fatal("expected error for file exceeding size limit")
+	}
+	if !strings.Contains(err.Error(), "10 MiB") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReadBodySource_ExactLimit(t *testing.T) {
+	// Create a file exactly at the limit - should succeed
+	tmp := filepath.Join(t.TempDir(), "exact.txt")
+	data := make([]byte, maxBodyFileSize)
+	for i := range data {
+		data[i] = 'y'
+	}
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	content, err := readBodySource(tmp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(content) != maxBodyFileSize {
+		t.Fatalf("content length = %d, want %d", len(content), maxBodyFileSize)
+	}
+}

--- a/cmd/camp/intent/edit.go
+++ b/cmd/camp/intent/edit.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/git/commit"
 	"github.com/Obedience-Corp/camp/internal/intent"
 	"github.com/Obedience-Corp/camp/internal/intent/audit"
+	navtui "github.com/Obedience-Corp/camp/internal/nav/tui"
 	"github.com/Obedience-Corp/camp/internal/paths"
 )
 
@@ -132,6 +133,10 @@ func runIntentEdit(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else {
+		// No ID + programmatic flags + no TTY = deterministic error
+		if programmatic && !navtui.IsTerminal() {
+			return fmt.Errorf("intent ID required in non-interactive mode\n       Usage: camp intent edit <id> [flags]")
+		}
 		// No ID - show fuzzy picker
 		selectedIntent, err = pickIntent(ctx, svc, statusFilter, typeFilter, projectFilter)
 		if err != nil {
@@ -219,7 +224,12 @@ func runProgrammaticEdit(
 
 	// Auto-commit (unless --no-commit)
 	if !noCommit {
-		files := commit.NormalizeFiles(campaignRoot, updated.Path, audit.FilePath(intentsDir))
+		filesToCommit := []string{updated.Path, audit.FilePath(intentsDir)}
+		// Status changes move the file — stage the old path deletion too
+		if target.Path != updated.Path {
+			filesToCommit = append(filesToCommit, target.Path)
+		}
+		files := commit.NormalizeFiles(campaignRoot, filesToCommit...)
 		commitResult := commit.Intent(ctx, commit.IntentOptions{
 			Options: commit.Options{
 				CampaignRoot:  campaignRoot,

--- a/cmd/camp/intent/edit.go
+++ b/cmd/camp/intent/edit.go
@@ -12,28 +12,57 @@ import (
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/editor"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git/commit"
 	"github.com/Obedience-Corp/camp/internal/intent"
+	"github.com/Obedience-Corp/camp/internal/intent/audit"
 	"github.com/Obedience-Corp/camp/internal/paths"
 )
 
 var intentEditCmd = &cobra.Command{
 	Use:   "edit [id]",
 	Short: "Edit an existing intent",
-	Long: `Edit an intent in your preferred editor.
+	Long: `Edit an intent in your preferred editor or programmatically via flags.
 
-If ID is provided, opens the intent directly (supports partial matching).
-If no ID is provided, shows a fuzzy picker to select an intent.
+If no programmatic flags are given, opens the intent in $EDITOR.
+If any programmatic flag is present, applies the update directly and
+emits an audit event — no editor is launched.
 
-PARTIAL ID MATCHING:
-  Full ID:       20260119-153412-add-retry-logic
-  Time suffix:   153412-add-retry
-  Slug portion:  add-retry
+PICKER / EDITOR PATH:
+  If ID is provided, opens the intent directly (supports partial matching).
+  If no ID is provided, shows a fuzzy picker to select an intent.
+
+PROGRAMMATIC FLAGS (skip $EDITOR):
+  --title            Set a new title
+  --body             Replace the body with a literal string
+  --body-file        Replace the body from a file (- for stdin)
+  --append-body      Append text to the existing body
+  --append-body-file Append text from a file (- for stdin)
+  --set-type         Change the intent type
+  --set-status       Change the intent status
+  --set-concept      Change the concept field
+  --priority         Change priority (low, medium, high)
+  --horizon          Change horizon (now, next, later, someday)
+  --author           Override the author attribution
+
+MUTUAL EXCLUSIVITY:
+  --body vs --body-file
+  --append-body vs --append-body-file
+  --body/--body-file vs --append-body/--append-body-file (replace vs append)
+
+FILTER FLAGS (for picker only, not update targets):
+  -s/--status        Filter picker by status
+  -t/--type          Filter picker by type
+  -p/--project       Filter picker by project/concept
 
 Examples:
-  camp intent edit                       Interactive picker
-  camp intent edit 20260119-153412...    Direct edit by full ID
-  camp intent edit retry-logic           Partial match edit
-  camp intent edit --status active       Picker filtered by status`,
+  camp intent edit                                Interactive picker + $EDITOR
+  camp intent edit retry-logic                    Direct edit by partial ID
+  camp intent edit --status active                Picker filtered by status
+  camp intent edit retry --title "Retry with backoff"
+  camp intent edit retry --body "New description"
+  camp intent edit retry --append-body "Additional note"
+  camp intent edit retry --set-type feature --priority high
+  echo "details" | camp intent edit retry --body-file -`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runIntentEdit,
 }
@@ -42,18 +71,39 @@ func init() {
 	Cmd.AddCommand(intentEditCmd)
 
 	flags := intentEditCmd.Flags()
+
+	// Filter flags (picker only)
 	flags.StringP("status", "s", "", "Filter picker by status")
 	flags.StringP("type", "t", "", "Filter picker by type")
 	flags.StringP("project", "p", "", "Filter picker by project")
+
+	// Programmatic update flags
+	flags.String("title", "", "Set a new title")
+	flags.String("body", "", "Replace the intent body")
+	flags.String("body-file", "", "Replace body from file (- for stdin, 10 MiB cap)")
+	flags.String("append-body", "", "Append text to the existing body")
+	flags.String("append-body-file", "", "Append text from file (- for stdin, 10 MiB cap)")
+	flags.String("set-type", "", "Change the intent type (idea, feature, bug, research, chore)")
+	flags.String("set-status", "", "Change the intent status")
+	flags.String("set-concept", "", "Change the concept field")
+	flags.String("priority", "", "Change priority (low, medium, high)")
+	flags.String("horizon", "", "Change horizon (now, next, later, someday)")
+	flags.String("author", "", "Override the author attribution")
+	flags.Bool("no-commit", false, "Don't create a git commit")
 }
 
 func runIntentEdit(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
-	// Parse flags
+	// Parse filter flags
 	statusFilter, _ := cmd.Flags().GetString("status")
 	typeFilter, _ := cmd.Flags().GetString("type")
 	projectFilter, _ := cmd.Flags().GetString("project")
+
+	// Validate mutual exclusivity of body flags
+	if err := validateEditBodyFlags(cmd); err != nil {
+		return err
+	}
 
 	// Find campaign root
 	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
@@ -68,10 +118,14 @@ func runIntentEdit(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "failed to ensure intent directories")
 	}
 
+	// Determine if we're in programmatic mode
+	programmatic := hasProgrammaticEditFlags(cmd)
+	noCommit, _ := cmd.Flags().GetBool("no-commit")
+
 	var selectedIntent *intent.Intent
 
 	if len(args) > 0 {
-		// Direct ID provided - resolve and edit
+		// Direct ID provided - resolve
 		partialID := args[0]
 		selectedIntent, err = resolveIntentByPartialID(ctx, svc, partialID)
 		if err != nil {
@@ -88,17 +142,205 @@ func runIntentEdit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Edit the intent
+	// Programmatic path: apply updates directly, skip $EDITOR
+	if programmatic {
+		return runProgrammaticEdit(ctx, cmd, svc, selectedIntent, resolver.Intents(), cfg, campaignRoot, noCommit)
+	}
+
+	// Editor path: open in $EDITOR
+	return runEditorEdit(ctx, svc, selectedIntent)
+}
+
+// runEditorEdit opens the intent in $EDITOR (the original behavior).
+func runEditorEdit(ctx context.Context, svc *intent.IntentService, i *intent.Intent) error {
 	editorFn := func(ctx context.Context, path string) error {
 		return editor.Edit(ctx, path)
 	}
 
-	updated, err := svc.Edit(ctx, selectedIntent.ID, editorFn)
+	updated, err := svc.Edit(ctx, i.ID, editorFn)
 	if err != nil {
 		return camperrors.Wrap(err, "failed to edit intent")
 	}
 
-	fmt.Printf("✓ Intent saved: %s\n", updated.Path)
+	fmt.Printf("Intent saved: %s\n", updated.Path)
+	return nil
+}
+
+// runProgrammaticEdit builds UpdateOptions from flags, calls UpdateDirect,
+// and emits an audit event with per-field change records.
+func runProgrammaticEdit(
+	ctx context.Context,
+	cmd *cobra.Command,
+	svc *intent.IntentService,
+	target *intent.Intent,
+	intentsDir string,
+	cfg *config.CampaignConfig,
+	campaignRoot string,
+	noCommit bool,
+) error {
+	opts, err := buildUpdateOptions(cmd)
+	if err != nil {
+		return err
+	}
+
+	updated, changes, err := svc.UpdateDirect(ctx, target.ID, opts)
+	if err != nil {
+		return camperrors.Wrap(err, "failed to update intent")
+	}
+
+	if len(changes) == 0 {
+		fmt.Println("No changes detected")
+		return nil
+	}
+
+	// Emit audit event with field-level changes
+	auditChanges := make([]audit.FieldChange, len(changes))
+	for i, c := range changes {
+		auditChanges[i] = audit.FieldChange{
+			Field: c.Field,
+			Old:   c.Old,
+			New:   c.New,
+		}
+	}
+
+	if err := appendIntentAuditEvent(ctx, intentsDir, audit.Event{
+		Type:    audit.EventEdit,
+		ID:      updated.ID,
+		Title:   updated.Title,
+		Changes: auditChanges,
+	}); err != nil {
+		return err
+	}
+
+	fmt.Printf("Intent updated: %s\n", updated.Path)
+	for _, c := range changes {
+		fmt.Printf("  %s: %q -> %q\n", c.Field, c.Old, c.New)
+	}
+
+	// Auto-commit (unless --no-commit)
+	if !noCommit {
+		files := commit.NormalizeFiles(campaignRoot, updated.Path, audit.FilePath(intentsDir))
+		commitResult := commit.Intent(ctx, commit.IntentOptions{
+			Options: commit.Options{
+				CampaignRoot:  campaignRoot,
+				CampaignID:    cfg.ID,
+				Files:         files,
+				SelectiveOnly: true,
+			},
+			Action:      commit.IntentEdit,
+			IntentTitle: updated.Title,
+		})
+		if commitResult.Message != "" {
+			fmt.Printf("  %s\n", commitResult.Message)
+		}
+	}
+
+	return nil
+}
+
+// buildUpdateOptions constructs an UpdateOptions from CLI flags.
+func buildUpdateOptions(cmd *cobra.Command) (intent.UpdateOptions, error) {
+	var opts intent.UpdateOptions
+
+	if cmd.Flags().Changed("title") {
+		v, _ := cmd.Flags().GetString("title")
+		opts.Title = &v
+	}
+
+	// Body replacement: --body or --body-file
+	if cmd.Flags().Changed("body") {
+		v, _ := cmd.Flags().GetString("body")
+		opts.Body = &v
+	} else if cmd.Flags().Changed("body-file") {
+		path, _ := cmd.Flags().GetString("body-file")
+		content, err := readBodySource(path)
+		if err != nil {
+			return opts, err
+		}
+		opts.Body = &content
+	}
+
+	// Body append: --append-body or --append-body-file
+	if cmd.Flags().Changed("append-body") {
+		v, _ := cmd.Flags().GetString("append-body")
+		opts.Append = &v
+	} else if cmd.Flags().Changed("append-body-file") {
+		path, _ := cmd.Flags().GetString("append-body-file")
+		content, err := readBodySource(path)
+		if err != nil {
+			return opts, err
+		}
+		opts.Append = &content
+	}
+
+	if cmd.Flags().Changed("set-type") {
+		v, _ := cmd.Flags().GetString("set-type")
+		t := intent.Type(v)
+		opts.Type = &t
+	}
+
+	if cmd.Flags().Changed("set-status") {
+		v, _ := cmd.Flags().GetString("set-status")
+		s := intent.Status(v)
+		opts.Status = &s
+	}
+
+	if cmd.Flags().Changed("set-concept") {
+		v, _ := cmd.Flags().GetString("set-concept")
+		opts.Concept = &v
+	}
+
+	if cmd.Flags().Changed("priority") {
+		v, _ := cmd.Flags().GetString("priority")
+		p := intent.Priority(v)
+		opts.Priority = &p
+	}
+
+	if cmd.Flags().Changed("horizon") {
+		v, _ := cmd.Flags().GetString("horizon")
+		h := intent.Horizon(v)
+		opts.Horizon = &h
+	}
+
+	if cmd.Flags().Changed("author") {
+		v, _ := cmd.Flags().GetString("author")
+		opts.Author = &v
+	}
+
+	return opts, nil
+}
+
+// hasProgrammaticEditFlags returns true if any update flag (as opposed to
+// filter flag) was explicitly set.
+func hasProgrammaticEditFlags(cmd *cobra.Command) bool {
+	programmaticFlags := []string{
+		"title", "body", "body-file", "append-body", "append-body-file",
+		"set-type", "set-status", "set-concept", "priority", "horizon", "author",
+	}
+	for _, name := range programmaticFlags {
+		if cmd.Flags().Changed(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// validateEditBodyFlags enforces mutual exclusivity among body-related flags.
+func validateEditBodyFlags(cmd *cobra.Command) error {
+	bodySet := cmd.Flags().Changed("body")
+	bodyFileSet := cmd.Flags().Changed("body-file")
+	appendSet := cmd.Flags().Changed("append-body")
+	appendFileSet := cmd.Flags().Changed("append-body-file")
+
+	if bodySet && bodyFileSet {
+		return fmt.Errorf("--body and --body-file are mutually exclusive")
+	}
+	if appendSet && appendFileSet {
+		return fmt.Errorf("--append-body and --append-body-file are mutually exclusive")
+	}
+	if (bodySet || bodyFileSet) && (appendSet || appendFileSet) {
+		return fmt.Errorf("--body/--body-file and --append-body/--append-body-file are mutually exclusive (replace vs append)")
+	}
 	return nil
 }
 

--- a/cmd/camp/intent/edit.go
+++ b/cmd/camp/intent/edit.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/ktr0731/go-fuzzyfinder"
 	"github.com/spf13/cobra"
@@ -199,21 +198,21 @@ func runProgrammaticEdit(
 	}
 
 	// Emit audit event with field-level changes
-	auditChanges := make([]audit.FieldChange, len(changes))
-	for i, c := range changes {
-		auditChanges[i] = audit.FieldChange{
-			Field: c.Field,
-			Old:   c.Old,
-			New:   c.New,
-		}
-	}
-
-	if err := appendIntentAuditEvent(ctx, intentsDir, audit.Event{
+	event := audit.Event{
 		Type:    audit.EventEdit,
 		ID:      updated.ID,
 		Title:   updated.Title,
-		Changes: auditChanges,
-	}); err != nil {
+		Changes: changes,
+	}
+	// Populate From/To on status changes for query consistency with move events
+	for _, c := range changes {
+		if c.Field == "status" {
+			event.From = c.Old
+			event.To = c.New
+			break
+		}
+	}
+	if err := appendIntentAuditEvent(ctx, intentsDir, event); err != nil {
 		return err
 	}
 
@@ -354,120 +353,3 @@ func validateEditBodyFlags(cmd *cobra.Command) error {
 	return nil
 }
 
-// resolveIntentByPartialID finds an intent by partial ID matching.
-func resolveIntentByPartialID(ctx context.Context, svc *intent.IntentService, partialID string) (*intent.Intent, error) {
-	// First try exact match via Find (which supports fuzzy)
-	result, err := svc.Find(ctx, partialID)
-	if err == nil {
-		return result, nil
-	}
-
-	// If Find failed with not found, provide helpful error
-	if errors.Is(err, camperrors.ErrNotFound) {
-		return nil, fmt.Errorf("intent not found: %s", partialID)
-	}
-
-	return nil, camperrors.Wrap(err, "failed to find intent")
-}
-
-// pickIntent shows a fuzzy picker for intent selection.
-func pickIntent(ctx context.Context, svc *intent.IntentService, status, typ, project string) (*intent.Intent, error) {
-	// Build list options
-	opts := &intent.ListOptions{
-		Concept:  project, // project from CLI maps to Concept field
-		SortBy:   "updated",
-		SortDesc: true,
-	}
-
-	if status != "" {
-		s := intent.Status(status)
-		opts.Status = &s
-	}
-	if typ != "" {
-		t := intent.Type(typ)
-		opts.Type = &t
-	}
-
-	// Get intents
-	intents, err := svc.List(ctx, opts)
-	if err != nil {
-		return nil, camperrors.Wrap(err, "failed to list intents")
-	}
-
-	if len(intents) == 0 {
-		return nil, fmt.Errorf("no intents found")
-	}
-
-	// Show fuzzy picker
-	idx, err := fuzzyfinder.Find(
-		intents,
-		func(i int) string {
-			intent := intents[i]
-			// Format: [status] ID - Title (concept)
-			concept := intent.Concept
-			if concept == "" {
-				concept = "-"
-			}
-			return fmt.Sprintf("[%s] %s - %s (%s)",
-				intent.Status,
-				truncateID(intent.ID),
-				intent.Title,
-				concept,
-			)
-		},
-		fuzzyfinder.WithPromptString("Select intent: "),
-		fuzzyfinder.WithPreviewWindow(func(i, w, h int) string {
-			if i < 0 || i >= len(intents) {
-				return ""
-			}
-			intent := intents[i]
-			return formatIntentPreview(intent)
-		}),
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return intents[idx], nil
-}
-
-// truncateID shortens ID for picker display.
-func truncateID(id string) string {
-	// Show timestamp-slug portion, truncate long slugs
-	if len(id) > 30 {
-		return id[:30] + "..."
-	}
-	return id
-}
-
-// formatIntentPreview formats an intent for the preview window.
-func formatIntentPreview(i *intent.Intent) string {
-	var sb strings.Builder
-
-	sb.WriteString(fmt.Sprintf("Title:    %s\n", i.Title))
-	sb.WriteString(fmt.Sprintf("ID:       %s\n", i.ID))
-	sb.WriteString(fmt.Sprintf("Status:   %s\n", i.Status))
-	sb.WriteString(fmt.Sprintf("Type:     %s\n", i.Type))
-
-	if i.Concept != "" {
-		sb.WriteString(fmt.Sprintf("Concept:  %s\n", i.Concept))
-	}
-	if i.Priority != "" {
-		sb.WriteString(fmt.Sprintf("Priority: %s\n", i.Priority))
-	}
-	if i.Horizon != "" {
-		sb.WriteString(fmt.Sprintf("Horizon:  %s\n", i.Horizon))
-	}
-
-	sb.WriteString(fmt.Sprintf("\nCreated:  %s\n", i.CreatedAt.Format("2006-01-02 15:04")))
-	if !i.UpdatedAt.IsZero() {
-		sb.WriteString(fmt.Sprintf("Updated:  %s\n", i.UpdatedAt.Format("2006-01-02 15:04")))
-	}
-
-	if i.Path != "" {
-		sb.WriteString(fmt.Sprintf("\nPath: %s\n", i.Path))
-	}
-
-	return sb.String()
-}

--- a/cmd/camp/intent/edit_picker.go
+++ b/cmd/camp/intent/edit_picker.go
@@ -1,0 +1,131 @@
+package intent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ktr0731/go-fuzzyfinder"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/intent"
+)
+
+// resolveIntentByPartialID finds an intent by partial ID matching.
+func resolveIntentByPartialID(ctx context.Context, svc *intent.IntentService, partialID string) (*intent.Intent, error) {
+	// First try exact match via Find (which supports fuzzy)
+	result, err := svc.Find(ctx, partialID)
+	if err == nil {
+		return result, nil
+	}
+
+	// If Find failed with not found, provide helpful error
+	if errors.Is(err, camperrors.ErrNotFound) {
+		return nil, fmt.Errorf("intent not found: %s", partialID)
+	}
+
+	return nil, camperrors.Wrap(err, "failed to find intent")
+}
+
+// pickIntent shows a fuzzy picker for intent selection.
+func pickIntent(ctx context.Context, svc *intent.IntentService, status, typ, project string) (*intent.Intent, error) {
+	// Build list options
+	opts := &intent.ListOptions{
+		Concept:  project, // project from CLI maps to Concept field
+		SortBy:   "updated",
+		SortDesc: true,
+	}
+
+	if status != "" {
+		s := intent.Status(status)
+		opts.Status = &s
+	}
+	if typ != "" {
+		t := intent.Type(typ)
+		opts.Type = &t
+	}
+
+	// Get intents
+	intents, err := svc.List(ctx, opts)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "failed to list intents")
+	}
+
+	if len(intents) == 0 {
+		return nil, fmt.Errorf("no intents found")
+	}
+
+	// Show fuzzy picker
+	idx, err := fuzzyfinder.Find(
+		intents,
+		func(i int) string {
+			intent := intents[i]
+			// Format: [status] ID - Title (concept)
+			concept := intent.Concept
+			if concept == "" {
+				concept = "-"
+			}
+			return fmt.Sprintf("[%s] %s - %s (%s)",
+				intent.Status,
+				truncateID(intent.ID),
+				intent.Title,
+				concept,
+			)
+		},
+		fuzzyfinder.WithPromptString("Select intent: "),
+		fuzzyfinder.WithPreviewWindow(func(i, w, h int) string {
+			if i < 0 || i >= len(intents) {
+				return ""
+			}
+			intent := intents[i]
+			return formatIntentPreview(intent)
+		}),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return intents[idx], nil
+}
+
+// truncateID shortens ID for picker display.
+func truncateID(id string) string {
+	// Show timestamp-slug portion, truncate long slugs
+	if len(id) > 30 {
+		return id[:30] + "..."
+	}
+	return id
+}
+
+// formatIntentPreview formats an intent for the preview window.
+func formatIntentPreview(i *intent.Intent) string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("Title:    %s\n", i.Title))
+	sb.WriteString(fmt.Sprintf("ID:       %s\n", i.ID))
+	sb.WriteString(fmt.Sprintf("Status:   %s\n", i.Status))
+	sb.WriteString(fmt.Sprintf("Type:     %s\n", i.Type))
+
+	if i.Concept != "" {
+		sb.WriteString(fmt.Sprintf("Concept:  %s\n", i.Concept))
+	}
+	if i.Priority != "" {
+		sb.WriteString(fmt.Sprintf("Priority: %s\n", i.Priority))
+	}
+	if i.Horizon != "" {
+		sb.WriteString(fmt.Sprintf("Horizon:  %s\n", i.Horizon))
+	}
+
+	sb.WriteString(fmt.Sprintf("\nCreated:  %s\n", i.CreatedAt.Format("2006-01-02 15:04")))
+	if !i.UpdatedAt.IsZero() {
+		sb.WriteString(fmt.Sprintf("Updated:  %s\n", i.UpdatedAt.Format("2006-01-02 15:04")))
+	}
+
+	if i.Path != "" {
+		sb.WriteString(fmt.Sprintf("\nPath: %s\n", i.Path))
+	}
+
+	return sb.String()
+}

--- a/cmd/camp/intent/edit_test.go
+++ b/cmd/camp/intent/edit_test.go
@@ -1,0 +1,233 @@
+package intent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newEditTestCmd returns a cobra.Command with all edit flags registered.
+func newEditTestCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "edit",
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	flags := cmd.Flags()
+	flags.String("body", "", "")
+	flags.String("body-file", "", "")
+	flags.String("append-body", "", "")
+	flags.String("append-body-file", "", "")
+	flags.String("title", "", "")
+	flags.String("set-type", "", "")
+	flags.String("set-status", "", "")
+	flags.String("set-concept", "", "")
+	flags.String("priority", "", "")
+	flags.String("horizon", "", "")
+	flags.String("author", "", "")
+	return cmd
+}
+
+func TestValidateEditBodyFlags_NoFlags(t *testing.T) {
+	cmd := newEditTestCmd()
+	if err := validateEditBodyFlags(cmd); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateEditBodyFlags_BodyOnly(t *testing.T) {
+	cmd := newEditTestCmd()
+	_ = cmd.Flags().Set("body", "some text")
+	if err := validateEditBodyFlags(cmd); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateEditBodyFlags_BodyFileOnly(t *testing.T) {
+	cmd := newEditTestCmd()
+	_ = cmd.Flags().Set("body-file", "file.txt")
+	if err := validateEditBodyFlags(cmd); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateEditBodyFlags_AppendBodyOnly(t *testing.T) {
+	cmd := newEditTestCmd()
+	_ = cmd.Flags().Set("append-body", "appended text")
+	if err := validateEditBodyFlags(cmd); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateEditBodyFlags_AppendBodyFileOnly(t *testing.T) {
+	cmd := newEditTestCmd()
+	_ = cmd.Flags().Set("append-body-file", "file.txt")
+	if err := validateEditBodyFlags(cmd); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateEditBodyFlags_BodyAndBodyFile(t *testing.T) {
+	cmd := newEditTestCmd()
+	_ = cmd.Flags().Set("body", "literal")
+	_ = cmd.Flags().Set("body-file", "file.txt")
+	err := validateEditBodyFlags(cmd)
+	if err == nil {
+		t.Fatal("expected error for --body + --body-file")
+	}
+	if !strings.Contains(err.Error(), "--body and --body-file are mutually exclusive") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateEditBodyFlags_AppendAndAppendFile(t *testing.T) {
+	cmd := newEditTestCmd()
+	_ = cmd.Flags().Set("append-body", "text")
+	_ = cmd.Flags().Set("append-body-file", "file.txt")
+	err := validateEditBodyFlags(cmd)
+	if err == nil {
+		t.Fatal("expected error for --append-body + --append-body-file")
+	}
+	if !strings.Contains(err.Error(), "--append-body and --append-body-file are mutually exclusive") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateEditBodyFlags_ReplaceAndAppend(t *testing.T) {
+	tests := []struct {
+		name    string
+		replace string
+		append  string
+	}{
+		{"body + append-body", "body", "append-body"},
+		{"body + append-body-file", "body", "append-body-file"},
+		{"body-file + append-body", "body-file", "append-body"},
+		{"body-file + append-body-file", "body-file", "append-body-file"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newEditTestCmd()
+			_ = cmd.Flags().Set(tt.replace, "value")
+			_ = cmd.Flags().Set(tt.append, "value")
+			err := validateEditBodyFlags(cmd)
+			if err == nil {
+				t.Fatal("expected error for replace + append combination")
+			}
+			if !strings.Contains(err.Error(), "replace vs append") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestHasProgrammaticEditFlags_None(t *testing.T) {
+	cmd := newEditTestCmd()
+	if hasProgrammaticEditFlags(cmd) {
+		t.Fatal("expected false when no programmatic flags set")
+	}
+}
+
+func TestHasProgrammaticEditFlags_TitleSet(t *testing.T) {
+	cmd := newEditTestCmd()
+	_ = cmd.Flags().Set("title", "new title")
+	if !hasProgrammaticEditFlags(cmd) {
+		t.Fatal("expected true when --title set")
+	}
+}
+
+func TestHasProgrammaticEditFlags_AllFlags(t *testing.T) {
+	flags := []string{
+		"title", "body", "body-file", "append-body", "append-body-file",
+		"set-type", "set-status", "set-concept", "priority", "horizon", "author",
+	}
+	for _, f := range flags {
+		t.Run(f, func(t *testing.T) {
+			cmd := newEditTestCmd()
+			_ = cmd.Flags().Set(f, "value")
+			if !hasProgrammaticEditFlags(cmd) {
+				t.Fatalf("expected true when --%s set", f)
+			}
+		})
+	}
+}
+
+func TestBuildUpdateOptions_Title(t *testing.T) {
+	cmd := newEditTestCmd()
+	_ = cmd.Flags().Set("title", "new title")
+	opts, err := buildUpdateOptions(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.Title == nil {
+		t.Fatal("expected Title to be set")
+	}
+	if *opts.Title != "new title" {
+		t.Fatalf("Title = %q, want %q", *opts.Title, "new title")
+	}
+	if opts.Body != nil {
+		t.Fatal("expected Body to be nil")
+	}
+}
+
+func TestBuildUpdateOptions_MultipleFields(t *testing.T) {
+	cmd := newEditTestCmd()
+	_ = cmd.Flags().Set("title", "updated")
+	_ = cmd.Flags().Set("set-type", "feature")
+	_ = cmd.Flags().Set("priority", "high")
+	_ = cmd.Flags().Set("horizon", "now")
+	_ = cmd.Flags().Set("author", "lance")
+
+	opts, err := buildUpdateOptions(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if opts.Title == nil || *opts.Title != "updated" {
+		t.Fatalf("Title mismatch")
+	}
+	if opts.Type == nil || string(*opts.Type) != "feature" {
+		t.Fatalf("Type mismatch")
+	}
+	if opts.Priority == nil || string(*opts.Priority) != "high" {
+		t.Fatalf("Priority mismatch")
+	}
+	if opts.Horizon == nil || string(*opts.Horizon) != "now" {
+		t.Fatalf("Horizon mismatch")
+	}
+	if opts.Author == nil || *opts.Author != "lance" {
+		t.Fatalf("Author mismatch")
+	}
+}
+
+func TestBuildUpdateOptions_AppendBody(t *testing.T) {
+	cmd := newEditTestCmd()
+	_ = cmd.Flags().Set("append-body", "appended text")
+	opts, err := buildUpdateOptions(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.Append == nil {
+		t.Fatal("expected Append to be set")
+	}
+	if *opts.Append != "appended text" {
+		t.Fatalf("Append = %q, want %q", *opts.Append, "appended text")
+	}
+	if opts.Body != nil {
+		t.Fatal("expected Body to be nil when only append set")
+	}
+}
+
+func TestBuildUpdateOptions_UnchangedFields(t *testing.T) {
+	cmd := newEditTestCmd()
+	// No flags set at all
+	opts, err := buildUpdateOptions(cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if opts.Title != nil || opts.Body != nil || opts.Append != nil ||
+		opts.Type != nil || opts.Status != nil || opts.Concept != nil ||
+		opts.Author != nil || opts.Priority != nil || opts.Horizon != nil {
+		t.Fatal("expected all fields to be nil when no flags changed")
+	}
+}

--- a/cmd/camp/intent/pipeline_test.go
+++ b/cmd/camp/intent/pipeline_test.go
@@ -113,19 +113,11 @@ func TestAgentPipeline_CreateThenEdit(t *testing.T) {
 	}
 
 	// Emit audit event (as the command handler would)
-	auditChanges := make([]audit.FieldChange, len(changes))
-	for i, c := range changes {
-		auditChanges[i] = audit.FieldChange{
-			Field: c.Field,
-			Old:   c.Old,
-			New:   c.New,
-		}
-	}
 	if err := appendIntentAuditEvent(ctx, intentsDir, audit.Event{
 		Type:    audit.EventEdit,
 		ID:      updated.ID,
 		Title:   updated.Title,
-		Changes: auditChanges,
+		Changes: changes,
 	}); err != nil {
 		t.Fatalf("appendIntentAuditEvent: %v", err)
 	}

--- a/cmd/camp/intent/pipeline_test.go
+++ b/cmd/camp/intent/pipeline_test.go
@@ -1,0 +1,342 @@
+package intent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	intentcore "github.com/Obedience-Corp/camp/internal/intent"
+	"github.com/Obedience-Corp/camp/internal/intent/audit"
+	"github.com/Obedience-Corp/camp/internal/paths"
+)
+
+// setupPipelineTest creates a full campaign environment and returns everything
+// needed for end-to-end agent pipeline testing.
+func setupPipelineTest(t *testing.T) (*intentcore.IntentService, string, *config.CampaignConfig, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	cfg := &config.CampaignConfig{
+		ID:        "pipeline-test",
+		Name:      "pipeline-campaign",
+		Type:      config.CampaignTypeProduct,
+		CreatedAt: time.Now(),
+	}
+	ctx := context.Background()
+	if err := config.SaveCampaignConfig(ctx, root, cfg); err != nil {
+		t.Fatalf("SaveCampaignConfig: %v", err)
+	}
+	jumps := config.DefaultJumpsConfig()
+	if err := config.SaveJumpsConfig(ctx, root, &jumps); err != nil {
+		t.Fatalf("SaveJumpsConfig: %v", err)
+	}
+
+	resolver := paths.NewResolverFromConfig(root, cfg)
+	svc := intentcore.NewIntentService(root, resolver.Intents())
+	if err := svc.EnsureDirectories(ctx); err != nil {
+		t.Fatalf("EnsureDirectories: %v", err)
+	}
+
+	return svc, resolver.Intents(), cfg, root
+}
+
+// TestAgentPipeline_CreateThenEdit tests the full agent lifecycle:
+// 1. Create intent with body/concept/author via CLI flags
+// 2. Programmatically edit title, body, type, priority
+// 3. Verify audit trail contains both create and edit events
+// 4. Verify the final state on disk
+func TestAgentPipeline_CreateThenEdit(t *testing.T) {
+	svc, intentsDir, cfg, root := setupPipelineTest(t)
+	ctx := context.Background()
+
+	// Step 1: Create intent (simulating: camp intent add "Fix login" --body "500 error" --concept projects/camp --author agent)
+	createOpts := intentcore.CreateOptions{
+		Title:   "Fix login page",
+		Type:    intentcore.TypeBug,
+		Author:  "agent",
+		Body:    "The login page returns 500 on POST",
+		Concept: "projects/camp",
+	}
+	err := runFastCapture(ctx, svc, intentsDir, cfg, root, true, createOpts)
+	if err != nil {
+		t.Fatalf("runFastCapture (create): %v", err)
+	}
+
+	// Find the created intent
+	intents, err := svc.List(ctx, nil)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(intents) != 1 {
+		t.Fatalf("expected 1 intent, got %d", len(intents))
+	}
+	created := intents[0]
+
+	// Verify creation state
+	if created.Title != "Fix login page" {
+		t.Fatalf("Title = %q", created.Title)
+	}
+	if created.Type != intentcore.TypeBug {
+		t.Fatalf("Type = %q", created.Type)
+	}
+	if created.Author != "agent" {
+		t.Fatalf("Author = %q", created.Author)
+	}
+	if created.Concept != "projects/camp" {
+		t.Fatalf("Concept = %q", created.Concept)
+	}
+	if !strings.Contains(created.Content, "500 on POST") {
+		t.Fatalf("Content missing body text")
+	}
+
+	// Step 2: Programmatic edit (simulating: camp intent edit <id> --title "Fix login 500" --set-type feature --priority high --body "Updated description")
+	newTitle := "Fix login 500 error"
+	newType := intentcore.TypeFeature
+	newPriority := intentcore.PriorityHigh
+	newBody := "Updated: login page returns 500 on POST with session cookie"
+	newAuthor := "lance"
+
+	updated, changes, err := svc.UpdateDirect(ctx, created.ID, intentcore.UpdateOptions{
+		Title:    &newTitle,
+		Type:     &newType,
+		Priority: &newPriority,
+		Body:     &newBody,
+		Author:   &newAuthor,
+	})
+	if err != nil {
+		t.Fatalf("UpdateDirect: %v", err)
+	}
+
+	// Emit audit event (as the command handler would)
+	auditChanges := make([]audit.FieldChange, len(changes))
+	for i, c := range changes {
+		auditChanges[i] = audit.FieldChange{
+			Field: c.Field,
+			Old:   c.Old,
+			New:   c.New,
+		}
+	}
+	if err := appendIntentAuditEvent(ctx, intentsDir, audit.Event{
+		Type:    audit.EventEdit,
+		ID:      updated.ID,
+		Title:   updated.Title,
+		Changes: auditChanges,
+	}); err != nil {
+		t.Fatalf("appendIntentAuditEvent: %v", err)
+	}
+
+	// Step 3: Verify final state
+	if updated.Title != newTitle {
+		t.Fatalf("Updated Title = %q, want %q", updated.Title, newTitle)
+	}
+	if updated.Type != newType {
+		t.Fatalf("Updated Type = %q, want %q", updated.Type, newType)
+	}
+	if updated.Priority != newPriority {
+		t.Fatalf("Updated Priority = %q, want %q", updated.Priority, newPriority)
+	}
+	if updated.Content != newBody {
+		t.Fatalf("Updated Content = %q, want %q", updated.Content, newBody)
+	}
+	if updated.Author != newAuthor {
+		t.Fatalf("Updated Author = %q, want %q", updated.Author, newAuthor)
+	}
+
+	// Verify changes recorded
+	if len(changes) != 5 {
+		t.Fatalf("changes count = %d, want 5", len(changes))
+	}
+
+	// Step 4: Verify audit trail
+	auditPath := audit.FilePath(intentsDir)
+	auditData, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("ReadFile(audit): %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(auditData)), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("audit log should have at least 2 entries (create + edit), got %d", len(lines))
+	}
+
+	// Verify last audit entry is an edit with changes
+	var lastEvent audit.Event
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &lastEvent); err != nil {
+		t.Fatalf("Unmarshal last audit event: %v", err)
+	}
+	if lastEvent.Type != audit.EventEdit {
+		t.Fatalf("last event type = %q, want %q", lastEvent.Type, audit.EventEdit)
+	}
+	if len(lastEvent.Changes) != 5 {
+		t.Fatalf("last event changes = %d, want 5", len(lastEvent.Changes))
+	}
+
+	// Step 5: Re-read from disk to verify persistence
+	reloaded, err := svc.Find(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Find after update: %v", err)
+	}
+	if reloaded.Title != newTitle {
+		t.Fatalf("Reloaded Title = %q, want %q", reloaded.Title, newTitle)
+	}
+	if reloaded.Type != newType {
+		t.Fatalf("Reloaded Type = %q", reloaded.Type)
+	}
+}
+
+// TestAgentPipeline_CreateThenAppend tests creating then appending body content.
+func TestAgentPipeline_CreateThenAppend(t *testing.T) {
+	svc, intentsDir, cfg, root := setupPipelineTest(t)
+	ctx := context.Background()
+
+	// Create
+	err := runFastCapture(ctx, svc, intentsDir, cfg, root, true, intentcore.CreateOptions{
+		Title:  "Research task",
+		Type:   intentcore.TypeResearch,
+		Author: "agent",
+		Body:   "Initial research notes",
+	})
+	if err != nil {
+		t.Fatalf("runFastCapture: %v", err)
+	}
+
+	intents, err := svc.List(ctx, nil)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	created := intents[0]
+
+	// Append body
+	appendText := "\n\n## Additional Findings\nFound a relevant paper on the topic."
+	updated, _, err := svc.UpdateDirect(ctx, created.ID, intentcore.UpdateOptions{
+		Append: &appendText,
+	})
+	if err != nil {
+		t.Fatalf("UpdateDirect(append): %v", err)
+	}
+
+	if !strings.Contains(updated.Content, "Initial research notes") {
+		t.Fatal("original body should be preserved")
+	}
+	if !strings.Contains(updated.Content, "Additional Findings") {
+		t.Fatal("appended text should be present")
+	}
+}
+
+// TestAgentPipeline_CreateThenStatusChange tests moving an intent through the lifecycle.
+func TestAgentPipeline_CreateThenStatusChange(t *testing.T) {
+	svc, intentsDir, cfg, root := setupPipelineTest(t)
+	ctx := context.Background()
+
+	// Create in inbox
+	err := runFastCapture(ctx, svc, intentsDir, cfg, root, true, intentcore.CreateOptions{
+		Title:  "Lifecycle test",
+		Type:   intentcore.TypeIdea,
+		Author: "agent",
+	})
+	if err != nil {
+		t.Fatalf("runFastCapture: %v", err)
+	}
+
+	intents, err := svc.List(ctx, nil)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	created := intents[0]
+	if created.Status != intentcore.StatusInbox {
+		t.Fatalf("initial status = %q, want inbox", created.Status)
+	}
+
+	// Move to ready via programmatic edit
+	readyStatus := intentcore.StatusReady
+	updated, changes, err := svc.UpdateDirect(ctx, created.ID, intentcore.UpdateOptions{
+		Status: &readyStatus,
+	})
+	if err != nil {
+		t.Fatalf("UpdateDirect(ready): %v", err)
+	}
+	if updated.Status != intentcore.StatusReady {
+		t.Fatalf("status after edit = %q, want ready", updated.Status)
+	}
+	if !strings.Contains(updated.Path, "/ready/") {
+		t.Fatalf("path should contain /ready/, got %q", updated.Path)
+	}
+
+	// Verify the change was recorded
+	found := false
+	for _, c := range changes {
+		if c.Field == "status" && c.Old == "inbox" && c.New == "ready" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("status change not recorded in changes")
+	}
+
+	// Verify old file is gone
+	oldPath := filepath.Join(intentsDir, "inbox", created.ID+".md")
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatal("old file in inbox should be removed")
+	}
+}
+
+// TestAgentPipeline_MultipleEdits verifies successive edits accumulate correctly.
+func TestAgentPipeline_MultipleEdits(t *testing.T) {
+	svc, intentsDir, cfg, root := setupPipelineTest(t)
+	ctx := context.Background()
+
+	err := runFastCapture(ctx, svc, intentsDir, cfg, root, true, intentcore.CreateOptions{
+		Title:  "Multi-edit intent",
+		Type:   intentcore.TypeIdea,
+		Author: "agent",
+	})
+	if err != nil {
+		t.Fatalf("runFastCapture: %v", err)
+	}
+
+	intents, err := svc.List(ctx, nil)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	id := intents[0].ID
+
+	// Edit 1: set type
+	featureType := intentcore.TypeFeature
+	_, _, err = svc.UpdateDirect(ctx, id, intentcore.UpdateOptions{Type: &featureType})
+	if err != nil {
+		t.Fatalf("edit 1: %v", err)
+	}
+
+	// Edit 2: set priority
+	highPriority := intentcore.PriorityHigh
+	_, _, err = svc.UpdateDirect(ctx, id, intentcore.UpdateOptions{Priority: &highPriority})
+	if err != nil {
+		t.Fatalf("edit 2: %v", err)
+	}
+
+	// Edit 3: set body
+	body := "Detailed description"
+	_, _, err = svc.UpdateDirect(ctx, id, intentcore.UpdateOptions{Body: &body})
+	if err != nil {
+		t.Fatalf("edit 3: %v", err)
+	}
+
+	// Verify final state
+	final, err := svc.Find(ctx, id)
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if final.Type != intentcore.TypeFeature {
+		t.Fatalf("Type = %q, want feature", final.Type)
+	}
+	if final.Priority != intentcore.PriorityHigh {
+		t.Fatalf("Priority = %q, want high", final.Priority)
+	}
+	if !strings.Contains(final.Content, "Detailed description") {
+		t.Fatalf("body not preserved, Content = %q", final.Content)
+	}
+}

--- a/internal/git/commit/intent.go
+++ b/internal/git/commit/intent.go
@@ -7,6 +7,7 @@ type IntentAction string
 
 const (
 	IntentCreate  IntentAction = "Create"
+	IntentEdit    IntentAction = "Edit"
 	IntentMove    IntentAction = "Move"
 	IntentArchive IntentAction = "Archive"
 	IntentDelete  IntentAction = "Delete"

--- a/internal/intent/audit/audit.go
+++ b/internal/intent/audit/audit.go
@@ -28,6 +28,7 @@ type EventType string
 
 const (
 	EventCreate  EventType = "create"
+	EventEdit    EventType = "edit"
 	EventMove    EventType = "move"
 	EventPromote EventType = "promote"
 	EventArchive EventType = "archive"
@@ -35,17 +36,25 @@ const (
 	EventGather  EventType = "gather"
 )
 
+// FieldChange records a single field's old and new value within an edit event.
+type FieldChange struct {
+	Field string `json:"field"`
+	Old   string `json:"old"`
+	New   string `json:"new"`
+}
+
 // Event represents a single audit trail entry.
 type Event struct {
-	Timestamp  time.Time `json:"ts"`
-	Type       EventType `json:"event"`
-	ID         string    `json:"id"`
-	Title      string    `json:"title"`
-	From       string    `json:"from,omitempty"`
-	To         string    `json:"to,omitempty"`
-	Reason     string    `json:"reason,omitempty"`
-	PromotedTo string    `json:"promoted_to,omitempty"`
-	Actor      string    `json:"actor,omitempty"`
+	Timestamp  time.Time     `json:"ts"`
+	Type       EventType     `json:"event"`
+	ID         string        `json:"id"`
+	Title      string        `json:"title"`
+	From       string        `json:"from,omitempty"`
+	To         string        `json:"to,omitempty"`
+	Reason     string        `json:"reason,omitempty"`
+	PromotedTo string        `json:"promoted_to,omitempty"`
+	Actor      string        `json:"actor,omitempty"`
+	Changes    []FieldChange `json:"changes,omitempty"`
 }
 
 // AppendEvent writes an audit event to the JSONL log file.

--- a/internal/intent/update.go
+++ b/internal/intent/update.go
@@ -1,0 +1,158 @@
+package intent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// UpdateOptions contains pointer fields so callers can distinguish "not set"
+// (nil) from "set to empty string" (pointer to ""). This is critical for
+// programmatic edits where only some fields should change.
+type UpdateOptions struct {
+	Title   *string
+	Body    *string   // Replaces the entire body/content section
+	Append  *string   // Appended to existing body (mutually exclusive with Body)
+	Type    *Type     // Set the intent type
+	Status  *Status   // Set the intent status
+	Concept *string   // Set the concept field
+	Author  *string   // Set the author attribution
+
+	Priority *Priority
+	Horizon  *Horizon
+}
+
+// FieldChange records a single field's old and new value for audit purposes.
+type FieldChange struct {
+	Field string `json:"field"`
+	Old   string `json:"old"`
+	New   string `json:"new"`
+}
+
+// hasChanges returns true if any field in the options is set.
+func (o *UpdateOptions) hasChanges() bool {
+	return o.Title != nil || o.Body != nil || o.Append != nil ||
+		o.Type != nil || o.Status != nil || o.Concept != nil ||
+		o.Author != nil || o.Priority != nil || o.Horizon != nil
+}
+
+// UpdateDirect applies programmatic field updates to an existing intent
+// without opening an editor. Returns the updated intent and a slice of
+// field changes for audit logging.
+func (s *IntentService) UpdateDirect(ctx context.Context, id string, opts UpdateOptions) (*Intent, []FieldChange, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, camperrors.Wrap(err, "context cancelled")
+	}
+
+	if !opts.hasChanges() {
+		return nil, nil, camperrors.Wrap(camperrors.ErrInvalidInput, "no update fields specified")
+	}
+
+	intent, err := s.Find(ctx, id)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var changes []FieldChange
+	originalPath := intent.Path
+	originalStatus := intent.Status
+
+	// Apply each field, recording changes
+	if opts.Title != nil && *opts.Title != intent.Title {
+		changes = append(changes, FieldChange{Field: "title", Old: intent.Title, New: *opts.Title})
+		intent.Title = *opts.Title
+	}
+
+	if opts.Body != nil {
+		old := intent.Content
+		intent.Content = *opts.Body
+		if old != *opts.Body {
+			changes = append(changes, FieldChange{Field: "body", Old: truncateForAudit(old), New: truncateForAudit(*opts.Body)})
+		}
+	}
+
+	if opts.Append != nil {
+		old := intent.Content
+		if intent.Content != "" && intent.Content[len(intent.Content)-1] != '\n' {
+			intent.Content += "\n"
+		}
+		intent.Content += *opts.Append
+		changes = append(changes, FieldChange{Field: "body", Old: truncateForAudit(old), New: truncateForAudit(intent.Content)})
+	}
+
+	if opts.Type != nil && *opts.Type != intent.Type {
+		changes = append(changes, FieldChange{Field: "type", Old: string(intent.Type), New: string(*opts.Type)})
+		intent.Type = *opts.Type
+	}
+
+	if opts.Status != nil && *opts.Status != intent.Status {
+		changes = append(changes, FieldChange{Field: "status", Old: string(intent.Status), New: string(*opts.Status)})
+		intent.Status = *opts.Status
+	}
+
+	if opts.Concept != nil && *opts.Concept != intent.Concept {
+		changes = append(changes, FieldChange{Field: "concept", Old: intent.Concept, New: *opts.Concept})
+		intent.Concept = *opts.Concept
+	}
+
+	if opts.Author != nil && *opts.Author != intent.Author {
+		changes = append(changes, FieldChange{Field: "author", Old: intent.Author, New: *opts.Author})
+		intent.Author = *opts.Author
+	}
+
+	if opts.Priority != nil && *opts.Priority != intent.Priority {
+		changes = append(changes, FieldChange{Field: "priority", Old: string(intent.Priority), New: string(*opts.Priority)})
+		intent.Priority = *opts.Priority
+	}
+
+	if opts.Horizon != nil && *opts.Horizon != intent.Horizon {
+		changes = append(changes, FieldChange{Field: "horizon", Old: string(intent.Horizon), New: string(*opts.Horizon)})
+		intent.Horizon = *opts.Horizon
+	}
+
+	if len(changes) == 0 {
+		// All values were identical to existing — no-op
+		return intent, nil, nil
+	}
+
+	// Validate after all changes applied
+	if errs := intent.Validate(); len(errs) > 0 {
+		return nil, nil, intentValidationError(errs)
+	}
+
+	intent.UpdatedAt = time.Now()
+
+	// Handle status change (move to new directory)
+	if intent.Status != originalStatus {
+		newPath := s.getIntentPath(intent.Status, intent.ID)
+		if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
+			return nil, nil, camperrors.Wrap(err, "creating directory for status change")
+		}
+		intent.Path = newPath
+	}
+
+	// Serialize and write
+	if err := s.Save(ctx, intent); err != nil {
+		return nil, nil, err
+	}
+
+	// Remove old file if status changed
+	if intent.Status != originalStatus && originalPath != intent.Path {
+		_ = os.Remove(originalPath)
+		s.removeAllCopies(intent.ID, intent.Path)
+	}
+
+	return intent, changes, nil
+}
+
+// truncateForAudit truncates long strings for audit log readability.
+func truncateForAudit(s string) string {
+	const maxLen = 200
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/internal/intent/update.go
+++ b/internal/intent/update.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+	"unicode/utf8"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/intent/audit"
 )
 
 // UpdateOptions contains pointer fields so callers can distinguish "not set"
@@ -25,13 +27,6 @@ type UpdateOptions struct {
 	Horizon  *Horizon
 }
 
-// FieldChange records a single field's old and new value for audit purposes.
-type FieldChange struct {
-	Field string `json:"field"`
-	Old   string `json:"old"`
-	New   string `json:"new"`
-}
-
 // hasChanges returns true if any field in the options is set.
 func (o *UpdateOptions) hasChanges() bool {
 	return o.Title != nil || o.Body != nil || o.Append != nil ||
@@ -42,7 +37,7 @@ func (o *UpdateOptions) hasChanges() bool {
 // UpdateDirect applies programmatic field updates to an existing intent
 // without opening an editor. Returns the updated intent and a slice of
 // field changes for audit logging.
-func (s *IntentService) UpdateDirect(ctx context.Context, id string, opts UpdateOptions) (*Intent, []FieldChange, error) {
+func (s *IntentService) UpdateDirect(ctx context.Context, id string, opts UpdateOptions) (*Intent, []audit.FieldChange, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, nil, camperrors.Wrap(err, "context cancelled")
 	}
@@ -56,13 +51,13 @@ func (s *IntentService) UpdateDirect(ctx context.Context, id string, opts Update
 		return nil, nil, err
 	}
 
-	var changes []FieldChange
+	var changes []audit.FieldChange
 	originalPath := intent.Path
 	originalStatus := intent.Status
 
 	// Apply each field, recording changes
 	if opts.Title != nil && *opts.Title != intent.Title {
-		changes = append(changes, FieldChange{Field: "title", Old: intent.Title, New: *opts.Title})
+		changes = append(changes, audit.FieldChange{Field: "title", Old: intent.Title, New: *opts.Title})
 		intent.Title = *opts.Title
 	}
 
@@ -70,7 +65,7 @@ func (s *IntentService) UpdateDirect(ctx context.Context, id string, opts Update
 		old := intent.Content
 		intent.Content = *opts.Body
 		if old != *opts.Body {
-			changes = append(changes, FieldChange{Field: "body", Old: truncateForAudit(old), New: truncateForAudit(*opts.Body)})
+			changes = append(changes, audit.FieldChange{Field: "body", Old: truncateForAudit(old), New: truncateForAudit(*opts.Body)})
 		}
 	}
 
@@ -80,36 +75,36 @@ func (s *IntentService) UpdateDirect(ctx context.Context, id string, opts Update
 			intent.Content += "\n"
 		}
 		intent.Content += *opts.Append
-		changes = append(changes, FieldChange{Field: "body", Old: truncateForAudit(old), New: truncateForAudit(intent.Content)})
+		changes = append(changes, audit.FieldChange{Field: "body", Old: truncateForAudit(old), New: truncateForAudit(intent.Content)})
 	}
 
 	if opts.Type != nil && *opts.Type != intent.Type {
-		changes = append(changes, FieldChange{Field: "type", Old: string(intent.Type), New: string(*opts.Type)})
+		changes = append(changes, audit.FieldChange{Field: "type", Old: string(intent.Type), New: string(*opts.Type)})
 		intent.Type = *opts.Type
 	}
 
 	if opts.Status != nil && *opts.Status != intent.Status {
-		changes = append(changes, FieldChange{Field: "status", Old: string(intent.Status), New: string(*opts.Status)})
+		changes = append(changes, audit.FieldChange{Field: "status", Old: string(intent.Status), New: string(*opts.Status)})
 		intent.Status = *opts.Status
 	}
 
 	if opts.Concept != nil && *opts.Concept != intent.Concept {
-		changes = append(changes, FieldChange{Field: "concept", Old: intent.Concept, New: *opts.Concept})
+		changes = append(changes, audit.FieldChange{Field: "concept", Old: intent.Concept, New: *opts.Concept})
 		intent.Concept = *opts.Concept
 	}
 
 	if opts.Author != nil && *opts.Author != intent.Author {
-		changes = append(changes, FieldChange{Field: "author", Old: intent.Author, New: *opts.Author})
+		changes = append(changes, audit.FieldChange{Field: "author", Old: intent.Author, New: *opts.Author})
 		intent.Author = *opts.Author
 	}
 
 	if opts.Priority != nil && *opts.Priority != intent.Priority {
-		changes = append(changes, FieldChange{Field: "priority", Old: string(intent.Priority), New: string(*opts.Priority)})
+		changes = append(changes, audit.FieldChange{Field: "priority", Old: string(intent.Priority), New: string(*opts.Priority)})
 		intent.Priority = *opts.Priority
 	}
 
 	if opts.Horizon != nil && *opts.Horizon != intent.Horizon {
-		changes = append(changes, FieldChange{Field: "horizon", Old: string(intent.Horizon), New: string(*opts.Horizon)})
+		changes = append(changes, audit.FieldChange{Field: "horizon", Old: string(intent.Horizon), New: string(*opts.Horizon)})
 		intent.Horizon = *opts.Horizon
 	}
 
@@ -148,11 +143,15 @@ func (s *IntentService) UpdateDirect(ctx context.Context, id string, opts Update
 	return intent, changes, nil
 }
 
+// maxAuditFieldLen is the maximum rune length for audit log field values.
+const maxAuditFieldLen = 200
+
 // truncateForAudit truncates long strings for audit log readability.
+// Truncates on rune boundaries to avoid splitting multi-byte UTF-8 characters.
 func truncateForAudit(s string) string {
-	const maxLen = 200
-	if len(s) <= maxLen {
+	if utf8.RuneCountInString(s) <= maxAuditFieldLen {
 		return s
 	}
-	return s[:maxLen] + "..."
+	runes := []rune(s)
+	return string(runes[:maxAuditFieldLen]) + "..."
 }

--- a/internal/intent/update_test.go
+++ b/internal/intent/update_test.go
@@ -1,0 +1,397 @@
+package intent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// setupTestService creates a temp campaign with an intent service and a single
+// test intent in inbox. Returns the service, intent ID, and intents directory.
+func setupTestService(t *testing.T) (*IntentService, string, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	intentsDir := filepath.Join(root, ".campaign", "intents")
+	svc := NewIntentService(root, intentsDir)
+	if err := svc.EnsureDirectories(context.Background()); err != nil {
+		t.Fatalf("EnsureDirectories: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 13, 10, 0, 0, 0, time.UTC)
+	opts := CreateOptions{
+		Title:     "Test intent title",
+		Type:      TypeIdea,
+		Author:    "agent",
+		Body:      "Original body content",
+		Concept:   "projects/camp",
+		Timestamp: ts,
+	}
+	result, err := svc.CreateDirect(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+
+	return svc, result.ID, intentsDir
+}
+
+func TestUpdateDirect_Title(t *testing.T) {
+	svc, id, _ := setupTestService(t)
+	ctx := context.Background()
+
+	newTitle := "Updated title"
+	updated, changes, err := svc.UpdateDirect(ctx, id, UpdateOptions{
+		Title: &newTitle,
+	})
+	if err != nil {
+		t.Fatalf("UpdateDirect: %v", err)
+	}
+
+	if updated.Title != newTitle {
+		t.Fatalf("Title = %q, want %q", updated.Title, newTitle)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("changes count = %d, want 1", len(changes))
+	}
+	if changes[0].Field != "title" {
+		t.Fatalf("change field = %q, want %q", changes[0].Field, "title")
+	}
+	if changes[0].Old != "Test intent title" {
+		t.Fatalf("change old = %q, want %q", changes[0].Old, "Test intent title")
+	}
+	if changes[0].New != newTitle {
+		t.Fatalf("change new = %q, want %q", changes[0].New, newTitle)
+	}
+}
+
+func TestUpdateDirect_Body(t *testing.T) {
+	svc, id, _ := setupTestService(t)
+	ctx := context.Background()
+
+	newBody := "Completely new body"
+	updated, changes, err := svc.UpdateDirect(ctx, id, UpdateOptions{
+		Body: &newBody,
+	})
+	if err != nil {
+		t.Fatalf("UpdateDirect: %v", err)
+	}
+
+	if updated.Content != newBody {
+		t.Fatalf("Content = %q, want %q", updated.Content, newBody)
+	}
+
+	found := false
+	for _, c := range changes {
+		if c.Field == "body" {
+			found = true
+			if c.New != newBody {
+				t.Fatalf("body change new = %q, want %q", c.New, newBody)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected body change in changes slice")
+	}
+}
+
+func TestUpdateDirect_AppendBody(t *testing.T) {
+	svc, id, _ := setupTestService(t)
+	ctx := context.Background()
+
+	appendText := "\nAdditional note"
+	updated, changes, err := svc.UpdateDirect(ctx, id, UpdateOptions{
+		Append: &appendText,
+	})
+	if err != nil {
+		t.Fatalf("UpdateDirect: %v", err)
+	}
+
+	if !strings.HasSuffix(updated.Content, appendText) {
+		t.Fatalf("Content should end with appended text, got %q", updated.Content)
+	}
+
+	if len(changes) == 0 {
+		t.Fatal("expected at least one change for append")
+	}
+}
+
+func TestUpdateDirect_MultipleFields(t *testing.T) {
+	svc, id, _ := setupTestService(t)
+	ctx := context.Background()
+
+	newTitle := "Multi-field update"
+	newType := TypeFeature
+	newPriority := PriorityHigh
+	newHorizon := HorizonNow
+	newConcept := "projects/fest"
+	newAuthor := "human"
+
+	updated, changes, err := svc.UpdateDirect(ctx, id, UpdateOptions{
+		Title:    &newTitle,
+		Type:     &newType,
+		Priority: &newPriority,
+		Horizon:  &newHorizon,
+		Concept:  &newConcept,
+		Author:   &newAuthor,
+	})
+	if err != nil {
+		t.Fatalf("UpdateDirect: %v", err)
+	}
+
+	if updated.Title != newTitle {
+		t.Fatalf("Title = %q, want %q", updated.Title, newTitle)
+	}
+	if updated.Type != newType {
+		t.Fatalf("Type = %q, want %q", updated.Type, newType)
+	}
+	if updated.Priority != newPriority {
+		t.Fatalf("Priority = %q, want %q", updated.Priority, newPriority)
+	}
+	if updated.Horizon != newHorizon {
+		t.Fatalf("Horizon = %q, want %q", updated.Horizon, newHorizon)
+	}
+	if updated.Concept != newConcept {
+		t.Fatalf("Concept = %q, want %q", updated.Concept, newConcept)
+	}
+	if updated.Author != newAuthor {
+		t.Fatalf("Author = %q, want %q", updated.Author, newAuthor)
+	}
+
+	// Should have 6 changes
+	if len(changes) != 6 {
+		t.Fatalf("changes count = %d, want 6", len(changes))
+	}
+}
+
+func TestUpdateDirect_StatusChange(t *testing.T) {
+	svc, id, _ := setupTestService(t)
+	ctx := context.Background()
+
+	newStatus := StatusReady
+	updated, changes, err := svc.UpdateDirect(ctx, id, UpdateOptions{
+		Status: &newStatus,
+	})
+	if err != nil {
+		t.Fatalf("UpdateDirect: %v", err)
+	}
+
+	if updated.Status != StatusReady {
+		t.Fatalf("Status = %q, want %q", updated.Status, StatusReady)
+	}
+
+	// Verify the file was moved to the ready directory
+	if !strings.Contains(updated.Path, "/ready/") {
+		t.Fatalf("Path should contain /ready/, got %q", updated.Path)
+	}
+
+	// Verify the file exists at the new location
+	if _, err := os.Stat(updated.Path); err != nil {
+		t.Fatalf("file should exist at new path: %v", err)
+	}
+
+	// Verify at least one change (status)
+	found := false
+	for _, c := range changes {
+		if c.Field == "status" {
+			found = true
+			if c.Old != "inbox" || c.New != "ready" {
+				t.Fatalf("status change: old=%q new=%q, want old=inbox new=ready", c.Old, c.New)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected status change in changes slice")
+	}
+}
+
+func TestUpdateDirect_NoChanges(t *testing.T) {
+	svc, id, _ := setupTestService(t)
+	ctx := context.Background()
+
+	// Set title to the same value
+	sameTitle := "Test intent title"
+	updated, changes, err := svc.UpdateDirect(ctx, id, UpdateOptions{
+		Title: &sameTitle,
+	})
+	if err != nil {
+		t.Fatalf("UpdateDirect: %v", err)
+	}
+
+	if len(changes) != 0 {
+		t.Fatalf("expected 0 changes for identical values, got %d", len(changes))
+	}
+	if updated == nil {
+		t.Fatal("expected non-nil intent even with no changes")
+	}
+}
+
+func TestUpdateDirect_NoFieldsSpecified(t *testing.T) {
+	svc, id, _ := setupTestService(t)
+	ctx := context.Background()
+
+	_, _, err := svc.UpdateDirect(ctx, id, UpdateOptions{})
+	if err == nil {
+		t.Fatal("expected error when no update fields specified")
+	}
+}
+
+func TestUpdateDirect_NotFound(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	ctx := context.Background()
+
+	newTitle := "Won't work"
+	_, _, err := svc.UpdateDirect(ctx, "nonexistent-id", UpdateOptions{
+		Title: &newTitle,
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent intent")
+	}
+}
+
+func TestUpdateDirect_InvalidTypeValidation(t *testing.T) {
+	svc, id, _ := setupTestService(t)
+	ctx := context.Background()
+
+	invalidType := Type("invalid-type")
+	_, _, err := svc.UpdateDirect(ctx, id, UpdateOptions{
+		Type: &invalidType,
+	})
+	if err == nil {
+		t.Fatal("expected validation error for invalid type")
+	}
+}
+
+func TestUpdateDirect_InvalidPriorityValidation(t *testing.T) {
+	svc, id, _ := setupTestService(t)
+	ctx := context.Background()
+
+	invalidPriority := Priority("critical")
+	_, _, err := svc.UpdateDirect(ctx, id, UpdateOptions{
+		Priority: &invalidPriority,
+	})
+	if err == nil {
+		t.Fatal("expected validation error for invalid priority")
+	}
+}
+
+func TestUpdateDirect_InvalidHorizonValidation(t *testing.T) {
+	svc, id, _ := setupTestService(t)
+	ctx := context.Background()
+
+	invalidHorizon := Horizon("yesterday")
+	_, _, err := svc.UpdateDirect(ctx, id, UpdateOptions{
+		Horizon: &invalidHorizon,
+	})
+	if err == nil {
+		t.Fatal("expected validation error for invalid horizon")
+	}
+}
+
+func TestUpdateDirect_ContextCancellation(t *testing.T) {
+	svc, id, _ := setupTestService(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	newTitle := "Won't work"
+	_, _, err := svc.UpdateDirect(ctx, id, UpdateOptions{
+		Title: &newTitle,
+	})
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestUpdateDirect_AppendToEmptyBody(t *testing.T) {
+	root := t.TempDir()
+	intentsDir := filepath.Join(root, ".campaign", "intents")
+	svc := NewIntentService(root, intentsDir)
+	if err := svc.EnsureDirectories(context.Background()); err != nil {
+		t.Fatalf("EnsureDirectories: %v", err)
+	}
+
+	ts := time.Date(2026, 4, 13, 10, 0, 0, 0, time.UTC)
+	// Create intent with empty body
+	result, err := svc.CreateDirect(context.Background(), CreateOptions{
+		Title:     "Empty body intent",
+		Type:      TypeIdea,
+		Author:    "agent",
+		Timestamp: ts,
+	})
+	if err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+
+	appendText := "First content"
+	updated, _, err := svc.UpdateDirect(context.Background(), result.ID, UpdateOptions{
+		Append: &appendText,
+	})
+	if err != nil {
+		t.Fatalf("UpdateDirect: %v", err)
+	}
+
+	if !strings.Contains(updated.Content, "First content") {
+		t.Fatalf("Content should contain appended text, got %q", updated.Content)
+	}
+}
+
+func TestUpdateDirect_Persistence(t *testing.T) {
+	svc, id, _ := setupTestService(t)
+	ctx := context.Background()
+
+	newTitle := "Persisted title"
+	newBody := "Persisted body"
+	_, _, err := svc.UpdateDirect(ctx, id, UpdateOptions{
+		Title: &newTitle,
+		Body:  &newBody,
+	})
+	if err != nil {
+		t.Fatalf("UpdateDirect: %v", err)
+	}
+
+	// Re-read from disk
+	reloaded, err := svc.Find(ctx, id)
+	if err != nil {
+		t.Fatalf("Find after update: %v", err)
+	}
+
+	if reloaded.Title != newTitle {
+		t.Fatalf("persisted Title = %q, want %q", reloaded.Title, newTitle)
+	}
+	if reloaded.Content != newBody+"\n" && reloaded.Content != newBody {
+		// Body may have trailing newline from serialization
+		if !strings.HasPrefix(reloaded.Content, newBody) {
+			t.Fatalf("persisted Content = %q, want prefix %q", reloaded.Content, newBody)
+		}
+	}
+}
+
+func TestTruncateForAudit(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantLen  int
+		wantFull bool
+	}{
+		{"short", "hello", 5, true},
+		{"exact200", strings.Repeat("x", 200), 200, true},
+		{"over200", strings.Repeat("x", 201), 203, false}, // 200 + "..."
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := truncateForAudit(tt.input)
+			if len(result) != tt.wantLen {
+				t.Fatalf("length = %d, want %d", len(result), tt.wantLen)
+			}
+			if tt.wantFull && result != tt.input {
+				t.Fatalf("expected full string preserved")
+			}
+			if !tt.wantFull && !strings.HasSuffix(result, "...") {
+				t.Fatal("expected truncated string to end with ...")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #209. Gives agents full programmatic parity with the TUI/editor paths for `intent add` and `intent edit`.

- **`intent add`**: new `--body`, `--body-file`, `--concept`, `--author` flags with mutual exclusivity enforcement, non-TTY guard, and `--full`/`--edit` interaction rules
- **`intent edit`**: new `--title`, `--body`, `--body-file`, `--append-body`, `--append-body-file`, `--set-type`, `--set-status`, `--set-concept`, `--priority`, `--horizon`, `--author` flags that skip $EDITOR and apply updates via `UpdateDirect`
- **Service layer**: `UpdateOptions` struct with pointer fields (nil = unset), `UpdateDirect` method with validation, status-aware file moves, and `FieldChange` tracking
- **Audit**: `EventEdit` type with per-field old/new change records in the JSONL audit log
- **Shared**: `resolveBody(cmd)` helper for body flag resolution with 10 MiB stdin cap

## Test plan

- [x] Unit tests for `resolveBody` (no flags, body, body-file, mutual exclusivity, missing file, empty body, size limit at boundary)
- [x] Unit tests for `validateEditBodyFlags` (all 4 body flags in isolation, body+body-file, append+append-file, all replace-vs-append combos)
- [x] Unit tests for `hasProgrammaticEditFlags` (none set, each of 11 flags individually)
- [x] Unit tests for `buildUpdateOptions` (title only, multiple fields, append body, no flags)
- [x] Unit tests for `UpdateDirect` (title, body, append, multi-field, status change with file move, no-op identical values, no fields specified, not found, invalid type/priority/horizon validation, context cancellation, append to empty body, persistence round-trip)
- [x] Integration tests for full agent pipeline (create with body/concept/author -> programmatic edit -> verify audit trail, create then append, create then status change with file move, multiple successive edits)
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass (no regressions)
- [x] `go build ./...` clean