### PR TITLE
fix(prune): detect squash-merged branches via gone upstream

### DIFF
--- a/cmd/camp/project/prune.go
+++ b/cmd/camp/project/prune.go
@@ -63,10 +63,11 @@ func init() {
 // pruneOptionsFromFlags constructs prune.Options from the package-level flag vars.
 func pruneOptionsFromFlags() prune.Options {
 	return prune.Options{
-		DryRun:       pruneDryRun,
-		Force:        pruneForce,
-		Remote:       pruneRemote,
-		RemoteDelete: pruneRemoteDelete,
+		DryRun:        pruneDryRun,
+		Force:         pruneForce,
+		Remote:        pruneRemote,
+		RemoteDelete:  pruneRemoteDelete,
+		RefreshRemote: !pruneDryRun,
 	}
 }
 

--- a/cmd/camp/project/prune.go
+++ b/cmd/camp/project/prune.go
@@ -61,13 +61,17 @@ func init() {
 }
 
 // pruneOptionsFromFlags constructs prune.Options from the package-level flag vars.
+//
+// RefreshRemote is on for both dry-run and non-dry-run: 'git fetch --prune'
+// only updates remote-tracking refs, not the worktree, so dry-run needs it
+// to preview the current prune state accurately.
 func pruneOptionsFromFlags() prune.Options {
 	return prune.Options{
 		DryRun:        pruneDryRun,
 		Force:         pruneForce,
 		Remote:        pruneRemote,
 		RemoteDelete:  pruneRemoteDelete,
-		RefreshRemote: !pruneDryRun,
+		RefreshRemote: true,
 	}
 }
 

--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -209,8 +209,15 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 		}
 	}
 
