### PR TITLE
docs: reposition camp as the workspace layer of Obey attention infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # camp
 
-> **Part of [Festival](https://github.com/Obedience-Corp/festival)** - mission-based AI workspace management. Camp handles workspace management; [fest](https://github.com/Obedience-Corp/fest) handles hierarchical planning. Together they give structure to how you work across multiple projects, contexts, and AI agents.
+> The workspace layer of **[Obey](https://github.com/Obedience-Corp)** — user-controlled attention infrastructure. Camp bounds what's in scope for your current attention: the projects, tools, and context you're engaging with. [fest](https://github.com/Obedience-Corp/fest) handles what you do inside that scope. Together they form [Festival](https://github.com/Obedience-Corp/festival).
 
-Campaign workspace manager for multi-project AI development.
+Campaign workspace manager — group related projects into a campaign, navigate instantly between them, and only engage with what's in scope.
 
 ## Features
 
@@ -444,13 +444,15 @@ just docs                 # Regenerate CLI reference docs
 just run <args>           # Run with arguments
 ```
 
-## Part of Festival
+## Part of Obey
 
-Camp is one half of the Festival product. The other half is [fest](https://github.com/Obedience-Corp/fest), which manages hierarchical planning - festivals, phases, sequences, and tasks that AI agents can execute autonomously. Together, camp + fest = Festival.
+Camp is the workspace layer of [Obey](https://github.com/Obedience-Corp) — user-controlled attention infrastructure.
 
-- [Festival documentation](https://fest.build) - Full docs, methodology, tutorials
-- [fest CLI](https://github.com/Obedience-Corp/fest) - Festival planning and execution
-- [Festival repo](https://github.com/Obedience-Corp/festival) - Distribution hub and releases
+- **camp** — the outermost attention boundary. Decides what projects, tools, and context are in scope for the work you're doing right now.
+- **[fest](https://github.com/Obedience-Corp/fest)** — plans and executes work within that boundary (hierarchical planning: festival → phase → sequence → task).
+- **[Festival](https://github.com/Obedience-Corp/festival)** — combined distribution of camp + fest. Full docs at [fest.build](https://fest.build).
+
+Hierarchy is the filter. Each level decides what gets surfaced upward. Camp sets the outermost scope; fest refines it into executable steps; the system surfaces only what's worth your attention.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # camp
 
-> The workspace layer of **[Obey](https://github.com/Obedience-Corp)** — user-controlled attention infrastructure. Camp bounds what's in scope for your current attention: the projects, tools, and context you're engaging with. [fest](https://github.com/Obedience-Corp/fest) handles what you do inside that scope. Together they form [Festival](https://github.com/Obedience-Corp/festival).
+> **One place for all your context and all your work.** Part of [Festival](https://github.com/Obedience-Corp/festival). Camp handles the workspace — your projects, tools, intents, and context. [fest](https://github.com/Obedience-Corp/fest) handles the planning and execution inside it.
 
-Campaign workspace manager — group related projects into a campaign, navigate instantly between them, and only engage with what's in scope.
+Campaign workspace manager — group every project, tool, and piece of context you care about into a single campaign, and navigate between them instantly.
 
 ## Features
 
@@ -444,15 +444,13 @@ just docs                 # Regenerate CLI reference docs
 just run <args>           # Run with arguments
 ```
 
-## Part of Obey
+## Part of Festival
 
-Camp is the workspace layer of [Obey](https://github.com/Obedience-Corp) — user-controlled attention infrastructure.
+Camp is one half of [Festival](https://github.com/Obedience-Corp/festival), the current product from [Obedience Corp](https://github.com/Obedience-Corp).
 
-- **camp** — the outermost attention boundary. Decides what projects, tools, and context are in scope for the work you're doing right now.
-- **[fest](https://github.com/Obedience-Corp/fest)** — plans and executes work within that boundary (hierarchical planning: festival → phase → sequence → task).
+- **camp** — workspace and context. One place for all your projects, tools, intents, agents, and work.
+- **[fest](https://github.com/Obedience-Corp/fest)** — planning and execution. Hierarchical: festival → phase → sequence → task.
 - **[Festival](https://github.com/Obedience-Corp/festival)** — combined distribution of camp + fest. Full docs at [fest.build](https://fest.build).
-
-Hierarchy is the filter. Each level decides what gets surfaced upward. Camp sets the outermost scope; fest refines it into executable steps; the system surfaces only what's worth your attention.
 
 ## License
 


### PR DESCRIPTION
## Summary

Updates the camp README to match the new canonical positioning established today: Obedience Corp builds **user-controlled attention infrastructure**.

Camp's previous framing — *"mission-based AI workspace management"* and *"campaign workspace manager for multi-project AI development"* — described the feature surface without naming the category. This PR:

- Reframes the top blurb so camp is explicitly *the workspace layer of Obey* and the outermost attention boundary.
- Replaces the tagline with a functional description of what that actually buys the user (group, navigate, scope).
- Rewrites the closing *Part of Festival* section as *Part of Obey*, making the camp → fest → Festival relationship concrete in attention-filter terms.
- Adds the *hierarchy is the filter* line that ties the camp/fest product structure to the broader Obey thesis.

No feature or command sections changed — the descriptive middle of the README (Features, Installation, Quick Start, Commands, Docs, Development) is intact.

Canonical positioning doc: [obey-campaign/docs/business/positioning/attention-infrastructure/](https://github.com/Obedience-Corp) (in the campaign workspace, not pushed to this repo).

## Test plan

- [x] Diff reviewed — only README.md changed
- [ ] Read rendered README on the PR page to confirm voice lands
- [ ] Confirm the *workspace layer of Obey* framing doesn't collide with any downstream docs (fest README, festival README — these will be updated in follow-up PRs)
- [ ] Decide on the repo short description update (currently "Multi-project AI Workspace" — proposal: "Campaign workspace manager — the workspace layer of user-controlled attention infrastructure")