### PR TITLE
[codex] fix leverage recent history snapshot persistence

### DIFF
--- a/cmd/camp/leverage/helpers.go
+++ b/cmd/camp/leverage/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -244,6 +245,14 @@ type scoreParams struct {
 	FallbackElapsed float64
 }
 
+type currentSnapshotInput struct {
+	project intleverage.ResolvedProject
+	result  *intleverage.SCCResult
+	score   *intleverage.LeverageScore
+}
+
+type headCommitResolver func(context.Context, string) (string, time.Time, error)
+
 func computeProjectScore(ctx context.Context, proj intleverage.ResolvedProject, result *intleverage.SCCResult, params scoreParams) *intleverage.LeverageScore {
 	var projActualPM float64
 	var projPeople int
@@ -308,6 +317,43 @@ func computeProjectScore(ctx context.Context, proj intleverage.ResolvedProject, 
 	}
 
 	return score
+}
+
+func persistCurrentSnapshots(ctx context.Context, store intleverage.SnapshotStorer, inputs []currentSnapshotInput, sampledAt time.Time, resolveHead headCommitResolver) error {
+	if resolveHead == nil {
+		resolveHead = getHeadCommit
+	}
+
+	type commitMeta struct {
+		hash string
+		date time.Time
+	}
+
+	byGitDir := make(map[string]commitMeta)
+
+	for _, input := range inputs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		meta, ok := byGitDir[input.project.GitDir]
+		if !ok {
+			hash, date, err := resolveHead(ctx, input.project.GitDir)
+			if err != nil {
+				return camperrors.Wrapf(err, "reading HEAD commit for %s", input.project.Name)
+			}
+			meta = commitMeta{hash: hash, date: date}
+			byGitDir[input.project.GitDir] = meta
+		}
+
+		scc := intleverage.SCCResultToSnapshotSCC(input.result)
+		snapshot := intleverage.NewSnapshot(input.project.Name, meta.hash, meta.date, sampledAt, scc, input.score, input.project.Authors)
+		if err := store.Save(ctx, snapshot); err != nil {
+			return camperrors.Wrapf(err, "saving current snapshot for %s", input.project.Name)
+		}
+	}
+
+	return nil
 }
 
 func buildScoreRows(scores []*intleverage.LeverageScore) [][]string {

--- a/cmd/camp/leverage/main_command.go
+++ b/cmd/camp/leverage/main_command.go
@@ -81,6 +81,7 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 	elapsed := intleverage.ElapsedMonths(cfg.ProjectStart, now)
 
 	var scores []*intleverage.LeverageScore
+	var snapshotInputs []currentSnapshotInput
 	for _, proj := range resolved {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -102,6 +103,11 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 			FallbackElapsed: elapsed,
 		})
 		scores = append(scores, score)
+		snapshotInputs = append(snapshotInputs, currentSnapshotInput{
+			project: proj,
+			result:  result,
+			score:   score,
+		})
 	}
 
 	if projectFilter != "" && len(scores) == 0 {
@@ -132,6 +138,13 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 	}
 
 	store := intleverage.NewFileSnapshotStore(intleverage.DefaultSnapshotDir(setup.Root))
+	existingSnapshots, listErr := store.ListProjects(ctx)
+	hadSnapshots := listErr == nil && len(existingSnapshots) > 0
+	if authorFilter == "" && peopleOverride == 0 {
+		if err := persistCurrentSnapshots(ctx, store, snapshotInputs, now, nil); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to save leverage snapshots: %v\n", err)
+		}
+	}
 	week7, has7 := intleverage.RecentLeverage(ctx, store, scores, effectivePeople, now.AddDate(0, 0, -7))
 	month30, has30 := intleverage.RecentLeverage(ctx, store, scores, effectivePeople, now.AddDate(0, 0, -30))
 
@@ -139,7 +152,13 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 		return leverageOutputJSON(cmd, agg, scores)
 	}
 
-	recent := recentLeverage{week7: week7, has7: has7, month30: month30, has30: has30}
+	recent := recentLeverage{
+		week7:         week7,
+		has7:          has7,
+		month30:       month30,
+		has30:         has30,
+		needsBackfill: authorFilter == "" && peopleOverride == 0 && len(scores) > 0 && !hadSnapshots && !has7 && !has30,
+	}
 	opts := leverageOutputOpts{
 		authorFilter:   authorFilter,
 		authorExcluded: authorExcluded,

--- a/cmd/camp/leverage/main_command_test.go
+++ b/cmd/camp/leverage/main_command_test.go
@@ -258,6 +258,160 @@ func TestLeverageConfigCommand_ValidationDate(t *testing.T) {
 	}
 }
 
