### PR TITLE
docs(skills): teach camp-projects skill to choose link vs submodule

### DIFF
--- a/internal/scaffold/campaign/templates/.campaign/skills/camp-projects/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/camp-projects/SKILL.md.tmpl
@@ -62,9 +62,11 @@ camp refs-sync
 camp refs-sync projects/camp
 ```
 
-## Worktrees
+## Other Project Operations
 
-See shared reference.
+Other project subcommands — `list`, `new`, `run`, `prune`, `remote`,
+`worktree` — plus the project-scoped `camp fresh` (post-merge reset) are
+all documented in the shared reference.
 
 ## Common Mistakes
 

--- a/internal/scaffold/campaign/templates/.campaign/skills/camp-projects/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/camp-projects/SKILL.md.tmpl
@@ -8,16 +8,18 @@ description: Manage campaign projects with `camp project`. Use when the user wan
 Read shared contracts first: `../references/camp-command-contracts.md`.
 
 A project in a campaign is either a git submodule under `projects/` or a
-symlink (a "linked project") to a directory on the same machine. Most
-users prefer linking. Default toward link unless the user has stated a
-reason for a submodule.
+linked project — a symlink placed at `projects/<name>` that points to a
+directory elsewhere on the same machine. Most users prefer linking.
+Default toward link unless the user has stated a reason for a submodule.
 
 ## Decide: `add` or `link` — ASK the User
 
 - **URL given, not cloned locally** → `camp project add <url>`. Only
   reasonable choice.
 - **Already cloned on the user's machine** → ask: "Link it, or add as a
-  submodule?" Default recommendation is `camp project link <path>`. Use
+  submodule?" Default recommendation is `camp project link <path>`, which
+  creates a symlink at `projects/<name>` pointing back to the user's
+  existing directory (the directory stays where it is on disk). Use
   `camp project add --local <path>` only when the user has explicitly
   asked for multi-device use.
 - **User wants multi-device campaign** → submodules are required. Linked

--- a/internal/scaffold/campaign/templates/.campaign/skills/camp-projects/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/camp-projects/SKILL.md.tmpl
@@ -1,73 +1,54 @@
 ---
 name: camp-projects
-description: Manage campaign projects with `camp project`. Use when the user wants to add, link, or remove a project; when committing inside `projects/*`; when deciding status/pull/push scope (root vs submodule vs all); or when managing project worktrees.
+description: Manage campaign projects with `camp project`. Use when the user wants to add, link, or remove a project; when deciding between `camp project add` and `camp project link`; or when committing inside `projects/*`.
 ---
 
 # Campaign Projects
 
 Read shared contracts first: `../references/camp-command-contracts.md`.
 
-A project in a campaign is either a **git submodule** under `projects/` or a
-**linked local directory** (a symlink under `projects/` pointing to a
-directory on the same machine). Most users prefer linking — submodules add
-complexity they don't always want — so default toward linking unless the
-user has stated a reason for a submodule.
+A project in a campaign is either a git submodule under `projects/` or a
+symlink (a "linked project") to a directory on the same machine. Most
+users prefer linking. Default toward link unless the user has stated a
+reason for a submodule.
 
-## Decide: `add` or `link` — and ASK the User First
+## Decide: `add` or `link` — ASK the User
 
-When the user wants to bring a project into the campaign, identify the case
-and ask before choosing. **Do not assume.**
+- **URL given, not cloned locally** → `camp project add <url>`. Only
+  reasonable choice.
+- **Already cloned on the user's machine** → ask: "Link it, or add as a
+  submodule?" Default recommendation is `camp project link <path>`. Use
+  `camp project add --local <path>` only when the user has explicitly
+  asked for multi-device use.
+- **User wants multi-device campaign** → submodules are required. Linked
+  projects only work on a device where the linked path exists at the same
+  filesystem location.
 
-### Case 1 — user gave a URL (not cloned locally)
-
-```bash
-camp project add <url>
-```
-
-This is the only reasonable choice: there's nothing on disk to link. The
-project is cloned as a git submodule under `projects/`.
-
-### Case 2 — the project is already cloned somewhere on the user's machine
-
-**Ask the user:** "Do you want to add this as a git submodule, or link the
-existing directory?"
-
-- **Link it (default recommendation)** — `camp project link <path>`
-  - Creates a symlink under `projects/<name>` and writes a `.camp` marker
-    into the target directory.
-  - Machine-local: the symlink is not versioned with the campaign.
-  - The project stays where it is on disk.
-  - Good fit when the user wants the repo visible in the campaign workflow
-    without turning it into a submodule.
-
-- **Submodule it** — `camp project add --local <path>`
-  - Converts the directory into a git submodule of the campaign.
-  - Only choose this when the user has explicitly said they want the
-    campaign to travel across devices and include this project at the same
-    commit on every device.
-
-### Case 3 — user wants to use the campaign on multiple devices
-
-Submodules are required. Linked projects only work on a device where the
-linked path exists at the exact same filesystem location. Tell the user
-this tradeoff if they're choosing between the two.
-
-### When in doubt
-
-Ask. Never convert an already-local directory into a submodule without
-explicit user confirmation — that modifies the campaign's git history and
-can surprise users who expected a lightweight link.
+Never convert an already-local directory into a submodule without
+explicit user confirmation — that modifies the campaign's git history.
 
 ## Remove
 
-- `camp project unlink <name>` — remove a linked project. Safe: deletes the
-  symlink and cleans up the `.camp` marker, but never touches the external
-  directory's contents.
-- `camp project remove <name>` — remove a submodule. Modifies the
-  campaign's git history.
-- If the user says "remove this project" without specifying, check
-  `camp project list` (or the `projects/` directory) to see whether the
-  entry is a symlink or a submodule, and pick accordingly.
+`camp project remove <name>` works for both kinds without `--delete`:
+
+- Linked project → safely unlinks (identical to `camp project unlink`).
+- Submodule → deinits from git without deleting files on disk.
+
+`--delete` is the destructive path. It errors on linked projects (camp
+won't delete an external target) and deletes the submodule's directory
+on disk for submodules.
+
+Prefer `camp project unlink <name>` when the intent is specifically to
+remove a link.
+
+## Scope Limits for Links (Current Behavior)
+
+`camp status --sub`, `camp pull --sub`, `camp push --sub`, and the
+`status all` / `pull all` / `push all` paths enumerate **submodules
+only** today. They error or skip when the current project is linked.
+
+To operate on a linked project, cd into the linked directory and use
+`git` directly, or use `camp project run -p <name> <cmd>`.
 
 ## Commit in Submodules
 
@@ -75,58 +56,24 @@ can surprise users who expected a lightweight link.
 camp p commit -m "fix: message"
 ```
 
-Pointer sync is intentional and root-level:
+Pointer sync is a separate intentional action:
 
 ```bash
 camp refs-sync
 camp refs-sync projects/camp
 ```
 
-Linked projects commit to their own repositories; the campaign-root git does
-not track their commits and does not need `camp refs-sync` for them.
-
-## Scope-Safe Status / Sync
-
-`camp status`, `camp pull`, and `camp push` without arguments act on the
-**campaign root repo itself**, not on projects. To touch the current project
-from inside it, use `--sub`. To act across every project in the campaign,
-use `all`.
-
-```bash
-camp status              # campaign root
-camp status --sub        # current project (submodule or link)
-camp status all          # dashboard across every project
-
-camp pull all            # pull every project (works on submodules and links alike,
-                         # as long as the target directory is a git repo)
-camp push all            # push every project with pending pushes
-camp pull --sub          # pull the current project
-camp push --sub          # push the current project
-```
-
-Use `all` commands only when broad workspace churn is intended.
-
 ## Worktrees
 
-```bash
-camp project worktree add <name>
-camp project worktree list
-camp project worktree remove <name>
-```
+See shared reference.
 
 ## Common Mistakes
 
-- Silently running `camp project add` (or `add --local`) when the user
-  already had the repo cloned locally. Ask first — most users prefer
-  linking.
-- Assuming submodule commits should auto-update campaign-root pointers
-  (they don't — use `camp refs-sync` intentionally).
-- Running `camp pull` / `camp push` at campaign root and expecting it to
-  touch projects. It doesn't — that's the campaign's own git repo. Use
-  `--sub` for the current project or `all` to cross every project.
-- Passing a worktree path to `worktree remove`; the command expects the
-  worktree name.
-- Using `camp project remove` on a linked project when the safe command is
-  `camp project unlink`.
-- Telling a user they need a submodule to "use the project in the campaign"
-  — a link works for everything the user does on that machine.
+- Running `camp project add --local` on an already-cloned project without
+  asking. Most users prefer `camp project link`.
+- Assuming submodule commits auto-update campaign-root pointers — they
+  don't. Use `camp refs-sync` intentionally.
+- Expecting `--sub` or `all` to cover linked projects. They don't today.
+- Using `remove --delete` when `remove` alone would do the right thing.
+- Using `camp project remove` on a link when the intent is specifically
+  "unlink" — `camp project unlink` reads clearer at the call site.

--- a/internal/scaffold/campaign/templates/.campaign/skills/camp-projects/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/camp-projects/SKILL.md.tmpl
@@ -14,20 +14,17 @@ Default toward link unless the user has stated a reason for a submodule.
 
 ## Decide: `add` or `link` — ASK the User
 
-- **URL given, not cloned locally** → `camp project add <url>`. Only
-  reasonable choice.
-- **Already cloned on the user's machine** → ask: "Link it, or add as a
-  submodule?" Default recommendation is `camp project link <path>`, which
-  creates a symlink at `projects/<name>` pointing back to the user's
-  existing directory (the directory stays where it is on disk). Use
-  `camp project add --local <path>` only when the user has explicitly
-  asked for multi-device use.
+- **URL given, not cloned locally** → `camp project add <url>`. Clones
+  the repo as a git submodule under `projects/<name>`.
+- **Already cloned on the user's machine** → `camp project link <path>`.
+  Creates a symlink at `projects/<name>` pointing back to the user's
+  existing directory; the directory stays where it is on disk.
 - **User wants multi-device campaign** → submodules are required. Linked
-  projects only work on a device where the linked path exists at the same
-  filesystem location.
+  projects only resolve on a device where the linked path exists at the
+  same filesystem location. If the user has an already-local repo and
+  wants it to travel with the campaign, tell them so and let them decide.
 
-Never convert an already-local directory into a submodule without
-explicit user confirmation — that modifies the campaign's git history.
+See `docs/cli-reference/` for niche flags like `add --local`.
 
 ## Remove
 
@@ -71,8 +68,8 @@ See shared reference.
 
 ## Common Mistakes
 
-- Running `camp project add --local` on an already-cloned project without
-  asking. Most users prefer `camp project link`.
+- Using `camp project add` paths on a repo that already lives on the
+  user's machine. Default to `camp project link` instead.
 - Assuming submodule commits auto-update campaign-root pointers — they
   don't. Use `camp refs-sync` intentionally.
 - Expecting `--sub` or `all` to cover linked projects. They don't today.

--- a/internal/scaffold/campaign/templates/.campaign/skills/camp-projects/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/camp-projects/SKILL.md.tmpl
@@ -1,11 +1,73 @@
 ---
 name: camp-projects
-description: Manage campaign submodule projects. Use when committing inside `projects/*`, deciding status/pull/push scope (root vs submodule vs all), or creating/removing project worktrees.
+description: Manage campaign projects with `camp project`. Use when the user wants to add, link, or remove a project; when committing inside `projects/*`; when deciding status/pull/push scope (root vs submodule vs all); or when managing project worktrees.
 ---
 
 # Campaign Projects
 
 Read shared contracts first: `../references/camp-command-contracts.md`.
+
+A project in a campaign is either a **git submodule** under `projects/` or a
+**linked local directory** (a symlink under `projects/` pointing to a
+directory on the same machine). Most users prefer linking — submodules add
+complexity they don't always want — so default toward linking unless the
+user has stated a reason for a submodule.
+
+## Decide: `add` or `link` — and ASK the User First
+
+When the user wants to bring a project into the campaign, identify the case
+and ask before choosing. **Do not assume.**
+
+### Case 1 — user gave a URL (not cloned locally)
+
+```bash
+camp project add <url>
+```
+
+This is the only reasonable choice: there's nothing on disk to link. The
+project is cloned as a git submodule under `projects/`.
+
+### Case 2 — the project is already cloned somewhere on the user's machine
+
+**Ask the user:** "Do you want to add this as a git submodule, or link the
+existing directory?"
+
+- **Link it (default recommendation)** — `camp project link <path>`
+  - Creates a symlink under `projects/<name>` and writes a `.camp` marker
+    into the target directory.
+  - Machine-local: the symlink is not versioned with the campaign.
+  - The project stays where it is on disk.
+  - Good fit when the user wants the repo visible in the campaign workflow
+    without turning it into a submodule.
+
+- **Submodule it** — `camp project add --local <path>`
+  - Converts the directory into a git submodule of the campaign.
+  - Only choose this when the user has explicitly said they want the
+    campaign to travel across devices and include this project at the same
+    commit on every device.
+
+### Case 3 — user wants to use the campaign on multiple devices
+
+Submodules are required. Linked projects only work on a device where the
+linked path exists at the exact same filesystem location. Tell the user
+this tradeoff if they're choosing between the two.
+
+### When in doubt
+
+Ask. Never convert an already-local directory into a submodule without
+explicit user confirmation — that modifies the campaign's git history and
+can surprise users who expected a lightweight link.
+
+## Remove
+
+- `camp project unlink <name>` — remove a linked project. Safe: deletes the
+  symlink and cleans up the `.camp` marker, but never touches the external
+  directory's contents.
+- `camp project remove <name>` — remove a submodule. Modifies the
+  campaign's git history.
+- If the user says "remove this project" without specifying, check
+  `camp project list` (or the `projects/` directory) to see whether the
+  entry is a symlink or a submodule, and pick accordingly.
 
 ## Commit in Submodules
 
@@ -20,15 +82,26 @@ camp refs-sync
 camp refs-sync projects/camp
 ```
 
+Linked projects commit to their own repositories; the campaign-root git does
+not track their commits and does not need `camp refs-sync` for them.
+
 ## Scope-Safe Status / Sync
 
-```bash
-camp status
-camp status --sub
-camp status all
+`camp status`, `camp pull`, and `camp push` without arguments act on the
+**campaign root repo itself**, not on projects. To touch the current project
+from inside it, use `--sub`. To act across every project in the campaign,
+use `all`.
 
-camp pull --sub
-camp push --sub
+```bash
+camp status              # campaign root
+camp status --sub        # current project (submodule or link)
+camp status all          # dashboard across every project
+
+camp pull all            # pull every project (works on submodules and links alike,
+                         # as long as the target directory is a git repo)
+camp push all            # push every project with pending pushes
+camp pull --sub          # pull the current project
+camp push --sub          # push the current project
 ```
 
 Use `all` commands only when broad workspace churn is intended.
@@ -43,6 +116,17 @@ camp project worktree remove <name>
 
 ## Common Mistakes
 
-- Assuming submodule commits should auto-update campaign-root pointers.
-- Running `camp pull`/`camp push` expecting submodule scope without `--sub`.
-- Passing worktree path to remove; command expects worktree name.
+- Silently running `camp project add` (or `add --local`) when the user
+  already had the repo cloned locally. Ask first — most users prefer
+  linking.
+- Assuming submodule commits should auto-update campaign-root pointers
+  (they don't — use `camp refs-sync` intentionally).
+- Running `camp pull` / `camp push` at campaign root and expecting it to
+  touch projects. It doesn't — that's the campaign's own git repo. Use
+  `--sub` for the current project or `all` to cross every project.
+- Passing a worktree path to `worktree remove`; the command expects the
+  worktree name.
+- Using `camp project remove` on a linked project when the safe command is
+  `camp project unlink`.
+- Telling a user they need a submodule to "use the project in the campaign"
+  — a link works for everything the user does on that machine.

--- a/internal/scaffold/campaign/templates/.campaign/skills/references/camp-command-contracts.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/references/camp-command-contracts.md.tmpl
@@ -35,6 +35,26 @@ history — another machine that clones the campaign will see that a link
 exists. What's machine-local is the symlink's **target**: the link only
 resolves on a device where the same filesystem path exists.
 
+## Other Project Operations
+
+```bash
+camp project list [--format table|simple|json]
+camp project new <name> [--no-commit]                   # scaffold new submodule project
+camp project run -p <name> -- <command>                 # run command inside a project
+camp project prune [<name>] [--dry-run] [--remote] [--remote-delete]
+camp project remote {list|add|set-url|remove|rename} [args] [-p <name>]
+```
+
+`camp fresh` is project-scoped (not a campaign-root command) — it resets
+a project's working state after a merge:
+
+```bash
+camp fresh [<name>]                         # checkout default, pull, prune
+camp fresh [<name>] --branch <branch>       # plus create a working branch
+camp fresh [<name>] --no-prune | --dry-run
+camp fresh all                              # run across every submodule
+```
+
 ## Submodule Commits
 
 ```bash

--- a/internal/scaffold/campaign/templates/.campaign/skills/references/camp-command-contracts.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/references/camp-command-contracts.md.tmpl
@@ -49,25 +49,26 @@ camp refs-sync projects/camp
 
 ```bash
 camp status           # campaign root git repo
-camp status --sub     # current project (submodule or linked)
-camp status all       # cross-project dashboard
+camp status --sub     # current submodule (errors on linked projects)
+camp status all       # dashboard across every submodule
 ```
 
 ## Pull/Push Scope
 
 `camp pull` and `camp push` without flags operate on the **campaign root
-repo**, not on projects. The `all` subcommand works across every project
-regardless of whether it's a submodule or a linked local directory — as
-long as the target is a git repo.
+repo**, not on projects. `--sub` acts on the current submodule, and `all`
+iterates every submodule. **These scope flags don't currently cover
+linked projects** — to work inside a link, cd in and use `git` directly,
+or use `camp project run -p <name> <cmd>`.
 
 ```bash
 camp pull             # campaign root
-camp pull --sub       # current project
-camp pull all         # every project in the campaign
+camp pull --sub       # current submodule
+camp pull all         # every submodule
 
 camp push             # campaign root
-camp push --sub       # current project
-camp push all         # every project with pending pushes
+camp push --sub       # current submodule
+camp push all         # every submodule with pending pushes
 ```
 
 ## Worktrees

--- a/internal/scaffold/campaign/templates/.campaign/skills/references/camp-command-contracts.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/references/camp-command-contracts.md.tmpl
@@ -24,13 +24,16 @@ camp project add --local <path> [--name <n>] [--campaign <name-or-id>]
 camp project link <path> [--name <n>] [--campaign <name-or-id>]
 camp project link                                        # link current directory
 
-# Remove
-camp project unlink [<name>]   # remove a link; external directory untouched
-camp project remove <name>     # remove a submodule (modifies campaign history)
+# Remove (works for both kinds)
+camp project remove <name>            # unlinks a link; deinits a submodule without touching disk
+camp project remove <name> --delete   # destructive — errors on links; deletes disk files for submodules
+camp project unlink [<name>]          # explicit unlink alias (links only)
 ```
 
-Linked projects are not versioned with the campaign and must exist at the
-same filesystem path on every device that opens the campaign.
+Linking records the `projects/<name>` symlink entry in campaign git
+history — another machine that clones the campaign will see that a link
+exists. What's machine-local is the symlink's **target**: the link only
+resolves on a device where the same filesystem path exists.
 
 ## Submodule Commits
 

--- a/internal/scaffold/campaign/templates/.campaign/skills/references/camp-command-contracts.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/references/camp-command-contracts.md.tmpl
@@ -11,6 +11,27 @@ camp go <shortcut> --print
 
 `cgo` changes shell directory. `camp go` resolves/prints paths.
 
+## Adding and Linking Projects
+
+```bash
+# Clone a remote repo as a git submodule under projects/
+camp project add <url> [--name <n>] [--campaign <name-or-id>]
+
+# Add an existing local directory as a git submodule (modifies campaign history)
+camp project add --local <path> [--name <n>] [--campaign <name-or-id>]
+
+# Link an existing local directory as a machine-local symlink under projects/
+camp project link <path> [--name <n>] [--campaign <name-or-id>]
+camp project link                                        # link current directory
+
+# Remove
+camp project unlink [<name>]   # remove a link; external directory untouched
+camp project remove <name>     # remove a submodule (modifies campaign history)
+```
+
+Linked projects are not versioned with the campaign and must exist at the
+same filesystem path on every device that opens the campaign.
+
 ## Submodule Commits
 
 ```bash
@@ -27,21 +48,26 @@ camp refs-sync projects/camp
 ## Status Scope
 
 ```bash
-camp status           # campaign root
-camp status --sub     # current submodule
-camp status all       # cross-project status
+camp status           # campaign root git repo
+camp status --sub     # current project (submodule or linked)
+camp status all       # cross-project dashboard
 ```
 
 ## Pull/Push Scope
 
+`camp pull` and `camp push` without flags operate on the **campaign root
+repo**, not on projects. The `all` subcommand works across every project
+regardless of whether it's a submodule or a linked local directory — as
+long as the target is a git repo.
+
 ```bash
 camp pull             # campaign root
-camp pull --sub       # current submodule
-camp pull all         # all repos
+camp pull --sub       # current project
+camp pull all         # every project in the campaign
 
 camp push             # campaign root
-camp push --sub       # current submodule
-camp push all         # all repos with pending pushes
+camp push --sub       # current project
+camp push all         # every project with pending pushes
 ```
 
 ## Worktrees


### PR DESCRIPTION
## Summary

Updates the embedded \`camp-projects\` skill template so AI agents understand when to reach for \`camp project add\` vs \`camp project link\`, and actively **ask the user** when the choice isn't obvious from context.

## Background

Most users don't want the complexity of git submodules. Linking is typically the better default when a project is already cloned on the user's machine. But submodules are still the right call when the campaign needs to travel across devices (linked projects only work where the linked path exists on the filesystem).

The prior skill template predated \`camp project link\` and described projects only as submodules, so agents would silently default to \`camp project add --local\` even when the user had no intent to version the project with the campaign.

## Changes

**\`internal/scaffold/campaign/templates/.campaign/skills/camp-projects/SKILL.md.tmpl\`**
- Broadened the front-matter description so the skill triggers on \"add / link / remove\" flows, not just submodule commits.
- Added a decision framework with three cases:
  - URL given → \`camp project add <url>\`
  - Already cloned locally → **ask the user**; link is the default recommendation, submodule only when the user explicitly wants multi-device use.
  - User wants multi-device → submodules are required; explain the tradeoff.
- Added a Remove section distinguishing safe \`unlink\` from history-modifying \`remove\`.
- Common Mistakes now includes the new pitfalls: silently adding as a submodule without asking, and telling users a submodule is required when a link would work fine.

**\`internal/scaffold/campaign/templates/.campaign/skills/references/camp-command-contracts.md.tmpl\`**
- New \"Adding and Linking Projects\" section with the exact command forms and flags, so the skill can cite the reference.
- Fixed the Pull/Push Scope section: \`camp pull\` / \`camp push\` without flags touch the campaign root repo (not projects). \`all\` works across every project regardless of whether it's a submodule or a linked local directory.
- Fixed the Status Scope wording: \`--sub\` acts on the current project (submodule or link), not exclusively submodules.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/scaffold/... ./internal/skills/...\` green
- [x] Rebuilt via \`just install stable\` and ran \`camp init\` in a fresh temp campaign — verified the rendered \`.campaign/skills/camp-projects/SKILL.md\` and \`.campaign/skills/references/camp-command-contracts.md\` contain the new content end to end.