### PR TITLE
Address PR #270 non-blocking follow-ups

### DIFF
--- a/internal/attach/attach.go
+++ b/internal/attach/attach.go
@@ -79,13 +79,9 @@ func Attach(ctx context.Context, campaignRoot, campaignID, input string, opts Op
 		return nil, camperrors.Wrapf(camperrors.ErrInvalidInput, "attach target %q is not a directory", target)
 	}
 
-	// Check for an existing marker at target first. A self-attached
-	// directory will detect its own marker via campaign.Detect, so we
-	// must distinguish that case before the any-campaign check.
+	// Check for an existing marker at target first.
 	markerPath := campaign.MarkerPath(target)
-	hasExistingMarker := false
 	if existing, readErr := campaign.ReadMarker(target); readErr == nil {
-		hasExistingMarker = true
 		if !opts.Force {
 			return nil, camperrors.Wrapf(camperrors.ErrAlreadyExists,
 				"marker already exists at %q (kind=%q); use --force to overwrite", markerPath, existing.Kind)
@@ -99,9 +95,11 @@ func Attach(ctx context.Context, campaignRoot, campaignID, input string, opts Op
 		return nil, camperrors.Wrapf(readErr, "read existing marker at %q", markerPath)
 	}
 
-	// Walk from the parent so an attachment marker AT target itself does
-	// not falsely report "already inside a campaign".
-	if existingRoot, ok := detectExistingCampaign(ctx, filepath.Dir(target)); ok && !hasExistingMarker {
+	// Walk from the parent so an attachment marker AT target itself is
+	// invisible to Detect. This lets the any-campaign check run on the
+	// --force re-attach path too: a target now inside another campaign
+	// (e.g. moved under a new campaign root) would otherwise shadow it.
+	if existingRoot, ok := detectExistingCampaign(ctx, filepath.Dir(target)); ok {
 		switch {
 		case sameCampaignRoot(existingRoot, campaignRoot):
 			return nil, camperrors.Wrapf(camperrors.ErrInvalidInput,
@@ -130,9 +128,11 @@ func Attach(ctx context.Context, campaignRoot, campaignID, input string, opts Op
 		FollowedSymlink: target != abs,
 	}
 	if git.IsRepo(target) {
-		if err := git.EnsureInfoExclude(ctx, target, campaign.LinkMarkerFile); err != nil {
+		updated, err := git.EnsureInfoExclude(ctx, target, campaign.LinkMarkerFile)
+		switch {
+		case err != nil:
 			res.GitExcludeWarning = err.Error()
-		} else {
+		case updated:
 			res.GitExcludeUpdated = true
 		}
 	}
@@ -182,9 +182,11 @@ func Detach(ctx context.Context, input string) (*Result, error) {
 		FollowedSymlink: target != abs,
 	}
 	if git.IsRepo(target) {
-		if err := git.RemoveInfoExclude(ctx, target, campaign.LinkMarkerFile); err != nil {
+		updated, err := git.RemoveInfoExclude(ctx, target, campaign.LinkMarkerFile)
+		switch {
+		case err != nil:
 			res.GitExcludeWarning = err.Error()
-		} else {
+		case updated:
 			res.GitExcludeUpdated = true
 		}
 	}

--- a/internal/git/info_exclude.go
+++ b/internal/git/info_exclude.go
@@ -13,20 +13,26 @@ import (
 // EnsureInfoExclude adds pattern to the repo's .git/info/exclude if not
 // already present. repoRoot is a working tree directory; its actual git dir
 // may live elsewhere (worktrees, submodules) and is resolved via git.
-func EnsureInfoExclude(ctx context.Context, repoRoot, pattern string) error {
+//
+// The returned bool reports whether the file was actually modified: false
+// means the pattern was already present and no write occurred.
+func EnsureInfoExclude(ctx context.Context, repoRoot, pattern string) (bool, error) {
 	path, err := infoExcludePath(ctx, repoRoot)
 	if err != nil {
-		return err
+		return false, err
 	}
 	return ensurePatternInFile(path, pattern)
 }
 
 // RemoveInfoExclude removes pattern from the repo's .git/info/exclude if
 // present. Missing files are treated as success.
-func RemoveInfoExclude(ctx context.Context, repoRoot, pattern string) error {
+//
+// The returned bool reports whether the pattern was actually removed: false
+// means the file did not exist or did not contain the pattern.
+func RemoveInfoExclude(ctx context.Context, repoRoot, pattern string) (bool, error) {
 	path, err := infoExcludePath(ctx, repoRoot)
 	if err != nil {
-		return err
+		return false, err
 	}
 	return removePatternFromFile(path, pattern)
 }
@@ -51,19 +57,19 @@ func infoExcludePath(ctx context.Context, repoRoot string) (string, error) {
 	return path, nil
 }
 
-func ensurePatternInFile(path, pattern string) error {
+func ensurePatternInFile(path, pattern string) (bool, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
+		return false, err
 	}
 
 	data, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		return false, err
 	}
 	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
 	for _, line := range lines {
 		if strings.TrimSpace(line) == pattern {
-			return nil
+			return false, nil
 		}
 	}
 
@@ -72,30 +78,41 @@ func ensurePatternInFile(path, pattern string) error {
 		content += "\n"
 	}
 	content += pattern + "\n"
-	return fsutil.WriteFileAtomically(path, []byte(content), 0644)
+	if err := fsutil.WriteFileAtomically(path, []byte(content), 0644); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
-func removePatternFromFile(path, pattern string) error {
+func removePatternFromFile(path, pattern string) (bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return false, nil
 		}
-		return err
+		return false, err
 	}
 
 	lines := strings.Split(string(data), "\n")
 	filtered := make([]string, 0, len(lines))
+	removed := false
 	for _, line := range lines {
 		if strings.TrimSpace(line) == pattern {
+			removed = true
 			continue
 		}
 		filtered = append(filtered, line)
+	}
+	if !removed {
+		return false, nil
 	}
 
 	content := strings.TrimRight(strings.Join(filtered, "\n"), "\n")
 	if content != "" {
 		content += "\n"
 	}
-	return fsutil.WriteFileAtomically(path, []byte(content), 0644)
+	if err := fsutil.WriteFileAtomically(path, []byte(content), 0644); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/internal/project/link.go
+++ b/internal/project/link.go
@@ -379,11 +379,13 @@ func normalizeCampaignRoot(root string) (string, error) {
 }
 
 func ensureGitInfoExclude(ctx context.Context, repoRoot, pattern string) error {
-	return git.EnsureInfoExclude(ctx, repoRoot, pattern)
+	_, err := git.EnsureInfoExclude(ctx, repoRoot, pattern)
+	return err
 }
 
 func removeGitInfoExclude(ctx context.Context, repoRoot, pattern string) error {
-	return git.RemoveInfoExclude(ctx, repoRoot, pattern)
+	_, err := git.RemoveInfoExclude(ctx, repoRoot, pattern)
+	return err
 }
 
 func formatLinkedRepoWarning(action string, err error) string {


### PR DESCRIPTION
Stacked on top of #270. Addresses the non-blocking follow-ups obey-agent flagged in the approval review.

## Changes

**1. `internal/attach/attach.go` — drop `!hasExistingMarker` guard.**
Since `Detect` is called from `filepath.Dir(target)`, the target's own marker is already invisible to the check. The guard's only effect was that `attach --force` on an existing attachment marker would skip the cross-campaign shadowing check. Removed so `--force` re-attach onto a path that now lives inside a different campaign is also rejected.

**2. `internal/git/info_exclude.go` — return `(bool, error)`.**
`EnsureInfoExclude` and `RemoveInfoExclude` now report whether the file was actually modified. `Attach`/`Detach` only set `GitExcludeUpdated = true` on real changes, so the CLI no longer prints "removed .camp from .git/info/exclude" when nothing was present.

**3. `internal/project/link.go` — wrappers updated to discard the new bool.**
Linked-project callers don't need the bool; one-line fix to keep them compiling.

## Deferred to a future PR

- Removing the `ensureGitInfoExclude` / `removeGitInfoExclude` wrappers in `internal/project/link.go` (obey-agent follow-up #3, pure tidiness).
- Direct unit tests for `internal/git/info_exclude.go` (obey-agent follow-up #4, coverage is currently transitive through `internal/attach` and `internal/project`).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/attach/... ./internal/git/... ./internal/project/...` pass
- [x] `gofmt -l` clean on touched packages
- [x] `golangci-lint run --new-from-rev=origin/main` on touched packages — 0 issues

Marked draft until the broader test suite and any additional review feedback are addressed.