### PR TITLE
test: stop leverage unit tests from writing to host campaign

### DIFF
--- a/cmd/camp/leverage/main_command_test.go
+++ b/cmd/camp/leverage/main_command_test.go
@@ -3,8 +3,6 @@ package leverage
 import (
 	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -95,148 +93,16 @@ func stubPopulateMetrics() func(ctx context.Context, campaignRoot string, resolv
 	}
 }
 
-func TestLeverageCommand_TableOutput(t *testing.T) {
-	origRunner := sccRunner
-	origPopulate := populateMetrics
-	t.Cleanup(func() { sccRunner = origRunner; populateMetrics = origPopulate })
-	populateMetrics = stubPopulateMetrics()
-
-	sccRunner = &mockRunner{
-		results: map[string]*intleverage.SCCResult{
-			"camp": sampleResult(10.68, 18.72, 2251607, 65641),
-			"fest": sampleResult(8.20, 15.50, 1500000, 45000),
-		},
-	}
-
-	output, err := executeLeverage(t)
-	if err != nil {
-		t.Fatalf("command failed: %v", err)
-	}
-
-	wantStrings := []string{
-		"Campaign Leverage:",
-		"COCOMO Estimate:",
-		"person-months",
-		"Actual Effort:",
-		"Team Equivalent:",
-		"PROJECT",
-		"FILES",
-		"CODE",
-		"AUTHORS",
-		"EST COST",
-		"EST PM",
-		"ACTUAL PM",
-		"LEVERAGE",
-	}
-
-	for _, want := range wantStrings {
-		if !strings.Contains(output, want) {
-			t.Errorf("output missing %q\nGot:\n%s", want, output)
-		}
-	}
-}
-
-func TestLeverageCommand_JSONOutput(t *testing.T) {
-	origRunner := sccRunner
-	origPopulate := populateMetrics
-	t.Cleanup(func() { sccRunner = origRunner; populateMetrics = origPopulate })
-	populateMetrics = stubPopulateMetrics()
-
-	sccRunner = &mockRunner{
-		results: map[string]*intleverage.SCCResult{
-			"camp": sampleResult(10.68, 18.72, 2251607, 65641),
-		},
-	}
-
-	output, err := executeLeverage(t, "--json")
-	if err != nil {
-		t.Fatalf("command failed: %v", err)
-	}
-
-	var result struct {
-		Campaign *intleverage.LeverageScore   `json:"campaign"`
-		Projects []*intleverage.LeverageScore `json:"projects"`
-	}
-
-	if err := json.Unmarshal([]byte(output), &result); err != nil {
-		t.Fatalf("failed to parse JSON: %v\nGot:\n%s", err, output)
-	}
-	if result.Campaign == nil {
-		t.Fatal("campaign score is nil in JSON output")
-	}
-	if result.Campaign.TotalCode == 0 {
-		t.Error("campaign total_code is zero")
-	}
-	if len(result.Projects) == 0 {
-		t.Error("no projects in JSON output")
-	}
-}
-
-func TestLeverageCommand_ProjectFilter(t *testing.T) {
-	origRunner := sccRunner
-	origPopulate := populateMetrics
-	t.Cleanup(func() { sccRunner = origRunner; populateMetrics = origPopulate })
-	populateMetrics = stubPopulateMetrics()
-
-	sccRunner = &mockRunner{
-		results: map[string]*intleverage.SCCResult{
-			"camp": sampleResult(10.68, 18.72, 2251607, 65641),
-			"fest": sampleResult(8.20, 15.50, 1500000, 45000),
-		},
-	}
-
-	t.Run("valid project filter", func(t *testing.T) {
-		output, err := executeLeverage(t, "--project", "camp")
-		if err != nil {
-			t.Fatalf("command failed: %v", err)
-		}
-		if !strings.Contains(output, "camp") {
-			t.Errorf("output should contain filtered project 'camp'\nGot:\n%s", output)
-		}
-	})
-
-	t.Run("invalid project filter returns error", func(t *testing.T) {
-		_, err := executeLeverage(t, "--project", "nonexistent")
-		if err == nil {
-			t.Fatal("expected error for invalid project, got nil")
-		}
-		if !strings.Contains(err.Error(), "project not found") {
-			t.Errorf("error = %q, want substring 'project not found'", err.Error())
-		}
-	})
-}
-
-func TestLeverageCommand_RunnerError(t *testing.T) {
-	origRunner := sccRunner
-	origPopulate := populateMetrics
-	t.Cleanup(func() { sccRunner = origRunner; populateMetrics = origPopulate })
-	populateMetrics = stubPopulateMetrics()
-
-	sccRunner = &mockRunner{
-		err: fmt.Errorf("scc not found: install with 'brew install scc'"),
-	}
-
-	output, err := executeLeverage(t)
-	if err != nil {
-		t.Fatalf("command should not error, got: %v", err)
-	}
-	if !strings.Contains(output, "Warning") {
-		t.Errorf("output should contain warnings for skipped projects\nGot:\n%s", output)
-	}
-}
-
-func TestLeverageConfigCommand_Display(t *testing.T) {
-	output, err := executeLeverage(t, "config")
-	if err != nil {
-		t.Skipf("skipping: not in a campaign directory: %v", err)
-	}
-
-	for _, want := range []string{"Team Size:", "COCOMO Type:", "Config path:"} {
-		if !strings.Contains(output, want) {
-			t.Errorf("output missing %q\nGot:\n%s", want, output)
-		}
-	}
-}
+// NOTE: TestLeverageCommand_TableOutput, _JSONOutput, _ProjectFilter,
+// _RunnerError, and TestLeverageConfigCommand_Display previously lived here
+// as unit tests. They invoked the live cobra RunE, which calls
+// campaign.DetectCached and walks up the filesystem to the real campaign
+// root, then writes to .campaign/leverage/ — meaning every `just test unit`
+// run silently dirtied the host campaign's snapshot files.
+//
+// Those scenarios were moved to tests/integration/leverage_test.go where the
+// command runs against an ephemeral campaign inside the shared container and
+// host filesystem mutation is impossible.
 
 func TestLeverageConfigCommand_ValidationPeople(t *testing.T) {
 	_, err := executeLeverage(t, "config", "--people", "-1")

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -118,6 +118,23 @@ func NewSharedContainer() (*TestContainer, error) {
 		}
 	}
 