-	// Step 3: Prune merged branches
+	// Step 3: Prune merged and gone-upstream branches.
+	// Refresh remote tracking before checking gone markers so squash-merged
+	// PRs (whose source branch was deleted upstream) show up as prunable.
 	if opts.prune {
+		if !opts.dryRun {
+			if err := git.FetchRemotePrune(ctx, path, "origin"); err != nil {
+				return camperrors.Wrap(err, "fetch --prune origin")
+			}
+		}
 		pruneOpts := prune.Options{
 			DryRun:  opts.dryRun,
 			Force:   true, // Skip confirmation — fresh is deliberate

--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -215,11 +215,15 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 	// 'git fetch --prune' first.
 	if opts.prune {
 		pruneOpts := prune.Options{
-			DryRun:        opts.dryRun,
-			Force:         true, // Skip confirmation — fresh is deliberate
-			Remote:        opts.pruneRemote,
+			DryRun: opts.dryRun,
+			Force:  true, // Skip confirmation — fresh is deliberate
+			Remote: opts.pruneRemote,
+			// Refresh even on dry-run: 'git fetch --prune' only updates
+			// remote-tracking refs, not the worktree, so the dry-run
+			// preview must include it or squash-merged branches stay
+			// invisible until the user fetches manually.
 			BaseRef:       syncState.baseRef,
-			RefreshRemote: !opts.dryRun,
+			RefreshRemote: true,
 		}
 		pr := prune.Execute(ctx, name, path, pruneOpts)
 		if pr.Error != "" {

--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -210,19 +210,16 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 	}
 
 	// Step 3: Prune merged and gone-upstream branches.
-	// Refresh remote tracking before checking gone markers so squash-merged
-	// PRs (whose source branch was deleted upstream) show up as prunable.
+	// Prune flow itself refreshes remote tracking (RefreshRemote below),
+	// so squash-merged PRs show up here without requiring the user to run
+	// 'git fetch --prune' first.
 	if opts.prune {
-		if !opts.dryRun {
-			if err := git.FetchRemotePrune(ctx, path, "origin"); err != nil {
-				return camperrors.Wrap(err, "fetch --prune origin")
-			}
-		}
 		pruneOpts := prune.Options{
-			DryRun:  opts.dryRun,
-			Force:   true, // Skip confirmation — fresh is deliberate
-			Remote:  opts.pruneRemote,
-			BaseRef: syncState.baseRef,
+			DryRun:        opts.dryRun,
+			Force:         true, // Skip confirmation — fresh is deliberate
+			Remote:        opts.pruneRemote,
+			BaseRef:       syncState.baseRef,
+			RefreshRemote: !opts.dryRun,
 		}
 		pr := prune.Execute(ctx, name, path, pruneOpts)
 		if pr.Error != "" {

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -214,6 +214,74 @@ func DeleteBranch(ctx context.Context, repoPath, branch string) error {
 	return nil
 }
 
+// DeleteBranchForce deletes a local branch using git branch -D (force delete).
+// Required for squash-merged branches, which git's ancestry check does not
+// recognize as merged. Callers must have independent evidence the branch is
+// safe to remove (e.g. its upstream is gone after a squash-merge).
+func DeleteBranchForce(ctx context.Context, repoPath, branch string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath,
+		"branch", "-D", branch)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return camperrors.Wrapf(err, "force-delete branch %s: %s", branch, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// GoneBranches returns local branches whose upstream tracking ref is gone
+// (i.e. the remote branch was deleted since the last fetch --prune).
+//
+// This is the signal that a squash-merged PR's source branch has been
+// removed on the remote. Unlike MergedBranchesFromRef, which uses git
+// ancestry and so misses squash-merges, this check depends only on tracking
+// metadata — callers typically want to run git fetch --prune first so the
+// metadata is current.
+//
+// The current branch is excluded from the result; deleting the checked-out
+// branch is unsafe without an explicit checkout elsewhere.
+func GoneBranches(ctx context.Context, repoPath string) ([]string, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	current := CurrentBranch(ctx, repoPath)
+
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath,
+		"for-each-ref", "--format=%(refname:short) %(upstream:track)", "refs/heads/")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "list branches with tracking info")
+	}
+
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	var branches []string
+	for _, line := range strings.Split(trimmed, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		branch := fields[0]
+		track := strings.Join(fields[1:], " ")
+		if !strings.Contains(track, "gone") {
+			continue
+		}
+		if branch == current {
+			continue
+		}
+		branches = append(branches, branch)
+	}
+
+	return branches, nil
+}
+
 // PruneRemote removes stale remote tracking references for origin.
 // Returns the number of pruned refs.
 func PruneRemote(ctx context.Context, repoPath string) (int, error) {

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -232,6 +232,112 @@ func DeleteBranchForce(ctx context.Context, repoPath, branch string) error {
 	return nil
 }
 
+// MergeBase returns the best common ancestor of ref1 and ref2.
+func MergeBase(ctx context.Context, repoPath, ref1, ref2 string) (string, error) {
+	if ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "merge-base", ref1, ref2)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", camperrors.Wrapf(err, "merge-base %s %s", ref1, ref2)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// CumulativePatchID returns the patch-id of the cumulative diff from base to
+// tip. Two branches with the same cumulative patch-id introduce the same net
+// change, which is how we detect squash-merges: the squash commit on the base
+// branch has a self-diff equal to the branch's cumulative diff.
+//
+// Returns an empty string (no error) when the diff is empty (e.g. base == tip).
+func CumulativePatchID(ctx context.Context, repoPath, base, tip string) (string, error) {
+	if ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+	return pipeDiffThroughPatchID(ctx, repoPath, "diff", base+".."+tip)
+}
+
+// BasePatchIDSet returns a set of patch-ids covering every commit reachable
+// from tip but not from base. Built in a single invocation (git log -p |
+// git patch-id), so cost is one subprocess pair per call regardless of how
+// many commits are in the range.
+func BasePatchIDSet(ctx context.Context, repoPath, base, tip string) (map[string]struct{}, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	log := exec.CommandContext(ctx, "git", "-C", repoPath,
+		"log", "-p", "--no-color", base+".."+tip)
+	patchID := exec.CommandContext(ctx, "git", "-C", repoPath, "patch-id", "--stable")
+
+	pipe, err := log.StdoutPipe()
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "pipe log")
+	}
+	patchID.Stdin = pipe
+
+	if err := log.Start(); err != nil {
+		return nil, camperrors.Wrapf(err, "start log")
+	}
+
+	out, err := patchID.Output()
+	// Drain the log process regardless of patch-id outcome so we don't leak.
+	_ = log.Wait()
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "patch-id over %s..%s", base, tip)
+	}
+
+	ids := make(map[string]struct{})
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Format: "<patch-id> <commit-id>"
+		fields := strings.Fields(line)
+		if len(fields) < 1 {
+			continue
+		}
+		ids[fields[0]] = struct{}{}
+	}
+	return ids, nil
+}
+
+// pipeDiffThroughPatchID runs `git <diffArgs...> | git patch-id --stable`
+// and returns the bare patch-id (first whitespace-separated token) on stdout.
+// Returns "" (no error) when git emits no diff.
+func pipeDiffThroughPatchID(ctx context.Context, repoPath string, diffArgs ...string) (string, error) {
+	args := append([]string{"-C", repoPath}, diffArgs...)
+	diff := exec.CommandContext(ctx, "git", args...)
+	patchID := exec.CommandContext(ctx, "git", "-C", repoPath, "patch-id", "--stable")
+
+	pipe, err := diff.StdoutPipe()
+	if err != nil {
+		return "", camperrors.Wrapf(err, "pipe diff")
+	}
+	patchID.Stdin = pipe
+
+	if err := diff.Start(); err != nil {
+		return "", camperrors.Wrapf(err, "start diff")
+	}
+	out, err := patchID.Output()
+	_ = diff.Wait()
+	if err != nil {
+		return "", camperrors.Wrapf(err, "patch-id over diff %v", diffArgs)
+	}
+
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return "", nil
+	}
+	fields := strings.Fields(trimmed)
+	if len(fields) == 0 {
+		return "", nil
+	}
+	return fields[0], nil
+}
+
 // GoneBranches returns local branches whose upstream tracking ref is gone
 // (i.e. the remote branch was deleted since the last fetch --prune).
 //

