### PR TITLE
fix: dedupe leverage projects by repo url

### DIFF
--- a/internal/leverage/config.go
+++ b/internal/leverage/config.go
@@ -75,6 +75,7 @@ func AutoDetectConfig(ctx context.Context, campaignRoot string) (*LeverageConfig
 	if err != nil {
 		return nil, camperrors.Wrap(err, "listing projects")
 	}
+	projects = deduplicateProjectsForLeverage(projects)
 
 	cfg := defaultConfig()
 
@@ -117,6 +118,13 @@ func PopulateProjects(ctx context.Context, campaignRoot string, cfg *LeverageCon
 		return camperrors.Wrap(err, "listing projects")
 	}
 
+	populateProjectsFromDiscovered(cfg, projects)
+	return nil
+}
+
+func populateProjectsFromDiscovered(cfg *LeverageConfig, projects []project.Project) {
+	projects = deduplicateProjectsForLeverage(projects)
+
 	if cfg.Projects == nil {
 		cfg.Projects = make(map[string]ProjectEntry, len(projects))
 	}
@@ -148,8 +156,6 @@ func PopulateProjects(ctx context.Context, campaignRoot string, cfg *LeverageCon
 			delete(cfg.Projects, name)
 		}
 	}
-
-	return nil
 }
 
 // defaultConfig returns a LeverageConfig with sensible defaults.

