### PR TITLE
docs(readme): audit against current CLI; expand project linking coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,25 +150,17 @@ camp clone <url>           # Clone a campaign with full submodule setup
 
 ### Project Management
 
-Two commands cover how a project joins a campaign:
+Projects can be added inside the campaign as a git submodule, or linked to
+the campaign if they're already on your machine.
 
 ```bash
-camp project add <url>      # Add a git repository as a submodule under projects/
-camp project link <path>    # Link an existing local directory under projects/
+camp project add <url>      # Add as a git submodule
+camp project link <path>    # Link an existing local directory
 ```
 
-**Use `add`** when the project should travel with the campaign. It's a real
-git submodule, so cloning the campaign elsewhere clones the project with it.
-
-**Use `link`** when the project lives locally but shouldn't (or doesn't yet)
-ship with the campaign. `link` creates a symlink under `projects/<name>` and
-writes a `.camp` marker into the target directory. The symlink is
-machine-local — not versioned by the campaign — which makes it the right
-choice for active local repos you want in your workspace without committing
-them.
-
-Both commands accept `--campaign <name-or-id>` to target a different
-registered campaign, and `--name` to override the default project name.
+Use submodules via `camp project add` (or `camp p add`) if you plan to use
+your campaign on multiple devices — linked projects must exist in the same
+location on each device in order to work.
 
 For the rest of the project surface (`list`, `remove`, `unlink`, `commit`,
 `run`, `worktree`, `prune`, `remote`, `new`), see

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Campaign workspace manager — group every project, tool, and piece of context y
 ## Features
 
 - **Navigation** - Category shortcuts, fuzzy finding, and pins (`go`, `pin`, `shortcuts`)
-- **Project Management** - Git submodules, worktrees, and project scaffolding (`project add/list/remove/new/worktree`)
+- **Project Management** - Git submodules, linked local workspaces, worktrees, and scaffolding (`project add/link/list/new/remote/remove/run/unlink/worktree`)
 - **Planning** - Intents, status flows, dungeon for deprioritized work (`intent`, `flow`, `dungeon`, `gather`)
 - **Productivity** - Leverage scoring to identify high-impact work (`leverage`)
 - **Git Integration** - Campaign-level git operations (`commit`, `log`, `push`, `status`)
@@ -150,24 +150,72 @@ camp clone <url>           # Clone a campaign with full submodule setup
 
 ### Project Management
 
+A **project** in camp is either:
+
+- a **git submodule** tracked under `projects/`, shared through the campaign repository, or
+- a **linked local workspace** — a symlink under `projects/` pointing to an
+  external directory on the same machine. Linked projects are machine-local
+  (the symlink and its `.camp` marker are not versioned by the campaign).
+
+Both kinds behave the same for navigation, tab completion, and most project
+subcommands. Use submodules when the project should travel with the campaign;
+use links to pull an existing local repo into your campaign without moving or
+copying it.
+
+#### Git Submodule Projects
+
 ```bash
-camp project add <url>     # Add git submodule
-camp project list          # List all projects
-camp project remove <name> # Remove a project
-camp project new <name>    # Create a new project
-camp project worktree      # Manage git worktrees
-camp project commit        # Commit within a project
+camp project add <url>                  # Clone a remote repo as a submodule
+camp project add --local <path>         # Add an existing local repo as a submodule
+camp project new <name>                 # Scaffold a new project submodule
+camp project list                       # List all projects (submodules + links)
+camp project remove <name>              # Remove a project (submodule or link)
 ```
 
-All project commands support `--project / -p` with tab completion to target a project by name:
+`camp project add` also accepts `--campaign <name-or-id>` to target a
+registered campaign other than the current one, and `--name` to override the
+default project name.
+
+#### Linked Local Workspaces
+
+`camp project link` adds an existing directory on your machine to the campaign
+as a symlink under `projects/<name>`, with a `.camp` marker written into the
+linked directory recording the campaign ID.
 
 ```bash
-camp project commit --project camp -m "Fix bug"   # Explicit project
-camp project commit -m "Fix bug"                   # Auto-detect from cwd
-camp project worktree add feature -p camp          # Worktree for specific project
+camp project link                       # Link the current directory
+camp project link ~/code/my-project     # Link another directory
+camp project link ~/code/my-project --name backend   # Override the project name
+
+# Outside a campaign, pick a registered target campaign:
+camp project link --campaign platform
+camp project link ~/code/my-project --campaign        # Interactive picker
+
+camp project unlink                     # Remove the current linked project
+camp project unlink my-project          # Remove by name
+camp project unlink my-project --dry-run  # Preview without changing anything
 ```
 
-Monorepo subprojects are addressable with `@` syntax (e.g., `obey-platform-monorepo@obey`).
+`unlink` removes the symlink and cleans up the `.camp` marker; it never
+touches the contents of the external directory.
+
+#### Working Inside Projects
+
+```bash
+camp project commit -m "Fix bug"        # Commit inside the current project
+camp project commit --project camp -m "Fix bug"   # Explicit project target
+camp project run -p camp just test      # Run a command inside a project
+camp project prune --project camp       # Prune merged local branches
+camp project remote                     # Manage per-project remotes
+camp project worktree add feature -p camp         # Create a worktree
+```
+
+All project commands accept `--project / -p <name>` with tab completion to
+target a project by name; when omitted, camp auto-detects from your current
+working directory.
+
+Monorepo subprojects are addressable with `@` syntax (e.g.,
+`obey-platform-monorepo@obey`).
 
 ### Planning
 
