### PR TITLE
fix: prune merged detached worktrees during fresh

### DIFF
--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -223,16 +223,28 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 		}
 
 		deletedNames := pruneResultNames(pr.Results, prune.StatusDeleted, prune.StatusWouldDelete)
+		removedWorktrees := pruneResultCount(pr.Results, prune.StatusWorktreeRemoved, prune.StatusWorktreeWouldRemove)
 
 		switch {
-		case len(deletedNames) > 0:
+		case len(deletedNames) > 0 || removedWorktrees > 0:
 			action := "deleted"
+			worktreeAction := "removed"
 			style := freshStepGreen
 			if opts.dryRun {
 				action = "would delete"
+				worktreeAction = "would remove"
 				style = freshStepDim
 			}
 			detail := fmt.Sprintf("%s: %s", action, strings.Join(deletedNames, ", "))
+			if len(deletedNames) == 0 {
+				detail = "removed merged detached worktrees"
+				if opts.dryRun {
+					detail = "would remove merged detached worktrees"
+				}
+			}
+			if removedWorktrees > 0 {
+				detail = fmt.Sprintf("%s; %s %d worktree(s)", detail, worktreeAction, removedWorktrees)
+			}
 			fmt.Printf("%s── Prune merged branches           %s\n", prefix, style.Render(detail))
 		default:
 			fmt.Printf("%s── Prune merged branches           %s\n", prefix, freshStepDim.Render("nothing to prune"))
@@ -359,6 +371,10 @@ func pruneResultNames(results []prune.Result, statuses ...prune.Status) []string
 		}
 	}
 	return names
+}
+
+func pruneResultCount(results []prune.Result, statuses ...prune.Status) int {
+	return len(pruneResultNames(results, statuses...))
 }
 
 // freshSafetyChecks verifies the repo is in a safe state for fresh.

--- a/internal/commands/fresh/fresh_integration_test.go
+++ b/internal/commands/fresh/fresh_integration_test.go
@@ -258,6 +258,62 @@ func TestIntegration_ExecuteFresh_HandlesDefaultBranchInAnotherWorktree(t *testi
 	}
 }
 
+func TestIntegration_ExecuteFresh_RemovesMergedDetachedWorktreesOnly(t *testing.T) {
+	campDir, _ := setupCampaignWithSubmodule(t)
+	subDir := filepath.Join(campDir, "projects", "test-project")
+
+	run(t, "git", "-C", subDir, "checkout", "-b", "feature-merged")
+	if err := os.WriteFile(filepath.Join(subDir, "feature.txt"), []byte("feature"), 0o644); err != nil {
+		t.Fatalf("failed to write feature.txt: %v", err)
+	}
+	run(t, "git", "-C", subDir, "add", ".")
+	run(t, "git", "-C", subDir, "commit", "-m", "Feature work")
+
+	mainWorktree := t.TempDir()
+	run(t, "git", "-C", subDir, "worktree", "add", mainWorktree, "main")
+
+	mergedReviewWorktree := t.TempDir()
+	run(t, "git", "-C", subDir, "worktree", "add", "--detach", mergedReviewWorktree, "feature-merged")
+
+	unmergedReviewWorktree := t.TempDir()
+	run(t, "git", "-C", subDir, "worktree", "add", "--detach", unmergedReviewWorktree, "feature-merged")
+	run(t, "git", "-C", unmergedReviewWorktree, "config", "user.email", "test@test.com")
+	run(t, "git", "-C", unmergedReviewWorktree, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(unmergedReviewWorktree, "draft.txt"), []byte("draft"), 0o644); err != nil {
+		t.Fatalf("failed to write draft.txt: %v", err)
+	}
+	run(t, "git", "-C", unmergedReviewWorktree, "add", ".")
+	run(t, "git", "-C", unmergedReviewWorktree, "commit", "-m", "Detached draft work")
+
+	run(t, "git", "-C", mainWorktree, "merge", "feature-merged")
+	run(t, "git", "-C", mainWorktree, "push", "origin", "main")
+
+	err := executeFresh(context.Background(), "test-project", subDir, freshOptions{
+		branch: "develop",
+		prune:  true,
+		push:   false,
+	})
+	if err != nil {
+		t.Fatalf("executeFresh() error = %v", err)
+	}
+
+	current := strings.TrimSpace(run(t, "git", "-C", subDir, "rev-parse", "--abbrev-ref", "HEAD"))
+	if current != "develop" {
+		t.Fatalf("current branch = %q, want %q", current, "develop")
+	}
+
+	worktrees := run(t, "git", "-C", subDir, "worktree", "list", "--porcelain")
+	if strings.Contains(worktrees, mergedReviewWorktree) {
+		t.Fatalf("expected merged detached worktree to be removed, got:\n%s", worktrees)
+	}
+	if !strings.Contains(worktrees, unmergedReviewWorktree) {
+		t.Fatalf("expected unmerged detached worktree to remain, got:\n%s", worktrees)
+	}
+	if _, err := os.Stat(unmergedReviewWorktree); err != nil {
+		t.Fatalf("expected unmerged detached worktree directory to remain: %v", err)
+	}
+}
+
 func TestIntegration_ExecuteFresh_IgnoresNestedSubmoduleRefDrift(t *testing.T) {
 	campDir := setupCampaignWithNestedSubmoduleProject(t)
 	projectDir := filepath.Join(campDir, "projects", "test-project")

--- a/internal/commands/fresh/fresh_integration_test.go
+++ b/internal/commands/fresh/fresh_integration_test.go
@@ -314,6 +314,83 @@ func TestIntegration_ExecuteFresh_RemovesMergedDetachedWorktreesOnly(t *testing.
 	}
 }
 
