### PR TITLE
Scaffold standalone workflow skill

### DIFF
--- a/internal/scaffold/campaign/templates/.campaign/skills/fest-standalone-workflows/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/fest-standalone-workflows/SKILL.md.tmpl
@@ -16,7 +16,7 @@ WORKFLOW.md -> fest next -> do step -> fest workflow advance -> repeat
 
 No `fest init` is required.
 
-## Preferred Creation Path
+## Create
 
 Run from the directory that should own the workflow:
 
@@ -46,9 +46,8 @@ fest create workflow my-workflow --no-init --steps '{
 fest next
 ```
 
-`--no-init` keeps the first run lightweight: `fest next` can render step 1
-before `.workflow/` runtime state exists. The first `fest workflow advance`
-bootstraps local `.workflow/` state when progress is actually recorded.
+For the current standalone first-run flow, include `--no-init` before running
+`fest next`.
 
 For human interactive creation, run the command without `--steps` from a TTY:
 
@@ -93,34 +92,6 @@ fest workflow advance
 fest next
 ```
 
-In anonymous mode, `fest next` is read-only and shows step 1. The first
-`fest workflow advance` creates:
-
-```text
-.workflow/workflow.yaml
-.workflow/runs/<run-id>/run.yaml
-.workflow/runs/<run-id>/progress_events.jsonl
-```
-
-## Current Default Behavior
-
-Without `--no-init`, standalone creation initializes `.workflow/workflow.yaml`
-immediately:
-
-```bash
-fest create workflow my-workflow --steps '...'
-```
-
-That path is functional, but `fest next` then requires an active run:
-
-```bash
-fest workflow start
-fest next
-```
-
-Use `--no-init` when the user wants the smoothest "create workflow, then
-`fest next`" first-run experience.
-
 ## Common Mistakes
 
 - Passing `--path` for standalone workflow creation. In standalone mode, run
@@ -128,5 +99,5 @@ Use `--no-init` when the user wants the smoothest "create workflow, then
 - Using `title` inside each step. Step objects require `name` and `goal`.
 - Running `fest init` for a lightweight workflow. Standalone `WORKFLOW.md` does
   not need a full festival.
-- Treating `.workflow/runs/` as durable docs. It is local runtime progress
-  state; promote durable findings into docs/design/festivals when needed.
+- Omitting `--no-init` in the current standalone first-run flow and expecting
+  immediate `fest next` behavior.

--- a/internal/scaffold/campaign/templates/.campaign/skills/fest-standalone-workflows/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/fest-standalone-workflows/SKILL.md.tmpl
@@ -50,6 +50,14 @@ fest next
 before `.workflow/` runtime state exists. The first `fest workflow advance`
 bootstraps local `.workflow/` state when progress is actually recorded.
 
+For human interactive creation, run the command without `--steps` from a TTY:
+
+```bash
+fest create workflow my-workflow --no-init
+```
+
+It prompts for title, intent, and step lines in `Name|Goal` form.
+
 ## Step JSON Contract
 
 Workflow-level fields:

