### PR TITLE
Create custom workflow collections

### DIFF
--- a/cmd/camp/navigation/go.go
+++ b/cmd/camp/navigation/go.go
@@ -65,21 +65,9 @@ func runGo(cmd *cobra.Command, args []string) error {
 		return handleToggle(ctx, campaignRoot, printOnly)
 	}
 
-	// Check if the first arg is a custom navigation shortcut with non-standard path
-	if len(args) > 0 {
-		shortcutName := args[0]
-		if sc, ok := cfg.Shortcuts()[shortcutName]; ok && sc.IsNavigation() {
-			// If this is a custom path (not a standard directory), use direct navigation
-			// Standard paths are handled below via ParseShortcut for fuzzy search support
-			if !nav.IsStandardPath(sc.Path) {
-				return handleCustomNavShortcut(ctx, sc, campaignRoot, printOnly, command)
-			}
-		}
-	}
-
 	// Resolve configured navigation from shortcuts, long-form directory aliases,
-	// and configured concepts. Deferred until after the short-circuits above so
-	// toggle and custom-path shortcuts don't pay the resolution cost.
+	// and configured concepts. Deferred until after the toggle short-circuit
+	// above so the no-arg toggle path stays minimal.
 	resolved := nav.ResolveConfiguredTarget(cfg, args)
 
 	result := nav.ParseResult{
@@ -343,38 +331,6 @@ func listProjectShortcuts(result *index.ResolveResult) error {
 		fmt.Printf("  %-12s %s\n", ui.Accent(name), ui.Dim(path))
 	}
 
-	return nil
-}
-
-// handleCustomNavShortcut handles navigation to a custom path shortcut.
-func handleCustomNavShortcut(ctx context.Context, sc config.ShortcutConfig, campaignRoot string, printOnly bool, command []string) error {
-	// Jump to the custom path
-	jumpResult, err := nav.JumpToPathFromRoot(ctx, campaignRoot, sc.Path)
-	if err != nil {
-		return err
-	}
-
-	// Command execution mode
-	if len(command) > 0 {
-		execResult, err := nav.ExecInDir(ctx, jumpResult.Path, campaignRoot, command)
-		if err != nil {
-			return err
-		}
-		if execResult.ExitCode != 0 {
-			return camperrors.NewCommand("", execResult.ExitCode, "", nil)
-		}
-		return nil
-	}
-
-	// Save current location (source) so toggle can return here
-	cwd, _ := os.Getwd()
-	_ = state.SetLastLocation(ctx, campaignRoot, cwd)
-
-	if printOnly {
-		fmt.Println(jumpResult.Path)
-	} else {
-		fmt.Printf("cd %s\n", jumpResult.Path)
-	}
 	return nil
 }
 

