### PR TITLE
Add commit message auto-write hook

### DIFF
--- a/cmd/camp/autowrite_alias.go
+++ b/cmd/camp/autowrite_alias.go
@@ -1,0 +1,14 @@
+package main
+
+// normalizeAutoWriteAlias rewrites the exact -aw token before cobra parses
+// flags. Cobra/pflag only supports single-character shorthand flags.
+func normalizeAutoWriteAlias(args []string) []string {
+	out := make([]string, len(args))
+	copy(out, args)
+	for i, arg := range out {
+		if arg == "-aw" {
+			out[i] = "--auto-write"
+		}
+	}
+	return out
+}

--- a/cmd/camp/autowrite_alias_test.go
+++ b/cmd/camp/autowrite_alias_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeAutoWriteAlias(t *testing.T) {
+	got := normalizeAutoWriteAlias([]string{"camp", "p", "commit", "-aw", "-m", "msg", "-aw=false"})
+	want := []string{"camp", "p", "commit", "--auto-write", "-m", "msg", "-aw=false"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizeAutoWriteAlias() = %#v, want %#v", got, want)
+	}
+}

--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/git"
 	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
 	"github.com/spf13/cobra"
 )
 
@@ -46,15 +47,17 @@ var (
 	commitSub         bool
 	commitProject     string
 	commitIncludeRefs bool
+	commitAutoWrite   bool
 )
 
 func init() {
-	commitCmd.Flags().StringVarP(&commitMessage, "message", "m", "", "Commit message (required)")
+	commitCmd.Flags().StringVarP(&commitMessage, "message", "m", "", "Commit message (required unless --auto-write)")
 	commitCmd.Flags().BoolVarP(&commitAll, "all", "a", true, "Stage all changes before committing")
 	commitCmd.Flags().BoolVar(&commitAmend, "amend", false, "Amend the previous commit")
 	commitCmd.Flags().BoolVar(&commitSub, "sub", false, "Operate on the submodule detected from current directory")
 	commitCmd.Flags().StringVarP(&commitProject, "project", "p", "", "Operate on a specific project/submodule path")
 	commitCmd.Flags().BoolVar(&commitIncludeRefs, "include-refs", false, "Include submodule ref changes when staging at campaign root")
+	commitCmd.Flags().BoolVar(&commitAutoWrite, "auto-write", false, "Run configured commit message writer")
 
 	rootCmd.AddCommand(commitCmd)
 	commitCmd.GroupID = "git"
@@ -105,6 +108,10 @@ func runCommit(cmd *cobra.Command, args []string) error {
 		fmt.Println(ui.Info(fmt.Sprintf("Operating on submodule: %s", target.Name)))
 	}
 
+	if commitAutoWrite && commitMessage != "" {
+		return fmt.Errorf("--auto-write cannot be used with --message")
+	}
+
 	// Create executor
 	executor, err := git.NewExecutor(target.Path)
 	if err != nil {
@@ -113,7 +120,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 
 	// Get commit message - prompt if not provided
 	message := commitMessage
-	if message == "" && !commitAmend {
+	if !commitAutoWrite && message == "" && !commitAmend {
 		var promptErr error
 		message, promptErr = ui.PromptCommitMessageSimple(ctx, executor, !target.IsSubmodule && !commitIncludeRefs)
 		if promptErr != nil {
@@ -155,6 +162,15 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	if !hasChanges && !commitAmend {
 		fmt.Println(ui.Success("Nothing to commit, working tree clean"))
 		return nil
+	}
+
+	if commitAutoWrite {
+		fmt.Println(ui.Info("Writing commit message..."))
+		var hookErr error
+		message, hookErr = commitkit.AutoWriteCommitMessage(ctx, campRoot, target.Path)
+		if hookErr != nil {
+			return hookErr
+		}
 	}
 
 	// Prepend campaign tag (graceful degradation if config unavailable)

--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/git"
 	projectsvc "github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
 	"github.com/spf13/cobra"
 )
 
@@ -35,19 +36,21 @@ Examples:
 }
 
 var (
-	projectCommitProject string
-	projectCommitMessage string
-	projectCommitAll     bool
-	projectCommitAmend   bool
-	projectCommitSync    bool
+	projectCommitProject   string
+	projectCommitMessage   string
+	projectCommitAll       bool
+	projectCommitAmend     bool
+	projectCommitSync      bool
+	projectCommitAutoWrite bool
 )
 
 func init() {
 	projectCommitCmd.Flags().StringVarP(&projectCommitProject, "project", "p", "", "Project name (auto-detected from cwd if not specified)")
-	projectCommitCmd.Flags().StringVarP(&projectCommitMessage, "message", "m", "", "Commit message (required)")
+	projectCommitCmd.Flags().StringVarP(&projectCommitMessage, "message", "m", "", "Commit message (required unless --auto-write)")
 	projectCommitCmd.Flags().BoolVarP(&projectCommitAll, "all", "a", true, "Stage all changes")
 	projectCommitCmd.Flags().BoolVar(&projectCommitAmend, "amend", false, "Amend the previous commit")
 	projectCommitCmd.Flags().BoolVar(&projectCommitSync, "sync", false, "Sync submodule ref at campaign root after commit (opt-in)")
+	projectCommitCmd.Flags().BoolVar(&projectCommitAutoWrite, "auto-write", false, "Run configured commit message writer")
 
 	if err := projectCommitCmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjectName); err != nil {
 		panic(err)
@@ -94,9 +97,13 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "failed to initialize git")
 	}
 
+	if projectCommitAutoWrite && projectCommitMessage != "" {
+		return fmt.Errorf("--auto-write cannot be used with --message")
+	}
+
 	// Get commit message - prompt if not provided
 	message := projectCommitMessage
-	if message == "" && !projectCommitAmend {
+	if !projectCommitAutoWrite && message == "" && !projectCommitAmend {
 		var promptErr error
 		message, promptErr = ui.PromptCommitMessageSimple(ctx, executor, false)
 		if promptErr != nil {
@@ -130,6 +137,15 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 
 	// Load campaign config (used for tag and parent sync)
 	cfg, _ := config.LoadCampaignConfig(ctx, campRoot)
+
+	if projectCommitAutoWrite {
+		fmt.Println(ui.Info("Writing commit message..."))
+		var hookErr error
+		message, hookErr = commitkit.AutoWriteCommitMessage(ctx, campRoot, resolvedPath)
+		if hookErr != nil {
+			return hookErr
+		}
+	}
 
 	// Prepend campaign tag (graceful degradation if config unavailable)
 	if cfg != nil {

--- a/cmd/camp/root.go
+++ b/cmd/camp/root.go
@@ -56,6 +56,8 @@ var rootCmd = &cobra.Command{
 
 // Execute runs the root command
 func Execute() error {
+	os.Args = normalizeAutoWriteAlias(os.Args)
+
 	// Expand shortcuts before command execution
 	expandShortcuts()
 

--- a/cmd/camp/worktrees/commit.go
+++ b/cmd/camp/worktrees/commit.go
@@ -13,13 +13,15 @@ import (
 	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/Obedience-Corp/camp/internal/worktree"
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
 	"github.com/spf13/cobra"
 )
 
 var (
-	wtCommitMessage string
-	wtCommitAll     bool
-	wtCommitAmend   bool
+	wtCommitMessage   string
+	wtCommitAll       bool
+	wtCommitAmend     bool
+	wtCommitAutoWrite bool
 )
 
 var worktreesCommitCmd = &cobra.Command{
@@ -46,11 +48,13 @@ func init() {
 	Cmd.AddCommand(worktreesCommitCmd)
 
 	worktreesCommitCmd.Flags().StringVarP(&wtCommitMessage, "message", "m", "",
-		"Commit message")
+		"Commit message (required unless --auto-write)")
 	worktreesCommitCmd.Flags().BoolVarP(&wtCommitAll, "all", "a", true,
 		"Stage all changes before committing")
 	worktreesCommitCmd.Flags().BoolVar(&wtCommitAmend, "amend", false,
 		"Amend the previous commit")
+	worktreesCommitCmd.Flags().BoolVar(&wtCommitAutoWrite, "auto-write", false,
+		"Run configured commit message writer")
 }
 
 func runWorktreesCommit(cmd *cobra.Command, args []string) error {
@@ -89,9 +93,13 @@ func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "failed to initialize git")
 	}
 
+	if wtCommitAutoWrite && wtCommitMessage != "" {
+		return fmt.Errorf("--auto-write cannot be used with --message")
+	}
+
 	// Get commit message - prompt if not provided
 	message := wtCommitMessage
-	if message == "" && !wtCommitAmend {
+	if !wtCommitAutoWrite && message == "" && !wtCommitAmend {
 		message, err = ui.PromptCommitMessageSimple(ctx, executor, false)
 		if err != nil {
 			return camperrors.Wrap(err, "prompt failed")
@@ -121,6 +129,14 @@ func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 
 	// Show what's staged
 	cmdutil.ShowStagedSummary(ctx, wtCtx.WorktreePath)
+
+	if wtCommitAutoWrite {
+		fmt.Println(ui.Info("Writing commit message..."))
+		message, err = commitkit.AutoWriteCommitMessage(ctx, campRoot, wtCtx.WorktreePath)
+		if err != nil {
+			return err
+		}
+	}
 
 	// Prepend campaign tag
 	message = git.PrependCampaignTag(cfg.ID, message)

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -331,9 +331,10 @@ camp commit [flags]
 ```
   -a, --all              Stage all changes before committing (default true)
       --amend            Amend the previous commit
+      --auto-write       Run configured commit message writer
   -h, --help             help for commit
       --include-refs     Include submodule ref changes when staging at campaign root
-  -m, --message string   Commit message (required)
+  -m, --message string   Commit message (required unless --auto-write)
   -p, --project string   Operate on a specific project/submodule path
       --sub              Operate on the submodule detected from current directory
 ```
@@ -2691,8 +2692,9 @@ camp project commit [flags]
 ```
   -a, --all              Stage all changes (default true)
       --amend            Amend the previous commit
+      --auto-write       Run configured commit message writer
   -h, --help             help for commit
-  -m, --message string   Commit message (required)
+  -m, --message string   Commit message (required unless --auto-write)
   -p, --project string   Project name (auto-detected from cwd if not specified)
       --sync             Sync submodule ref at campaign root after commit (opt-in)
 ```

--- a/docs/cli-reference/camp_commit.md
+++ b/docs/cli-reference/camp_commit.md
@@ -33,9 +33,10 @@ camp commit [flags]
 ```
   -a, --all              Stage all changes before committing (default true)
       --amend            Amend the previous commit
+      --auto-write       Run configured commit message writer
   -h, --help             help for commit
       --include-refs     Include submodule ref changes when staging at campaign root
-  -m, --message string   Commit message (required)
+  -m, --message string   Commit message (required unless --auto-write)
   -p, --project string   Operate on a specific project/submodule path
       --sub              Operate on the submodule detected from current directory
 ```

--- a/docs/cli-reference/camp_project_commit.md
+++ b/docs/cli-reference/camp_project_commit.md
@@ -26,8 +26,9 @@ camp project commit [flags]
 ```
   -a, --all              Stage all changes (default true)
       --amend            Amend the previous commit
+      --auto-write       Run configured commit message writer
   -h, --help             help for commit
-  -m, --message string   Commit message (required)
+  -m, --message string   Commit message (required unless --auto-write)
   -p, --project string   Project name (auto-detected from cwd if not specified)
       --sync             Sync submodule ref at campaign root after commit (opt-in)
 ```

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -36,10 +36,24 @@ type CampaignConfig struct {
 	// ConceptList defines concepts for the picker (order is preserved).
 	// If empty, concepts are derived from Paths.
 	ConceptList []ConceptEntry `yaml:"concepts,omitempty"`
+	// Hooks contains optional campaign-local command hooks.
+	Hooks HooksConfig `yaml:"hooks,omitempty"`
 
 	// Jumps holds the loaded jumps configuration (from .campaign/settings/jumps.yaml).
 	// This field is not serialized to campaign.yaml - it's loaded separately.
 	Jumps *JumpsConfig `yaml:"-"`
+}
+
+// HooksConfig contains optional campaign-local command hooks.
+type HooksConfig struct {
+	// CommitMessage configures the command used by commit --auto-write.
+	CommitMessage CommitMessageHookConfig `yaml:"commit_message,omitempty"`
+}
+
+// CommitMessageHookConfig configures an external commit message writer.
+type CommitMessageHookConfig struct {
+	// Command is executed as-written from the target repository.
+	Command string `yaml:"command,omitempty"`
 }
 
 // ConceptEntry defines a concept for the picker with ordering and depth control.

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -19,6 +19,9 @@ projects:
   - name: project-a
     path: projects/project-a
     url: https://github.com/example/project-a
+hooks:
+  commit_message:
+    command: ob commit
 `
 	var cfg CampaignConfig
 	err := yaml.Unmarshal([]byte(yamlData), &cfg)
@@ -47,6 +50,9 @@ projects:
 	}
 	if cfg.Projects[0].Name != "project-a" {
 		t.Errorf("Projects[0].Name = %q, want %q", cfg.Projects[0].Name, "project-a")
+	}
+	if cfg.Hooks.CommitMessage.Command != "ob commit" {
+		t.Errorf("Hooks.CommitMessage.Command = %q, want %q", cfg.Hooks.CommitMessage.Command, "ob commit")
 	}
 }
 

--- a/pkg/commitkit/autowrite.go
+++ b/pkg/commitkit/autowrite.go
@@ -1,0 +1,119 @@
+package commitkit
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+)
+
+// ErrCommitMessageHookNotConfigured is returned when --auto-write is requested
+// but .campaign/campaign.yaml does not configure hooks.commit_message.command.
+var ErrCommitMessageHookNotConfigured = errors.New(`auto-write commit message command is not configured
+
+Add this to .campaign/campaign.yaml:
+hooks:
+  commit_message:
+    command: ob commit`)
+
+// ErrCommitMessageHookEmptyOutput is returned when the hook succeeds but writes
+// no commit message to stdout.
+var ErrCommitMessageHookEmptyOutput = errors.New("auto-write commit message command produced no message")
+
+// CommitMessageHook is the configured commit message writer command.
+type CommitMessageHook struct {
+	Command string
+}
+
+// LoadCommitMessageHook loads hooks.commit_message.command from campaign config.
+func LoadCommitMessageHook(ctx context.Context, campaignRoot string) (*CommitMessageHook, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	cfg, err := config.LoadCampaignConfig(ctx, campaignRoot)
+	if err != nil {
+		return nil, fmt.Errorf("commitkit: load campaign config at %s: %w", campaignRoot, err)
+	}
+
+	command := strings.TrimSpace(cfg.Hooks.CommitMessage.Command)
+	if command == "" {
+		return nil, ErrCommitMessageHookNotConfigured
+	}
+
+	return &CommitMessageHook{Command: command}, nil
+}
+
+// AutoWriteCommitMessage runs the configured commit message hook from repoPath.
+func AutoWriteCommitMessage(ctx context.Context, campaignRoot, repoPath string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	hook, err := LoadCommitMessageHook(ctx, campaignRoot)
+	if err != nil {
+		return "", err
+	}
+
+	return RunCommitMessageCommand(ctx, repoPath, hook.Command)
+}
+
+// RunCommitMessageCommand executes command exactly as configured from repoPath
+// and returns trimmed stdout as the raw commit message.
+func RunCommitMessageCommand(ctx context.Context, repoPath, command string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return "", ErrCommitMessageHookNotConfigured
+	}
+
+	name, args := shellCommand(command)
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = repoPath
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		msg := strings.TrimSpace(stderr.String())
+		if msg != "" {
+			return "", fmt.Errorf("auto-write commit message command failed: %w: %s", err, msg)
+		}
+		return "", fmt.Errorf("auto-write commit message command failed: %w", err)
+	}
+
+	message := strings.TrimSpace(stdout.String())
+	if message == "" {
+		return "", ErrCommitMessageHookEmptyOutput
+	}
+
+	return message, nil
+}
+
+func shellCommand(command string) (string, []string) {
+	if runtime.GOOS == "windows" {
+		if comspec := os.Getenv("ComSpec"); comspec != "" {
+			return comspec, []string{"/C", command}
+		}
+		return "cmd", []string{"/C", command}
+	}
+
+	if shell := os.Getenv("SHELL"); shell != "" {
+		return shell, []string{"-lc", command}
+	}
+	return "/bin/sh", []string{"-lc", command}
+}

--- a/pkg/commitkit/commitkit_test.go
+++ b/pkg/commitkit/commitkit_test.go
@@ -99,6 +99,67 @@ func TestPrependCampaignTag(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Auto-write commit message hook
+// ---------------------------------------------------------------------------
+
+func TestRunCommitMessageCommand(t *testing.T) {
+	t.Run("returns trimmed stdout", func(t *testing.T) {
+		wd, err := os.Getwd()
+		require.NoError(t, err)
+
+		got, err := commitkit.RunCommitMessageCommand(context.Background(), wd, "printf 'feat: generated message\\n'")
+		require.NoError(t, err)
+		assert.Equal(t, "feat: generated message", got)
+	})
+
+	t.Run("preserves internal newlines", func(t *testing.T) {
+		wd, err := os.Getwd()
+		require.NoError(t, err)
+
+		got, err := commitkit.RunCommitMessageCommand(context.Background(), wd, "printf 'feat: subject\\n\\nbody line\\n'")
+		require.NoError(t, err)
+		assert.Equal(t, "feat: subject\n\nbody line", got)
+	})
+
+	t.Run("runs from target repository directory", func(t *testing.T) {
+		wd, err := os.Getwd()
+		require.NoError(t, err)
+
+		got, err := commitkit.RunCommitMessageCommand(context.Background(), wd, "pwd")
+		require.NoError(t, err)
+		assert.Equal(t, wd, got)
+	})
+
+	t.Run("fails on empty stdout", func(t *testing.T) {
+		wd, err := os.Getwd()
+		require.NoError(t, err)
+
+		_, err = commitkit.RunCommitMessageCommand(context.Background(), wd, "printf ''")
+		assert.ErrorIs(t, err, commitkit.ErrCommitMessageHookEmptyOutput)
+	})
+
+	t.Run("fails on non-zero exit", func(t *testing.T) {
+		wd, err := os.Getwd()
+		require.NoError(t, err)
+
+		_, err = commitkit.RunCommitMessageCommand(context.Background(), wd, "echo bad >&2; exit 2")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bad")
+	})
+
+	t.Run("honors canceled context", func(t *testing.T) {
+		wd, err := os.Getwd()
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err = commitkit.RunCommitMessageCommand(ctx, wd, "printf 'unused\\n'")
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Helpers for creating a real campaign on disk
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Summary
- Add campaign config for hooks.commit_message.command.
- Add --auto-write and -aw support for camp commit, camp project commit, and camp worktrees commit.
- Run the configured command from the exact repository context and use stdout as the commit message.

Validation
- git diff --check
- go test ./pkg/commitkit ./internal/config ./cmd/camp ./cmd/camp/project ./cmd/camp/worktrees
- just test unit
- just docs

Note
- just lint still reports existing repository-wide lint findings outside this change.