+func TestIntegration_ExecuteFresh_RemovesMergedDetachedWorktreesAfterBranchDeleted(t *testing.T) {
+	campDir, _ := setupCampaignWithSubmodule(t)
+	subDir := filepath.Join(campDir, "projects", "test-project")
+
+	run(t, "git", "-C", subDir, "checkout", "-b", "feature-merged")
+	if err := os.WriteFile(filepath.Join(subDir, "feature.txt"), []byte("feature"), 0o644); err != nil {
+		t.Fatalf("failed to write feature.txt: %v", err)
+	}
+	run(t, "git", "-C", subDir, "add", ".")
+	run(t, "git", "-C", subDir, "commit", "-m", "Feature work")
+
+	mainWorktree := t.TempDir()
+	run(t, "git", "-C", subDir, "worktree", "add", mainWorktree, "main")
+
+	mergedReviewWorktree := t.TempDir()
+	run(t, "git", "-C", subDir, "worktree", "add", "--detach", mergedReviewWorktree, "feature-merged")
+
+	run(t, "git", "-C", subDir, "checkout", "-b", "scratch-work")
+	run(t, "git", "-C", mainWorktree, "merge", "feature-merged")
+	run(t, "git", "-C", mainWorktree, "push", "origin", "main")
+	run(t, "git", "-C", subDir, "branch", "-d", "feature-merged")
+
+	err := executeFresh(context.Background(), "test-project", subDir, freshOptions{
+		prune: true,
+		push:  false,
+	})
+	if err != nil {
+		t.Fatalf("executeFresh() error = %v", err)
+	}
+
+	worktrees := run(t, "git", "-C", subDir, "worktree", "list", "--porcelain")
+	if strings.Contains(worktrees, mergedReviewWorktree) {
+		t.Fatalf("expected merged detached worktree to be removed after source branch deletion, got:\n%s", worktrees)
+	}
+}
+
+func TestIntegration_ExecuteFresh_KeepsDirtyMergedDetachedWorktrees(t *testing.T) {
+	campDir, _ := setupCampaignWithSubmodule(t)
+	subDir := filepath.Join(campDir, "projects", "test-project")
+
+	run(t, "git", "-C", subDir, "checkout", "-b", "feature-merged")
+	if err := os.WriteFile(filepath.Join(subDir, "feature.txt"), []byte("feature"), 0o644); err != nil {
+		t.Fatalf("failed to write feature.txt: %v", err)
+	}
+	run(t, "git", "-C", subDir, "add", ".")
+	run(t, "git", "-C", subDir, "commit", "-m", "Feature work")
+
+	mainWorktree := t.TempDir()
+	run(t, "git", "-C", subDir, "worktree", "add", mainWorktree, "main")
+
+	dirtyReviewWorktree := t.TempDir()
+	run(t, "git", "-C", subDir, "worktree", "add", "--detach", dirtyReviewWorktree, "feature-merged")
+	if err := os.WriteFile(filepath.Join(dirtyReviewWorktree, "wip.txt"), []byte("wip"), 0o644); err != nil {
+		t.Fatalf("failed to write wip.txt: %v", err)
+	}
+
+	run(t, "git", "-C", mainWorktree, "merge", "feature-merged")
+	run(t, "git", "-C", mainWorktree, "push", "origin", "main")
+
+	err := executeFresh(context.Background(), "test-project", subDir, freshOptions{
+		branch: "develop",
+		prune:  true,
+		push:   false,
+	})
+	if err != nil {
+		t.Fatalf("executeFresh() error = %v", err)
+	}
+
+	worktrees := run(t, "git", "-C", subDir, "worktree", "list", "--porcelain")
+	if !strings.Contains(worktrees, dirtyReviewWorktree) {
+		t.Fatalf("expected dirty merged detached worktree to remain, got:\n%s", worktrees)
+	}
+	if _, err := os.Stat(dirtyReviewWorktree); err != nil {
+		t.Fatalf("expected dirty detached worktree directory to remain: %v", err)
+	}
+}
+
 func TestIntegration_ExecuteFresh_IgnoresNestedSubmoduleRefDrift(t *testing.T) {
 	campDir := setupCampaignWithNestedSubmoduleProject(t)
 	projectDir := filepath.Join(campDir, "projects", "test-project")

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -251,4 +252,31 @@ func DeleteRemoteBranch(ctx context.Context, repoPath, branch string) error {
 		return camperrors.Wrapf(err, "delete remote branch %s: %s", branch, strings.TrimSpace(string(output)))
 	}
 	return nil
+}
+
+// IsAncestor reports whether ancestor is reachable from descendant.
+func IsAncestor(ctx context.Context, repoPath, ancestor, descendant string) (bool, error) {
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	if strings.TrimSpace(ancestor) == "" {
+		return false, fmt.Errorf("ancestor is required")
+	}
+	if strings.TrimSpace(descendant) == "" {
+		return false, fmt.Errorf("descendant is required")
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath,
+		"merge-base", "--is-ancestor", ancestor, descendant)
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+
+	return false, camperrors.Wrapf(err, "check %s reachable from %s", ancestor, descendant)
 }

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -260,10 +260,10 @@ func IsAncestor(ctx context.Context, repoPath, ancestor, descendant string) (boo
 		return false, ctx.Err()
 	}
 	if strings.TrimSpace(ancestor) == "" {
-		return false, fmt.Errorf("ancestor is required")
+		return false, camperrors.Wrap(camperrors.ErrInvalidInput, "ancestor is required")
 	}
 	if strings.TrimSpace(descendant) == "" {
-		return false, fmt.Errorf("descendant is required")
+		return false, camperrors.Wrap(camperrors.ErrInvalidInput, "descendant is required")
 	}
 
 	cmd := exec.CommandContext(ctx, "git", "-C", repoPath,

--- a/internal/git/branches_test.go
+++ b/internal/git/branches_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -263,6 +264,49 @@ func TestMergedBranches_NoMerged(t *testing.T) {
 	if len(branches) != 0 {
 		t.Fatalf("expected 0 merged branches, got %d: %v", len(branches), branches)
 	}
+}
+
+func TestIsAncestor(t *testing.T) {
+	dir := initBranchTestRepo(t, "main")
+	run := gitRunner(t, dir)
+
+	baseCommit := strings.TrimSpace(runOutput(t, dir, "rev-parse", "HEAD"))
+
+	run("checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "feature")
+	featureCommit := strings.TrimSpace(runOutput(t, dir, "rev-parse", "HEAD"))
+
+	ctx := context.Background()
+
+	merged, err := IsAncestor(ctx, dir, baseCommit, featureCommit)
+	if err != nil {
+		t.Fatalf("IsAncestor() error = %v", err)
+	}
+	if !merged {
+		t.Fatal("expected base commit to be reachable from feature commit")
+	}
+
+	merged, err = IsAncestor(ctx, dir, featureCommit, "main")
+	if err != nil {
+		t.Fatalf("IsAncestor() error = %v", err)
+	}
+	if merged {
+		t.Fatal("expected feature commit to not be reachable from main")
+	}
+}
+
+func runOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+	return string(output)
 }
 
 func TestMergedBranches_ReturnsMerged(t *testing.T) {

--- a/internal/git/branches_test.go
+++ b/internal/git/branches_test.go
@@ -2,12 +2,15 @@ package git
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 
 // initBranchTestRepo creates a temp git repo with an initial commit on the given branch.
@@ -296,6 +299,21 @@ func TestIsAncestor(t *testing.T) {
 	}
 	if merged {
 		t.Fatal("expected feature commit to not be reachable from main")
+	}
+}
+
+func TestIsAncestor_RequiresRefs(t *testing.T) {
+	dir := initBranchTestRepo(t, "main")
+	ctx := context.Background()
+
+	_, err := IsAncestor(ctx, dir, "", "main")
+	if !errors.Is(err, camperrors.ErrInvalidInput) {
+		t.Fatalf("expected invalid input for empty ancestor, got %v", err)
+	}
+
+	_, err = IsAncestor(ctx, dir, "HEAD", " ")
+	if !errors.Is(err, camperrors.ErrInvalidInput) {
+		t.Fatalf("expected invalid input for empty descendant, got %v", err)
 	}
 }
 

--- a/internal/prune/prune.go
+++ b/internal/prune/prune.go
@@ -27,6 +27,7 @@ const (
 	StatusWorktreeWouldRemove Status = "wt would remove"
 
 	SkipReasonActiveWorktree SkipReason = "active_worktree"
+	SkipReasonDirtyWorktree  SkipReason = "dirty_worktree"
 )
 
 // Options holds configuration for a prune operation.
@@ -64,26 +65,26 @@ func Execute(ctx context.Context, name, path string, opts Options) ProjectResult
 	pr := ProjectResult{Name: name, Path: path}
 
 	baseRef := strings.TrimSpace(opts.BaseRef)
-	var (
-		merged []string
-		err    error
-	)
 	if baseRef == "" {
-		merged, err = git.MergedBranches(ctx, path)
-	} else {
-		merged, err = git.MergedBranchesFromRef(ctx, path, baseRef)
+		baseRef = git.DefaultBranch(ctx, path)
+		if baseRef == "" {
+			pr.Error = "could not determine default branch"
+			return pr
+		}
 	}
+
+	merged, err := git.MergedBranchesFromRef(ctx, path, baseRef)
 	if err != nil {
 		pr.Error = err.Error()
 		return pr
 	}
 
+	deleteDetachedWorktrees(ctx, path, baseRef, opts, &pr)
 	if len(merged) == 0 && !opts.Remote {
 		return pr
 	}
 
 	deleteLocalBranches(ctx, path, merged, opts, &pr)
-	deleteDetachedWorktrees(ctx, path, baseRef, opts, &pr)
 
 	// Remote branch deletion uses the original merged list intentionally —
 	// remote branches should be cleaned up regardless of local deletion outcome.
@@ -119,7 +120,38 @@ func deleteDetachedWorktrees(ctx context.Context, path, baseRef string, opts Opt
 		}
 
 		merged, err := git.IsAncestor(ctx, path, entry.Commit, baseRef)
-		if err != nil || !merged {
+		if err != nil {
+			pr.Results = append(pr.Results, Result{
+				Branch: formatDetachedWorktreeLabel(entry.Commit),
+				Status: StatusError,
+				Detail: fmt.Sprintf("merge-base check for %s: %s", entry.Path, err),
+			})
+			continue
+		}
+		if !merged {
+			continue
+		}
+
+		clean, err := detachedWorktreeClean(ctx, entry.Path)
+		if err != nil {
+			pr.Results = append(pr.Results, Result{
+				Branch: formatDetachedWorktreeLabel(entry.Commit),
+				Status: StatusError,
+				Detail: fmt.Sprintf("dirty check for %s: %s", entry.Path, err),
+			})
+			continue
+		}
+		if !clean {
+			detail := fmt.Sprintf("dirty detached worktree: %s", entry.Path)
+			if opts.DryRun {
+				detail = fmt.Sprintf("would keep dirty detached worktree: %s", entry.Path)
+			}
+			pr.Results = append(pr.Results, Result{
+				Branch:     formatDetachedWorktreeLabel(entry.Commit),
+				Status:     StatusSkipped,
+				Detail:     detail,
+				SkipReason: SkipReasonDirtyWorktree,
+			})
 			continue
 		}
 
@@ -157,6 +189,14 @@ func formatDetachedWorktreeLabel(commit string) string {
 		commit = commit[:shortSHA]
 	}
 	return "detached@" + commit
+}
+
+func detachedWorktreeClean(ctx context.Context, path string) (bool, error) {
+	hasChanges, err := git.HasChanges(ctx, path)
+	if err != nil {
+		return false, err
+	}
+	return !hasChanges, nil
 }
 
 // detectWorktreesForBranches lists worktrees and returns a map of branch name → worktree entry

--- a/internal/prune/prune.go
+++ b/internal/prune/prune.go
@@ -3,6 +3,7 @@ package prune
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/Obedience-Corp/camp/internal/git"
@@ -82,6 +83,7 @@ func Execute(ctx context.Context, name, path string, opts Options) ProjectResult
 	}
 
 	deleteLocalBranches(ctx, path, merged, opts, &pr)