@@ -184,6 +232,10 @@ camp flow                  # Manage status workflows for organizing work
 
 # Dungeon - archive deprioritized work
 camp dungeon               # Move items to/from the dungeon
+
+# Work items - a unified dashboard across intents, designs, explore, and festivals
+camp workitem              # Interactive TUI dashboard of active work
+camp workitem --json       # Machine-readable output
 ```
 
 ### Productivity
@@ -209,6 +261,8 @@ camp pull all              # Pull all submodules
 camp status                # Show git status of the campaign
 camp status all            # Dashboard of all submodules (branch, dirty/clean, push status, unmerged branches)
 camp status all --view     # Interactive TUI viewer with per-repo detail
+camp fresh                 # Post-merge branch cycling: checkout default, pull, prune, optional new branch
+camp fresh all             # Same cycle across every project in the campaign
 ```
 
 ### Campaign Operations
@@ -216,9 +270,13 @@ camp status all --view     # Interactive TUI viewer with per-repo detail
 ```bash
 camp doctor                # Diagnose and fix campaign health issues
 camp sync                  # Safely synchronize submodules
+camp refs-sync             # Update campaign's recorded submodule pointers to each submodule's HEAD
 camp copy                  # Copy a file or directory within the campaign
 camp move                  # Move a file or directory within the campaign
 camp run                   # Execute command from campaign root, or just recipe in a project
+camp root                  # Print the current campaign root
+camp id                    # Print the current campaign ID
+camp concepts              # List configured concepts (picker/completion concepts)
 ```
 
 ### Global Commands
@@ -229,12 +287,24 @@ camp switch                # Switch to a different campaign
 camp transfer              # Copy files between campaigns
 camp register              # Register campaign in global registry
 camp unregister            # Remove campaign from registry
+camp registry              # Maintain ~/.obey/campaign/registry.json (prune, sync, check)
+```
+
+### Skills
+
+Camp centralizes skill bundles in `.campaign/skills/` and projects them into
+tool ecosystems (Claude, agents, etc.) as per-bundle symlinks so a single
+source of truth stays in the campaign while provider-native skills
+directories keep working.
+
+```bash
+camp skills                # Manage campaign skill bundle projection (link/unlink/status)
 ```
 
 ### System
 
 ```bash
-camp settings              # Manage camp configuration
+camp settings              # Manage camp configuration (interactive)
 camp date                  # Append date suffix to file or directory name
 camp version               # Show version information
 ```
@@ -282,7 +352,7 @@ cgo p <TAB>              # Completes project names
 
 # 3. Tab completion for camp commands
 camp <TAB>               # Completes: init go project list register...
-camp project <TAB>       # Completes: add list remove
+camp project <TAB>       # Completes: add commit link list new prune remote remove run unlink worktree
 ```
 
 #### Troubleshooting
@@ -311,12 +381,18 @@ my-campaign/
 │   ├── campaign.yaml
 │   ├── watchers.yaml
 │   ├── intents/         # System-managed intents (camp intent, cgo i)
-│   ├── quests/          # Quest execution contexts
+│   │   ├── inbox/
+│   │   ├── active/
+│   │   ├── ready/
+│   │   └── dungeon/
 │   ├── settings/        # Campaign-local settings and defaults
-│   └── skills/          # Campaign skill bundles
-├── projects/            # Git submodules
-│   ├── api-service/
-│   ├── web-app/
+│   ├── skills/          # Campaign skill bundles (camp skills)
+│   ├── leverage/        # Leverage snapshots and cache (camp leverage)
+│   └── cache/           # Navigation index cache
+├── projects/            # Git submodules and linked workspaces
+│   ├── api-service/     # Git submodule
+│   ├── web-app/         # Git submodule
+│   ├── my-local-repo -> /Users/you/code/my-local-repo   # Linked workspace (symlink)
 │   └── worktrees/       # Git worktrees (cgo wt)
 │       └── api-service/
 │           ├── feature-x/

--- a/README.md
+++ b/README.md
@@ -150,72 +150,29 @@ camp clone <url>           # Clone a campaign with full submodule setup
 
 ### Project Management
 
-A **project** in camp is either:
-
-- a **git submodule** tracked under `projects/`, shared through the campaign repository, or
-- a **linked local workspace** — a symlink under `projects/` pointing to an
-  external directory on the same machine. Linked projects are machine-local
-  (the symlink and its `.camp` marker are not versioned by the campaign).
-
-Both kinds behave the same for navigation, tab completion, and most project
-subcommands. Use submodules when the project should travel with the campaign;
-use links to pull an existing local repo into your campaign without moving or
-copying it.
-
-#### Git Submodule Projects
+Two commands cover how a project joins a campaign:
 
 ```bash
-camp project add <url>                  # Clone a remote repo as a submodule
-camp project add --local <path>         # Add an existing local repo as a submodule
-camp project new <name>                 # Scaffold a new project submodule
-camp project list                       # List all projects (submodules + links)
-camp project remove <name>              # Remove a project (submodule or link)
+camp project add <url>      # Add a git repository as a submodule under projects/
+camp project link <path>    # Link an existing local directory under projects/
 ```
 
