### PR TITLE
fix stale lock cleanup during camp pull

### DIFF
--- a/cmd/camp/pull.go
+++ b/cmd/camp/pull.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -67,13 +70,7 @@ func runPull(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, ui.Info(fmt.Sprintf("Submodule: %s", target.Name)))
 	}
 
-	fullArgs := append([]string{"-C", target.Path, "pull"}, gitArgs...)
-	gitCmd := exec.CommandContext(ctx, "git", fullArgs...)
-	gitCmd.Stdout = os.Stdout
-	gitCmd.Stderr = os.Stderr
-	gitCmd.Stdin = os.Stdin
-
-	if err := gitCmd.Run(); err != nil {
+	if _, err := runGitPullWithLockRetry(ctx, target.Path, gitArgs, true); err != nil {
 		// Suppress cobra's usage output — this isn't a usage error.
 		cmd.SilenceUsage = true
 
@@ -89,6 +86,51 @@ func runPull(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func runGitPullWithLockRetry(ctx context.Context, repoPath string, gitArgs []string, stream bool) ([]byte, error) {
+	cfg := git.DefaultRetryConfig()
+	cfg.OperationName = "pull"
+
+	var output []byte
+	err := git.WithLockRetry(ctx, repoPath, cfg, func() error {
+		pullArgs := append([]string{"-C", repoPath, "pull"}, gitArgs...)
+		gitCmd := exec.CommandContext(ctx, "git", pullArgs...)
+		gitCmd.Stdin = os.Stdin
+
+		var err error
+		if stream {
+			var stderr bytes.Buffer
+			gitCmd.Stdout = os.Stdout
+			gitCmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
+			err = gitCmd.Run()
+			output = stderr.Bytes()
+		} else {
+			output, err = gitCmd.CombinedOutput()
+		}
+		if err != nil {
+			return classifyPullCommandError(repoPath, output, err)
+		}
+		return nil
+	})
+	return output, err
+}
+
+func classifyPullCommandError(repoPath string, output []byte, err error) error {
+	exitCode := 0
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		exitCode = exitErr.ExitCode()
+	}
+
+	if git.ClassifyGitError(string(output), exitCode) == git.GitErrorLock {
+		lockPath := "index.lock"
+		if gitDir, resolveErr := git.ResolveGitDir(repoPath); resolveErr == nil {
+			lockPath = filepath.Join(gitDir, "index.lock")
+		}
+		return &git.LockError{Path: lockPath, Err: err}
+	}
+	return err
 }
 
 // PullAllOptions holds configuration for pull-all operations.
@@ -241,13 +283,12 @@ func pullSingleTarget(
 	}
 
 	// Execute pull
-	pullArgs := []string{"-C", t.path, "pull"}
+	pullArgs := make([]string, 0, len(gitArgs)+1)
 	if t.isRoot {
 		pullArgs = append(pullArgs, "--no-recurse-submodules")
 	}
 	pullArgs = append(pullArgs, gitArgs...)
-	gitCmd := exec.CommandContext(ctx, "git", pullArgs...)
-	output, err := gitCmd.CombinedOutput()
+	output, err := runGitPullWithLockRetry(ctx, t.path, pullArgs, false)
 	if err != nil {
 		return handlePullError(ctx, t, output, err, red)
 	}

--- a/cmd/camp/pull_test.go
+++ b/cmd/camp/pull_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestRunGitPullWithLockRetry_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	output, err := runGitPullWithLockRetry(ctx, "/path/that/should/not/be/touched", nil, false)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runGitPullWithLockRetry() error = %v, want context.Canceled", err)
+	}
+	if len(output) != 0 {
+		t.Fatalf("runGitPullWithLockRetry() output = %q, want empty output", output)
+	}
+}

