### PR TITLE
Remove camp init --skip-fest flag (#254)

### DIFF
--- a/cmd/camp/init/command.go
+++ b/cmd/camp/init/command.go
@@ -77,12 +77,6 @@ Use --no-git to skip git initialization.`,
 	return cmd
 }
 
-// envSkipFest is an unsupported, test-only escape hatch that bypasses
-// Festival Methodology initialization. It is intentionally not exposed
-// as a CLI flag — production users should always receive Festival
-// scaffolding so that the documented `fest next` first-run path works.
-const envSkipFest = "CAMP_INIT_SKIP_FEST"
-
 // Params is the full set of inputs the init flow needs, already
 // parsed from flags or constructed by another command (e.g., create).
 type Params struct {
@@ -265,10 +259,9 @@ func RunFlow(ctx context.Context, p Params, w Writers, isInteractive bool) error
 		commitRepairChanges(ctx, result, opts.RepairPlan, migrationCount, w)
 	}
 
-	// Initialize Festival Methodology (unless dry-run or test-only env override).
-	skipFest := os.Getenv(envSkipFest) != ""
+	// Initialize Festival Methodology (unless dry-run).
 	var festInitialized bool
-	if !p.DryRun && !skipFest {
+	if !p.DryRun {
 		festInitialized, _ = initializeFestivals(ctx, result.CampaignRoot, w)
 	}
 

--- a/cmd/camp/init/command.go
+++ b/cmd/camp/init/command.go
@@ -73,10 +73,15 @@ Use --no-git to skip git initialization.`,
 	cmd.Flags().Bool("dry-run", false, "Show what would be done without creating anything")
 	cmd.Flags().Bool("repair", false, "Add missing files to existing campaign")
 	cmd.Flags().Bool("yes", false, "Skip repair confirmation prompt (for scripting)")
-	cmd.Flags().Bool("skip-fest", false, "Skip automatic Festival Methodology initialization")
 
 	return cmd
 }
+
+// envSkipFest is an unsupported, test-only escape hatch that bypasses
+// Festival Methodology initialization. It is intentionally not exposed
+// as a CLI flag — production users should always receive Festival
+// scaffolding so that the documented `fest next` first-run path works.
+const envSkipFest = "CAMP_INIT_SKIP_FEST"
 
 // Params is the full set of inputs the init flow needs, already
 // parsed from flags or constructed by another command (e.g., create).
@@ -92,7 +97,6 @@ type Params struct {
 	DryRun        bool
 	Repair        bool
 	Yes           bool
-	SkipFest      bool
 	VerboseOutput bool
 }
 
@@ -140,7 +144,6 @@ func runInit(cmd *cobra.Command, args []string) error {
 		DryRun:        cmdutil.GetFlagBool(cmd, "dry-run"),
 		Repair:        cmdutil.GetFlagBool(cmd, "repair"),
 		Yes:           cmdutil.GetFlagBool(cmd, "yes"),
-		SkipFest:      cmdutil.GetFlagBool(cmd, "skip-fest"),
 		VerboseOutput: verboseOutput,
 	}
 	w := ChooseWriters()
@@ -262,12 +265,11 @@ func RunFlow(ctx context.Context, p Params, w Writers, isInteractive bool) error
 		commitRepairChanges(ctx, result, opts.RepairPlan, migrationCount, w)
 	}
 
-	// Initialize Festival Methodology (unless skipped or dry-run).
+	// Initialize Festival Methodology (unless dry-run or test-only env override).
+	skipFest := os.Getenv(envSkipFest) != ""
 	var festInitialized bool
