### PR TITLE
Fix workitem Enter actions

### DIFF
--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/Obedience-Corp/camp/internal/editor"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/paths"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
@@ -101,7 +102,7 @@ Examples:
 			case flagJSON:
 				return outputJSON(campaignRoot, items)
 			case !interactive:
-				// Non-interactive --print: output first item path directly
+				// Non-interactive --print/--path-output: output first item path directly.
 				if len(items) == 0 {
 					return fmt.Errorf("no work items found")
 				}
@@ -141,11 +142,61 @@ func outputSelectedPath(item wkitem.WorkItem, printOnly bool, pathOutput string)
 	return nil
 }
 
+type selectedAction string
+
+const (
+	selectedActionJumpDirectory selectedAction = "jump_directory"
+	selectedActionOpenEditor    selectedAction = "open_editor"
+)
+
+func selectedDefaultAction(item wkitem.WorkItem) selectedAction {
+	if item.ItemKind == wkitem.ItemKindFile {
+		return selectedActionOpenEditor
+	}
+	return selectedActionJumpDirectory
+}
+
 func selectedJumpPath(item wkitem.WorkItem) string {
 	if item.ItemKind == wkitem.ItemKindFile {
 		return filepath.Dir(item.RelativePath)
 	}
 	return item.RelativePath
+}
+
+func selectedOpenPath(item wkitem.WorkItem, campaignRoot string) string {
+	if item.PrimaryDoc != "" {
+		return item.AbsPrimaryDoc(campaignRoot)
+	}
+	if item.RelativePath != "" {
+		return item.AbsPath(campaignRoot)
+	}
+	return ""
+}
+
+func runSelectedAction(ctx context.Context, item wkitem.WorkItem, printOnly bool, pathOutput string, campaignRoot string) error {
+	if printOnly {
+		return outputSelectedPath(item, true, "")
+	}
+	if selectedDefaultAction(item) == selectedActionOpenEditor {
+		return openSelectedItem(ctx, item, campaignRoot)
+	}
+	return outputSelectedPath(item, false, pathOutput)
+}
+
+func openSelectedItem(ctx context.Context, item wkitem.WorkItem, campaignRoot string) error {
+	path := selectedOpenPath(item, campaignRoot)
+	if path == "" {
+		return fmt.Errorf("selected work item has no path to open")
+	}
+	editorName := editor.GetEditor(ctx)
+	cmd := editor.BuildEditorCommand(ctx, editorName, path)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return camperrors.Wrap(err, "opening selected work item")
+	}
+	return nil
 }
 
 func isInteractive() bool {
@@ -203,5 +254,5 @@ func runTUI(ctx context.Context, items []wkitem.WorkItem, printOnly bool, pathOu
 	if !ok || m.Selected == nil {
 		return nil
 	}
-	return outputSelectedPath(*m.Selected, printOnly, pathOutput)
+	return runSelectedAction(ctx, *m.Selected, printOnly, pathOutput, campaignRoot)
 }

--- a/internal/commands/workitem/workitem_test.go
+++ b/internal/commands/workitem/workitem_test.go
@@ -36,6 +36,42 @@ func TestSelectedJumpPathUsesFileParent(t *testing.T) {
 	}
 }
 
