### PR TITLE
fix(init): preserve hooks on --repair, scaffold commented placeholder

### DIFF
--- a/internal/config/campaign.go
+++ b/internal/config/campaign.go
@@ -138,9 +138,29 @@ func SaveCampaignConfig(ctx context.Context, campaignRoot string, cfg *CampaignC
 		return camperrors.Wrap(err, "failed to marshal campaign config")
 	}
 
+	if (cfg.Hooks == HooksConfig{}) {
+		data = append(data, commentedHooksPlaceholder()...)
+	}
+
 	if err := os.WriteFile(configPath, data, 0644); err != nil {
 		return camperrors.Wrap(err, "failed to write campaign config")
 	}
 
 	return nil
+}
+
+// commentedHooksPlaceholder returns a commented-out hooks block to append to
+// campaign.yaml when no hooks are configured. Surfacing the option as a
+// discoverable comment lets users opt into commit --auto-write without having
+// to read the docs first. The example is intentionally generic: the command
+// can be any tool that prints the desired commit message to stdout.
+func commentedHooksPlaceholder() []byte {
+	return []byte(`
+# hooks:
+#   commit_message:
+#     # Command run from the target repo working tree by 'camp commit --auto-write'
+#     # (-aw). Its stdout is used verbatim as the commit message. Any tool works;
+#     # 'ob commit' is one example.
+#     command: ob commit
+`)
 }

