### PR TITLE
Tolerate duplicate scaffold files during intent migration

### DIFF
--- a/internal/intent/migration.go
+++ b/internal/intent/migration.go
@@ -18,6 +18,27 @@ var legacyIntentScaffoldFiles = []string{
 	filepath.Join("dungeon", ".crawl.yaml"),
 }
 
+// intentScaffoldBasenames is the set of filenames that the intent scaffold
+// generates verbatim in multiple places. When migrating a legacy intent tree
+// into the canonical root, identically-named scaffold files at the destination
+// are safe to skip — the canonical copy is equivalent and the legacy one will
+// be cleaned up by cleanupLegacyIntentScaffold afterwards.
+var intentScaffoldBasenames = func() map[string]struct{} {
+	set := make(map[string]struct{}, len(legacyIntentScaffoldFiles))
+	for _, rel := range legacyIntentScaffoldFiles {
+		set[filepath.Base(rel)] = struct{}{}
+	}
+	return set
+}()
+
+// isIntentScaffoldBasename reports whether name is a scaffold-generated file
+// (e.g. .gitkeep, .crawl.yaml) that can be safely skipped during migration
+// when the same basename already exists at the destination.
+func isIntentScaffoldBasename(name string) bool {
+	_, ok := intentScaffoldBasenames[name]
+	return ok
+}
+
 // PlannedPathMove describes a filesystem move that migration would perform.
 type PlannedPathMove struct {
 	Source string

--- a/internal/intent/migration_filesystem.go
+++ b/internal/intent/migration_filesystem.go
@@ -146,7 +146,7 @@ func collectIntentTreeMoves(srcDir, dstDir string, moves *[]PlannedPathMove) err
 		}
 
 		if _, err := os.Stat(dstPath); err == nil {
-			if entry.Name() == ".gitkeep" {
+			if isIntentScaffoldBasename(entry.Name()) {
 				continue
 			}
 			return camperrors.Wrapf(ErrIntentMigrationConflict, "destination already exists for %s", dstPath)
@@ -263,7 +263,7 @@ func moveIntentTree(srcDir, dstDir string) error {
 		}
 
 		if _, err := os.Stat(dstPath); err == nil {
-			if entry.Name() == ".gitkeep" {
+			if isIntentScaffoldBasename(entry.Name()) {
 				if err := os.Remove(srcPath); err != nil {
 					return camperrors.Wrapf(err, "removing %s", srcPath)
 				}

--- a/internal/intent/migration_filesystem.go
+++ b/internal/intent/migration_filesystem.go
@@ -147,7 +147,13 @@ func collectIntentTreeMoves(srcDir, dstDir string, moves *[]PlannedPathMove) err
 
 		if _, err := os.Stat(dstPath); err == nil {
 			if isIntentScaffoldBasename(entry.Name()) {
-				continue
+				matches, matchErr := scaffoldFilesMatch(srcPath, dstPath)
+				if matchErr != nil {
+					return matchErr
+				}
+				if matches {
+					continue
+				}
 			}
 			return camperrors.Wrapf(ErrIntentMigrationConflict, "destination already exists for %s", dstPath)
 		} else if !os.IsNotExist(err) {
@@ -264,10 +270,16 @@ func moveIntentTree(srcDir, dstDir string) error {
 
 		if _, err := os.Stat(dstPath); err == nil {
 			if isIntentScaffoldBasename(entry.Name()) {
-				if err := os.Remove(srcPath); err != nil {
-					return camperrors.Wrapf(err, "removing %s", srcPath)
+				matches, matchErr := scaffoldFilesMatch(srcPath, dstPath)
+				if matchErr != nil {
+					return matchErr
 				}
-				continue
+				if matches {
+					if err := os.Remove(srcPath); err != nil {
+						return camperrors.Wrapf(err, "removing %s", srcPath)
+					}
+					continue
+				}
 			}
 			return camperrors.Wrapf(ErrIntentMigrationConflict, "destination already exists for %s", dstPath)
 		} else if !os.IsNotExist(err) {
@@ -284,4 +296,18 @@ func moveIntentTree(srcDir, dstDir string) error {
 	}
 
 	return nil
+}
+
+func scaffoldFilesMatch(srcPath, dstPath string) (bool, error) {
+	srcData, err := os.ReadFile(srcPath)
+	if err != nil {
+		return false, camperrors.Wrapf(err, "reading %s", srcPath)
+	}
+
+	dstData, err := os.ReadFile(dstPath)
+	if err != nil {
+		return false, camperrors.Wrapf(err, "reading %s", dstPath)
+	}
+
+	return bytes.Equal(srcData, dstData), nil
 }

--- a/internal/intent/service_test.go
+++ b/internal/intent/service_test.go
@@ -1522,6 +1522,69 @@ func TestIntentService_PlanLegacyIntentRootMigration_SkipsDuplicateCrawlConfig(t
 	}
 }
 
+// Divergent scaffold content is treated as a real conflict rather than being
+// silently discarded. This preserves any user edits to legacy .crawl.yaml.
+func TestIntentService_EnsureDirectories_DivergentCrawlConfigConflicts(t *testing.T) {
+	campaignRoot := t.TempDir()
+	legacyRoot := filepath.Join(campaignRoot, "workflow", "intents")
+	svc := NewIntentService(campaignRoot, filepath.Join(campaignRoot, ".campaign", "intents"))
+	ctx := context.Background()
+
+	legacyCrawl := filepath.Join(legacyRoot, "dungeon", ".crawl.yaml")
+	if err := os.MkdirAll(filepath.Dir(legacyCrawl), 0755); err != nil {
+		t.Fatalf("failed to create legacy dungeon dir: %v", err)
+	}
+	if err := os.WriteFile(legacyCrawl, []byte("excludes:\n  - inbox\n  - custom\n"), 0644); err != nil {
+		t.Fatalf("failed to write legacy .crawl.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyRoot, "OBEY.md"), []byte("# legacy\n"), 0644); err != nil {
+		t.Fatalf("failed to write legacy OBEY.md: %v", err)
+	}
+
+	canonicalCrawl := filepath.Join(svc.intentsDir, "dungeon", ".crawl.yaml")
+	if err := os.MkdirAll(filepath.Dir(canonicalCrawl), 0755); err != nil {
+		t.Fatalf("failed to create canonical dungeon dir: %v", err)
+	}
+	if err := os.WriteFile(canonicalCrawl, []byte("excludes:\n  - inbox\n"), 0644); err != nil {
+		t.Fatalf("failed to write canonical .crawl.yaml: %v", err)
+	}
+
+	err := svc.EnsureDirectories(ctx)
+	if !errors.Is(err, ErrIntentMigrationConflict) {
+		t.Fatalf("EnsureDirectories() error = %v, want ErrIntentMigrationConflict", err)
+	}
+}
+
+func TestIntentService_PlanLegacyIntentRootMigration_DivergentCrawlConfigConflicts(t *testing.T) {
+	campaignRoot := t.TempDir()
+	legacyRoot := filepath.Join(campaignRoot, "workflow", "intents")
+	svc := NewIntentService(campaignRoot, filepath.Join(campaignRoot, ".campaign", "intents"))
+
+	legacyCrawl := filepath.Join(legacyRoot, "dungeon", ".crawl.yaml")
+	if err := os.MkdirAll(filepath.Dir(legacyCrawl), 0755); err != nil {
+		t.Fatalf("failed to create legacy dungeon dir: %v", err)
+	}
+	if err := os.WriteFile(legacyCrawl, []byte("excludes:\n  - inbox\n  - custom\n"), 0644); err != nil {
+		t.Fatalf("failed to write legacy .crawl.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyRoot, "OBEY.md"), []byte("# legacy\n"), 0644); err != nil {
+		t.Fatalf("failed to write legacy OBEY.md: %v", err)
+	}
+
+	canonicalCrawl := filepath.Join(svc.intentsDir, "dungeon", ".crawl.yaml")
+	if err := os.MkdirAll(filepath.Dir(canonicalCrawl), 0755); err != nil {
+		t.Fatalf("failed to create canonical dungeon dir: %v", err)
+	}
+	if err := os.WriteFile(canonicalCrawl, []byte("excludes:\n  - inbox\n"), 0644); err != nil {
+		t.Fatalf("failed to write canonical .crawl.yaml: %v", err)
+	}
+
+	_, err := svc.PlanLegacyIntentRootMigration()
+	if !errors.Is(err, ErrIntentMigrationConflict) {
+		t.Fatalf("PlanLegacyIntentRootMigration() error = %v, want ErrIntentMigrationConflict", err)
+	}
+}
+
 func TestIsIntentScaffoldBasename(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/intent/service_test.go
+++ b/internal/intent/service_test.go
@@ -1431,6 +1431,117 @@ func TestIntentService_PlanLegacyIntentRootCleanup(t *testing.T) {
 	}
 }
 
+// TestIntentService_EnsureDirectories_DuplicateCrawlConfigTolerated guards the
+// regression where `camp init --repair` would fail on campaigns scaffolded
+// before the canonical-intent-root migration: Phase 2 of repair writes a
+// fresh .crawl.yaml at the canonical path, then Phase 8 migration refused to
+// reconcile the identical legacy copy. Scaffold files listed in
+// legacyIntentScaffoldFiles (currently .gitkeep and .crawl.yaml) must be
+// treated as safe-to-skip when the destination already exists, not just
+// .gitkeep.
+func TestIntentService_EnsureDirectories_DuplicateCrawlConfigTolerated(t *testing.T) {
+	campaignRoot := t.TempDir()
+	legacyRoot := filepath.Join(campaignRoot, "workflow", "intents")
+	svc := NewIntentService(campaignRoot, filepath.Join(campaignRoot, ".campaign", "intents"))
+	ctx := context.Background()
+
+	// Simulate the pre-Mar-16 layout: legacy dungeon with .crawl.yaml scaffold.
+	legacyCrawl := filepath.Join(legacyRoot, "dungeon", ".crawl.yaml")
+	if err := os.MkdirAll(filepath.Dir(legacyCrawl), 0755); err != nil {
+		t.Fatalf("failed to create legacy dungeon dir: %v", err)
+	}
+	if err := os.WriteFile(legacyCrawl, []byte("excludes:\n  - inbox\n"), 0644); err != nil {
+		t.Fatalf("failed to write legacy .crawl.yaml: %v", err)
+	}
+	// Also include a legacy marker so migration actually runs.
+	if err := os.WriteFile(filepath.Join(legacyRoot, "OBEY.md"), []byte("# legacy\n"), 0644); err != nil {
+		t.Fatalf("failed to write legacy OBEY.md: %v", err)
+	}
+
+	// Simulate the in-repair state: canonical dungeon also has .crawl.yaml,
+	// written by the scaffold phase that ran before migration.
+	canonicalCrawl := filepath.Join(svc.intentsDir, "dungeon", ".crawl.yaml")
+	if err := os.MkdirAll(filepath.Dir(canonicalCrawl), 0755); err != nil {
+		t.Fatalf("failed to create canonical dungeon dir: %v", err)
+	}
+	if err := os.WriteFile(canonicalCrawl, []byte("excludes:\n  - inbox\n"), 0644); err != nil {
+		t.Fatalf("failed to write canonical .crawl.yaml: %v", err)
+	}
+
+	if err := svc.EnsureDirectories(ctx); err != nil {
+		t.Fatalf("EnsureDirectories() error = %v (regression: migration should tolerate duplicate scaffold files)", err)
+	}
+
+	// Canonical .crawl.yaml should remain.
+	if _, err := os.Stat(canonicalCrawl); err != nil {
+		t.Fatalf("canonical .crawl.yaml should still exist: %v", err)
+	}
+	// Legacy .crawl.yaml should have been removed (skipped during move, then cleaned up).
+	if _, err := os.Stat(legacyCrawl); !os.IsNotExist(err) {
+		t.Fatalf("legacy .crawl.yaml should be removed after migration, err = %v", err)
+	}
+}
+
+// TestIntentService_PlanLegacyIntentRootMigration_SkipsDuplicateCrawlConfig is
+// the planning-side counterpart to the above: PlanLegacyIntentRootMigration
+// must not return an error or a planned move for .crawl.yaml when it exists
+// at both roots.
+func TestIntentService_PlanLegacyIntentRootMigration_SkipsDuplicateCrawlConfig(t *testing.T) {
+	campaignRoot := t.TempDir()
+	legacyRoot := filepath.Join(campaignRoot, "workflow", "intents")
+	svc := NewIntentService(campaignRoot, filepath.Join(campaignRoot, ".campaign", "intents"))
+
+	legacyCrawl := filepath.Join(legacyRoot, "dungeon", ".crawl.yaml")
+	if err := os.MkdirAll(filepath.Dir(legacyCrawl), 0755); err != nil {
+		t.Fatalf("failed to create legacy dungeon dir: %v", err)
+	}
+	if err := os.WriteFile(legacyCrawl, []byte("excludes:\n  - inbox\n"), 0644); err != nil {
+		t.Fatalf("failed to write legacy .crawl.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyRoot, "OBEY.md"), []byte("# legacy\n"), 0644); err != nil {
+		t.Fatalf("failed to write legacy OBEY.md: %v", err)
+	}
+
+	canonicalCrawl := filepath.Join(svc.intentsDir, "dungeon", ".crawl.yaml")
+	if err := os.MkdirAll(filepath.Dir(canonicalCrawl), 0755); err != nil {
+		t.Fatalf("failed to create canonical dungeon dir: %v", err)
+	}
+	if err := os.WriteFile(canonicalCrawl, []byte("excludes:\n  - inbox\n"), 0644); err != nil {
+		t.Fatalf("failed to write canonical .crawl.yaml: %v", err)
+	}
+
+	moves, err := svc.PlanLegacyIntentRootMigration()
+	if err != nil {
+		t.Fatalf("PlanLegacyIntentRootMigration() error = %v (should skip duplicate scaffold)", err)
+	}
+
+	for _, move := range moves {
+		if filepath.Base(move.Source) == ".crawl.yaml" {
+			t.Fatalf("duplicate .crawl.yaml should be skipped, not planned: %s -> %s", move.Source, move.Dest)
+		}
+	}
+}
+
+func TestIsIntentScaffoldBasename(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: ".gitkeep", want: true},
+		{name: ".crawl.yaml", want: true},
+		{name: "OBEY.md", want: false},
+		{name: "intent-1.md", want: false},
+		{name: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isIntentScaffoldBasename(tt.name); got != tt.want {
+				t.Errorf("isIntentScaffoldBasename(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIntentService_List_EmptyDirectories(t *testing.T) {
 	tmpDir := t.TempDir()
 	svc := NewIntentService(tmpDir, filepath.Join(tmpDir, "intents"))


### PR DESCRIPTION
## Problem

`camp init --repair` fails on campaigns scaffolded before `f476a19` (Mar 16, 2026 — the commit that moved the canonical intent root from `workflow/intents/` to `.campaign/intents/`):

```
Error: failed to compute repair plan: destination already exists for
  .../.campaign/intents/dungeon/.crawl.yaml: intent migration conflict: conflict
```

Hit this on CC_GO_PLANNING (originally scaffolded Mar 5).

## Root Cause

Repair's phase ordering is self-conflicting:

- **Phase 2** writes canonical intent scaffold (including `.campaign/intents/dungeon/.crawl.yaml`)
- **Phase 8** plans the legacy `workflow/intents/` → `.campaign/intents/` migration and refuses any conflicts

Migration's conflict check at `migration_filesystem.go:148` already recognized `.gitkeep` as safe-to-skip when the destination exists. But `.crawl.yaml` — also scaffold-generated, also listed in `legacyIntentScaffoldFiles` for post-migration cleanup — had no such exception. Migration thus rejects its own idempotent output.

## Fix

Replace the hard-coded `.gitkeep` check with `isIntentScaffoldBasename()`, derived from the existing `legacyIntentScaffoldFiles` list. Any filename already declared as scaffold (today: `.gitkeep`, `.crawl.yaml`) is safe-to-skip when the destination exists.

Applied in both:
- `collectIntentTreeMoves` — planning path (`PlanLegacyIntentRootMigration`)
- `moveIntentTree` — execution path (`migrateLegacyIntentRoot` → `EnsureDirectories`)

So plan and apply stay consistent, and adding a new scaffold file to the list in the future extends the tolerance automatically.

## Blast Radius

Affects only campaigns scaffolded before `f476a19` that run `camp init --repair` after it. New campaigns never hit this path.

## Test plan
- [x] `go test -short ./internal/intent/... ./internal/scaffold/...` — all pass
- [x] `go test -short ./...` — no regressions
- [x] New tests exercise both the planning path (`TestIntentService_PlanLegacyIntentRootMigration_SkipsDuplicateCrawlConfig`), the execution path (`TestIntentService_EnsureDirectories_DuplicateCrawlConfigTolerated`), and the helper (`TestIsIntentScaffoldBasename`)
- [x] Manually verified on CC_GO_PLANNING: `camp init --repair` now completes after removing the legacy duplicate — this PR makes that manual step unnecessary for the next affected campaign