### PR TITLE
Promote workitem command to stable

### DIFF
--- a/cmd/camp/release_profile_dev_test.go
+++ b/cmd/camp/release_profile_dev_test.go
@@ -12,6 +12,10 @@ func TestReleaseProfileDev_DevCommandsRegistered(t *testing.T) {
 	assertDevCommandsRegistered(t)
 }
 
+func TestReleaseProfileDev_StableCommandsRegistered(t *testing.T) {
+	assertStableCommandsRegistered(t)
+}
+
 func TestReleaseProfileDev_BuildProfileRegistered(t *testing.T) {
 	assertBuildProfileCommand(t)
 }

--- a/cmd/camp/release_profile_stable_test.go
+++ b/cmd/camp/release_profile_stable_test.go
@@ -12,6 +12,10 @@ func TestReleaseProfileStable_DevCommandsAbsent(t *testing.T) {
 	assertDevCommandsAbsent(t)
 }
 
+func TestReleaseProfileStable_StableCommandsRegistered(t *testing.T) {
+	assertStableCommandsRegistered(t)
+}
+
 func TestReleaseProfileStable_BuildProfileRegistered(t *testing.T) {
 	assertBuildProfileCommand(t)
 }

--- a/cmd/camp/release_profile_test.go
+++ b/cmd/camp/release_profile_test.go
@@ -12,7 +12,7 @@ import (
 
 // devOnlyCommands is the single source of truth for commands gated behind
 // //go:build dev. Update this list when promoting a command to stable.
-var devOnlyCommands = []string{"flow", "quest", "workitem"}
+var devOnlyCommands = []string{"flow", "quest"}
 
 func assertDevCommandsRegistered(t *testing.T) {
 	t.Helper()
@@ -31,6 +31,14 @@ func assertDevCommandsAbsent(t *testing.T) {
 		if err == nil && cmd != nil && cmd.Name() == name {
 			t.Errorf("dev command %q should not be registered in stable build", name)
 		}
+	}
+}
+
+func assertStableCommandsRegistered(t *testing.T) {
+	t.Helper()
+	cmd, _, err := rootCmd.Find([]string{"workitem"})
+	if err != nil || cmd == nil || cmd.Name() != "workitem" {
+		t.Fatal("workitem command should be registered in stable and dev builds")
 	}
 }
 

--- a/cmd/camp/root.go
+++ b/cmd/camp/root.go
@@ -21,6 +21,7 @@ import (
 	worktreespkg "github.com/Obedience-Corp/camp/cmd/camp/worktrees"
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/commands/release"
+	workitemcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/Obedience-Corp/camp/internal/version"
@@ -203,6 +204,10 @@ func init() {
 	rootCmd.AddCommand(worktreespkg.Cmd)
 	rootCmd.AddCommand(refspkg.Cmd)
 	rootCmd.AddCommand(pluginsCmd)
+
+	workitemCmd := workitemcmd.NewWorkitemCommand()
+	workitemCmd.GroupID = "planning"
+	rootCmd.AddCommand(workitemCmd)
 
 	attachResolverFactory := func(stderr io.Writer, usageLine string) attachpkg.CampaignResolver {
 		return attachpkg.NewResolver(stderr, usageLine)

--- a/internal/commands/release/register_dev.go
+++ b/internal/commands/release/register_dev.go
@@ -4,7 +4,6 @@ package release
 
 import (
 	flowcmd "github.com/Obedience-Corp/camp/internal/commands/flow"
-	workitemcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/spf13/cobra"
 )
 
@@ -13,9 +12,4 @@ func registerDev(root *cobra.Command) {
 	flowCmd.GroupID = "planning"
 	MarkDevOnly(flowCmd)
 	root.AddCommand(flowCmd)
-
-	workitemCmd := workitemcmd.NewWorkitemCommand()
-	workitemCmd.GroupID = "planning"
-	MarkDevOnly(workitemCmd)
-	root.AddCommand(workitemCmd)
 }


### PR DESCRIPTION
## Summary
- Move `workitem` command registration from `registerDev()` to the always-on root in `cmd/camp/root.go`.
- Drop `workitem` from `devOnlyCommands` in `release_profile_test.go` and add `assertStableCommandsRegistered` covering it.
- Exercise the new assertion under both `release_profile_stable_test.go` and `release_profile_dev_test.go` so the command is verified present in both builds.

Promotes `camp workitem` so it ships in stable builds ahead of the next camp release.

## Test plan
- [x] `go test ./cmd/camp/...`