+	deleteDetachedWorktrees(ctx, path, baseRef, opts, &pr)
 
 	// Remote branch deletion uses the original merged list intentionally —
 	// remote branches should be cleaned up regardless of local deletion outcome.
@@ -90,6 +92,71 @@ func Execute(ctx context.Context, name, path string, opts Options) ProjectResult
 	pruneTrackingRefs(ctx, path, opts, &pr)
 
 	return pr
+}
+
+func deleteDetachedWorktrees(ctx context.Context, path, baseRef string, opts Options, pr *ProjectResult) {
+	entries, err := worktree.NewGitWorktree(path).List(ctx)
+	if err != nil {
+		return
+	}
+
+	skipPaths := map[string]struct{}{
+		filepath.Clean(path): {},
+	}
+	if gitDir, err := git.Output(ctx, path, "rev-parse", "--absolute-git-dir"); err == nil {
+		skipPaths[filepath.Clean(gitDir)] = struct{}{}
+	}
+
+	wt := worktree.NewGitWorktree(path)
+	removedAny := false
+	for _, entry := range entries {
+		if entry.Branch != "HEAD (detached)" || entry.Commit == "" || entry.IsBare || entry.IsLocked {
+			continue
+		}
+
+		if _, skip := skipPaths[filepath.Clean(entry.Path)]; skip {
+			continue
+		}
+
+		merged, err := git.IsAncestor(ctx, path, entry.Commit, baseRef)
+		if err != nil || !merged {
+			continue
+		}
+
+		result := Result{
+			Branch: formatDetachedWorktreeLabel(entry.Commit),
+			Detail: entry.Path,
+		}
+
+		if opts.DryRun {
+			result.Status = StatusWorktreeWouldRemove
+			pr.Results = append(pr.Results, result)
+			continue
+		}
+
+		if err := wt.Remove(ctx, entry.Path, true); err != nil {
+			result.Status = StatusError
+			result.Detail = fmt.Sprintf("%s: %s", entry.Path, err)
+			pr.Results = append(pr.Results, result)
+			continue
+		}
+
+		result.Status = StatusWorktreeRemoved
+		pr.Results = append(pr.Results, result)
+		removedAny = true
+	}
+
+	if !opts.DryRun && removedAny {
+		wt.Prune(ctx, false)
+	}
+}
+
+func formatDetachedWorktreeLabel(commit string) string {
+	const shortSHA = 7
+	if len(commit) > shortSHA {
+		commit = commit[:shortSHA]
+	}
+	return "detached@" + commit
 }
 
 // detectWorktreesForBranches lists worktrees and returns a map of branch name → worktree entry