--- a/internal/scaffold/campaign/templates/.campaign/skills/fest-standalone-workflows/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/fest-standalone-workflows/SKILL.md.tmpl
@@ -1,0 +1,124 @@
+---
+name: fest-standalone-workflows
+description: Create and run lightweight standalone `WORKFLOW.md` loops with `fest create workflow`, `fest next`, and `fest workflow advance` without requiring `fest init` or a full festival. Use when a user wants step-by-step workflow guidance inside any ordinary directory, explore/design work item, project folder, or thin-start workflow.
+---
+
+# Fest Standalone Workflows
+
+Use standalone `WORKFLOW.md` when work needs a guided step loop but not a full
+festival yet.
+
+This is the thin-start path:
+
+```text
+WORKFLOW.md -> fest next -> do step -> fest workflow advance -> repeat
+```
+
+No `fest init` is required.
+
+## Preferred Creation Path
+
+Run from the directory that should own the workflow:
+
+```bash
+mkdir -p workflow/explore/my-workflow
+cd workflow/explore/my-workflow
+
+fest create workflow my-workflow --no-init --steps '{
+  "title": "My Workflow",
+  "description": "A lightweight guided loop.",
+  "steps": [
+    {
+      "name": "PLAN",
+      "goal": "Decide what needs to happen.",
+      "actions": ["Write the goal.", "List the unknowns."],
+      "checkpoint": "none"
+    },
+    {
+      "name": "DO",
+      "goal": "Do the work.",
+      "actions": ["Make the change.", "Validate it."],
+      "checkpoint": "verification"
+    }
+  ]
+}'
+
+fest next
+```
+
+`--no-init` keeps the first run lightweight: `fest next` can render step 1
+before `.workflow/` runtime state exists. The first `fest workflow advance`
+bootstraps local `.workflow/` state when progress is actually recorded.
+
+## Step JSON Contract
+
+Workflow-level fields:
+
+- `title` (required)
+- `description` (optional)
+- `steps` (required, non-empty)
+
+Each step needs:
+
+- `name`
+- `goal`
+
+Useful optional step fields:
+
+- `actions`
+- `output`
+- `checkpoint`
+
+Valid checkpoint values:
+
+- `none`
+- `verification`
+- `documentation`
+- `approval_required`
+
+## Execution Loop
+
+```bash
+fest next
+# do the visible step
+fest workflow advance
+fest next
+```
+
+In anonymous mode, `fest next` is read-only and shows step 1. The first
+`fest workflow advance` creates:
+
+```text
+.workflow/workflow.yaml
+.workflow/runs/<run-id>/run.yaml
+.workflow/runs/<run-id>/progress_events.jsonl
+```
+
+## Current Default Behavior
+
+Without `--no-init`, standalone creation initializes `.workflow/workflow.yaml`
+immediately:
+
+```bash
+fest create workflow my-workflow --steps '...'
+```
+
+That path is functional, but `fest next` then requires an active run:
+
+```bash
+fest workflow start
+fest next
+```
+
+Use `--no-init` when the user wants the smoothest "create workflow, then
+`fest next`" first-run experience.
+
+## Common Mistakes
+
+- Passing `--path` for standalone workflow creation. In standalone mode, run
+  the command from the target directory; `--path` is for festival phase targets.
+- Using `title` inside each step. Step objects require `name` and `goal`.
+- Running `fest init` for a lightweight workflow. Standalone `WORKFLOW.md` does
+  not need a full festival.
+- Treating `.workflow/runs/` as durable docs. It is local runtime progress
+  state; promote durable findings into docs/design/festivals when needed.

--- a/internal/scaffold/campaign/templates/.campaign/skills/fest-standalone-workflows/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/fest-standalone-workflows/SKILL.md.tmpl
@@ -1,20 +1,18 @@
 ---
 name: fest-standalone-workflows
-description: Create and run lightweight standalone `WORKFLOW.md` loops with `fest create workflow`, `fest next`, and `fest workflow advance` without requiring `fest init` or a full festival. Use when a user wants step-by-step workflow guidance inside any ordinary directory, explore/design work item, project folder, or thin-start workflow.
+description: Create and run lightweight standalone `WORKFLOW.md` loops with `fest create workflow`, `fest next`, and `fest workflow advance`. Use when a user wants step-by-step workflow guidance inside any ordinary directory, explore/design work item, project folder, or thin-start workflow.
 ---
 
 # Fest Standalone Workflows
 
-Use standalone `WORKFLOW.md` when work needs a guided step loop but not a full
-festival yet.
+Use standalone `WORKFLOW.md` when work needs a guided step loop in an ordinary
+directory.
 
 This is the thin-start path:
 
 ```text
 WORKFLOW.md -> fest next -> do step -> fest workflow advance -> repeat
 ```
