### PR TITLE
Scaffold camp workitems skill

### DIFF
--- a/docs/campaign-directory-reference.md
+++ b/docs/campaign-directory-reference.md
@@ -139,8 +139,8 @@ The campaign-local source of truth for skill bundles. `camp skills` projects
 these bundles into provider/tool-specific locations such as `.claude/skills/`
 or `.agents/skills/`.
 
-This directory is scaffolded so campaigns start with baseline navigation and
-workflow skills.
+This directory is scaffolded so campaigns start with baseline navigation,
+workflow, and work-item discovery skills.
 
 ### `.campaign/cache/`
 

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -4975,3 +4975,99 @@ camp version [flags]
       --no-color        disable colored output
       --verbose         enable verbose output
 ```
+---
+
+## camp workitem
+
+View active campaign work items
+
+### Synopsis
+
+View active campaign work items across intents, designs, explore, and festivals.
+
+Default mode launches an interactive TUI dashboard. Use --json for machine-readable
+output or --print to select and print a path for shell integration.
+
+Examples:
+  camp workitem                              # interactive dashboard
+  camp workitem --json                       # JSON output for agents/scripts
+  camp workitem --json --type design         # filter by type
+  camp workitem --json --type intent --limit 5
+  camp workitem --print                      # select and print path
+
+```
+camp workitem [flags]
+```
+
+### Options
+
+```
+  -h, --help                help for workitem
+      --json                Output as JSON
+      --limit int           Maximum number of items to return
+      --print               Print path only (for shell integration)
+      --query string        Search query to filter items
+      --stage stringArray   Filter by lifecycle stage (inbox, active, ready, planning)
+      --type stringArray    Filter by workflow type (builtin: intent, design, explore, festival; or any slug-safe custom type produced by 'camp workitem create --type <name>')
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workitem adopt
+
+Attach .workitem metadata to an existing directory
+
+```
+camp workitem adopt <dir> [flags]
+```
+
+### Options
+
+```
+  -h, --help           help for adopt
+      --id string      override the generated id
+      --title string   human-readable title
+      --type string    workitem type (feature, bug, chore, or custom) (default "feature")
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workitem create
+
+Create a new workitem with v1 minimum metadata
+
+```
+camp workitem create <slug> [flags]
+```
+
+### Options
+
+```
+      --dir string     parent dir override (default: workflow/<type>)
+  -h, --help           help for create
+      --id string      override the generated id
+      --title string   human-readable title
+      --type string    workitem type (feature, bug, chore, or custom) (default "feature")
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```

--- a/docs/cli-reference/camp.md
+++ b/docs/cli-reference/camp.md
@@ -88,3 +88,4 @@ camp [flags]
 * [camp unpin](camp_unpin.md)	 - Remove a saved pin
 * [camp unregister](camp_unregister.md)	 - Remove campaign from registry
 * [camp version](camp_version.md)	 - Show version information
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/docs/cli-reference/camp_workitem.md
+++ b/docs/cli-reference/camp_workitem.md
@@ -1,0 +1,47 @@
+## camp workitem
+
+View active campaign work items
+
+### Synopsis
+
+View active campaign work items across intents, designs, explore, and festivals.
+
+Default mode launches an interactive TUI dashboard. Use --json for machine-readable
+output or --print to select and print a path for shell integration.
+
+Examples:
+  camp workitem                              # interactive dashboard
+  camp workitem --json                       # JSON output for agents/scripts
+  camp workitem --json --type design         # filter by type
+  camp workitem --json --type intent --limit 5
+  camp workitem --print                      # select and print path
+
+```
+camp workitem [flags]
+```
+
+### Options
+
+```
+  -h, --help                help for workitem
+      --json                Output as JSON
+      --limit int           Maximum number of items to return
+      --print               Print path only (for shell integration)
+      --query string        Search query to filter items
+      --stage stringArray   Filter by lifecycle stage (inbox, active, ready, planning)
+      --type stringArray    Filter by workflow type (builtin: intent, design, explore, festival; or any slug-safe custom type produced by 'camp workitem create --type <name>')
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
+* [camp workitem adopt](camp_workitem_adopt.md)	 - Attach .workitem metadata to an existing directory
+* [camp workitem create](camp_workitem_create.md)	 - Create a new workitem with v1 minimum metadata

