### PR TITLE
fix: clarify attach campaign picker help

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ target so detection works from inside it:
 ln -s ~/Dev/external-repo ai_docs/examples/external-repo
 camp attach ai_docs/examples/external-repo
 
+# Force the campaign picker instead of using the current campaign:
+camp attach ai_docs/examples/external-repo --campaign
+
 # now you can pin and navigate to it:
 cd ai_docs/examples/external-repo
 camp pin external-repo

--- a/cmd/camp/attach/attach.go
+++ b/cmd/camp/attach/attach.go
@@ -42,9 +42,16 @@ campaign owns it.
 If the target is reached through a symlink, camp follows it once and writes
 the marker at the final directory.
 
+Campaign selection:
+  - inside a campaign, omit --campaign to attach to the current campaign
+  - outside a campaign in an interactive terminal, omit --campaign to pick
+  - use a bare --campaign to force the picker even inside a campaign
+  - use --campaign <name-or-id> for scripts or to skip the picker
+
 Examples:
   camp attach ai_docs/examples/external-repo
   camp attach ~/scratch/notes-link
+  camp attach ~/scratch/notes-link --campaign
   camp attach /abs/path/to/dir --campaign platform`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -74,7 +81,7 @@ Examples:
 	}
 
 	flags := cmd.Flags()
-	flags.StringP("campaign", "c", "", "Target campaign by name or ID; defaults to current campaign or interactive picker")
+	flags.StringP("campaign", "c", "", "Target campaign by name or ID; omit value to pick interactively")
 	flags.Bool("force", false, "Overwrite an existing attachment marker")
 	flags.Lookup("campaign").NoOptDefVal = NoOptCampaign
 

--- a/cmd/camp/help.go
+++ b/cmd/camp/help.go
@@ -1,0 +1,32 @@
+package main
+
+import "strings"
+
+// cleanFlagUsages removes internal optional-value sentinels from runtime help.
+// Bare optional flags use a NUL-prefixed NoOptDefVal so command parsing can
+// distinguish `--campaign` from `--campaign pick`; pflag renders that value
+// verbatim in help unless we clean the already-formatted usage line.
+func cleanFlagUsages(usages string) string {
+	lines := strings.Split(usages, "\n")
+	for i, line := range lines {
+		lines[i] = cleanFlagUsageLine(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func cleanFlagUsageLine(line string) string {
+	for {
+		nul := strings.IndexRune(line, '\x00')
+		if nul == -1 {
+			return line
+		}
+
+		start := strings.LastIndex(line[:nul], `[="`)
+		if start == -1 {
+			line = line[:nul] + line[nul+1:]
+			continue
+		}
+
+		line = line[:start] + "   " + line[nul+1:]
+	}
+}

--- a/cmd/camp/help_test.go
+++ b/cmd/camp/help_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCleanFlagUsagesStripsInternalNoOptSentinel(t *testing.T) {
+	input := "  -c, --campaign string[=\"          pick\"]\x00Target campaign by name or ID"
+
+	got := cleanFlagUsages(input)
+
+	if strings.ContainsRune(got, '\x00') {
+		t.Fatalf("cleanFlagUsages left NUL sentinel in output: %q", got)
+	}
+	if strings.Contains(got, "string[=") {
+		t.Fatalf("cleanFlagUsages left optional default in output: %q", got)
+	}
+	if !strings.Contains(got, "--campaign string   Target campaign by name or ID") {
+		t.Fatalf("cleanFlagUsages output = %q", got)
+	}
+}
+
+func TestCleanFlagUsagesLeavesNormalUsageUnchanged(t *testing.T) {
+	input := "      --verbose   enable verbose output"
+	if got := cleanFlagUsages(input); got != input {
+		t.Fatalf("cleanFlagUsages(%q) = %q", input, got)
+	}
+}

