### PR TITLE
fix(intent/tui): harden explorer against log corruption, dungeon-move freeze, unselectable filtered search

### DIFF
--- a/cmd/camp/intent/explore.go
+++ b/cmd/camp/intent/explore.go
@@ -1,6 +1,11 @@
 package intent
 
 import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -99,6 +104,18 @@ func runIntentExplore(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Route slog output away from stderr for the duration of the TUI session.
+	// Without this, INFO-level slog calls from anywhere in the call chain (notably
+	// the git auto-commit retry / lock subsystem) write to the same TTY that
+	// bubbletea is painting, corrupting the rendered frame and making the TUI
+	// appear frozen. Restore the previous default on exit so non-TUI commands in
+	// the same process keep their normal behavior.
+	restoreLogger, err := quietSlogDuringTUI(campaignRoot)
+	if err != nil {
+		return camperrors.Wrap(err, "configuring TUI logger")
+	}
+	defer restoreLogger()
+
 	// Create and run the TUI
 	model := explorer.NewModel(ctx, svc, conceptSvc, intentsDir, campaignRoot, cfg.ID, author, shortcuts)
 	p := tea.NewProgram(model, tea.WithAltScreen())
@@ -108,4 +125,45 @@ func runIntentExplore(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// quietSlogDuringTUI swaps slog.Default with a handler that writes to a log
+// file under <campaignRoot>/.campaign/logs/ instead of stderr. It returns a
+// restore function that reinstalls the previous default and closes the log
+// file. If the log directory cannot be created or the file cannot be opened,
+// it falls back to discarding slog output entirely so the TUI is still safe.
+func quietSlogDuringTUI(campaignRoot string) (restore func(), err error) {
+	previous := slog.Default()
+	restore = func() { slog.SetDefault(previous) }
+
+	logDir := filepath.Join(campaignRoot, ".campaign", "logs")
+	if mkErr := os.MkdirAll(logDir, 0o755); mkErr != nil {
+		// Fallback: discard slog output entirely. The TUI is still protected.
+		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+		return restore, nil
+	}
+
+	f, openErr := os.OpenFile(
+		filepath.Join(logDir, "intent-explore.log"),
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY,
+		0o644,
+	)
+	if openErr != nil {
+		// Fallback: discard slog output entirely.
+		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+		return restore, nil
+	}
+
+	previousRestore := restore
+	restore = func() {
+		previousRestore()
+		_ = f.Close()
+	}
+
+	// Debug level captures everything (including the auto-commit retry logs
+	// that were demoted from Info to Debug in this same change set) so a
+	// post-mortem can always recover what happened.
+	handler := slog.NewTextHandler(f, &slog.HandlerOptions{Level: slog.LevelDebug})
+	slog.SetDefault(slog.New(handler))
+	return restore, nil
 }

--- a/cmd/camp/intent/explore_test.go
+++ b/cmd/camp/intent/explore_test.go
@@ -1,0 +1,106 @@
+package intent
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestQuietSlogDuringTUI_RedirectsToLogFile asserts that slog.Default no
+// longer points at stderr after quietSlogDuringTUI runs, and that messages
+// emitted while the swap is active land in the campaign log file instead of
+// the user-facing TTY.
+//
+// Regression test for bug 003: auto-commit INFO logs (now Debug) used to
+// collide with bubbletea rendering on the same TTY. Even after demoting the
+// known noise to Debug, this swap is the defense-in-depth that prevents any
+// future INFO emission from anywhere in the call chain from corrupting the
+// TUI render frame.
+func TestQuietSlogDuringTUI_RedirectsToLogFile(t *testing.T) {
+	campaignRoot := t.TempDir()
+	previousDefault := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(previousDefault) })
+
+	// Capture stderr while the swap is active. If any slog call leaks to
+	// stderr, this buffer would not be empty (we cannot literally redirect
+	// os.Stderr here without affecting the test runner, so we assert on the
+	// handler identity instead: the swapped default must NOT be the previous
+	// default that was pointing at stderr).
+	stderrBuf := &bytes.Buffer{}
+	_ = stderrBuf // kept for parity; identity assertion below is the real check
+
+	restore, err := quietSlogDuringTUI(campaignRoot)
+	if err != nil {
+		t.Fatalf("quietSlogDuringTUI returned error: %v", err)
+	}
+	t.Cleanup(restore)
+
+	if slog.Default() == previousDefault {
+		t.Fatal("slog.Default was not swapped; TUI would still leak logs to stderr")
+	}
+
+	// Emit at every level. None should hit stderr.
+	slog.Debug("debug-from-test", "key", "value")
+	slog.Info("info-from-test", "key", "value")
+	slog.Warn("warn-from-test", "key", "value")
+	slog.Error("error-from-test", "key", "value")
+
+	// Restore must put the previous default back so non-TUI code paths are
+	// unaffected.
+	restore()
+	if slog.Default() != previousDefault {
+		t.Fatal("restore() did not reinstall the previous slog.Default")
+	}
+
+	// The log file should exist and contain the messages we emitted.
+	logPath := filepath.Join(campaignRoot, ".campaign", "logs", "intent-explore.log")
+	contents, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("expected log file at %s, got error: %v", logPath, err)
+	}
+	body := string(contents)
+
+	wantSubstrings := []string{
+		"debug-from-test",
+		"info-from-test",
+		"warn-from-test",
+		"error-from-test",
+	}
+	for _, want := range wantSubstrings {
+		if !bytes.Contains(contents, []byte(want)) {
+			t.Errorf("log file missing %q. body=%q", want, body)
+		}
+	}
+}
+
+// TestQuietSlogDuringTUI_FallsBackToDiscardOnDirError verifies that if the
+// log directory cannot be created (e.g. permission denied on a read-only
+// campaign), the function still installs a quiet handler rather than letting
+// slog continue to write to stderr.
+func TestQuietSlogDuringTUI_FallsBackToDiscardOnDirError(t *testing.T) {
+	// Create a regular file where .campaign would need to live; MkdirAll
+	// will fail because the parent path component is not a directory.
+	parent := t.TempDir()
+	blocker := filepath.Join(parent, ".campaign")
+	if err := os.WriteFile(blocker, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("preparing blocker file: %v", err)
+	}
+
+	previousDefault := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(previousDefault) })
+
+	restore, err := quietSlogDuringTUI(parent)
+	if err != nil {
+		t.Fatalf("quietSlogDuringTUI returned error on fallback path: %v", err)
+	}
+	t.Cleanup(restore)
+
+	if slog.Default() == previousDefault {
+		t.Fatal("slog.Default was not swapped on fallback path; TUI would still leak to stderr")
+	}
+
+	// Should not panic when emitting to the discard handler.
+	slog.Info("info-to-discard", "key", "value")
+}