--- a/tests/integration/pull_test.go
+++ b/tests/integration/pull_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPull_RemovesStaleIndexLock(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	const campaignDir = "/campaigns/pull-lock"
+	setupPullLockRootRepo(t, tc, campaignDir)
+
+	tc.Shell(t, fmt.Sprintf(`
+		git clone /test/root-remote.git /test/root-seed
+		cd /test/root-seed
+		printf 'remote content' > remote.txt
+		git add remote.txt
+		git commit -m 'remote change'
+		git push origin main
+		printf 'stale lock' > %s/.git/index.lock
+	`, campaignDir))
+
+	output, err := tc.RunCampInDir(campaignDir, "pull", "--ff-only")
+	require.NoError(t, err, output)
+
+	exists, err := tc.CheckFileExists(campaignDir + "/.git/index.lock")
+	require.NoError(t, err)
+	require.False(t, exists, "stale root index.lock should be removed")
+
+	exists, err = tc.CheckFileExists(campaignDir + "/remote.txt")
+	require.NoError(t, err)
+	require.True(t, exists, "remote file should be pulled after stale lock cleanup")
+}
+
+func TestPullAll_RemovesSubmoduleStaleIndexLock(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	const campaignDir = "/campaigns/pull-all-lock"
+	const subDir = campaignDir + "/projects/test-project"
+	setupPullLockCampaignWithSubmodule(t, tc, campaignDir, subDir)
+
+	tc.Shell(t, `
+		git clone /test/submodule-remote.git /test/submodule-seed-2
+		cd /test/submodule-seed-2
+		printf 'remote submodule content' > pulled.txt
+		git add pulled.txt
+		git commit -m 'remote submodule change'
+		git push origin main
+		sub_git_dir="$(git -C /campaigns/pull-all-lock/projects/test-project rev-parse --absolute-git-dir)"
+		printf 'stale lock' > "$sub_git_dir/index.lock"
+	`)
+
+	output, err := tc.RunCampInDir(campaignDir, "pull", "all", "--ff-only")
+	require.NoError(t, err, output)
+
+	subGitDir := strings.TrimSpace(tc.GitOutput(t, subDir, "rev-parse", "--absolute-git-dir"))
+	exists, err := tc.CheckFileExists(subGitDir + "/index.lock")
+	require.NoError(t, err)
+	require.False(t, exists, "stale submodule index.lock should be removed")
+
+	exists, err = tc.CheckFileExists(subDir + "/pulled.txt")
+	require.NoError(t, err)
+	require.True(t, exists, "submodule file should be pulled after stale lock cleanup")
+}
+
+func setupPullLockRootRepo(t *testing.T, tc *TestContainer, campaignDir string) {
+	t.Helper()
+
+	_, err := tc.InitCampaign(campaignDir, "Pull Lock", "")
+	require.NoError(t, err)
+
+	tc.Shell(t, fmt.Sprintf(`
+		git init --bare --initial-branch=main /test/root-remote.git
+		cd %s
+		git branch -M main
+		git remote add origin /test/root-remote.git
+		git push -u origin main
+	`, campaignDir))
+}
+
+func setupPullLockCampaignWithSubmodule(t *testing.T, tc *TestContainer, campaignDir, subDir string) {
+	t.Helper()
+
+	tc.Shell(t, `
+		git init --bare --initial-branch=main /test/submodule-remote.git
+		git clone /test/submodule-remote.git /test/submodule-seed
+		cd /test/submodule-seed
+		printf '# Test Project' > README.md
+		git add README.md
+		git commit -m 'initial submodule commit'
+		git push origin main
+	`)
+
+	_, err := tc.InitCampaign(campaignDir, "Pull All Lock", "")
+	require.NoError(t, err)
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		git branch -M main
+		GIT_ALLOW_PROTOCOL=file git submodule add /test/submodule-remote.git projects/test-project
+		git commit -m 'add submodule'
+		git -C %s branch --set-upstream-to=origin/main main
+	`, campaignDir, subDir))
+}


### PR DESCRIPTION
## Summary

- Route `camp pull` and `camp pull all` through the existing lock-aware retry path.
- Classify `git pull` `index.lock` failures as `git.LockError`, including the resolved lock path, so stale locks are removed before retry.
- Add containerized integration coverage for root pulls and submodule `pull all` stale-lock cleanup.
- Add non-mutating context-cancellation coverage for the retry helper.

## Root Cause

`camp pull` invoked `git pull` directly with `exec.CommandContext`, so it never returned the structured `git.LockError` required by `git.WithLockRetry`. The stale-lock cleanup path existed for stage/commit and some project operations, but pull bypassed it.

## Review Follow-Up

- Replaced the `LockError{Path: "index.lock"}` literal with a path resolved through `git.ResolveGitDir(repoPath)` and `filepath.Join(gitDir, "index.lock")`.
- Added `TestRunGitPullWithLockRetry_ContextCancelled`, which uses a pre-canceled context and an invalid path to assert cancellation returns before any git operation or filesystem mutation.
- Removed host-temp filesystem mutation coverage; stale-lock behavior is now exercised only in the containerized integration harness under `tests/integration/pull_test.go`.

## Validation

- `just test all` - 68 packages, 2284/2284 unit tests passed; 227/227 container integration tests passed.
- `go test ./cmd/camp`
- `go test ./cmd/camp -run TestRunGitPullWithLockRetry_ContextCancelled -count=1`
- `go test -tags integration ./tests/integration -run "TestPull(_|All_)" -count=1`
- `git diff --check HEAD`
- Earlier: `just build-camp`, `just test unit`
- Earlier: `just lint` still fails on existing repo-wide lint debt unrelated to this change.