--- a/cmd/camp/root.go
+++ b/cmd/camp/root.go
@@ -161,6 +161,7 @@ func init() {
 	cobra.AddTemplateFunc("styleBold", ui.BoldText)
 	cobra.AddTemplateFunc("styleHeader", ui.Header)
 	cobra.AddTemplateFunc("styleHelp", ui.StyleHelpText)
+	cobra.AddTemplateFunc("cleanFlagUsages", cleanFlagUsages)
 
 	// Set styled Long description for root command
 	rootCmd.Long = styledLongDescription()
@@ -266,10 +267,10 @@ func styledUsageTemplate() string {
   {{styleAccent (rpad .Name .NamePadding)}} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 {{styleCategory "Flags:"}}
-{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+{{cleanFlagUsages .LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
 {{styleCategory "Global Flags:"}}
-{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+{{cleanFlagUsages .InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
 
 {{styleCategory "Additional help topics:"}}{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -66,9 +66,16 @@ campaign owns it.
 If the target is reached through a symlink, camp follows it once and writes
 the marker at the final directory.
 
+Campaign selection:
+  - inside a campaign, omit --campaign to attach to the current campaign
+  - outside a campaign in an interactive terminal, omit --campaign to pick
+  - use a bare --campaign to force the picker even inside a campaign
+  - use --campaign <name-or-id> for scripts or to skip the picker
+
 Examples:
   camp attach ai_docs/examples/external-repo
   camp attach ~/scratch/notes-link
+  camp attach ~/scratch/notes-link --campaign
   camp attach /abs/path/to/dir --campaign platform
 
 ```
@@ -78,7 +85,7 @@ camp attach <path> [flags]
 ### Options
 
 ```
-  -c, --campaign string   Target campaign by name or ID; defaults to current campaign or interactive picker
+  -c, --campaign string   Target campaign by name or ID; omit value to pick interactively
       --force             Overwrite an existing attachment marker
   -h, --help              help for attach
 ```

--- a/docs/cli-reference/camp_attach.md
+++ b/docs/cli-reference/camp_attach.md
@@ -13,9 +13,16 @@ campaign owns it.
 If the target is reached through a symlink, camp follows it once and writes
 the marker at the final directory.
 
+Campaign selection:
+  - inside a campaign, omit --campaign to attach to the current campaign
+  - outside a campaign in an interactive terminal, omit --campaign to pick
+  - use a bare --campaign to force the picker even inside a campaign
+  - use --campaign <name-or-id> for scripts or to skip the picker
+
 Examples:
   camp attach ai_docs/examples/external-repo
   camp attach ~/scratch/notes-link
+  camp attach ~/scratch/notes-link --campaign
   camp attach /abs/path/to/dir --campaign platform
 
 ```
@@ -25,7 +32,7 @@ camp attach <path> [flags]
 ### Options
 
 ```
-  -c, --campaign string   Target campaign by name or ID; defaults to current campaign or interactive picker
+  -c, --campaign string   Target campaign by name or ID; omit value to pick interactively
       --force             Overwrite an existing attachment marker
   -h, --help              help for attach
 ```


### PR DESCRIPTION
## Summary
- remove internal optional-value sentinels from runtime help output so `--campaign` no longer renders as `string[=" pick"]`
- clarify `camp attach` campaign selection behavior, including bare `--campaign` forcing the picker
- update CLI reference docs and README attach example

## Verification
- `go test ./cmd/camp -run 'TestCleanFlagUsages'`
- `go test ./cmd/camp/attach -run '^$'` (compile-only; no tests executed)
- `go run ./cmd/camp attach --help` verified no NUL sentinel and no `string[=...]` output
- `git diff --check main...HEAD`
- added-diff audit for filesystem-mutating test calls (`TempDir`, `MkdirAll`, `WriteFile`, `Chdir`, `Remove`, `RemoveAll`, `chmod`, `git init`, `CreateTemp`, `MkdirTemp`, `os.Rename`, `exec.Command`): no matches

Note: I did not run the broader host test suite because existing tests may mutate the filesystem and should run through the appropriate containerized harness.