--- a/cmd/camp/root.go
+++ b/cmd/camp/root.go
@@ -21,6 +21,7 @@ import (
 	worktreespkg "github.com/Obedience-Corp/camp/cmd/camp/worktrees"
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/commands/release"
+	workflowcmd "github.com/Obedience-Corp/camp/internal/commands/workflow"
 	workitemcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/ui"
@@ -208,6 +209,9 @@ func init() {
 	workitemCmd := workitemcmd.NewWorkitemCommand()
 	workitemCmd.GroupID = "planning"
 	rootCmd.AddCommand(workitemCmd)
+	workflowCmd := workflowcmd.NewWorkflowCommand()
+	workflowCmd.GroupID = "planning"
+	rootCmd.AddCommand(workflowCmd)
 
 	attachResolverFactory := func(stderr io.Writer, usageLine string) attachpkg.CampaignResolver {
 		return attachpkg.NewResolver(stderr, usageLine)

--- a/internal/commands/flow/flow.go
+++ b/internal/commands/flow/flow.go
@@ -16,7 +16,7 @@ import (
 func NewFlowCommand() *cobra.Command {
 	flowCmd := &cobra.Command{
 		Use:     "flow",
-		Aliases: []string{"workflow", "wf"},
+		Aliases: []string{"wf"},
 		Short:   "Manage status workflows for organizing work",
 		Long: `Manage status workflows for organizing work.
 

--- a/internal/commands/workflow/create.go
+++ b/internal/commands/workflow/create.go
@@ -1,0 +1,202 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
+)
+
+var pathSegmentPattern = regexp.MustCompile(`^[^\s/\\.\-\x00-\x1f][^\s/\\\x00-\x1f]{0,79}$`)
+
+func newCreateCommand() *cobra.Command {
+	var shortcut, title string
+	var replace bool
+
+	cmd := &cobra.Command{
+		Use:   "create <type>",
+		Short: "Create a custom workflow collection",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCreate(cmd.Context(), cmd, createOptions{
+				Type:     args[0],
+				Shortcut: shortcut,
+				Title:    title,
+				Replace:  replace,
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&shortcut, "shortcut", "", "navigation shortcut for this workflow")
+	cmd.Flags().StringVar(&title, "title", "", "human-readable workflow title")
+	cmd.Flags().BoolVar(&replace, "replace", false, "replace an existing shortcut or concept with the same name")
+	_ = cmd.MarkFlagRequired("shortcut")
+
+	return cmd
+}
+
+type createOptions struct {
+	Type     string
+	Shortcut string
+	Title    string
+	Replace  bool
+}
+
+func runCreate(ctx context.Context, cmd *cobra.Command, opts createOptions) error {
+	if err := validatePathSegment("type", opts.Type); err != nil {
+		return err
+	}
+	if err := validatePathSegment("shortcut", opts.Shortcut); err != nil {
+		return err
+	}
+
+	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	workflowTitle := opts.Title
+	if workflowTitle == "" {
+		workflowTitle = opts.Type
+	}
+
+	relPath := path.Join("workflow", opts.Type) + "/"
+	absPath := filepath.Join(campaignRoot, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(absPath, 0o755); err != nil {
+		return camperrors.Wrapf(err, "create workflow directory %s", relPath)
+	}
+
+	if err := writeOBEYIfMissing(absPath, opts.Type, workflowTitle); err != nil {
+		return err
+	}
+
+	if err := upsertShortcut(ctx, campaignRoot, cfg, opts.Shortcut, relPath, workflowTitle, opts.Replace); err != nil {
+		return err
+	}
+	if err := upsertConcept(ctx, campaignRoot, cfg, opts.Type, relPath, workflowTitle, opts.Replace); err != nil {
+		return err
+	}
+	invalidateNavigationCache(cmd, campaignRoot)
+
+	fmt.Fprintf(cmd.OutOrStdout(),
+		"created %s\n  shortcut: %s -> %s\n  workitem type: %s\nnext: camp workitem create <slug> --type %s\n",
+		strings.TrimRight(relPath, "/"), opts.Shortcut, relPath, opts.Type, opts.Type)
+	return nil
+}
+
+func validatePathSegment(field, value string) error {
+	if value == "" {
+		return camperrors.NewValidation(field, field+" must not be empty", nil)
+	}
+	if !pathSegmentPattern.MatchString(value) {
+		return camperrors.NewValidation(field,
+			"invalid "+field+" "+value+": must not be empty, must not contain '/', '\\', whitespace, or control characters, must not start with '.' or '-', max 80 chars", nil)
+	}
+	return nil
+}
+
+func writeOBEYIfMissing(absPath, workflowType, title string) error {
+	obeyPath := filepath.Join(absPath, "OBEY.md")
+	if _, err := os.Stat(obeyPath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return camperrors.Wrap(err, "stat workflow OBEY.md")
+	}
+
+	content := fmt.Sprintf(`# %s
+
+Custom workflow collection for %q workitems.
+
+Create a workitem:
+
+`+"```bash"+`
+camp workitem create <slug> --type %s
+`+"```"+`
+`, title, workflowType, workflowType)
+
+	if err := os.WriteFile(obeyPath, []byte(content), 0o644); err != nil {
+		return camperrors.Wrap(err, "write workflow OBEY.md")
+	}
+	return nil
+}
+
+func upsertShortcut(ctx context.Context, campaignRoot string, cfg *config.CampaignConfig, shortcut, relPath, title string, replace bool) error {
+	jumps := cfg.Jumps
+	if jumps == nil {
+		defaults := config.DefaultJumpsConfig()
+		jumps = &defaults
+	}
+	if jumps.Shortcuts == nil {
+		jumps.Shortcuts = make(map[string]config.ShortcutConfig)
+	}
+
+	if existing, ok := jumps.Shortcuts[shortcut]; ok && !replace {
+		if existing.Path == relPath {
+			return nil
+		}
+		return camperrors.NewValidation("shortcut",
+			"shortcut "+shortcut+" already points to "+existing.Path+"; use --replace to update it", nil)
+	}
+
+	jumps.Shortcuts[shortcut] = config.ShortcutConfig{
+		Path:        relPath,
+		Description: title + " workflow",
+		Source:      config.ShortcutSourceUser,
+	}
+	cfg.Jumps = jumps
+
+	if err := config.SaveJumpsConfig(ctx, campaignRoot, jumps); err != nil {
+		return err
+	}
+	return nil
+}
+
+func upsertConcept(ctx context.Context, campaignRoot string, cfg *config.CampaignConfig, name, relPath, title string, replace bool) error {
+	concepts := cfg.ConceptList
+	if len(concepts) == 0 {
+		concepts = cfg.Concepts()
+	}
+
+	for i, concept := range concepts {
+		if strings.EqualFold(concept.Name, name) {
+			if concept.Path == relPath {
+				cfg.ConceptList = concepts
+				return nil
+			}
+			if !replace {
+				return camperrors.NewValidation("type",
+					"concept "+name+" already points to "+concept.Path+"; use --replace to update it", nil)
+			}
+			concepts[i] = config.ConceptEntry{
+				Name:        name,
+				Path:        relPath,
+				Description: title + " workflow",
+			}
+			cfg.ConceptList = concepts
+			return config.SaveCampaignConfig(ctx, campaignRoot, cfg)
+		}
+	}
+
+	concepts = append(concepts, config.ConceptEntry{
+		Name:        name,
+		Path:        relPath,
+		Description: title + " workflow",
+	})
+	cfg.ConceptList = concepts
+	return config.SaveCampaignConfig(ctx, campaignRoot, cfg)
+}
+
+func invalidateNavigationCache(cmd *cobra.Command, campaignRoot string) {
+	if err := navindex.Delete(campaignRoot); err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: failed to invalidate navigation cache: %v\n", err)
+	}
+}

--- a/internal/commands/workflow/create.go
+++ b/internal/commands/workflow/create.go
@@ -6,17 +6,17 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/nav"
 	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
+	"github.com/Obedience-Corp/camp/internal/pathsafe"
 )
-
-var pathSegmentPattern = regexp.MustCompile(`^[^\s/\\.\-\x00-\x1f][^\s/\\\x00-\x1f]{0,79}$`)
 
 func newCreateCommand() *cobra.Command {
 	var shortcut, title string
@@ -58,6 +58,7 @@ func runCreate(ctx context.Context, cmd *cobra.Command, opts createOptions) erro
 	if err := validatePathSegment("shortcut", opts.Shortcut); err != nil {
 		return err
 	}
+	shortcutKey := nav.NormalizeNavigationName(opts.Shortcut)
 
 	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
 	if err != nil {
@@ -79,7 +80,7 @@ func runCreate(ctx context.Context, cmd *cobra.Command, opts createOptions) erro
 		return err
 	}
 
-	if err := upsertShortcut(ctx, campaignRoot, cfg, opts.Shortcut, relPath, workflowTitle, opts.Replace); err != nil {
+	if err := upsertShortcut(ctx, campaignRoot, cfg, shortcutKey, relPath, workflowTitle, opts.Replace); err != nil {
 		return err
 	}
 	if err := upsertConcept(ctx, campaignRoot, cfg, opts.Type, relPath, workflowTitle, opts.Replace); err != nil {
@@ -89,19 +90,12 @@ func runCreate(ctx context.Context, cmd *cobra.Command, opts createOptions) erro
 
 	fmt.Fprintf(cmd.OutOrStdout(),
 		"created %s\n  shortcut: %s -> %s\n  workitem type: %s\nnext: camp workitem create <slug> --type %s\n",
-		strings.TrimRight(relPath, "/"), opts.Shortcut, relPath, opts.Type, opts.Type)
+		strings.TrimRight(relPath, "/"), shortcutKey, relPath, opts.Type, opts.Type)
 	return nil
 }
 
 func validatePathSegment(field, value string) error {
-	if value == "" {
-		return camperrors.NewValidation(field, field+" must not be empty", nil)
-	}
-	if !pathSegmentPattern.MatchString(value) {
-		return camperrors.NewValidation(field,
-			"invalid "+field+" "+value+": must not be empty, must not contain '/', '\\', whitespace, or control characters, must not start with '.' or '-', max 80 chars", nil)
-	}
-	return nil
+	return pathsafe.ValidateSegment(field, value)
 }
 
 func writeOBEYIfMissing(absPath, workflowType, title string) error {
@@ -139,15 +133,22 @@ func upsertShortcut(ctx context.Context, campaignRoot string, cfg *config.Campai
 		jumps.Shortcuts = make(map[string]config.ShortcutConfig)
 	}
 
-	if existing, ok := jumps.Shortcuts[shortcut]; ok && !replace {
-		if existing.Path == relPath {
-			return nil
+	shortcutKey := nav.NormalizeNavigationName(shortcut)
+	matches := matchingShortcutKeys(jumps.Shortcuts, shortcutKey)
+	for _, match := range matches {
+		existing := jumps.Shortcuts[match]
+		if existing.Path != relPath && !replace {
+			return camperrors.NewValidation("shortcut",
+				"shortcut "+shortcutKey+" already points to "+existing.Path+"; use --replace to update it", nil)
 		}
-		return camperrors.NewValidation("shortcut",
-			"shortcut "+shortcut+" already points to "+existing.Path+"; use --replace to update it", nil)
+	}
+	for _, match := range matches {
+		if match != shortcutKey {
+			delete(jumps.Shortcuts, match)
+		}
 	}
 
-	jumps.Shortcuts[shortcut] = config.ShortcutConfig{
+	jumps.Shortcuts[shortcutKey] = config.ShortcutConfig{
 		Path:        relPath,
 		Description: title + " workflow",
 		Source:      config.ShortcutSourceUser,
@@ -158,6 +159,18 @@ func upsertShortcut(ctx context.Context, campaignRoot string, cfg *config.Campai
 		return err
 	}
 	return nil
+}
+
+func matchingShortcutKeys(shortcuts map[string]config.ShortcutConfig, shortcut string) []string {
+	normalized := nav.NormalizeNavigationName(shortcut)
+	var matches []string
+	for key := range shortcuts {
+		if nav.NormalizeNavigationName(key) == normalized {
+			matches = append(matches, key)
+		}
+	}
+	sort.Strings(matches)
+	return matches
 }
 
 func upsertConcept(ctx context.Context, campaignRoot string, cfg *config.CampaignConfig, name, relPath, title string, replace bool) error {

--- a/internal/commands/workflow/create_test.go
+++ b/internal/commands/workflow/create_test.go
@@ -1,0 +1,433 @@
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+)
+
+func TestValidatePathSegment(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		ok    bool
+	}{
+		{name: "simple", value: "research", ok: true},
+		{name: "uppercase", value: "Research", ok: true},
+		{name: "dotted", value: "v1.2", ok: true},
+		{name: "empty", value: "", ok: false},
+		{name: "slash", value: "research/notes", ok: false},
+		{name: "backslash", value: `research\notes`, ok: false},
+		{name: "leading dot", value: ".research", ok: false},
+		{name: "leading dash", value: "-research", ok: false},
+		{name: "space", value: "research notes", ok: false},
+		{name: "control", value: "research\x1fnotes", ok: false},
+		{name: "too long", value: strings.Repeat("a", 81), ok: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePathSegment("type", tc.value)
+			if (err == nil) != tc.ok {
+				t.Fatalf("validatePathSegment(%q) error = %v, want ok %v", tc.value, err, tc.ok)
+			}
+		})
+	}
+}
+
+func TestWriteOBEYIfMissingDoesNotOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	obeyPath := filepath.Join(dir, "OBEY.md")
+	const existing = "custom user workflow docs\n"
+	if err := os.WriteFile(obeyPath, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeOBEYIfMissing(dir, "research", "Research"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(obeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != existing {
+		t.Fatalf("OBEY.md was overwritten: got %q, want %q", got, existing)
+	}
+}
+
+func TestUpsertShortcutIdempotentAndNormalizesStorageKey(t *testing.T) {
+	root := t.TempDir()
+	cfg := &config.CampaignConfig{
+		Jumps: &config.JumpsConfig{
+			Shortcuts: map[string]config.ShortcutConfig{
+				"RE": {Path: "workflow/research/"},
+			},
+		},
+	}
+
+	err := upsertShortcut(context.Background(), root, cfg, "re", "workflow/research/", "Research", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Jumps.Shortcuts["RE"]; ok {
+		t.Fatal("uppercase shortcut key was not normalized away")
+	}
+	got, ok := cfg.Jumps.Shortcuts["re"]
+	if !ok {
+		t.Fatal("normalized shortcut key re was not persisted")
+	}
+	if got.Path != "workflow/research/" {
+		t.Fatalf("shortcut path = %q, want workflow/research/", got.Path)
+	}
+
+	reloaded, err := config.LoadJumpsConfig(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := reloaded.Shortcuts["RE"]; ok {
+		t.Fatal("uppercase shortcut key was persisted to jumps.yaml")
+	}
+	if reloaded.Shortcuts["re"].Path != "workflow/research/" {
+		t.Fatalf("persisted shortcut path = %q, want workflow/research/", reloaded.Shortcuts["re"].Path)
+	}
+}
+
+func TestUpsertShortcutCollisionWithoutReplace(t *testing.T) {
+	root := t.TempDir()
+	cfg := &config.CampaignConfig{
+		Jumps: &config.JumpsConfig{
+			Shortcuts: map[string]config.ShortcutConfig{
+				"re": {Path: "workflow/old-research/"},
+			},
+		},
+	}
+
+	err := upsertShortcut(context.Background(), root, cfg, "RE", "workflow/research/", "Research", false)
+	if err == nil {
+		t.Fatal("upsertShortcut collision returned nil, want validation error")
+	}
+	if !strings.Contains(err.Error(), "workflow/old-research/") {
+		t.Fatalf("collision error = %q, want existing path", err)
+	}
+}
+
+func TestUpsertShortcutReplaceRemovesCaseVariants(t *testing.T) {
+	root := t.TempDir()
+	cfg := &config.CampaignConfig{
+		Jumps: &config.JumpsConfig{
+			Shortcuts: map[string]config.ShortcutConfig{
+				"re": {Path: "workflow/old-research/"},
+				"RE": {Path: "workflow/research/"},
+			},
+		},
+	}
+
+	err := upsertShortcut(context.Background(), root, cfg, "RE", "workflow/new-research/", "Research", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Jumps.Shortcuts["RE"]; ok {
+		t.Fatal("case-variant shortcut key was not removed")
+	}
+	got, ok := cfg.Jumps.Shortcuts["re"]
+	if !ok {
+		t.Fatal("normalized shortcut key re was not persisted")
+	}
+	if got.Path != "workflow/new-research/" {
+		t.Fatalf("shortcut path = %q, want workflow/new-research/", got.Path)
+	}
+
+	reloaded, err := config.LoadJumpsConfig(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := reloaded.Shortcuts["RE"]; ok {
+		t.Fatal("case-variant shortcut key was persisted to jumps.yaml")
+	}
+	if reloaded.Shortcuts["re"].Path != "workflow/new-research/" {
+		t.Fatalf("persisted shortcut path = %q, want workflow/new-research/", reloaded.Shortcuts["re"].Path)
+	}
+}
+
+func TestUpsertConceptCollisionWithoutReplace(t *testing.T) {
+	root := t.TempDir()
+	cfg := &config.CampaignConfig{
+		ConceptList: []config.ConceptEntry{
+			{Name: "Research", Path: "workflow/old-research/"},
+		},
+	}
+
+	err := upsertConcept(context.Background(), root, cfg, "research", "workflow/research/", "Research", false)
+	if err == nil {
+		t.Fatal("upsertConcept collision returned nil, want validation error")
+	}
+	if !strings.Contains(err.Error(), "workflow/old-research/") {
+		t.Fatalf("collision error = %q, want existing path", err)
+	}
+}
+
+func TestUpsertConceptReplace(t *testing.T) {
+	root := t.TempDir()
+	cfg := &config.CampaignConfig{
+		ConceptList: []config.ConceptEntry{
+			{Name: "Research", Path: "workflow/old-research/"},
+		},
+	}
+
+	err := upsertConcept(context.Background(), root, cfg, "research", "workflow/research/", "Research", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.ConceptList) != 1 {
+		t.Fatalf("len(ConceptList) = %d, want 1", len(cfg.ConceptList))
+	}
+	if cfg.ConceptList[0].Name != "research" {
+		t.Fatalf("concept name = %q, want research", cfg.ConceptList[0].Name)
+	}
+	if cfg.ConceptList[0].Path != "workflow/research/" {
+		t.Fatalf("concept path = %q, want workflow/research/", cfg.ConceptList[0].Path)
+	}
+
+	campaignYAML, err := os.ReadFile(config.CampaignConfigPath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(campaignYAML), "path: workflow/research/") {
+		t.Fatalf("campaign.yaml did not persist replacement concept:\n%s", campaignYAML)
+	}
+}
+
+func TestRunCreateRegistersExistingUserWorkflow(t *testing.T) {
+	root := newWorkflowTestCampaign(t)
+	workflowDir := filepath.Join(root, "workflow", "research")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const existingOBEY = "user-authored workflow docs\n"
+	if err := os.WriteFile(filepath.Join(workflowDir, "OBEY.md"), []byte(existingOBEY), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}()
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err = runCreate(context.Background(), cmd, createOptions{
+		Type:     "research",
+		Shortcut: "RE",
+		Title:    "Research",
+	})
+	if err != nil {
+		t.Fatalf("runCreate returned error: %v; stderr=%s", err, stderr.String())
+	}
+
+	if !strings.Contains(stdout.String(), "shortcut: re -> workflow/research/") {
+		t.Fatalf("stdout = %q, want normalized shortcut", stdout.String())
+	}
+	gotOBEY, err := os.ReadFile(filepath.Join(workflowDir, "OBEY.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotOBEY) != existingOBEY {
+		t.Fatalf("existing OBEY.md was overwritten: got %q", gotOBEY)
+	}
+
+	jumps, err := config.LoadJumpsConfig(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := jumps.Shortcuts["RE"]; ok {
+		t.Fatal("uppercase shortcut key was persisted")
+	}
+	gotShortcut, ok := jumps.Shortcuts["re"]
+	if !ok {
+		t.Fatal("shortcut re missing from jumps.yaml")
+	}
+	if gotShortcut.Path != "workflow/research/" {
+		t.Fatalf("shortcut path = %q, want workflow/research/", gotShortcut.Path)
+	}
+
+	cfg, err := config.LoadCampaignConfig(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundConcept := false
+	for _, concept := range cfg.ConceptList {
+		if concept.Name == "research" && concept.Path == "workflow/research/" {
+			foundConcept = true
+			break
+		}
+	}
+	if !foundConcept {
+		t.Fatalf("research concept missing from campaign config: %#v", cfg.ConceptList)
+	}
+}
+
+func TestRunCreateIdempotentForSameWorkflow(t *testing.T) {
+	root := newWorkflowTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := &cobra.Command{}
+	err := runCreate(context.Background(), cmd, createOptions{
+		Type:     "research",
+		Shortcut: "re",
+		Title:    "Research",
+	})
+	if err != nil {
+		t.Fatalf("first runCreate returned error: %v", err)
+	}
+
+	cmd = &cobra.Command{}
+	err = runCreate(context.Background(), cmd, createOptions{
+		Type:     "research",
+		Shortcut: "RE",
+		Title:    "Research",
+	})
+	if err != nil {
+		t.Fatalf("second runCreate returned error: %v", err)
+	}
+
+	jumps, err := config.LoadJumpsConfig(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := jumps.Shortcuts["RE"]; ok {
+		t.Fatal("case-variant shortcut key was persisted")
+	}
+	if jumps.Shortcuts["re"].Path != "workflow/research/" {
+		t.Fatalf("shortcut path = %q, want workflow/research/", jumps.Shortcuts["re"].Path)
+	}
+
+	cfg, err := config.LoadCampaignConfig(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, concept := range cfg.ConceptList {
+		if strings.EqualFold(concept.Name, "research") && concept.Path == "workflow/research/" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("research concept count = %d, want 1: %#v", count, cfg.ConceptList)
+	}
+}
+
+func TestRunCreateReplacePersistsShortcutAndConcept(t *testing.T) {
+	root := newWorkflowTestCampaign(t)
+	cfg := &config.CampaignConfig{
+		ID:   "test-campaign",
+		Name: "Workflow Test",
+		Type: config.CampaignTypeProduct,
+		ConceptList: []config.ConceptEntry{
+			{Name: "Research", Path: "workflow/old-research/"},
+		},
+	}
+	if err := config.SaveCampaignConfig(context.Background(), root, cfg); err != nil {
+		t.Fatal(err)
+	}
+	jumps := &config.JumpsConfig{
+		Shortcuts: map[string]config.ShortcutConfig{
+			"RE": {Path: "workflow/old-research/"},
+		},
+	}
+	if err := config.SaveJumpsConfig(context.Background(), root, jumps); err != nil {
+		t.Fatal(err)
+	}
+
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := &cobra.Command{}
+	err := runCreate(context.Background(), cmd, createOptions{
+		Type:     "research",
+		Shortcut: "re",
+		Title:    "Research",
+		Replace:  true,
+	})
+	if err != nil {
+		t.Fatalf("runCreate replace returned error: %v", err)
+	}
+
+	reloadedJumps, err := config.LoadJumpsConfig(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := reloadedJumps.Shortcuts["RE"]; ok {
+		t.Fatal("case-variant shortcut key was persisted")
+	}
+	if reloadedJumps.Shortcuts["re"].Path != "workflow/research/" {
+		t.Fatalf("persisted shortcut path = %q, want workflow/research/", reloadedJumps.Shortcuts["re"].Path)
+	}
+
+	reloadedCfg, err := config.LoadCampaignConfig(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reloadedCfg.ConceptList) != 1 {
+		t.Fatalf("len(ConceptList) = %d, want 1: %#v", len(reloadedCfg.ConceptList), reloadedCfg.ConceptList)
+	}
+	if reloadedCfg.ConceptList[0].Name != "research" {
+		t.Fatalf("concept name = %q, want research", reloadedCfg.ConceptList[0].Name)
+	}
+	if reloadedCfg.ConceptList[0].Path != "workflow/research/" {
+		t.Fatalf("concept path = %q, want workflow/research/", reloadedCfg.ConceptList[0].Path)
+	}
+}
+
+func chdir(t *testing.T, dir string) func() {
+	t.Helper()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	return func() {
+		t.Helper()
+		if err := os.Chdir(oldWd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}
+}
+
+func newWorkflowTestCampaign(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	campaignDir := filepath.Join(root, ".campaign")
+	if err := os.MkdirAll(campaignDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const campaignYAML = `id: test-campaign
+name: Workflow Test
+type: product
+`
+	if err := os.WriteFile(filepath.Join(campaignDir, "campaign.yaml"), []byte(campaignYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}

--- a/internal/commands/workflow/workflow.go
+++ b/internal/commands/workflow/workflow.go
@@ -1,0 +1,18 @@
+package workflow
+
+import "github.com/spf13/cobra"
+
+// NewWorkflowCommand creates the camp workflow command.
+func NewWorkflowCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "workflow",
+		Short: "Manage workflow collections",
+		Long: `Manage workflow collections.
+
+A workflow collection is a campaign directory under workflow/<type>/ with
+navigation config and workitem type support.`,
+	}
+
+	cmd.AddCommand(newCreateCommand())
+	return cmd
+}

--- a/internal/commands/workitem/create.go
+++ b/internal/commands/workitem/create.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -17,25 +16,9 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/pathsafe"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
-
-// slugPattern is a path-safety check, not a style enforcer. It permits any
-// naming convention users already use (kebab-case, snake_case, camelCase,
-// PascalCase, dotted versions like v1.2, etc.) and only rejects values that
-// would be unsafe as filesystem path segments or confuse shell tooling:
-//
-//   - empty
-//   - contains '/' or '\' (would split into multiple path segments;
-//     '\' is the path separator on Windows)
-//   - starts with '.' (reserved for hidden / "." / ".." traversal)
-//   - starts with '-' (would parse as a CLI flag in downstream tools)
-//   - contains whitespace, NUL, or ASCII control characters
-//   - longer than 80 chars (cross-fs name-length headroom)
-//
-// Anything else — including uppercase, dots, unicode letters — is accepted
-// because the project does not own its users' naming conventions.
-var slugPattern = regexp.MustCompile(`^[^\s/\\.\-\x00-\x1f][^\s/\\\x00-\x1f]{0,79}$`)
 
 func newCreateCommand() *cobra.Command {
 	var typeFlag, title, idOverride, dirOverride string
@@ -114,14 +97,7 @@ func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, i
 }
 
 func validateSlug(slug string) error {
-	if slug == "" {
-		return camperrors.NewValidation("slug", "slug must not be empty", nil)
-	}
-	if !slugPattern.MatchString(slug) {
-		return camperrors.NewValidation("slug",
-			"invalid slug "+slug+": must not be empty, must not contain '/', '\\', whitespace, or control characters, must not start with '.' or '-', max 80 chars", nil)
-	}
-	return nil
+	return pathsafe.ValidateSegment("slug", slug)
 }
 
 func validateParentPath(parent string) error {

--- a/internal/complete/complete.go
+++ b/internal/complete/complete.go
@@ -348,6 +348,7 @@ func listPathCandidates(ctx context.Context, absPath, prefix string) ([]string, 
 	if err != nil {
 		return nil, err
 	}
+	entries = orderPathCandidates(absPath, entries)
 
 	var candidates []string
 	prefixLower := strings.ToLower(prefix)
@@ -375,6 +376,7 @@ func listPathCandidatesRich(ctx context.Context, absPath, relativePath, prefix s
 	if err != nil {
 		return nil, err
 	}
+	entries = orderPathCandidates(absPath, entries)
 
 	var candidates []index.CompletionCandidate
 	prefixLower := strings.ToLower(prefix)
@@ -416,6 +418,52 @@ func readDirForCompletion(absPath string) ([]os.DirEntry, error) {
 		return nil, err
 	}
 	return entries, nil
+}
+
+func orderPathCandidates(absPath string, entries []os.DirEntry) []os.DirEntry {
+	type rankedEntry struct {
+		entry      os.DirEntry
+		isWorkitem bool
+		modTime    time.Time
+	}
+
+	ranked := make([]rankedEntry, len(entries))
+	hasWorkitems := false
+	for i, entry := range entries {
+		ranked[i] = rankedEntry{entry: entry}
+		if !entry.IsDir() {
+			continue
+		}
+		markerPath := filepath.Join(absPath, entry.Name(), ".workitem")
+		info, err := os.Stat(markerPath)
+		if err != nil {
+			continue
+		}
+		ranked[i].isWorkitem = true
+		ranked[i].modTime = info.ModTime()
+		hasWorkitems = true
+	}
+
+	if !hasWorkitems {
+		return entries
+	}
+
+	sort.SliceStable(ranked, func(i, j int) bool {
+		a, b := ranked[i], ranked[j]
+		if a.isWorkitem != b.isWorkitem {
+			return a.isWorkitem
+		}
+		if a.isWorkitem && !a.modTime.Equal(b.modTime) {
+			return a.modTime.After(b.modTime)
+		}
+		return strings.ToLower(a.entry.Name()) < strings.ToLower(b.entry.Name())
+	})
+
+	ordered := make([]os.DirEntry, len(ranked))
+	for i, item := range ranked {
+		ordered[i] = item.entry
+	}
+	return ordered
 }
 
 func completeSubdirectoryInPath(ctx context.Context, basePath, query string) ([]string, error) {

--- a/internal/complete/complete_test.go
+++ b/internal/complete/complete_test.go
@@ -212,6 +212,59 @@ func TestGenerate_CategoryWithQuery(t *testing.T) {
 	}
 }
 
+func TestGenerate_CustomWorkflowShortcutRecentFirst(t *testing.T) {
+	root := createTestCampaign(t)
+	settingsDir := filepath.Join(root, ".campaign", "settings")
+	if err := os.MkdirAll(settingsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	jumps := `paths:
+  workflow: "workflow/"
+shortcuts:
+  re:
+    path: "workflow/research/"
+    description: "Research workflow"
+`
+	if err := os.WriteFile(filepath.Join(settingsDir, "jumps.yaml"), []byte(jumps), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	olderDir := filepath.Join(root, "workflow", "research", "older-work")
+	newerDir := filepath.Join(root, "workflow", "research", "newer-work")
+	for _, dir := range []string{olderDir, newerDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, ".workitem"), []byte("kind: workitem\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	now := time.Now()
+	if err := os.Chtimes(filepath.Join(olderDir, ".workitem"), now.Add(-1*time.Hour), now.Add(-1*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(filepath.Join(newerDir, ".workitem"), now, now); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWd, _ := os.Getwd()
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+
+	candidates, err := Generate(context.Background(), []string{"re"})
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	if len(candidates) < 2 {
+		t.Fatalf("Got %d candidates, want at least 2: %v", len(candidates), candidates)
+	}
+	if candidates[0] != "newer-work/" || candidates[1] != "older-work/" {
+		t.Fatalf("candidates = %v, want newer workitem before older workitem", candidates)
+	}
+}
+
 func TestGenerate_PartialShortcut(t *testing.T) {
 	// Create test campaign with shortcuts
 	root := createTestCampaign(t)

--- a/internal/nav/configured_navigation.go
+++ b/internal/nav/configured_navigation.go
@@ -172,7 +172,14 @@ func findNavigationShortcut(shortcuts map[string]config.ShortcutConfig, name str
 	if shortcut, ok := shortcuts[normalized]; ok {
 		return shortcut, true
 	}
-	for key, shortcut := range shortcuts {
+
+	keys := make([]string, 0, len(shortcuts))
+	for key := range shortcuts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		shortcut := shortcuts[key]
 		if NormalizeNavigationName(key) == normalized {
 			return shortcut, true
 		}

--- a/internal/nav/configured_navigation.go
+++ b/internal/nav/configured_navigation.go
@@ -111,29 +111,19 @@ func ResolveConfiguredTarget(cfg *config.CampaignConfig, args []string) Configur
 	// Compute shortcut and alias maps once — both branches below may consult
 	// them, and this is on the shell-completion hot path.
 	shortcuts := cfg.Shortcuts()
-	shortcutMappings := BuildCategoryMappings(shortcuts)
 	aliases := BuildPathAliasMappings(shortcuts)
 
 	// (1) Shortcut-drill form: "de@foo"
 	if parsedArgs, ok := splitShortcutDrillArgs(args); ok {
-		parsed := ParseShortcut(parsedArgs, shortcutMappings)
-		if parsed.IsShortcut {
-			return ConfiguredTarget{
-				Category: parsed.Category,
-				Query:    parsed.Query,
-				Drill:    true,
-				Matched:  true,
-			}
+		if target, ok := resolveNavigationShortcut(shortcuts, parsedArgs); ok {
+			target.Drill = true
+			return target
 		}
 	}
 
 	// (2) Plain shortcut key: "de"
-	if parsed := ParseShortcut(args, shortcutMappings); parsed.IsShortcut {
-		return ConfiguredTarget{
-			Category: parsed.Category,
-			Query:    parsed.Query,
-			Matched:  true,
-		}
+	if target, ok := resolveNavigationShortcut(shortcuts, args); ok {
+		return target
 	}
 
 	// (3) Slash-drill form: "design/foo" — resolve token via concept/alias.
@@ -145,6 +135,49 @@ func ResolveConfiguredTarget(cfg *config.CampaignConfig, args []string) Configur
 
 	// (4)/(5) Plain concept or path alias: "design" or "ai_docs"
 	return resolveDrillTarget(cfg, aliases, args)
+}
+
+func resolveNavigationShortcut(shortcuts map[string]config.ShortcutConfig, args []string) (ConfiguredTarget, bool) {
+	if len(args) == 0 {
+		return ConfiguredTarget{}, false
+	}
+
+	shortcut, ok := findNavigationShortcut(shortcuts, args[0])
+	if !ok || !shortcut.IsNavigation() {
+		return ConfiguredTarget{}, false
+	}
+
+	query := ""
+	if len(args) > 1 {
+		query = strings.Join(args[1:], " ")
+	}
+
+	if cat, ok := CategoryForStandardPath(shortcut.Path); ok {
+		return ConfiguredTarget{
+			Category: cat,
+			Query:    query,
+			Matched:  true,
+		}, true
+	}
+
+	return ConfiguredTarget{
+		RelativePath: shortcut.Path,
+		Query:        query,
+		Matched:      true,
+	}, true
+}
+
+func findNavigationShortcut(shortcuts map[string]config.ShortcutConfig, name string) (config.ShortcutConfig, bool) {
+	normalized := NormalizeNavigationName(name)
+	if shortcut, ok := shortcuts[normalized]; ok {
+		return shortcut, true
+	}
+	for key, shortcut := range shortcuts {
+		if NormalizeNavigationName(key) == normalized {
+			return shortcut, true
+		}
+	}
+	return config.ShortcutConfig{}, false
 }
 
 func resolveDrillTarget(cfg *config.CampaignConfig, aliases map[string]PathAliasTarget, args []string) ConfiguredTarget {

--- a/internal/nav/configured_navigation_test.go
+++ b/internal/nav/configured_navigation_test.go
@@ -24,6 +24,69 @@ func TestResolveConfiguredTarget_UsesShortcutKey(t *testing.T) {
 	}
 }
 
+func TestResolveConfiguredTarget_UsesCustomShortcutPath(t *testing.T) {
+	cfg := &config.CampaignConfig{
+		Jumps: &config.JumpsConfig{
+			Shortcuts: map[string]config.ShortcutConfig{
+				"re": {Path: "workflow/research/"},
+			},
+		},
+	}
+
+	got := ResolveConfiguredTarget(cfg, []string{"re", "compare-llms"})
+	if !got.Matched {
+		t.Fatal("ResolveConfiguredTarget() did not match custom shortcut key")
+	}
+	if got.RelativePath != "workflow/research/" {
+		t.Fatalf("RelativePath = %q, want %q", got.RelativePath, "workflow/research/")
+	}
+	if got.Query != "compare-llms" {
+		t.Fatalf("Query = %q, want %q", got.Query, "compare-llms")
+	}
+}
+
+func TestResolveConfiguredTarget_UsesCustomShortcutPathCaseInsensitive(t *testing.T) {
+	cfg := &config.CampaignConfig{
+		Jumps: &config.JumpsConfig{
+			Shortcuts: map[string]config.ShortcutConfig{
+				"RE": {Path: "workflow/research/"},
+			},
+		},
+	}
+
+	got := ResolveConfiguredTarget(cfg, []string{"re", "compare-llms"})
+	if !got.Matched {
+		t.Fatal("ResolveConfiguredTarget() did not match custom shortcut key")
+	}
+	if got.RelativePath != "workflow/research/" {
+		t.Fatalf("RelativePath = %q, want %q", got.RelativePath, "workflow/research/")
+	}
+}
+
+func TestResolveConfiguredTarget_SupportsCustomShortcutAtDrill(t *testing.T) {
+	cfg := &config.CampaignConfig{
+		Jumps: &config.JumpsConfig{
+			Shortcuts: map[string]config.ShortcutConfig{
+				"re": {Path: "workflow/research/"},
+			},
+		},
+	}
+
+	got := ResolveConfiguredTarget(cfg, []string{"re@compare-llms/docs"})
+	if !got.Matched {
+		t.Fatal("ResolveConfiguredTarget() did not match custom shortcut drill")
+	}
+	if got.RelativePath != "workflow/research/" {
+		t.Fatalf("RelativePath = %q, want %q", got.RelativePath, "workflow/research/")
+	}
+	if got.Query != "compare-llms/docs" {
+		t.Fatalf("Query = %q, want %q", got.Query, "compare-llms/docs")
+	}
+	if !got.Drill {
+		t.Fatal("Drill = false, want true")
+	}
+}
+
 func TestResolveConfiguredTarget_UsesConfiguredConceptName(t *testing.T) {
 	cfg := &config.CampaignConfig{
 		ConceptList: []config.ConceptEntry{

--- a/internal/pathsafe/segment.go
+++ b/internal/pathsafe/segment.go
@@ -1,0 +1,37 @@
+// Package pathsafe owns path segment validation shared by campaign workflows.
+package pathsafe
+
+import (
+	"regexp"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// SegmentPattern is a path-safety check, not a style enforcer. It permits any
+// naming convention users already use (kebab-case, snake_case, camelCase,
+// PascalCase, dotted versions like v1.2, etc.) and only rejects values that
+// would be unsafe as filesystem path segments or confuse shell tooling:
+//
+//   - empty
+//   - contains '/' or '\' (would split into multiple path segments; '\' is the
+//     path separator on Windows)
+//   - starts with '.' (reserved for hidden / "." / ".." traversal)
+//   - starts with '-' (would parse as a CLI flag in downstream tools)
+//   - contains whitespace, NUL, or ASCII control characters
+//   - longer than 80 chars (cross-fs name-length headroom)
+//
+// Anything else, including uppercase, dots, and unicode letters, is accepted
+// because the project does not own its users' naming conventions.
+var SegmentPattern = regexp.MustCompile(`^[^\s/\\.\-\x00-\x1f][^\s/\\\x00-\x1f]{0,79}$`)
+
+// ValidateSegment verifies value is safe as one filesystem path segment.
+func ValidateSegment(field, value string) error {
+	if value == "" {
+		return camperrors.NewValidation(field, field+" must not be empty", nil)
+	}
+	if !SegmentPattern.MatchString(value) {
+		return camperrors.NewValidation(field,
+			"invalid "+field+" "+value+": must not be empty, must not contain '/', '\\', whitespace, or control characters, must not start with '.' or '-', max 80 chars", nil)
+	}
+	return nil
+}

--- a/internal/pathsafe/segment_test.go
+++ b/internal/pathsafe/segment_test.go
@@ -1,0 +1,34 @@
+package pathsafe
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateSegment(t *testing.T) {
+	cases := []struct {
+		value string
+		ok    bool
+	}{
+		{"foo", true},
+		{"foo-bar", true},
+		{"foo_bar", true},
+		{"Foo", true},
+		{"v1.2", true},
+		{"", false},
+		{"foo bar", false},
+		{"foo/bar", false},
+		{`foo\bar`, false},
+		{".hidden", false},
+		{"-flaglike", false},
+		{"foo\x00bar", false},
+		{strings.Repeat("a", 81), false},
+	}
+
+	for _, tc := range cases {
+		err := ValidateSegment("slug", tc.value)
+		if (err == nil) != tc.ok {
+			t.Fatalf("ValidateSegment(%q) error = %v, want ok %v", tc.value, err, tc.ok)
+		}
+	}
+}

--- a/tests/integration/attachment_pin_test.go
+++ b/tests/integration/attachment_pin_test.go
@@ -139,6 +139,7 @@ func TestAttachmentPin_RejectsAttachInsideOtherCampaign(t *testing.T) {
 	require.NoError(t, err)
 
 	insideB := campaignB + "/festivals"
+	tc.Shell(t, "mkdir -p "+insideB)
 
 	output, exitCode, err := tc.ExecCommand("sh", "-c",
 		"cd "+campaignA+" && /camp attach "+insideB+" 2>&1")

--- a/tests/integration/workflow_create_test.go
+++ b/tests/integration/workflow_create_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_WorkflowCreateCustomWorkflow(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	const campaignDir = "/test/workflow-create"
+	_, err := tc.RunCamp(
+		"init", campaignDir,
+		"--name", "Workflow Create Test",
+		"--type", "product",
+		"-d", "Workflow create integration",
+		"-m", "Verify custom workflow creation",
+		"--force",
+		"--no-register",
+		"--no-git",
+	)
+	require.NoError(t, err, "camp init should succeed")
+
+	out, err := tc.RunCampInDir(campaignDir,
+		"workflow", "create", "research",
+		"--shortcut", "re",
+		"--title", "Research",
+	)
+	require.NoError(t, err, "camp workflow create: %s", out)
+	assert.Contains(t, out, "created workflow/research")
+	assert.Contains(t, out, "shortcut: re -> workflow/research/")
+	assert.Contains(t, out, "workitem type: research")
+
+	jumps, err := tc.ReadFile(campaignDir + "/.campaign/settings/jumps.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, jumps, "re:")
+	assert.Contains(t, jumps, "path: workflow/research/")
+
+	campaignYAML, err := tc.ReadFile(campaignDir + "/.campaign/campaign.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, campaignYAML, "name: research")
+	assert.Contains(t, campaignYAML, "path: workflow/research/")
+
+	out, err = tc.RunCampInDir(campaignDir,
+		"workitem", "create", "compare-llms",
+		"--type", "research",
+		"--title", "Compare LLMs",
+	)
+	require.NoError(t, err, "camp workitem create custom type: %s", out)
+	assert.Contains(t, out, "created workflow/research/compare-llms")
+
+	out, err = tc.RunCampInDir(campaignDir, "complete", "re")
+	require.NoError(t, err, "camp complete re: %s", out)
+	assert.Contains(t, out, "compare-llms")
+
+	out, err = tc.RunCampInDir(campaignDir, "complete", "research")
+	require.NoError(t, err, "camp complete research: %s", out)
+	assert.Contains(t, out, "compare-llms")
+
+	out, err = tc.RunCampInDir(campaignDir, "go", "re", "compare-llms", "--print")
+	require.NoError(t, err, "camp go re compare-llms --print: %s", out)
+	assert.Contains(t, out, "workflow/research/compare-llms")
+}


### PR DESCRIPTION
## Summary
- add `camp workflow create <type> --shortcut <key>` for user-defined workflow collections under `workflow/<type>/`
- route custom navigation shortcuts through the configured navigation resolver so `camp go re ...` and shortcut drill forms work for non-standard paths
- order workitem-backed completion candidates by recent `.workitem` updates so new custom workitems are easier to find

## Validation
- `go test ./internal/nav ./internal/complete ./internal/commands/workflow ./cmd/camp`
- `just test unit`
- `DOCKER_HOST="unix://${HOME}/.colima/default/docker.sock" TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock go test -count=1 -v -tags=integration ./tests/integration/... -run 'TestIntegration_WorkflowCreateCustomWorkflow|TestIntegration_WorkitemCreateAndAdopt' -timeout 5m`
