### PR TITLE
Add camp attach/detach for non-project symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ the campaign if they're already on your machine.
 
 ```bash
 camp project add <url>      # Add as a git submodule
-camp project link <path>    # Link an existing local directory
+camp project link <path>    # Link an existing local directory as a project
 ```
 
 Use submodules via `camp project add` (or `camp p add`) if you plan to use
@@ -168,6 +168,26 @@ location on each device in order to work.
 For the rest of the project surface (`list`, `remove`, `unlink`, `commit`,
 `run`, `worktree`, `prune`, `remote`, `new`), see
 [`docs/cli-reference/`](docs/cli-reference/).
+
+### Attaching Non-Project Directories
+
+Some directories belong to a campaign for context but aren't full projects
+(notes, reference repos, scratch dirs). After creating a symlink to one
+inside the campaign tree, run `camp attach` on the symlink to bind its
+target so detection works from inside it:
+
+```bash
+ln -s ~/Dev/external-repo ai_docs/examples/external-repo
+camp attach ai_docs/examples/external-repo
+
+# now you can pin and navigate to it:
+cd ai_docs/examples/external-repo
+camp pin external-repo
+cgo external-repo
+```
+
+`camp detach <path>` removes the marker. Linked projects keep using
+`camp project link` / `camp project unlink`.
 
 ### Planning
 

--- a/cmd/camp/attach/attach.go
+++ b/cmd/camp/attach/attach.go
@@ -120,6 +120,12 @@ func printAttachResult(r *attach.Result, campaignName string) {
 		fmt.Println(ui.KeyValue("  Input:", r.Input+" (followed symlink)"))
 	}
 	fmt.Println(ui.KeyValue("  Campaign ID:", r.CampaignID))
+	if r.GitExcludeUpdated {
+		fmt.Println(ui.KeyValue("  Git exclude:", "added .camp to .git/info/exclude"))
+	}
+	if r.GitExcludeWarning != "" {
+		fmt.Printf("%s %s\n", ui.WarningIcon(), ui.Warning("could not update .git/info/exclude: "+r.GitExcludeWarning))
+	}
 	fmt.Println()
 	fmt.Println(ui.Dim("  Commands run from inside the target now resolve to this campaign."))
 }
@@ -130,5 +136,11 @@ func printDetachResult(r *attach.Result) {
 	fmt.Println(ui.KeyValue("  Target:", r.Target))
 	if r.FollowedSymlink {
 		fmt.Println(ui.KeyValue("  Input:", r.Input+" (followed symlink)"))
+	}
+	if r.GitExcludeUpdated {
+		fmt.Println(ui.KeyValue("  Git exclude:", "removed .camp from .git/info/exclude"))
+	}
+	if r.GitExcludeWarning != "" {
+		fmt.Printf("%s %s\n", ui.WarningIcon(), ui.Warning("could not update .git/info/exclude: "+r.GitExcludeWarning))
 	}
 }

--- a/cmd/camp/attach/attach.go
+++ b/cmd/camp/attach/attach.go
@@ -1,0 +1,134 @@
+// Package attach provides the camp attach / camp detach top-level commands
+// for binding non-project directories to a campaign via the .camp marker.
+package attach
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/Obedience-Corp/camp/internal/attach"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+// CampaignResolver selects a target campaign for attach, mirroring the
+// linked-project resolver contract.
+type CampaignResolver interface {
+	Resolve(ctx context.Context, targetCampaign string, targetChanged bool) (*config.CampaignConfig, string, error)
+}
+
+// CampaignResolverFactory creates a campaign resolver for a command instance.
+type CampaignResolverFactory func(stderr io.Writer, usageLine string) CampaignResolver
+
+// NoOptCampaign mirrors the linked-project NoOptDefVal so a bare --campaign
+// triggers the picker in interactive shells.
+const NoOptCampaign = "\x00pick"
+
+// NewAttachCommand builds the camp attach command.
+func NewAttachCommand(newResolver CampaignResolverFactory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "attach <path>",
+		Short:   "Attach an external directory to a campaign",
+		GroupID: "campaign",
+		Long: `Attach a non-project directory to a campaign by writing a .camp marker.
+
+The user manages the symlink (if any). camp attach only writes the marker at
+the resolved target so commands run from inside that directory know which
+campaign owns it.
+
+If the target is reached through a symlink, camp follows it once and writes
+the marker at the final directory.
+
+Examples:
+  camp attach ai_docs/examples/external-repo
+  camp attach ~/scratch/notes-link
+  camp attach /abs/path/to/dir --campaign platform`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			input := args[0]
+
+			targetCampaign, _ := cmd.Flags().GetString("campaign")
+			force, _ := cmd.Flags().GetBool("force")
+
+			resolver := newResolver(cmd.ErrOrStderr(), "camp attach <path> --campaign <name>")
+			cfg, root, err := resolver.Resolve(ctx, targetCampaign, cmd.Flags().Changed("campaign"))
+			if err != nil {
+				return err
+			}
+			if cfg == nil {
+				return camperrors.Wrap(camperrors.ErrNotFound, "could not resolve target campaign")
+			}
+
+			result, err := attach.Attach(ctx, root, cfg.ID, input, attach.Options{Force: force})
+			if err != nil {
+				return err
+			}
+
+			printAttachResult(result, cfg.Name)
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringP("campaign", "c", "", "Target campaign by name or ID; defaults to current campaign or interactive picker")
+	flags.Bool("force", false, "Overwrite an existing attachment marker")
+	flags.Lookup("campaign").NoOptDefVal = NoOptCampaign
+
+	return cmd
+}
+
+// NewDetachCommand builds the camp detach command.
+func NewDetachCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "detach <path>",
+		Short:   "Remove the attachment marker from a directory",
+		GroupID: "campaign",
+		Long: `Remove the .camp attachment marker from the target directory.
+
+Refuses on linked-project markers; use 'camp project unlink' for those.
+The user-managed symlink (if any) is not modified.
+
+Examples:
+  camp detach ai_docs/examples/external-repo
+  camp detach ~/scratch/notes-link`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			input := args[0]
+
+			result, err := attach.Detach(ctx, input)
+			if err != nil {
+				return err
+			}
+
+			printDetachResult(result)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func printAttachResult(r *attach.Result, campaignName string) {
+	fmt.Printf("%s %s\n", ui.SuccessIcon(), ui.Success("Attached to campaign: "+campaignName))
+	fmt.Println()
+	fmt.Println(ui.KeyValue("  Target:", r.Target))
+	if r.FollowedSymlink {
+		fmt.Println(ui.KeyValue("  Input:", r.Input+" (followed symlink)"))
+	}
+	fmt.Println(ui.KeyValue("  Campaign ID:", r.CampaignID))
+	fmt.Println()
+	fmt.Println(ui.Dim("  Commands run from inside the target now resolve to this campaign."))
+}
+
+func printDetachResult(r *attach.Result) {
+	fmt.Printf("%s %s\n", ui.SuccessIcon(), ui.Success("Detached attachment"))
+	fmt.Println()
+	fmt.Println(ui.KeyValue("  Target:", r.Target))
+	if r.FollowedSymlink {
+		fmt.Println(ui.KeyValue("  Input:", r.Input+" (followed symlink)"))
+	}
+}

--- a/cmd/camp/attach/resolver.go
+++ b/cmd/camp/attach/resolver.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
 	"github.com/Obedience-Corp/camp/internal/config"
-	navtui "github.com/Obedience-Corp/camp/internal/nav/tui"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	navtui "github.com/Obedience-Corp/camp/internal/nav/tui"
 )
 
 // attachResolver picks a target campaign for camp attach. It mirrors the

--- a/cmd/camp/attach/resolver.go
+++ b/cmd/camp/attach/resolver.go
@@ -1,0 +1,91 @@
+package attach
+
+import (
+	"context"
+	"io"
+
+	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
+	"github.com/Obedience-Corp/camp/internal/config"
+	navtui "github.com/Obedience-Corp/camp/internal/nav/tui"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// attachResolver picks a target campaign for camp attach. It mirrors the
+// linked-project resolver but skips project-specific registry checks because
+// attachments are not registered as projects.
+type attachResolver struct {
+	stderr        io.Writer
+	usageLine     string
+	isInteractive func() bool
+	loadCurrent   func(context.Context) (*config.CampaignConfig, string, error)
+	loadRegistry  func(context.Context) (*config.Registry, error)
+	loadCampaign  func(context.Context, string) (*config.CampaignConfig, error)
+	saveRegistry  func(context.Context, *config.Registry) error
+	pickCampaign  func(context.Context, *config.Registry) (config.RegisteredCampaign, error)
+}
+
+// NewResolver returns a CampaignResolver suitable for camp attach.
+func NewResolver(stderr io.Writer, usageLine string) CampaignResolver {
+	return attachResolver{
+		stderr:        stderr,
+		usageLine:     usageLine,
+		isInteractive: navtui.IsTerminal,
+		loadCurrent:   config.LoadCampaignConfigFromCwd,
+		loadRegistry:  config.LoadRegistry,
+		loadCampaign:  config.LoadCampaignConfig,
+		saveRegistry:  config.SaveRegistry,
+		pickCampaign:  cmdutil.PickCampaign,
+	}
+}
+
+func (r attachResolver) Resolve(ctx context.Context, targetCampaign string, targetChanged bool) (*config.CampaignConfig, string, error) {
+	if targetCampaign == NoOptCampaign {
+		targetCampaign = ""
+	}
+
+	if !targetChanged {
+		cfg, root, err := r.loadCurrent(ctx)
+		if err == nil {
+			return cfg, root, nil
+		}
+	}
+
+	reg, err := r.loadRegistry(ctx)
+	if err != nil {
+		return nil, "", camperrors.Wrap(err, "load registry")
+	}
+	if reg.Len() == 0 {
+		return nil, "", camperrors.Wrap(camperrors.ErrNotInitialized,
+			"no campaigns registered (use 'camp init' to create one)")
+	}
+
+	var selected config.RegisteredCampaign
+	switch targetCampaign {
+	case "":
+		if !r.isInteractive() {
+			return nil, "", camperrors.Wrapf(camperrors.ErrInvalidInput,
+				"campaign name required in non-interactive mode\n       Usage: %s", r.usageLine)
+		}
+		selected, err = r.pickCampaign(ctx, reg)
+		if err != nil {
+			return nil, "", err
+		}
+	default:
+		selected, err = cmdutil.ResolveCampaignSelection(targetCampaign, reg, r.stderr)
+		if err != nil {
+			return nil, "", err
+		}
+	}
+
+	cfg, err := r.loadCampaign(ctx, selected.Path)
+	if err != nil {
+		return nil, "", camperrors.Wrapf(err, "load target campaign %s", selected.Path)
+	}
+
+	reg.UpdateLastAccess(selected.ID)
+	if r.saveRegistry != nil {
+		_ = r.saveRegistry(ctx, reg)
+	}
+
+	return cfg, selected.Path, nil
+}

--- a/cmd/camp/gendocs.go
+++ b/cmd/camp/gendocs.go
@@ -67,6 +67,9 @@ func runGendocs(cmd *cobra.Command, args []string) error {
 		if err := doc.GenMarkdownTree(rootForDocs, gendocsOutput); err != nil {
 			return camperrors.Wrap(err, "generate markdown")
 		}
+		if err := trimTrailingBlankLines(gendocsOutput); err != nil {
+			return camperrors.Wrap(err, "trim trailing blank lines")
+		}
 		fmt.Fprintf(os.Stderr, "Markdown docs written to %s\n", gendocsOutput)
 	case "yaml":
 		if err := doc.GenYamlTree(rootForDocs, gendocsOutput); err != nil {
@@ -161,6 +164,34 @@ func hideDevOnlyCommands(parent *cobra.Command) {
 			hideDevOnlyCommands(child)
 		}
 	}
+}
+
+// trimTrailingBlankLines collapses trailing blank lines on every .md file in
+// dir to a single newline. cobra/doc emits "...content\n\n" which trips
+// `git diff --check` with "new blank line at EOF".
+func trimTrailingBlankLines(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		trimmed := strings.TrimRight(string(data), "\n") + "\n"
+		if trimmed == string(data) {
+			continue
+		}
+		if err := os.WriteFile(path, []byte(trimmed), 0644); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func removeGeneratedDocs(dir, name string) error {

--- a/cmd/camp/navigation/go.go
+++ b/cmd/camp/navigation/go.go
@@ -572,7 +572,11 @@ func resolvePin(campaignRoot, query string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	// After migration all paths should be relative; reject any remaining absolute paths
+	// Attachment pins use AbsPath directly; in-tree pins resolve through
+	// campaignRoot. Reject any remaining absolute paths that aren't AbsPath.
+	if pin.IsAttachment() {
+		return pin.AbsPath, true
+	}
 	if filepath.IsAbs(pin.Path) {
 		return "", false
 	}

--- a/cmd/camp/pins.go
+++ b/cmd/camp/pins.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"context"
 	"fmt"
-	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/pins"
 	"github.com/spf13/cobra"
 )
@@ -100,9 +101,19 @@ func runPinsList(cmd *cobra.Command, args []string) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(w, "NAME\tPATH\tCREATED\n")
+	if _, err := fmt.Fprintln(w, "NAME\tKIND\tPATH\tCREATED"); err != nil {
+		return err
+	}
 	for _, p := range pinList {
-		fmt.Fprintf(w, "%s\t%s\t%s\n", p.Name, p.Path, p.CreatedAt.Format(time.RFC3339))
+		kind := "in-tree"
+		path := p.Path
+		if p.IsAttachment() {
+			kind = "attachment"
+			path = p.AbsPath
+		}
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", p.Name, kind, path, p.CreatedAt.Format(time.RFC3339)); err != nil {
+			return err
+		}
 	}
 	return w.Flush()
 }
@@ -146,29 +157,68 @@ func runPin(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Store path relative to campaign root for portability
-	relPath, err := filepath.Rel(campaignRoot, absPath)
+	pin, display, err := buildPinForPath(absPath, campaignRoot)
 	if err != nil {
-		return camperrors.Wrapf(err, "compute relative path for %q", absPath)
+		return err
 	}
-	if relPath == ".." || strings.HasPrefix(relPath, "../") {
-		return camperrors.Wrapf(fmt.Errorf("outside campaign root"), "pin path %q", absPath)
-	}
+	pin.Name = name
 
-	result := store.Toggle(name, relPath)
+	result := store.TogglePin(pin)
 	if err := store.Save(); err != nil {
 		return err
 	}
 
 	switch result {
 	case pins.Pinned:
-		fmt.Printf("Pinned %q → %s\n", name, relPath)
+		fmt.Printf("Pinned %q → %s\n", name, display)
 	case pins.Unpinned:
 		fmt.Printf("Unpinned %q (was already pinned to same path)\n", name)
 	case pins.Updated:
-		fmt.Printf("Updated pin %q → %s\n", name, relPath)
+		fmt.Printf("Updated pin %q → %s\n", name, display)
 	}
 	return nil
+}
+
+// buildPinForPath returns a Pin record (without Name) and a display string for
+// the given absolute path. In-tree paths get a campaign-relative Path. Paths
+// outside the campaign tree are accepted only when they resolve through a
+// .camp attachment marker that points at the active campaign; those become
+// AbsPath pins.
+func buildPinForPath(absPath, campaignRoot string) (pins.Pin, string, error) {
+	relPath, err := filepath.Rel(campaignRoot, absPath)
+	if err != nil {
+		return pins.Pin{}, "", camperrors.Wrapf(err, "compute relative path for %q", absPath)
+	}
+	if relPath != ".." && !strings.HasPrefix(relPath, "../") {
+		return pins.Pin{Path: relPath}, relPath, nil
+	}
+
+	// Outside the campaign tree: only allow if a marker resolves to this
+	// campaign root.
+	if !markerResolvesToCampaign(absPath, campaignRoot) {
+		return pins.Pin{}, "", camperrors.Wrapf(fmt.Errorf("outside campaign root"),
+			"pin path %q (run 'camp attach %s' first to bind this directory to the campaign)",
+			absPath, absPath)
+	}
+	return pins.Pin{AbsPath: absPath}, absPath + " (attachment)", nil
+}
+
+// markerResolvesToCampaign returns true when walking up from path reaches a
+// campaign root that matches campaignRoot. This succeeds for paths under an
+// attachment marker pointing at the active campaign.
+func markerResolvesToCampaign(path, campaignRoot string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), campaign.DefaultDetectTimeout)
+	defer cancel()
+
+	root, err := campaign.Detect(ctx, path)
+	if err != nil {
+		return false
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(campaignRoot)
+	if err != nil {
+		resolvedRoot = campaignRoot
+	}
+	return root == resolvedRoot
 }
 
 func runUnpin(cmd *cobra.Command, args []string) error {
@@ -190,13 +240,9 @@ func runUnpin(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return camperrors.Wrap(err, "resolve symlinks for working directory")
 		}
-		relCwd, err := filepath.Rel(campaignRoot, cwd)
-		if err != nil {
-			return camperrors.Wrap(err, "compute relative path")
-		}
-		pin, ok := store.FindByPath(relCwd)
+		pin, ok := findPinForCwd(store, cwd, campaignRoot)
 		if !ok {
-			return fmt.Errorf("directory not pinned: %s", relCwd)
+			return fmt.Errorf("directory not pinned: %s", cwd)
 		}
 		name = pin.Name
 	}