+func TestSelectedDefaultActionOpensFileItems(t *testing.T) {
+	item := wkitem.WorkItem{
+		RelativePath: ".campaign/intents/inbox/example.md",
+		ItemKind:     wkitem.ItemKindFile,
+	}
+
+	if got := selectedDefaultAction(item); got != selectedActionOpenEditor {
+		t.Fatalf("selectedDefaultAction() = %q, want %q", got, selectedActionOpenEditor)
+	}
+}
+
+func TestSelectedDefaultActionJumpsDirectoryItems(t *testing.T) {
+	item := wkitem.WorkItem{
+		RelativePath: "workflow/design/example",
+		ItemKind:     wkitem.ItemKindDirectory,
+	}
+
+	if got := selectedDefaultAction(item); got != selectedActionJumpDirectory {
+		t.Fatalf("selectedDefaultAction() = %q, want %q", got, selectedActionJumpDirectory)
+	}
+}
+
+func TestSelectedOpenPathUsesPrimaryDoc(t *testing.T) {
+	item := wkitem.WorkItem{
+		RelativePath: ".campaign/intents/inbox/example.md",
+		PrimaryDoc:   ".campaign/intents/inbox/example.md",
+		ItemKind:     wkitem.ItemKindFile,
+	}
+
+	got := selectedOpenPath(item, "/campaign")
+	want := filepath.Join("/campaign", ".campaign/intents/inbox/example.md")
+	if got != want {
+		t.Fatalf("selectedOpenPath() = %q, want %q", got, want)
+	}
+}
+
 func TestOutputSelectedPathWritesRelativePath(t *testing.T) {
 	item := wkitem.WorkItem{
 		RelativePath: "workflow/design/example",

--- a/internal/workitem/tui/view.go
+++ b/internal/workitem/tui/view.go
@@ -287,7 +287,7 @@ func renderPreview(item workitem.WorkItem, width, height int) string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(previewHelpStyle.Render("Enter select  e edit  o open  y copy"))
+	b.WriteString(previewHelpStyle.Render("Enter open/jump  e edit  o open  y copy"))
 
 	// Pad remaining height
 	lines := strings.Count(b.String(), "\n") + 1
@@ -325,7 +325,7 @@ func (m Model) renderHelp() string {
 			{"4", "Filter: festival"},
 		}},
 		{"Actions", [][2]string{
-			{"Enter", "Select item and exit"},
+			{"Enter", "Open intents or jump to directories"},
 			{"e", "Open primary doc in $EDITOR"},
 			{"o", "Open with system handler"},
 			{"y", "Copy absolute path"},

--- a/tests/integration/workitem_test.go
+++ b/tests/integration/workitem_test.go
@@ -65,10 +65,13 @@ func TestIntegration_WorkitemShellWrapperChangesDirectory(t *testing.T) {
 	)
 	require.NoError(t, err, "camp init should succeed")
 
-	_, err = tc.RunCampInDir(campaignDir,
-		"intent", "add", "Shell jump intent", "--no-commit",
-	)
-	require.NoError(t, err, "camp intent add should succeed")
+	output, exitCode, err := tc.ExecCommand("sh", "-lc", fmt.Sprintf(
+		"mkdir -p %s/workflow/design/shell-jump-design && printf '# Shell Jump Design\n' > %s/workflow/design/shell-jump-design/README.md",
+		shellQuote(campaignDir),
+		shellQuote(campaignDir),
+	))
+	require.NoError(t, err, "create design work item")
+	require.Equal(t, 0, exitCode, "create design work item failed:\n%s", output)
 
 	script := fmt.Sprintf(`
 set -e
@@ -79,12 +82,83 @@ camp workitem
 printf '\nPWD_AFTER=%%s\n' "$PWD"
 `, shellQuote(campaignDir))
 
-	output, err := runInteractiveShellSteps(t, tc, script, []InteractiveStep{
-		{WaitFor: "Shell jump intent", Input: "\r"},
+	output, err = runInteractiveShellSteps(t, tc, script, []InteractiveStep{
+		{WaitFor: "Shell Jump Design", Input: "\r"},
 		{WaitFor: "PWD_AFTER="},
 	})
 	require.NoError(t, err, "shell-integrated camp workitem should succeed; output:\n%s", output)
-	assert.Contains(t, output, "PWD_AFTER="+campaignDir+"/.campaign/intents/inbox")
+	assert.Contains(t, output, "PWD_AFTER="+campaignDir+"/workflow/design/shell-jump-design")
+}
+
+func TestIntegration_WorkitemShellWrapperEnterOpensIntentEditor(t *testing.T) {
+	tc := GetSharedContainer(t)
+	installShells(t, tc)
+	ensureCampInPath(t, tc)
+
+	const (
+		campaignDir = "/test/workitem-shell-open-intent"
+		editorPath  = "/test/enter-intent-editor.sh"
+		editorLog   = "/test/enter-intent-editor.log"
+	)
+	_, err := tc.RunCamp(
+		"init", campaignDir,
+		"--name", "Workitem Shell Open Intent Test",
+		"--type", "product",
+		"-d", "Workitem shell open intent test campaign",
+		"-m", "Verify workitem shell wrapper opens intents",
+		"--force",
+		"--no-register",
+		"--no-git",
+	)
+	require.NoError(t, err, "camp init should succeed")
+
+	_, err = tc.RunCampInDir(campaignDir,
+		"intent", "add", "Enter opens intent", "--no-commit",
+	)
+	require.NoError(t, err, "camp intent add should succeed")
+
+	intentDoc := findContainerIntentDoc(t, tc, campaignDir)
+
+	editorScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+
+log_file=%s
+
+printf 'PATH=%%s\n' "$1" > "$log_file"
+printf 'EDITOR_START\n'
+printf '\nenter-editor-opened\n' >> "$1"
+printf 'EDITOR_DONE\n'
+`, shellQuote(editorLog))
+
+	require.NoError(t, tc.WriteFile(editorPath, editorScript))
+	tc.Shell(t, fmt.Sprintf("chmod +x %s", editorPath))
+
+	script := fmt.Sprintf(`
+set -e
+export PATH="/camp-bin:$PATH"
+export EDITOR=%s
+cd %s
+eval "$(camp shell-init bash)"
+camp workitem
+printf '\nPWD_AFTER=%%s\n' "$PWD"
+`, shellQuote(editorPath), shellQuote(campaignDir))
+
+	output, err := runInteractiveShellSteps(t, tc, script, []InteractiveStep{
+		{WaitFor: "Enter opens intent", Input: "\r"},
+		{WaitFor: "EDITOR_DONE"},
+		{WaitFor: "PWD_AFTER="},
+	})
+	require.NoError(t, err, "shell-integrated camp workitem should open intent; output:\n%s", output)
+	assert.Contains(t, output, "PWD_AFTER="+campaignDir)
+	assert.NotContains(t, output, "PWD_AFTER="+campaignDir+"/.campaign/intents/inbox")
+
+	logData, err := tc.ReadFile(editorLog)
+	require.NoError(t, err, "editor log should exist after editor exits")
+	assert.Equal(t, intentDoc, logFieldValue(t, logData, "PATH"))
+
+	intentBody, err := tc.ReadFile(intentDoc)
+	require.NoError(t, err)
+	assert.Contains(t, intentBody, "enter-editor-opened")
 }
 
 // TestIntegration_WorkitemEditorHandsOffTTY verifies that `camp workitem`


### PR DESCRIPTION
## Summary
- make `camp workitem` Enter perform the selected item's default action
- open intent/file-backed work items in the configured editor after the TUI exits
- keep directory-backed workflow/festival selections as shell-wrapper jumps
- update TUI help text and integration coverage for intent-open vs directory-jump behavior

## Tests
- `go test ./internal/commands/workitem ./internal/workitem/... ./internal/shell`
- `go test ./cmd/camp/...`
- `go test -tags=integration ./tests/integration -run Workitem -count=1`
- `go test -tags=integration ./tests/integration -run ShellInit -count=1`
- `just build-camp`
