### PR TITLE
refactor: normalize intent CLI error handling

### DIFF
--- a/cmd/camp/intent/body.go
+++ b/cmd/camp/intent/body.go
@@ -1,7 +1,6 @@
 package intent
 
 import (
-	"fmt"
 	"io"
 	"os"
 
@@ -24,7 +23,7 @@ func resolveBody(cmd *cobra.Command) (string, bool, error) {
 	bodyFileSet := cmd.Flags().Changed("body-file")
 
 	if bodySet && bodyFileSet {
-		return "", false, fmt.Errorf("--body and --body-file are mutually exclusive")
+		return "", false, camperrors.Wrap(camperrors.ErrInvalidInput, "--body and --body-file are mutually exclusive")
 	}
 
 	if bodySet {
@@ -66,7 +65,7 @@ func readBodySource(path string) (string, error) {
 		return "", camperrors.Wrap(err, "reading body input")
 	}
 	if len(data) > maxBodyFileSize {
-		return "", fmt.Errorf("body input exceeds maximum size of 10 MiB")
+		return "", camperrors.Wrap(camperrors.ErrInvalidInput, "body input exceeds maximum size of 10 MiB")
 	}
 
 	return string(data), nil

--- a/cmd/camp/intent/edit.go
+++ b/cmd/camp/intent/edit.go
@@ -2,7 +2,6 @@ package intent
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/ktr0731/go-fuzzyfinder"
@@ -134,13 +133,13 @@ func runIntentEdit(cmd *cobra.Command, args []string) error {
 	} else {
 		// No ID + programmatic flags + no TTY = deterministic error
 		if programmatic && !navtui.IsTerminal() {
-			return fmt.Errorf("intent ID required in non-interactive mode\n       Usage: camp intent edit <id> [flags]")
+			return camperrors.Wrap(camperrors.ErrInvalidInput, "intent ID required in non-interactive mode")
 		}
 		// No ID - show fuzzy picker
 		selectedIntent, err = pickIntent(ctx, svc, statusFilter, typeFilter, projectFilter)
 		if err != nil {
-			if errors.Is(err, fuzzyfinder.ErrAbort) {
-				return fmt.Errorf("edit cancelled")
+			if camperrors.Is(err, fuzzyfinder.ErrAbort) {
+				return camperrors.Wrap(camperrors.ErrCancelled, "edit")
 			}
 			return err
 		}
@@ -342,13 +341,13 @@ func validateEditBodyFlags(cmd *cobra.Command) error {
 	appendFileSet := cmd.Flags().Changed("append-body-file")
 
 	if bodySet && bodyFileSet {
-		return fmt.Errorf("--body and --body-file are mutually exclusive")
+		return camperrors.Wrap(camperrors.ErrInvalidInput, "--body and --body-file are mutually exclusive")
 	}
 	if appendSet && appendFileSet {
-		return fmt.Errorf("--append-body and --append-body-file are mutually exclusive")
+		return camperrors.Wrap(camperrors.ErrInvalidInput, "--append-body and --append-body-file are mutually exclusive")
 	}
 	if (bodySet || bodyFileSet) && (appendSet || appendFileSet) {
-		return fmt.Errorf("--body/--body-file and --append-body/--append-body-file are mutually exclusive (replace vs append)")
+		return camperrors.Wrap(camperrors.ErrInvalidInput, "--body/--body-file and --append-body/--append-body-file are mutually exclusive")
 	}
 	return nil
 }

--- a/cmd/camp/intent/edit_picker.go
+++ b/cmd/camp/intent/edit_picker.go
@@ -2,7 +2,6 @@ package intent
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -21,8 +20,8 @@ func resolveIntentByPartialID(ctx context.Context, svc *intent.IntentService, pa
 	}
 
 	// If Find failed with not found, provide helpful error
-	if errors.Is(err, camperrors.ErrNotFound) {
-		return nil, fmt.Errorf("intent not found: %s", partialID)
+	if camperrors.Is(err, camperrors.ErrNotFound) {
+		return nil, camperrors.NewNotFound("intent", partialID, nil)
 	}
 
 	return nil, camperrors.Wrap(err, "failed to find intent")
@@ -53,7 +52,7 @@ func pickIntent(ctx context.Context, svc *intent.IntentService, status, typ, pro
 	}
 
 	if len(intents) == 0 {
-		return nil, fmt.Errorf("no intents found")
+		return nil, camperrors.Wrap(camperrors.ErrNotFound, "no intents found")
 	}
 
 	// Show fuzzy picker

--- a/cmd/camp/intent/edit_test.go
+++ b/cmd/camp/intent/edit_test.go
@@ -114,7 +114,7 @@ func TestValidateEditBodyFlags_ReplaceAndAppend(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected error for replace + append combination")
 			}
-			if !strings.Contains(err.Error(), "replace vs append") {
+			if !strings.Contains(err.Error(), "mutually exclusive") {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		})


### PR DESCRIPTION
## Summary

- Replay the remaining intent CLI error-package cleanup onto current `main`
- Replace raw `fmt.Errorf` usage in `intent edit`, `edit_picker`, and body helpers with `camperrors` sentinels/wrappers
- Keep newer `intent add` behavior from current `main` where the old branch no longer applied cleanly

## Validation

- `go test ./cmd/camp/intent ./cmd/camp`

## Notes

- This is the surviving follow-up from the old `issue-209-intent-cli-parity` branch after refreshing it onto current `main`.