-	if !p.DryRun && !p.SkipFest {
+	if !p.DryRun && !skipFest {
 		festInitialized, _ = initializeFestivals(ctx, result.CampaignRoot, w)
-	} else if p.SkipFest && !p.DryRun {
-		writeLine(w.HumanOut, ui.Info("Skipping Festival Methodology (--skip-fest)"))
 	}
 
 	// Print results

--- a/cmd/camp/manifest_test.go
+++ b/cmd/camp/manifest_test.go
@@ -338,7 +338,7 @@ func TestCampCreate_ManifestAnnotations(t *testing.T) {
 	}
 
 	// Absent flags: create must NOT support init-only controls.
-	absentFlags := []string{"force", "repair", "no-register", "yes", "skip-fest"}
+	absentFlags := []string{"force", "repair", "no-register", "yes"}
 	for _, flag := range absentFlags {
 		if cmd.Flags().Lookup(flag) != nil {
 			t.Errorf("camp create should NOT have flag --%s", flag)

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -1295,7 +1295,6 @@ camp init [path] [flags]
       --no-git               Skip git repository initialization
       --no-register          Don't add to global registry
       --repair               Add missing files to existing campaign
-      --skip-fest            Skip automatic Festival Methodology initialization
   -t, --type string          Campaign type (product, research, tools, personal) (default "product")
       --yes                  Skip repair confirmation prompt (for scripting)
 ```

--- a/docs/cli-reference/camp_create.md
+++ b/docs/cli-reference/camp_create.md
@@ -43,3 +43,4 @@ camp create <name> [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
+

--- a/docs/cli-reference/camp_init.md
+++ b/docs/cli-reference/camp_init.md
@@ -55,7 +55,6 @@ camp init [path] [flags]
       --no-git               Skip git repository initialization
       --no-register          Don't add to global registry
       --repair               Add missing files to existing campaign
-      --skip-fest            Skip automatic Festival Methodology initialization
   -t, --type string          Campaign type (product, research, tools, personal) (default "product")
       --yes                  Skip repair confirmation prompt (for scripting)
 ```

--- a/internal/commands/workitem/workitem_integration_test.go
+++ b/internal/commands/workitem/workitem_integration_test.go
@@ -24,15 +24,15 @@ import (
 func TestIntegration_WorkitemEditorHandsOffTTY(t *testing.T) {
 	projectRoot := testProjectRoot(t)
 	campBinary := buildCampBinary(t, projectRoot)
-	festBinDir := buildFestBinaryDir(t, projectRoot)
+	festBinDir := installFestBinaryDir(t)
 
 	tempRoot := t.TempDir()
 	homeDir := filepath.Join(tempRoot, "home")
 	require.NoError(t, os.MkdirAll(filepath.Join(homeDir, ".config"), 0o755))
 
-	// Prepend the freshly-built fest binary to PATH so `camp init` runs the
-	// real Festival Methodology setup, mirroring how a user installs fest
-	// (build from source, place on PATH) and what the container suite does.
+	// Prepend the freshly-installed fest binary to PATH so `camp init` runs
+	// the real Festival Methodology setup against the publicly-released
+	// fest CLI, exactly as an end user would.
 	baseEnv := append(os.Environ(),
 		"HOME="+homeDir,
 		"XDG_CONFIG_HOME="+filepath.Join(homeDir, ".config"),
@@ -246,29 +246,20 @@ func buildCampBinary(t *testing.T, projectRoot string) string {
 	return binaryPath
 }
 
-// buildFestBinaryDir builds the fest CLI from the sibling projects/fest
-// submodule and returns the directory containing the binary, suitable for
-// prepending to PATH. Fails the test if fest source is missing — the
-// workitem TTY integration test exercises the real `camp init` ->
-// `fest init` handoff and must run with fest available.
-func buildFestBinaryDir(t *testing.T, projectRoot string) string {
+// installFestBinaryDir installs the fest CLI the same way a user would —
+// `go install github.com/Obedience-Corp/fest/cmd/fest@latest` — and returns
+// the GOBIN directory to prepend to PATH. Using the public install path
+// means this test catches release-coupling issues (e.g. camp depending on
+// an unreleased fest feature) rather than silently passing against a
+// local development build.
+func installFestBinaryDir(t *testing.T) string {
 	t.Helper()
 
-	festRoot, err := filepath.Abs(filepath.Join(projectRoot, "..", "fest"))
-	require.NoError(t, err, "resolve fest source root")
-	if _, err := os.Stat(filepath.Join(festRoot, "cmd", "fest")); err != nil {
-		t.Fatalf("fest source not found at %s: %v\n"+
-			"This integration test requires the sibling projects/fest "+
-			"submodule to be checked out so it can build fest the way a "+
-			"user would install it.", festRoot, err)
-	}
-
 	binDir := t.TempDir()
-	binaryPath := filepath.Join(binDir, "fest")
-	cmd := exec.Command("go", "build", "-o", binaryPath, "./cmd/fest")
-	cmd.Dir = festRoot
+	cmd := exec.Command("go", "install", "github.com/Obedience-Corp/fest/cmd/fest@latest")
+	cmd.Env = append(os.Environ(), "GOBIN="+binDir)
 	output, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "fest build failed:\n%s", output)
+	require.NoErrorf(t, err, "go install fest@latest failed:\n%s", output)
 	return binDir
 }
 

--- a/internal/commands/workitem/workitem_integration_test.go
+++ b/internal/commands/workitem/workitem_integration_test.go
@@ -24,19 +24,21 @@ import (
 func TestIntegration_WorkitemEditorHandsOffTTY(t *testing.T) {
 	projectRoot := testProjectRoot(t)
 	campBinary := buildCampBinary(t, projectRoot)
+	festBinDir := buildFestBinaryDir(t, projectRoot)
 
 	tempRoot := t.TempDir()
 	homeDir := filepath.Join(tempRoot, "home")
 	require.NoError(t, os.MkdirAll(filepath.Join(homeDir, ".config"), 0o755))
 
+	// Prepend the freshly-built fest binary to PATH so `camp init` runs the
+	// real Festival Methodology setup, mirroring how a user installs fest
+	// (build from source, place on PATH) and what the container suite does.
 	baseEnv := append(os.Environ(),
 		"HOME="+homeDir,
 		"XDG_CONFIG_HOME="+filepath.Join(homeDir, ".config"),
 		"TERM=dumb",
 		"NO_COLOR=1",
-		// Test-only escape hatch — bypass Festival Methodology init so
-		// this test does not depend on the fest CLI being installed.
-		"CAMP_INIT_SKIP_FEST=1",
+		"PATH="+festBinDir+string(os.PathListSeparator)+os.Getenv("PATH"),
 	)
 
 	campaignRoot := filepath.Join(tempRoot, "campaign")
@@ -242,6 +244,32 @@ func buildCampBinary(t *testing.T, projectRoot string) string {
 	output, err := cmd.CombinedOutput()
 	require.NoErrorf(t, err, "go build failed:\n%s", output)
 	return binaryPath
+}
+
+// buildFestBinaryDir builds the fest CLI from the sibling projects/fest
+// submodule and returns the directory containing the binary, suitable for
+// prepending to PATH. Fails the test if fest source is missing — the
+// workitem TTY integration test exercises the real `camp init` ->
+// `fest init` handoff and must run with fest available.
+func buildFestBinaryDir(t *testing.T, projectRoot string) string {
+	t.Helper()
+
+	festRoot, err := filepath.Abs(filepath.Join(projectRoot, "..", "fest"))
+	require.NoError(t, err, "resolve fest source root")
+	if _, err := os.Stat(filepath.Join(festRoot, "cmd", "fest")); err != nil {
+		t.Fatalf("fest source not found at %s: %v\n"+
+			"This integration test requires the sibling projects/fest "+
+			"submodule to be checked out so it can build fest the way a "+
+			"user would install it.", festRoot, err)
+	}
+
+	binDir := t.TempDir()
+	binaryPath := filepath.Join(binDir, "fest")
+	cmd := exec.Command("go", "build", "-o", binaryPath, "./cmd/fest")
+	cmd.Dir = festRoot
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "fest build failed:\n%s", output)
+	return binDir
 }
 
 func testProjectRoot(t *testing.T) string {

--- a/internal/commands/workitem/workitem_integration_test.go
+++ b/internal/commands/workitem/workitem_integration_test.go
@@ -34,6 +34,9 @@ func TestIntegration_WorkitemEditorHandsOffTTY(t *testing.T) {
 		"XDG_CONFIG_HOME="+filepath.Join(homeDir, ".config"),
 		"TERM=dumb",
 		"NO_COLOR=1",
+		// Test-only escape hatch — bypass Festival Methodology init so
+		// this test does not depend on the fest CLI being installed.
+		"CAMP_INIT_SKIP_FEST=1",
 	)
 
 	campaignRoot := filepath.Join(tempRoot, "campaign")
@@ -46,7 +49,6 @@ func TestIntegration_WorkitemEditorHandsOffTTY(t *testing.T) {
 		"--force",
 		"--no-register",
 		"--no-git",
-		"--skip-fest",
 	)
 	runCommand(t, campaignRoot, baseEnv, campBinary,
 		"intent", "add", "TTY editor integration intent", "--no-commit",


### PR DESCRIPTION
Closes #254.

## Summary

- Remove the `--skip-fest` flag from `camp init` (and `Params.SkipFest`).
- New campaigns now always receive Festival Methodology scaffolding, so the documented first-run `fest next` path works out of the box.
- Replace the public flag with a private, undocumented `CAMP_INIT_SKIP_FEST` env var as a narrower test-only escape hatch.
- Update the workitem editor TTY integration test to set `CAMP_INIT_SKIP_FEST=1` in its base env instead of passing `--skip-fest`.
- Update `camp create`'s `absentFlags` assertion (skip-fest is no longer init-only — it doesn't exist anywhere on the public CLI).
- Regenerate `docs/cli-reference/camp_init.md` and `camp-reference.md`; both no longer mention the flag.

## Acceptance criteria (from #254)

- `camp init --help` no longer lists `--skip-fest`. ✓
- CLI reference docs no longer document `--skip-fest`. ✓
- Init/create tests cover the default Festival initialization path without relying on the public flag. ✓ (the workitem test still uses an escape hatch, but via env var, not a public flag)
- Any retained bypass is explicitly private or clearly documented as test-only. ✓ (`CAMP_INIT_SKIP_FEST` is documented in code as an unsupported test-only escape hatch and is not exposed in help or generated docs)

## Test plan

- [x] `just build` passes
- [x] `go test ./cmd/camp/... ./internal/scaffold/...` passes
- [x] `just docs` regenerated cleanly with no `skip-fest` references remaining
- [ ] CI integration suite green