### PR TITLE
route linked-project error paths through camp errors

### DIFF
--- a/cmd/camp/intent/add.go
+++ b/cmd/camp/intent/add.go
@@ -108,7 +108,7 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 
 	// --full + body flags = usage error (body in TUI conflicts with programmatic body)
 	if fullMode && bodySet {
-		return fmt.Errorf("--full and --body/--body-file are mutually exclusive")
+		return camperrors.Wrap(camperrors.ErrInvalidInput, "--full and --body/--body-file are mutually exclusive")
 	}
 
 	campaignResolver := newIntentAddCampaignResolver(cmd.ErrOrStderr())
@@ -157,7 +157,7 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 	// Programmatic flags like --body/--concept/--author supplement a title,
 	// they don't replace it.
 	if !navtui.IsTerminal() {
-		return fmt.Errorf("title argument required in non-interactive mode\n       Usage: camp intent add <title> [flags]")
+		return camperrors.Wrap(camperrors.ErrInvalidInput, "title argument required in non-interactive mode\n       Usage: camp intent add <title> [flags]")
 	}
 
 	// TUI path: use git config author (human), unless --author overrides
@@ -207,7 +207,7 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 			// User saved some intents via Ctrl-n, then cancelled the last one
 			return nil
 		}
-		return fmt.Errorf("intent creation cancelled")
+		return intent.ErrCancelled
 	}
 
 	// Build create options from TUI result