--- a/docs/cli-reference/camp_workitem_adopt.md
+++ b/docs/cli-reference/camp_workitem_adopt.md
@@ -1,0 +1,28 @@
+## camp workitem adopt
+
+Attach .workitem metadata to an existing directory
+
+```
+camp workitem adopt <dir> [flags]
+```
+
+### Options
+
+```
+  -h, --help           help for adopt
+      --id string      override the generated id
+      --title string   human-readable title
+      --type string    workitem type (feature, bug, chore, or custom) (default "feature")
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/docs/cli-reference/camp_workitem_create.md
+++ b/docs/cli-reference/camp_workitem_create.md
@@ -1,0 +1,29 @@
+## camp workitem create
+
+Create a new workitem with v1 minimum metadata
+
+```
+camp workitem create <slug> [flags]
+```
+
+### Options
+
+```
+      --dir string     parent dir override (default: workflow/<type>)
+  -h, --help           help for create
+      --id string      override the generated id
+      --title string   human-readable title
+      --type string    workitem type (feature, bug, chore, or custom) (default "feature")
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/internal/scaffold/campaign/templates/.campaign/skills/camp-workitems/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/camp-workitems/SKILL.md.tmpl
@@ -1,0 +1,64 @@
+---
+name: camp-workitems
+description: Discover, triage, and create campaign work items with `camp workitem` / `camp workitems`. Use when finding active work across intents, designs, explore notes, festivals, or custom `.workitem` directories; when agents need `camp workitem --json`; or when creating/adopting tracked work-item folders.
+---
+
+# Camp Workitems
+
+`camp workitem` is the canonical command. `camp wi` and `camp workitems` are aliases.
+
+Use it to find active campaign work across intents, workflow design/explore
+docs, festivals, and custom `.workitem`-tracked workflow directories.
+
+## Agent-Safe Discovery
+
+Agents and scripts should use non-interactive output:
+
+```bash
+camp workitem --json
+camp workitem --json --type intent --limit 5
+camp workitem --json --type design --query auth
+camp workitem --print --type festival
+```
+
+Non-interactive use requires `--json` or `--print`.
+
+Useful filters:
+
+- `--type intent|design|explore|festival|<custom>`
+- `--stage inbox|active|ready|planning`
+- `--query <text>`
+- `--limit <n>`
+
+## Interactive Use
+
+```bash
+camp workitem
+```
+
+The default command opens the TUI dashboard. Use this for human browsing,
+prioritization, and selection.
+
+## Create Or Adopt Custom Workitems
+
+Use custom workitems when work belongs under `workflow/<type>/<slug>` and
+should appear in the dashboard.
+
+```bash
+camp workitem create <slug> --type feature --title "Human title"
+camp workitem adopt workflow/feature/existing-dir --type feature --title "Human title"
+```
+
+`create` makes `workflow/<type>/<slug>/` by default and writes `.workitem`.
+`adopt` attaches `.workitem` metadata to an existing directory.
+
+Slug and type values must be path-safe: no `/`, `\`, whitespace, or control
+characters; no leading `.` or `-`; max 80 characters.
+
+## Common Mistakes
+
+- Running the interactive TUI from an agent session instead of using `--json`.
+- Creating custom `workflow/<type>/...` directories without `.workitem`; custom
+  types only surface when the marker exists.
+- Editing `.campaign/settings/workitems.json` manually. It is tool-managed
+  priority state, not the work-item source of truth.

--- a/tests/integration/init_test.go
+++ b/tests/integration/init_test.go
@@ -118,6 +118,24 @@ func TestInit_DirectoryStructure(t *testing.T) {
 	assert.True(t, exists, "campaign.yaml should exist")
 }
 
+func TestInit_ScaffoldsCampWorkitemsSkill(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	path := "/campaigns/test-workitems-skill"
+	_, err := tc.InitCampaign(path, "test-workitems-skill", "product")
+	require.NoError(t, err)
+
+	skillPath := path + "/.campaign/skills/camp-workitems/SKILL.md"
+	exists, err := tc.CheckFileExists(skillPath)
+	require.NoError(t, err)
+	assert.True(t, exists, "camp-workitems skill should be scaffolded")
+
+	content, err := tc.ReadFile(skillPath)
+	require.NoError(t, err)
+	assert.Contains(t, content, "camp workitem --json", "skill should document agent-safe JSON discovery")
+	assert.Contains(t, content, "camp workitems", "skill should mention the plural alias")
+}
+
 // TestInit_FestivalOwnership verifies that default init creates festivals/
 // when the fest binary is available.
 func TestInit_FestivalOwnership(t *testing.T) {

--- a/tests/integration/repair_test.go
+++ b/tests/integration/repair_test.go
@@ -105,6 +105,7 @@ func TestInitRepair_RestoresMissingSkillFiles(t *testing.T) {
 		path + "/.campaign/skills/camp-navigation/SKILL.md",
 		path + "/.campaign/skills/campaign-commit/SKILL.md",
 		path + "/.campaign/skills/camp-projects/SKILL.md",
+		path + "/.campaign/skills/camp-workitems/SKILL.md",
 		path + "/.campaign/skills/fest-execution/SKILL.md",
 	}
 	for _, item := range removed {


### PR DESCRIPTION
## Summary
- add a scaffolded `camp-workitems` skill for `camp workitem` / `camp workitems` discovery and custom workitem creation
- add containerized integration coverage for fresh init and repair installing the skill
- regenerate CLI reference docs for the stable `camp workitem` command

## Validation
- `just docs`
- `go test ./cmd/camp ./internal/scaffold ./internal/skills`
- `go test -tags integration ./tests/integration -run 'TestInit_(ScaffoldsCampWorkitemsSkill|Repair_RestoresMissingSkillFiles)$' -count=1`