+type snapshotStoreMock struct {
+	saved map[string]*intleverage.Snapshot
+}
+
+func newSnapshotStoreMock() *snapshotStoreMock {
+	return &snapshotStoreMock{saved: make(map[string]*intleverage.Snapshot)}
+}
+
+func (m *snapshotStoreMock) Save(_ context.Context, snapshot *intleverage.Snapshot) error {
+	key := snapshot.Project + ":" + snapshot.Date
+	m.saved[key] = snapshot
+	return nil
+}
+
+func (m *snapshotStoreMock) Load(_ context.Context, project, date string) (*intleverage.Snapshot, error) {
+	return m.saved[project+":"+date], nil
+}
+
+func (m *snapshotStoreMock) List(_ context.Context, project string) ([]string, error) {
+	var dates []string
+	prefix := project + ":"
+	for key := range m.saved {
+		if strings.HasPrefix(key, prefix) {
+			dates = append(dates, strings.TrimPrefix(key, prefix))
+		}
+	}
+	return dates, nil
+}
+
+func (m *snapshotStoreMock) LoadAll(ctx context.Context, project string) ([]*intleverage.Snapshot, error) {
+	dates, _ := m.List(ctx, project)
+	var snapshots []*intleverage.Snapshot
+	for _, date := range dates {
+		snapshots = append(snapshots, m.saved[project+":"+date])
+	}
+	return snapshots, nil
+}
+
+func (m *snapshotStoreMock) ListProjects(_ context.Context) ([]string, error) {
+	projects := make(map[string]struct{})
+	for key := range m.saved {
+		parts := strings.SplitN(key, ":", 2)
+		projects[parts[0]] = struct{}{}
+	}
+	var out []string
+	for project := range projects {
+		out = append(out, project)
+	}
+	return out, nil
+}
+
+func TestPersistCurrentSnapshots_SavesEachProjectAndReusesHeadLookup(t *testing.T) {
+	store := newSnapshotStoreMock()
+	commitDate := time.Date(2026, 4, 18, 10, 0, 0, 0, time.UTC)
+	sampledAt := commitDate.Add(2 * time.Hour)
+
+	inputs := []currentSnapshotInput{
+		{
+			project: intleverage.ResolvedProject{
+				Name:   "obey-platform-monorepo",
+				GitDir: "/tmp/obey-platform-monorepo",
+				Authors: []intleverage.AuthorContribution{
+					{Name: "A", Email: "a@example.com", Lines: 10},
+				},
+			},
+			result: sampleResult(10, 12, 1000, 500),
+			score:  &intleverage.LeverageScore{ProjectName: "obey-platform-monorepo"},
+		},
+		{
+			project: intleverage.ResolvedProject{
+				Name:   "obey-platform-monorepo@festui",
+				GitDir: "/tmp/obey-platform-monorepo",
+			},
+			result: sampleResult(2, 3, 100, 50),
+			score:  &intleverage.LeverageScore{ProjectName: "obey-platform-monorepo@festui"},
+		},
+	}
+
+	headCalls := 0
+	resolveHead := func(_ context.Context, gitDir string) (string, time.Time, error) {
+		headCalls++
+		if gitDir != "/tmp/obey-platform-monorepo" {
+			t.Fatalf("unexpected git dir: %s", gitDir)
+		}
+		return "abc123", commitDate, nil
+	}
+
+	if err := persistCurrentSnapshots(context.Background(), store, inputs, sampledAt, resolveHead); err != nil {
+		t.Fatalf("persistCurrentSnapshots failed: %v", err)
+	}
+
+	if headCalls != 1 {
+		t.Fatalf("resolveHead called %d times, want 1", headCalls)
+	}
+
+	if len(store.saved) != 2 {
+		t.Fatalf("saved %d snapshots, want 2", len(store.saved))
+	}
+
+	snap := store.saved["obey-platform-monorepo:"+commitDate.Format("2006-01-02")]
+	if snap == nil {
+		t.Fatal("expected root project snapshot to be saved")
+	}
+	if snap.CommitHash != "abc123" {
+		t.Fatalf("commit hash = %q, want abc123", snap.CommitHash)
+	}
+	if snap.SampledAt != sampledAt {
+		t.Fatalf("sampled_at = %s, want %s", snap.SampledAt, sampledAt)
+	}
+	if snap.SCC == nil || snap.SCC.TotalCode == 0 {
+		t.Fatal("expected SCC summary to be stored")
+	}
+}
+
+func TestLeverageOutputTable_ShowsBackfillHintWhenRecentHistoryMissing(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	cmd.Flags().Bool("no-legend", false, "")
+
+	score := &intleverage.LeverageScore{
+		ProjectName:        "camp",
+		EstimatedPeople:    10,
+		EstimatedMonths:    12,
+		EstimatedCost:      1000,
+		ActualPeople:       1,
+		ElapsedMonths:      1,
+		ActualPersonMonths: 1,
+		TotalFiles:         10,
+		TotalLines:         600,
+		TotalCode:          500,
+		AuthorCount:        1,
+		FullLeverage:       120,
+		SimpleLeverage:     10,
+	}
+	cfg := &intleverage.LeverageConfig{
+		ProjectStart: time.Date(2025, 4, 28, 0, 0, 0, 0, time.UTC),
+	}
+
+	if err := leverageOutputTable(cmd, score, []*intleverage.LeverageScore{score}, cfg, false, recentLeverage{
+		needsBackfill: true,
+	}, leverageOutputOpts{}); err != nil {
+		t.Fatalf("leverageOutputTable failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Recent leverage history unavailable yet") {
+		t.Fatalf("output missing backfill hint\nGot:\n%s", output)
+	}
+	if !strings.Contains(output, "camp leverage backfill") {
+		t.Fatalf("output missing backfill command hint\nGot:\n%s", output)
+	}
+}
+
 func TestLeverageConfigCommand_ValidationCOCOMO(t *testing.T) {
 	_, err := executeLeverage(t, "config", "--cocomo-type", "invalid")
 	if err == nil {

--- a/cmd/camp/leverage/output.go
+++ b/cmd/camp/leverage/output.go
@@ -16,6 +16,7 @@ import (
 type recentLeverage struct {
 	week7, month30 float64
 	has7, has30    bool
+	needsBackfill  bool
 }
 
 type leverageOutputOpts struct {
@@ -120,6 +121,9 @@ func leverageOutputTable(cmd *cobra.Command, agg *intleverage.LeverageScore, sco
 				ui.Value(fmtRecentLeverage(recent.month30)+"x", ui.SuccessColor))
 		}
 		fmt.Fprintf(out, "  %s\n", ui.Dim("(new estimated effort added in period vs actual effort spent)"))
+		fmt.Fprintln(out)
+	} else if recent.needsBackfill {
+		fmt.Fprintf(out, "  %s\n", ui.Dim("Recent leverage history unavailable yet. This run saved current snapshots; run `camp leverage backfill` once to seed Last 7/30 days."))
 		fmt.Fprintln(out)
 	}
 


### PR DESCRIPTION
## What changed
- persist current leverage snapshots during normal `camp leverage` runs
- reuse one HEAD commit lookup per git repo when saving those snapshots
- show an explicit note when recent 7/30 day leverage is unavailable because historical snapshots have not been seeded yet
- add tests covering snapshot persistence and the missing-history output path

## Why
`camp leverage` computed the recent 7-day and 30-day values only from stored snapshots. If `.campaign/leverage/snapshots/` was empty or missing, the recent section disappeared even though the main leverage table still rendered.

## Root cause
The command relied on snapshot history for recent leverage, but normal `camp leverage` runs did not write a current snapshot. That meant the feature only worked after a manual `camp leverage backfill` or `camp leverage snapshot`, and could appear to "break again" whenever snapshot history was absent.

## Impact
- normal `camp leverage` usage now keeps current snapshot data fresh automatically
- campaigns with no seeded history get a clear instruction to run `camp leverage backfill` once instead of silently losing the recent section
- the change preserves the existing backfill-based historical model for true 7-day and 30-day comparisons

## Validation
- `go test ./cmd/camp/leverage ./internal/leverage`
- `just build-camp`
- `just test short`
- manual verification with `./projects/camp/bin/camp leverage` showing `Last 7 days` and `Last 30 days` again after the run populated snapshots
