### PR TITLE
Tag CLI-created shortcuts as user-sourced (fixes #224)

### DIFF
--- a/cmd/camp/navigation/shortcuts.go
+++ b/cmd/camp/navigation/shortcuts.go
@@ -552,12 +552,9 @@ func runShortcutsAddJump(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%s Adding shortcut '%s'\n", ui.SuccessIcon(), shortcutName)
 	}
 
-	// Create shortcut config
-	sc := config.ShortcutConfig{
-		Path:        shortcutPath,
-		Description: description,
-		Concept:     concept,
-	}
+	// Create shortcut config. Shortcuts added via the CLI are always
+	// user-sourced so the repair system preserves them on reset/diff.
+	sc := newUserShortcut(shortcutPath, description, concept)
 
 	// Add/update the shortcut
 	jumps.Shortcuts[shortcutName] = sc
@@ -577,6 +574,18 @@ func runShortcutsAddJump(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// newUserShortcut builds a ShortcutConfig for a shortcut added via the CLI.
+// Source is always ShortcutSourceUser so the repair system preserves it on
+// reset and diff operations (see internal/scaffold/repair.go).
+func newUserShortcut(path, description, concept string) config.ShortcutConfig {
+	return config.ShortcutConfig{
+		Path:        path,
+		Description: description,
+		Concept:     concept,
+		Source:      config.ShortcutSourceUser,
+	}
 }
 
 // isAutoShortcut returns true if the shortcut was auto-generated (not user-defined).

--- a/cmd/camp/navigation/shortcuts_test.go
+++ b/cmd/camp/navigation/shortcuts_test.go
@@ -281,3 +281,70 @@ func TestResetHasFlags(t *testing.T) {
 		}
 	}
 }
+
+// TestNewUserShortcut_SetsSourceUser guards against regression of issue #224.
+// Shortcuts added via the CLI must be tagged ShortcutSourceUser so the repair
+// system preserves them instead of treating them as legacy entries subject to
+// the default-match heuristic.
+func TestNewUserShortcut_SetsSourceUser(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		description string
+		concept     string
+	}{
+		{
+			name:        "path only",
+			path:        "projects/api/",
+			description: "",
+			concept:     "",
+		},
+		{
+			name:        "concept only",
+			path:        "",
+			description: "",
+			concept:     "build",
+		},
+		{
+			name:        "path with description and concept",
+			path:        "projects/api/",
+			description: "API service",
+			concept:     "service",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := newUserShortcut(tt.path, tt.description, tt.concept)
+
+			if sc.Source != config.ShortcutSourceUser {
+				t.Errorf("Source = %q, want %q", sc.Source, config.ShortcutSourceUser)
+			}
+			if sc.Path != tt.path {
+				t.Errorf("Path = %q, want %q", sc.Path, tt.path)
+			}
+			if sc.Description != tt.description {
+				t.Errorf("Description = %q, want %q", sc.Description, tt.description)
+			}
+			if sc.Concept != tt.concept {
+				t.Errorf("Concept = %q, want %q", sc.Concept, tt.concept)
+			}
+		})
+	}
+}
+
+// TestNewUserShortcut_NotTreatedAsAuto verifies that shortcuts created via the
+// CLI helper are recognized by isAutoShortcut() as user-defined (not auto),
+// which is the semantic property the repair system relies on.
+func TestNewUserShortcut_NotTreatedAsAuto(t *testing.T) {
+	defaults := config.DefaultNavigationShortcuts()
+	sc := newUserShortcut("projects/api/", "API", "service")
+
+	// Even if the key happens to collide with a default key, a user-sourced
+	// shortcut must not be classified as auto.
+	for _, key := range []string{"api", "p", "unknown-key"} {
+		if isAutoShortcut(sc, key, defaults) {
+			t.Errorf("isAutoShortcut(key=%q) = true, want false for user-sourced shortcut", key)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `camp shortcuts add` was writing `ShortcutConfig` entries without `Source`, so the repair system (`internal/scaffold/repair.go`) fell through to the legacy default-match heuristic. This works today but is semantically wrong and would break if the heuristic changes.
- Extract `newUserShortcut(path, description, concept)` and use it in `runShortcutsAddJump` so CLI-added shortcuts are explicitly tagged `Source: ShortcutSourceUser`.
- Add unit tests covering the field-set behavior and the downstream `isAutoShortcut()` classification, so a regression fails at the unit level instead of silently drifting through the repair path.

## Context
Discovered while fixing PR #222. Full analysis in issue #224.

## Test plan
- [x] `go test -short ./...` — all packages pass
- [x] `go test -v -run TestNewUserShortcut ./cmd/camp/navigation/...` — new tests (`TestNewUserShortcut_SetsSourceUser` table-driven + `TestNewUserShortcut_NotTreatedAsAuto`) pass
- [x] `just lint` — no new warnings introduced
- [ ] Manual: `camp shortcuts add test-shortcut projects/` and confirm `.campaign/jumps.yaml` shows `source: user` for the new entry

Fixes #224