### PR TITLE
Add camp stage and camp project stage commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Campaign workspace manager — group every project, tool, and piece of context y
 - **Project Management** — Git submodules, linked local workspaces, worktrees, and scaffolding (`project add/link/list/new/remote/remove/run/unlink/worktree/prune`)
 - **Planning** — Intents, status flows, dungeon for deprioritized work, and a unified work-item dashboard (`intent`, `flow`, `dungeon`, `gather`, `workitem`)
 - **Productivity** — Leverage scoring to identify high-impact work (`leverage`)
-- **Git Integration** — Campaign-level git operations with submodule fan-out (`commit`, `log`, `push [all]`, `pull [all]`, `status [all]`, `fresh [all]`, `refs-sync`)
+- **Git Integration** — Campaign-level git operations with submodule fan-out (`stage`, `commit`, `log`, `push [all]`, `pull [all]`, `status [all]`, `fresh [all]`, `refs-sync`)
 - **Campaign Ops** — Health checks, file operations, cross-campaign tools (`doctor`, `copy`, `move`, `sync`, `transfer`)
 - **Shell Integration** — Native `cd` behavior with zsh, bash, and fish (`shell-init`)
 - **Tab Completion** — Smart completion for categories, projects, and paths
@@ -165,8 +165,8 @@ Use submodules via `camp project add` (or `camp p add`) if you plan to use
 your campaign on multiple devices — linked projects must exist in the same
 location on each device in order to work.
 
-For the rest of the project surface (`list`, `remove`, `unlink`, `commit`,
-`run`, `worktree`, `prune`, `remote`, `new`), see
+For the rest of the project surface (`list`, `remove`, `unlink`, `stage`,
+`commit`, `run`, `worktree`, `prune`, `remote`, `new`), see
 [`docs/cli-reference/`](docs/cli-reference/).
 
 ### Attaching Non-Project Directories