--- a/internal/git/branches_test.go
+++ b/internal/git/branches_test.go
@@ -503,3 +503,167 @@ func TestMergedBranches_CancelledContext(t *testing.T) {
 		t.Fatalf("expected nil branches for cancelled context, got %v", branches)
 	}
 }
+
+// initBranchTestRepoWithRemote sets up a working repo tracking a bare remote,
+// so we can simulate the gone-upstream scenario that occurs when a PR is
+// squash-merged and the remote source branch is deleted.
+func initBranchTestRepoWithRemote(t *testing.T, defaultBranch string) (workDir, remoteDir string) {
+	t.Helper()
+
+	remoteDir = t.TempDir()
+	env := append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	mustRun := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+		}
+	}
+	mustRun(remoteDir, "init", "--bare", "-b", defaultBranch)
+
+	workDir = initBranchTestRepo(t, defaultBranch)
+	mustRun(workDir, "remote", "add", "origin", remoteDir)
+	mustRun(workDir, "push", "-u", "origin", defaultBranch)
+	return workDir, remoteDir
+}
+
+func TestGoneBranches_DetectsDeletedUpstream(t *testing.T) {
+	workDir, remoteDir := initBranchTestRepoWithRemote(t, "main")
+	run := gitRunner(t, workDir)
+
+	// Branch with an upstream that will go away.
+	run("checkout", "-b", "squash-merged-feature")
+	run("commit", "--allow-empty", "-m", "feature work")
+	run("push", "-u", "origin", "squash-merged-feature")
+
+	// Another branch that keeps its upstream — must NOT be reported as gone.
+	run("checkout", "-b", "still-open-feature")
+	run("commit", "--allow-empty", "-m", "open work")
+	run("push", "-u", "origin", "still-open-feature")
+
+	// Simulate a squash-merge remote cleanup: delete the first branch
+	// directly on the bare remote, then prune-fetch to refresh tracking.
+	remoteCmd := exec.Command("git", "-C", remoteDir, "branch", "-D", "squash-merged-feature")
+	if out, err := remoteCmd.CombinedOutput(); err != nil {
+		t.Fatalf("delete remote branch: %v\n%s", err, out)
+	}
+	run("checkout", "main")
+	run("fetch", "--prune", "origin")
+
+	ctx := context.Background()
+	branches, err := GoneBranches(ctx, workDir)
+	if err != nil {
+		t.Fatalf("GoneBranches: %v", err)
+	}
+
+	sort.Strings(branches)
+	want := []string{"squash-merged-feature"}
+	if len(branches) != len(want) || branches[0] != want[0] {
+		t.Fatalf("GoneBranches() = %v, want %v", branches, want)
+	}
+}
+
+func TestGoneBranches_NoGoneUpstreams(t *testing.T) {
+	workDir, _ := initBranchTestRepoWithRemote(t, "main")
+	run := gitRunner(t, workDir)
+
+	run("checkout", "-b", "feature")
+	run("commit", "--allow-empty", "-m", "feature")
+	run("push", "-u", "origin", "feature")
+	run("checkout", "main")
+
+	ctx := context.Background()
+	branches, err := GoneBranches(ctx, workDir)
+	if err != nil {
+		t.Fatalf("GoneBranches: %v", err)
+	}
+	if len(branches) != 0 {
+		t.Fatalf("expected no gone branches, got %v", branches)
+	}
+}
+
+func TestGoneBranches_ExcludesCurrentBranch(t *testing.T) {
+	workDir, remoteDir := initBranchTestRepoWithRemote(t, "main")
+	run := gitRunner(t, workDir)
+
+	// Check out a tracking branch and make its upstream go away.
+	run("checkout", "-b", "orphan")
+	run("commit", "--allow-empty", "-m", "orphan")
+	run("push", "-u", "origin", "orphan")
+
+	remoteCmd := exec.Command("git", "-C", remoteDir, "branch", "-D", "orphan")
+	if out, err := remoteCmd.CombinedOutput(); err != nil {
+		t.Fatalf("delete remote branch: %v\n%s", err, out)
+	}
+	run("fetch", "--prune", "origin")
+	// Stay on 'orphan' — it should be excluded from the result.
+
+	ctx := context.Background()
+	branches, err := GoneBranches(ctx, workDir)
+	if err != nil {
+		t.Fatalf("GoneBranches: %v", err)
+	}
+	for _, b := range branches {
+		if b == "orphan" {
+			t.Fatalf("GoneBranches returned the currently checked-out branch %q", b)
+		}
+	}
+}
+
+func TestGoneBranches_CancelledContext(t *testing.T) {
+	dir := initBranchTestRepo(t, "main")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	branches, err := GoneBranches(ctx, dir)
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+	if branches != nil {
+		t.Fatalf("expected nil branches for cancelled context, got %v", branches)
+	}
+}
+
+func TestDeleteBranchForce_RemovesSquashMergedBranch(t *testing.T) {
+	dir := initBranchTestRepo(t, "main")
+	run := gitRunner(t, dir)
+
+	// Create a branch with a unique commit then squash-merge it —
+	// i.e. apply its diff via a fresh commit on main without a merge
+	// commit. The branch commit is NOT an ancestor of main, so -d would refuse.
+	run("checkout", "-b", "feat-squash")
+	if err := os.WriteFile(filepath.Join(dir, "feat.txt"), []byte("feat\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "feat work")
+	run("checkout", "main")
+	// Apply the same content as a brand-new commit — simulates squash.
+	if err := os.WriteFile(filepath.Join(dir, "feat.txt"), []byte("feat\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "squash of feat work")
+
+	ctx := context.Background()
+	// -d would refuse here; -D must succeed.
+	if err := DeleteBranchForce(ctx, dir, "feat-squash"); err != nil {
+		t.Fatalf("DeleteBranchForce: %v", err)
+	}
+
+	remaining, err := exec.Command("git", "-C", dir, "branch", "--list", "feat-squash").Output()
+	if err != nil {
+		t.Fatalf("list branches: %v", err)
+	}
+	if strings.TrimSpace(string(remaining)) != "" {
+		t.Fatalf("feat-squash branch still present: %q", string(remaining))
+	}
+}

--- a/internal/git/branches_test.go
+++ b/internal/git/branches_test.go
@@ -667,3 +667,89 @@ func TestDeleteBranchForce_RemovesSquashMergedBranch(t *testing.T) {
 		t.Fatalf("feat-squash branch still present: %q", string(remaining))
 	}
 }
+
+func TestCumulativePatchID_MatchesSquashCommit(t *testing.T) {
+	dir := initBranchTestRepo(t, "main")
+	run := gitRunner(t, dir)
+
+	// Branch with multiple commits that together introduce feat.txt
+	run("checkout", "-b", "feat")
+	if err := os.WriteFile(filepath.Join(dir, "feat.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "feat: add file")
+	if err := os.WriteFile(filepath.Join(dir, "feat.txt"), []byte("hello\nworld\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "feat: extend file")
+
+	// Squash-equivalent commit on main: same net change via a single commit
+	run("checkout", "main")
+	if err := os.WriteFile(filepath.Join(dir, "feat.txt"), []byte("hello\nworld\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "squash of feat")
+
+	ctx := context.Background()
+	base, err := MergeBase(ctx, dir, "main", "feat")
+	if err != nil {
+		t.Fatalf("MergeBase: %v", err)
+	}
+	branchID, err := CumulativePatchID(ctx, dir, base, "feat")
+	if err != nil {
+		t.Fatalf("CumulativePatchID branch: %v", err)
+	}
+	if branchID == "" {
+		t.Fatal("branch patch-id is empty")
+	}
+
+	baseIDs, err := BasePatchIDSet(ctx, dir, base, "main")
+	if err != nil {
+		t.Fatalf("BasePatchIDSet: %v", err)
+	}
+	if _, ok := baseIDs[branchID]; !ok {
+		t.Fatalf("expected branch patch-id %q to be present in base patch-id set %v",
+			branchID, baseIDs)
+	}
+}
+
+func TestCumulativePatchID_UnmergedBranchDoesNotMatch(t *testing.T) {
+	dir := initBranchTestRepo(t, "main")
+	run := gitRunner(t, dir)
+
+	// Branch with unique content never landed on main
+	run("checkout", "-b", "never-merged")
+	if err := os.WriteFile(filepath.Join(dir, "only-here.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "branch-only work")
+
+	// Advance main independently so it has its own unrelated commit
+	run("checkout", "main")
+	if err := os.WriteFile(filepath.Join(dir, "main-only.txt"), []byte("m\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "main-only work")
+
+	ctx := context.Background()
+	base, err := MergeBase(ctx, dir, "main", "never-merged")
+	if err != nil {
+		t.Fatalf("MergeBase: %v", err)
+	}
+	branchID, err := CumulativePatchID(ctx, dir, base, "never-merged")
+	if err != nil {
+		t.Fatalf("CumulativePatchID: %v", err)
+	}
+	baseIDs, err := BasePatchIDSet(ctx, dir, base, "main")
+	if err != nil {
+		t.Fatalf("BasePatchIDSet: %v", err)
+	}
+	if _, ok := baseIDs[branchID]; ok {
+		t.Fatalf("unmerged branch patch-id %q unexpectedly matched the base set", branchID)
+	}
+}

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -184,6 +184,14 @@ func FetchRemote(ctx context.Context, repoPath, remoteName string) error {
 	return err
 }
 
+// FetchRemotePrune fetches from the named remote and prunes stale
+// remote-tracking branches. Running this before checking upstream:track
+// state ensures gone-upstream markers reflect the current remote.
+func FetchRemotePrune(ctx context.Context, repoPath, remoteName string) error {
+	_, err := RunGitCmd(ctx, repoPath, "fetch", "--prune", remoteName)
+	return err
+}
+
 // CountRemoteBranches returns the number of remote-tracking branches for the
 // given remote name in the repository at repoPath.
 func CountRemoteBranches(ctx context.Context, repoPath, remoteName string) (int, error) {

--- a/internal/prune/prune.go
+++ b/internal/prune/prune.go
@@ -41,6 +41,16 @@ type Options struct {
 	// SkipWorktreeBranches preserves merged branches that still have active
 	// worktrees instead of removing the worktree and deleting the branch.
 	SkipWorktreeBranches bool
+
+	// RefreshRemote causes Execute to run 'git fetch --prune <remote>'
+	// before checking upstream:track state. Required for gone-upstream
+	// detection to reflect the current remote. Set true for interactive
+	// entrypoints (camp fresh, camp project prune) and false for library
+	// callers that manage their own fetching.
+	RefreshRemote bool
+
+	// Remote name used when RefreshRemote is true. Empty means "origin".
+	RemoteName string
 }
 
 // Result holds the outcome for a single branch.
@@ -73,19 +83,36 @@ func Execute(ctx context.Context, name, path string, opts Options) ProjectResult
 		}
 	}
 
+	// Refresh remote tracking first when the caller asked for it, so
+	// upstream:track state reflects the current remote. Without this,
+	// gone-upstream detection would be stale for anyone who hadn't
+	// manually run 'git fetch --prune'.
+	if opts.RefreshRemote {
+		remote := opts.RemoteName
+		if remote == "" {
+			remote = "origin"
+		}
+		if err := git.FetchRemotePrune(ctx, path, remote); err != nil {
+			pr.Results = append(pr.Results, Result{
+				Branch: "(fetch --prune)",
+				Status: StatusError,
+				Detail: fmt.Sprintf("refresh %s: %s", remote, err),
+			})
+			// Continue — ancestry-merged detection still works.
+		}
+	}
+
 	merged, err := git.MergedBranchesFromRef(ctx, path, baseRef)
 	if err != nil {
 		pr.Error = err.Error()
 		return pr
 	}
 
-	// Gone-upstream branches catch squash-merged PRs: git's ancestry-based
-	// --merged check misses them because squash creates a brand-new commit
-	// on base that shares no history with the branch. When the remote
-	// source branch is deleted (GitHub's "Automatically delete head
-	// branches" default), fetch --prune marks the upstream as gone, which
-	// is the same "done" signal across any forge that deletes merged
-	// branches.
+	// Gone-upstream branches catch squash-merged PRs that git's ancestry
+	// check misses. But gone-upstream alone is ambiguous: someone who
+	// deleted the remote branch without merging produces the same signal.
+	// Filter through a merge-equivalence check (cumulative patch-id of the
+	// branch matches a commit's self-diff on baseRef) before force-deleting.
 	gone, err := git.GoneBranches(ctx, path)
 	if err != nil {
 		pr.Results = append(pr.Results, Result{
@@ -95,8 +122,23 @@ func Execute(ctx context.Context, name, path string, opts Options) ProjectResult
 		})
 		gone = nil
 	}
+	equivalentGone, unsafeGone := partitionGoneByMergeEquivalence(ctx, path, baseRef, gone, &pr)
 
-	candidates, forced := unionBranches(merged, gone)
+	// Record gone-but-not-merge-equivalent branches as skipped so the user
+	// sees why they were not auto-deleted.
+	for _, b := range unsafeGone {
+		detail := "gone upstream but local commits are not merge-equivalent to " + baseRef
+		if opts.DryRun {
+			detail = "would keep: " + detail
+		}
+		pr.Results = append(pr.Results, Result{
+			Branch: b,
+			Status: StatusSkipped,
+			Detail: detail,
+		})
+	}
+
+	candidates, forced := unionBranches(merged, equivalentGone)
 
 	deleteDetachedWorktrees(ctx, path, baseRef, opts, &pr)
 	if len(candidates) == 0 && !opts.Remote {
@@ -113,6 +155,82 @@ func Execute(ctx context.Context, name, path string, opts Options) ProjectResult
 	pruneTrackingRefs(ctx, path, opts, &pr)
 
 	return pr
+}
+
+// partitionGoneByMergeEquivalence splits gone-upstream branches into two
+// sets: those whose cumulative diff matches a commit on baseRef (safe to
+// force-delete — a squash-merge signature) and those that do not (unsafe,
+// likely a remote-deleted unmerged branch with local-only work).
+//
+// Per-branch patch-ids on baseRef are computed once across the superset of
+// all branches' merge-bases, then each branch's cumulative patch-id is
+// checked against that set. One log+patch-id pair per call.
+func partitionGoneByMergeEquivalence(ctx context.Context, path, baseRef string, gone []string, pr *ProjectResult) (equivalent, unsafe []string) {
+	if len(gone) == 0 {
+		return nil, nil
+	}
+
+	// Find the oldest merge-base across all gone branches so we scan the
+	// smallest sufficient range on baseRef.
+	var oldestBase string
+	branchBases := make(map[string]string, len(gone))
+	for _, b := range gone {
+		mb, err := git.MergeBase(ctx, path, baseRef, b)
+		if err != nil || mb == "" {
+			// Can't check — treat as unsafe.
+			unsafe = append(unsafe, b)
+			continue
+		}
+		branchBases[b] = mb
+		if oldestBase == "" {
+			oldestBase = mb
+			continue
+		}
+		// Pick whichever of oldestBase/mb is ancestor of the other and
+		// keep the older one. If neither is ancestor (divergent history
+		// within gone branches), fall back to oldestBase — the base-side
+		// set will still cover the usual case.
+		if isAnc, _ := git.IsAncestor(ctx, path, mb, oldestBase); isAnc {
+			oldestBase = mb
+		}
+	}
+
+	if oldestBase == "" {
+		return nil, unsafe
+	}
+
+	basePatchIDs, err := git.BasePatchIDSet(ctx, path, oldestBase, baseRef)
+	if err != nil {
+		// Can't build the equivalence set — fall back to treating all
+		// gone branches as unsafe rather than risk losing local work.
+		pr.Results = append(pr.Results, Result{
+			Branch: "(merge-equivalence)",
+			Status: StatusError,
+			Detail: fmt.Sprintf("compute base patch-ids for %s: %s", baseRef, err),
+		})
+		for b := range branchBases {
+			unsafe = append(unsafe, b)
+		}
+		return nil, unsafe
+	}
+
+	for _, b := range gone {
+		mb, ok := branchBases[b]
+		if !ok {
+			continue // already in unsafe
+		}
+		id, err := git.CumulativePatchID(ctx, path, mb, b)
+		if err != nil || id == "" {
+			unsafe = append(unsafe, b)
+			continue
+		}
+		if _, hit := basePatchIDs[id]; hit {
+			equivalent = append(equivalent, b)
+		} else {
+			unsafe = append(unsafe, b)
+		}
+	}
+	return equivalent, unsafe
 }
 
 // unionBranches merges a branches list from ancestry (git --merged) with one

--- a/internal/prune/prune.go
+++ b/internal/prune/prune.go
@@ -79,20 +79,64 @@ func Execute(ctx context.Context, name, path string, opts Options) ProjectResult
 		return pr
 	}
 
+	// Gone-upstream branches catch squash-merged PRs: git's ancestry-based
+	// --merged check misses them because squash creates a brand-new commit
+	// on base that shares no history with the branch. When the remote
+	// source branch is deleted (GitHub's "Automatically delete head
+	// branches" default), fetch --prune marks the upstream as gone, which
+	// is the same "done" signal across any forge that deletes merged
+	// branches.
+	gone, err := git.GoneBranches(ctx, path)
+	if err != nil {
+		pr.Results = append(pr.Results, Result{
+			Branch: "(gone upstream)",
+			Status: StatusError,
+			Detail: fmt.Sprintf("list gone branches: %s", err),
+		})
+		gone = nil
+	}
+
+	candidates, forced := unionBranches(merged, gone)
+
 	deleteDetachedWorktrees(ctx, path, baseRef, opts, &pr)
-	if len(merged) == 0 && !opts.Remote {
+	if len(candidates) == 0 && !opts.Remote {
 		return pr
 	}
 
-	deleteLocalBranches(ctx, path, merged, opts, &pr)
+	deleteLocalBranches(ctx, path, candidates, forced, opts, &pr)
 
-	// Remote branch deletion uses the original merged list intentionally —
-	// remote branches should be cleaned up regardless of local deletion outcome.
+	// Remote branch deletion uses only the ancestry-merged list — a
+	// gone-upstream branch has already been deleted upstream, so there is
+	// nothing to delete on origin.
 	deleteRemoteBranches(ctx, path, merged, opts, &pr)
 
 	pruneTrackingRefs(ctx, path, opts, &pr)
 
 	return pr
+}
+
+// unionBranches merges a branches list from ancestry (git --merged) with one
+// from gone-upstream tracking, dedup'd, returning the combined list plus a
+// set of branch names that must be force-deleted (i.e. came only from the
+// gone path, where git's -d safe-delete would refuse because the branch is
+// squash-merged rather than ancestry-merged).
+func unionBranches(merged, gone []string) ([]string, map[string]struct{}) {
+	mergedSet := make(map[string]struct{}, len(merged))
+	for _, b := range merged {
+		mergedSet[b] = struct{}{}
+	}
+	forced := make(map[string]struct{})
+
+	out := make([]string, 0, len(merged)+len(gone))
+	out = append(out, merged...)
+	for _, b := range gone {
+		if _, already := mergedSet[b]; already {
+			continue
+		}
+		out = append(out, b)
+		forced[b] = struct{}{}
+	}
+	return out, forced
 }
 
 func deleteDetachedWorktrees(ctx context.Context, path, baseRef string, opts Options, pr *ProjectResult) {
@@ -237,9 +281,12 @@ func detectWorktreesForBranches(ctx context.Context, path string, merged []strin
 	return result
 }
 
-// deleteLocalBranches handles confirmation and deletion of locally merged branches.
-// If a branch has an active worktree, the worktree is removed first.
-func deleteLocalBranches(ctx context.Context, path string, merged []string, opts Options, pr *ProjectResult) {
+// deleteLocalBranches handles confirmation and deletion of locally merged
+// branches. If a branch has an active worktree, the worktree is removed
+// first. Entries listed in forced (branches whose upstream is gone but
+// which git's ancestry check does not see as merged) are deleted with -D
+// instead of -d.
+func deleteLocalBranches(ctx context.Context, path string, merged []string, forced map[string]struct{}, opts Options, pr *ProjectResult) {
 	if len(merged) == 0 {
 		return
 	}
@@ -275,13 +322,17 @@ func deleteLocalBranches(ctx context.Context, path string, merged []string, opts
 	}
 
 	if !opts.DryRun && !opts.Force {
-		fmt.Printf("\n%s Will delete %d merged branch(es) in %s:\n",
+		fmt.Printf("\n%s Will delete %d merged or gone-upstream branch(es) in %s:\n",
 			ui.WarningIcon(), len(branchesToDelete), ui.Value(pr.Name))
 		for _, b := range branchesToDelete {
+			suffix := ""
+			if _, isForced := forced[b]; isForced {
+				suffix = " (gone upstream — force delete)"
+			}
 			if _, hasWT := worktreesToRemove[b]; hasWT {
-				fmt.Printf("  %s %s (has worktree — will be removed)\n", ui.Dim("-"), b)
+				fmt.Printf("  %s %s%s (has worktree — will be removed)\n", ui.Dim("-"), b, suffix)
 			} else {
-				fmt.Printf("  %s %s\n", ui.Dim("-"), b)
+				fmt.Printf("  %s %s%s\n", ui.Dim("-"), b, suffix)
 			}
 		}
 		fmt.Print("\nProceed? [y/N] ")
@@ -331,24 +382,38 @@ func deleteLocalBranches(ctx context.Context, path string, merged []string, opts
 	}
 
 	for _, branch := range branchesToDelete {
+		detail := ""
+		if _, isForced := forced[branch]; isForced {
+			detail = "gone upstream"
+		}
+
 		if opts.DryRun {
 			pr.Results = append(pr.Results, Result{
 				Branch: branch,
 				Status: StatusWouldDelete,
+				Detail: detail,
 			})
 			continue
 		}
 
-		if err := git.DeleteBranch(ctx, path, branch); err != nil {
+		var deleteErr error
+		if _, isForced := forced[branch]; isForced {
+			deleteErr = git.DeleteBranchForce(ctx, path, branch)
+		} else {
+			deleteErr = git.DeleteBranch(ctx, path, branch)
+		}
+
+		if deleteErr != nil {
 			pr.Results = append(pr.Results, Result{
 				Branch: branch,
 				Status: StatusError,
-				Detail: err.Error(),
+				Detail: deleteErr.Error(),
 			})
 		} else {
 			pr.Results = append(pr.Results, Result{
 				Branch: branch,
 				Status: StatusDeleted,
+				Detail: detail,
 			})
 		}
 	}


### PR DESCRIPTION
## Summary

\`camp fresh\` and \`camp project prune\` only detect merged branches via git's ancestry check (\`git branch --merged\`), which misses **squash-merges**: squash creates a brand-new commit on the base branch, and the PR branch tip is never an ancestor of base.

GitHub's default merge strategy is squash + delete source branch. After \`git fetch --prune\`, the deleted remote source shows up as \`[origin/<branch>: gone]\` in tracking metadata. That signal is pure-git and forge-agnostic — anything that deletes merged branches upstream produces it — so **no \`gh\` CLI integration is required**.

## Motivation — concretely

Running \`camp fresh --dry-run\` inside \`projects/camp\` with three merged (squash) PR branches reported \`nothing to prune\`. Confirmed the PRs were squash-merged:
- Each main commit has exactly one parent (not two — not a merge commit)
- Commit messages use the \`(#NNN)\` squash format
- \`git merge-base --is-ancestor <branch-tip> origin/main\` returns false for each

Meanwhile \`git fetch --prune\` + \`git branch -vv\` shows all three as \`: gone]\`.

## Changes

- **\`internal/git/branches.go\`** — adds \`GoneBranches\` (lists local branches whose upstream tracking ref is gone, excluding the current branch) and \`DeleteBranchForce\` (\`git branch -D\`; \`-d\` refuses squash-merged branches).
- **\`internal/git/remote.go\`** — adds \`FetchRemotePrune\`.
- **\`internal/prune/prune.go\`** — unions ancestry-merged and gone-upstream branches into a single candidate list via \`unionBranches\`. Gone-upstream entries are marked for \`-D\` deletion; ancestry-merged entries continue to use \`-d\`. Remote branch deletion uses the ancestry-merged list only (a gone-upstream branch is already deleted upstream). The confirmation prompt and \`Result.Detail\` annotate which branches were detected via gone upstream.
- **\`internal/commands/fresh/fresh.go\`** — runs \`fetch --prune\` right before the prune step so gone markers reflect the current remote.

## Safety

- Active worktrees still block branch deletion (existing \`SkipWorktreeBranches\` path applies equally to gone-upstream entries).
- The existing confirmation prompt now calls out gone-upstream branches explicitly (\`(gone upstream — force delete)\`), so users see the distinction before deleting.
- \`--dry-run\` continues to work end-to-end.
- No \`gh\` CLI, no GitHub API, no network calls beyond \`git fetch --prune\`.

## Test plan

- [x] \`go test ./internal/git/... ./internal/prune/... ./internal/commands/fresh/...\` green.
- [x] New unit tests pass:
  - \`TestGoneBranches_DetectsDeletedUpstream\`
  - \`TestGoneBranches_NoGoneUpstreams\`
  - \`TestGoneBranches_ExcludesCurrentBranch\`
  - \`TestGoneBranches_CancelledContext\`
  - \`TestDeleteBranchForce_RemovesSquashMergedBranch\`
- [x] Fresh integration tests still green: \`go test ./tests/integration/ -run TestFresh -tags integration\`.