### PR TITLE
Drop link wrappers and add git/info_exclude unit tests

### DIFF
--- a/internal/git/info_exclude_test.go
+++ b/internal/git/info_exclude_test.go
@@ -16,7 +16,7 @@ func initRepo(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("eval symlinks: %v", err)
 	}
-	cmd := exec.Command("git", "init", "-q", dir)
+	cmd := exec.CommandContext(t.Context(), "git", "init", "-q", dir)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init: %v\n%s", err, out)
 	}
@@ -187,6 +187,16 @@ func TestEnsureInfoExclude_ContextCancelled(t *testing.T) {
 	cancel()
 
 	if _, err := EnsureInfoExclude(ctx, repo, ".camp"); err == nil {
+		t.Error("expected error on cancelled context, got nil")
+	}
+}
+
+func TestRemoveInfoExclude_ContextCancelled(t *testing.T) {
+	repo := initRepo(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := RemoveInfoExclude(ctx, repo, ".camp"); err == nil {
 		t.Error("expected error on cancelled context, got nil")
 	}
 }

--- a/internal/git/info_exclude_test.go
+++ b/internal/git/info_exclude_test.go
@@ -1,0 +1,192 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func initRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	dir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("eval symlinks: %v", err)
+	}
+	cmd := exec.Command("git", "init", "-q", dir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	return dir
+}
+
+func readExclude(t *testing.T, repo string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repo, ".git", "info", "exclude"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatalf("read exclude: %v", err)
+	}
+	return string(data)
+}
+
+func TestIsRepo(t *testing.T) {
+	repo := initRepo(t)
+	if !IsRepo(repo) {
+		t.Errorf("IsRepo(%q) = false, want true", repo)
+	}
+	plain := t.TempDir()
+	if IsRepo(plain) {
+		t.Errorf("IsRepo(%q) = true for non-repo, want false", plain)
+	}
+}
+
+func TestEnsureInfoExclude_AddsPattern(t *testing.T) {
+	repo := initRepo(t)
+
+	added, err := EnsureInfoExclude(context.Background(), repo, ".camp")
+	if err != nil {
+		t.Fatalf("EnsureInfoExclude: %v", err)
+	}
+	if !added {
+		t.Fatal("added = false, want true on first add")
+	}
+	if got := readExclude(t, repo); !strings.Contains(got, ".camp") {
+		t.Errorf("exclude does not contain .camp; got:\n%s", got)
+	}
+}
+
+func TestEnsureInfoExclude_Idempotent(t *testing.T) {
+	repo := initRepo(t)
+
+	if _, err := EnsureInfoExclude(context.Background(), repo, ".camp"); err != nil {
+		t.Fatalf("first EnsureInfoExclude: %v", err)
+	}
+	before := readExclude(t, repo)
+
+	added, err := EnsureInfoExclude(context.Background(), repo, ".camp")
+	if err != nil {
+		t.Fatalf("second EnsureInfoExclude: %v", err)
+	}
+	if added {
+		t.Error("added = true on second call, want false (already present)")
+	}
+	if after := readExclude(t, repo); after != before {
+		t.Errorf("file mutated on idempotent call\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func TestEnsureInfoExclude_PreservesExistingPatterns(t *testing.T) {
+	repo := initRepo(t)
+
+	excludePath := filepath.Join(repo, ".git", "info", "exclude")
+	if err := os.WriteFile(excludePath, []byte("*.tmp\nbuild/\n"), 0644); err != nil {
+		t.Fatalf("seed exclude: %v", err)
+	}
+
+	if _, err := EnsureInfoExclude(context.Background(), repo, ".camp"); err != nil {
+		t.Fatalf("EnsureInfoExclude: %v", err)
+	}
+	got := readExclude(t, repo)
+	for _, want := range []string{"*.tmp", "build/", ".camp"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in exclude:\n%s", want, got)
+		}
+	}
+}
+
+func TestRemoveInfoExclude_RemovesPattern(t *testing.T) {
+	repo := initRepo(t)
+
+	if _, err := EnsureInfoExclude(context.Background(), repo, ".camp"); err != nil {
+		t.Fatalf("EnsureInfoExclude: %v", err)
+	}
+
+	removed, err := RemoveInfoExclude(context.Background(), repo, ".camp")
+	if err != nil {
+		t.Fatalf("RemoveInfoExclude: %v", err)
+	}
+	if !removed {
+		t.Fatal("removed = false, want true when pattern present")
+	}
+	if got := readExclude(t, repo); strings.Contains(got, ".camp") {
+		t.Errorf("exclude still contains .camp:\n%s", got)
+	}
+}
+
+func TestRemoveInfoExclude_MissingFile(t *testing.T) {
+	repo := initRepo(t)
+	// Force exclude file out of existence; git init usually leaves it
+	// in place but be explicit.
+	_ = os.Remove(filepath.Join(repo, ".git", "info", "exclude"))
+
+	removed, err := RemoveInfoExclude(context.Background(), repo, ".camp")
+	if err != nil {
+		t.Fatalf("RemoveInfoExclude on missing file: %v", err)
+	}
+	if removed {
+		t.Error("removed = true on missing file, want false")
+	}
+}
+
+func TestRemoveInfoExclude_PatternNotPresent(t *testing.T) {
+	repo := initRepo(t)
+
+	excludePath := filepath.Join(repo, ".git", "info", "exclude")
+	original := []byte("*.tmp\nbuild/\n")
+	if err := os.WriteFile(excludePath, original, 0644); err != nil {
+		t.Fatalf("seed exclude: %v", err)
+	}
+
+	removed, err := RemoveInfoExclude(context.Background(), repo, ".camp")
+	if err != nil {
+		t.Fatalf("RemoveInfoExclude: %v", err)
+	}
+	if removed {
+		t.Error("removed = true when pattern absent, want false")
+	}
+	got, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Errorf("file rewritten on no-op removal\nwant: %q\ngot:  %q", original, got)
+	}
+}
+
+func TestRemoveInfoExclude_PreservesOtherPatterns(t *testing.T) {
+	repo := initRepo(t)
+
+	excludePath := filepath.Join(repo, ".git", "info", "exclude")
+	if err := os.WriteFile(excludePath, []byte("*.tmp\n.camp\nbuild/\n"), 0644); err != nil {
+		t.Fatalf("seed exclude: %v", err)
+	}
+
+	if _, err := RemoveInfoExclude(context.Background(), repo, ".camp"); err != nil {
+		t.Fatalf("RemoveInfoExclude: %v", err)
+	}
+	got := readExclude(t, repo)
+	if strings.Contains(got, ".camp\n") {
+		t.Errorf("exclude still contains .camp line:\n%s", got)
+	}
+	for _, want := range []string{"*.tmp", "build/"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("removal stripped unrelated pattern %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestEnsureInfoExclude_ContextCancelled(t *testing.T) {
+	repo := initRepo(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := EnsureInfoExclude(ctx, repo, ".camp"); err == nil {
+		t.Error("expected error on cancelled context, got nil")
+	}
+}

--- a/internal/project/link.go
+++ b/internal/project/link.go
@@ -140,7 +140,7 @@ func AddLinked(ctx context.Context, campaignRoot, localPath string, opts LinkOpt
 	}
 
 	if isGit {
-		if err := ensureGitInfoExclude(ctx, absLocal, campaign.LinkMarkerFile); err != nil {
+		if _, err := git.EnsureInfoExclude(ctx, absLocal, campaign.LinkMarkerFile); err != nil {
 			warnings = append(warnings, formatLinkedRepoWarning("could not update linked repo .git/info/exclude for .camp", err))
 		}
 	}
@@ -222,7 +222,7 @@ func UnlinkProject(ctx context.Context, campaignRoot, name, targetPath string) (
 				return nil, err
 			}
 			if isGitRepo(targetPath) {
-				if err := removeGitInfoExclude(ctx, targetPath, campaign.LinkMarkerFile); err != nil {
+				if _, err := git.RemoveInfoExclude(ctx, targetPath, campaign.LinkMarkerFile); err != nil {
 					warnings = append(warnings, formatLinkedRepoWarning("could not clean up linked repo .git/info/exclude for .camp", err))
 				}
 			}
@@ -376,16 +376,6 @@ func normalizeCampaignRoot(root string) (string, error) {
 		return resolvedRoot, nil
 	}
 	return absRoot, nil
-}
-
-func ensureGitInfoExclude(ctx context.Context, repoRoot, pattern string) error {
-	_, err := git.EnsureInfoExclude(ctx, repoRoot, pattern)
-	return err
-}
-
-func removeGitInfoExclude(ctx context.Context, repoRoot, pattern string) error {
-	_, err := git.RemoveInfoExclude(ctx, repoRoot, pattern)
-	return err
 }
 
 func formatLinkedRepoWarning(action string, err error) string {


### PR DESCRIPTION
Stacked on top of #270. Lands the remaining two follow-ups obey-agent flagged in the approval review and that PR #271 explicitly deferred.

## Changes

**1. `internal/project/link.go` — drop the `ensureGitInfoExclude` / `removeGitInfoExclude` wrappers.**
After the previous follow-up the wrappers were one-line passthroughs to `git.EnsureInfoExclude` / `git.RemoveInfoExclude`. Inlined the two call sites and removed the wrappers so there's a single canonical entry point in the `internal/git` package.

**2. `internal/git/info_exclude_test.go` — direct unit tests.**
Coverage was previously transitive through `internal/attach` and `internal/project`. Added focused tests against a real `git init` working tree:

- `TestIsRepo` — repo vs non-repo
- `TestEnsureInfoExclude_AddsPattern` — first-add returns `added=true` and writes
- `TestEnsureInfoExclude_Idempotent` — second-add returns `added=false` and file is byte-identical
- `TestEnsureInfoExclude_PreservesExistingPatterns` — append doesn't clobber prior entries
- `TestRemoveInfoExclude_RemovesPattern` — present case returns `removed=true`
- `TestRemoveInfoExclude_MissingFile` — missing exclude is a no-op (`removed=false`, no error)
- `TestRemoveInfoExclude_PatternNotPresent` — file untouched when pattern absent, `removed=false`
- `TestRemoveInfoExclude_PreservesOtherPatterns` — only the matching line is stripped
- `TestEnsureInfoExclude_ContextCancelled` — cancellation surfaces from the underlying `git rev-parse`

## Verification

- `go build ./...` clean
- `go test ./internal/git/... ./internal/attach/... ./internal/project/...` pass (new tests included)
- `gofmt -l ./internal/git ./internal/project` clean
- `golangci-lint run --new-from-rev=origin/non-project-symlinks-design ./internal/git/... ./internal/project/...` — 0 issues