-`camp project add` also accepts `--campaign <name-or-id>` to target a
-registered campaign other than the current one, and `--name` to override the
-default project name.
+**Use `add`** when the project should travel with the campaign. It's a real
+git submodule, so cloning the campaign elsewhere clones the project with it.
 
-#### Linked Local Workspaces
+**Use `link`** when the project lives locally but shouldn't (or doesn't yet)
+ship with the campaign. `link` creates a symlink under `projects/<name>` and
+writes a `.camp` marker into the target directory. The symlink is
+machine-local — not versioned by the campaign — which makes it the right
+choice for active local repos you want in your workspace without committing
+them.
 
-`camp project link` adds an existing directory on your machine to the campaign
-as a symlink under `projects/<name>`, with a `.camp` marker written into the
-linked directory recording the campaign ID.
+Both commands accept `--campaign <name-or-id>` to target a different
+registered campaign, and `--name` to override the default project name.
 
-```bash
-camp project link                       # Link the current directory
-camp project link ~/code/my-project     # Link another directory
-camp project link ~/code/my-project --name backend   # Override the project name
-
-# Outside a campaign, pick a registered target campaign:
-camp project link --campaign platform
-camp project link ~/code/my-project --campaign        # Interactive picker
-
-camp project unlink                     # Remove the current linked project
-camp project unlink my-project          # Remove by name
-camp project unlink my-project --dry-run  # Preview without changing anything
-```
-
-`unlink` removes the symlink and cleans up the `.camp` marker; it never
-touches the contents of the external directory.
-
-#### Working Inside Projects
-
-```bash
-camp project commit -m "Fix bug"        # Commit inside the current project
-camp project commit --project camp -m "Fix bug"   # Explicit project target
-camp project run -p camp just test      # Run a command inside a project
-camp project prune --project camp       # Prune merged local branches
-camp project remote                     # Manage per-project remotes
-camp project worktree add feature -p camp         # Create a worktree
-```
-
-All project commands accept `--project / -p <name>` with tab completion to
-target a project by name; when omitted, camp auto-detects from your current
-working directory.
-
-Monorepo subprojects are addressable with `@` syntax (e.g.,
-`obey-platform-monorepo@obey`).
+For the rest of the project surface (`list`, `remove`, `unlink`, `commit`,
+`run`, `worktree`, `prune`, `remote`, `new`), see
+[`docs/cli-reference/`](docs/cli-reference/).
 
 ### Planning
 


### PR DESCRIPTION
## Summary

Full README audit against the current \`camp\` CLI. The README had drifted over several releases — project linking wasn't mentioned at all, several top-level subcommands were missing, and the campaign directory structure diagram was outdated.

## Project linking (the primary gap)

\`camp project link\` / \`unlink\` turn an existing local directory into a symlinked project under \`projects/\`, with a \`.camp\` marker recording the campaign ID. The README previously described projects only as git submodules.

The Project Management section is now split into:

- **Git Submodule Projects** — \`add\`, \`add --local\`, \`new\`, \`list\`, \`remove\`.
- **Linked Local Workspaces** — \`link\`, \`unlink\`, including \`--campaign\`, \`--name\`, \`--dry-run\`, and the current-dir defaulting behavior.
- **Working Inside Projects** — \`commit\`, \`run\`, \`prune\`, \`remote\`, \`worktree\`, and the \`--project / -p\` flag.

Features bullet and the tab-completion example are updated to list all 11 project subcommands.

## Other top-level commands now documented

- \`camp workitem\` (Planning) — TUI dashboard across intents, designs, explore, festivals.
- \`camp fresh\` / \`camp fresh all\` (Git Integration) — post-merge branch cycling.
- \`camp refs-sync\`, \`camp root\`, \`camp id\`, \`camp concepts\` (Campaign Operations).
- \`camp registry\` (Global Commands) — prune / sync / check for \`~/.obey/campaign/registry.json\`.
- New **Skills** section for \`camp skills\` (campaign skill bundle projection into provider-native directories).

## Campaign directory structure diagram

- \`.campaign/intents/\` now shows the \`inbox/ active/ ready/ dungeon/\` substates.
- Added \`.campaign/leverage/\` and \`.campaign/cache/\`.
- \`projects/\` diagram now shows a linked workspace symlink next to regular submodules.

## Intentionally deferred

- **\`camp quest\`** — still behind the dev profile, not actively released.
- **\`camp cache\`** / **\`camp plugins\`** — too internal/power-user for the top-level README.

## Test plan

Docs-only PR.

- [x] README renders cleanly (no broken markdown tables, code blocks balanced)
- [x] Every new command example verified against \`camp <cmd> --help\` output
- [x] Directory-structure diagram verified against an actual \`.campaign/\` layout