@@ -210,6 +256,25 @@ func runUnpin(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Unpinned %q\n", name)
 	return nil
+}
+
+// findPinForCwd returns the pin matching cwd, looking up either by
+// campaign-relative Path (in-tree) or by AbsPath (attachment).
+func findPinForCwd(store *pins.Store, cwd, campaignRoot string) (pins.Pin, bool) {
+	if pin, ok := store.FindByPath(cwd); ok {
+		return pin, true
+	}
+	for _, p := range store.List() {
+		if p.AbsPath != "" && p.AbsPath == cwd {
+			return p, true
+		}
+	}
+	if relCwd, err := filepath.Rel(campaignRoot, cwd); err == nil {
+		if pin, ok := store.FindByPath(relCwd); ok {
+			return pin, true
+		}
+	}
+	return pins.Pin{}, false
 }
 
 // pinNotFoundError returns an error with suggestions for similar pin names.

--- a/cmd/camp/root.go
+++ b/cmd/camp/root.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 
+	attachpkg "github.com/Obedience-Corp/camp/cmd/camp/attach"
 	cachepkg "github.com/Obedience-Corp/camp/cmd/camp/cache"
 	dungeonpkg "github.com/Obedience-Corp/camp/cmd/camp/dungeon"
 	initcmd "github.com/Obedience-Corp/camp/cmd/camp/init"
@@ -198,6 +200,12 @@ func init() {
 	rootCmd.AddCommand(worktreespkg.Cmd)
 	rootCmd.AddCommand(refspkg.Cmd)
 	rootCmd.AddCommand(pluginsCmd)
+
+	attachResolverFactory := func(stderr io.Writer, usageLine string) attachpkg.CampaignResolver {
+		return attachpkg.NewResolver(stderr, usageLine)
+	}
+	rootCmd.AddCommand(attachpkg.NewAttachCommand(attachResolverFactory))
+	rootCmd.AddCommand(attachpkg.NewDetachCommand())
 
 	release.Register(rootCmd)
 }

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -51,6 +51,47 @@ camp [flags]
 ```
 ---
 
+## camp attach
+
+Attach an external directory to a campaign
+
+### Synopsis
+
+Attach a non-project directory to a campaign by writing a .camp marker.
+
+The user manages the symlink (if any). camp attach only writes the marker at
+the resolved target so commands run from inside that directory know which
+campaign owns it.
+
+If the target is reached through a symlink, camp follows it once and writes
+the marker at the final directory.
+
+Examples:
+  camp attach ai_docs/examples/external-repo
+  camp attach ~/scratch/notes-link
+  camp attach /abs/path/to/dir --campaign platform
+
+```
+camp attach <path> [flags]
+```
+
+### Options
+
+```
+  -c, --campaign string   Target campaign by name or ID; defaults to current campaign or interactive picker
+      --force             Overwrite an existing attachment marker
+  -h, --help              help for attach
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
 ## camp cache
 
 Manage the navigation index cache
@@ -646,6 +687,40 @@ camp date <path> [flags]
   -h, --help            help for date
   -m, --mtime           Use file's last modified date
   -y, --yes             Skip confirmation prompt
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp detach
+
+Remove the attachment marker from a directory
+
+### Synopsis
+
+Remove the .camp attachment marker from the target directory.
+
+Refuses on linked-project markers; use 'camp project unlink' for those.
+The user-managed symlink (if any) is not modified.
+
+Examples:
+  camp detach ai_docs/examples/external-repo
+  camp detach ~/scratch/notes-link
+
+```
+camp detach <path> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for detach
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp.md
+++ b/docs/cli-reference/camp.md
@@ -43,6 +43,7 @@ camp [flags]
 
 ### SEE ALSO
 
+* [camp attach](camp_attach.md)	 - Attach an external directory to a campaign
 * [camp cache](camp_cache.md)	 - Manage the navigation index cache
 * [camp clone](camp_clone.md)	 - Clone a campaign with full submodule setup
 * [camp commit](camp_commit.md)	 - Commit changes in the campaign root
@@ -51,6 +52,7 @@ camp [flags]
 * [camp copy](camp_copy.md)	 - Copy a file or directory within the campaign
 * [camp create](camp_create.md)	 - Create a new campaign at the default campaigns directory
 * [camp date](camp_date.md)	 - Append date suffix to file or directory name
+* [camp detach](camp_detach.md)	 - Remove the attachment marker from a directory
 * [camp doctor](camp_doctor.md)	 - Diagnose and fix campaign health issues
 * [camp dungeon](camp_dungeon.md)	 - Manage the campaign dungeon
 * [camp fresh](camp_fresh.md)	 - Post-merge branch cycling: sync to default branch and optionally create a new working branch

--- a/docs/cli-reference/camp.md
+++ b/docs/cli-reference/camp.md
@@ -87,4 +87,3 @@ camp [flags]
 * [camp unpin](camp_unpin.md)	 - Remove a saved pin
 * [camp unregister](camp_unregister.md)	 - Remove campaign from registry
 * [camp version](camp_version.md)	 - Show version information
-

--- a/docs/cli-reference/camp_attach.md
+++ b/docs/cli-reference/camp_attach.md
@@ -41,4 +41,3 @@ camp attach <path> [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_attach.md
+++ b/docs/cli-reference/camp_attach.md
@@ -1,0 +1,44 @@
+## camp attach
+
+Attach an external directory to a campaign
+
+### Synopsis
+
+Attach a non-project directory to a campaign by writing a .camp marker.
+
+The user manages the symlink (if any). camp attach only writes the marker at
+the resolved target so commands run from inside that directory know which
+campaign owns it.
+
+If the target is reached through a symlink, camp follows it once and writes
+the marker at the final directory.
+
+Examples:
+  camp attach ai_docs/examples/external-repo
+  camp attach ~/scratch/notes-link
+  camp attach /abs/path/to/dir --campaign platform
+
+```
+camp attach <path> [flags]
+```
+
+### Options
+
+```
+  -c, --campaign string   Target campaign by name or ID; defaults to current campaign or interactive picker
+      --force             Overwrite an existing attachment marker
+  -h, --help              help for attach
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
+

--- a/docs/cli-reference/camp_cache.md
+++ b/docs/cli-reference/camp_cache.md
@@ -30,4 +30,3 @@ camp cache [flags]
 * [camp cache clear](camp_cache_clear.md)	 - Delete the navigation cache
 * [camp cache info](camp_cache_info.md)	 - Show cache status and metadata
 * [camp cache rebuild](camp_cache_rebuild.md)	 - Force rebuild the navigation cache
-

--- a/docs/cli-reference/camp_cache_clear.md
+++ b/docs/cli-reference/camp_cache_clear.md
@@ -27,4 +27,3 @@ camp cache clear [flags]
 ### SEE ALSO
 
 * [camp cache](camp_cache.md)	 - Manage the navigation index cache
-

--- a/docs/cli-reference/camp_cache_info.md
+++ b/docs/cli-reference/camp_cache_info.md
@@ -27,4 +27,3 @@ camp cache info [flags]
 ### SEE ALSO
 
 * [camp cache](camp_cache.md)	 - Manage the navigation index cache
-

--- a/docs/cli-reference/camp_cache_rebuild.md
+++ b/docs/cli-reference/camp_cache_rebuild.md
@@ -27,4 +27,3 @@ camp cache rebuild [flags]
 ### SEE ALSO
 
 * [camp cache](camp_cache.md)	 - Manage the navigation index cache
-