--- a/internal/git/lock_unix.go
+++ b/internal/git/lock_unix.go
@@ -173,7 +173,7 @@ func removeSingleLock(ctx context.Context, lockPath string, logger *slog.Logger)
 	}
 
 	// Step 3: Remove the lock file
-	logger.Info("removing stale lock", "path", lockPath)
+	logger.Debug("removing stale lock", "path", lockPath)
 	if err := os.Remove(lockPath); err != nil {
 		return info, camperrors.WrapJoinf(ErrLockRemovalFailed, err, "failed to remove lock file %s", lockPath)
 	}

--- a/internal/git/retry.go
+++ b/internal/git/retry.go
@@ -119,7 +119,7 @@ func WithLockRetry(ctx context.Context, repoPath string, cfg RetryConfig, operat
 				cfg.OperationName, cycle)
 		}
 
-		cfg.Logger.Info("cycle completed, cleaning locks",
+		cfg.Logger.Debug("cycle completed, cleaning locks",
 			"operation", cfg.OperationName,
 			"cycle", cycle,
 			"removed", len(result.Removed),
@@ -152,7 +152,7 @@ func WithLockRetry(ctx context.Context, repoPath string, cfg RetryConfig, operat
 
 		// Apply backoff between cycles
 		if cycle < cfg.MaxCycles {
-			cfg.Logger.Info("waiting before next cycle",
+			cfg.Logger.Debug("waiting before next cycle",
 				"operation", cfg.OperationName,
 				"cycle", cycle,
 				"backoff", backoff)

--- a/internal/intent/tui/explorer/actions.go
+++ b/internal/intent/tui/explorer/actions.go
@@ -454,10 +454,18 @@ func (m *Model) updateDungeonReason(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.dungeonReasonAction = ""
 		m.focus = focusList
 
-		// Append decision record and move
+		// Surface in-progress feedback immediately. The actual move runs
+		// asynchronously inside a tea.Cmd and may stall briefly while the
+		// auto-commit subsystem cleans up stale git locks. Without this,
+		// users see a blank-looking list and assume the TUI froze
+		// (regression for #278). The terminal status update is replaced by
+		// the success or failure message when moveFinishedMsg / archiveFinishedMsg
+		// arrives.
 		if action == "archive" {
+			m.statusMessage = "Archiving..."
 			return m, m.archiveIntentWithReason(i, reason)
 		}
+		m.statusMessage = fmt.Sprintf("Moving to %s...", newStatus)
 		return m, m.moveIntentWithReason(i, newStatus, reason)
 	default:
 		var cmd tea.Cmd

--- a/internal/intent/tui/explorer/dungeon_move_test.go
+++ b/internal/intent/tui/explorer/dungeon_move_test.go
@@ -1,0 +1,141 @@
+package explorer
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Obedience-Corp/camp/internal/intent"
+)
+
+// TestDungeonMove_SomedayToDone_TransitionsAndSurfacesProgress is a
+// regression test for #278: moving an intent from one dungeon status to
+// another (e.g. Someday → Done) used to appear frozen because the
+// auto-commit retry path stalled briefly without surfacing any in-progress
+// feedback. The user could not tell whether the TUI was alive or hung.
+//
+// After the fix, pressing enter in the dungeon reason input:
+//   - immediately sets focus back to focusList so the user can interact
+//   - sets statusMessage to a "Moving to ..." progress indicator
+//   - returns a non-nil tea.Cmd that performs the actual move
+//
+// The underlying move continues asynchronously and the moveFinishedMsg
+// handler replaces the progress message with the final outcome.
+func TestDungeonMove_SomedayToDone_TransitionsAndSurfacesProgress(t *testing.T) {
+	ctx := context.Background()
+	m := NewModel(ctx, nil, nil, "/tmp/intents", "/tmp/campaign", "test-id", "", nil)
+	m.ready = true
+
+	somedayIntent := &intent.Intent{
+		ID:        "someday-1",
+		Title:     "Someday item",
+		Status:    intent.StatusSomeday,
+		Type:      intent.TypeFeature,
+		CreatedAt: time.Now(),
+	}
+	m.intents = []*intent.Intent{somedayIntent}
+	m.filteredIntents = m.intents
+
+	// Open the dungeon-reason input directly (the same call updateMove makes
+	// when the user picks a dungeon destination from the move overlay).
+	m.startDungeonReasonInput(somedayIntent, intent.StatusDone, "move")
+
+	if m.focus != focusDungeonReason {
+		t.Fatalf("expected focusDungeonReason after startDungeonReasonInput, got %v", m.focus)
+	}
+	if !m.dungeonReasonInput.Focused() {
+		t.Fatal("expected reason textinput to be focused so the user can type")
+	}
+	if m.dungeonReasonFor != intent.StatusDone {
+		t.Fatalf("dungeonReasonFor = %v, want StatusDone", m.dungeonReasonFor)
+	}
+
+	// Verify viewDungeonReason actually renders (regression for the original
+	// "freeze" report — if no render branch existed, the View would silently
+	// fall through to the previous frame).
+	rendered := m.View()
+	if rendered == "" {
+		t.Fatal("View() returned empty string while focusDungeonReason was active")
+	}
+	if !strings.Contains(rendered, "Reason") {
+		t.Fatalf("expected dungeon-reason dialog to render, got: %q", rendered)
+	}
+
+	// Type a reason character-by-character so we go through the same key
+	// routing the user does. Empty-reason rejection is also exercised.
+	model, _ := m.updateDungeonReason(tea.KeyMsg{Type: tea.KeyEnter})
+	if got := model.(*Model); got.statusMessage != "Reason is required for dungeon moves" {
+		t.Fatalf("empty-reason enter should reject with helpful statusMessage, got %q",
+			got.statusMessage)
+	}
+	if got := model.(*Model); got.focus != focusDungeonReason {
+		t.Fatal("empty-reason enter should keep focus on the reason input")
+	}
+
+	for _, r := range "reclassifying" {
+		model, _ = m.updateDungeonReason(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		_ = model // mutations happen through the *Model receiver; m already reflects them
+	}
+
+	if strings.TrimSpace(m.dungeonReasonInput.Value()) == "" {
+		t.Fatal("textinput did not accept typed characters")
+	}
+
+	model, cmd := m.updateDungeonReason(tea.KeyMsg{Type: tea.KeyEnter})
+	got := model.(*Model)
+
+	if got.focus != focusList {
+		t.Fatalf("expected focusList after committing reason, got %v", got.focus)
+	}
+	if !strings.Contains(got.statusMessage, "Moving to") {
+		t.Fatalf("expected 'Moving to ...' progress message, got %q", got.statusMessage)
+	}
+	if got.dungeonReasonIntent != nil {
+		t.Fatal("dungeonReasonIntent should be cleared after committing")
+	}
+	if got.dungeonReasonAction != "" {
+		t.Fatal("dungeonReasonAction should be cleared after committing")
+	}
+	if cmd == nil {
+		t.Fatal("expected a non-nil tea.Cmd to dispatch the move; got nil")
+	}
+}
+
+// TestDungeonMove_EscCancelsAndRestoresList confirms the cancel path leaves
+// the model in a clean state, independent of the freeze fix.
+func TestDungeonMove_EscCancelsAndRestoresList(t *testing.T) {
+	ctx := context.Background()
+	m := NewModel(ctx, nil, nil, "/tmp/intents", "/tmp/campaign", "test-id", "", nil)
+	m.ready = true
+
+	somedayIntent := &intent.Intent{
+		ID:        "someday-1",
+		Title:     "Someday item",
+		Status:    intent.StatusSomeday,
+		Type:      intent.TypeFeature,
+		CreatedAt: time.Now(),
+	}
+	m.intents = []*intent.Intent{somedayIntent}
+	m.filteredIntents = m.intents
+
+	m.startDungeonReasonInput(somedayIntent, intent.StatusDone, "move")
+
+	model, cmd := m.updateDungeonReason(tea.KeyMsg{Type: tea.KeyEsc})
+	got := model.(*Model)
+
+	if got.focus != focusList {
+		t.Fatalf("esc should return to focusList, got %v", got.focus)
+	}
+	if got.dungeonReasonIntent != nil {
+		t.Fatal("dungeonReasonIntent should be cleared on cancel")
+	}
+	if got.dungeonReasonAction != "" {
+		t.Fatal("dungeonReasonAction should be cleared on cancel")
+	}
+	if cmd != nil {
+		t.Fatal("cancel should not dispatch any tea.Cmd")
+	}
+}

--- a/internal/intent/tui/explorer/navigation.go
+++ b/internal/intent/tui/explorer/navigation.go
@@ -13,8 +13,24 @@ import (
 // selection rather than landing on a group header (cursorItem=-1). Without
 // this, j/k looked like a no-op and users could not tell the list was
 // navigable (regression #279).
+//
+// Special case: when the Dungeon parent is collapsed (m.dungeonExpanded ==
+// false), groupIntentsByStatus does not include the dungeon child groups in
+// m.groups — only a single Dungeon parent with DungeonCount and an empty
+// Intents slice. If the active filter has matches only in the dungeon, the
+// naive iteration would conclude "no matches reachable" and surface the
+// recovery hint even though dungeon results exist. Expand the parent and
+// rebuild groups so the children become visible, then place the cursor on
+// the first one.
 func (m *Model) placeCursorAtFirstItem() bool {
 	for gi := range m.groups {
+		// Auto-expand the Dungeon parent if it holds the only matches.
+		if m.groups[gi].IsDungeonParent && m.groups[gi].DungeonCount > 0 && !m.dungeonExpanded {
+			m.dungeonExpanded = true
+			m.groups = groupIntentsByStatus(m.filteredIntents, m.dungeonExpanded)
+			// Restart with the rebuilt slice — dungeon children are now present.
+			return m.placeCursorAtFirstItem()
+		}
 		if len(m.groups[gi].Intents) == 0 {
 			continue
 		}

--- a/internal/intent/tui/explorer/navigation.go
+++ b/internal/intent/tui/explorer/navigation.go
@@ -4,6 +4,36 @@ import (
 	"github.com/Obedience-Corp/camp/internal/intent/tui"
 )
 
+// placeCursorAtFirstItem positions the cursor on the first item of the first
+// group that has at least one intent, expanding the group if needed. It
+// returns true when an item was reachable and the cursor was placed there,
+// false when the visible groups are all empty (e.g. no search matches).
+//
+// Used after the user exits search mode so the filtered list has a visible
+// selection rather than landing on a group header (cursorItem=-1). Without
+// this, j/k looked like a no-op and users could not tell the list was
+// navigable (regression #279).
+func (m *Model) placeCursorAtFirstItem() bool {
+	for gi := range m.groups {
+		if len(m.groups[gi].Intents) == 0 {
+			continue
+		}
+		// Expand the group so the chosen item is actually visible. Without
+		// this a collapsed first-non-empty group would still hide the cursor.
+		m.groups[gi].Expanded = true
+		m.cursorGroup = gi
+		m.cursorItem = 0
+		m.scrollOffset = 0
+		m.ensureCursorVisible()
+		return true
+	}
+	// No matches reachable — leave cursor at the safe header position.
+	m.cursorGroup = 0
+	m.cursorItem = -1
+	m.scrollOffset = 0
+	return false
+}
+
 // moveCursorDown moves the cursor down one position and adjusts scroll.
 func (m *Model) moveCursorDown() {
 	m.moveCursorDownOne()

--- a/internal/intent/tui/explorer/render.go
+++ b/internal/intent/tui/explorer/render.go
@@ -253,7 +253,7 @@ func (m *Model) buildMainView() string {
 		header.WriteString(m.searchInput.View())
 		if m.focus == focusSearch {
 			header.WriteString("  ")
-			header.WriteString(tui.HelpStyle.Render("(enter to search, esc to cancel)"))
+			header.WriteString(tui.HelpStyle.Render("(enter to navigate filtered list, esc to clear)"))
 		}
 	}
 

--- a/internal/intent/tui/explorer/search_handoff_test.go
+++ b/internal/intent/tui/explorer/search_handoff_test.go
@@ -1,0 +1,134 @@
+package explorer
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Obedience-Corp/camp/internal/intent"
+)
+
+// TestSearchEnterHandoff_PlacesCursorOnFirstFilteredItem is a regression
+// test for #279: after typing a search query and pressing Enter, the
+// cursor used to remain at cursorItem=-1 (a group header) so j/k looked
+// like a no-op and users could not pick from the filtered results.
+//
+// After the fix, pressing Enter in search mode:
+//   - blurs the search input and returns focus to focusList (existing behavior)
+//   - positions the cursor on the first item of the first non-empty group
+//   - expands that group so the cursor is actually visible
+func TestSearchEnterHandoff_PlacesCursorOnFirstFilteredItem(t *testing.T) {
+	ctx := context.Background()
+	m := NewModel(ctx, nil, nil, "/tmp/intents", "/tmp/campaign", "test-id", "", nil)
+	m.ready = true
+
+	now := time.Now()
+	m.intents = []*intent.Intent{
+		{ID: "alpha", Title: "Alpha foo", Status: intent.StatusInbox, Type: intent.TypeFeature, CreatedAt: now},
+		{ID: "beta", Title: "Beta foo", Status: intent.StatusReady, Type: intent.TypeFeature, CreatedAt: now},
+		{ID: "gamma", Title: "Gamma unrelated", Status: intent.StatusInbox, Type: intent.TypeFeature, CreatedAt: now},
+	}
+	m.filteredIntents = m.intents
+	m.groups = groupIntentsByStatus(m.intents, m.dungeonExpanded)
+
+	// Simulate the post-live-filter state: user typed "foo", applyFilters
+	// narrowed to two intents, cursor parked at (0, -1) which is the
+	// regression baseline that made the list look unselectable.
+	m.focus = focusSearch
+	m.searchInput.SetValue("foo")
+	m.filteredIntents = []*intent.Intent{m.intents[0], m.intents[1]}
+	m.groups = groupIntentsByStatus(m.filteredIntents, m.dungeonExpanded)
+	m.cursorGroup = 0
+	m.cursorItem = -1
+	m.scrollOffset = 0
+
+	// Sanity: applyFilters parks the cursor on a header (the behavior the user hit).
+	if m.cursorItem != -1 {
+		t.Fatalf("baseline: cursorItem=-1 (regression baseline), got %d", m.cursorItem)
+	}
+
+	// Press Enter to exit search and hand focus to the list.
+	model, cmd := m.updateSearch(tea.KeyMsg{Type: tea.KeyEnter})
+	got := model.(Model)
+
+	if cmd != nil {
+		t.Fatal("search Enter should not dispatch a tea.Cmd")
+	}
+	if got.focus != focusList {
+		t.Fatalf("expected focusList after enter, got %v", got.focus)
+	}
+	if got.searchInput.Focused() {
+		t.Fatal("expected searchInput to be blurred after enter")
+	}
+	if got.cursorItem != 0 {
+		t.Fatalf("expected cursor on first item (cursorItem=0), got %d", got.cursorItem)
+	}
+	if !got.groups[got.cursorGroup].Expanded {
+		t.Fatal("the group holding the cursor should be expanded so the cursor is visible")
+	}
+
+	// The first non-empty group must hold one of the matching intents.
+	pointedAt := got.groups[got.cursorGroup].Intents[got.cursorItem]
+	if !strings.Contains(strings.ToLower(pointedAt.Title), "foo") {
+		t.Fatalf("cursor should point at a filtered intent (title containing 'foo'), got %q", pointedAt.Title)
+	}
+}
+
+// TestSearchEnterHandoff_NoMatchesSurfacesHint covers the case where the
+// search query filters everything out. The cursor must not crash on an
+// empty group set and the user must get a hint about how to recover.
+func TestSearchEnterHandoff_NoMatchesSurfacesHint(t *testing.T) {
+	ctx := context.Background()
+	m := NewModel(ctx, nil, nil, "/tmp/intents", "/tmp/campaign", "test-id", "", nil)
+	m.ready = true
+
+	m.intents = []*intent.Intent{
+		{ID: "alpha", Title: "Alpha", Status: intent.StatusInbox, Type: intent.TypeFeature, CreatedAt: time.Now()},
+	}
+	m.filteredIntents = m.intents
+	m.groups = groupIntentsByStatus(m.intents, m.dungeonExpanded)
+
+	// Simulate the empty-result state: user typed a query that filtered
+	// everything out, applyFilters left filteredIntents empty, groups
+	// regrouped accordingly, cursor parked at (0, -1).
+	m.focus = focusSearch
+	m.searchInput.SetValue("nomatch-zzz")
+	m.filteredIntents = nil
+	m.groups = groupIntentsByStatus(nil, m.dungeonExpanded)
+	m.cursorGroup = 0
+	m.cursorItem = -1
+
+	model, _ := m.updateSearch(tea.KeyMsg{Type: tea.KeyEnter})
+	got := model.(Model)
+
+	if got.focus != focusList {
+		t.Fatalf("focus should be focusList even with no matches, got %v", got.focus)
+	}
+	if !strings.Contains(strings.ToLower(got.statusMessage), "no matches") {
+		t.Fatalf("expected a 'No matches' hint in statusMessage, got %q", got.statusMessage)
+	}
+}
+
+// TestPlaceCursorAtFirstItem_NoGroupsHasItems exercises the helper directly
+// with an explicit empty-groups state to confirm it falls back safely.
+func TestPlaceCursorAtFirstItem_NoGroupsHasItems(t *testing.T) {
+	ctx := context.Background()
+	m := NewModel(ctx, nil, nil, "/tmp/intents", "/tmp/campaign", "test-id", "", nil)
+	m.ready = true
+	m.intents = nil
+	m.filteredIntents = nil
+	m.groups = groupIntentsByStatus(nil, m.dungeonExpanded)
+
+	placed := m.placeCursorAtFirstItem()
+
+	if placed {
+		t.Fatal("expected false when no groups have items")
+	}
+	if m.cursorGroup != 0 || m.cursorItem != -1 {
+		t.Fatalf("expected safe fallback (cursorGroup=0, cursorItem=-1); got (%d, %d)",
+			m.cursorGroup, m.cursorItem)
+	}
+}

--- a/internal/intent/tui/explorer/search_handoff_test.go
+++ b/internal/intent/tui/explorer/search_handoff_test.go
@@ -112,6 +112,94 @@ func TestSearchEnterHandoff_NoMatchesSurfacesHint(t *testing.T) {
 	}
 }
 
+// TestSearchEnterHandoff_DungeonOnlyMatchesAutoExpand is a regression test
+// for the obey-agent review on PR #282: when the Dungeon parent is
+// collapsed and the active filter has matches only in dungeon child groups,
+// the cursor placement must still find the matches. Without the auto-expand
+// path the helper iterated m.groups looking for non-empty Intents — but the
+// Dungeon parent has only DungeonCount and an empty Intents slice while
+// collapsed, and the dungeon child groups are absent from m.groups
+// entirely. The user would see "No matches" even though their query hit a
+// Someday item.
+func TestSearchEnterHandoff_DungeonOnlyMatchesAutoExpand(t *testing.T) {
+	ctx := context.Background()
+	m := NewModel(ctx, nil, nil, "/tmp/intents", "/tmp/campaign", "test-id", "", nil)
+	m.ready = true
+
+	now := time.Now()
+	somedayMatch := &intent.Intent{
+		ID:        "someday-foo",
+		Title:     "Foo someday item",
+		Status:    intent.StatusSomeday,
+		Type:      intent.TypeFeature,
+		CreatedAt: now,
+	}
+	m.intents = []*intent.Intent{
+		{ID: "inbox-1", Title: "Inbox unrelated", Status: intent.StatusInbox, Type: intent.TypeFeature, CreatedAt: now},
+		somedayMatch,
+	}
+	// Dungeon starts collapsed (the default the user filed the bug under).
+	m.dungeonExpanded = false
+
+	// Simulate the post-live-filter state: user typed a query that matches
+	// only the Someday item. filteredIntents holds only the dungeon match;
+	// groups was rebuilt with dungeonExpanded=false so the Someday group is
+	// not present in m.groups — only a Dungeon parent with DungeonCount=1.
+	m.focus = focusSearch
+	m.searchInput.SetValue("foo")
+	m.filteredIntents = []*intent.Intent{somedayMatch}
+	m.groups = groupIntentsByStatus(m.filteredIntents, m.dungeonExpanded)
+	m.cursorGroup = 0
+	m.cursorItem = -1
+	m.scrollOffset = 0
+
+	// Verify the baseline state matches the bug condition: a Dungeon parent
+	// exists with a non-zero count, but the matching child is not in groups.
+	dungeonParentFound := false
+	someDayChildPresent := false
+	for _, g := range m.groups {
+		if g.IsDungeonParent {
+			dungeonParentFound = true
+			if g.DungeonCount != 1 {
+				t.Fatalf("baseline: dungeon parent should report 1 match, got %d", g.DungeonCount)
+			}
+		}
+		if g.IsDungeonChild && g.Status == intent.StatusSomeday {
+			someDayChildPresent = true
+		}
+	}
+	if !dungeonParentFound {
+		t.Fatal("baseline: dungeon parent should be in m.groups")
+	}
+	if someDayChildPresent {
+		t.Fatal("baseline: someday child should NOT be in m.groups before fix triggers (collapsed parent)")
+	}
+
+	// Press Enter to commit the filter and hand focus to the list.
+	model, _ := m.updateSearch(tea.KeyMsg{Type: tea.KeyEnter})
+	got := model.(Model)
+
+	if got.focus != focusList {
+		t.Fatalf("focus should be focusList, got %v", got.focus)
+	}
+	if !got.dungeonExpanded {
+		t.Fatal("dungeon parent should have been auto-expanded to expose the matching child")
+	}
+	if got.cursorItem != 0 {
+		t.Fatalf("cursor should point at the first matching item (cursorItem=0), got %d", got.cursorItem)
+	}
+	if !got.groups[got.cursorGroup].IsDungeonChild {
+		t.Fatalf("cursor should land on a dungeon child group, got group %+v", got.groups[got.cursorGroup])
+	}
+	pointedAt := got.groups[got.cursorGroup].Intents[got.cursorItem]
+	if pointedAt.ID != somedayMatch.ID {
+		t.Fatalf("cursor should point at the matching Someday intent, got %q", pointedAt.ID)
+	}
+	if strings.Contains(strings.ToLower(got.statusMessage), "no matches") {
+		t.Fatalf("must not show no-matches hint when dungeon matches exist; got %q", got.statusMessage)
+	}
+}
+
 // TestPlaceCursorAtFirstItem_NoGroupsHasItems exercises the helper directly
 // with an explicit empty-groups state to confirm it falls back safely.
 func TestPlaceCursorAtFirstItem_NoGroupsHasItems(t *testing.T) {

--- a/internal/intent/tui/explorer/update_overlays.go
+++ b/internal/intent/tui/explorer/update_overlays.go
@@ -19,9 +19,16 @@ func (m Model) updateSearch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.applyFilters()
 		return m, nil
 	case "enter":
-		// Exit search mode but keep filter active
+		// Exit search mode but keep filter active. Place the cursor on the
+		// first item of the first non-empty group so the user has a visible
+		// selection to navigate from. Without this, the cursor stays at
+		// cursorItem=-1 (group header) and pressing j/k looks like a no-op
+		// (regression for #279: filtered list appeared unselectable).
 		m.focus = focusList
 		m.searchInput.Blur()
+		if !m.placeCursorAtFirstItem() {
+			m.statusMessage = "No matches — press / to refine or Esc to clear"
+		}
 		return m, nil
 	}
 	// Pass all other keys to the text input


### PR DESCRIPTION
## Summary

Fixes three bugs in the `camp intent explore` TUI surfaced while triaging the intent inbox:

- **#280 (High)** — auto-commit INFO logs corrupted bubbletea rendering, making the TUI appear frozen and forcing kills.
- **#278 (High)** — dungeon→dungeon moves (e.g. Someday → Done) appeared frozen because the auto-commit retry stalled without any in-progress feedback.
- **#279 (Medium)** — the \`/\` search filter narrowed the list live but pressing Enter left the cursor on a group header (\`cursorItem=-1\`), so j/k looked like a no-op and the filtered list felt unselectable.

The fixes are scoped to the explorer TUI and the small slice of \`internal/git\` that emits the noisy lock-cleanup logs. No protocol or schema changes.

## Commits

1. \`silence auto-commit logs that corrupted explorer TUI\` — closes #280
2. \`surface in-progress feedback during dungeon-move auto-commit\` — closes #278
3. \`hand cursor to first filtered item when exiting search\` — closes #279
4. \`update search-mode help text to match new Enter behavior\` — follow-up to #279

Each commit can be reverted independently if needed.

### Commit 1 — log corruption defense in depth

Two-part fix:

- **Demote three chatty INFO logs to Debug** in \`internal/git/retry.go\` and \`internal/git/lock_unix.go\`. They were operational chatter (\`removing stale lock\`, \`cycle completed, cleaning locks\`, \`waiting before next cycle\`) with no user-actionable information at INFO level. The \`lock is active, cannot remove\` Warn is preserved. Errors are still returned through the normal Go error path.
- **Install a file-routing slog handler at the TUI entry point** in \`cmd/camp/intent/explore.go\`. Writes to \`<campaignRoot>/.campaign/logs/intent-explore.log\` instead of stderr, restored to the previous default on exit. Falls back to \`io.Discard\` if the log dir cannot be created so the TUI is still safe.

Regression tests cover the swap, message capture, and the fallback path.

### Commit 2 — dungeon-move freeze (in-progress feedback)

The dungeon reason flow itself was wired correctly (View branch, key router, focused textinput). What looked like a freeze was the auto-commit retry stalling while clearing stale git index locks, combined with the log corruption (#280). Once the user committed a reason and focus returned to the list, there was no in-progress indicator so they assumed the TUI was hung.

Fix: set \`statusMessage\` to \`Moving to <status>...\` or \`Archiving...\` immediately when the reason is accepted. The \`moveFinishedMsg\` / \`archiveFinishedMsg\` handler replaces it with the final outcome when the async path completes.

Regression test covers the Someday → Done transition end-to-end: focus through \`focusDungeonReason\` and back to \`focusList\`, the reason input actually rendering (guards against future regressions that remove the View branch), empty-reason rejection, esc cancel, and that a non-nil tea.Cmd is dispatched.

### Commits 3 + 4 — search Enter handoff

After typing in \`/\` search, \`applyFilters\` reset the cursor to \`cursorGroup=0, cursorItem=-1\` — a group header position. Pressing Enter blurred the input and returned focus to the list, but the cursor stayed at the header, so j/k looked like a no-op and users could not select from the filtered results.

Fix:

- New \`placeCursorAtFirstItem\` helper in \`navigation.go\` that finds the first non-empty group, expands it, and parks the cursor on item 0. Returns false on no matches so the caller can surface a recovery hint.
- \`updateSearch\` calls it on Enter. On no-match, sets \`statusMessage\` to \`No matches — press / to refine or Esc to clear\`.
- Help text in render.go updated from \`(enter to search, esc to cancel)\` to \`(enter to navigate filtered list, esc to clear)\` — \"enter to search\" was misleading since typing already searches live.

Regression tests cover: cursor placement on a real intent after Enter, group auto-expansion, the no-matches hint path, and the safe fallback when called with empty groups.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — full suite passes
- [x] New regression tests pass:
  - \`TestQuietSlogDuringTUI_RedirectsToLogFile\`
  - \`TestQuietSlogDuringTUI_FallsBackToDiscardOnDirError\`
  - \`TestDungeonMove_SomedayToDone_TransitionsAndSurfacesProgress\`
  - \`TestDungeonMove_EscCancelsAndRestoresList\`
  - \`TestSearchEnterHandoff_PlacesCursorOnFirstFilteredItem\`
  - \`TestSearchEnterHandoff_NoMatchesSurfacesHint\`
  - \`TestPlaceCursorAtFirstItem_NoGroupsHasItems\`
- [ ] Manual smoke: run \`camp intent explore\`, move an intent from Someday to Done (verify clean render, in-progress hint, auto-commit succeeds with no TTY corruption). Repeat with \`/\` search → Enter → j/k navigation → Enter to open viewer.