@@ -231,6 +231,8 @@ See [docs/leverage-score.md](docs/leverage-score.md) for details on the scoring 
 Campaign-level git operations:
 
 ```bash
+camp stage                 # Stage changes (same scope as commit) without committing
+camp stage --include-refs  # Also stage submodule ref updates at campaign root
 camp commit                # Commit changes in the campaign root
 camp log                   # Show git log of the campaign
 camp push                  # Push campaign changes to remote

--- a/cmd/camp/project/stage.go
+++ b/cmd/camp/project/stage.go
@@ -87,18 +87,17 @@ func runProjectStage(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "failed to stage")
 	}
 
-	cmdutil.ShowStagedSummary(ctx, resolvedPath)
-
-	hasChanges, err := executor.HasChanges(ctx)
+	staged, err := git.HasStagedChanges(ctx, resolvedPath)
 	if err != nil {
 		return err
 	}
-	if !hasChanges {
+	if !staged {
 		fmt.Println(ui.Success("Nothing to stage in project"))
 		return nil
 	}
 
+	cmdutil.ShowStagedSummary(ctx, resolvedPath)
 	fmt.Println(ui.Success("✓ Project changes staged"))
-	fmt.Println(ui.Dim("Run 'git commit' inside the project or 'camp p commit --amend' to record them."))
+	fmt.Println(ui.Dim("Run 'camp p commit' to record them."))
 	return nil
 }

--- a/cmd/camp/project/stage.go
+++ b/cmd/camp/project/stage.go
@@ -98,6 +98,10 @@ func runProjectStage(cmd *cobra.Command, args []string) error {
 
 	cmdutil.ShowStagedSummary(ctx, resolvedPath)
 	fmt.Println(ui.Success("✓ Project changes staged"))
-	fmt.Println(ui.Dim("Run 'camp p commit' to record them."))
+	hint := "camp p commit"
+	if projectStageProject != "" {
+		hint = "camp p commit --project " + projectStageProject
+	}
+	fmt.Println(ui.Dim(fmt.Sprintf("Run '%s' to record them.", hint)))
 	return nil
 }

--- a/cmd/camp/project/stage.go
+++ b/cmd/camp/project/stage.go
@@ -1,0 +1,104 @@
+package project
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git"
+	projectsvc "github.com/Obedience-Corp/camp/internal/project"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var projectStageCmd = &cobra.Command{
+	Use:   "stage",
+	Short: "Stage changes in a project submodule",
+	Long: `Stage changes within a project submodule without committing.
+
+Runs the same auto-staging logic as 'camp project commit' (including
+stale lock file cleanup) but stops before creating a commit, so you can
+use a different commit strategy.
+
+Auto-detects the current project from your working directory,
+or use --project to specify a project by name.
+
+Examples:
+  # From within a project directory
+  cd projects/my-api
+  camp project stage
+
+  # Specify project by name
+  camp project stage --project my-api`,
+	RunE: runProjectStage,
+}
+
+var projectStageProject string
+
+func init() {
+	projectStageCmd.Flags().StringVarP(&projectStageProject, "project", "p", "", "Project name (auto-detected from cwd if not specified)")
+
+	if err := projectStageCmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjectName); err != nil {
+		panic(err)
+	}
+
+	Cmd.AddCommand(projectStageCmd)
+}
+
+func runProjectStage(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	campRoot, err := campaign.DetectCached(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign")
+	}
+
+	result, err := projectsvc.Resolve(ctx, campRoot, projectStageProject)
+	if err != nil {
+		var notFound *projectsvc.ProjectNotFoundError
+		if errors.As(err, &notFound) {
+			fmt.Println(ui.Dim("\n" + projectsvc.FormatProjectList(notFound.AvailableProjects())))
+		}
+		return err
+	}
+
+	resolvedPath := result.Path
+
+	if err := result.RequireGit("git staging"); err != nil {
+		return err
+	}
+
+	relPath := result.LogicalPath
+	if relPath == "" {
+		relPath, _ = filepath.Rel(campRoot, resolvedPath)
+	}
+	fmt.Printf("Project: %s\n", ui.Value(relPath))
+
+	executor, err := git.NewExecutor(resolvedPath)
+	if err != nil {
+		return camperrors.Wrap(err, "failed to initialize git")
+	}
+
+	fmt.Println(ui.Info("Staging changes..."))
+	if err := executor.StageAll(ctx); err != nil {
+		return camperrors.Wrap(err, "failed to stage")
+	}
+
+	cmdutil.ShowStagedSummary(ctx, resolvedPath)
+
+	hasChanges, err := executor.HasChanges(ctx)
+	if err != nil {
+		return err
+	}
+	if !hasChanges {
+		fmt.Println(ui.Success("Nothing to stage in project"))
+		return nil
+	}
+
+	fmt.Println(ui.Success("✓ Project changes staged"))
+	fmt.Println(ui.Dim("Run 'git commit' inside the project or 'camp p commit --amend' to record them."))
+	return nil
+}

--- a/cmd/camp/root_registration_test.go
+++ b/cmd/camp/root_registration_test.go
@@ -125,6 +125,24 @@ func TestRefsSyncRootUsesMainHandler(t *testing.T) {
 	}
 }
 
+func TestStageCommandsRegistered(t *testing.T) {
+	if findChildByName(rootCmd, "stage") == nil {
+		t.Fatal("root command does not register 'stage' subcommand")
+	}
+	if findChildByName(projectpkg.Cmd, "stage") == nil {
+		t.Fatal("project command does not register 'stage' subcommand")
+	}
+}
+
+func findChildByName(parent *cobra.Command, name string) *cobra.Command {
+	for _, child := range parent.Commands() {
+		if child.Name() == name {
+			return child
+		}
+	}
+	return nil
+}
+
 func hasCommandPointer(parent *cobra.Command, want *cobra.Command) bool {
 	for _, child := range parent.Commands() {
 		if child == want {

--- a/cmd/camp/stage.go
+++ b/cmd/camp/stage.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git"
+	"github.com/Obedience-Corp/camp/internal/ui"
+
+	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+var stageCmd = &cobra.Command{
+	Use:   "stage",
+	Short: "Stage changes in the campaign root",
+	Long: `Stage changes in the campaign root directory without committing.
+
+Runs the same auto-staging logic as 'camp commit' (including stale lock
+file cleanup) but stops before creating a commit, so you can use a
+different commit strategy (interactive 'git commit --patch', a GUI
+client, signing flow, etc.).
+
+At the campaign root, submodule ref changes (projects/*) are excluded
+from staging by default to prevent accidental ref conflicts across
+machines. Use --include-refs to stage them explicitly.
+
+Use --sub to stage in the submodule detected from your current directory.
+Use -p/--project to stage in a specific project (e.g., -p projects/camp).
+
+Examples:
+  camp stage
+  camp stage --include-refs
+  camp stage --sub
+  camp stage -p projects/camp`,
+	RunE: runStage,
+}
+
+var (
+	stageSub         bool
+	stageProject     string
+	stageIncludeRefs bool
+)
+
+func init() {
+	stageCmd.Flags().BoolVar(&stageSub, "sub", false, "Operate on the submodule detected from current directory")
+	stageCmd.Flags().StringVarP(&stageProject, "project", "p", "", "Operate on a specific project/submodule path")
+	stageCmd.Flags().BoolVar(&stageIncludeRefs, "include-refs", false, "Include submodule ref changes when staging at campaign root")
+
+	rootCmd.AddCommand(stageCmd)
+	stageCmd.GroupID = "git"
+
+	if err := stageCmd.RegisterFlagCompletionFunc("project", completeProjectFlag); err != nil {
+		panic(err)
+	}
+}
+
+func runStage(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	campRoot, err := campaign.DetectCached(ctx)
+	if err != nil {
+		return err
+	}
+
+	target, err := git.ResolveTarget(ctx, campRoot, stageSub, stageProject)
+	if err != nil {
+		return camperrors.Wrap(err, "failed to resolve target")
+	}
+
+	if target.IsSubmodule {
+		fmt.Println(ui.Info(fmt.Sprintf("Operating on submodule: %s", target.Name)))
+	}
+
+	executor, err := git.NewExecutor(target.Path)
+	if err != nil {
+		return camperrors.Wrap(err, "failed to initialize git")
+	}
+
+	fmt.Println(ui.Info("Staging changes..."))
+	if target.IsSubmodule || stageIncludeRefs {
+		if err := executor.StageAll(ctx); err != nil {
+			return err
+		}
+	} else {
+		paths, pathErr := git.ListSubmodulePaths(ctx, target.Path)
+		if pathErr != nil {
+			return pathErr
+		}
+		if err := git.StageAllExcluding(ctx, target.Path, paths); err != nil {
+			return err
+		}
+	}
+
+	cmdutil.ShowStagedSummary(ctx, target.Path)
+
+	hasChanges, err := executor.HasChanges(ctx)
+	if err != nil {
+		return err
+	}
+	if !hasChanges {
+		fmt.Println(ui.Success("Nothing to stage, working tree clean"))
+		return nil
+	}
+
+	fmt.Println(ui.Success("Changes staged"))
+	fmt.Println(ui.Dim("Run 'git commit' or 'camp commit --amend' to record them."))
+	return nil
+}

--- a/cmd/camp/stage.go
+++ b/cmd/camp/stage.go
@@ -83,11 +83,8 @@ func runStage(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println(ui.Info("Staging changes..."))
-	if target.IsSubmodule || stageIncludeRefs {
-		if err := executor.StageAll(ctx); err != nil {
-			return err
-		}
-	} else {
+	refsExcluded := !target.IsSubmodule && !stageIncludeRefs
+	if refsExcluded {
 		paths, pathErr := git.ListSubmodulePaths(ctx, target.Path)
 		if pathErr != nil {
 			return pathErr
@@ -95,20 +92,33 @@ func runStage(cmd *cobra.Command, args []string) error {
 		if err := git.StageAllExcluding(ctx, target.Path, paths); err != nil {
 			return err
 		}
+	} else {
+		if err := executor.StageAll(ctx); err != nil {
+			return err
+		}
 	}
 
-	cmdutil.ShowStagedSummary(ctx, target.Path)
-
-	hasChanges, err := executor.HasChanges(ctx)
+	staged, err := git.HasStagedChanges(ctx, target.Path)
 	if err != nil {
 		return err
 	}
-	if !hasChanges {
+	if !staged {
+		if refsExcluded {
+			hasAny, hErr := executor.HasChanges(ctx)
+			if hErr != nil {
+				return hErr
+			}
+			if hasAny {
+				fmt.Println(ui.Success("Nothing staged. Submodule ref changes were excluded; rerun with --include-refs to stage them."))
+				return nil
+			}
+		}
 		fmt.Println(ui.Success("Nothing to stage, working tree clean"))
 		return nil
 	}
 
+	cmdutil.ShowStagedSummary(ctx, target.Path)
 	fmt.Println(ui.Success("Changes staged"))
-	fmt.Println(ui.Dim("Run 'git commit' or 'camp commit --amend' to record them."))
+	fmt.Println(ui.Dim("Run 'camp commit' to record them."))
 	return nil
 }

--- a/cmd/camp/stage.go
+++ b/cmd/camp/stage.go
@@ -119,6 +119,17 @@ func runStage(cmd *cobra.Command, args []string) error {
 
 	cmdutil.ShowStagedSummary(ctx, target.Path)
 	fmt.Println(ui.Success("Changes staged"))
-	fmt.Println(ui.Dim("Run 'camp commit' to record them."))
+	fmt.Println(ui.Dim(fmt.Sprintf("Run '%s' to record them.", commitHintForStage())))
 	return nil
+}
+
+func commitHintForStage() string {
+	switch {
+	case stageProject != "":
+		return "camp commit -p " + stageProject
+	case stageSub:
+		return "camp commit --sub"
+	default:
+		return "camp commit"
+	}
 }

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -3271,6 +3271,49 @@ camp project run [--project <name>] [--] <command> [args...] [flags]
 ```
 ---
 
+## camp project stage
+
+Stage changes in a project submodule
+
+### Synopsis
+
+Stage changes within a project submodule without committing.
+
+Runs the same auto-staging logic as 'camp project commit' (including
+stale lock file cleanup) but stops before creating a commit, so you can
+use a different commit strategy.
+
+Auto-detects the current project from your working directory,
+or use --project to specify a project by name.
+
+Examples:
+  # From within a project directory
+  cd projects/my-api
+  camp project stage
+
+  # Specify project by name
+  camp project stage --project my-api
+
+```
+camp project stage [flags]
+```
+
+### Options
+
+```
+  -h, --help             help for stage
+  -p, --project string   Project name (auto-detected from cwd if not specified)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
 ## camp project unlink
 
 Unlink a linked project from a campaign
@@ -4520,6 +4563,54 @@ camp skills unlink [flags]
   -h, --help          help for unlink
   -p, --path string   Custom destination directory to unlink
   -t, --tool string   Tool to unlink: claude, agents
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp stage
+
+Stage changes in the campaign root
+
+### Synopsis
+
+Stage changes in the campaign root directory without committing.
+
+Runs the same auto-staging logic as 'camp commit' (including stale lock
+file cleanup) but stops before creating a commit, so you can use a
+different commit strategy (interactive 'git commit --patch', a GUI
+client, signing flow, etc.).
+
+At the campaign root, submodule ref changes (projects/*) are excluded
+from staging by default to prevent accidental ref conflicts across
+machines. Use --include-refs to stage them explicitly.
+
+Use --sub to stage in the submodule detected from your current directory.
+Use -p/--project to stage in a specific project (e.g., -p projects/camp).
+
+Examples:
+  camp stage
+  camp stage --include-refs
+  camp stage --sub
+  camp stage -p projects/camp
+
+```
+camp stage [flags]
+```
+
+### Options
+
+```
+  -h, --help             help for stage
+      --include-refs     Include submodule ref changes when staging at campaign root
+  -p, --project string   Operate on a specific project/submodule path
+      --sub              Operate on the submodule detected from current directory
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp.md
+++ b/docs/cli-reference/camp.md
@@ -80,6 +80,7 @@ camp [flags]
 * [camp shell-init](camp_shell-init.md)	 - Output shell initialization code
 * [camp shortcuts](camp_shortcuts.md)	 - List all available shortcuts
 * [camp skills](camp_skills.md)	 - Manage campaign skill directory links
+* [camp stage](camp_stage.md)	 - Stage changes in the campaign root
 * [camp status](camp_status.md)	 - Show git status of the campaign
 * [camp switch](camp_switch.md)	 - Switch to a different campaign
 * [camp sync](camp_sync.md)	 - Safely synchronize submodules

--- a/docs/cli-reference/camp_project.md
+++ b/docs/cli-reference/camp_project.md
@@ -49,5 +49,6 @@ camp project [flags]
 * [camp project remote](camp_project_remote.md)	 - Manage remotes for a project
 * [camp project remove](camp_project_remove.md)	 - Remove a project from campaign
 * [camp project run](camp_project_run.md)	 - Run a command inside a project directory
+* [camp project stage](camp_project_stage.md)	 - Stage changes in a project submodule
 * [camp project unlink](camp_project_unlink.md)	 - Unlink a linked project from a campaign
 * [camp project worktree](camp_project_worktree.md)	 - Manage worktrees for a project

--- a/docs/cli-reference/camp_project_stage.md
+++ b/docs/cli-reference/camp_project_stage.md
@@ -1,0 +1,45 @@
+## camp project stage
+
+Stage changes in a project submodule
+
+### Synopsis
+
+Stage changes within a project submodule without committing.
+
+Runs the same auto-staging logic as 'camp project commit' (including
+stale lock file cleanup) but stops before creating a commit, so you can
+use a different commit strategy.
+
+Auto-detects the current project from your working directory,
+or use --project to specify a project by name.
+
+Examples:
+  # From within a project directory
+  cd projects/my-api
+  camp project stage
+
+  # Specify project by name
+  camp project stage --project my-api
+
+```
+camp project stage [flags]
+```
+
+### Options
+
+```
+  -h, --help             help for stage
+  -p, --project string   Project name (auto-detected from cwd if not specified)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp project](camp_project.md)	 - Manage campaign projects

--- a/docs/cli-reference/camp_stage.md
+++ b/docs/cli-reference/camp_stage.md
@@ -1,0 +1,50 @@
+## camp stage
+
+Stage changes in the campaign root
+
+### Synopsis
+
+Stage changes in the campaign root directory without committing.
+
+Runs the same auto-staging logic as 'camp commit' (including stale lock
+file cleanup) but stops before creating a commit, so you can use a
+different commit strategy (interactive 'git commit --patch', a GUI
+client, signing flow, etc.).
+
+At the campaign root, submodule ref changes (projects/*) are excluded
+from staging by default to prevent accidental ref conflicts across
+machines. Use --include-refs to stage them explicitly.
+
+Use --sub to stage in the submodule detected from your current directory.
+Use -p/--project to stage in a specific project (e.g., -p projects/camp).
+
+Examples:
+  camp stage
+  camp stage --include-refs
+  camp stage --sub
+  camp stage -p projects/camp
+
+```
+camp stage [flags]
+```
+
+### Options
+
+```
+  -h, --help             help for stage
+      --include-refs     Include submodule ref changes when staging at campaign root
+  -p, --project string   Operate on a specific project/submodule path
+      --sub              Operate on the submodule detected from current directory
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces

--- a/tests/integration/stage_test.go
+++ b/tests/integration/stage_test.go
@@ -81,6 +81,39 @@ func TestStage_Root_ExcludesSubmoduleRefs(t *testing.T) {
 		"submodule ref should NOT be staged at campaign root by default")
 }
 
+func TestStage_Root_OnlyExcludedRefs_ReportsNothingStaged(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaignPath := "/campaigns/stage-only-refs"
+	subPath := "/test/stage-only-refs-sub"
+
+	_, err := tc.InitCampaign(campaignPath, "stage-only-refs", "product")
+	require.NoError(t, err)
+	require.NoError(t, tc.CreateGitRepo(subPath))
+
+	tc.Shell(t, fmt.Sprintf(
+		"cd %s && git -c protocol.file.allow=always submodule add %s projects/sub && "+
+			"git commit -m 'add submodule'",
+		campaignPath, subPath,
+	))
+
+	tc.Shell(t, fmt.Sprintf(
+		"cd %s/projects/sub && echo local > local.txt && git add local.txt && "+
+			"git commit -m 'sub local change'",
+		campaignPath,
+	))
+
+	output, err := tc.RunCampInDir(campaignPath, "stage")
+	require.NoError(t, err)
+	assert.NotContains(t, output, "Changes staged",
+		"with only excluded submodule refs dirty, output must NOT claim changes were staged")
+	assert.Contains(t, output, "--include-refs",
+		"output should point users at --include-refs when refs are the only pending change")
+
+	staged := tc.GitOutput(t, campaignPath, "diff", "--cached", "--name-only")
+	assert.Empty(t, strings.TrimSpace(staged),
+		"index should remain empty when only excluded submodule refs are dirty")
+}
+
 func TestStage_Root_IncludeRefs(t *testing.T) {
 	tc := GetSharedContainer(t)
 	campaignPath := "/campaigns/stage-include-refs"

--- a/tests/integration/stage_test.go
+++ b/tests/integration/stage_test.go
@@ -25,9 +25,61 @@ func TestStage_Root_BasicFile(t *testing.T) {
 	require.NoError(t, err, "camp stage should succeed")
 	assert.Contains(t, output, "Staging changes")
 	assert.Contains(t, output, "Changes staged")
+	assert.Contains(t, output, "Run 'camp commit'",
+		"root stage with no --sub/-p should suggest plain 'camp commit'")
+	assert.NotContains(t, output, "camp commit --sub")
+	assert.NotContains(t, output, "camp commit -p")
 
 	staged := tc.GitOutput(t, campaignPath, "diff", "--cached", "--name-only")
 	assert.Contains(t, staged, "notes.md", "notes.md should be staged")
+}
+
+func TestStage_Root_WithProjectFlag_HintMatches(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaignPath := "/campaigns/stage-root-p-flag"
+	subPath := "/test/stage-root-p-flag-sub"
+
+	_, err := tc.InitCampaign(campaignPath, "stage-root-p-flag", "product")
+	require.NoError(t, err)
+	require.NoError(t, tc.CreateGitRepo(subPath))
+
+	tc.Shell(t, fmt.Sprintf(
+		"cd %s && git -c protocol.file.allow=always submodule add %s projects/sub && "+
+			"git commit -m 'add submodule'",
+		campaignPath, subPath,
+	))
+
+	require.NoError(t, tc.WriteFile(campaignPath+"/projects/sub/note.md", "via -p"))
+
+	output, err := tc.RunCampInDir(campaignPath, "stage", "-p", "projects/sub")
+	require.NoError(t, err)
+	assert.Contains(t, output, "Changes staged")
+	assert.Contains(t, output, "camp commit -p projects/sub",
+		"hint must include -p flag so the suggested commit targets the same project")
+}
+
+func TestStage_Sub_HintMatches(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaignPath := "/campaigns/stage-sub-hint"
+	subPath := "/test/stage-sub-hint-sub"
+
+	_, err := tc.InitCampaign(campaignPath, "stage-sub-hint", "product")
+	require.NoError(t, err)
+	require.NoError(t, tc.CreateGitRepo(subPath))
+
+	tc.Shell(t, fmt.Sprintf(
+		"cd %s && git -c protocol.file.allow=always submodule add %s projects/sub && "+
+			"git commit -m 'add submodule'",
+		campaignPath, subPath,
+	))
+
+	require.NoError(t, tc.WriteFile(campaignPath+"/projects/sub/note.md", "via --sub"))
+
+	output, err := tc.RunCampInDir(campaignPath+"/projects/sub", "stage", "--sub")
+	require.NoError(t, err)
+	assert.Contains(t, output, "Changes staged")
+	assert.Contains(t, output, "camp commit --sub",
+		"hint must include --sub so suggested commit targets the same submodule")
 }
 
 func TestStage_Root_NothingToStage(t *testing.T) {
@@ -164,6 +216,9 @@ func TestStage_Project_FromInsideProject(t *testing.T) {
 	output, err := tc.RunCampInDir(campaignPath+"/projects/sub", "project", "stage")
 	require.NoError(t, err, "camp project stage from inside project should succeed")
 	assert.Contains(t, output, "Project changes staged")
+	assert.Contains(t, output, "Run 'camp p commit'",
+		"auto-detected project stage should suggest plain 'camp p commit'")
+	assert.NotContains(t, output, "camp p commit --project")
 
 	staged := tc.GitOutput(t, campaignPath+"/projects/sub", "diff", "--cached", "--name-only")
 	assert.Contains(t, staged, "feature.md")
@@ -193,6 +248,8 @@ func TestStage_Project_WithProjectFlag(t *testing.T) {
 	output, err := tc.RunCampInDir(campaignPath, "project", "stage", "--project", "sub")
 	require.NoError(t, err)
 	assert.Contains(t, output, "Project changes staged")
+	assert.Contains(t, output, "camp p commit --project sub",
+		"when --project was used, hint must include --project so suggested commit hits the same project")
 
 	staged := tc.GitOutput(t, campaignPath+"/projects/sub", "diff", "--cached", "--name-only")
 	assert.Contains(t, staged, "feature.md")

--- a/tests/integration/stage_test.go
+++ b/tests/integration/stage_test.go
@@ -1,0 +1,193 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStage_Root_BasicFile(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaignPath := "/campaigns/stage-basic"
+
+	_, err := tc.InitCampaign(campaignPath, "stage-basic", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(campaignPath+"/notes.md", "hello"))
+
+	output, err := tc.RunCampInDir(campaignPath, "stage")
+	require.NoError(t, err, "camp stage should succeed")
+	assert.Contains(t, output, "Staging changes")
+	assert.Contains(t, output, "Changes staged")
+
+	staged := tc.GitOutput(t, campaignPath, "diff", "--cached", "--name-only")
+	assert.Contains(t, staged, "notes.md", "notes.md should be staged")
+}
+
+func TestStage_Root_NothingToStage(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaignPath := "/campaigns/stage-empty"
+
+	_, err := tc.InitCampaign(campaignPath, "stage-empty", "product")
+	require.NoError(t, err)
+
+	output, err := tc.RunCampInDir(campaignPath, "stage")
+	require.NoError(t, err)
+	assert.Contains(t, output, "Nothing to stage")
+}
+
+func TestStage_Root_ExcludesSubmoduleRefs(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaignPath := "/campaigns/stage-ref-excl"
+	subPath := "/test/stage-sub-repo"
+
+	_, err := tc.InitCampaign(campaignPath, "stage-ref-excl", "product")
+	require.NoError(t, err)
+	require.NoError(t, tc.CreateGitRepo(subPath))
+
+	tc.Shell(t, fmt.Sprintf(
+		"cd %s && git -c protocol.file.allow=always submodule add %s projects/sub && "+
+			"git commit -m 'add submodule'",
+		campaignPath, subPath,
+	))
+
+	tc.Shell(t, fmt.Sprintf(
+		"cd %s && echo bump > bump.txt && git add bump.txt && "+
+			"git commit -m 'sub bump' && "+
+			"cd %s/projects/sub && git fetch origin && git reset --hard origin/HEAD || true",
+		subPath, campaignPath,
+	))
+	tc.Shell(t, fmt.Sprintf(
+		"cd %s/projects/sub && echo local > local.txt && git add local.txt && "+
+			"git commit -m 'sub local change'",
+		campaignPath,
+	))
+
+	require.NoError(t, tc.WriteFile(campaignPath+"/root-note.md", "root content"))
+
+	output, err := tc.RunCampInDir(campaignPath, "stage")
+	require.NoError(t, err)
+	assert.Contains(t, output, "Changes staged")
+
+	staged := tc.GitOutput(t, campaignPath, "diff", "--cached", "--name-only")
+	assert.Contains(t, staged, "root-note.md", "root file should be staged")
+	assert.NotContains(t, staged, "projects/sub",
+		"submodule ref should NOT be staged at campaign root by default")
+}
+
+func TestStage_Root_IncludeRefs(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaignPath := "/campaigns/stage-include-refs"
+	subPath := "/test/stage-include-sub"
+
+	_, err := tc.InitCampaign(campaignPath, "stage-include-refs", "product")
+	require.NoError(t, err)
+	require.NoError(t, tc.CreateGitRepo(subPath))
+
+	tc.Shell(t, fmt.Sprintf(
+		"cd %s && git -c protocol.file.allow=always submodule add %s projects/sub && "+
+			"git commit -m 'add submodule'",
+		campaignPath, subPath,
+	))
+
+	tc.Shell(t, fmt.Sprintf(
+		"cd %s/projects/sub && echo local > local.txt && git add local.txt && "+
+			"git commit -m 'sub local change'",
+		campaignPath,
+	))
+
+	output, err := tc.RunCampInDir(campaignPath, "stage", "--include-refs")
+	require.NoError(t, err)
+	assert.Contains(t, output, "Changes staged")
+
+	staged := tc.GitOutput(t, campaignPath, "diff", "--cached", "--name-only")
+	assert.Contains(t, staged, "projects/sub",
+		"submodule ref should be staged with --include-refs")
+}
+
+func TestStage_Project_FromInsideProject(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaignPath := "/campaigns/stage-proj"
+	subPath := "/test/stage-proj-sub"
+
+	_, err := tc.InitCampaign(campaignPath, "stage-proj", "product")
+	require.NoError(t, err)
+	require.NoError(t, tc.CreateGitRepo(subPath))
+
+	tc.Shell(t, fmt.Sprintf(
+		"cd %s && git -c protocol.file.allow=always submodule add %s projects/sub && "+
+			"git commit -m 'add submodule'",
+		campaignPath, subPath,
+	))
+
+	require.NoError(t, tc.WriteFile(campaignPath+"/projects/sub/feature.md", "feature"))
+
+	output, err := tc.RunCampInDir(campaignPath+"/projects/sub", "project", "stage")
+	require.NoError(t, err, "camp project stage from inside project should succeed")
+	assert.Contains(t, output, "Project changes staged")
+
+	staged := tc.GitOutput(t, campaignPath+"/projects/sub", "diff", "--cached", "--name-only")
+	assert.Contains(t, staged, "feature.md")
+
+	rootStaged := tc.GitOutput(t, campaignPath, "diff", "--cached", "--name-only")
+	assert.NotContains(t, rootStaged, "projects/sub",
+		"campaign root should not have submodule ref staged by project stage")
+}
+
+func TestStage_Project_WithProjectFlag(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaignPath := "/campaigns/stage-proj-flag"
+	subPath := "/test/stage-proj-flag-sub"
+
+	_, err := tc.InitCampaign(campaignPath, "stage-proj-flag", "product")
+	require.NoError(t, err)
+	require.NoError(t, tc.CreateGitRepo(subPath))
+
+	tc.Shell(t, fmt.Sprintf(
+		"cd %s && git -c protocol.file.allow=always submodule add %s projects/sub && "+
+			"git commit -m 'add submodule'",
+		campaignPath, subPath,
+	))
+
+	require.NoError(t, tc.WriteFile(campaignPath+"/projects/sub/feature.md", "feature"))
+
+	output, err := tc.RunCampInDir(campaignPath, "project", "stage", "--project", "sub")
+	require.NoError(t, err)
+	assert.Contains(t, output, "Project changes staged")
+
+	staged := tc.GitOutput(t, campaignPath+"/projects/sub", "diff", "--cached", "--name-only")
+	assert.Contains(t, staged, "feature.md")
+}
+
+func TestStage_Root_StaleLockRecovery(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaignPath := "/campaigns/stage-stale-lock"
+
+	_, err := tc.InitCampaign(campaignPath, "stage-stale-lock", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(campaignPath+"/note.md", "stale-lock content"))
+
+	tc.Shell(t, fmt.Sprintf(
+		"touch -d '5 minutes ago' %s/.git/index.lock 2>/dev/null || "+
+			"touch -t 197001010001 %s/.git/index.lock",
+		campaignPath, campaignPath,
+	))
+
+	output, err := tc.RunCampInDir(campaignPath, "stage")
+	require.NoError(t, err, "camp stage should recover from a stale lock")
+	assert.Contains(t, output, "Changes staged")
+
+	exists, err := tc.CheckFileExists(campaignPath + "/.git/index.lock")
+	require.NoError(t, err)
+	assert.False(t, exists, "stale index.lock should be removed by retry logic")
+
+	staged := tc.GitOutput(t, campaignPath, "diff", "--cached", "--name-only")
+	assert.Contains(t, strings.TrimSpace(staged), "note.md")
+}


### PR DESCRIPTION
## Summary

- Adds `camp stage` — runs the same auto-staging as `camp commit` (ref-sync exclusion at campaign root, stale lock retry) but stops before the commit step
- Adds `camp project stage` (aliased `camp p stage`) — same auto-staging as `camp p commit` for project submodules
- Regenerated CLI reference docs and updated README

## Why

Users sometimes want camp's correct staging scope and lock handling but a different commit strategy: interactive `git commit --patch`, a GUI client, signed commits, amend workflows, etc. Exposing stage as a standalone command unblocks that without touching existing commit behavior.

No changes to existing commands or to the staging primitives in `internal/git/`. The new commands reuse `git.StageAll`, `git.StageAllExcluding`, and `git.ListSubmodulePaths` directly.

## Test plan

- [x] \`just build-camp\` succeeds
- [x] \`just test unit\` passes (2320/2320)
- [x] \`just lint\` clean on new files
- [x] Integration suite \`TestStage*\` passes (7/7) in containerized harness covering:
  - root stage of a plain file
  - nothing-to-stage on a clean tree
  - submodule ref exclusion at campaign root (default)
  - \`--include-refs\` stages the submodule ref
  - project stage from inside the project dir
  - project stage with \`--project\` from campaign root
  - stale \`.git/index.lock\` recovery
- [x] Manual smoke: \`camp stage\`, \`camp stage --include-refs\`, \`camp p stage\` in a scratch campaign with a real submodule

## Out of scope

- No shared helper extracted between commit and stage handlers. The duplication is ~15 lines per command and the two paths may legitimately diverge later (e.g. project stage could grow its own sync semantics). Revisit if a third caller appears.