+	// Build and copy scc binary (best-effort — scc is required by leverage tests
+	// only). scc is a third-party Go binary at github.com/boyter/scc/v3 that the
+	// `camp leverage` command shells out to via PATH lookup.
+	sccBinary, err := buildSCCBinaryShared()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARN: scc binary not available: %v\n", err)
+		sccAvailable = false
+	} else {
+		defer os.RemoveAll(filepath.Dir(sccBinary))
+		if err := container.CopyFileToContainer(ctx, sccBinary, "/usr/local/bin/scc", 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "WARN: failed to copy scc binary into container: %v\n", err)
+			sccAvailable = false
+		} else {
+			sccAvailable = true
+		}
+	}
+
 	// Install git (required for project operations)
 	exitCode, output, err := container.Exec(ctx, []string{"apk", "add", "--no-cache", "git"})
 	if err != nil {
@@ -244,6 +261,42 @@ func buildFestBinaryShared() (string, error) {
 	cmd := fmt.Sprintf("cd %s && GOOS=linux GOARCH=%s go build -o %s ./cmd/fest", festRoot, runtime.GOARCH, binaryPath)
 	if err := runCommand(cmd); err != nil {
 		return "", fmt.Errorf("failed to build fest binary: %w", err)
+	}
+
+	return binaryPath, nil
+}
+
+// buildSCCBinaryShared builds the third-party scc binary into a temp directory
+// and returns its path. scc is required by the `camp leverage` command (it
+// shells out to it for source-code counting). We build it on the host with
+// GOOS=linux so the resulting binary runs in the alpine container, matching
+// the camp/fest binary build pattern above.
+//
+// Returns ("", error) if the build fails — callers should treat this as
+// non-fatal since scc is only required by leverage tests.
+func buildSCCBinaryShared() (string, error) {
+	binDir, err := os.MkdirTemp("", "scc-integration-bin-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary scc binary directory: %w", err)
+	}
+
+	// Build scc from a throwaway Go module so we don't pollute the camp module.
+	// `go install` with GOOS != host OS ignores GOBIN, so we use a tmp module
+	// + `go build` pointing at the package import path.
+	modDir := filepath.Join(binDir, "buildmod")
+	if err := os.MkdirAll(modDir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create scc build module dir: %w", err)
+	}
+
+	binaryPath := filepath.Join(binDir, "scc")
+	cmd := fmt.Sprintf(
+		"cd %s && go mod init sccbuild >/dev/null 2>&1 && "+
+			"go get github.com/boyter/scc/v3@latest && "+
+			"GOOS=linux GOARCH=%s go build -o %s github.com/boyter/scc/v3",
+		modDir, runtime.GOARCH, binaryPath,
+	)
+	if err := runCommand(cmd); err != nil {
+		return "", fmt.Errorf("failed to build scc binary: %w", err)
 	}
 
 	return binaryPath, nil

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -118,7 +118,7 @@ func NewSharedContainer() (*TestContainer, error) {
 		}
 	}
 
