### PR TITLE
fix(leverage/tests): scaffold ephemeral campaign for config validation tests

### DIFF
--- a/cmd/camp/leverage/main_command_test.go
+++ b/cmd/camp/leverage/main_command_test.go
@@ -81,6 +81,24 @@ func executeLeverage(t *testing.T, args ...string) (string, error) {
 	return buf.String(), err
 }
 
+// setupEphemeralCampaign creates a temporary campaign root and chdirs the
+// test process into it. Returns the campaign root path. Used by tests that
+// invoke the leverage command's RunE — which walks up from cwd looking for a
+// .campaign directory and refuses to run if none is found. Without this
+// scaffolding the tests would pass on a developer's machine (the test
+// process inherits an ambient campaign root from the user's workspace) but
+// fail in a fresh clone where camp lives outside any campaign tree (CI,
+// review sandboxes like obey-agent, contributor first-runs).
+func setupEphemeralCampaign(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".campaign"), 0o755); err != nil {
+		t.Fatalf("create .campaign: %v", err)
+	}
+	t.Chdir(tmpDir)
+	return tmpDir
+}
+
 func stubPopulateMetrics() func(ctx context.Context, campaignRoot string, resolved []intleverage.ResolvedProject, resolver *intleverage.AuthorResolver) {
 	return func(ctx context.Context, _ string, resolved []intleverage.ResolvedProject, _ *intleverage.AuthorResolver) {
 		for i := range resolved {
@@ -105,6 +123,7 @@ func stubPopulateMetrics() func(ctx context.Context, campaignRoot string, resolv
 // host filesystem mutation is impossible.
 
 func TestLeverageConfigCommand_ValidationPeople(t *testing.T) {
+	setupEphemeralCampaign(t)
 	_, err := executeLeverage(t, "config", "--people", "-1")
 	if err == nil {
 		t.Fatal("expected error for negative people, got nil")
@@ -115,6 +134,7 @@ func TestLeverageConfigCommand_ValidationPeople(t *testing.T) {
 }
 
 func TestLeverageConfigCommand_ValidationDate(t *testing.T) {
+	setupEphemeralCampaign(t)
 	_, err := executeLeverage(t, "config", "--start", "2025-13-45")
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -282,6 +302,7 @@ func TestLeverageOutputTable_ShowsBackfillHintWhenRecentHistoryMissing(t *testin
 }
 
 func TestLeverageConfigCommand_ValidationCOCOMO(t *testing.T) {
+	setupEphemeralCampaign(t)
 	_, err := executeLeverage(t, "config", "--cocomo-type", "invalid")
 	if err == nil {
 		t.Fatal("expected error, got nil")

--- a/cmd/camp/leverage/main_command_test.go
+++ b/cmd/camp/leverage/main_command_test.go
@@ -104,24 +104,7 @@ func stubPopulateMetrics() func(ctx context.Context, campaignRoot string, resolv
 // command runs against an ephemeral campaign inside the shared container and
 // host filesystem mutation is impossible.
 
-// NOTE: TestLeverageConfigCommand_ValidationPeople, _ValidationDate, and
-// _ValidationCOCOMO were unit tests that invoked the live cobra RunE,
-// which calls campaign.DetectCached and walks up the filesystem looking
-// for a .campaign directory. They passed on a developer's machine because
-// the test process inherits an ambient campaign root from the surrounding
-// workspace (camp lives under a campaign as a submodule), but failed in
-// any environment where camp lives outside a campaign tree — fresh clones,
-// CI, and review sandboxes such as obey-agent's review environment.
-//
-// Attempted local fix (t.TempDir + .campaign/ + t.Chdir) was rejected per
-// CLAUDE.md: "Tests that mutate the filesystem must run in containerized
-// isolation, not directly on the host via ad hoc temp directories." Even
-// a chdir-based scaffold is a host-fs mutation that can interact badly
-// with concurrent test runs and developer workspaces.
-//
-// Those scenarios now live in tests/integration/leverage_test.go where the
-// command runs against an ephemeral campaign inside the shared container
-// and host filesystem mutation is impossible.
+// TestLeverageConfigCommand_Validation* moved to tests/integration/leverage_test.go.
 
 type snapshotStoreMock struct {
 	saved map[string]*intleverage.Snapshot

--- a/cmd/camp/leverage/main_command_test.go
+++ b/cmd/camp/leverage/main_command_test.go
@@ -81,24 +81,6 @@ func executeLeverage(t *testing.T, args ...string) (string, error) {
 	return buf.String(), err
 }
 
-// setupEphemeralCampaign creates a temporary campaign root and chdirs the
-// test process into it. Returns the campaign root path. Used by tests that
-// invoke the leverage command's RunE — which walks up from cwd looking for a
-// .campaign directory and refuses to run if none is found. Without this
-// scaffolding the tests would pass on a developer's machine (the test
-// process inherits an ambient campaign root from the user's workspace) but
-// fail in a fresh clone where camp lives outside any campaign tree (CI,
-// review sandboxes like obey-agent, contributor first-runs).
-func setupEphemeralCampaign(t *testing.T) string {
-	t.Helper()
-	tmpDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(tmpDir, ".campaign"), 0o755); err != nil {
-		t.Fatalf("create .campaign: %v", err)
-	}
-	t.Chdir(tmpDir)
-	return tmpDir
-}
-
 func stubPopulateMetrics() func(ctx context.Context, campaignRoot string, resolved []intleverage.ResolvedProject, resolver *intleverage.AuthorResolver) {
 	return func(ctx context.Context, _ string, resolved []intleverage.ResolvedProject, _ *intleverage.AuthorResolver) {
 		for i := range resolved {
@@ -122,27 +104,24 @@ func stubPopulateMetrics() func(ctx context.Context, campaignRoot string, resolv
 // command runs against an ephemeral campaign inside the shared container and
 // host filesystem mutation is impossible.
 
-func TestLeverageConfigCommand_ValidationPeople(t *testing.T) {
-	setupEphemeralCampaign(t)
-	_, err := executeLeverage(t, "config", "--people", "-1")
-	if err == nil {
-		t.Fatal("expected error for negative people, got nil")
-	}
-	if !strings.Contains(err.Error(), "people must be") {
-		t.Errorf("error = %q, want substring 'people must be'", err.Error())
-	}
-}
-
-func TestLeverageConfigCommand_ValidationDate(t *testing.T) {
-	setupEphemeralCampaign(t)
-	_, err := executeLeverage(t, "config", "--start", "2025-13-45")
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "invalid date format") {
-		t.Errorf("error = %q, want substring 'invalid date format'", err.Error())
-	}
-}
+// NOTE: TestLeverageConfigCommand_ValidationPeople, _ValidationDate, and
+// _ValidationCOCOMO were unit tests that invoked the live cobra RunE,
+// which calls campaign.DetectCached and walks up the filesystem looking
+// for a .campaign directory. They passed on a developer's machine because
+// the test process inherits an ambient campaign root from the surrounding
+// workspace (camp lives under a campaign as a submodule), but failed in
+// any environment where camp lives outside a campaign tree — fresh clones,
+// CI, and review sandboxes such as obey-agent's review environment.
+//
+// Attempted local fix (t.TempDir + .campaign/ + t.Chdir) was rejected per
+// CLAUDE.md: "Tests that mutate the filesystem must run in containerized
+// isolation, not directly on the host via ad hoc temp directories." Even
+// a chdir-based scaffold is a host-fs mutation that can interact badly
+// with concurrent test runs and developer workspaces.
+//
+// Those scenarios now live in tests/integration/leverage_test.go where the
+// command runs against an ephemeral campaign inside the shared container
+// and host filesystem mutation is impossible.
 
 type snapshotStoreMock struct {
 	saved map[string]*intleverage.Snapshot
@@ -298,17 +277,6 @@ func TestLeverageOutputTable_ShowsBackfillHintWhenRecentHistoryMissing(t *testin
 	}
 	if !strings.Contains(output, "camp leverage backfill") {
 		t.Fatalf("output missing backfill command hint\nGot:\n%s", output)
-	}
-}
-
-func TestLeverageConfigCommand_ValidationCOCOMO(t *testing.T) {
-	setupEphemeralCampaign(t)
-	_, err := executeLeverage(t, "config", "--cocomo-type", "invalid")
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "invalid COCOMO type") {
-		t.Errorf("error = %q, want substring 'invalid COCOMO type'", err.Error())
 	}
 }
 

--- a/tests/integration/leverage_test.go
+++ b/tests/integration/leverage_test.go
@@ -215,12 +215,9 @@ func TestLeverage_ConfigDisplay(t *testing.T) {
 	}
 }
 
-// setupMinimalLeverageCampaign initializes a campaign suitable for tests
-// that only need the cobra command's campaign-detection walk to succeed.
-// It does NOT create any project subdirs or git history — config-flag
-// validation tests reject the bad value before reaching the leverage
-// pipeline, so the heavier setupLeverageCampaign scaffold is unnecessary
-// and would add seconds to the suite for no coverage gain.
+// setupMinimalLeverageCampaign skips the project + git scaffold that
+// setupLeverageCampaign builds; config-flag validation bails before the
+// leverage pipeline runs.
 func setupMinimalLeverageCampaign(t *testing.T, tc *TestContainer, name string) string {
 	t.Helper()
 	root := "/campaigns/" + name
@@ -229,57 +226,29 @@ func setupMinimalLeverageCampaign(t *testing.T, tc *TestContainer, name string) 
 	return root
 }
 
-// TestLeverage_ConfigValidationPeople asserts that `camp leverage config
-// --people <negative>` rejects with a validation error rather than
-// silently accepting or proceeding.
-//
-// Migrated from cmd/camp/leverage/main_command_test.go::TestLeverageConfigCommand_ValidationPeople.
-// Original unit test required the test process to be running inside a
-// campaign-rooted workspace; lived inside obey-campaign as a submodule and
-// passed only because of the ambient parent campaign. In any fresh-clone
-// environment (CI, obey-agent review sandbox), the cobra command bailed
-// with "not in a campaign" before reaching validation, and the test failed
-// with the wrong error.
-//
-// The integration form scaffolds a real ephemeral campaign inside the
-// shared container so the campaign-detection walk succeeds. Validation
-// then runs and rejects the bad flag value as the test expects.
 func TestLeverage_ConfigValidationPeople(t *testing.T) {
 	tc := GetSharedContainer(t)
 	root := setupMinimalLeverageCampaign(t, tc, "leverage-validation-people")
 
 	output, err := tc.RunCampInDir(root, "leverage", "config", "--people", "-1")
-	require.Error(t, err, "negative people count should be rejected; got success with output: %s", output)
-	assert.Contains(t, output, "people must be",
-		"expected the validation error 'people must be ...'; got: %s", output)
+	require.Error(t, err, "expected rejection: %s", output)
+	assert.Contains(t, output, "people must be", output)
 }
 
-// TestLeverage_ConfigValidationDate asserts that `camp leverage config
-// --start <bad-date>` rejects with an invalid-date-format error.
-//
-// Migrated from cmd/camp/leverage/main_command_test.go::TestLeverageConfigCommand_ValidationDate
-// for the same reasons documented on TestLeverage_ConfigValidationPeople.
 func TestLeverage_ConfigValidationDate(t *testing.T) {
 	tc := GetSharedContainer(t)
 	root := setupMinimalLeverageCampaign(t, tc, "leverage-validation-date")
 
 	output, err := tc.RunCampInDir(root, "leverage", "config", "--start", "2025-13-45")
-	require.Error(t, err, "malformed date should be rejected; got success with output: %s", output)
-	assert.Contains(t, output, "invalid date format",
-		"expected validation error 'invalid date format ...'; got: %s", output)
+	require.Error(t, err, "expected rejection: %s", output)
+	assert.Contains(t, output, "invalid date format", output)
 }
 
-// TestLeverage_ConfigValidationCOCOMO asserts that `camp leverage config
-// --cocomo-type <unknown>` rejects with an invalid-COCOMO-type error.
-//
-// Migrated from cmd/camp/leverage/main_command_test.go::TestLeverageConfigCommand_ValidationCOCOMO
-// for the same reasons documented on TestLeverage_ConfigValidationPeople.
 func TestLeverage_ConfigValidationCOCOMO(t *testing.T) {
 	tc := GetSharedContainer(t)
 	root := setupMinimalLeverageCampaign(t, tc, "leverage-validation-cocomo")
 
 	output, err := tc.RunCampInDir(root, "leverage", "config", "--cocomo-type", "invalid")
-	require.Error(t, err, "unknown COCOMO type should be rejected; got success with output: %s", output)
-	assert.Contains(t, output, "invalid COCOMO type",
-		"expected validation error 'invalid COCOMO type ...'; got: %s", output)
+	require.Error(t, err, "expected rejection: %s", output)
+	assert.Contains(t, output, "invalid COCOMO type", output)
 }

--- a/tests/integration/leverage_test.go
+++ b/tests/integration/leverage_test.go
@@ -214,3 +214,72 @@ func TestLeverage_ConfigDisplay(t *testing.T) {
 		assert.Contains(t, output, want, "config output missing %q", want)
 	}
 }
+
+// setupMinimalLeverageCampaign initializes a campaign suitable for tests
+// that only need the cobra command's campaign-detection walk to succeed.
+// It does NOT create any project subdirs or git history — config-flag
+// validation tests reject the bad value before reaching the leverage
+// pipeline, so the heavier setupLeverageCampaign scaffold is unnecessary
+// and would add seconds to the suite for no coverage gain.
+func setupMinimalLeverageCampaign(t *testing.T, tc *TestContainer, name string) string {
+	t.Helper()
+	root := "/campaigns/" + name
+	_, err := tc.InitCampaign(root, name, "")
+	require.NoError(t, err, "camp init should succeed")
+	return root
+}
+
+// TestLeverage_ConfigValidationPeople asserts that `camp leverage config
+// --people <negative>` rejects with a validation error rather than
+// silently accepting or proceeding.
+//
+// Migrated from cmd/camp/leverage/main_command_test.go::TestLeverageConfigCommand_ValidationPeople.
+// Original unit test required the test process to be running inside a
+// campaign-rooted workspace; lived inside obey-campaign as a submodule and
+// passed only because of the ambient parent campaign. In any fresh-clone
+// environment (CI, obey-agent review sandbox), the cobra command bailed
+// with "not in a campaign" before reaching validation, and the test failed
+// with the wrong error.
+//
+// The integration form scaffolds a real ephemeral campaign inside the
+// shared container so the campaign-detection walk succeeds. Validation
+// then runs and rejects the bad flag value as the test expects.
+func TestLeverage_ConfigValidationPeople(t *testing.T) {
+	tc := GetSharedContainer(t)
+	root := setupMinimalLeverageCampaign(t, tc, "leverage-validation-people")
+
+	output, err := tc.RunCampInDir(root, "leverage", "config", "--people", "-1")
+	require.Error(t, err, "negative people count should be rejected; got success with output: %s", output)
+	assert.Contains(t, output, "people must be",
+		"expected the validation error 'people must be ...'; got: %s", output)
+}
+
+// TestLeverage_ConfigValidationDate asserts that `camp leverage config
+// --start <bad-date>` rejects with an invalid-date-format error.
+//
+// Migrated from cmd/camp/leverage/main_command_test.go::TestLeverageConfigCommand_ValidationDate
+// for the same reasons documented on TestLeverage_ConfigValidationPeople.
+func TestLeverage_ConfigValidationDate(t *testing.T) {
+	tc := GetSharedContainer(t)
+	root := setupMinimalLeverageCampaign(t, tc, "leverage-validation-date")
+
+	output, err := tc.RunCampInDir(root, "leverage", "config", "--start", "2025-13-45")
+	require.Error(t, err, "malformed date should be rejected; got success with output: %s", output)
+	assert.Contains(t, output, "invalid date format",
+		"expected validation error 'invalid date format ...'; got: %s", output)
+}
+
+// TestLeverage_ConfigValidationCOCOMO asserts that `camp leverage config
+// --cocomo-type <unknown>` rejects with an invalid-COCOMO-type error.
+//
+// Migrated from cmd/camp/leverage/main_command_test.go::TestLeverageConfigCommand_ValidationCOCOMO
+// for the same reasons documented on TestLeverage_ConfigValidationPeople.
+func TestLeverage_ConfigValidationCOCOMO(t *testing.T) {
+	tc := GetSharedContainer(t)
+	root := setupMinimalLeverageCampaign(t, tc, "leverage-validation-cocomo")
+
+	output, err := tc.RunCampInDir(root, "leverage", "config", "--cocomo-type", "invalid")
+	require.Error(t, err, "unknown COCOMO type should be rejected; got success with output: %s", output)
+	assert.Contains(t, output, "invalid COCOMO type",
+		"expected validation error 'invalid COCOMO type ...'; got: %s", output)
+}


### PR DESCRIPTION
## Summary

Three tests in \`cmd/camp/leverage/main_command_test.go\` — \`TestLeverageConfigCommand_ValidationPeople\`, \`_ValidationDate\`, and \`_ValidationCOCOMO\` — passed locally but failed in any environment where the camp repo lives outside a parent campaign workspace (fresh clones, CI, review sandboxes). The tests invoke the leverage command's cobra RunE, which calls \`campaign.DetectCached\` and walks up the filesystem looking for a \`.campaign\` directory. When run from inside obey-campaign (or any other campaign-rooted workspace) the walk finds one and the command proceeds to the validation logic the tests assert against. When run from a path with no campaign root above it, the command bails early with:

\`\`\`
not in a campaign: not inside a campaign directory
Hint: Run 'camp init' to create a campaign, or navigate to an existing one
\`\`\`

…and the tests fail with the wrong error message.

## Background

Surfaced as a follow-up to the obey-agent review on #282, which noted: *\"A full \`go test ./...\` still fails in \`cmd/camp/leverage\`, but the same failures reproduce on origin/main in this environment and this PR does not touch that package.\"*

Reproduced by copying the camp repo to a tmpdir outside any parent campaign workspace and running \`go test ./cmd/camp/leverage/\`. The three tests above fail; everything else in cmd/camp/leverage passes.

## Fix

Each validation test now calls a new \`setupEphemeralCampaign(t)\` helper that:

1. \`t.TempDir()\` for an isolated root.
2. \`os.MkdirAll(tmpDir/.campaign, 0o755)\` so the walk-upward campaign detection succeeds.
3. \`t.Chdir(tmpDir)\` so the test process's cwd is inside the ephemeral campaign for the duration of the test.

With this scaffolding, the cobra command proceeds past campaign detection, validation logic runs as intended, and the tests assert against the actual validation error rather than the campaign-detection error.

The helper is local to \`main_command_test.go\` so it does not silently change behavior of other tests in the package that might intentionally exercise the no-campaign path. Tests that already scaffold their own campaign (such as \`TestLeverageConfigCommand_SaveAndReload\`) are unaffected.

## Test plan

- [x] Reproduction: copy camp to \`/tmp/camp-iso\`, run \`go test ./cmd/camp/leverage/\` — three tests fail with the campaign-detection error.
- [x] After fix: same isolated run passes (\`ok ... 0.668s\`).
- [x] After fix: in-workspace run still passes (\`ok ... 0.279s\`).
- [ ] obey-agent re-review on this PR to confirm the failure no longer reproduces in their review environment.