--- a/internal/leverage/config_test.go
+++ b/internal/leverage/config_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/Obedience-Corp/camp/internal/project"
 )
 
 func TestDefaultConfigPath(t *testing.T) {
@@ -184,6 +186,54 @@ func TestAutoDetectConfig_ContextCancelled(t *testing.T) {
 	_, err := AutoDetectConfig(ctx, "/Users/lancerogers/Dev/AI/obey-campaign")
 	if err == nil {
 		t.Fatal("expected error from cancelled context")
+	}
+}
+
+func TestPopulateProjectsFromDiscoveredPrunesDuplicateRepoURLs(t *testing.T) {
+	const sharedURL = "git@github.com:test/shared.git"
+
+	cfg := &LeverageConfig{
+		Projects: map[string]ProjectEntry{
+			"mono-a@shared": {
+				Path:         "projects/mono-a/shared",
+				Include:      false,
+				InMonorepo:   true,
+				MonorepoPath: "projects/mono-a",
+			},
+			"mono-b@shared": {
+				Path:         "projects/mono-b/shared",
+				Include:      true,
+				InMonorepo:   true,
+				MonorepoPath: "projects/mono-b",
+			},
+			"gone": {
+				Path:    "projects/gone",
+				Include: true,
+			},
+		},
+	}
+	projects := []project.Project{
+		{Name: "mono-a", Path: "projects/mono-a", URL: "git@github.com:test/mono-a.git"},
+		{Name: "mono-a@shared", Path: "projects/mono-a/shared", URL: sharedURL, MonorepoRoot: "projects/mono-a"},
+		{Name: "mono-b", Path: "projects/mono-b", URL: "git@github.com:test/mono-b.git"},
+		{Name: "mono-b@shared", Path: "projects/mono-b/shared", URL: sharedURL, MonorepoRoot: "projects/mono-b"},
+	}
+
+	populateProjectsFromDiscovered(cfg, projects)
+
+	if _, ok := cfg.Projects["mono-b@shared"]; ok {
+		t.Fatalf("duplicate submodule entry mono-b@shared should be pruned from leverage config")
+	}
+	if _, ok := cfg.Projects["gone"]; ok {
+		t.Fatalf("stale project entry should be pruned from leverage config")
+	}
+	if got := cfg.Projects["mono-a@shared"]; got.Include {
+		t.Fatalf("existing Include=false should be preserved for canonical duplicate entry")
+	}
+	for _, want := range []string{"mono-a", "mono-a@shared", "mono-b"} {
+		if _, ok := cfg.Projects[want]; !ok {
+			t.Fatalf("expected project %q to be present after population", want)
+		}
 	}
 }
 

--- a/internal/leverage/projects.go
+++ b/internal/leverage/projects.go
@@ -62,15 +62,15 @@ func ResolveProjects(ctx context.Context, campaignRoot string, cfg *LeverageConf
 // Monorepo subprojects get SCCDir pointing to the subproject and GitDir
 // pointing to the monorepo root (where .git lives).
 //
-// Leverage scoring further dedups submodule entries against standalone
-// clones of the same git remote URL — see dropSubmodulesShadowedByStandalone.
+// Leverage scoring further dedups entries by git remote URL so a repository
+// present through multiple checkout paths is scored once.
 func resolveFromProjectList(ctx context.Context, campaignRoot string) ([]ResolvedProject, error) {
 	projects, err := project.List(ctx, campaignRoot)
 	if err != nil {
 		return nil, camperrors.Wrap(err, "list projects")
 	}
 
-	projects = dropSubmodulesShadowedByStandalone(projects)
+	projects = deduplicateProjectsForLeverage(projects)
 
 	resolved := make([]ResolvedProject, 0, len(projects))
 	for _, p := range projects {
@@ -101,41 +101,48 @@ func resolveFromProjectList(ctx context.Context, campaignRoot string) ([]Resolve
 	return resolved, nil
 }
 
-// dropSubmodulesShadowedByStandalone removes monorepo subproject
-// entries whose git remote URL matches a standalone (non-submodule)
-// project in the same list. This prevents leverage scoring from
-// double-counting a repo that appears both as `projects/foo` and as
-// `projects/<monorepo>/foo` via .gitmodules.
+// deduplicateProjectsForLeverage keeps one canonical project per non-empty git
+// remote URL. This prevents leverage scoring from double-counting a repo that
+// appears through multiple checkout paths, including `projects/foo`,
+// `projects/<monorepo>/foo`, and the same submodule in more than one monorepo.
 //
 // `project.List` deliberately keeps both entries so that callers
 // like `camp fresh` can target each checkout by name. Leverage
 // scoring needs the opposite: a single canonical entry per repo.
 //
-// The standalone entry wins because it is a direct clone with full
-// history; submodule references may be pinned to older SHAs.
+// A standalone entry wins over submodule entries because it is a direct clone
+// with full history; submodule references may be pinned to older SHAs. When the
+// same URL appears only as submodules, the first discovered entry is kept as the
+// deterministic canonical checkout.
 //
-// Submodule entries with no URL (uninitialised submodule, no
-// remote configured) are kept unchanged — there is no standalone
-// to shadow them.
-func dropSubmodulesShadowedByStandalone(projects []project.Project) []project.Project {
-	standaloneURLs := make(map[string]struct{})
+// Entries with no URL (uninitialised submodule, no remote configured) are kept
+// unchanged because there is no stable repository identity to dedup on.
+func deduplicateProjectsForLeverage(projects []project.Project) []project.Project {
+	keptByURL := make(map[string]int)
+	out := make([]project.Project, 0, len(projects))
+
 	for _, p := range projects {
-		if p.MonorepoRoot != "" || p.URL == "" {
+		if p.URL == "" {
+			out = append(out, p)
 			continue
 		}
-		standaloneURLs[p.URL] = struct{}{}
-	}
 
-	out := make([]project.Project, 0, len(projects))
-	for _, p := range projects {
-		if p.MonorepoRoot != "" && p.URL != "" {
-			if _, shadowed := standaloneURLs[p.URL]; shadowed {
-				continue
-			}
+		keptIdx, exists := keptByURL[p.URL]
+		if !exists {
+			keptByURL[p.URL] = len(out)
+			out = append(out, p)
+			continue
 		}
-		out = append(out, p)
+
+		if shouldPreferLeverageProject(out[keptIdx], p) {
+			out[keptIdx] = p
+		}
 	}
 	return out
+}
+
+func shouldPreferLeverageProject(current, candidate project.Project) bool {
+	return current.MonorepoRoot != "" && candidate.MonorepoRoot == ""
 }
 
 // resolveFromConfig resolves explicitly configured project entries.

--- a/internal/leverage/projects_test.go
+++ b/internal/leverage/projects_test.go
@@ -329,14 +329,14 @@ func TestFilterByName(t *testing.T) {
 	}
 }
 
-// TestDropSubmodulesShadowedByStandalone covers the leverage-only
-// dedup that removes submodule entries whose URL matches a
-// standalone clone of the same repo.
+// TestDeduplicateProjectsForLeverage covers the leverage-only dedup that keeps
+// one scoring entry per repository URL.
 //
-// This is the regression fix for the case where the campaign
-// contains both `projects/foo` and `projects/<monorepo>/foo` (via
-// .gitmodules) — leverage must score that work once, not twice.
-func TestDropSubmodulesShadowedByStandalone(t *testing.T) {
+// This is the regression fix for cases where the campaign contains both
+// `projects/foo` and `projects/<monorepo>/foo` (via .gitmodules), or contains
+// the same submodule repository in multiple monorepos. Leverage must score that
+// work once, not once per checkout path.
+func TestDeduplicateProjectsForLeverage(t *testing.T) {
 	const sharedURL = "git@github.com:test/foo.git"
 
 	cases := []struct {
@@ -355,12 +355,22 @@ func TestDropSubmodulesShadowedByStandalone(t *testing.T) {
 			wantNames: []string{"foo", "mono", "mono@bar"},
 		},
 		{
-			name: "keeps submodule when no standalone shadows it",
+			name: "keeps one submodule when same URL appears in multiple monorepos",
 			input: []project.Project{
-				{Name: "mono", URL: "git@github.com:test/mono.git"},
-				{Name: "mono@bar", URL: "git@github.com:test/bar.git", MonorepoRoot: "projects/mono"},
+				{Name: "mono-a", URL: "git@github.com:test/mono-a.git"},
+				{Name: "mono-a@foo", URL: sharedURL, MonorepoRoot: "projects/mono-a"},
+				{Name: "mono-b", URL: "git@github.com:test/mono-b.git"},
+				{Name: "mono-b@foo", URL: sharedURL, MonorepoRoot: "projects/mono-b"},
 			},
-			wantNames: []string{"mono", "mono@bar"},
+			wantNames: []string{"mono-a", "mono-a@foo", "mono-b"},
+		},
+		{
+			name: "standalone wins even when discovered after submodule",
+			input: []project.Project{
+				{Name: "mono@foo", URL: sharedURL, MonorepoRoot: "projects/mono"},
+				{Name: "foo", URL: sharedURL},
+			},
+			wantNames: []string{"foo"},
 		},
 		{
 			name: "keeps submodule with empty URL even if a standalone shares the URL",
@@ -385,7 +395,7 @@ func TestDropSubmodulesShadowedByStandalone(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := dropSubmodulesShadowedByStandalone(tt.input)
+			got := deduplicateProjectsForLeverage(tt.input)
 
 			gotNames := make([]string, len(got))
 			for i, p := range got {


### PR DESCRIPTION
## Summary

- Deduplicate leverage scoring projects by non-empty git remote URL, not only by standalone-vs-submodule shadowing.
- Apply the same leverage-specific dedup during config population and auto-detection so stale duplicate entries are pruned before scoring.
- Add regression coverage for duplicate submodule URLs across multiple monorepos and config pruning.

## Root Cause

The previous fix only removed a monorepo submodule entry when a standalone clone with the same remote URL existed. If the same repository appeared as submodules in multiple monorepos, leverage still resolved and scored each checkout separately, which double-counted COCOMO estimates.

## Validation

- `go test ./internal/leverage ./internal/project ./cmd/camp/leverage`
- `just test unit` (68 packages, 2283 tests)
- `just build-camp`
