### PR TITLE
Always auto-commit dungeon moves

### DIFF
--- a/cmd/camp/dungeon/move.go
+++ b/cmd/camp/dungeon/move.go
@@ -141,6 +141,8 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 	files := commit.NormalizeFiles(cmdCtx.CampaignRoot, destinationPaths...)
 	preStaged, err := stageTrackedMoveSourceDeletions(ctx, cmdCtx.CampaignRoot, sourcePaths)
 	if err != nil {
+		fmt.Printf("%s Move was applied on disk, but staging the source deletion failed.\n", ui.WarningIcon())
+		fmt.Printf("%s %v\n", ui.WarningIcon(), err)
 		return camperrors.Wrap(err, "staging move source deletions")
 	}
 	result := commit.Crawl(ctx, commit.CrawlOptions{

--- a/cmd/camp/dungeon/move.go
+++ b/cmd/camp/dungeon/move.go
@@ -1,6 +1,7 @@
 package dungeon
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -8,6 +9,7 @@ import (
 
 	intdungeon "github.com/Obedience-Corp/camp/internal/dungeon"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git"
 	"github.com/Obedience-Corp/camp/internal/git/commit"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/spf13/cobra"
@@ -21,6 +23,7 @@ var dungeonMoveCmd = &cobra.Command{
 Without --triage, moves an item already in the dungeon root to a status directory.
 With --triage, moves an item from the parent directory into the dungeon.
 With --triage and --to-docs, routes an item to an existing campaign-root docs/<subdirectory>.
+Moves are always auto-committed so dungeon history remains auditable.
 
 Statuses: completed, archived, someday
 
@@ -44,7 +47,6 @@ func init() {
 	flags := dungeonMoveCmd.Flags()
 	flags.Bool("triage", false, "Move from parent directory (not from dungeon root)")
 	flags.String("to-docs", "", "Route triage item into an existing campaign-root docs/<subdir> (requires --triage)")
-	flags.Bool("no-commit", false, "Don't create a git commit")
 }
 
 func runDungeonMove(cmd *cobra.Command, args []string) error {
@@ -52,7 +54,6 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 
 	triageMode, _ := cmd.Flags().GetBool("triage")
 	toDocs, _ := cmd.Flags().GetString("to-docs")
-	noCommit, _ := cmd.Flags().GetBool("no-commit")
 
 	itemName := args[0]
 	status := ""
@@ -76,7 +77,8 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 	svc := intdungeon.NewService(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath)
 
 	var description string
-	var movedPaths []string
+	var sourcePaths []string
+	var destinationPaths []string
 
 	if triageMode {
 		if toDocs != "" {
@@ -88,10 +90,8 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 			dst := relFromRoot(cmdCtx.CampaignRoot, targetPath)
 			fmt.Printf("%s Moved %s (%s → %s)\n", ui.SuccessIcon(), itemName, src, dst)
 			description = fmt.Sprintf("Route %s → %s", itemName, dst)
-			movedPaths = []string{
-				filepath.Join(cmdCtx.Dungeon.ParentPath, itemName),
-				targetPath,
-			}
+			sourcePaths = []string{filepath.Join(cmdCtx.Dungeon.ParentPath, itemName)}
+			destinationPaths = []string{targetPath}
 		} else if status != "" {
 			// Triage directly to a status directory
 			targetPath, err := svc.MoveToDungeonStatus(ctx, itemName, cmdCtx.Dungeon.ParentPath, status)
@@ -102,10 +102,8 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 			dst := relFromRoot(cmdCtx.CampaignRoot, targetPath)
 			fmt.Printf("%s Moved %s (%s → %s)\n", ui.SuccessIcon(), itemName, src, dst)
 			description = fmt.Sprintf("Triage %s → dungeon/%s", itemName, status)
-			movedPaths = []string{
-				filepath.Join(cmdCtx.Dungeon.ParentPath, itemName),
-				targetPath,
-			}
+			sourcePaths = []string{filepath.Join(cmdCtx.Dungeon.ParentPath, itemName)}
+			destinationPaths = []string{targetPath}
 		} else {
 			// Triage to dungeon root
 			if err := svc.MoveToDungeon(ctx, itemName, cmdCtx.Dungeon.ParentPath); err != nil {
@@ -115,10 +113,8 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 			dst := filepath.Join(relFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath), itemName)
 			fmt.Printf("%s Moved %s (%s → %s)\n", ui.SuccessIcon(), itemName, src, dst)
 			description = fmt.Sprintf("Triage %s → dungeon", itemName)
-			movedPaths = []string{
-				filepath.Join(cmdCtx.Dungeon.ParentPath, itemName),
-				filepath.Join(cmdCtx.Dungeon.DungeonPath, itemName),
-			}
+			sourcePaths = []string{filepath.Join(cmdCtx.Dungeon.ParentPath, itemName)}
+			destinationPaths = []string{filepath.Join(cmdCtx.Dungeon.DungeonPath, itemName)}
 		}
 	} else {
 		// Inner move: dungeon root → status directory
@@ -138,31 +134,55 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 			relDir = cmdCtx.Dungeon.ParentPath
 		}
 		description = fmt.Sprintf("Moved to dungeon/%s:\n  - %s/%s", status, relDir, itemName)
-		movedPaths = []string{
-			filepath.Join(cmdCtx.Dungeon.DungeonPath, itemName),
-			targetPath,
-		}
+		sourcePaths = []string{filepath.Join(cmdCtx.Dungeon.DungeonPath, itemName)}
+		destinationPaths = []string{targetPath}
 	}
 
-	// Auto-commit
-	if !noCommit {
-		files := commit.NormalizeFiles(cmdCtx.CampaignRoot, movedPaths...)
-		result := commit.Crawl(ctx, commit.CrawlOptions{
-			Options: commit.Options{
-				CampaignRoot: cmdCtx.CampaignRoot,
-				CampaignID:   cmdCtx.Config.ID,
-			},
-			Description: strings.TrimSpace(description),
-			Files:       files,
-		})
-		if result.Committed {
-			fmt.Printf("%s %s\n", ui.SuccessIcon(), result.Message)
-		} else if result.Message != "" {
-			fmt.Printf("%s %s\n", ui.InfoIcon(), result.Message)
-		}
+	files := commit.NormalizeFiles(cmdCtx.CampaignRoot, destinationPaths...)
+	preStaged, err := stageTrackedMoveSourceDeletions(ctx, cmdCtx.CampaignRoot, sourcePaths)
+	if err != nil {
+		return camperrors.Wrap(err, "staging move source deletions")
+	}
+	result := commit.Crawl(ctx, commit.CrawlOptions{
+		Options: commit.Options{
+			CampaignRoot: cmdCtx.CampaignRoot,
+			CampaignID:   cmdCtx.Config.ID,
+			PreStaged:    preStaged,
+		},
+		Description: strings.TrimSpace(description),
+		Files:       files,
+	})
+	if result.Committed {
+		fmt.Printf("%s %s\n", ui.SuccessIcon(), result.Message)
+	} else if result.NoChanges {
+		fmt.Printf("%s %s\n", ui.InfoIcon(), result.Message)
+	} else if result.Err != nil {
+		fmt.Printf("%s Move was applied on disk, but auto-commit failed.\n", ui.WarningIcon())
+		fmt.Printf("%s %v\n", ui.WarningIcon(), result.Err)
+		return camperrors.Wrap(result.Err, "auto-committing dungeon move")
+	} else if result.Message != "" {
+		fmt.Printf("%s %s\n", ui.InfoIcon(), result.Message)
 	}
 
 	return nil
+}
+
+func stageTrackedMoveSourceDeletions(ctx context.Context, campaignRoot string, sourcePaths []string) ([]string, error) {
+	sources := commit.NormalizeFiles(campaignRoot, sourcePaths...)
+	if len(sources) == 0 {
+		return nil, nil
+	}
+	tracked, err := git.FilterTracked(ctx, campaignRoot, sources)
+	if err != nil {
+		return nil, err
+	}
+	if len(tracked) == 0 {
+		return nil, nil
+	}
+	if err := git.StageTrackedChanges(ctx, campaignRoot, tracked...); err != nil {
+		return nil, err
+	}
+	return tracked, nil
 }
 
 func wrapDungeonMoveError(err error, itemName, status string) error {

--- a/cmd/camp/dungeon/move_test.go
+++ b/cmd/camp/dungeon/move_test.go
@@ -30,6 +30,12 @@ func TestWrapDungeonMoveError_InvalidItemPath(t *testing.T) {
 	}
 }
 
+func TestDungeonMove_NoCommitFlagRemoved(t *testing.T) {
+	if dungeonMoveCmd.Flags().Lookup("no-commit") != nil {
+		t.Fatal("dungeon move should always auto-commit; --no-commit must not be registered")
+	}
+}
+
 func TestWrapDungeonDocsRouteError_InvalidItemPath(t *testing.T) {
 	err := wrapDungeonDocsRouteError(intdungeon.ErrInvalidItemPath, "../secret.md", "architecture")
 	if err == nil {

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -910,6 +910,7 @@ Move items within the dungeon or from the parent directory into the dungeon.
 Without --triage, moves an item already in the dungeon root to a status directory.
 With --triage, moves an item from the parent directory into the dungeon.
 With --triage and --to-docs, routes an item to an existing campaign-root docs/<subdirectory>.
+Moves are always auto-committed so dungeon history remains auditable.
 
 Statuses: completed, archived, someday
 
@@ -928,7 +929,6 @@ camp dungeon move <item> [status] [flags]
 
 ```
   -h, --help             help for move
-      --no-commit        Don't create a git commit
       --to-docs string   Route triage item into an existing campaign-root docs/<subdir> (requires --triage)
       --triage           Move from parent directory (not from dungeon root)
 ```

--- a/docs/cli-reference/camp_dungeon_move.md
+++ b/docs/cli-reference/camp_dungeon_move.md
@@ -9,6 +9,7 @@ Move items within the dungeon or from the parent directory into the dungeon.
 Without --triage, moves an item already in the dungeon root to a status directory.
 With --triage, moves an item from the parent directory into the dungeon.
 With --triage and --to-docs, routes an item to an existing campaign-root docs/<subdirectory>.
+Moves are always auto-committed so dungeon history remains auditable.
 
 Statuses: completed, archived, someday
 
@@ -27,7 +28,6 @@ camp dungeon move <item> [status] [flags]
 
 ```
   -h, --help             help for move
-      --no-commit        Don't create a git commit
       --to-docs string   Route triage item into an existing campaign-root docs/<subdir> (requires --triage)
       --triage           Move from parent directory (not from dungeon root)
 ```

--- a/docs/migrations/dungeon-behavior-upgrade-2026-03.md
+++ b/docs/migrations/dungeon-behavior-upgrade-2026-03.md
@@ -60,12 +60,15 @@ Use this checklist when upgrading active campaign workspaces.
 1. Validate nearest-context command behavior.
    - From nested directory with local dungeon, run:
      - `camp dungeon list`
-     - `camp dungeon move <item> --triage --no-commit`
+     - `camp dungeon move <item> --triage`
    - Confirm operations target nearest dungeon context.
+   - Confirm successful moves auto-commit; dungeon triage history depends on
+     those commits.
 2. Validate docs routing behavior.
-   - Run `camp dungeon move <item> --triage --to-docs <subdir> --no-commit`.
+   - Run `camp dungeon move <item> --triage --to-docs <subdir>`.
    - Confirm destination path is under campaign-root `docs/`.
    - Confirm traversal attempts fail with clear errors.
+   - Confirm successful docs routing auto-commits.
 3. Validate scaffold defaults on a scratch campaign.
    - Initialize new campaign.
    - Confirm `workflow/explore/` and `workflow/explore/OBEY.md` exist.

--- a/tests/integration/dungeon_test.go
+++ b/tests/integration/dungeon_test.go
@@ -214,7 +214,7 @@ func TestDungeonMove_ToStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	// Move to archived
-	output, err := tc.RunCampInDir(path, "dungeon", "move", "old-feature.md", "archived", "--no-commit")
+	output, err := tc.RunCampInDir(path, "dungeon", "move", "old-feature.md", "archived")
 	require.NoError(t, err)
 	assert.Contains(t, output, "Moved old-feature.md", "should confirm move")
 	assert.Contains(t, output, "archived", "should mention target status")
@@ -237,7 +237,7 @@ func TestDungeonMove_ToCompleted(t *testing.T) {
 	err := tc.WriteFile(path+"/dungeon/done-work.md", "# Done Work\n")
 	require.NoError(t, err)
 
-	output, err := tc.RunCampInDir(path, "dungeon", "move", "done-work.md", "completed", "--no-commit")
+	output, err := tc.RunCampInDir(path, "dungeon", "move", "done-work.md", "completed")
 	require.NoError(t, err)
 	assert.Contains(t, output, "completed")
 
@@ -253,7 +253,7 @@ func TestDungeonMove_ToSomeday(t *testing.T) {
 	err := tc.WriteFile(path+"/dungeon/maybe-later.md", "# Maybe Later\n")
 	require.NoError(t, err)
 
-	output, err := tc.RunCampInDir(path, "dungeon", "move", "maybe-later.md", "someday", "--no-commit")
+	output, err := tc.RunCampInDir(path, "dungeon", "move", "maybe-later.md", "someday")
 	require.NoError(t, err)
 	assert.Contains(t, output, "someday")
 
@@ -279,7 +279,7 @@ func TestDungeonMove_NotFoundError(t *testing.T) {
 	tc := GetSharedContainer(t)
 	path := setupDungeonCampaign(t, tc, "dmove-notfound")
 
-	output, err := tc.RunCampInDir(path, "dungeon", "move", "nonexistent.md", "archived", "--no-commit")
+	output, err := tc.RunCampInDir(path, "dungeon", "move", "nonexistent.md", "archived")
 	assert.Error(t, err, "should fail for nonexistent item")
 	assert.Contains(t, output, "not found", "error should mention item not found")
 }
@@ -294,7 +294,7 @@ func TestDungeonMove_TriageToDungeonRoot(t *testing.T) {
 	err := tc.WriteFile(path+"/old-project.md", "# Old Project\n")
 	require.NoError(t, err)
 
-	output, err := tc.RunCampInDir(path, "dungeon", "move", "old-project.md", "--triage", "--no-commit")
+	output, err := tc.RunCampInDir(path, "dungeon", "move", "old-project.md", "--triage")
 	require.NoError(t, err)
 	assert.Contains(t, output, "Moved old-project.md", "should confirm triage")
 
@@ -317,7 +317,7 @@ func TestDungeonMove_TriageDirectToStatus(t *testing.T) {
 	err := tc.WriteFile(path+"/legacy-code.md", "# Legacy Code\n")
 	require.NoError(t, err)
 
-	output, err := tc.RunCampInDir(path, "dungeon", "move", "legacy-code.md", "archived", "--triage", "--no-commit")
+	output, err := tc.RunCampInDir(path, "dungeon", "move", "legacy-code.md", "archived", "--triage")
 	require.NoError(t, err)
 	assert.Contains(t, output, "archived", "should mention target status")
 
@@ -416,7 +416,6 @@ func TestDungeonMove_TriageToDocsDestination(t *testing.T) {
 		"dungeon", "move", "legacy-notes.md",
 		"--triage",
 		"--to-docs", "architecture/api",
-		"--no-commit",
 	)
 	require.NoError(t, err)
 	assert.Contains(t, output, "Moved legacy-notes.md", "should confirm docs routing move")
@@ -443,7 +442,6 @@ func TestDungeonMove_TriageToDocsRequiresExistingSubdirectory(t *testing.T) {
 		"dungeon", "move", "legacy-notes.md",
 		"--triage",
 		"--to-docs", "architecture/api",
-		"--no-commit",
 	)
 	assert.Error(t, err)
 	assert.Contains(t, output, "invalid docs destination", "error should explain destination rules")
@@ -462,7 +460,6 @@ func TestDungeonMove_ToDocsRequiresTriage(t *testing.T) {
 		path,
 		"dungeon", "move", "anything.md",
 		"--to-docs", "architecture/api",
-		"--no-commit",
 	)
 	assert.Error(t, err)
 	assert.Contains(t, output, "--to-docs requires --triage")
@@ -480,7 +477,6 @@ func TestDungeonMove_TriageToDocsRejectsTraversal(t *testing.T) {
 		"dungeon", "move", "legacy-notes.md",
 		"--triage",
 		"--to-docs", "../escape",
-		"--no-commit",
 	)
 	assert.Error(t, err)
 	assert.Contains(t, output, "invalid docs destination", "error should explain destination rules")
@@ -512,7 +508,6 @@ func TestDungeonMove_TriageToDocsRejectsTraversalItemName(t *testing.T) {
 		"dungeon", "move", "../secret.md",
 		"--triage",
 		"--to-docs", "architecture",
-		"--no-commit",
 	)
 	assert.Error(t, err)
 	assert.Contains(t, output, "invalid item path")
@@ -543,7 +538,6 @@ func TestDungeonMove_TriageRejectsNestedItemPath(t *testing.T) {
 		path,
 		"dungeon", "move", "nested/legacy.md",
 		"--triage",
-		"--no-commit",
 	)
 	assert.Error(t, err)
 	assert.Contains(t, output, "invalid item path")
@@ -580,7 +574,6 @@ func TestDungeonMove_TriageToDocsFromNestedDirAnchorsToCampaignRootDocs(t *testi
 		"dungeon", "move", "legacy-spec.md",
 		"--triage",
 		"--to-docs", "architecture/reference",
-		"--no-commit",
 	)
 	require.NoError(t, err)
 	assert.Contains(t, output, "docs/architecture/reference/legacy-spec.md")
@@ -627,7 +620,7 @@ func TestDungeonMove_TriageFromNestedDirUsesNearestContext(t *testing.T) {
 	err = tc.WriteFile(path+"/workflow/design/nested-old.md", "# Nested Old\n")
 	require.NoError(t, err)
 
-	output, err := tc.RunCampInDir(path+"/workflow/design/subdir", "dungeon", "move", "nested-old.md", "--triage", "--no-commit")
+	output, err := tc.RunCampInDir(path+"/workflow/design/subdir", "dungeon", "move", "nested-old.md", "--triage")
 	require.NoError(t, err)
 	assert.Contains(t, output, "Moved nested-old.md", "should confirm move from nested context")
 
@@ -651,7 +644,7 @@ func TestDungeonCommands_NoDungeonContextError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, output, "no dungeon context found", "list should instruct user to create context")
 
-	output, err = tc.RunCampInDir(path, "dungeon", "move", "orphan.md", "--triage", "--no-commit")
+	output, err = tc.RunCampInDir(path, "dungeon", "move", "orphan.md", "--triage")
 	assert.Error(t, err)
 	assert.Contains(t, output, "no dungeon context found", "move should instruct user to create context")
 

--- a/tests/integration/dungeon_test.go
+++ b/tests/integration/dungeon_test.go
@@ -44,6 +44,24 @@ func checkDatedDungeonStatusItemExists(tc *TestContainer, statusPath, itemName s
 	return strings.TrimSpace(output) != "", nil
 }
 
+func assertLastDungeonMoveCommit(t *testing.T, tc *TestContainer, repoPath, wantBody string, wantNameStatus ...string) string {
+	t.Helper()
+
+	subject := tc.GitOutput(t, repoPath, "log", "-1", "--pretty=%s")
+	assert.Contains(t, subject, "Crawl: dungeon crawl completed", "dungeon move should create a crawl commit")
+
+	body := tc.GitOutput(t, repoPath, "log", "-1", "--pretty=%B")
+	if wantBody != "" {
+		assert.Contains(t, body, wantBody, "crawl commit body should describe the move")
+	}
+
+	diff := tc.GitOutput(t, repoPath, "diff-tree", "--no-commit-id", "--name-status", "--no-renames", "-r", "HEAD")
+	for _, want := range wantNameStatus {
+		assert.Contains(t, diff, want, "crawl commit should include expected name-status entry")
+	}
+	return diff
+}
+
 // --- dungeon list ---
 
 func TestDungeonList_EmptyDungeon(t *testing.T) {
@@ -228,6 +246,15 @@ func TestDungeonMove_ToStatus(t *testing.T) {
 	exists, err = tc.CheckFileExists(path + "/dungeon/old-feature.md")
 	require.NoError(t, err)
 	assert.False(t, exists, "file should no longer be in dungeon root")
+
+	diff := assertLastDungeonMoveCommit(
+		t,
+		tc,
+		path,
+		"Moved to dungeon/archived:",
+		"D\tdungeon/old-feature.md",
+	)
+	assert.Regexp(t, `(?m)^A\tdungeon/archived/[0-9]{4}-[0-9]{2}-[0-9]{2}/old-feature\.md$`, diff)
 }
 
 func TestDungeonMove_ToCompleted(t *testing.T) {
@@ -362,10 +389,43 @@ func TestDungeonMove_TriageWithCommit_IncludesSourceDeletion(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, exists, "file should no longer be in parent")
 
-	// Verify git log shows the commit with both source and destination
-	gitOutput, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git diff-tree --no-commit-id --name-status -r HEAD")
+	assertLastDungeonMoveCommit(
+		t,
+		tc,
+		path,
+		"Triage tracked-item.md",
+		"D\ttracked-item.md",
+		"A\tdungeon/tracked-item.md",
+	)
+}
+
+func TestDungeonMove_TriageStagingFailureWarnsMoveApplied(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupDungeonCampaign(t, tc, "dmove-triage-stage-fail")
+
+	err := tc.WriteFile(path+"/tracked-broken.md", "# Tracked Broken\n")
 	require.NoError(t, err)
-	assert.Contains(t, gitOutput, "tracked-item.md", "commit should reference the moved file")
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+path+" && git add . && git commit -m 'add tracked broken'")
+	require.NoError(t, err)
+
+	output, exitCode, err := tc.ExecCommand(
+		"sh",
+		"-c",
+		"cd "+path+" && PATH=/tmp/no-git /camp dungeon move tracked-broken.md --triage 2>&1",
+	)
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, exitCode, "missing git should make pre-staging fail")
+	assert.Contains(t, output, "Moved tracked-broken.md", "move should happen before staging failure")
+	assert.Contains(t, output, "Move was applied on disk, but staging the source deletion failed.")
+	assert.Contains(t, output, "staging move source deletions")
+
+	exists, err := tc.CheckFileExists(path + "/dungeon/tracked-broken.md")
+	require.NoError(t, err)
+	assert.True(t, exists, "destination should remain after staging failure")
+
+	exists, err = tc.CheckFileExists(path + "/tracked-broken.md")
+	require.NoError(t, err)
+	assert.False(t, exists, "source should already be moved after staging failure")
 }
 
 func TestDungeonMove_TriageDirectToStatusWithCommit(t *testing.T) {
@@ -398,6 +458,15 @@ func TestDungeonMove_TriageDirectToStatusWithCommit(t *testing.T) {
 	statusOutput, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git status --porcelain")
 	require.NoError(t, err)
 	assert.Empty(t, strings.TrimSpace(statusOutput), "git status should be clean after commit")
+
+	diff := assertLastDungeonMoveCommit(
+		t,
+		tc,
+		path,
+		"Triage stale-doc.md",
+		"D\tstale-doc.md",
+	)
+	assert.Regexp(t, `(?m)^A\tdungeon/archived/[0-9]{4}-[0-9]{2}-[0-9]{2}/stale-doc\.md$`, diff)
 }
 
 func TestDungeonMove_TriageToDocsDestination(t *testing.T) {
@@ -410,6 +479,8 @@ func TestDungeonMove_TriageToDocsDestination(t *testing.T) {
 	// Create item in parent directory.
 	err = tc.WriteFile(path+"/legacy-notes.md", "# Legacy Notes\n")
 	require.NoError(t, err)
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+path+" && git add legacy-notes.md && git commit -m 'add legacy notes'")
+	require.NoError(t, err)
 
 	output, err := tc.RunCampInDir(
 		path,
@@ -420,6 +491,7 @@ func TestDungeonMove_TriageToDocsDestination(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, output, "Moved legacy-notes.md", "should confirm docs routing move")
 	assert.Contains(t, output, "docs/architecture/api/legacy-notes.md", "should show docs destination")
+	assert.Contains(t, output, "Committed", "should auto-commit docs routing move")
 
 	exists, err := tc.CheckFileExists(path + "/docs/architecture/api/legacy-notes.md")
 	require.NoError(t, err)
@@ -428,6 +500,15 @@ func TestDungeonMove_TriageToDocsDestination(t *testing.T) {
 	exists, err = tc.CheckFileExists(path + "/legacy-notes.md")
 	require.NoError(t, err)
 	assert.False(t, exists, "file should no longer be in parent")
+
+	assertLastDungeonMoveCommit(
+		t,
+		tc,
+		path,
+		"Route legacy-notes.md",
+		"D\tlegacy-notes.md",
+		"A\tdocs/architecture/api/legacy-notes.md",
+	)
 }
 
 func TestDungeonMove_TriageToDocsRequiresExistingSubdirectory(t *testing.T) {


### PR DESCRIPTION
## Summary

- Remove the `--no-commit` escape hatch from `camp dungeon move`.
- Always run the dungeon crawl commit path after successful dungeon moves and docs routing.
- Stage moved destinations separately from tracked source deletions so untracked triage items can still auto-commit cleanly.
- Regenerate CLI reference docs and update the dungeon behavior rollout note.

## Why

Dungeon triage history is designed around automatic commits. Allowing `camp dungeon move --no-commit` makes it easy to bypass that audit trail, especially when routing workflow/explore work into docs.

## Validation

- `go test ./cmd/camp/dungeon ./internal/git/commit`
- `just docs`
- `go test -tags=integration ./tests/integration -run 'TestDungeonMove|TestDungeonCommands_NoDungeonContextError'`
- `git diff --check`
