### PR TITLE
Refresh navigation cache for workitem changes

### DIFF
--- a/internal/commands/workitem/adopt.go
+++ b/internal/commands/workitem/adopt.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
 
@@ -88,6 +89,7 @@ func runAdopt(ctx context.Context, cmd *cobra.Command, dir, typeFlag, title, idO
 	if err := atomicWriteFile(markerPath, buf, 0o644); err != nil {
 		return err
 	}
+	_ = navindex.Delete(campaignRoot)
 
 	fmt.Fprintf(cmd.OutOrStdout(),
 		"adopted %s\n  id: %s\n  type: %s\n",

--- a/internal/commands/workitem/adopt.go
+++ b/internal/commands/workitem/adopt.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
-	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
 
@@ -89,7 +88,9 @@ func runAdopt(ctx context.Context, cmd *cobra.Command, dir, typeFlag, title, idO
 	if err := atomicWriteFile(markerPath, buf, 0o644); err != nil {
 		return err
 	}
-	_ = navindex.Delete(campaignRoot)
+	// Adoption writes inside an existing directory, which may not update the
+	// workflow/type parent mtime watched by passive cache staleness checks.
+	invalidateNavigationCache(cmd, campaignRoot)
 
 	fmt.Fprintf(cmd.OutOrStdout(),
 		"adopted %s\n  id: %s\n  type: %s\n",

--- a/internal/commands/workitem/create.go
+++ b/internal/commands/workitem/create.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
 
@@ -104,6 +105,7 @@ func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, i
 	if err := atomicWriteFile(filepath.Join(target, ".workitem"), buf, 0o644); err != nil {
 		return err
 	}
+	_ = navindex.Delete(campaignRoot)
 
 	rel := filepath.Join(parent, slug)
 	fmt.Fprintf(cmd.OutOrStdout(),

--- a/internal/commands/workitem/create.go
+++ b/internal/commands/workitem/create.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
-	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
 
@@ -105,7 +104,7 @@ func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, i
 	if err := atomicWriteFile(filepath.Join(target, ".workitem"), buf, 0o644); err != nil {
 		return err
 	}
-	_ = navindex.Delete(campaignRoot)
+	invalidateNavigationCache(cmd, campaignRoot)
 
 	rel := filepath.Join(parent, slug)
 	fmt.Fprintf(cmd.OutOrStdout(),

--- a/internal/commands/workitem/nav_cache.go
+++ b/internal/commands/workitem/nav_cache.go
@@ -1,0 +1,15 @@
+package workitem
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
+)
+
+func invalidateNavigationCache(cmd *cobra.Command, campaignRoot string) {
+	if err := navindex.Delete(campaignRoot); err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: failed to invalidate navigation cache: %v\n", err)
+	}
+}

--- a/internal/nav/index/cache.go
+++ b/internal/nav/index/cache.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/fsutil"
+	"github.com/Obedience-Corp/camp/internal/nav"
 )
 
 const (
@@ -125,7 +126,7 @@ func IsStale(idx *Index, campaignRoot string) bool {
 		return true
 	}
 
-	if anyNavigationTopologyChanged(campaignRoot, idx.BuildTime) {
+	if workitemTopologyChanged(campaignRoot, idx.BuildTime) {
 		return true
 	}
 
@@ -166,19 +167,21 @@ func IsStale(idx *Index, campaignRoot string) bool {
 	return false
 }
 
-func anyNavigationTopologyChanged(campaignRoot string, buildTime time.Time) bool {
-	for _, rel := range []string{
-		"workflow",
-		".campaign/intents",
-		"festivals",
+func workitemTopologyChanged(campaignRoot string, buildTime time.Time) bool {
+	for _, cat := range []nav.Category{
+		nav.CategoryWorkflow,
+		nav.CategoryIntents,
+		nav.CategoryFestivals,
 	} {
-		if dirOrImmediateChildChangedAfter(campaignRoot, rel, buildTime) {
+		if dirOrImmediateChildChangedAfter(campaignRoot, cat.Dir(), buildTime) {
 			return true
 		}
 	}
 	return false
 }
 
+// This is intentionally depth-bounded: root and immediate child mtimes catch
+// workitem/festival/intent additions without invalidating on ordinary file edits.
 func dirOrImmediateChildChangedAfter(root, rel string, buildTime time.Time) bool {
 	dir := filepath.Join(root, rel)
 	info, err := os.Stat(dir)

--- a/internal/nav/index/cache.go
+++ b/internal/nav/index/cache.go
@@ -91,7 +91,7 @@ func IsFresh(idx *Index) bool {
 
 // IsStale checks if the cache should be rebuilt.
 // Returns true if the cache is nil, too old, if the index version changed,
-// if the camp binary was rebuilt, or if project configuration changed.
+// if the camp binary was rebuilt, or if navigation topology changed.
 func IsStale(idx *Index, campaignRoot string) bool {
 	if !IsFresh(idx) {
 		return true
@@ -122,6 +122,10 @@ func IsStale(idx *Index, campaignRoot string) bool {
 	campaignYaml := filepath.Join(campaignRoot, ".campaign", "campaign.yaml")
 	info, err = os.Stat(campaignYaml)
 	if err == nil && info.ModTime().After(idx.BuildTime) {
+		return true
+	}
+
+	if anyNavigationTopologyChanged(campaignRoot, idx.BuildTime) {
 		return true
 	}
 
@@ -159,6 +163,48 @@ func IsStale(idx *Index, campaignRoot string) bool {
 		}
 	}
 
+	return false
+}
+
+func anyNavigationTopologyChanged(campaignRoot string, buildTime time.Time) bool {
+	for _, rel := range []string{
+		"workflow",
+		".campaign/intents",
+		"festivals",
+	} {
+		if dirOrImmediateChildChangedAfter(campaignRoot, rel, buildTime) {
+			return true
+		}
+	}
+	return false
+}
+
+func dirOrImmediateChildChangedAfter(root, rel string, buildTime time.Time) bool {
+	dir := filepath.Join(root, rel)
+	info, err := os.Stat(dir)
+	if err != nil {
+		return false
+	}
+	if info.ModTime().After(buildTime) {
+		return true
+	}
+	if !info.IsDir() {
+		return false
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		childInfo, err := os.Stat(filepath.Join(dir, entry.Name()))
+		if err == nil && childInfo.ModTime().After(buildTime) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/internal/nav/index/cache_test.go
+++ b/internal/nav/index/cache_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Obedience-Corp/camp/internal/nav"
 )
 
 func TestCachePath(t *testing.T) {
@@ -323,6 +325,116 @@ func TestIsStale_CampaignYamlChanged(t *testing.T) {
 
 	if !IsStale(idx, root) {
 		t.Error("Index should be stale when campaign.yaml is newer")
+	}
+}
+
+func TestIsStale_WorkflowTopologyChanged(t *testing.T) {
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+
+	buildTime := time.Now()
+	workflowDir := filepath.Join(root, nav.CategoryWorkflow.Dir())
+	designDir := filepath.Join(workflowDir, "design")
+	if err := os.MkdirAll(designDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	older := buildTime.Add(-1 * time.Minute)
+	if err := os.Chtimes(workflowDir, older, older); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(designDir, buildTime.Add(1*time.Minute), buildTime.Add(1*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := &Index{BuildTime: buildTime, Version: IndexVersion}
+	if !IsStale(idx, root) {
+		t.Error("Index should be stale when workflow immediate-child topology is newer")
+	}
+}
+
+func TestIsStale_IntentsTopologyChanged(t *testing.T) {
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+
+	buildTime := time.Now()
+	intentsDir := filepath.Join(root, nav.CategoryIntents.Dir())
+	inboxDir := filepath.Join(intentsDir, "inbox")
+	if err := os.MkdirAll(inboxDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(inboxDir, "new-intent.md"), []byte("# New intent\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	older := buildTime.Add(-1 * time.Minute)
+	if err := os.Chtimes(intentsDir, older, older); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(inboxDir, buildTime.Add(1*time.Minute), buildTime.Add(1*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := &Index{BuildTime: buildTime, Version: IndexVersion}
+	if !IsStale(idx, root) {
+		t.Error("Index should be stale when intent immediate-child topology is newer")
+	}
+}
+
+func TestIsStale_FestivalsTopologyChanged(t *testing.T) {
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+
+	buildTime := time.Now()
+	festivalsDir := filepath.Join(root, nav.CategoryFestivals.Dir())
+	activeDir := filepath.Join(festivalsDir, "active")
+	if err := os.MkdirAll(activeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	older := buildTime.Add(-1 * time.Minute)
+	if err := os.Chtimes(festivalsDir, older, older); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(activeDir, buildTime.Add(1*time.Minute), buildTime.Add(1*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := &Index{BuildTime: buildTime, Version: IndexVersion}
+	if !IsStale(idx, root) {
+		t.Error("Index should be stale when festivals immediate-child topology is newer")
+	}
+}
+
+func TestIsStale_DeepFileEditDoesNotInvalidate(t *testing.T) {
+	root := t.TempDir()
+	root, _ = filepath.EvalSymlinks(root)
+
+	buildTime := time.Now()
+	workflowDir := filepath.Join(root, nav.CategoryWorkflow.Dir())
+	designDir := filepath.Join(workflowDir, "design")
+	workitemDir := filepath.Join(designDir, "existing-workitem")
+	if err := os.MkdirAll(workitemDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	notePath := filepath.Join(workitemDir, "notes.md")
+	if err := os.WriteFile(notePath, []byte("# Notes\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	older := buildTime.Add(-1 * time.Minute)
+	for _, dir := range []string{workflowDir, designDir, workitemDir} {
+		if err := os.Chtimes(dir, older, older); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chtimes(notePath, buildTime.Add(1*time.Minute), buildTime.Add(1*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := &Index{BuildTime: buildTime, Version: IndexVersion}
+	if IsStale(idx, root) {
+		t.Error("Index should not be stale for a deep file edit inside a workitem")
 	}
 }
 

--- a/tests/integration/workitem_create_test.go
+++ b/tests/integration/workitem_create_test.go
@@ -27,6 +27,26 @@ func TestIntegration_WorkitemCreateAndAdopt(t *testing.T) {
 	)
 	require.NoError(t, err, "camp init should succeed")
 
+	t.Run("CreateRefreshesNavigationCache", func(t *testing.T) {
+		_, err := tc.RunCampInDir(campaignDir, "complete", "de")
+		require.NoError(t, err, "initial design completion should build nav cache")
+		_, _, err = tc.ExecCommand("test", "-f", campaignDir+"/.campaign/cache/nav-index.json")
+		require.NoError(t, err, "expected initial completion to create nav cache")
+
+		out, err := tc.RunCampInDir(campaignDir, "workitem", "create", "nav-design", "--type", "design", "--title", "Navigation Design")
+		require.NoError(t, err, "camp workitem create design: %s", out)
+		assert.Contains(t, out, "created workflow/design/nav-design")
+
+		out, err = tc.RunCampInDir(campaignDir, "complete", "de")
+		require.NoError(t, err, "completion after workitem create: %s", out)
+		assert.Contains(t, out, "nav-design",
+			"newly created design workitem must be visible without manual cache rebuild:\n%s", out)
+
+		out, err = tc.RunCampInDir(campaignDir, "go", "de", "nav-design", "--print")
+		require.NoError(t, err, "navigation after workitem create: %s", out)
+		assert.Contains(t, out, "workflow/design/nav-design")
+	})
+
 	t.Run("CreateBuildsDirectoryAndWorkitem", func(t *testing.T) {
 		out, err := tc.RunCampInDir(campaignDir, "workitem", "create", "demo-feature", "--type", "feature", "--title", "Demo")
 		require.NoError(t, err, "camp workitem create: %s", out)


### PR DESCRIPTION
## Summary
- invalidate the navigation index after `camp workitem create` and `camp workitem adopt`
- rebuild stale navigation caches when workflow, intent, or festival topology changes outside Camp
- add an integration regression proving newly created design workitems complete and navigate without manual `camp cache rebuild`

## Validation
- `go test ./internal/nav/index ./internal/commands/workitem`
- `just test integration-run TestIntegration_WorkitemCreateAndAdopt`
- `just test unit`