### PR TITLE
docs: shrink banner to width=400 via HTML tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-![camp banner](docs/images/banner.jpg)
+<p align="center">
+  <img src="docs/images/banner.jpg" alt="camp banner" width="400">
+</p>
 
 # camp
 


### PR DESCRIPTION
1024x1024 square banner was rendering at full container width on GitHub. Wrapping in centered HTML with explicit width preserves the image and cuts rendered size without modifying the file.