### PR TITLE
fix(skills): correct outdated workflow/intents/ references in distributed skill templates

### DIFF
--- a/internal/scaffold/campaign/templates/.campaign/skills/camp-navigation/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/camp-navigation/SKILL.md.tmpl
@@ -13,7 +13,7 @@ Use `cgo` for interactive directory changes and `camp go --print` for scripts.
 cgo                  # toggle campaign root <-> last location
 cgo p                # projects/
 cgo f                # festivals/
-cgo i                # workflow/intents/
+cgo i                # .campaign/intents/ (intents)
 cgo cr               # workflow/code_reviews/
 cgo p camp           # projects/camp/
 ```

--- a/internal/scaffold/campaign/templates/.campaign/skills/campaign-structure/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/campaign-structure/SKILL.md.tmpl
@@ -7,33 +7,50 @@ description: Orient within campaign directory structure. Use when deciding where
 
 ## Placement Rules
 
-- Raw idea / bug / future work: `workflow/intents/`
-- Structured execution plan: `festivals/`
-- Internal design/spec: `workflow/design/`
-- User-facing docs: `docs/`
-- AI-generated analysis/research: `ai_docs/`
-- Archive/defer: local `dungeon/` or campaign `dungeon/`
+- Raw idea / bug / future work / quick capture: `.campaign/intents/inbox/` (use `camp intent add`)
+- Enriching or preparing for execution: `.campaign/intents/active/`
+- Ready for structured work: `.campaign/intents/ready/` → promote to festival
+- Structured multi-phase execution: `festivals/`
+- Internal design, architecture, or deep exploration: `workflow/design/`
+- User-facing documentation: `docs/`
+- AI-generated research and analysis: `ai_docs/`
+- Historical exploration notes: `workflow/explore/`
+- Archive / defer / killed: `.campaign/intents/dungeon/` or top-level `dungeon/`
 
 ## Critical Distinctions
 
-- `workflow/intents/` is idea capture.
-- `festivals/dungeon/` is for already-planned festivals in terminal states.
-- `docs/` and `workflow/design/` serve different audiences.
+- `.campaign/intents/` (especially `inbox/`) is the primary capture surface for new ideas, bugs, and tasks.
+- `workflow/design/` is for thoughtful internal design documents and specs.
+- `festivals/` is for planned, phased execution (not raw ideas).
+- `docs/` is user-facing; `ai_docs/` and `workflow/explore/` are internal.
 
-## Layout Snapshot
+Canonical reference: `.campaign/intents/OBEY.md`
+
+## Layout Snapshot (Current)
 
 ```text
 .campaign/
-projects/
-festivals/
+├── intents/          # Idea capture (inbox / active / ready / dungeon)
+│   └── OBEY.md       # Authoritative intent guide
+├── quests/           # Long-lived working contexts
+└── skills/           # Campaign-specific agent skills (loaded at runtime)
+
+projects/             # Git submodules (the actual codebases)
 workflow/
-ai_docs/
-docs/
-dungeon/
+├── code_reviews/
+├── pipelines/
+├── design/           # Design documents & specs
+└── explore/          # Historical research notes
+
+festivals/            # Festival methodology (planning + active)
+docs/                 # User-facing documentation
+ai_docs/              # AI-generated research
+dungeon/              # Top-level archive
 ```
 
 ## Common Mistakes
 
-- Putting unplanned ideas directly into festival dungeons.
-- Treating all documentation as `docs/`.
-- Creating new top-level directories instead of using campaign taxonomy.
+- Putting raw ideas directly into `festivals/` or `workflow/design/` without going through intents first.
+- Treating `docs/` as the place for internal specs (use `workflow/design/` or `.campaign/intents/`).
+- Creating ad-hoc top-level directories instead of using the established taxonomy.
+- Forgetting that `cgo i` now navigates to `.campaign/intents/`.


### PR DESCRIPTION
## Summary

This is a clean redo of the skill template fixes.

The default skill templates distributed by \`camp init\` into new campaigns' \`.campaign/skills/\` still referenced the legacy \`workflow/intents/\` structure.

## Changes (Clean Diff)

Only two files changed, based on latest \`origin/main\`:

- \`internal/scaffold/campaign/templates/.campaign/skills/campaign-structure/SKILL.md.tmpl\`
  - Modernized Placement Rules, Critical Distinctions, Layout Snapshot, and Common Mistakes to reflect \`.campaign/intents/\` as the canonical idea capture location.
  - Added reference to \`.campaign/intents/OBEY.md\`.

- \`internal/scaffold/campaign/templates/.campaign/skills/camp-navigation/SKILL.md.tmpl\`
  - Fixed the \`cgo i\` shortcut comment from legacy \`workflow/intents/\` to \`.campaign/intents/ (intents)\`.

## Worktree

- Fresh worktree created with \`camp project worktree add ... --start-point origin/main\`
- All work done in isolation: \`projects/worktrees/camp/fix-skill-references-clean\`
- Committed using \`camp commit --sub\`

This PR contains **only** the intended skill fixes with no unrelated commits.