--- a/docs/cli-reference/camp_clone.md
+++ b/docs/cli-reference/camp_clone.md
@@ -89,4 +89,3 @@ camp clone <url> [directory] [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_commit.md
+++ b/docs/cli-reference/camp_commit.md
@@ -51,4 +51,3 @@ camp commit [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_completion.md
+++ b/docs/cli-reference/camp_completion.md
@@ -29,4 +29,3 @@ See each sub-command's help for details on how to use the generated script.
 * [camp completion fish](camp_completion_fish.md)	 - Generate the autocompletion script for fish
 * [camp completion powershell](camp_completion_powershell.md)	 - Generate the autocompletion script for powershell
 * [camp completion zsh](camp_completion_zsh.md)	 - Generate the autocompletion script for zsh
-

--- a/docs/cli-reference/camp_completion_bash.md
+++ b/docs/cli-reference/camp_completion_bash.md
@@ -48,4 +48,3 @@ camp completion bash
 ### SEE ALSO
 
 * [camp completion](camp_completion.md)	 - Generate the autocompletion script for the specified shell
-

--- a/docs/cli-reference/camp_completion_fish.md
+++ b/docs/cli-reference/camp_completion_fish.md
@@ -39,4 +39,3 @@ camp completion fish [flags]
 ### SEE ALSO
 
 * [camp completion](camp_completion.md)	 - Generate the autocompletion script for the specified shell
-

--- a/docs/cli-reference/camp_completion_powershell.md
+++ b/docs/cli-reference/camp_completion_powershell.md
@@ -36,4 +36,3 @@ camp completion powershell [flags]
 ### SEE ALSO
 
 * [camp completion](camp_completion.md)	 - Generate the autocompletion script for the specified shell
-

--- a/docs/cli-reference/camp_completion_zsh.md
+++ b/docs/cli-reference/camp_completion_zsh.md
@@ -50,4 +50,3 @@ camp completion zsh [flags]
 ### SEE ALSO
 
 * [camp completion](camp_completion.md)	 - Generate the autocompletion script for the specified shell
-

--- a/docs/cli-reference/camp_concepts.md
+++ b/docs/cli-reference/camp_concepts.md
@@ -23,4 +23,3 @@ camp concepts [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_copy.md
+++ b/docs/cli-reference/camp_copy.md
@@ -46,4 +46,3 @@ camp copy <src> <dest> [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_create.md
+++ b/docs/cli-reference/camp_create.md
@@ -43,4 +43,3 @@ camp create <name> [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_date.md
+++ b/docs/cli-reference/camp_date.md
@@ -48,4 +48,3 @@ camp date <path> [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_detach.md
+++ b/docs/cli-reference/camp_detach.md
@@ -34,4 +34,3 @@ camp detach <path> [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_detach.md
+++ b/docs/cli-reference/camp_detach.md
@@ -1,0 +1,37 @@
+## camp detach
+
+Remove the attachment marker from a directory
+
+### Synopsis
+
+Remove the .camp attachment marker from the target directory.
+
+Refuses on linked-project markers; use 'camp project unlink' for those.
+The user-managed symlink (if any) is not modified.
+
+Examples:
+  camp detach ai_docs/examples/external-repo
+  camp detach ~/scratch/notes-link
+
+```
+camp detach <path> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for detach
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
+

--- a/docs/cli-reference/camp_doctor.md
+++ b/docs/cli-reference/camp_doctor.md
@@ -62,4 +62,3 @@ camp doctor [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_dungeon.md
+++ b/docs/cli-reference/camp_dungeon.md
@@ -47,4 +47,3 @@ camp dungeon [flags]
 * [camp dungeon crawl](camp_dungeon_crawl.md)	 - Interactive dungeon review
 * [camp dungeon list](camp_dungeon_list.md)	 - List dungeon items
 * [camp dungeon move](camp_dungeon_move.md)	 - Move dungeon items between statuses
-

--- a/docs/cli-reference/camp_dungeon_add.md
+++ b/docs/cli-reference/camp_dungeon_add.md
@@ -45,4 +45,3 @@ camp dungeon add [flags]
 ### SEE ALSO
 
 * [camp dungeon](camp_dungeon.md)	 - Manage the campaign dungeon
-

--- a/docs/cli-reference/camp_dungeon_crawl.md
+++ b/docs/cli-reference/camp_dungeon_crawl.md
@@ -46,4 +46,3 @@ camp dungeon crawl [flags]
 ### SEE ALSO
 
 * [camp dungeon](camp_dungeon.md)	 - Manage the campaign dungeon
-

--- a/docs/cli-reference/camp_dungeon_list.md
+++ b/docs/cli-reference/camp_dungeon_list.md
@@ -46,4 +46,3 @@ camp dungeon list [flags]
 ### SEE ALSO
 
 * [camp dungeon](camp_dungeon.md)	 - Manage the campaign dungeon
-

--- a/docs/cli-reference/camp_dungeon_move.md
+++ b/docs/cli-reference/camp_dungeon_move.md
@@ -43,4 +43,3 @@ camp dungeon move <item> [status] [flags]
 ### SEE ALSO
 
 * [camp dungeon](camp_dungeon.md)	 - Manage the campaign dungeon
-

--- a/docs/cli-reference/camp_fresh.md
+++ b/docs/cli-reference/camp_fresh.md
@@ -50,4 +50,3 @@ camp fresh [project-name] [flags]
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
 * [camp fresh all](camp_fresh_all.md)	 - Run fresh across all project submodules
-

--- a/docs/cli-reference/camp_fresh_all.md
+++ b/docs/cli-reference/camp_fresh_all.md
@@ -39,4 +39,3 @@ camp fresh all [flags]
 ### SEE ALSO
 
 * [camp fresh](camp_fresh.md)	 - Post-merge branch cycling: sync to default branch and optionally create a new working branch
-

--- a/docs/cli-reference/camp_gather.md
+++ b/docs/cli-reference/camp_gather.md
@@ -34,4 +34,3 @@ camp gather [flags]
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
 * [camp gather feedback](camp_gather_feedback.md)	 - Gather feedback observations from festivals into intents
-

--- a/docs/cli-reference/camp_gather_feedback.md
+++ b/docs/cli-reference/camp_gather_feedback.md
@@ -61,4 +61,3 @@ camp gather feedback [flags]
 ### SEE ALSO
 
 * [camp gather](camp_gather.md)	 - Import external data into the intent system
-

--- a/docs/cli-reference/camp_go.md
+++ b/docs/cli-reference/camp_go.md
@@ -81,4 +81,3 @@ camp go [shortcut] [query...] [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_id.md
+++ b/docs/cli-reference/camp_id.md
@@ -33,4 +33,3 @@ camp id [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_init.md
+++ b/docs/cli-reference/camp_init.md
@@ -70,4 +70,3 @@ camp init [path] [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_intent.md
+++ b/docs/cli-reference/camp_intent.md
@@ -64,4 +64,3 @@ camp intent [flags]
 * [camp intent move](camp_intent_move.md)	 - Move intent to a different status
 * [camp intent promote](camp_intent_promote.md)	 - Promote an intent through the pipeline
 * [camp intent show](camp_intent_show.md)	 - Show detailed intent information
-

--- a/docs/cli-reference/camp_intent_add.md
+++ b/docs/cli-reference/camp_intent_add.md
@@ -68,4 +68,3 @@ camp intent add [title] [flags]
 ### SEE ALSO
 
 * [camp intent](camp_intent.md)	 - Manage campaign intents
-

--- a/docs/cli-reference/camp_intent_archive.md
+++ b/docs/cli-reference/camp_intent_archive.md
@@ -39,4 +39,3 @@ camp intent archive <id> [flags]
 ### SEE ALSO
 
 * [camp intent](camp_intent.md)	 - Manage campaign intents
-

--- a/docs/cli-reference/camp_intent_count.md
+++ b/docs/cli-reference/camp_intent_count.md
@@ -36,4 +36,3 @@ camp intent count [flags]
 ### SEE ALSO
 
 * [camp intent](camp_intent.md)	 - Manage campaign intents
-

--- a/docs/cli-reference/camp_intent_crawl.md
+++ b/docs/cli-reference/camp_intent_crawl.md
@@ -44,4 +44,3 @@ camp intent crawl [flags]
 ### SEE ALSO
 
 * [camp intent](camp_intent.md)	 - Manage campaign intents
-

--- a/docs/cli-reference/camp_intent_edit.md
+++ b/docs/cli-reference/camp_intent_edit.md
@@ -83,4 +83,3 @@ camp intent edit [id] [flags]
 ### SEE ALSO
 
 * [camp intent](camp_intent.md)	 - Manage campaign intents
-

--- a/docs/cli-reference/camp_intent_explore.md
+++ b/docs/cli-reference/camp_intent_explore.md
@@ -69,4 +69,3 @@ camp intent explore [flags]
 ### SEE ALSO
 
 * [camp intent](camp_intent.md)	 - Manage campaign intents
-

--- a/docs/cli-reference/camp_intent_find.md
+++ b/docs/cli-reference/camp_intent_find.md
@@ -43,4 +43,3 @@ camp intent find [query] [flags]
 ### SEE ALSO
 
 * [camp intent](camp_intent.md)	 - Manage campaign intents
-

--- a/docs/cli-reference/camp_intent_gather.md
+++ b/docs/cli-reference/camp_intent_gather.md
@@ -72,4 +72,3 @@ camp intent gather [ids...] [flags]
 ### SEE ALSO
 
 * [camp intent](camp_intent.md)	 - Manage campaign intents
-

--- a/docs/cli-reference/camp_intent_list.md
+++ b/docs/cli-reference/camp_intent_list.md
@@ -50,4 +50,3 @@ camp intent list [flags]
 ### SEE ALSO
 
 * [camp intent](camp_intent.md)	 - Manage campaign intents
-

--- a/docs/cli-reference/camp_intent_move.md
+++ b/docs/cli-reference/camp_intent_move.md
@@ -50,4 +50,3 @@ camp intent move <id> <status> [flags]
 ### SEE ALSO
 
 * [camp intent](camp_intent.md)	 - Manage campaign intents
-

--- a/docs/cli-reference/camp_intent_promote.md
+++ b/docs/cli-reference/camp_intent_promote.md
@@ -45,4 +45,3 @@ camp intent promote <id> [flags]
 ### SEE ALSO
 
 * [camp intent](camp_intent.md)	 - Manage campaign intents
-

--- a/docs/cli-reference/camp_intent_show.md
+++ b/docs/cli-reference/camp_intent_show.md
@@ -44,4 +44,3 @@ camp intent show <id> [flags]
 ### SEE ALSO
 
 * [camp intent](camp_intent.md)	 - Manage campaign intents
-

--- a/docs/cli-reference/camp_leverage.md
+++ b/docs/cli-reference/camp_leverage.md
@@ -56,4 +56,3 @@ camp leverage [directory] [flags]
 * [camp leverage history](camp_leverage_history.md)	 - Show leverage score history over time
 * [camp leverage reset](camp_leverage_reset.md)	 - Clear all cached leverage data to allow full recomputation
 * [camp leverage snapshot](camp_leverage_snapshot.md)	 - Capture current leverage state as a snapshot
-

--- a/docs/cli-reference/camp_leverage_backfill.md
+++ b/docs/cli-reference/camp_leverage_backfill.md
@@ -43,4 +43,3 @@ camp leverage backfill [flags]
 ### SEE ALSO
 
 * [camp leverage](camp_leverage.md)	 - Compute leverage scores for campaign projects
-

--- a/docs/cli-reference/camp_leverage_config.md
+++ b/docs/cli-reference/camp_leverage_config.md
@@ -50,4 +50,3 @@ camp leverage config [flags]
 ### SEE ALSO
 
 * [camp leverage](camp_leverage.md)	 - Compute leverage scores for campaign projects
-

--- a/docs/cli-reference/camp_leverage_history.md
+++ b/docs/cli-reference/camp_leverage_history.md
@@ -45,4 +45,3 @@ camp leverage history [flags]
 ### SEE ALSO
 
 * [camp leverage](camp_leverage.md)	 - Compute leverage scores for campaign projects
-

--- a/docs/cli-reference/camp_leverage_reset.md
+++ b/docs/cli-reference/camp_leverage_reset.md
@@ -36,4 +36,3 @@ camp leverage reset [flags]
 ### SEE ALSO
 
 * [camp leverage](camp_leverage.md)	 - Compute leverage scores for campaign projects
-

--- a/docs/cli-reference/camp_leverage_snapshot.md
+++ b/docs/cli-reference/camp_leverage_snapshot.md
@@ -39,4 +39,3 @@ camp leverage snapshot [flags]
 ### SEE ALSO
 
 * [camp leverage](camp_leverage.md)	 - Compute leverage scores for campaign projects
-

--- a/docs/cli-reference/camp_list.md
+++ b/docs/cli-reference/camp_list.md
@@ -49,4 +49,3 @@ camp list [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_log.md
+++ b/docs/cli-reference/camp_log.md
@@ -41,4 +41,3 @@ camp log [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_move.md
+++ b/docs/cli-reference/camp_move.md
@@ -45,4 +45,3 @@ camp move <src> <dest> [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_pin.md
+++ b/docs/cli-reference/camp_pin.md
@@ -38,4 +38,3 @@ camp pin <name> [path] [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_pins.md
+++ b/docs/cli-reference/camp_pins.md
@@ -27,4 +27,3 @@ camp pins [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_plugins.md
+++ b/docs/cli-reference/camp_plugins.md
@@ -23,4 +23,3 @@ camp plugins [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_project.md
+++ b/docs/cli-reference/camp_project.md
@@ -51,4 +51,3 @@ camp project [flags]
 * [camp project run](camp_project_run.md)	 - Run a command inside a project directory
 * [camp project unlink](camp_project_unlink.md)	 - Unlink a linked project from a campaign
 * [camp project worktree](camp_project_worktree.md)	 - Manage worktrees for a project
-

--- a/docs/cli-reference/camp_project_add.md
+++ b/docs/cli-reference/camp_project_add.md
@@ -51,4 +51,3 @@ camp project add [source] [flags]
 ### SEE ALSO
 
 * [camp project](camp_project.md)	 - Manage campaign projects
-

--- a/docs/cli-reference/camp_project_commit.md
+++ b/docs/cli-reference/camp_project_commit.md
@@ -43,4 +43,3 @@ camp project commit [flags]
 ### SEE ALSO
 
 * [camp project](camp_project.md)	 - Manage campaign projects
-

--- a/docs/cli-reference/camp_project_link.md
+++ b/docs/cli-reference/camp_project_link.md
@@ -47,4 +47,3 @@ camp project link [path] [flags]
 ### SEE ALSO
 
 * [camp project](camp_project.md)	 - Manage campaign projects
-

--- a/docs/cli-reference/camp_project_list.md
+++ b/docs/cli-reference/camp_project_list.md
@@ -41,4 +41,3 @@ camp project list [flags]
 ### SEE ALSO
 
 * [camp project](camp_project.md)	 - Manage campaign projects
-

--- a/docs/cli-reference/camp_project_new.md
+++ b/docs/cli-reference/camp_project_new.md
@@ -40,4 +40,3 @@ camp project new <name> [flags]
 ### SEE ALSO
 
 * [camp project](camp_project.md)	 - Manage campaign projects
-

--- a/docs/cli-reference/camp_project_prune.md
+++ b/docs/cli-reference/camp_project_prune.md
@@ -46,4 +46,3 @@ camp project prune [project-name] [flags]
 
 * [camp project](camp_project.md)	 - Manage campaign projects
 * [camp project prune all](camp_project_prune_all.md)	 - Delete merged branches across all projects
-

--- a/docs/cli-reference/camp_project_prune_all.md
+++ b/docs/cli-reference/camp_project_prune_all.md
@@ -36,4 +36,3 @@ camp project prune all [flags]
 ### SEE ALSO
 
 * [camp project prune](camp_project_prune.md)	 - Delete merged branches in a project
-

--- a/docs/cli-reference/camp_project_remote.md
+++ b/docs/cli-reference/camp_project_remote.md
@@ -55,4 +55,3 @@ camp project remote [flags]
 * [camp project remote remove](camp_project_remote_remove.md)	 - Remove a remote from the project
 * [camp project remote rename](camp_project_remote_rename.md)	 - Rename a remote in the project
 * [camp project remote set-url](camp_project_remote_set-url.md)	 - Update a remote URL for the project
-

--- a/docs/cli-reference/camp_project_remote_add.md
+++ b/docs/cli-reference/camp_project_remote_add.md
@@ -39,4 +39,3 @@ camp project remote add <name> <url> [flags]
 ### SEE ALSO
 
 * [camp project remote](camp_project_remote.md)	 - Manage remotes for a project
-

--- a/docs/cli-reference/camp_project_remote_list.md
+++ b/docs/cli-reference/camp_project_remote_list.md
@@ -35,4 +35,3 @@ camp project remote list [flags]
 ### SEE ALSO
 
 * [camp project remote](camp_project_remote.md)	 - Manage remotes for a project
-

--- a/docs/cli-reference/camp_project_remote_remove.md
+++ b/docs/cli-reference/camp_project_remote_remove.md
@@ -42,4 +42,3 @@ camp project remote remove <name> [flags]
 ### SEE ALSO
 
 * [camp project remote](camp_project_remote.md)	 - Manage remotes for a project
-

--- a/docs/cli-reference/camp_project_remote_rename.md
+++ b/docs/cli-reference/camp_project_remote_rename.md
@@ -44,4 +44,3 @@ camp project remote rename <old> <new> [flags]
 ### SEE ALSO
 
 * [camp project remote](camp_project_remote.md)	 - Manage remotes for a project
-

--- a/docs/cli-reference/camp_project_remote_set-url.md
+++ b/docs/cli-reference/camp_project_remote_set-url.md
@@ -52,4 +52,3 @@ camp project remote set-url <url> [flags]
 ### SEE ALSO
 
 * [camp project remote](camp_project_remote.md)	 - Manage remotes for a project
-

--- a/docs/cli-reference/camp_project_remove.md
+++ b/docs/cli-reference/camp_project_remove.md
@@ -46,4 +46,3 @@ camp project remove <name> [flags]
 ### SEE ALSO
 
 * [camp project](camp_project.md)	 - Manage campaign projects
-

--- a/docs/cli-reference/camp_project_run.md
+++ b/docs/cli-reference/camp_project_run.md
@@ -48,4 +48,3 @@ camp project run [--project <name>] [--] <command> [args...] [flags]
 ### SEE ALSO
 
 * [camp project](camp_project.md)	 - Manage campaign projects
-

--- a/docs/cli-reference/camp_project_unlink.md
+++ b/docs/cli-reference/camp_project_unlink.md
@@ -50,4 +50,3 @@ camp project unlink [name] [flags]
 ### SEE ALSO
 
 * [camp project](camp_project.md)	 - Manage campaign projects
-

--- a/docs/cli-reference/camp_project_worktree.md
+++ b/docs/cli-reference/camp_project_worktree.md
@@ -54,4 +54,3 @@ camp project worktree [flags]
 * [camp project worktree add](camp_project_worktree_add.md)	 - Create a new worktree for the project
 * [camp project worktree list](camp_project_worktree_list.md)	 - List worktrees for the project
 * [camp project worktree remove](camp_project_worktree_remove.md)	 - Remove a worktree
-

--- a/docs/cli-reference/camp_project_worktree_add.md
+++ b/docs/cli-reference/camp_project_worktree_add.md
@@ -55,4 +55,3 @@ camp project worktree add <name> [flags]
 ### SEE ALSO
 
 * [camp project worktree](camp_project_worktree.md)	 - Manage worktrees for a project
-

--- a/docs/cli-reference/camp_project_worktree_list.md
+++ b/docs/cli-reference/camp_project_worktree_list.md
@@ -39,4 +39,3 @@ camp project worktree list [flags]
 ### SEE ALSO
 
 * [camp project worktree](camp_project_worktree.md)	 - Manage worktrees for a project
-

--- a/docs/cli-reference/camp_project_worktree_remove.md
+++ b/docs/cli-reference/camp_project_worktree_remove.md
@@ -43,4 +43,3 @@ camp project worktree remove <name> [flags]
 ### SEE ALSO
 
 * [camp project worktree](camp_project_worktree.md)	 - Manage worktrees for a project
-

--- a/docs/cli-reference/camp_pull.md
+++ b/docs/cli-reference/camp_pull.md
@@ -46,4 +46,3 @@ camp pull [flags] [remote] [branch]
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
 * [camp pull all](camp_pull_all.md)	 - Pull latest changes for all repos
-

--- a/docs/cli-reference/camp_pull_all.md
+++ b/docs/cli-reference/camp_pull_all.md
@@ -46,4 +46,3 @@ camp pull all [git pull flags] [flags]
 ### SEE ALSO
 
 * [camp pull](camp_pull.md)	 - Pull latest changes from remote
-

--- a/docs/cli-reference/camp_push.md
+++ b/docs/cli-reference/camp_push.md
@@ -45,4 +45,3 @@ camp push [flags] [remote] [branch]
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
 * [camp push all](camp_push_all.md)	 - Push all repos with unpushed commits
-

--- a/docs/cli-reference/camp_push_all.md
+++ b/docs/cli-reference/camp_push_all.md
@@ -40,4 +40,3 @@ camp push all [git push flags] [flags]
 ### SEE ALSO
 
 * [camp push](camp_push.md)	 - Push campaign changes to remote
-

--- a/docs/cli-reference/camp_refs-sync.md
+++ b/docs/cli-reference/camp_refs-sync.md
@@ -37,4 +37,3 @@ camp refs-sync [submodule...] [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_register.md
+++ b/docs/cli-reference/camp_register.md
@@ -44,4 +44,3 @@ camp register [path] [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_registry.md
+++ b/docs/cli-reference/camp_registry.md
@@ -44,4 +44,3 @@ camp registry [flags]
 * [camp registry check](camp_registry_check.md)	 - Check registry integrity
 * [camp registry prune](camp_registry_prune.md)	 - Remove stale registry entries
 * [camp registry sync](camp_registry_sync.md)	 - Sync current campaign with registry
-

--- a/docs/cli-reference/camp_registry_check.md
+++ b/docs/cli-reference/camp_registry_check.md
@@ -36,4 +36,3 @@ camp registry check [flags]
 ### SEE ALSO
 
 * [camp registry](camp_registry.md)	 - Manage the campaign registry
-

--- a/docs/cli-reference/camp_registry_prune.md
+++ b/docs/cli-reference/camp_registry_prune.md
@@ -42,4 +42,3 @@ camp registry prune [flags]
 ### SEE ALSO
 
 * [camp registry](camp_registry.md)	 - Manage the campaign registry
-

--- a/docs/cli-reference/camp_registry_sync.md
+++ b/docs/cli-reference/camp_registry_sync.md
@@ -34,4 +34,3 @@ camp registry sync [flags]
 ### SEE ALSO
 
 * [camp registry](camp_registry.md)	 - Manage the campaign registry
-

--- a/docs/cli-reference/camp_root.md
+++ b/docs/cli-reference/camp_root.md
@@ -35,4 +35,3 @@ camp root [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_run.md
+++ b/docs/cli-reference/camp_run.md
@@ -58,4 +58,3 @@ camp run [project | @shortcut] [command | recipe] [args...] [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_settings.md
+++ b/docs/cli-reference/camp_settings.md
@@ -41,4 +41,3 @@ camp settings [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_shell-init.md
+++ b/docs/cli-reference/camp_shell-init.md
@@ -56,4 +56,3 @@ camp shell-init <shell> [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_shortcuts.md
+++ b/docs/cli-reference/camp_shortcuts.md
@@ -51,4 +51,3 @@ camp shortcuts [flags]
 * [camp shortcuts list](camp_shortcuts_list.md)	 - List shortcuts for a specific project
 * [camp shortcuts remove](camp_shortcuts_remove.md)	 - Remove a shortcut (campaign-level or project sub-shortcut)
 * [camp shortcuts reset](camp_shortcuts_reset.md)	 - Reset auto-generated shortcuts to current defaults
-

--- a/docs/cli-reference/camp_shortcuts_add.md
+++ b/docs/cli-reference/camp_shortcuts_add.md
@@ -50,4 +50,3 @@ camp shortcuts add [name] [path] or [project] [name] [path] [flags]
 ### SEE ALSO
 
 * [camp shortcuts](camp_shortcuts.md)	 - List all available shortcuts
-

--- a/docs/cli-reference/camp_shortcuts_diff.md
+++ b/docs/cli-reference/camp_shortcuts_diff.md
@@ -42,4 +42,3 @@ camp shortcuts diff [flags]
 ### SEE ALSO
 
 * [camp shortcuts](camp_shortcuts.md)	 - List all available shortcuts
-

--- a/docs/cli-reference/camp_shortcuts_list.md
+++ b/docs/cli-reference/camp_shortcuts_list.md
@@ -36,4 +36,3 @@ camp shortcuts list [project] [flags]
 ### SEE ALSO
 
 * [camp shortcuts](camp_shortcuts.md)	 - List all available shortcuts
-

--- a/docs/cli-reference/camp_shortcuts_remove.md
+++ b/docs/cli-reference/camp_shortcuts_remove.md
@@ -40,4 +40,3 @@ camp shortcuts remove <name> or <project> <name> [flags]
 ### SEE ALSO
 
 * [camp shortcuts](camp_shortcuts.md)	 - List all available shortcuts
-

--- a/docs/cli-reference/camp_shortcuts_reset.md
+++ b/docs/cli-reference/camp_shortcuts_reset.md
@@ -50,4 +50,3 @@ camp shortcuts reset [flags]
 ### SEE ALSO
 
 * [camp shortcuts](camp_shortcuts.md)	 - List all available shortcuts
-

--- a/docs/cli-reference/camp_skills.md
+++ b/docs/cli-reference/camp_skills.md
@@ -45,4 +45,3 @@ camp skills [flags]
 * [camp skills link](camp_skills_link.md)	 - Project campaign skill bundles into tool-specific skills directories
 * [camp skills status](camp_skills_status.md)	 - Show the current state of projected skill bundle symlinks
 * [camp skills unlink](camp_skills_unlink.md)	 - Remove projected skill bundle symlinks
-

--- a/docs/cli-reference/camp_skills_link.md
+++ b/docs/cli-reference/camp_skills_link.md
@@ -42,4 +42,3 @@ camp skills link [flags]
 ### SEE ALSO
 
 * [camp skills](camp_skills.md)	 - Manage campaign skill directory links
-

--- a/docs/cli-reference/camp_skills_status.md
+++ b/docs/cli-reference/camp_skills_status.md
@@ -36,4 +36,3 @@ camp skills status [flags]
 ### SEE ALSO
 
 * [camp skills](camp_skills.md)	 - Manage campaign skill directory links
-

--- a/docs/cli-reference/camp_skills_unlink.md
+++ b/docs/cli-reference/camp_skills_unlink.md
@@ -39,4 +39,3 @@ camp skills unlink [flags]
 ### SEE ALSO
 
 * [camp skills](camp_skills.md)	 - Manage campaign skill directory links
-

--- a/docs/cli-reference/camp_status.md
+++ b/docs/cli-reference/camp_status.md
@@ -41,4 +41,3 @@ camp status [flags]
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
 * [camp status all](camp_status_all.md)	 - Show git status of all submodules
-

--- a/docs/cli-reference/camp_status_all.md
+++ b/docs/cli-reference/camp_status_all.md
@@ -41,4 +41,3 @@ camp status all [flags]
 ### SEE ALSO
 
 * [camp status](camp_status.md)	 - Show git status of the campaign
-

--- a/docs/cli-reference/camp_switch.md
+++ b/docs/cli-reference/camp_switch.md
@@ -48,4 +48,3 @@ camp switch [campaign] [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_sync.md
+++ b/docs/cli-reference/camp_sync.md
@@ -74,4 +74,3 @@ camp sync [submodule...] [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_transfer.md
+++ b/docs/cli-reference/camp_transfer.md
@@ -44,4 +44,3 @@ camp transfer <src> <dest> [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_unpin.md
+++ b/docs/cli-reference/camp_unpin.md
@@ -29,4 +29,3 @@ camp unpin [name] [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_unregister.md
+++ b/docs/cli-reference/camp_unregister.md
@@ -43,4 +43,3 @@ camp unregister <name-or-id> [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/docs/cli-reference/camp_version.md
+++ b/docs/cli-reference/camp_version.md
@@ -34,4 +34,3 @@ camp version [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git"
 )
 
 // Options controls Attach behavior.
@@ -23,7 +24,7 @@ type Options struct {
 	Force bool
 }
 
-// Result describes the outcome of a successful attach.
+// Result describes the outcome of a successful attach or detach.
 type Result struct {
 	// Input is the path the user passed (for display purposes).
 	Input string
@@ -33,6 +34,12 @@ type Result struct {
 	CampaignID string
 	// FollowedSymlink is true when Input != Target.
 	FollowedSymlink bool
+	// GitExcludeUpdated is true when the operation also updated the
+	// target repo's .git/info/exclude file.
+	GitExcludeUpdated bool
+	// GitExcludeWarning is non-empty when a best-effort exclude update
+	// failed; the marker write/remove still succeeded.
+	GitExcludeWarning string
 }
 
 // Attach writes a Kind="attachment" marker at the resolved target of input,
@@ -40,8 +47,14 @@ type Result struct {
 //
 // Refuses if:
 //   - input does not resolve.
-//   - target is already inside a campaign root.
+//   - target is already inside any campaign tree (the selected one or
+//     another). A nested marker would shadow the parent .campaign/ during
+//     detection.
 //   - target already has a marker (unless opts.Force).
+//
+// When the target is a Git working tree, .camp is added to that repo's
+// .git/info/exclude on a best-effort basis so campaign-local state is not
+// accidentally committed to the attached repo.
 func Attach(ctx context.Context, campaignRoot, campaignID, input string, opts Options) (*Result, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
@@ -66,13 +79,13 @@ func Attach(ctx context.Context, campaignRoot, campaignID, input string, opts Op
 		return nil, camperrors.Wrapf(camperrors.ErrInvalidInput, "attach target %q is not a directory", target)
 	}
 
-	if isUnderCampaignRoot(target, campaignRoot) {
-		return nil, camperrors.Wrapf(camperrors.ErrInvalidInput,
-			"target %q is already inside a campaign tree; attach is for external directories", target)
-	}
-
+	// Check for an existing marker at target first. A self-attached
+	// directory will detect its own marker via campaign.Detect, so we
+	// must distinguish that case before the any-campaign check.
 	markerPath := campaign.MarkerPath(target)
+	hasExistingMarker := false
 	if existing, readErr := campaign.ReadMarker(target); readErr == nil {
+		hasExistingMarker = true
 		if !opts.Force {
 			return nil, camperrors.Wrapf(camperrors.ErrAlreadyExists,
 				"marker already exists at %q (kind=%q); use --force to overwrite", markerPath, existing.Kind)
@@ -86,6 +99,21 @@ func Attach(ctx context.Context, campaignRoot, campaignID, input string, opts Op
 		return nil, camperrors.Wrapf(readErr, "read existing marker at %q", markerPath)
 	}
 
+	// Walk from the parent so an attachment marker AT target itself does
+	// not falsely report "already inside a campaign".
+	if existingRoot, ok := detectExistingCampaign(ctx, filepath.Dir(target)); ok && !hasExistingMarker {
+		switch {
+		case sameCampaignRoot(existingRoot, campaignRoot):
+			return nil, camperrors.Wrapf(camperrors.ErrInvalidInput,
+				"target %q is already inside campaign root %q; attach is for external directories",
+				target, existingRoot)
+		default:
+			return nil, camperrors.Wrapf(camperrors.ErrInvalidInput,
+				"target %q is already inside a different campaign at %q; refusing to write a shadowing .camp marker",
+				target, existingRoot)
+		}
+	}
+
 	marker := campaign.LinkMarker{
 		Version:          campaign.LinkMarkerVersion,
 		Kind:             campaign.KindAttachment,
@@ -95,16 +123,27 @@ func Attach(ctx context.Context, campaignRoot, campaignID, input string, opts Op
 		return nil, camperrors.Wrapf(err, "write marker at %q", markerPath)
 	}
 
-	return &Result{
+	res := &Result{
 		Input:           input,
 		Target:          target,
 		CampaignID:      campaignID,
 		FollowedSymlink: target != abs,
-	}, nil
+	}
+	if git.IsRepo(target) {
+		if err := git.EnsureInfoExclude(ctx, target, campaign.LinkMarkerFile); err != nil {
+			res.GitExcludeWarning = err.Error()
+		} else {
+			res.GitExcludeUpdated = true
+		}
+	}
+	return res, nil
 }
 
 // Detach removes the attachment marker at the resolved target of input.
 // Refuses if the marker is missing or has Kind="project".
+//
+// When the target is a Git working tree, .camp is removed from that repo's
+// .git/info/exclude on a best-effort basis to mirror Attach.
 func Detach(ctx context.Context, input string) (*Result, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
@@ -136,35 +175,42 @@ func Detach(ctx context.Context, input string) (*Result, error) {
 		return nil, camperrors.Wrapf(err, "remove marker at %q", markerPath)
 	}
 
-	return &Result{
+	res := &Result{
 		Input:           input,
 		Target:          target,
 		CampaignID:      marker.EffectiveCampaignID(),
 		FollowedSymlink: target != abs,
-	}, nil
-}
-
-func isUnderCampaignRoot(target, campaignRoot string) bool {
-	if campaignRoot == "" {
-		return false
 	}
-	resolvedRoot, err := filepath.EvalSymlinks(campaignRoot)
-	if err != nil {
-		resolvedRoot = campaignRoot
-	}
-	rel, err := filepath.Rel(resolvedRoot, target)
-	if err != nil {
-		return false
-	}
-	return rel == "." || (rel != ".." && !startsWithDotDot(rel))
-}
-
-func startsWithDotDot(p string) bool {
-	if len(p) >= 2 && p[0] == '.' && p[1] == '.' {
-		if len(p) == 2 {
-			return true
+	if git.IsRepo(target) {
+		if err := git.RemoveInfoExclude(ctx, target, campaign.LinkMarkerFile); err != nil {
+			res.GitExcludeWarning = err.Error()
+		} else {
+			res.GitExcludeUpdated = true
 		}
-		return p[2] == '/' || p[2] == filepath.Separator
 	}
-	return false
+	return res, nil
+}
+
+// detectExistingCampaign returns the existing campaign root for target, if
+// any. It uses the same Detect path as the rest of the CLI so attachments
+// cannot shadow another campaign by writing a .camp marker inside it.
+func detectExistingCampaign(ctx context.Context, target string) (string, bool) {
+	root, err := campaign.Detect(ctx, target)
+	if err != nil {
+		return "", false
+	}
+	return root, true
+}
+
+func sameCampaignRoot(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	resolveOrSelf := func(p string) string {
+		if r, err := filepath.EvalSymlinks(p); err == nil {
+			return r
+		}
+		return p
+	}
+	return resolveOrSelf(a) == resolveOrSelf(b)
 }

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -79,13 +79,9 @@ func Attach(ctx context.Context, campaignRoot, campaignID, input string, opts Op
 		return nil, camperrors.Wrapf(camperrors.ErrInvalidInput, "attach target %q is not a directory", target)
 	}
 
-	// Check for an existing marker at target first. A self-attached
-	// directory will detect its own marker via campaign.Detect, so we
-	// must distinguish that case before the any-campaign check.
+	// Check for an existing marker at target first.
 	markerPath := campaign.MarkerPath(target)
-	hasExistingMarker := false
 	if existing, readErr := campaign.ReadMarker(target); readErr == nil {
-		hasExistingMarker = true
 		if !opts.Force {
 			return nil, camperrors.Wrapf(camperrors.ErrAlreadyExists,
 				"marker already exists at %q (kind=%q); use --force to overwrite", markerPath, existing.Kind)
@@ -99,9 +95,11 @@ func Attach(ctx context.Context, campaignRoot, campaignID, input string, opts Op
 		return nil, camperrors.Wrapf(readErr, "read existing marker at %q", markerPath)
 	}
 
-	// Walk from the parent so an attachment marker AT target itself does
-	// not falsely report "already inside a campaign".
-	if existingRoot, ok := detectExistingCampaign(ctx, filepath.Dir(target)); ok && !hasExistingMarker {
+	// Walk from the parent so an attachment marker AT target itself is
+	// invisible to Detect. This lets the any-campaign check run on the
+	// --force re-attach path too: a target now inside another campaign
+	// (e.g. moved under a new campaign root) would otherwise shadow it.
+	if existingRoot, ok := detectExistingCampaign(ctx, filepath.Dir(target)); ok {
 		switch {
 		case sameCampaignRoot(existingRoot, campaignRoot):
 			return nil, camperrors.Wrapf(camperrors.ErrInvalidInput,
@@ -130,9 +128,11 @@ func Attach(ctx context.Context, campaignRoot, campaignID, input string, opts Op
 		FollowedSymlink: target != abs,
 	}
 	if git.IsRepo(target) {
-		if err := git.EnsureInfoExclude(ctx, target, campaign.LinkMarkerFile); err != nil {
+		updated, err := git.EnsureInfoExclude(ctx, target, campaign.LinkMarkerFile)
+		switch {
+		case err != nil:
 			res.GitExcludeWarning = err.Error()
-		} else {
+		case updated:
 			res.GitExcludeUpdated = true
 		}
 	}
@@ -182,9 +182,11 @@ func Detach(ctx context.Context, input string) (*Result, error) {
 		FollowedSymlink: target != abs,
 	}
 	if git.IsRepo(target) {
-		if err := git.RemoveInfoExclude(ctx, target, campaign.LinkMarkerFile); err != nil {
+		updated, err := git.RemoveInfoExclude(ctx, target, campaign.LinkMarkerFile)
+		switch {
+		case err != nil:
 			res.GitExcludeWarning = err.Error()
-		} else {
+		case updated:
 			res.GitExcludeUpdated = true
 		}
 	}

--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -1,0 +1,170 @@
+// Package attach implements non-project attachment of arbitrary directories
+// to a campaign via the .camp link marker (Kind="attachment").
+//
+// Unlike linked projects, attachments do not create a projects/<name> symlink
+// and are not registered as projects. The user manages whatever symlink (if
+// any) they use to reach the directory; this package only writes/removes the
+// marker so context detection works from inside the attached target.
+package attach
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// Options controls Attach behavior.
+type Options struct {
+	// Force overwrites an existing marker at the target.
+	Force bool
+}
+
+// Result describes the outcome of a successful attach.
+type Result struct {
+	// Input is the path the user passed (for display purposes).
+	Input string
+	// Target is the resolved directory where the marker was written.
+	Target string
+	// CampaignID is the campaign the target is now attached to.
+	CampaignID string
+	// FollowedSymlink is true when Input != Target.
+	FollowedSymlink bool
+}
+
+// Attach writes a Kind="attachment" marker at the resolved target of input,
+// binding it to the given campaign.
+//
+// Refuses if:
+//   - input does not resolve.
+//   - target is already inside a campaign root.
+//   - target already has a marker (unless opts.Force).
+func Attach(ctx context.Context, campaignRoot, campaignID, input string, opts Options) (*Result, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	if campaignID == "" {
+		return nil, camperrors.Wrap(camperrors.ErrInvalidInput, "campaign ID required")
+	}
+
+	abs, err := filepath.Abs(input)
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "resolve %q", input)
+	}
+	target, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "resolve symlinks for %q", input)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "stat target %q", target)
+	}
+	if !info.IsDir() {
+		return nil, camperrors.Wrapf(camperrors.ErrInvalidInput, "attach target %q is not a directory", target)
+	}
+
+	if isUnderCampaignRoot(target, campaignRoot) {
+		return nil, camperrors.Wrapf(camperrors.ErrInvalidInput,
+			"target %q is already inside a campaign tree; attach is for external directories", target)
+	}
+
+	markerPath := campaign.MarkerPath(target)
+	if existing, readErr := campaign.ReadMarker(target); readErr == nil {
+		if !opts.Force {
+			return nil, camperrors.Wrapf(camperrors.ErrAlreadyExists,
+				"marker already exists at %q (kind=%q); use --force to overwrite", markerPath, existing.Kind)
+		}
+		if existing.Kind == campaign.KindProject {
+			return nil, camperrors.Wrapf(camperrors.ErrInvalidInput,
+				"refusing to overwrite linked-project marker at %q with --force; use 'camp project unlink' first",
+				markerPath)
+		}
+	} else if !errors.Is(readErr, os.ErrNotExist) && !os.IsNotExist(readErr) {
+		return nil, camperrors.Wrapf(readErr, "read existing marker at %q", markerPath)
+	}
+
+	marker := campaign.LinkMarker{
+		Version:          campaign.LinkMarkerVersion,
+		Kind:             campaign.KindAttachment,
+		ActiveCampaignID: campaignID,
+	}
+	if err := campaign.WriteMarker(target, marker); err != nil {
+		return nil, camperrors.Wrapf(err, "write marker at %q", markerPath)
+	}
+
+	return &Result{
+		Input:           input,
+		Target:          target,
+		CampaignID:      campaignID,
+		FollowedSymlink: target != abs,
+	}, nil
+}
+
+// Detach removes the attachment marker at the resolved target of input.
+// Refuses if the marker is missing or has Kind="project".
+func Detach(ctx context.Context, input string) (*Result, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	abs, err := filepath.Abs(input)
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "resolve %q", input)
+	}
+	target, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "resolve symlinks for %q", input)
+	}
+
+	markerPath := campaign.MarkerPath(target)
+	marker, err := campaign.ReadMarker(target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, camperrors.Wrapf(camperrors.ErrNotFound, "no marker at %q", markerPath)
+		}
+		return nil, camperrors.Wrapf(err, "read marker at %q", markerPath)
+	}
+	if marker.Kind == campaign.KindProject {
+		return nil, camperrors.Wrapf(camperrors.ErrInvalidInput,
+			"%q is a linked project; use 'camp project unlink' instead", target)
+	}
+
+	if err := campaign.RemoveMarker(target); err != nil {
+		return nil, camperrors.Wrapf(err, "remove marker at %q", markerPath)
+	}
+
+	return &Result{
+		Input:           input,
+		Target:          target,
+		CampaignID:      marker.EffectiveCampaignID(),
+		FollowedSymlink: target != abs,
+	}, nil
+}
+
+func isUnderCampaignRoot(target, campaignRoot string) bool {
+	if campaignRoot == "" {
+		return false
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(campaignRoot)
+	if err != nil {
+		resolvedRoot = campaignRoot
+	}
+	rel, err := filepath.Rel(resolvedRoot, target)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !startsWithDotDot(rel))
+}
+
+func startsWithDotDot(p string) bool {
+	if len(p) >= 2 && p[0] == '.' && p[1] == '.' {
+		if len(p) == 2 {
+			return true
+		}
+		return p[2] == '/' || p[2] == filepath.Separator
+	}
+	return false
+}

--- a/internal/attach/attach_test.go
+++ b/internal/attach/attach_test.go
@@ -1,0 +1,275 @@
+package attach
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+func setupCampaign(t *testing.T) (campaignRoot, registryPath string) {
+	t.Helper()
+	tmp := t.TempDir()
+	tmp, _ = filepath.EvalSymlinks(tmp)
+
+	campaignRoot = filepath.Join(tmp, "campaign")
+	if err := os.MkdirAll(filepath.Join(campaignRoot, campaign.CampaignDir), 0755); err != nil {
+		t.Fatalf("mkdir campaign: %v", err)
+	}
+
+	registryPath = filepath.Join(tmp, "registry.json")
+	registryData := []byte(`{
+  "version": 1,
+  "campaigns": {
+    "campaign-xyz": {
+      "name": "campaign",
+      "path": "` + campaignRoot + `"
+    }
+  }
+}`)
+	if err := os.WriteFile(registryPath, registryData, 0644); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	t.Setenv("CAMP_REGISTRY_PATH", registryPath)
+	return campaignRoot, registryPath
+}
+
+func TestAttach_WritesAttachmentMarker(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not supported on Windows")
+	}
+
+	campaignRoot, _ := setupCampaign(t)
+
+	external := filepath.Join(t.TempDir(), "external")
+	external, _ = filepath.EvalSymlinks(filepath.Dir(external))
+	external = filepath.Join(external, "external")
+	if err := os.MkdirAll(external, 0755); err != nil {
+		t.Fatalf("mkdir external: %v", err)
+	}
+
+	res, err := Attach(context.Background(), campaignRoot, "campaign-xyz", external, Options{})
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	if res.CampaignID != "campaign-xyz" {
+		t.Errorf("CampaignID = %q, want %q", res.CampaignID, "campaign-xyz")
+	}
+
+	marker, err := campaign.ReadMarker(external)
+	if err != nil {
+		t.Fatalf("ReadMarker: %v", err)
+	}
+	if marker.Kind != campaign.KindAttachment {
+		t.Errorf("Kind = %q, want %q", marker.Kind, campaign.KindAttachment)
+	}
+	if marker.Version != campaign.LinkMarkerVersion {
+		t.Errorf("Version = %d, want %d", marker.Version, campaign.LinkMarkerVersion)
+	}
+	if marker.ActiveCampaignID != "campaign-xyz" {
+		t.Errorf("ActiveCampaignID = %q, want %q", marker.ActiveCampaignID, "campaign-xyz")
+	}
+}
+
+func TestAttach_FollowsSymlinkInput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not supported on Windows")
+	}
+
+	campaignRoot, _ := setupCampaign(t)
+
+	tmp := t.TempDir()
+	tmp, _ = filepath.EvalSymlinks(tmp)
+	target := filepath.Join(tmp, "real-dir")
+	if err := os.MkdirAll(target, 0755); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	symlinkParent := filepath.Join(campaignRoot, "ai_docs", "examples")
+	if err := os.MkdirAll(symlinkParent, 0755); err != nil {
+		t.Fatalf("mkdir symlink parent: %v", err)
+	}
+	symlink := filepath.Join(symlinkParent, "external-repo")
+	if err := os.Symlink(target, symlink); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	res, err := Attach(context.Background(), campaignRoot, "campaign-xyz", symlink, Options{})
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	if res.Target != target {
+		t.Errorf("Target = %q, want %q", res.Target, target)
+	}
+	if !res.FollowedSymlink {
+		t.Errorf("FollowedSymlink = false, want true")
+	}
+
+	if _, err := os.Stat(filepath.Join(target, campaign.LinkMarkerFile)); err != nil {
+		t.Errorf("marker not at resolved target: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(symlinkParent, campaign.LinkMarkerFile)); !os.IsNotExist(err) {
+		t.Errorf("marker should not be next to symlink")
+	}
+}
+
+func TestAttach_RefusesPathInsideCampaign(t *testing.T) {
+	campaignRoot, _ := setupCampaign(t)
+
+	inside := filepath.Join(campaignRoot, "festivals", "active", "foo")
+	if err := os.MkdirAll(inside, 0755); err != nil {
+		t.Fatalf("mkdir inside: %v", err)
+	}
+
+	_, err := Attach(context.Background(), campaignRoot, "campaign-xyz", inside, Options{})
+	if err == nil {
+		t.Fatal("expected error for path inside campaign tree")
+	}
+	if !errors.Is(err, camperrors.ErrInvalidInput) {
+		t.Errorf("error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestAttach_RefusesExistingMarkerWithoutForce(t *testing.T) {
+	campaignRoot, _ := setupCampaign(t)
+
+	external := filepath.Join(t.TempDir(), "external")
+	external, _ = filepath.EvalSymlinks(filepath.Dir(external))
+	external = filepath.Join(external, "external")
+	if err := os.MkdirAll(external, 0755); err != nil {
+		t.Fatalf("mkdir external: %v", err)
+	}
+	if _, err := Attach(context.Background(), campaignRoot, "campaign-xyz", external, Options{}); err != nil {
+		t.Fatalf("first Attach: %v", err)
+	}
+
+	_, err := Attach(context.Background(), campaignRoot, "campaign-xyz", external, Options{})
+	if err == nil {
+		t.Fatal("expected error on duplicate attach")
+	}
+	if !errors.Is(err, camperrors.ErrAlreadyExists) {
+		t.Errorf("error = %v, want ErrAlreadyExists", err)
+	}
+}
+
+func TestAttach_ForceOverwritesAttachment(t *testing.T) {
+	campaignRoot, _ := setupCampaign(t)
+
+	external := filepath.Join(t.TempDir(), "external")
+	external, _ = filepath.EvalSymlinks(filepath.Dir(external))
+	external = filepath.Join(external, "external")
+	if err := os.MkdirAll(external, 0755); err != nil {
+		t.Fatalf("mkdir external: %v", err)
+	}
+	if _, err := Attach(context.Background(), campaignRoot, "campaign-xyz", external, Options{}); err != nil {
+		t.Fatalf("first Attach: %v", err)
+	}
+
+	if _, err := Attach(context.Background(), campaignRoot, "campaign-xyz", external, Options{Force: true}); err != nil {
+		t.Errorf("Force attach: %v", err)
+	}
+}
+
+func TestAttach_ForceRefusesProjectMarker(t *testing.T) {
+	campaignRoot, _ := setupCampaign(t)
+
+	external := filepath.Join(t.TempDir(), "external")
+	external, _ = filepath.EvalSymlinks(filepath.Dir(external))
+	external = filepath.Join(external, "external")
+	if err := os.MkdirAll(external, 0755); err != nil {
+		t.Fatalf("mkdir external: %v", err)
+	}
+
+	// Hand-write a project marker.
+	projectMarker := campaign.LinkMarker{
+		Version:          campaign.LinkMarkerVersion,
+		Kind:             campaign.KindProject,
+		ActiveCampaignID: "campaign-xyz",
+		ProjectName:      "example",
+	}
+	if err := campaign.WriteMarker(external, projectMarker); err != nil {
+		t.Fatalf("WriteMarker: %v", err)
+	}
+
+	_, err := Attach(context.Background(), campaignRoot, "campaign-xyz", external, Options{Force: true})
+	if err == nil {
+		t.Fatal("expected error refusing to overwrite project marker")
+	}
+	if !errors.Is(err, camperrors.ErrInvalidInput) {
+		t.Errorf("error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestDetach_RemovesAttachmentMarker(t *testing.T) {
+	campaignRoot, _ := setupCampaign(t)
+
+	external := filepath.Join(t.TempDir(), "external")
+	external, _ = filepath.EvalSymlinks(filepath.Dir(external))
+	external = filepath.Join(external, "external")
+	if err := os.MkdirAll(external, 0755); err != nil {
+		t.Fatalf("mkdir external: %v", err)
+	}
+	if _, err := Attach(context.Background(), campaignRoot, "campaign-xyz", external, Options{}); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+
+	res, err := Detach(context.Background(), external)
+	if err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	if res.Target != external {
+		t.Errorf("Target = %q, want %q", res.Target, external)
+	}
+
+	if _, err := os.Stat(filepath.Join(external, campaign.LinkMarkerFile)); !os.IsNotExist(err) {
+		t.Errorf("marker still present: %v", err)
+	}
+}
+
+func TestDetach_RefusesProjectMarker(t *testing.T) {
+	external := filepath.Join(t.TempDir(), "external")
+	external, _ = filepath.EvalSymlinks(filepath.Dir(external))
+	external = filepath.Join(external, "external")
+	if err := os.MkdirAll(external, 0755); err != nil {
+		t.Fatalf("mkdir external: %v", err)
+	}
+
+	projectMarker := campaign.LinkMarker{
+		Version:          campaign.LinkMarkerVersion,
+		Kind:             campaign.KindProject,
+		ActiveCampaignID: "campaign-xyz",
+	}
+	if err := campaign.WriteMarker(external, projectMarker); err != nil {
+		t.Fatalf("WriteMarker: %v", err)
+	}
+
+	_, err := Detach(context.Background(), external)
+	if err == nil {
+		t.Fatal("expected error refusing to detach project marker")
+	}
+	if !errors.Is(err, camperrors.ErrInvalidInput) {
+		t.Errorf("error = %v, want ErrInvalidInput", err)
+	}
+}
+
+func TestDetach_NoMarkerError(t *testing.T) {
+	external := filepath.Join(t.TempDir(), "external")
+	external, _ = filepath.EvalSymlinks(filepath.Dir(external))
+	external = filepath.Join(external, "external")
+	if err := os.MkdirAll(external, 0755); err != nil {
+		t.Fatalf("mkdir external: %v", err)
+	}
+
+	_, err := Detach(context.Background(), external)
+	if err == nil {
+		t.Fatal("expected error when no marker present")
+	}
+	if !errors.Is(err, camperrors.ErrNotFound) {
+		t.Errorf("error = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/attach/attach_test.go
+++ b/internal/attach/attach_test.go
@@ -4,13 +4,24 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
+
+func mustRunGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s in %s: %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+}
 
 func setupCampaign(t *testing.T) (campaignRoot, registryPath string) {
 	t.Helper()
@@ -254,6 +265,117 @@ func TestDetach_RefusesProjectMarker(t *testing.T) {
 	}
 	if !errors.Is(err, camperrors.ErrInvalidInput) {
 		t.Errorf("error = %v, want ErrInvalidInput", err)
+	}
+}
+
+// TestAttach_RefusesPathInsideOtherCampaign covers the security gap obey-agent
+// flagged in PR #270 review: previously, the in-tree check only rejected the
+// selected campaign root, so attaching inside ANOTHER campaign would write a
+// shadowing .camp marker. Detection must now reject any campaign context.
+func TestAttach_RefusesPathInsideOtherCampaign(t *testing.T) {
+	tmp := t.TempDir()
+	tmp, _ = filepath.EvalSymlinks(tmp)
+
+	// Selected campaign (target of the attach call).
+	selected := filepath.Join(tmp, "selected")
+	if err := os.MkdirAll(filepath.Join(selected, campaign.CampaignDir), 0755); err != nil {
+		t.Fatalf("mkdir selected: %v", err)
+	}
+	// Other campaign — totally unrelated, target lives inside it.
+	other := filepath.Join(tmp, "other")
+	if err := os.MkdirAll(filepath.Join(other, campaign.CampaignDir), 0755); err != nil {
+		t.Fatalf("mkdir other: %v", err)
+	}
+	insideOther := filepath.Join(other, "subdir")
+	if err := os.MkdirAll(insideOther, 0755); err != nil {
+		t.Fatalf("mkdir insideOther: %v", err)
+	}
+
+	registryPath := filepath.Join(tmp, "registry.json")
+	registryData := []byte(`{
+  "version": 1,
+  "campaigns": {
+    "selected-id": {"name": "selected", "path": "` + selected + `"},
+    "other-id":    {"name": "other",    "path": "` + other + `"}
+  }
+}`)
+	if err := os.WriteFile(registryPath, registryData, 0644); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	t.Setenv("CAMP_REGISTRY_PATH", registryPath)
+
+	_, err := Attach(context.Background(), selected, "selected-id", insideOther, Options{})
+	if err == nil {
+		t.Fatal("expected error for path inside another campaign")
+	}
+	if !errors.Is(err, camperrors.ErrInvalidInput) {
+		t.Errorf("error = %v, want ErrInvalidInput", err)
+	}
+	// No .camp marker should have been written into the other campaign.
+	if _, statErr := os.Stat(filepath.Join(insideOther, campaign.LinkMarkerFile)); !os.IsNotExist(statErr) {
+		t.Errorf("marker leaked into other campaign: %v", statErr)
+	}
+}
+
+// TestAttach_AddsGitInfoExclude covers the second gap obey-agent flagged: when
+// the target is a Git repo, .camp must be added to .git/info/exclude so
+// campaign-local state is not accidentally committed.
+func TestAttach_AddsGitInfoExclude(t *testing.T) {
+	campaignRoot, _ := setupCampaign(t)
+
+	external := filepath.Join(t.TempDir(), "external")
+	external, _ = filepath.EvalSymlinks(filepath.Dir(external))
+	external = filepath.Join(external, "external")
+	if err := os.MkdirAll(external, 0755); err != nil {
+		t.Fatalf("mkdir external: %v", err)
+	}
+	// Initialize the directory as a real git repo via plumbing.
+	mustRunGit(t, external, "init", "-q")
+
+	res, err := Attach(context.Background(), campaignRoot, "campaign-xyz", external, Options{})
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	if res.GitExcludeWarning != "" {
+		t.Fatalf("unexpected GitExcludeWarning: %s", res.GitExcludeWarning)
+	}
+	if !res.GitExcludeUpdated {
+		t.Fatal("GitExcludeUpdated = false, want true for git target")
+	}
+
+	excludePath := filepath.Join(external, ".git", "info", "exclude")
+	data, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	if !strings.Contains(string(data), campaign.LinkMarkerFile) {
+		t.Errorf(".git/info/exclude does not contain %q; got:\n%s", campaign.LinkMarkerFile, string(data))
+	}
+}
+
+// TestDetach_RemovesGitInfoExclude verifies the symmetric cleanup on detach.
+func TestDetach_RemovesGitInfoExclude(t *testing.T) {
+	campaignRoot, _ := setupCampaign(t)
+
+	external := filepath.Join(t.TempDir(), "external")
+	external, _ = filepath.EvalSymlinks(filepath.Dir(external))
+	external = filepath.Join(external, "external")
+	if err := os.MkdirAll(external, 0755); err != nil {
+		t.Fatalf("mkdir external: %v", err)
+	}
+	mustRunGit(t, external, "init", "-q")
+
+	if _, err := Attach(context.Background(), campaignRoot, "campaign-xyz", external, Options{}); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	if _, err := Detach(context.Background(), external); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+
+	excludePath := filepath.Join(external, ".git", "info", "exclude")
+	data, _ := os.ReadFile(excludePath)
+	if strings.Contains(string(data), campaign.LinkMarkerFile) {
+		t.Errorf(".git/info/exclude still contains %q after detach; got:\n%s", campaign.LinkMarkerFile, string(data))
 	}
 }
 

--- a/internal/campaign/detect_attachment_test.go
+++ b/internal/campaign/detect_attachment_test.go
@@ -1,0 +1,141 @@
+package campaign
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestDetect_AttachmentMarker_ResolvesViaRegistry is part of the
+// non-project-symlinks design. A directory outside the campaign tree that
+// carries a Kind="attachment" marker should resolve to the campaign root via
+// the registry, exactly as a linked-project marker does today.
+//
+// This test sets CAMP_REGISTRY_PATH to an isolated registry file and writes a
+// V3 attachment marker into an external directory.
+func TestDetect_AttachmentMarker_ResolvesViaRegistry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	// Real campaign root.
+	campaignRoot := filepath.Join(tmpDir, "real-campaign")
+	if err := os.MkdirAll(filepath.Join(campaignRoot, CampaignDir), 0755); err != nil {
+		t.Fatalf("mkdir campaign: %v", err)
+	}
+
+	// Isolated registry file with this campaign registered.
+	regPath := filepath.Join(tmpDir, "registry.json")
+	regData := []byte(`{
+  "version": 1,
+  "campaigns": {
+    "campaign-xyz": {
+      "name": "real-campaign",
+      "path": "` + campaignRoot + `"
+    }
+  }
+}`)
+	if err := os.WriteFile(regPath, regData, 0644); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	t.Setenv("CAMP_REGISTRY_PATH", regPath)
+
+	// External directory with attachment marker pointing at campaign-xyz.
+	external := filepath.Join(tmpDir, "external", "some-dir")
+	if err := os.MkdirAll(external, 0755); err != nil {
+		t.Fatalf("mkdir external: %v", err)
+	}
+
+	marker := LinkMarker{
+		Version:          3,
+		Kind:             "attachment",
+		ActiveCampaignID: "campaign-xyz",
+	}
+	if err := WriteMarker(external, marker); err != nil {
+		t.Fatalf("WriteMarker: %v", err)
+	}
+
+	// Detection from inside the attached external directory should resolve
+	// to the campaign root.
+	ClearCache()
+	got, err := Detect(context.Background(), external)
+	if err != nil {
+		t.Fatalf("Detect from attached dir: %v", err)
+	}
+	if got != campaignRoot {
+		t.Errorf("Detect = %q, want %q", got, campaignRoot)
+	}
+}
+
+// TestDetect_AttachmentMarker_ViaSymlinkInTree mirrors the canonical user
+// workflow: a symlink lives inside the campaign tree, its target lives
+// outside the campaign tree and carries an attachment marker. cwd-ing through
+// the symlink and detecting from there should reach the campaign.
+func TestDetect_AttachmentMarker_ViaSymlinkInTree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	campaignRoot := filepath.Join(tmpDir, "real-campaign")
+	if err := os.MkdirAll(filepath.Join(campaignRoot, CampaignDir), 0755); err != nil {
+		t.Fatalf("mkdir campaign: %v", err)
+	}
+
+	regPath := filepath.Join(tmpDir, "registry.json")
+	regData := []byte(`{
+  "version": 1,
+  "campaigns": {
+    "campaign-xyz": {
+      "name": "real-campaign",
+      "path": "` + campaignRoot + `"
+    }
+  }
+}`)
+	if err := os.WriteFile(regPath, regData, 0644); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	t.Setenv("CAMP_REGISTRY_PATH", regPath)
+
+	// External directory with attachment marker.
+	external := filepath.Join(tmpDir, "external", "some-dir")
+	if err := os.MkdirAll(external, 0755); err != nil {
+		t.Fatalf("mkdir external: %v", err)
+	}
+	marker := LinkMarker{
+		Version:          3,
+		Kind:             "attachment",
+		ActiveCampaignID: "campaign-xyz",
+	}
+	if err := WriteMarker(external, marker); err != nil {
+		t.Fatalf("WriteMarker: %v", err)
+	}
+
+	// Symlink inside the campaign tree pointing at the external dir.
+	symlinkParent := filepath.Join(campaignRoot, "ai_docs", "examples")
+	if err := os.MkdirAll(symlinkParent, 0755); err != nil {
+		t.Fatalf("mkdir symlink parent: %v", err)
+	}
+	symlinkPath := filepath.Join(symlinkParent, "external-repo")
+	if err := os.Symlink(external, symlinkPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	// Detection from the symlink path should reach the campaign root via
+	// either the in-tree walk-up (logical path) or the resolved-path walk.
+	ClearCache()
+	got, err := Detect(context.Background(), symlinkPath)
+	if err != nil {
+		t.Fatalf("Detect from symlink: %v", err)
+	}
+	if got != campaignRoot {
+		t.Errorf("Detect = %q, want %q", got, campaignRoot)
+	}
+}

--- a/internal/campaign/link_marker.go
+++ b/internal/campaign/link_marker.go
@@ -13,17 +13,32 @@ import (
 const LinkMarkerFile = ".camp"
 
 // LinkMarkerVersion is the current .camp schema version.
-const LinkMarkerVersion = 2
+const LinkMarkerVersion = 3
 
-// LinkMarker records the active campaign context for a linked project.
+// Marker kinds. KindProject is the original linked-project shape;
+// KindAttachment is a non-project directory attached to a campaign so context
+// detection works from inside it without registering a project.
+const (
+	KindProject    = "project"
+	KindAttachment = "attachment"
+)
+
+// LinkMarker records the active campaign context for a linked directory.
+// A Kind="project" marker is the original linked-project shape and is paired
+// with a projects/<name> symlink and a registry entry. A Kind="attachment"
+// marker is a lighter binding for arbitrary directories the user has already
+// symlinked into the campaign.
 type LinkMarker struct {
 	Version          int    `json:"version"`
+	Kind             string `json:"kind,omitempty"`
 	ActiveCampaignID string `json:"active_campaign_id,omitempty"`
+
+	// Project-only; ignored when Kind="attachment".
+	ProjectName string `json:"project_name,omitempty"`
 
 	// Legacy fields kept for backward-compatible reads only.
 	CampaignID   string `json:"campaign_id,omitempty"`
 	CampaignRoot string `json:"campaign_root,omitempty"`
-	ProjectName  string `json:"project_name,omitempty"`
 }
 
 // MarkerPath returns the marker file path for a linked project directory.
@@ -53,6 +68,11 @@ func ReadMarkerFile(path string) (*LinkMarker, error) {
 	}
 	if marker.ActiveCampaignID == "" && marker.CampaignID != "" {
 		marker.ActiveCampaignID = marker.CampaignID
+	}
+	// Pre-V3 markers had no Kind field. Default to KindProject so existing
+	// linked-project markers continue to behave exactly as before.
+	if marker.Kind == "" {
+		marker.Kind = KindProject
 	}
 
 	return &marker, nil

--- a/internal/campaign/link_marker_test.go
+++ b/internal/campaign/link_marker_test.go
@@ -1,0 +1,98 @@
+package campaign
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLinkMarker_V3_RoundTrip is part of the non-project-symlinks design.
+// It locks in the V3 marker schema where attachments are distinguished from
+// linked projects by an explicit Kind field. This test will start passing
+// once Kind is added to LinkMarker and WriteMarker stamps Version 3.
+func TestLinkMarker_V3_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	in := LinkMarker{
+		Version:          3,
+		Kind:             "attachment",
+		ActiveCampaignID: "campaign-xyz",
+	}
+	if err := WriteMarker(dir, in); err != nil {
+		t.Fatalf("WriteMarker: %v", err)
+	}
+
+	got, err := ReadMarker(dir)
+	if err != nil {
+		t.Fatalf("ReadMarker: %v", err)
+	}
+
+	if got.Version != 3 {
+		t.Errorf("Version = %d, want 3", got.Version)
+	}
+	if got.Kind != "attachment" {
+		t.Errorf("Kind = %q, want %q", got.Kind, "attachment")
+	}
+	if got.ActiveCampaignID != "campaign-xyz" {
+		t.Errorf("ActiveCampaignID = %q, want %q", got.ActiveCampaignID, "campaign-xyz")
+	}
+}
+
+// TestLinkMarker_LegacyDefaultsToProject confirms that markers written before
+// Kind existed (v1/v2) are read as Kind="project" so existing linked projects
+// keep behaving exactly as before once V3 lands.
+func TestLinkMarker_LegacyDefaultsToProject(t *testing.T) {
+	dir := t.TempDir()
+
+	// Hand-write a v2 marker (no Kind field, no Version=3).
+	legacy := map[string]any{
+		"version":            2,
+		"active_campaign_id": "camp-1",
+		"project_name":       "example",
+	}
+	data, err := json.MarshalIndent(legacy, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, LinkMarkerFile), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ReadMarker(dir)
+	if err != nil {
+		t.Fatalf("ReadMarker: %v", err)
+	}
+
+	if got.Kind != "project" {
+		t.Errorf("legacy marker Kind = %q, want %q (default)", got.Kind, "project")
+	}
+}
+
+// TestLinkMarker_ProjectKindRoundTrip ensures linked-project writes can also
+// carry an explicit Kind="project" once the field exists.
+func TestLinkMarker_ProjectKindRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	in := LinkMarker{
+		Version:          3,
+		Kind:             "project",
+		ActiveCampaignID: "campaign-xyz",
+		ProjectName:      "example",
+	}
+	if err := WriteMarker(dir, in); err != nil {
+		t.Fatalf("WriteMarker: %v", err)
+	}
+
+	got, err := ReadMarker(dir)
+	if err != nil {
+		t.Fatalf("ReadMarker: %v", err)
+	}
+
+	if got.Kind != "project" {
+		t.Errorf("Kind = %q, want %q", got.Kind, "project")
+	}
+	if got.ProjectName != "example" {
+		t.Errorf("ProjectName = %q, want %q", got.ProjectName, "example")
+	}
+}

--- a/internal/git/info_exclude.go
+++ b/internal/git/info_exclude.go
@@ -13,20 +13,26 @@ import (
 // EnsureInfoExclude adds pattern to the repo's .git/info/exclude if not
 // already present. repoRoot is a working tree directory; its actual git dir
 // may live elsewhere (worktrees, submodules) and is resolved via git.
-func EnsureInfoExclude(ctx context.Context, repoRoot, pattern string) error {
+//
+// The returned bool reports whether the file was actually modified: false
+// means the pattern was already present and no write occurred.
+func EnsureInfoExclude(ctx context.Context, repoRoot, pattern string) (bool, error) {
 	path, err := infoExcludePath(ctx, repoRoot)
 	if err != nil {
-		return err
+		return false, err
 	}
 	return ensurePatternInFile(path, pattern)
 }
 
 // RemoveInfoExclude removes pattern from the repo's .git/info/exclude if
 // present. Missing files are treated as success.
-func RemoveInfoExclude(ctx context.Context, repoRoot, pattern string) error {
+//
+// The returned bool reports whether the pattern was actually removed: false
+// means the file did not exist or did not contain the pattern.
+func RemoveInfoExclude(ctx context.Context, repoRoot, pattern string) (bool, error) {
 	path, err := infoExcludePath(ctx, repoRoot)
 	if err != nil {
-		return err
+		return false, err
 	}
 	return removePatternFromFile(path, pattern)
 }
@@ -51,19 +57,19 @@ func infoExcludePath(ctx context.Context, repoRoot string) (string, error) {
 	return path, nil
 }
 
-func ensurePatternInFile(path, pattern string) error {
+func ensurePatternInFile(path, pattern string) (bool, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
+		return false, err
 	}
 
 	data, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		return false, err
 	}
 	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
 	for _, line := range lines {
 		if strings.TrimSpace(line) == pattern {
-			return nil
+			return false, nil
 		}
 	}
 
@@ -72,30 +78,41 @@ func ensurePatternInFile(path, pattern string) error {
 		content += "\n"
 	}
 	content += pattern + "\n"
-	return fsutil.WriteFileAtomically(path, []byte(content), 0644)
+	if err := fsutil.WriteFileAtomically(path, []byte(content), 0644); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
-func removePatternFromFile(path, pattern string) error {
+func removePatternFromFile(path, pattern string) (bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return false, nil
 		}
-		return err
+		return false, err
 	}
 
 	lines := strings.Split(string(data), "\n")
 	filtered := make([]string, 0, len(lines))
+	removed := false
 	for _, line := range lines {
 		if strings.TrimSpace(line) == pattern {
+			removed = true
 			continue
 		}
 		filtered = append(filtered, line)
+	}
+	if !removed {
+		return false, nil
 	}
 
 	content := strings.TrimRight(strings.Join(filtered, "\n"), "\n")
 	if content != "" {
 		content += "\n"
 	}
-	return fsutil.WriteFileAtomically(path, []byte(content), 0644)
+	if err := fsutil.WriteFileAtomically(path, []byte(content), 0644); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/internal/git/info_exclude.go
+++ b/internal/git/info_exclude.go
@@ -1,0 +1,101 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+)
+
+// EnsureInfoExclude adds pattern to the repo's .git/info/exclude if not
+// already present. repoRoot is a working tree directory; its actual git dir
+// may live elsewhere (worktrees, submodules) and is resolved via git.
+func EnsureInfoExclude(ctx context.Context, repoRoot, pattern string) error {
+	path, err := infoExcludePath(ctx, repoRoot)
+	if err != nil {
+		return err
+	}
+	return ensurePatternInFile(path, pattern)
+}
+
+// RemoveInfoExclude removes pattern from the repo's .git/info/exclude if
+// present. Missing files are treated as success.
+func RemoveInfoExclude(ctx context.Context, repoRoot, pattern string) error {
+	path, err := infoExcludePath(ctx, repoRoot)
+	if err != nil {
+		return err
+	}
+	return removePatternFromFile(path, pattern)
+}
+
+// IsRepo reports whether path is a git working tree (worktree, submodule, or
+// plain repo).
+func IsRepo(path string) bool {
+	_, err := os.Stat(filepath.Join(path, ".git"))
+	return err == nil
+}
+
+func infoExcludePath(ctx context.Context, repoRoot string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "rev-parse", "--git-path", "info/exclude")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	path := strings.TrimSpace(string(output))
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(repoRoot, path)
+	}
+	return path, nil
+}
+
+func ensurePatternInFile(path, pattern string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	for _, line := range lines {
+		if strings.TrimSpace(line) == pattern {
+			return nil
+		}
+	}
+
+	content := strings.TrimRight(string(data), "\n")
+	if content != "" {
+		content += "\n"
+	}
+	content += pattern + "\n"
+	return fsutil.WriteFileAtomically(path, []byte(content), 0644)
+}
+
+func removePatternFromFile(path, pattern string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	filtered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if strings.TrimSpace(line) == pattern {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+
+	content := strings.TrimRight(strings.Join(filtered, "\n"), "\n")
+	if content != "" {
+		content += "\n"
+	}
+	return fsutil.WriteFileAtomically(path, []byte(content), 0644)
+}

--- a/internal/git/info_exclude_test.go
+++ b/internal/git/info_exclude_test.go
@@ -16,7 +16,7 @@ func initRepo(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("eval symlinks: %v", err)
 	}
-	cmd := exec.Command("git", "init", "-q", dir)
+	cmd := exec.CommandContext(t.Context(), "git", "init", "-q", dir)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init: %v\n%s", err, out)
 	}
@@ -187,6 +187,16 @@ func TestEnsureInfoExclude_ContextCancelled(t *testing.T) {
 	cancel()
 
 	if _, err := EnsureInfoExclude(ctx, repo, ".camp"); err == nil {
+		t.Error("expected error on cancelled context, got nil")
+	}
+}
+
+func TestRemoveInfoExclude_ContextCancelled(t *testing.T) {
+	repo := initRepo(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := RemoveInfoExclude(ctx, repo, ".camp"); err == nil {
 		t.Error("expected error on cancelled context, got nil")
 	}
 }

--- a/internal/git/info_exclude_test.go
+++ b/internal/git/info_exclude_test.go
@@ -1,0 +1,192 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func initRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	dir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("eval symlinks: %v", err)
+	}
+	cmd := exec.Command("git", "init", "-q", dir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	return dir
+}
+
+func readExclude(t *testing.T, repo string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repo, ".git", "info", "exclude"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("read exclude: %v", err)
+	}
+	return string(data)
+}
+
+func TestIsRepo(t *testing.T) {
+	repo := initRepo(t)
+	if !IsRepo(repo) {
+		t.Errorf("IsRepo(%q) = false, want true", repo)
+	}
+	plain := t.TempDir()
+	if IsRepo(plain) {
+		t.Errorf("IsRepo(%q) = true for non-repo, want false", plain)
+	}
+}
+
+func TestEnsureInfoExclude_AddsPattern(t *testing.T) {
+	repo := initRepo(t)
+
+	added, err := EnsureInfoExclude(context.Background(), repo, ".camp")
+	if err != nil {
+		t.Fatalf("EnsureInfoExclude: %v", err)
+	}
+	if !added {
+		t.Fatal("added = false, want true on first add")
+	}
+	if got := readExclude(t, repo); !strings.Contains(got, ".camp") {
+		t.Errorf("exclude does not contain .camp; got:\n%s", got)
+	}
+}
+
+func TestEnsureInfoExclude_Idempotent(t *testing.T) {
+	repo := initRepo(t)
+
+	if _, err := EnsureInfoExclude(context.Background(), repo, ".camp"); err != nil {
+		t.Fatalf("first EnsureInfoExclude: %v", err)
+	}
+	before := readExclude(t, repo)
+
+	added, err := EnsureInfoExclude(context.Background(), repo, ".camp")
+	if err != nil {
+		t.Fatalf("second EnsureInfoExclude: %v", err)
+	}
+	if added {
+		t.Error("added = true on second call, want false (already present)")
+	}
+	if after := readExclude(t, repo); after != before {
+		t.Errorf("file mutated on idempotent call\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func TestEnsureInfoExclude_PreservesExistingPatterns(t *testing.T) {
+	repo := initRepo(t)
+
+	excludePath := filepath.Join(repo, ".git", "info", "exclude")
+	if err := os.WriteFile(excludePath, []byte("*.tmp\nbuild/\n"), 0644); err != nil {
+		t.Fatalf("seed exclude: %v", err)
+	}
+
+	if _, err := EnsureInfoExclude(context.Background(), repo, ".camp"); err != nil {
+		t.Fatalf("EnsureInfoExclude: %v", err)
+	}
+	got := readExclude(t, repo)
+	for _, want := range []string{"*.tmp", "build/", ".camp"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in exclude:\n%s", want, got)
+		}
+	}
+}
+
+func TestRemoveInfoExclude_RemovesPattern(t *testing.T) {
+	repo := initRepo(t)
+
+	if _, err := EnsureInfoExclude(context.Background(), repo, ".camp"); err != nil {
+		t.Fatalf("EnsureInfoExclude: %v", err)
+	}
+
+	removed, err := RemoveInfoExclude(context.Background(), repo, ".camp")
+	if err != nil {
+		t.Fatalf("RemoveInfoExclude: %v", err)
+	}
+	if !removed {
+		t.Fatal("removed = false, want true when pattern present")
+	}
+	if got := readExclude(t, repo); strings.Contains(got, ".camp") {
+		t.Errorf("exclude still contains .camp:\n%s", got)
+	}
+}
+
+func TestRemoveInfoExclude_MissingFile(t *testing.T) {
+	repo := initRepo(t)
+	// Force exclude file out of existence; git init usually leaves it
+	// in place but be explicit.
+	_ = os.Remove(filepath.Join(repo, ".git", "info", "exclude"))
+
+	removed, err := RemoveInfoExclude(context.Background(), repo, ".camp")
+	if err != nil {
+		t.Fatalf("RemoveInfoExclude on missing file: %v", err)
+	}
+	if removed {
+		t.Error("removed = true on missing file, want false")
+	}
+}
+
+func TestRemoveInfoExclude_PatternNotPresent(t *testing.T) {
+	repo := initRepo(t)
+
+	excludePath := filepath.Join(repo, ".git", "info", "exclude")
+	original := []byte("*.tmp\nbuild/\n")
+	if err := os.WriteFile(excludePath, original, 0644); err != nil {
+		t.Fatalf("seed exclude: %v", err)
+	}
+
+	removed, err := RemoveInfoExclude(context.Background(), repo, ".camp")
+	if err != nil {
+		t.Fatalf("RemoveInfoExclude: %v", err)
+	}
+	if removed {
+		t.Error("removed = true when pattern absent, want false")
+	}
+	got, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Errorf("file rewritten on no-op removal\nwant: %q\ngot:  %q", original, got)
+	}
+}
+
+func TestRemoveInfoExclude_PreservesOtherPatterns(t *testing.T) {
+	repo := initRepo(t)
+
+	excludePath := filepath.Join(repo, ".git", "info", "exclude")
+	if err := os.WriteFile(excludePath, []byte("*.tmp\n.camp\nbuild/\n"), 0644); err != nil {
+		t.Fatalf("seed exclude: %v", err)
+	}
+
+	if _, err := RemoveInfoExclude(context.Background(), repo, ".camp"); err != nil {
+		t.Fatalf("RemoveInfoExclude: %v", err)
+	}
+	got := readExclude(t, repo)
+	if strings.Contains(got, ".camp\n") {
+		t.Errorf("exclude still contains .camp line:\n%s", got)
+	}
+	for _, want := range []string{"*.tmp", "build/"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("removal stripped unrelated pattern %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestEnsureInfoExclude_ContextCancelled(t *testing.T) {
+	repo := initRepo(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := EnsureInfoExclude(ctx, repo, ".camp"); err == nil {
+		t.Error("expected error on cancelled context, got nil")
+	}
+}

--- a/internal/pins/pins.go
+++ b/internal/pins/pins.go
@@ -142,22 +142,50 @@ const (
 // If name exists with the same path: removes it (returns Unpinned).
 // If name exists with a different path: updates the path (returns Updated).
 func (s *Store) Toggle(name, path string) ToggleResult {
+	return s.TogglePin(Pin{Name: name, Path: path})
+}
+
+// TogglePin is the lower-level toggle that accepts a full Pin record so
+// callers can specify either Path (in-tree) or AbsPath (attachment) targets.
+// CreatedAt on the input is ignored; new pins are stamped with time.Now().
+func (s *Store) TogglePin(in Pin) ToggleResult {
 	for i, p := range s.pins {
-		if p.Name == name {
-			if p.Path == path {
+		if p.Name == in.Name {
+			if p.Path == in.Path && p.AbsPath == in.AbsPath {
 				s.pins = append(s.pins[:i], s.pins[i+1:]...)
 				return Unpinned
 			}
-			s.pins[i].Path = path
+			s.pins[i].Path = in.Path
+			s.pins[i].AbsPath = in.AbsPath
 			return Updated
 		}
 	}
 	s.pins = append(s.pins, Pin{
-		Name:      name,
-		Path:      path,
+		Name:      in.Name,
+		Path:      in.Path,
+		AbsPath:   in.AbsPath,
 		CreatedAt: time.Now(),
 	})
 	return Pinned
+}
+
+// Resolve returns the absolute on-disk path for a pin, given the campaign
+// root. In-tree pins are resolved relative to root; attachment pins return
+// AbsPath as-is.
+func (p Pin) Resolve(campaignRoot string) string {
+	if p.AbsPath != "" {
+		return p.AbsPath
+	}
+	if filepath.IsAbs(p.Path) {
+		return p.Path
+	}
+	return filepath.Join(campaignRoot, p.Path)
+}
+
+// IsAttachment reports whether the pin targets an attachment-marker dir
+// outside the campaign tree.
+func (p Pin) IsAttachment() bool {
+	return p.AbsPath != ""
 }
 
 // MigrateAbsoluteToRelative converts absolute paths to campaign-root-relative

--- a/internal/pins/pins.go
+++ b/internal/pins/pins.go
@@ -12,9 +12,17 @@ import (
 )
 
 // Pin represents a saved pinned directory.
+//
+// Path is set for in-tree pins and stored relative to the campaign root so
+// the pins file is portable when the campaign moves.
+//
+// AbsPath is set for attachment pins — pins targeting a directory outside
+// the campaign tree that is bound to this campaign via a Kind="attachment"
+// marker. Exactly one of Path or AbsPath should be set on a given pin.
 type Pin struct {
 	Name      string    `json:"name"`
-	Path      string    `json:"path"`
+	Path      string    `json:"path,omitempty"`
+	AbsPath   string    `json:"abs_path,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 }
 

--- a/internal/pins/pins_attachment_test.go
+++ b/internal/pins/pins_attachment_test.go
@@ -1,0 +1,93 @@
+package pins
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPin_AbsPath_RoundTrip is part of the non-project-symlinks design.
+// Pins targeting attachment-marker directories outside the campaign root must
+// be persistable via an AbsPath field. In-tree pins continue to use Path
+// (campaign-root-relative) as today. This test will start passing once Pin
+// gains an AbsPath JSON field.
+func TestPin_AbsPath_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pins.json")
+
+	// Hand-write a pins file that contains both an in-tree pin and an
+	// attachment pin. The attachment pin uses abs_path; Path is empty.
+	raw := []byte(`[
+  {
+    "name": "in-tree",
+    "path": "festivals/active/foo",
+    "created_at": "2026-05-02T00:00:00Z"
+  },
+  {
+    "name": "ext",
+    "abs_path": "/tmp/some-attached-dir",
+    "created_at": "2026-05-02T00:00:00Z"
+  }
+]`)
+	if err := os.WriteFile(path, raw, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewStore(path)
+	if err := s.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	pinList := s.List()
+	if len(pinList) != 2 {
+		t.Fatalf("len(pins) = %d, want 2", len(pinList))
+	}
+
+	// In-tree pin: Path set, AbsPath empty.
+	var inTree, ext Pin
+	for _, p := range pinList {
+		switch p.Name {
+		case "in-tree":
+			inTree = p
+		case "ext":
+			ext = p
+		}
+	}
+
+	if inTree.Path != "festivals/active/foo" {
+		t.Errorf("in-tree Path = %q, want %q", inTree.Path, "festivals/active/foo")
+	}
+	if inTree.AbsPath != "" {
+		t.Errorf("in-tree AbsPath = %q, want empty", inTree.AbsPath)
+	}
+
+	if ext.AbsPath != "/tmp/some-attached-dir" {
+		t.Errorf("attachment AbsPath = %q, want %q", ext.AbsPath, "/tmp/some-attached-dir")
+	}
+	if ext.Path != "" {
+		t.Errorf("attachment Path = %q, want empty", ext.Path)
+	}
+
+	// Save and reload to confirm AbsPath survives the round-trip.
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	saved, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed []map[string]any
+	if err := json.Unmarshal(saved, &parsed); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	var sawAbsPath bool
+	for _, m := range parsed {
+		if v, ok := m["abs_path"].(string); ok && v == "/tmp/some-attached-dir" {
+			sawAbsPath = true
+		}
+	}
+	if !sawAbsPath {
+		t.Errorf("saved pins file does not contain abs_path; got: %s", string(saved))
+	}
+}

--- a/internal/project/link.go
+++ b/internal/project/link.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
-	"github.com/Obedience-Corp/camp/internal/fsutil"
+	"github.com/Obedience-Corp/camp/internal/git"
 	"github.com/Obedience-Corp/camp/internal/pathutil"
 )
 
@@ -379,90 +378,12 @@ func normalizeCampaignRoot(root string) (string, error) {
 	return absRoot, nil
 }
 
-func ensureInfoExclude(ctx context.Context, repoRoot, pattern string) error {
-	path, err := gitInfoExcludePath(ctx, repoRoot)
-	if err != nil {
-		return err
-	}
-	return ensurePatternInFile(path, pattern)
-}
-
-func removeInfoExclude(ctx context.Context, repoRoot, pattern string) error {
-	path, err := gitInfoExcludePath(ctx, repoRoot)
-	if err != nil {
-		return err
-	}
-	return removePatternFromFile(path, pattern)
-}
-
 func ensureGitInfoExclude(ctx context.Context, repoRoot, pattern string) error {
-	return ensureInfoExclude(ctx, repoRoot, pattern)
+	return git.EnsureInfoExclude(ctx, repoRoot, pattern)
 }
 
 func removeGitInfoExclude(ctx context.Context, repoRoot, pattern string) error {
-	return removeInfoExclude(ctx, repoRoot, pattern)
-}
-
-func gitInfoExcludePath(ctx context.Context, repoRoot string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "rev-parse", "--git-path", "info/exclude")
-	output, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	path := strings.TrimSpace(string(output))
-	if !filepath.IsAbs(path) {
-		path = filepath.Join(repoRoot, path)
-	}
-	return path, nil
-}
-
-func ensurePatternInFile(path, pattern string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
-	for _, line := range lines {
-		if strings.TrimSpace(line) == pattern {
-			return nil
-		}
-	}
-
-	content := strings.TrimRight(string(data), "\n")
-	if content != "" {
-		content += "\n"
-	}
-	content += pattern + "\n"
-	return fsutil.WriteFileAtomically(path, []byte(content), 0644)
-}
-
-func removePatternFromFile(path, pattern string) error {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-
-	lines := strings.Split(string(data), "\n")
-	filtered := make([]string, 0, len(lines))
-	for _, line := range lines {
-		if strings.TrimSpace(line) == pattern {
-			continue
-		}
-		filtered = append(filtered, line)
-	}
-
-	content := strings.TrimRight(strings.Join(filtered, "\n"), "\n")
-	if content != "" {
-		content += "\n"
-	}
-	return fsutil.WriteFileAtomically(path, []byte(content), 0644)
+	return git.RemoveInfoExclude(ctx, repoRoot, pattern)
 }
 
 func formatLinkedRepoWarning(action string, err error) string {

--- a/internal/project/link.go
+++ b/internal/project/link.go
@@ -379,11 +379,13 @@ func normalizeCampaignRoot(root string) (string, error) {
 }
 
 func ensureGitInfoExclude(ctx context.Context, repoRoot, pattern string) error {
-	return git.EnsureInfoExclude(ctx, repoRoot, pattern)
+	_, err := git.EnsureInfoExclude(ctx, repoRoot, pattern)
+	return err
 }
 
 func removeGitInfoExclude(ctx context.Context, repoRoot, pattern string) error {
-	return git.RemoveInfoExclude(ctx, repoRoot, pattern)
+	_, err := git.RemoveInfoExclude(ctx, repoRoot, pattern)
+	return err
 }
 
 func formatLinkedRepoWarning(action string, err error) string {

--- a/internal/project/link.go
+++ b/internal/project/link.go
@@ -132,6 +132,7 @@ func AddLinked(ctx context.Context, campaignRoot, localPath string, opts LinkOpt
 	warnings := make([]string, 0, 1)
 	marker := campaign.LinkMarker{
 		Version:          campaign.LinkMarkerVersion,
+		Kind:             campaign.KindProject,
 		ActiveCampaignID: cfg.ID,
 	}
 	if err := campaign.WriteMarker(absLocal, marker); err != nil {

--- a/internal/project/link.go
+++ b/internal/project/link.go
@@ -140,7 +140,7 @@ func AddLinked(ctx context.Context, campaignRoot, localPath string, opts LinkOpt
 	}
 
 	if isGit {
-		if err := ensureGitInfoExclude(ctx, absLocal, campaign.LinkMarkerFile); err != nil {
+		if _, err := git.EnsureInfoExclude(ctx, absLocal, campaign.LinkMarkerFile); err != nil {
 			warnings = append(warnings, formatLinkedRepoWarning("could not update linked repo .git/info/exclude for .camp", err))
 		}
 	}
@@ -222,7 +222,7 @@ func UnlinkProject(ctx context.Context, campaignRoot, name, targetPath string) (
 				return nil, err
 			}
 			if isGitRepo(targetPath) {
-				if err := removeGitInfoExclude(ctx, targetPath, campaign.LinkMarkerFile); err != nil {
+				if _, err := git.RemoveInfoExclude(ctx, targetPath, campaign.LinkMarkerFile); err != nil {
 					warnings = append(warnings, formatLinkedRepoWarning("could not clean up linked repo .git/info/exclude for .camp", err))
 				}
 			}
@@ -376,16 +376,6 @@ func normalizeCampaignRoot(root string) (string, error) {
 		return resolvedRoot, nil
 	}
 	return absRoot, nil
-}
-
-func ensureGitInfoExclude(ctx context.Context, repoRoot, pattern string) error {
-	_, err := git.EnsureInfoExclude(ctx, repoRoot, pattern)
-	return err
-}
-
-func removeGitInfoExclude(ctx context.Context, repoRoot, pattern string) error {
-	_, err := git.RemoveInfoExclude(ctx, repoRoot, pattern)
-	return err
 }
 
 func formatLinkedRepoWarning(action string, err error) string {


### PR DESCRIPTION
## Summary

Closes a bug where `camp pin` and other context-aware commands fail from arbitrary directories the user has symlinked into the campaign tree. Adds a small command surface (`camp attach` / `camp detach`) for binding non-project directories to a campaign, mirroring the linked-project marker pattern but without project ceremony.

- New `camp attach <path>` writes a `Kind="attachment"` `.camp` marker at the symlink's resolved target. Refuses paths inside a campaign, refuses to overwrite project markers (even with `--force`), follows symlinks once.
- New `camp detach <path>` removes attachment markers. Refuses on project markers (those use `camp project unlink`).
- `LinkMarker` schema bumped to V3 with a `Kind` field. Pre-V3 markers default to `KindProject` on read for backward compatibility.
- `Pin` gains an `AbsPath` field. `runPin` now accepts paths outside the campaign root when they resolve through an attachment marker pointing at the active campaign; otherwise the existing rejection stands.
- `camp pins` listing gains a `KIND` column. `cgo` / pin lookup resolves attachment pins via `AbsPath`.
- Linked-project writes now stamp `Kind: KindProject` explicitly.
- README updated with the attach workflow.

Design: [`workflow/design/non-project-symlinks/`](https://github.com/Obedience-Corp/obey-campaign/tree/main/workflow/design/non-project-symlinks) (in the campaign repo).

## Test plan

- [x] Unit tests pass (2298/2298, +9 new in `internal/attach`, +marker/pin coverage)
- [x] `golangci-lint run --new-from-rev=origin/main` is clean
- [x] End-to-end smoke test: created symlink into a tmp dir, `camp attach` it, `cd` into target, `camp pin` succeeds, `camp pins` shows `attachment` row, `camp unpin` removes it
- [x] Linked-project flow unchanged (existing `internal/project` tests pass)
- [x] Backward compat: v1/v2 markers on disk read as `Kind: project` (covered by `TestLinkMarker_LegacyDefaultsToProject`)

## What's not in this PR

- `camp doctor` warning for orphaned attachments (deferred per design Step 6)
- `camp attachments` listing command (deferred per `05-open-questions.md` Q2)
- Pre-existing lint issues elsewhere in the codebase