--- a/internal/config/campaign_test.go
+++ b/internal/config/campaign_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -378,6 +379,70 @@ func TestSaveCampaignConfig(t *testing.T) {
 	}
 	if loaded.Type != cfg.Type {
 		t.Errorf("loaded Type = %q, want %q", loaded.Type, cfg.Type)
+	}
+}
+
+func TestSaveCampaignConfig_AppendsHooksPlaceholderWhenEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	cfg := &CampaignConfig{
+		Name: "no-hooks",
+		Type: CampaignTypeProduct,
+	}
+
+	ctx := context.Background()
+	if err := SaveCampaignConfig(ctx, tmpDir, cfg); err != nil {
+		t.Fatalf("SaveCampaignConfig() error = %v", err)
+	}
+
+	data, err := os.ReadFile(CampaignConfigPath(tmpDir))
+	if err != nil {
+		t.Fatalf("read campaign config: %v", err)
+	}
+
+	want := "# hooks:"
+	if !bytes.Contains(data, []byte(want)) {
+		t.Errorf("campaign.yaml missing commented hooks placeholder; got:\n%s", string(data))
+	}
+
+	// Round-trip must still load with empty Hooks (comments are ignored by yaml).
+	loaded, err := LoadCampaignConfig(ctx, tmpDir)
+	if err != nil {
+		t.Fatalf("LoadCampaignConfig() error = %v", err)
+	}
+	if (loaded.Hooks != HooksConfig{}) {
+		t.Errorf("loaded Hooks = %+v, want zero value (commented block should not parse)", loaded.Hooks)
+	}
+}
+
+func TestSaveCampaignConfig_SkipsPlaceholderWhenHooksSet(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+
+	cfg := &CampaignConfig{
+		Name: "has-hooks",
+		Type: CampaignTypeProduct,
+		Hooks: HooksConfig{
+			CommitMessage: CommitMessageHookConfig{Command: "my-tool"},
+		},
+	}
+
+	ctx := context.Background()
+	if err := SaveCampaignConfig(ctx, tmpDir, cfg); err != nil {
+		t.Fatalf("SaveCampaignConfig() error = %v", err)
+	}
+
+	data, err := os.ReadFile(CampaignConfigPath(tmpDir))
+	if err != nil {
+		t.Fatalf("read campaign config: %v", err)
+	}
+
+	if bytes.Contains(data, []byte("# hooks:")) {
+		t.Errorf("campaign.yaml unexpectedly contains commented hooks placeholder when hooks already set; got:\n%s", string(data))
+	}
+	if !bytes.Contains(data, []byte("command: my-tool")) {
+		t.Errorf("campaign.yaml missing configured command; got:\n%s", string(data))
 	}
 }
 

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -244,6 +244,7 @@ func Init(ctx context.Context, dir string, opts InitOptions) (*InitResult, error
 		cfg.CreatedAt = existingCfg.CreatedAt
 		cfg.Description = existingCfg.Description
 		cfg.Projects = existingCfg.Projects
+		cfg.Hooks = existingCfg.Hooks
 		// Preserve existing mission unless a new one was provided
 		if opts.Mission != "" {
 			cfg.Mission = opts.Mission

--- a/internal/scaffold/init_repair_test.go
+++ b/internal/scaffold/init_repair_test.go
@@ -63,6 +63,49 @@ func TestInit_RepairPreservesMission(t *testing.T) {
 	}
 }
 
+func TestInit_RepairPreservesHooks(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	campaignDir := filepath.Join(tmpDir, "repair-hooks")
+	mustMkdirAll(t, filepath.Join(campaignDir, config.CampaignDir))
+
+	ctx := context.Background()
+
+	initialCfg := &config.CampaignConfig{
+		ID:          "test-id",
+		Name:        "repair-hooks",
+		Type:        config.CampaignTypeProduct,
+		Description: "Has a commit_message hook",
+		Mission:     "Preserve hooks across repair",
+		CreatedAt:   time.Now(),
+		Hooks: config.HooksConfig{
+			CommitMessage: config.CommitMessageHookConfig{Command: "ob commit"},
+		},
+	}
+	if err := config.SaveCampaignConfig(ctx, campaignDir, initialCfg); err != nil {
+		t.Fatalf("SaveCampaignConfig() error = %v", err)
+	}
+
+	if _, err := Init(ctx, campaignDir, InitOptions{
+		Name:       "repair-hooks",
+		Repair:     true,
+		NoRegister: true,
+	}); err != nil {
+		t.Fatalf("Init() with repair error = %v", err)
+	}
+
+	cfg, err := config.LoadCampaignConfig(ctx, campaignDir)
+	if err != nil {
+		t.Fatalf("LoadCampaignConfig() error = %v", err)
+	}
+
+	if cfg.Hooks.CommitMessage.Command != "ob commit" {
+		t.Errorf("Hooks.CommitMessage.Command = %q, want %q (should preserve existing)", cfg.Hooks.CommitMessage.Command, "ob commit")
+	}
+}
+
 func TestInit_RepairMigratesLegacyIntentState(t *testing.T) {
 	tmpDir := t.TempDir()
 	tmpDir, _ = filepath.EvalSymlinks(tmpDir)

--- a/pkg/commitkit/autowrite.go
+++ b/pkg/commitkit/autowrite.go
@@ -17,7 +17,16 @@ import (
 // but .campaign/campaign.yaml does not configure hooks.commit_message.command.
 var ErrCommitMessageHookNotConfigured = errors.New(`auto-write commit message command is not configured
 
-Add this to .campaign/campaign.yaml:
+Configure a command in .campaign/campaign.yaml. It is run from the target
+repository's working tree and its stdout is used verbatim as the commit
+message, so any tool that emits a message on stdout works.
+
+hooks:
+  commit_message:
+    command: <your-commit-message-tool>
+
+Example (using the obey CLI):
+
 hooks:
   commit_message:
     command: ob commit`)


### PR DESCRIPTION
## Summary

`camp init --repair` silently stripped `hooks.commit_message.command` from `campaign.yaml`. That key drives `camp commit --auto-write` (`-aw`), so users who'd configured it lost auto-commit until they re-edited the file manually.

Two related fixes plus a docs-quality bump on the error message:

- **scaffold/init.go**: the repair branch reconstructs `CampaignConfig` and copies `existingCfg.{CreatedAt,Description,Projects,Mission,ConceptList}`, but never `Hooks`. Added `cfg.Hooks = existingCfg.Hooks`.
- **config/campaign.go**: `SaveCampaignConfig` now appends a commented-out `hooks:` block when `cfg.Hooks` is the zero value, so the option is discoverable in fresh `campaign.yaml` files without opting users into anything. Skipped when hooks are already configured.
- **commitkit/autowrite.go**: `ErrCommitMessageHookNotConfigured` no longer hardcodes `command: ob commit` as if it were the only choice. The error now explains the contract (any tool whose stdout becomes the commit message) and shows `ob commit` as one example.

## Test plan

- [x] `go test ./internal/config/... ./internal/scaffold/... ./pkg/commitkit/...` passes
- [x] New `TestInit_RepairPreservesHooks` fails without the scaffold fix, passes with it
- [x] New `TestSaveCampaignConfig_AppendsHooksPlaceholderWhenEmpty` verifies the placeholder is written and that the commented block round-trips to an empty `Hooks` value (yaml ignores comments)
- [x] New `TestSaveCampaignConfig_SkipsPlaceholderWhenHooksSet` verifies no duplicate placeholder when the user has configured a command
- [x] `just fmt` / `just vet` clean; `just lint` shows only pre-existing issues in unrelated files