### PR TITLE
fix(project): resolve nested submodules correctly in ResolveFromCwd

### DIFF
--- a/internal/project/list.go
+++ b/internal/project/list.go
@@ -223,10 +223,11 @@ func latestCommitDate(ctx context.Context, absPath string) string {
 	return strings.TrimSpace(string(output))
 }
 
-// deduplicateByRemoteURL groups projects by git remote URL and keeps only the
-// copy with the most recent commit. Projects with empty URL are always kept.
-// Monorepo subprojects skip URL-based dedup (they share the parent's URL) but
-// are dropped if a standalone project with the same base name exists.
+// deduplicateByRemoteURL groups standalone projects by git remote URL and keeps
+// only the copy with the most recent commit. Projects with empty URL are always
+// kept. Monorepo subprojects are always kept — they are separate checkouts that
+// can sit on different branches/commits than any standalone project with the
+// same base name, and callers (e.g. `camp fresh`) need to target them directly.
 func deduplicateByRemoteURL(ctx context.Context, campaignRoot string, projects []Project) []Project {
 	if ctx.Err() != nil {
 		return projects
@@ -236,17 +237,9 @@ func deduplicateByRemoteURL(ctx context.Context, campaignRoot string, projects [
 	bestIdx := make(map[string]int)
 	bestDate := make(map[string]string)
 
-	// Collect standalone project names for monorepo dedup.
-	standaloneNames := make(map[string]bool)
-	for _, p := range projects {
-		if p.MonorepoRoot == "" {
-			standaloneNames[p.Name] = true
-		}
-	}
-
 	for i, p := range projects {
-		// Skip monorepo subprojects — they share the parent's URL and are
-		// deduped by name against standalone repos instead.
+		// Monorepo subprojects share the parent's URL. They are not subject to
+		// URL-based dedup — each nested submodule is an independent checkout.
 		if p.URL == "" || p.MonorepoRoot != "" {
 			continue
 		}
@@ -278,11 +271,7 @@ func deduplicateByRemoteURL(ctx context.Context, campaignRoot string, projects [
 		case p.URL == "":
 			result = append(result, p)
 		case p.MonorepoRoot != "":
-			// Keep monorepo subproject only if no standalone repo has the same base name.
-			baseName := filepath.Base(p.Path)
-			if !standaloneNames[baseName] {
-				result = append(result, p)
-			}
+			result = append(result, p)
 		case keep[i]:
 			result = append(result, p)
 		}

--- a/internal/project/list_test.go
+++ b/internal/project/list_test.go
@@ -398,9 +398,12 @@ func TestList_StandaloneNotExpanded(t *testing.T) {
 	}
 }
 
-func TestList_GitmodulesSubmoduleDedupAgainstStandalone(t *testing.T) {
-	// When a .gitmodules repo has a submodule named "foo" and there's also
-	// a standalone project named "foo", the submodule entry should be deduped.
+func TestList_GitmodulesSubmoduleKeptAlongsideStandalone(t *testing.T) {
+	// When a .gitmodules repo has a submodule named "foo" and there's also a
+	// standalone project named "foo", both entries must appear: nested
+	// submodules are independent checkouts that can be on different branches
+	// or commits, and `camp fresh` / `camp <cmd> --project` need to target
+	// them explicitly via the `mono@foo` qualified name.
 	tmpDir := t.TempDir()
 	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
 
@@ -442,22 +445,15 @@ func TestList_GitmodulesSubmoduleDedupAgainstStandalone(t *testing.T) {
 		projectMap[p.Name] = p
 	}
 
-	// "foo" standalone should exist
 	if _, ok := projectMap["foo"]; !ok {
 		t.Error("missing standalone 'foo' project")
 	}
-
-	// "mono@foo" should be deduped (standalone "foo" takes precedence)
-	if _, ok := projectMap["mono@foo"]; ok {
-		t.Error("mono@foo should be deduped against standalone 'foo'")
+	if _, ok := projectMap["mono@foo"]; !ok {
+		t.Error("mono@foo must be kept — nested submodule is a separate checkout")
 	}
-
-	// "mono@bar" should exist (no standalone "bar")
 	if _, ok := projectMap["mono@bar"]; !ok {
 		t.Error("missing mono@bar subproject")
 	}
-
-	// "mono" root entry should exist
 	if _, ok := projectMap["mono"]; !ok {
 		t.Error("missing mono root entry")
 	}

--- a/internal/project/resolve.go
+++ b/internal/project/resolve.go
@@ -98,17 +98,43 @@ func ResolveFromCwd(ctx context.Context, campRoot string) (*ResolveResult, error
 		return nil, camperrors.Wrap(listErr, "failed to list projects")
 	}
 
-	for _, proj := range projects {
-		projectPath := ResolveProjectPath(campRoot, proj)
-		if isPathWithin(resolvedCwd, projectPath) || isPathWithin(cwd, filepath.Join(campRoot, proj.Path)) {
-			return &ResolveResult{
-				Name:        proj.Name,
-				Path:        projectPath,
-				LogicalPath: proj.Path,
-				Source:      proj.Source,
-				LinkedPath:  proj.LinkedPath,
-			}, nil
+	// Find the project with the longest (deepest) matching path. This ensures
+	// nested submodules win over their parent monorepo — e.g. from cwd inside
+	// `projects/mono/sub`, the resolver returns `mono@sub`, not `mono`.
+	var (
+		bestProject *Project
+		bestPath    string
+		bestLen     int
+	)
+	for i := range projects {
+		proj := &projects[i]
+		projectPath := ResolveProjectPath(campRoot, *proj)
+		logicalPath := filepath.Join(campRoot, proj.Path)
+
+		var match string
+		switch {
+		case isPathWithin(resolvedCwd, projectPath):
+			match = projectPath
+		case isPathWithin(cwd, logicalPath):
+			match = logicalPath
 		}
+		if match == "" {
+			continue
+		}
+		if len(match) > bestLen {
+			bestProject = proj
+			bestPath = projectPath
+			bestLen = len(match)
+		}
+	}
+	if bestProject != nil {
+		return &ResolveResult{
+			Name:        bestProject.Name,
+			Path:        bestPath,
+			LogicalPath: bestProject.Path,
+			Source:      bestProject.Source,
+			LinkedPath:  bestProject.LinkedPath,
+		}, nil
 	}
 
 	projectRoot, isSubmodule, err := git.FindProjectRootWithType(cwd)

--- a/internal/project/resolve_test.go
+++ b/internal/project/resolve_test.go
@@ -141,6 +141,62 @@ func TestResolveFromCwd(t *testing.T) {
 	}
 }
 
+// TestResolveFromCwd_NestedSubmoduleWins exercises the bug that caused
+// `camp fresh` to silently target the outer monorepo when run from inside a
+// nested submodule. The resolver must pick the project with the deepest (longest)
+// matching path, not the first one iterated.
+func TestResolveFromCwd_NestedSubmoduleWins(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	projectsDir := filepath.Join(tmpDir, "projects")
+	if err := os.MkdirAll(projectsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Monorepo with one submodule named "obey"
+	mono := filepath.Join(projectsDir, "mono")
+	if err := os.MkdirAll(mono, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoWithRemoteAndCommit(t, mono, "git@github.com:test/mono.git", "mono init")
+	writeGitmodules(t, mono, map[string]string{"obey": "obey"})
+
+	// Nested submodule checkout with its own .git
+	sub := filepath.Join(mono, "obey")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoWithRemoteAndCommit(t, sub, "git@github.com:test/obey.git", "obey init")
+	os.WriteFile(filepath.Join(sub, "go.mod"), []byte("module obey"), 0o644)
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	if err := os.Chdir(sub); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	result, err := ResolveFromCwd(ctx, tmpDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Name != "mono@obey" {
+		t.Fatalf("resolved name = %q, want %q (deepest-match should pick nested submodule over parent)", result.Name, "mono@obey")
+	}
+
+	wantPath, _ := filepath.EvalSymlinks(sub)
+	gotPath, _ := filepath.EvalSymlinks(result.Path)
+	if gotPath != wantPath {
+		t.Fatalf("resolved path = %q, want %q", gotPath, wantPath)
+	}
+}
+
 func TestResolve_WithFlag(t *testing.T) {
 	campRoot := setupTestCampaign(t, "api", "web")
 


### PR DESCRIPTION
## Summary

When running `camp fresh` (or any command relying on `ResolveFromCwd`) from inside a nested submodule checkout — e.g. `projects/obey-platform-monorepo/obey/` — the resolver silently targeted the *outer* monorepo instead of the nested submodule. The parent was on `main`, so every invocation reported

```
── Checkout main                     already on it
── Pull (ff-only)                  up-to-date
── Prune merged branches           nothing to prune
Fresh! Synced to main.
```

…while the user's actual working repo sat on a feature branch with stale merged branches and orphan worktrees that never got cleaned up.

## Root causes

1. **First-match resolver.** `ResolveFromCwd` in `internal/project/resolve.go` iterated projects and returned the first whose path contained cwd. Iteration order put the outer monorepo ahead of its submodule entries, so the outer always won.
2. **Base-name dedup dropping nested submodules.** `deduplicateByRemoteURL` in `internal/project/list.go` removed any monorepo subproject whose base name matched a standalone project. That meant `obey-platform-monorepo@obey` was dropped whenever top-level `obey` existed, even though the two are separate checkouts on potentially different branches/commits.

## Fix

- `ResolveFromCwd` now picks the project with the **longest (deepest) matching path**, so nested submodules win over their parent monorepos.
- Nested submodules are always kept in the project list. Only standalone projects are subject to URL-based dedup.

## Behavior change

`camp project list` now includes nested submodule entries that collide by base name with a standalone project (e.g. `obey-platform-monorepo@obey`, `@fest`, `@camp`, `@obey-shared`). Callers that care about dedup can filter on `Project.MonorepoRoot`. This is intentional — the two checkouts are operationally independent and `camp fresh` / `camp <cmd> --project mono@foo` need to address them directly.

## Verification

Repro against obey-campaign after the fix:

```
$ cd projects/obey-platform-monorepo/obey
$ camp fresh --dry-run
  obey-platform-monorepo@obey (dry-run)
  ── Checkout main                     already on it
  ── Would pull (ff-only)
  ── Prune merged branches           would delete: codex/issue-56-system-prompt-templates,
      codex/provider-list-command, codex/review-obey-pr58, lr/camputil-migration,
      lr/codex-output-schema, lr/obey-smoke-fixes; would remove 8 worktree(s)
```

From the monorepo root, resolution still correctly targets the parent monorepo — no regression.

## Test plan

- [x] `just test unit` — 2188/2188 passing
- [x] New `TestResolveFromCwd_NestedSubmoduleWins` covers the resolver fix.
- [x] Flipped `TestList_GitmodulesSubmoduleDedupAgainstStandalone` → `TestList_GitmodulesSubmoduleKeptAlongsideStandalone` to assert the new (correct) behavior.
- [x] Smoke-tested end-to-end with dev build against `projects/obey-platform-monorepo/obey`.