### PR TITLE
Tighten workitems skill guidance

### DIFF
--- a/internal/scaffold/campaign/templates/.campaign/skills/camp-workitems/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/camp-workitems/SKILL.md.tmpl
@@ -1,23 +1,28 @@
 ---
 name: camp-workitems
-description: Discover, triage, and create campaign work items with `camp workitem` / `camp workitems`. Use when finding active work across intents, designs, explore notes, festivals, or custom `.workitem` directories; when agents need `camp workitem --json`; or when creating/adopting tracked work-item folders.
+description: Find, filter, choose, create, or adopt campaign work items with `camp workitem`, `camp wi`, or `camp workitems`. Use when a user wants current active work across intents, designs, explore notes, festivals, or tracked workflow directories; when agents need safe `camp workitem --json` output; or when creating/adopting tracked workflow folders.
 ---
 
 # Camp Workitems
 
-`camp workitem` is the canonical command. `camp wi` and `camp workitems` are aliases.
+Use `camp workitem` to find current campaign work across intents, workflow
+design/explore docs, festivals, and tracked workflow directories.
 
-Use it to find active campaign work across intents, workflow design/explore
-docs, festivals, and custom `.workitem`-tracked workflow directories.
+`camp workitem` is canonical. `camp wi` and `camp workitems` are aliases.
 
-## Agent-Safe Discovery
+## Discover
 
-Agents and scripts should use non-interactive output:
+Agents and scripts should prefer JSON:
 
 ```bash
 camp workitem --json
-camp workitem --json --type intent --limit 5
 camp workitem --json --type design --query auth
+camp workitem --json --type intent --stage ready --limit 5
+```
+
+Use path output only when shell integration needs a destination:
+
+```bash
 camp workitem --print --type festival
 ```
 
@@ -30,35 +35,32 @@ Useful filters:
 - `--query <text>`
 - `--limit <n>`
 
-## Interactive Use
+## Interactive
 
 ```bash
 camp workitem
 ```
 
-The default command opens the TUI dashboard. Use this for human browsing,
-prioritization, and selection.
+Use the TUI for human browsing, prioritization, and selection.
 
-## Create Or Adopt Custom Workitems
+## Create Or Adopt
 
-Use custom workitems when work belongs under `workflow/<type>/<slug>` and
-should appear in the dashboard.
+Use custom workitems for `workflow/<type>/<slug>` directories that should
+appear in discovery.
 
 ```bash
 camp workitem create <slug> --type feature --title "Human title"
 camp workitem adopt workflow/feature/existing-dir --type feature --title "Human title"
 ```
 
-`create` makes `workflow/<type>/<slug>/` by default and writes `.workitem`.
-`adopt` attaches `.workitem` metadata to an existing directory.
-
 Slug and type values must be path-safe: no `/`, `\`, whitespace, or control
 characters; no leading `.` or `-`; max 80 characters.
 
-## Common Mistakes
+## Avoid
 
 - Running the interactive TUI from an agent session instead of using `--json`.
-- Creating custom `workflow/<type>/...` directories without `.workitem`; custom
-  types only surface when the marker exists.
+- Hand-writing tracking metadata for custom workitems. Use
+  `camp workitem create` or `camp workitem adopt` so discovery state stays
+  compatible.
 - Editing `.campaign/settings/workitems.json` manually. It is tool-managed
   priority state, not the work-item source of truth.


### PR DESCRIPTION
## Summary
- tighten the scaffolded `camp-workitems` skill using skill-authoring guidance
- keep the skill focused on discovery, interactive use, and create/adopt commands
- remove implementation-file details so agents use `camp workitem create` or `camp workitem adopt` instead of hand-writing tracking metadata

## Validation
- `go test ./internal/skills ./internal/scaffold`
- `go test -tags integration ./tests/integration -run 'TestInit_(ScaffoldsCampWorkitemsSkill|Repair_RestoresMissingSkillFiles)$' -count=1`