-
-No `fest init` is required.
 
 ## Create
 
@@ -97,7 +95,5 @@ fest next
 - Passing `--path` for standalone workflow creation. In standalone mode, run
   the command from the target directory; `--path` is for festival phase targets.
 - Using `title` inside each step. Step objects require `name` and `goal`.
-- Running `fest init` for a lightweight workflow. Standalone `WORKFLOW.md` does
-  not need a full festival.
 - Omitting `--no-init` in the current standalone first-run flow and expecting
   immediate `fest next` behavior.

--- a/tests/integration/init_test.go
+++ b/tests/integration/init_test.go
@@ -136,6 +136,25 @@ func TestInit_ScaffoldsCampWorkitemsSkill(t *testing.T) {
 	assert.Contains(t, content, "camp workitems", "skill should mention the plural alias")
 }
 
+func TestInit_ScaffoldsFestStandaloneWorkflowsSkill(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	path := "/campaigns/test-standalone-workflow-skill"
+	_, err := tc.InitCampaign(path, "test-standalone-workflow-skill", "product")
+	require.NoError(t, err)
+
+	skillPath := path + "/.campaign/skills/fest-standalone-workflows/SKILL.md"
+	exists, err := tc.CheckFileExists(skillPath)
+	require.NoError(t, err)
+	assert.True(t, exists, "fest-standalone-workflows skill should be scaffolded")
+
+	content, err := tc.ReadFile(skillPath)
+	require.NoError(t, err)
+	assert.Contains(t, content, "fest create workflow", "skill should document standalone workflow creation")
+	assert.Contains(t, content, "--no-init", "skill should document the smooth first fest next path")
+	assert.Contains(t, content, "No `fest init` is required", "skill should explain that full festival init is unnecessary")
+}
+
 // TestInit_FestivalOwnership verifies that default init creates festivals/
 // when the fest binary is available.
 func TestInit_FestivalOwnership(t *testing.T) {

--- a/tests/integration/init_test.go
+++ b/tests/integration/init_test.go
@@ -152,7 +152,7 @@ func TestInit_ScaffoldsFestStandaloneWorkflowsSkill(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, content, "fest create workflow", "skill should document standalone workflow creation")
 	assert.Contains(t, content, "--no-init", "skill should document the smooth first fest next path")
-	assert.Contains(t, content, "No `fest init` is required", "skill should explain that full festival init is unnecessary")
+	assert.Contains(t, content, "ordinary directory", "skill should frame standalone workflows by placement")
 }
 
 // TestInit_FestivalOwnership verifies that default init creates festivals/

--- a/tests/integration/repair_test.go
+++ b/tests/integration/repair_test.go
@@ -107,6 +107,7 @@ func TestInitRepair_RestoresMissingSkillFiles(t *testing.T) {
 		path + "/.campaign/skills/camp-projects/SKILL.md",
 		path + "/.campaign/skills/camp-workitems/SKILL.md",
 		path + "/.campaign/skills/fest-execution/SKILL.md",
+		path + "/.campaign/skills/fest-standalone-workflows/SKILL.md",
 	}
 	for _, item := range removed {
 		_, _, err := tc.ExecCommand("rm", "-f", item)


### PR DESCRIPTION
## Summary
- add a scaffolded `fest-standalone-workflows` skill for lightweight `WORKFLOW.md` loops
- document the current standalone first-run command sequence for agents
- include the TTY prompt-driven creation path for human users
- add containerized init and repair coverage for installing the skill

## Validation
- `go test ./internal/skills ./internal/scaffold`
- `go test -tags integration ./tests/integration -run 'TestInit_(ScaffoldsFestStandaloneWorkflowsSkill|Repair_RestoresMissingSkillFiles)$' -count=1`
- manual smoke: `fest create workflow <name> --no-init` from a TTY, followed by `fest next --json`