--- a/internal/prune/prune.go
+++ b/internal/prune/prune.go
@@ -116,7 +116,7 @@ func deleteDetachedWorktrees(ctx context.Context, path, baseRef string, opts Opt
 
 	removedAny := false
 	for _, entry := range entries {
-		if entry.Branch != "HEAD (detached)" || entry.Commit == "" || entry.IsBare || entry.IsLocked {
+		if !entry.IsDetached || entry.Commit == "" || entry.IsBare || entry.IsLocked {
 			continue
 		}
 

--- a/internal/prune/prune.go
+++ b/internal/prune/prune.go
@@ -96,8 +96,14 @@ func Execute(ctx context.Context, name, path string, opts Options) ProjectResult
 }
 
 func deleteDetachedWorktrees(ctx context.Context, path, baseRef string, opts Options, pr *ProjectResult) {
-	entries, err := worktree.NewGitWorktree(path).List(ctx)
+	wt := worktree.NewGitWorktree(path)
+	entries, err := wt.List(ctx)
 	if err != nil {
+		pr.Results = append(pr.Results, Result{
+			Branch: "(detached worktrees)",
+			Status: StatusError,
+			Detail: fmt.Sprintf("worktree list: %s", err),
+		})
 		return
 	}
 
@@ -108,7 +114,6 @@ func deleteDetachedWorktrees(ctx context.Context, path, baseRef string, opts Opt
 		skipPaths[filepath.Clean(gitDir)] = struct{}{}
 	}
 
-	wt := worktree.NewGitWorktree(path)
 	removedAny := false
 	for _, entry := range entries {
 		if entry.Branch != "HEAD (detached)" || entry.Commit == "" || entry.IsBare || entry.IsLocked {
@@ -179,7 +184,7 @@ func deleteDetachedWorktrees(ctx context.Context, path, baseRef string, opts Opt
 	}
 
 	if !opts.DryRun && removedAny {
-		wt.Prune(ctx, false)
+		appendWorktreePruneError(ctx, wt, pr)
 	}
 }
 
@@ -197,6 +202,16 @@ func detachedWorktreeClean(ctx context.Context, path string) (bool, error) {
 		return false, err
 	}
 	return !hasChanges, nil
+}
+
+func appendWorktreePruneError(ctx context.Context, wt *worktree.GitWorktree, pr *ProjectResult) {
+	if _, err := wt.Prune(ctx, false); err != nil {
+		pr.Results = append(pr.Results, Result{
+			Branch: "(worktree admin)",
+			Status: StatusError,
+			Detail: fmt.Sprintf("worktree prune: %s", err),
+		})
+	}
 }
 
 // detectWorktreesForBranches lists worktrees and returns a map of branch name → worktree entry
@@ -312,7 +327,7 @@ func deleteLocalBranches(ctx context.Context, path string, merged []string, opts
 
 	// Clean stale worktree refs after removals.
 	if !opts.DryRun && len(worktreesToRemove) > 0 {
-		wt.Prune(ctx, false)
+		appendWorktreePruneError(ctx, wt, pr)
 	}
 
 	for _, branch := range branchesToDelete {

--- a/internal/worktree/git.go
+++ b/internal/worktree/git.go
@@ -31,12 +31,13 @@ func (g *GitWorktree) WithTimeout(d time.Duration) *GitWorktree {
 
 // GitWorktreeEntry represents a worktree from git worktree list.
 type GitWorktreeEntry struct {
-	Path     string
-	Commit   string
-	Branch   string
-	IsBare   bool
-	IsLocked bool
-	Prunable string // Reason if prunable, empty otherwise
+	Path       string
+	Commit     string
+	Branch     string
+	IsDetached bool
+	IsBare     bool
+	IsLocked   bool
+	Prunable   string // Reason if prunable, empty otherwise
 }
 
 // CurrentBranch returns the current branch name.
@@ -255,6 +256,7 @@ func parseWorktreeList(output string) []GitWorktreeEntry {
 			case strings.HasPrefix(line, "prunable "):
 				current.Prunable = strings.TrimPrefix(line, "prunable ")
 			case line == "detached":
+				current.IsDetached = true
 				current.Branch = "HEAD (detached)"
 			}
 		}

--- a/internal/worktree/git_test.go
+++ b/internal/worktree/git_test.go
@@ -57,6 +57,9 @@ prunable gitdir file points to non-existent location
 	if entries[2].Prunable == "" {
 		t.Error("entries[2] should be prunable")
 	}
+	if !entries[2].IsDetached {
+		t.Error("entries[2] should be detached")
+	}
 	if entries[2].Branch != "HEAD (detached)" {
 		t.Errorf("entries[2].Branch = %q, want HEAD (detached)", entries[2].Branch)
 	}


### PR DESCRIPTION
## Summary
- teach prune/fresh to remove detached worktrees whose HEAD is already merged into the fresh sync base
- keep unmerged detached worktrees intact and skip the current checkout/git dir paths
- add unit and integration coverage for merge reachability and detached worktree cleanup behavior

## Root Cause
`camp fresh` only pruned merged local branches and branch-backed worktrees. Detached review worktrees stayed registered even when their commits were already merged into `main`, so repeated post-merge cleanup left stale worktrees behind.

## Impact
After this change, `camp fresh` cleans up the merged detached review worktrees it can prove are already contained in the target sync ref, while preserving detached worktrees that still contain unmerged work.

## Validation
- `go test ./internal/git`
- `go test ./internal/commands/fresh -tags integration`
- `go test ./cmd/camp/project ./cmd/camp`