@@ -289,13 +289,13 @@ func (r intentAddCampaignResolver) resolve(ctx context.Context, targetCampaign s
 		return nil, "", camperrors.Wrap(err, "load registry")
 	}
 	if reg.Len() == 0 {
-		return nil, "", fmt.Errorf("no campaigns registered (use 'camp init' to create one)")
+		return nil, "", camperrors.Wrap(camperrors.ErrNotInitialized, "no campaigns registered (use 'camp init' to create one)")
 	}
 
 	var selected config.RegisteredCampaign
 	if targetCampaign == "" {
 		if !r.isInteractive() {
-			return nil, "", fmt.Errorf("campaign name required in non-interactive mode\n       Usage: camp intent add --campaign <name> [title]")
+			return nil, "", camperrors.Wrap(camperrors.ErrInvalidInput, "campaign name required in non-interactive mode\n       Usage: camp intent add --campaign <name> [title]")
 		}
 		selected, err = r.pickCampaign(ctx, reg)
 		if err != nil {
@@ -334,7 +334,7 @@ func runIntentAddTUI(ctx context.Context, conceptSvc concept.Service, opts tui.A
 
 	m, ok := finalModel.(tui.IntentAddModel)
 	if !ok {
-		return nil, fmt.Errorf("unexpected model type: %T", finalModel)
+		return nil, camperrors.Wrapf(camperrors.ErrInvalidInput, "unexpected model type: %T", finalModel)
 	}
 
 	return &m, nil
@@ -360,7 +360,7 @@ func runDeepCapture(ctx context.Context, svc *intent.IntentService, intentsDir s
 	result, err := svc.CreateWithEditor(ctx, opts, editorFn)
 	if err != nil {
 		if errors.Is(err, camperrors.ErrCancelled) {
-			return fmt.Errorf("intent creation cancelled")
+			return intent.ErrCancelled
 		}
 		return camperrors.Wrap(err, "failed to create intent")
 	}

--- a/cmd/camp/project/add.go
+++ b/cmd/camp/project/add.go
@@ -73,7 +73,7 @@ func runProjectAdd(cmd *cobra.Command, args []string) error {
 	case local != "":
 		source = local
 	case len(args) == 0:
-		return fmt.Errorf("source URL is required")
+		return camperrors.Wrap(camperrors.ErrInvalidInput, "source URL is required")
 	default:
 		source = args[0]
 	}
@@ -215,14 +215,14 @@ func (r projectCampaignResolver) Resolve(ctx context.Context, targetCampaign str
 		return nil, "", camperrors.Wrap(err, "load registry")
 	}
 	if reg.Len() == 0 {
-		return nil, "", fmt.Errorf("no campaigns registered (use 'camp init' to create one)")
+		return nil, "", camperrors.Wrap(camperrors.ErrNotInitialized, "no campaigns registered (use 'camp init' to create one)")
 	}
 
 	var selected config.RegisteredCampaign
 	switch {
 	case targetCampaign == "":
 		if !r.isInteractive() {
-			return nil, "", fmt.Errorf("campaign name required in non-interactive mode\n       Usage: %s", r.usage())
+			return nil, "", camperrors.Wrapf(camperrors.ErrInvalidInput, "campaign name required in non-interactive mode\n       Usage: %s", r.usage())
 		}
 		selected, err = r.pickCampaign(ctx, reg)
 		if err != nil {
@@ -260,7 +260,7 @@ func (r projectCampaignResolver) usage() string {
 
 func ensureProjectCampaignRegistered(reg *config.Registry, cfg *config.CampaignConfig, campaignRoot string) error {
 	if cfg == nil {
-		return fmt.Errorf("target campaign config could not be loaded")
+		return camperrors.Wrap(camperrors.ErrNotFound, "target campaign config could not be loaded")
 	}
 
 	normalizedRoot, err := normalizeProjectCampaignRoot(campaignRoot)
@@ -286,7 +286,7 @@ func ensureProjectCampaignRegistered(reg *config.Registry, cfg *config.CampaignC
 	if strings.TrimSpace(name) == "" {
 		name = normalizedRoot
 	}
-	return fmt.Errorf("target campaign %q is not registered\n       Run 'camp register %s' before adding projects", name, normalizedRoot)
+	return camperrors.Wrapf(camperrors.ErrNotFound, "target campaign %q is not registered\n       Run 'camp register %s' before adding projects", name, normalizedRoot)
 }
 
 func normalizeProjectCampaignRoot(root string) (string, error) {
@@ -326,5 +326,5 @@ func formatGitError(gitErr *projectsvc.GitError) error {
 		b.WriteString("\n")
 	}
 
-	return fmt.Errorf("%s", b.String())
+	return camperrors.New(b.String())
 }

--- a/cmd/camp/project/linked/common.go
+++ b/cmd/camp/project/linked/common.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/git/commit"
 	projectsvc "github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
@@ -143,7 +144,7 @@ func resolveLinkSourcePath(campaignRoot string, args []string) (string, error) {
 		return "", err
 	}
 	if isWithinTargetCampaign(cwd, campaignRoot) {
-		return "", fmt.Errorf("link path required when current directory is already inside the target campaign")
+		return "", camperrors.Wrap(camperrors.ErrInvalidInput, "link path required when current directory is already inside the target campaign")
 	}
 	return cwd, nil
 }
@@ -155,7 +156,7 @@ func resolveUnlinkName(ctx context.Context, campaignRoot string, args []string) 
 
 	resolved, err := projectsvc.Resolve(ctx, campaignRoot, "")
 	if err != nil {
-		return "", fmt.Errorf("could not infer linked project from current directory: %w\n       Use 'camp project unlink <name>' to target it explicitly", err)
+		return "", camperrors.Wrap(err, "could not infer linked project from current directory\n       Use 'camp project unlink <name>' to target it explicitly")
 	}
 	return strings.TrimPrefix(resolved.Name, "projects/"), nil
 }

--- a/cmd/camp/project/remote/add.go
+++ b/cmd/camp/project/remote/add.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/git"
 	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
@@ -52,7 +53,7 @@ func runProjectRemoteAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := git.AddRemote(ctx, resolved.Path, remoteName, remoteURL); err != nil {
-		return fmt.Errorf("add remote: %w", err)
+		return camperrors.Wrap(err, "add remote")
 	}
 
 	fmt.Printf("%s Added remote %s → %s\n",

--- a/cmd/camp/project/remote/remove.go
+++ b/cmd/camp/project/remote/remove.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/git"
 	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
@@ -51,7 +52,7 @@ func runProjectRemoteRemove(cmd *cobra.Command, args []string) error {
 		fmt.Println(ui.Dim("  origin is the canonical remote for submodule tracking."))
 		fmt.Println(ui.Dim("  To change its URL, use: camp project remote set-url <url>"))
 		fmt.Println(ui.Dim("  To remove it anyway:    camp project remote remove origin --force"))
-		return fmt.Errorf("use --force to remove origin")
+		return camperrors.Wrap(camperrors.ErrInvalidInput, "use --force to remove origin")
 	}
 
 	campRoot, err := campaign.DetectCached(ctx)
@@ -68,7 +69,7 @@ func runProjectRemoteRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := git.RemoveRemote(ctx, resolved.Path, remoteName); err != nil {
-		return fmt.Errorf("remove remote: %w", err)
+		return camperrors.Wrap(err, "remove remote")
 	}
 
 	fmt.Printf("%s Removed remote %s from project %s\n",

--- a/cmd/camp/project/remote/rename.go
+++ b/cmd/camp/project/remote/rename.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/git"
 	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
@@ -70,7 +71,7 @@ func runProjectRemoteRename(cmd *cobra.Command, args []string) error {
 		fmt.Println(ui.Dim("  A future 'git submodule sync' would recreate origin, undoing this rename."))
 		fmt.Println(ui.Dim("  To change the URL instead: camp project remote set-url <url>"))
 		fmt.Println(ui.Dim("  To rename anyway:          camp project remote rename origin <new> --force"))
-		return fmt.Errorf("use --force to rename origin in submodule project")
+		return camperrors.Wrap(camperrors.ErrInvalidInput, "use --force to rename origin in submodule project")
 	}
 
 	if oldName == "origin" && !isSubmodule {
@@ -93,7 +94,7 @@ func runProjectRemoteRename(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := git.RenameRemote(ctx, resolved.Path, oldName, newName); err != nil {
-		return fmt.Errorf("rename remote: %w", err)
+		return camperrors.Wrap(err, "rename remote")
 	}
 
 	fmt.Printf("%s Renamed remote %s → %s in project %s\n",

--- a/cmd/camp/project/remote/set_url.go
+++ b/cmd/camp/project/remote/set_url.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/git"
 	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
@@ -164,7 +165,7 @@ func runProjectRemoteSetURL(cmd *cobra.Command, args []string) error {
 			return git.SetDeclaredURL(ctx, campRoot, submodulePath, newURL)
 		})
 		if setURLErr != nil {
-			return fmt.Errorf("update .gitmodules: %w", setURLErr)
+			return camperrors.Wrap(setURLErr, "update .gitmodules")
 		}
 		state.gitmodulesUpdated = true
 		state.addStep("updated .gitmodules")
@@ -183,7 +184,7 @@ func runProjectRemoteSetURL(cmd *cobra.Command, args []string) error {
 			} else {
 				fmt.Printf("  %s Rollback succeeded — no changes were applied\n", ui.SuccessIcon())
 			}
-			return fmt.Errorf("sync submodule config: %w", syncErr)
+			return camperrors.Wrap(syncErr, "sync submodule config")
 		}
 		state.syncCompleted = true
 		state.addStep("synced local submodule config")
@@ -200,7 +201,7 @@ func runProjectRemoteSetURL(cmd *cobra.Command, args []string) error {
 				fmt.Printf("  %s Rollback succeeded — no changes were applied\n", ui.SuccessIcon())
 			}
 		}
-		return fmt.Errorf("set remote URL in project: %w", err)
+		return camperrors.Wrap(err, "set remote URL in project")
 	}
 	state.remoteURLUpdated = true
 	state.addStep(fmt.Sprintf("set remote %s URL", remoteName))

--- a/cmd/camp/project/run.go
+++ b/cmd/camp/project/run.go
@@ -105,7 +105,7 @@ func runProjectRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(commandArgs) == 0 {
-		return fmt.Errorf("no command specified")
+		return camperrors.Wrap(camperrors.ErrInvalidInput, "no command specified")
 	}
 
 	// Show which project we're running in.
@@ -163,7 +163,7 @@ func pickProject(cmd *cobra.Command, campRoot string) (*projectsvc.Project, erro
 		return nil, camperrors.Wrap(err, "failed to list projects")
 	}
 	if len(projects) == 0 {
-		return nil, fmt.Errorf("no projects found in campaign")
+		return nil, camperrors.Wrap(camperrors.ErrNotFound, "no projects found in campaign")
 	}
 
 	idx, err := fuzzyfinder.Find(
@@ -187,7 +187,7 @@ func pickProject(cmd *cobra.Command, campRoot string) (*projectsvc.Project, erro
 	)
 	if err != nil {
 		if errors.Is(err, fuzzyfinder.ErrAbort) {
-			return nil, fmt.Errorf("cancelled")
+			return nil, camperrors.Wrap(camperrors.ErrCancelled, "cancelled")
 		}
 		return nil, camperrors.Wrap(err, "picker")
 	}

--- a/cmd/camp/project/worktree/remove.go
+++ b/cmd/camp/project/worktree/remove.go
@@ -82,7 +82,7 @@ func runProjectWorktreeRemove(cmd *cobra.Command, args []string) error {
 	resolver := paths.NewResolver(campRoot, cfg.Paths())
 	pathManager := intworktree.NewPathManager(resolver)
 	if !pathManager.WorktreeExists(projectName, worktreeName) {
-		return fmt.Errorf("worktree '%s' does not exist for project '%s'", worktreeName, projectName)
+		return camperrors.Wrapf(camperrors.ErrNotFound, "worktree '%s' does not exist for project '%s'", worktreeName, projectName)
 	}
 
 	wtPath := pathManager.WorktreePath(projectName, worktreeName)

--- a/cmd/camp/run.go
+++ b/cmd/camp/run.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
-	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +9,7 @@ import (
 	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/nav"
 	"github.com/Obedience-Corp/camp/internal/nav/index"
 	projectsvc "github.com/Obedience-Corp/camp/internal/project"
@@ -84,12 +83,12 @@ func runRun(cmd *cobra.Command, args []string) error {
 		// Look up shortcut
 		sc, ok := cfg.Shortcuts()[shortcutName]
 		if !ok {
-			return fmt.Errorf("unknown shortcut %q (run 'camp shortcuts' to see available shortcuts)", shortcutName)
+			return camperrors.Wrapf(camperrors.ErrNotFound, "unknown shortcut %q (run 'camp shortcuts' to see available shortcuts)", shortcutName)
 		}
 
 		// Only navigation shortcuts can be used for directory context
 		if !sc.IsNavigation() {
-			return fmt.Errorf("shortcut %q is not a navigation shortcut (only shortcuts with paths can be used)", shortcutName)
+			return camperrors.Wrapf(camperrors.ErrInvalidInput, "shortcut %q is not a navigation shortcut (only shortcuts with paths can be used)", shortcutName)
 		}
 
 		// Check if this is a standard path that supports project sub-shortcuts
@@ -149,13 +148,13 @@ func runRun(cmd *cobra.Command, args []string) error {
 
 					// Determine how many args were consumed
 					if consumed >= len(args) {
-						return fmt.Errorf("no command specified")
+						return camperrors.Wrap(camperrors.ErrInvalidInput, "no command specified")
 					}
 					commandArgs = args[consumed:]
 
 					// Verify directory exists
 					if stat, err := os.Stat(workDir); err != nil || !stat.IsDir() {
-						return fmt.Errorf("directory does not exist: %s", workDir)
+						return camperrors.Wrapf(camperrors.ErrNotFound, "directory does not exist: %s", workDir)
 					}
 
 					// Build and execute command
@@ -170,7 +169,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 
 		// Verify directory exists
 		if stat, err := os.Stat(workDir); err != nil || !stat.IsDir() {
-			return fmt.Errorf("shortcut directory does not exist: %s", workDir)
+			return camperrors.Wrapf(camperrors.ErrNotFound, "shortcut directory does not exist: %s", workDir)
 		}
 
 		// Remaining args are the command
@@ -186,7 +185,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(commandArgs) == 0 {
-		return fmt.Errorf("no command specified")
+		return camperrors.Wrap(camperrors.ErrInvalidInput, "no command specified")
 	}
 
 	// Build the full command string

--- a/internal/config/campaign.go
+++ b/internal/config/campaign.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"context"
-	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/google/uuid"
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
-	"os"
 )
 
 // CampaignConfigFile is the name of the campaign configuration file.
@@ -31,7 +30,7 @@ func LoadCampaignConfig(ctx context.Context, campaignRoot string) (*CampaignConf
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("campaign config not found: %s", configPath)
+			return nil, camperrors.NewNotFound("campaign config", configPath, nil)
 		}
 		return nil, camperrors.Wrapf(err, "failed to read campaign config %s", configPath)
 	}

--- a/internal/project/add.go
+++ b/internal/project/add.go
@@ -95,7 +95,7 @@ func Add(ctx context.Context, campaignRoot, source string, opts AddOptions) (*Ad
 	// Validate source
 	source = strings.TrimSpace(source)
 	if source == "" && opts.Local == "" {
-		return nil, fmt.Errorf("source URL is required\n" +
+		return nil, camperrors.Wrap(camperrors.ErrInvalidInput, "source URL is required\n"+
 			"Hint: Provide a git URL like 'git@github.com:org/repo.git' or use --local for existing repos")
 	}
 
@@ -281,7 +281,7 @@ func addLocalAsSubmodule(ctx context.Context, campaignRoot, localPath, destPath,
 	// Verify it's a git repo
 	gitPath := filepath.Join(absLocal, ".git")
 	if _, err := os.Stat(gitPath); os.IsNotExist(err) {
-		return fmt.Errorf("local path is not a git repository: %s\n"+
+		return camperrors.Wrapf(camperrors.ErrInvalidInput, "local path is not a git repository: %s\n"+
 			"Hint: Run 'git init' in the directory first, or provide a git repository URL instead", localPath)
 	}
 
@@ -318,7 +318,7 @@ func executeLocalSubmoduleAdd(ctx context.Context, campaignRoot, absLocal, destP
 func checkGitInstalled(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, "git", "--version")
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("git is not installed or not in PATH\n" +
+		return camperrors.Wrap(camperrors.ErrNotInitialized, "git is not installed or not in PATH\n"+
 			"Please install git: https://git-scm.com/downloads")
 	}
 	return nil
@@ -328,7 +328,7 @@ func checkGitInstalled(ctx context.Context) error {
 func checkIsGitRepo(ctx context.Context, campaignRoot string) error {
 	cmd := exec.CommandContext(ctx, "git", "-C", campaignRoot, "rev-parse", "--git-dir")
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("campaign directory is not a git repository\n" +
+		return camperrors.Wrap(camperrors.ErrNotInitialized, "campaign directory is not a git repository\n"+
 			"Hint: Run 'git init' in the campaign root, or use 'camp init' to create a new campaign")
 	}
 	return nil
@@ -348,7 +348,7 @@ func checkRepoNotEmpty(ctx context.Context, url string) error {
 		return nil
 	}
 	if len(strings.TrimSpace(string(output))) == 0 {
-		return fmt.Errorf("cannot add empty repository %q — push at least one commit first\n"+
+		return camperrors.Wrapf(camperrors.ErrInvalidInput, "cannot add empty repository %q — push at least one commit first\n"+
 			"Hint: Initialize the repo locally, make a commit, and push before adding it to a campaign", url)
 	}
 	return nil

--- a/internal/project/link.go
+++ b/internal/project/link.go
@@ -59,7 +59,7 @@ func AddLinked(ctx context.Context, campaignRoot, localPath string, opts LinkOpt
 
 	localPath = strings.TrimSpace(localPath)
 	if localPath == "" {
-		return nil, fmt.Errorf("link path is required")
+		return nil, camperrors.Wrap(camperrors.ErrInvalidInput, "link path is required")
 	}
 
 	absLocal, err := filepath.Abs(localPath)
@@ -75,7 +75,7 @@ func AddLinked(ctx context.Context, campaignRoot, localPath string, opts LinkOpt
 		return nil, camperrors.Wrap(err, "stat local path")
 	}
 	if !info.IsDir() {
-		return nil, fmt.Errorf("path is not a directory: %s", localPath)
+		return nil, camperrors.Wrapf(camperrors.ErrInvalidInput, "path is not a directory: %s", localPath)
 	}
 
 	normalizedCampaignRoot, err := normalizeCampaignRoot(campaignRoot)
@@ -87,7 +87,7 @@ func AddLinked(ctx context.Context, campaignRoot, localPath string, opts LinkOpt
 		return nil, camperrors.Wrap(err, "load campaign config")
 	}
 	if cfg.ID == "" {
-		return nil, fmt.Errorf("campaign config is missing an ID")
+		return nil, camperrors.Wrap(camperrors.ErrInvalidInput, "campaign config is missing an ID")
 	}
 	if err := ensureLinkMarkerAvailable(ctx, absLocal, normalizedCampaignRoot, cfg.ID); err != nil {
 		return nil, err
@@ -283,7 +283,7 @@ func ensureLinkMarkerAvailable(ctx context.Context, projectDir, campaignRoot, ca
 
 	existingID := marker.EffectiveCampaignID()
 	if existingID == "" {
-		return fmt.Errorf("linked project has an existing legacy .camp marker for another campaign; remove it before linking")
+		return camperrors.Wrap(camperrors.ErrConflict, "linked project has an existing legacy .camp marker for another campaign; remove it before linking")
 	}
 
 	msg := "linked project is already linked to another campaign"
@@ -300,7 +300,7 @@ func ensureLinkMarkerAvailable(ctx context.Context, projectDir, campaignRoot, ca
 			}
 		}
 	}
-	return fmt.Errorf("%s", msg)
+	return camperrors.Wrap(camperrors.ErrConflict, msg)
 }
 
 func ensureLinkedTargetUnique(campaignRoot, targetPath, destPath, attemptedName string) error {
@@ -337,7 +337,7 @@ func loadCampaignID(ctx context.Context, campaignRoot string) (string, error) {
 		return "", camperrors.Wrap(err, "load campaign config")
 	}
 	if cfg.ID == "" {
-		return "", fmt.Errorf("campaign config is missing an ID")
+		return "", camperrors.Wrap(camperrors.ErrInvalidInput, "campaign config is missing an ID")
 	}
 	return cfg.ID, nil
 }

--- a/internal/project/remove.go
+++ b/internal/project/remove.go
@@ -100,7 +100,7 @@ func Remove(ctx context.Context, campaignRoot, name string, opts RemoveOptions) 
 		return nil, err
 	} else if linked {
 		if opts.Delete {
-			return nil, fmt.Errorf("linked projects can only be unlinked; deleting external targets is not supported")
+			return nil, camperrors.Wrap(camperrors.ErrInvalidInput, "linked projects can only be unlinked; deleting external targets is not supported")
 		}
 		if opts.DryRun {
 			addStep(result, "would unlink project symlink and remove local marker state")

--- a/tests/integration/helpers_tty.go
+++ b/tests/integration/helpers_tty.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/creack/pty"
 )
 
@@ -35,7 +36,7 @@ func (tc *TestContainer) RunCampInteractiveInDir(dir, waitFor, input string, arg
 	cmd := exec.CommandContext(ctx, "docker", "exec", "-i", "-t", tc.container.GetContainerID(), "sh", "-lc", cmdStr)
 	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: 40, Cols: 120})
 	if err != nil {
-		return "", fmt.Errorf("failed to start interactive docker exec: %w", err)
+		return "", camperrors.Wrap(err, "failed to start interactive docker exec")
 	}
 	defer func() { _ = ptmx.Close() }()
 
@@ -60,7 +61,7 @@ func (tc *TestContainer) RunCampInteractiveInDir(dir, waitFor, input string, arg
 			case <-readerDone:
 			case <-time.After(time.Second):
 			}
-			return output.String(), fmt.Errorf("interactive camp session did not reach %q: %w\nterminal tail:\n%s", waitFor, err, output.Tail(4000))
+			return output.String(), camperrors.Wrapf(err, "interactive camp session did not reach %q\nterminal tail:\n%s", waitFor, output.Tail(4000))
 		}
 	} else {
 		time.Sleep(250 * time.Millisecond)
@@ -75,7 +76,7 @@ func (tc *TestContainer) RunCampInteractiveInDir(dir, waitFor, input string, arg
 			case <-readerDone:
 			case <-time.After(time.Second):
 			}
-			return output.String(), fmt.Errorf("failed to send interactive input: %w\nterminal tail:\n%s", err, output.Tail(4000))
+			return output.String(), camperrors.Wrapf(err, "failed to send interactive input\nterminal tail:\n%s", output.Tail(4000))
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
@@ -96,7 +97,7 @@ func (tc *TestContainer) RunCampInteractiveInDir(dir, waitFor, input string, arg
 	}
 
 	if waitErr != nil {
-		return output.String(), fmt.Errorf("interactive camp command failed: %w\nterminal tail:\n%s", waitErr, output.Tail(4000))
+		return output.String(), camperrors.Wrapf(waitErr, "interactive camp command failed\nterminal tail:\n%s", output.Tail(4000))
 	}
 
 	return output.String(), nil
@@ -136,7 +137,7 @@ func waitForBufferContains(output *lockedBuffer, want string, timeout time.Durat
 		time.Sleep(25 * time.Millisecond)
 	}
 
-	return fmt.Errorf("timed out waiting for %q", want)
+	return camperrors.Wrapf(camperrors.ErrTimeout, "timed out waiting for %q", want)
 }
 
 func shellQuote(s string) string {


### PR DESCRIPTION
## Summary
- replace the remaining `fmt.Errorf` usage in the #207 stack with `camperrors` helpers or typed camp errors
- preserve the existing user-facing linked-project and campaign-targeting messages while giving the error chain canonical camp categories
- convert the interactive integration harness to the same error package so the stacked diff is fully clean

## Why
Using raw `fmt.Errorf` in this stack would regress camp's structured error conventions right before merge. This keeps the linked-project work aligned with the repo's error package before #207 lands.

## Verification
- `go test ./cmd/camp/project ./cmd/camp/project/remote ./cmd/camp/project/worktree ./cmd/camp/intent ./internal/project ./internal/config`
- `go test ./tests/integration -tags integration -run 'TestProject_(Link_PicksCampaignOutsideCurrentContext|Link_NonGitDir)|TestProjectRun_|TestProject_.*Add_UsesCurrentCampaignEvenIfUnregistered'