-	// Build and copy scc binary (best-effort — scc is required by leverage tests
+	// Build and copy scc binary (best-effort; scc is required by leverage tests
 	// only). scc is a third-party Go binary at github.com/boyter/scc/v3 that the
 	// `camp leverage` command shells out to via PATH lookup.
 	sccBinary, err := buildSCCBinaryShared()
@@ -272,7 +272,14 @@ func buildFestBinaryShared() (string, error) {
 // GOOS=linux so the resulting binary runs in the alpine container, matching
 // the camp/fest binary build pattern above.
 //
-// Returns ("", error) if the build fails — callers should treat this as
+// We deliberately use @latest rather than pinning a version. Real users
+// install scc via `brew install scc` or `go install ...@latest`, so the
+// integration tests should validate against whatever the leverage command
+// will actually encounter in the wild. If a future scc release breaks the
+// CLI contract leverage depends on, we'd rather find out here than in
+// production.
+//
+// Returns ("", error) if the build fails. Callers should treat this as
 // non-fatal since scc is only required by leverage tests.
 func buildSCCBinaryShared() (string, error) {
 	binDir, err := os.MkdirTemp("", "scc-integration-bin-*")

--- a/tests/integration/leverage_test.go
+++ b/tests/integration/leverage_test.go
@@ -62,7 +62,11 @@ EOF
 // `just test unit` constantly dirty the campaign repo.
 func TestLeverage_TableOutput(t *testing.T) {
 	if !sccAvailable {
-		t.Skip("scc binary not available in container; skipping")
+		t.Fatal("scc binary failed to build at container init time. " +
+			"These tests gate the leverage integration coverage and must not " +
+			"silently skip on upstream scc breakage; investigate the build " +
+			"error logged by NewSharedContainer and either fix or roll back to " +
+			"a known-good scc release.")
 	}
 
 	tc := GetSharedContainer(t)
@@ -95,7 +99,11 @@ func TestLeverage_TableOutput(t *testing.T) {
 // Migrated from cmd/camp/leverage/main_command_test.go::TestLeverageCommand_JSONOutput.
 func TestLeverage_JSONOutput(t *testing.T) {
 	if !sccAvailable {
-		t.Skip("scc binary not available in container; skipping")
+		t.Fatal("scc binary failed to build at container init time. " +
+			"These tests gate the leverage integration coverage and must not " +
+			"silently skip on upstream scc breakage; investigate the build " +
+			"error logged by NewSharedContainer and either fix or roll back to " +
+			"a known-good scc release.")
 	}
 
 	tc := GetSharedContainer(t)
@@ -123,7 +131,11 @@ func TestLeverage_JSONOutput(t *testing.T) {
 // Migrated from cmd/camp/leverage/main_command_test.go::TestLeverageCommand_ProjectFilter.
 func TestLeverage_ProjectFilter(t *testing.T) {
 	if !sccAvailable {
-		t.Skip("scc binary not available in container; skipping")
+		t.Fatal("scc binary failed to build at container init time. " +
+			"These tests gate the leverage integration coverage and must not " +
+			"silently skip on upstream scc breakage; investigate the build " +
+			"error logged by NewSharedContainer and either fix or roll back to " +
+			"a known-good scc release.")
 	}
 
 	tc := GetSharedContainer(t)
@@ -154,7 +166,11 @@ func TestLeverage_ProjectFilter(t *testing.T) {
 // loop branch.
 func TestLeverage_RunnerError(t *testing.T) {
 	if !sccAvailable {
-		t.Skip("scc binary not available in container; skipping")
+		t.Fatal("scc binary failed to build at container init time. " +
+			"These tests gate the leverage integration coverage and must not " +
+			"silently skip on upstream scc breakage; investigate the build " +
+			"error logged by NewSharedContainer and either fix or roll back to " +
+			"a known-good scc release.")
 	}
 
 	tc := GetSharedContainer(t)

--- a/tests/integration/leverage_test.go
+++ b/tests/integration/leverage_test.go
@@ -1,0 +1,200 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupLeverageCampaign initializes a campaign with two small Go projects
+// committed to git so `camp leverage` has something to score. Returns the
+// campaign root path inside the container.
+//
+// scc and git history (at least one commit) are required by the leverage
+// pipeline — without commits, ResolveProjects/CountAuthors return empty
+// results and the table output skips the project rows we want to assert on.
+func setupLeverageCampaign(t *testing.T, tc *TestContainer, name string) string {
+	t.Helper()
+
+	root := "/campaigns/" + name
+	_, err := tc.InitCampaign(root, name, "")
+	require.NoError(t, err, "camp init should succeed")
+
+	// Create two project subdirs with a tiny Go file each, committed via git.
+	// Project layout matches what camp's project resolver expects (a git repo
+	// per project under projects/<name>/). Without InitGitRepo + a commit the
+	// leverage author resolver finds 0 authors and skips the project.
+	for _, project := range []string{"alpha", "beta"} {
+		projectPath := root + "/projects/" + project
+		tc.Shell(t, fmt.Sprintf(`
+			set -e
+			mkdir -p %s
+			cat > %s/main.go <<'EOF'
+package main
+
+func main() {
+	println("hello from %s")
+}
+EOF
+			cd %s
+			git init -q
+			git add main.go
+			git -c user.email=test@test.com -c user.name=Test commit -q -m "initial"
+		`, projectPath, projectPath, project, projectPath))
+	}
+
+	return root
+}
+
+// TestLeverage_TableOutput exercises the default table output of `camp leverage`.
+//
+// Migrated from cmd/camp/leverage/main_command_test.go::TestLeverageCommand_TableOutput
+// because the original test invoked the live cobra RunE against the host's
+// campaign root (via campaign.DetectCached), persisting snapshots to
+// .campaign/leverage/snapshots/ on every run. The host-fs mutation made
+// `just test unit` constantly dirty the campaign repo.
+func TestLeverage_TableOutput(t *testing.T) {
+	if !sccAvailable {
+		t.Skip("scc binary not available in container; skipping")
+	}
+
+	tc := GetSharedContainer(t)
+	root := setupLeverageCampaign(t, tc, "leverage-table")
+
+	output, err := tc.RunCampInDir(root, "leverage")
+	require.NoError(t, err, "camp leverage should succeed: %s", output)
+
+	for _, want := range []string{
+		"Campaign Leverage:",
+		"COCOMO Estimate:",
+		"person-months",
+		"Actual Effort:",
+		"Team Equivalent:",
+		"PROJECT",
+		"FILES",
+		"CODE",
+		"AUTHORS",
+		"EST COST",
+		"EST PM",
+		"ACTUAL PM",
+		"LEVERAGE",
+	} {
+		assert.Contains(t, output, want, "table output missing %q", want)
+	}
+}
+
+// TestLeverage_JSONOutput exercises the `--json` flag.
+//
+// Migrated from cmd/camp/leverage/main_command_test.go::TestLeverageCommand_JSONOutput.
+func TestLeverage_JSONOutput(t *testing.T) {
+	if !sccAvailable {
+		t.Skip("scc binary not available in container; skipping")
+	}
+
+	tc := GetSharedContainer(t)
+	root := setupLeverageCampaign(t, tc, "leverage-json")
+
+	output, err := tc.RunCampInDir(root, "leverage", "--json")
+	require.NoError(t, err, "camp leverage --json should succeed: %s", output)
+
+	// Output may have a leading `Created leverage config at ...` notice on the
+	// first run before the JSON. Strip everything before the first `{`.
+	jsonStart := strings.Index(output, "{")
+	require.GreaterOrEqual(t, jsonStart, 0, "no JSON object in output: %s", output)
+
+	var result struct {
+		Campaign map[string]any   `json:"campaign"`
+		Projects []map[string]any `json:"projects"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(output[jsonStart:]), &result), "parse JSON: %s", output)
+	require.NotNil(t, result.Campaign, "campaign score is nil in JSON")
+	assert.NotEmpty(t, result.Projects, "no projects in JSON output")
+}
+
+// TestLeverage_ProjectFilter exercises `--project` valid and invalid filters.
+//
+// Migrated from cmd/camp/leverage/main_command_test.go::TestLeverageCommand_ProjectFilter.
+func TestLeverage_ProjectFilter(t *testing.T) {
+	if !sccAvailable {
+		t.Skip("scc binary not available in container; skipping")
+	}
+
+	tc := GetSharedContainer(t)
+	root := setupLeverageCampaign(t, tc, "leverage-filter")
+
+	t.Run("valid project filter", func(t *testing.T) {
+		output, err := tc.RunCampInDir(root, "leverage", "--project", "alpha")
+		require.NoError(t, err, "camp leverage --project alpha should succeed: %s", output)
+		assert.Contains(t, output, "alpha", "output should contain filtered project 'alpha'")
+	})
+
+	t.Run("invalid project filter returns error", func(t *testing.T) {
+		output, err := tc.RunCampInDir(root, "leverage", "--project", "nonexistent")
+		require.Error(t, err, "camp leverage --project nonexistent should fail")
+		assert.Contains(t, output, "project not found", "error should mention project not found")
+	})
+}
+
+// TestLeverage_RunnerError verifies that `camp leverage` warns and continues
+// when the scc binary fails per-project (rather than hard-failing the whole
+// command).
+//
+// Migrated from cmd/camp/leverage/main_command_test.go::TestLeverageCommand_RunnerError.
+// The original mocked the Runner interface with an error from Run(). Here we
+// shadow the real scc binary with a stub that exits non-zero, so
+// `initRunner` (which exec.LookPath("scc")) succeeds but every per-project
+// Run() invocation fails — exercising the same `Warning: skipping <project>`
+// loop branch.
+func TestLeverage_RunnerError(t *testing.T) {
+	if !sccAvailable {
+		t.Skip("scc binary not available in container; skipping")
+	}
+
+	tc := GetSharedContainer(t)
+	root := setupLeverageCampaign(t, tc, "leverage-runner-err")
+
+	// Replace the real scc binary with a failing stub at the same path so
+	// exec.LookPath("scc") still finds something but every Run() invocation
+	// fails. Put the stub at /usr/local/bin/scc (where the real one lives) —
+	// in alpine /usr/local/bin precedes /usr/bin in PATH, so a stub elsewhere
+	// would be shadowed. Stash the real binary aside and restore on cleanup.
+	tc.Shell(t, `set -e
+mv /usr/local/bin/scc /usr/local/bin/scc.real
+cat > /usr/local/bin/scc <<'EOF'
+#!/bin/sh
+echo "stub scc: simulated failure" >&2
+exit 1
+EOF
+chmod +x /usr/local/bin/scc`)
+	t.Cleanup(func() {
+		_, _, _ = tc.ExecCommand("sh", "-c", "rm -f /usr/local/bin/scc && mv /usr/local/bin/scc.real /usr/local/bin/scc")
+	})
+
+	output, err := tc.RunCampInDir(root, "leverage")
+	require.NoError(t, err, "camp leverage should not hard-fail on per-project scc errors: %s", output)
+	assert.Contains(t, output, "Warning", "output should contain a Warning line for the failing scc run")
+}
+
+// TestLeverage_ConfigDisplay exercises `camp leverage config` with no flags.
+//
+// Migrated from cmd/camp/leverage/main_command_test.go::TestLeverageConfigCommand_Display.
+// The original test read the host's real campaign config; here we read a
+// fresh ephemeral campaign created inside the container.
+func TestLeverage_ConfigDisplay(t *testing.T) {
+	tc := GetSharedContainer(t)
+	root := setupLeverageCampaign(t, tc, "leverage-config")
+
+	output, err := tc.RunCampInDir(root, "leverage", "config")
+	require.NoError(t, err, "camp leverage config should succeed: %s", output)
+
+	for _, want := range []string{"Team Size:", "COCOMO Type:", "Config path:"} {
+		assert.Contains(t, output, want, "config output missing %q", want)
+	}
+}

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -16,6 +16,11 @@ var sharedContainer *TestContainer
 // copied into the shared container. Tests that require fest should skip if false.
 var festAvailable bool
 
+// sccAvailable indicates whether the scc binary was successfully built and
+// copied into the shared container. Leverage tests that require scc should
+// skip if false.
+var sccAvailable bool
+
 // TestMain sets up a shared container for all integration tests.
 // This avoids the overhead of spinning up a new container for each test.
 func TestMain(m *testing.M) {


### PR DESCRIPTION
## Summary

`just test unit` was silently dirtying the host campaign's `.campaign/leverage/snapshots/` on every run. Five tests in `cmd/camp/leverage/main_command_test.go` drove the live cobra `RunE` through `executeLeverage(t)`, which calls `campaign.DetectCached` to walk up to the real campaign root and then persists today's snapshots there. Only the `sampled_at` timestamp changed on each run, which is why this hid for so long — the leverage scores looked stable but the files kept showing up dirty in `git status`.

The fix moves the five offenders into `tests/integration/leverage_test.go` where they run against a fresh ephemeral campaign inside the shared alpine container. The remaining unit tests either drive `runLeverageDir` (which never touches the snapshot store) or are pure function-level tests with a mocked `SnapshotStorer`, so they stay put.

### What moved

| Removed from unit tests | Now in integration tests |
| --- | --- |
| `TestLeverageCommand_TableOutput` | `TestLeverage_TableOutput` |
| `TestLeverageCommand_JSONOutput` | `TestLeverage_JSONOutput` |
| `TestLeverageCommand_ProjectFilter` | `TestLeverage_ProjectFilter` |
| `TestLeverageCommand_RunnerError` | `TestLeverage_RunnerError` |
| `TestLeverageConfigCommand_Display` | `TestLeverage_ConfigDisplay` |

### Harness changes

- `tests/integration/helpers.go`: added `buildSCCBinaryShared()`, which `go build`s `github.com/boyter/scc/v3@latest` for `GOOS=linux` and copies it to `/usr/local/bin/scc` in the shared container (same pattern as the existing camp/fest binary build).
- `tests/integration/main_test.go`: added a package-level `sccAvailable` flag mirroring `festAvailable`. The new leverage tests skip if scc didn't build.
- `TestLeverage_RunnerError` swaps the real scc binary for a failing stub so `exec.LookPath("scc")` still resolves but every `Run()` exits non-zero, exercising the same per-project `Warning: skipping` branch the original mock test covered.

### Verification

```
$ stat -f %Sm .campaign/leverage/snapshots/camp/2026-04-29.json   # before
Apr 30 04:36:04 2026
$ just test unit                                                  # ALL 2201 PASS, 80s
$ stat -f %Sm .campaign/leverage/snapshots/camp/2026-04-29.json   # after — unchanged
Apr 30 04:36:04 2026
```

Integration suite (`just test integration-run TestLeverage`):

```
--- PASS: TestLeverage_TableOutput (3.88s)
--- PASS: TestLeverage_JSONOutput  (1.55s)
--- PASS: TestLeverage_ProjectFilter (1.76s)
--- PASS: TestLeverage_RunnerError (1.65s)
--- PASS: TestLeverage_ConfigDisplay (1.15s)
ok  	github.com/Obedience-Corp/camp/tests/integration	27.708s
```

## Test plan

- [x] `just build default-build` — clean
- [x] `just test unit` — all 2201 tests pass
- [x] `just test integration-run TestLeverage` — all 5 tests pass
- [x] Host `.campaign/leverage/snapshots/` mtimes unchanged after `just test unit`
- [x] `gofmt -l` clean on touched files