### PR TITLE
fix(leverage): drop submodule entries shadowed by standalone clones

### DIFF
--- a/internal/leverage/projects.go
+++ b/internal/leverage/projects.go
@@ -61,11 +61,16 @@ func ResolveProjects(ctx context.Context, campaignRoot string, cfg *LeverageConf
 // resolveFromProjectList falls back to project.List() discovery.
 // Monorepo subprojects get SCCDir pointing to the subproject and GitDir
 // pointing to the monorepo root (where .git lives).
+//
+// Leverage scoring further dedups submodule entries against standalone
+// clones of the same git remote URL — see dropSubmodulesShadowedByStandalone.
 func resolveFromProjectList(ctx context.Context, campaignRoot string) ([]ResolvedProject, error) {
 	projects, err := project.List(ctx, campaignRoot)
 	if err != nil {
 		return nil, camperrors.Wrap(err, "list projects")
 	}
+
+	projects = dropSubmodulesShadowedByStandalone(projects)
 
 	resolved := make([]ResolvedProject, 0, len(projects))
 	for _, p := range projects {
@@ -94,6 +99,43 @@ func resolveFromProjectList(ctx context.Context, campaignRoot string) ([]Resolve
 	})
 
 	return resolved, nil
+}
+
+// dropSubmodulesShadowedByStandalone removes monorepo subproject
+// entries whose git remote URL matches a standalone (non-submodule)
+// project in the same list. This prevents leverage scoring from
+// double-counting a repo that appears both as `projects/foo` and as
+// `projects/<monorepo>/foo` via .gitmodules.
+//
+// `project.List` deliberately keeps both entries so that callers
+// like `camp fresh` can target each checkout by name. Leverage
+// scoring needs the opposite: a single canonical entry per repo.
+//
+// The standalone entry wins because it is a direct clone with full
+// history; submodule references may be pinned to older SHAs.
+//
+// Submodule entries with no URL (uninitialised submodule, no
+// remote configured) are kept unchanged — there is no standalone
+// to shadow them.
+func dropSubmodulesShadowedByStandalone(projects []project.Project) []project.Project {
+	standaloneURLs := make(map[string]struct{})
+	for _, p := range projects {
+		if p.MonorepoRoot != "" || p.URL == "" {
+			continue
+		}
+		standaloneURLs[p.URL] = struct{}{}
+	}
+
+	out := make([]project.Project, 0, len(projects))
+	for _, p := range projects {
+		if p.MonorepoRoot != "" && p.URL != "" {
+			if _, shadowed := standaloneURLs[p.URL]; shadowed {
+				continue
+			}
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 // resolveFromConfig resolves explicitly configured project entries.

--- a/internal/leverage/projects_test.go
+++ b/internal/leverage/projects_test.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/project"
 )
 
 func TestResolveProjects_ConfigDriven(t *testing.T) {
@@ -324,5 +326,187 @@ func TestFilterByName(t *testing.T) {
 				t.Errorf("got %d projects, want %d", len(got), tt.wantCount)
 			}
 		})
+	}
+}
+
+// TestDropSubmodulesShadowedByStandalone covers the leverage-only
+// dedup that removes submodule entries whose URL matches a
+// standalone clone of the same repo.
+//
+// This is the regression fix for the case where the campaign
+// contains both `projects/foo` and `projects/<monorepo>/foo` (via
+// .gitmodules) — leverage must score that work once, not twice.
+func TestDropSubmodulesShadowedByStandalone(t *testing.T) {
+	const sharedURL = "git@github.com:test/foo.git"
+
+	cases := []struct {
+		name      string
+		input     []project.Project
+		wantNames []string
+	}{
+		{
+			name: "shadows submodule when standalone with same URL exists",
+			input: []project.Project{
+				{Name: "foo", URL: sharedURL},
+				{Name: "mono", URL: "git@github.com:test/mono.git"},
+				{Name: "mono@foo", URL: sharedURL, MonorepoRoot: "projects/mono"},
+				{Name: "mono@bar", URL: "git@github.com:test/bar.git", MonorepoRoot: "projects/mono"},
+			},
+			wantNames: []string{"foo", "mono", "mono@bar"},
+		},
+		{
+			name: "keeps submodule when no standalone shadows it",
+			input: []project.Project{
+				{Name: "mono", URL: "git@github.com:test/mono.git"},
+				{Name: "mono@bar", URL: "git@github.com:test/bar.git", MonorepoRoot: "projects/mono"},
+			},
+			wantNames: []string{"mono", "mono@bar"},
+		},
+		{
+			name: "keeps submodule with empty URL even if a standalone shares the URL",
+			input: []project.Project{
+				{Name: "foo", URL: sharedURL},
+				// Submodule with no URL (uninitialised, no remote).
+				// Drop is keyed on URL match, so an empty-URL
+				// submodule cannot be shadowed.
+				{Name: "mono@orphan", URL: "", MonorepoRoot: "projects/mono"},
+			},
+			wantNames: []string{"foo", "mono@orphan"},
+		},
+		{
+			name: "no-op when no submodule entries present",
+			input: []project.Project{
+				{Name: "foo", URL: sharedURL},
+				{Name: "bar", URL: "git@github.com:test/bar.git"},
+			},
+			wantNames: []string{"foo", "bar"},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dropSubmodulesShadowedByStandalone(tt.input)
+
+			gotNames := make([]string, len(got))
+			for i, p := range got {
+				gotNames[i] = p.Name
+			}
+
+			if len(gotNames) != len(tt.wantNames) {
+				t.Fatalf("got %v, want %v", gotNames, tt.wantNames)
+			}
+			for i, want := range tt.wantNames {
+				if gotNames[i] != want {
+					t.Errorf("idx %d: got %q, want %q (full: %v)", i, gotNames[i], want, gotNames)
+				}
+			}
+		})
+	}
+}
+
+// TestResolveProjects_FallbackDropsSubmoduleShadowedByStandalone is
+// the end-to-end regression test for the "double-counting" bug
+// reported in issue #263. A campaign with both `projects/child` and
+// `projects/mono` (where mono lists child as a .gitmodules entry
+// pointing at the same remote URL) must surface only the standalone
+// child to leverage scoring.
+func TestResolveProjects_FallbackDropsSubmoduleShadowedByStandalone(t *testing.T) {
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+
+	const childURL = "git@github.com:test/child.git"
+
+	projectsDir := filepath.Join(root, "projects")
+	if err := os.MkdirAll(projectsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Standalone child clone.
+	standaloneChild := filepath.Join(projectsDir, "child")
+	if err := os.MkdirAll(standaloneChild, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initLeverageRepo(t, standaloneChild, childURL)
+
+	// Monorepo containing a "child" submodule whose remote matches.
+	mono := filepath.Join(projectsDir, "mono")
+	if err := os.MkdirAll(mono, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initLeverageRepo(t, mono, "git@github.com:test/mono.git")
+
+	subChild := filepath.Join(mono, "child")
+	if err := os.MkdirAll(subChild, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initLeverageRepo(t, subChild, childURL)
+
+	// .gitmodules entry so project.List sees `mono@child` as a
+	// monorepo subproject.
+	gitmodules := fmt.Sprintf("[submodule %q]\n\tpath = child\n\turl = %s\n", "child", childURL)
+	if err := os.WriteFile(filepath.Join(mono, ".gitmodules"), []byte(gitmodules), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &LeverageConfig{}
+	got, err := ResolveProjects(context.Background(), root, cfg)
+	if err != nil {
+		t.Fatalf("ResolveProjects error = %v", err)
+	}
+
+	names := make([]string, len(got))
+	for i, p := range got {
+		names[i] = p.Name
+	}
+
+	for _, n := range names {
+		if n == "mono@child" {
+			t.Fatalf("mono@child should be dropped (shadowed by standalone child); got %v", names)
+		}
+	}
+	hasStandalone := false
+	hasMono := false
+	for _, n := range names {
+		switch n {
+		case "child":
+			hasStandalone = true
+		case "mono":
+			hasMono = true
+		}
+	}
+	if !hasStandalone {
+		t.Errorf("standalone 'child' missing from result: %v", names)
+	}
+	if !hasMono {
+		t.Errorf("monorepo root 'mono' missing from result: %v", names)
+	}
+}
+
+// initLeverageRepo initialises a git repo at path with the given
+// remote URL and creates one commit so commands like
+// `git remote get-url origin` and `git log` work.
+func initLeverageRepo(t *testing.T, path, remoteURL string) {
+	t.Helper()
+	cmds := [][]string{
+		{"git", "init", path},
+		{"git", "-C", path, "remote", "add", "origin", remoteURL},
+		{"git", "-C", path, "config", "user.email", "test@test.com"},
+		{"git", "-C", path, "config", "user.name", "Test"},
+	}
+	for _, args := range cmds {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(path, "README.md"), []byte("seed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "-C", path, "add", "."},
+		{"git", "-C", path, "commit", "-m", "seed"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, out)
+		}
 	}
 }

--- a/internal/project/list.go
+++ b/internal/project/list.go
@@ -100,11 +100,17 @@ func resolveLinkedProject(ctx context.Context, name, logicalPath, resolvedPath s
 		})
 		for _, subPath := range submodulePaths {
 			subFullPath := filepath.Join(resolvedPath, subPath)
+			// Each submodule has its own remote. Recording the
+			// submodule's own URL (rather than the parent's) lets
+			// downstream consumers like leverage scoring dedup a
+			// submodule entry against a standalone clone of the
+			// same repo. Empty URL is fine — uninitialised submodules
+			// are kept as-is.
 			expanded = append(expanded, Project{
 				Name:         name + "@" + subPath,
 				Path:         filepath.Join(relPath, subPath),
 				Type:         detectProjectType(subFullPath),
-				URL:          url,
+				URL:          getGitRemoteURL(ctx, subFullPath),
 				Source:       source,
 				LinkedPath:   resolvedPath,
 				MonorepoRoot: relPath,
@@ -155,11 +161,17 @@ func resolveProject(ctx context.Context, name, projectPath string) []Project {
 
 	for _, subPath := range submodulePaths {
 		subFullPath := filepath.Join(projectPath, subPath)
+		// Use the submodule's own remote URL rather than the
+		// parent monorepo's URL. This makes the URL field honest
+		// (each entry's URL identifies its own repo) and lets
+		// leverage-level dedup recognise when a submodule and a
+		// standalone clone refer to the same repo. Empty URL is
+		// fine — uninitialised submodules are kept as-is.
 		expanded = append(expanded, Project{
 			Name:         name + "@" + subPath,
 			Path:         filepath.Join(relPath, subPath),
 			Type:         detectProjectType(subFullPath),
-			URL:          url,
+			URL:          getGitRemoteURL(ctx, subFullPath),
 			MonorepoRoot: relPath,
 		})
 	}

--- a/internal/project/list_test.go
+++ b/internal/project/list_test.go
@@ -543,6 +543,61 @@ func writeGitmodules(t *testing.T, repoPath string, submodules map[string]string
 	}
 }
 
+// TestList_GitmodulesSubmoduleCarriesOwnURL verifies that each
+// submodule entry records its own remote URL, not the parent
+// monorepo's. Downstream consumers (notably leverage scoring)
+// rely on the URL field identifying the submodule's own repo so
+// they can dedup it against a standalone clone of the same repo.
+func TestList_GitmodulesSubmoduleCarriesOwnURL(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	projectsDir := filepath.Join(tmpDir, "projects")
+	if err := os.MkdirAll(projectsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Monorepo with a submodule pointing at its own remote.
+	mono := filepath.Join(projectsDir, "mono")
+	if err := os.MkdirAll(mono, 0755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoWithRemoteAndCommit(t, mono, "git@github.com:test/mono.git", "mono init")
+
+	// Submodule directory with its own initialised git repo and remote.
+	subPath := filepath.Join(mono, "child")
+	if err := os.MkdirAll(subPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepoWithRemoteAndCommit(t, subPath, "git@github.com:test/child.git", "child init")
+
+	writeGitmodules(t, mono, map[string]string{
+		"child": "child",
+	})
+
+	ctx := context.Background()
+	projects, err := List(ctx, tmpDir)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	var sub *Project
+	for i, p := range projects {
+		if p.Name == "mono@child" {
+			sub = &projects[i]
+			break
+		}
+	}
+	if sub == nil {
+		t.Fatal("expected mono@child entry in result")
+	}
+
+	want := "git@github.com:test/child.git"
+	if sub.URL != want {
+		t.Errorf("submodule URL = %q, want %q (own URL, not parent's)", sub.URL, want)
+	}
+}
+
 // initGitRepoWithRemoteAndCommit initializes a git repo, sets a remote URL,
 // and creates an initial commit so that git log returns a date.
 func initGitRepoWithRemoteAndCommit(t *testing.T, path, remoteURL, message string) {


### PR DESCRIPTION
Fixes #263

## Summary

Campaign-wide leverage scoring was double-counting work for repos that appear both as standalone projects and as submodules of another project. For example, `obey-platform-monorepo` lists `camp`, `fest`, and others under its `.gitmodules`, and those repos are also registered as standalone projects under `projects/`. The same authors/LOC were being scored twice (once via the standalone clone and once via the submodule reference).

## Root cause

Commit `5d0b582` added a "skip dedup for monorepo subprojects" exception to `internal/project/list.go`'s `deduplicateByRemoteURL`. The motivation was correct — multiple submodules of the same monorepo would otherwise collapse onto each other — but the exception was over-broad. It worked because submodule entries were tagged with the **parent's** URL rather than their own, so the URL-based dedup could not actually distinguish them.

The result: when a submodule and a standalone clone of the same repo coexisted in the campaign (the common case for `camp`, `fest`, etc. alongside `obey-platform-monorepo`), both entries were preserved and both contributed to leverage totals.

## Fix

Two-layer change:

**1. `internal/project/list.go`** — each submodule entry now carries its **own** remote URL via `getGitRemoteURL(ctx, subFullPath)` instead of inheriting the parent monorepo's URL. This is the honest representation. `project.List` itself still keeps both `foo` and `mono@foo` so `camp fresh` and shell completion can target each checkout independently (`TestList_GitmodulesSubmoduleKeptAlongsideStandalone` preserved).

**2. `internal/leverage/projects.go`** — `resolveFromProjectList` runs a new `dropSubmodulesShadowedByStandalone` pass that removes submodule entries whose URL matches a standalone entry. The standalone wins because it is a direct clone with full history; submodule references may be pinned to older SHAs.

Submodule entries with no URL (uninitialised submodules, no remote configured) are kept unchanged — they cannot be shadowed.

## Tests

- `TestList_GitmodulesSubmoduleCarriesOwnURL` — new submodule entries carry their own remote URL.
- `TestDropSubmodulesShadowedByStandalone` (table) — unit coverage of the dedup helper across the shadow / no-shadow / empty-URL / no-op cases.
- `TestResolveProjects_FallbackDropsSubmoduleShadowedByStandalone` — end-to-end regression test for issue #263 using a real on-disk monorepo + `.gitmodules` + standalone child.

Existing tests preserved:
- `TestList_GitmodulesSubmoduleKeptAlongsideStandalone` — `project.List` still returns both forms.
- `TestList_DeduplicatesByRemoteURL` — standalone-vs-standalone dedup unchanged.
- `TestResolveProjects_FallbackMonorepoExpansion` — no-shadow monorepo still produces root + submodule entries.

## Test plan

- [x] `just test unit` — 2209/2209 pass
- [x] `just build default-build` — clean
- [ ] Manual verification on the obey campaign: `camp leverage` campaign totals should drop now that overlapping repos are not double-counted.

## Out of scope

The existing `.campaign/leverage/snapshots/<name>@<sub>/` directories on disk (e.g. `obey-platform-monorepo@camp`) will no longer be written to going forward, but historical snapshot files remain. Cleanup of those stale directories is a separate concern; happy to follow up if desired.