### PR TITLE
Move workitems to local dungeon

### DIFF
--- a/cmd/camp/dungeon/move.go
+++ b/cmd/camp/dungeon/move.go
@@ -23,6 +23,8 @@ var dungeonMoveCmd = &cobra.Command{
 Without --triage, moves an item already in the dungeon root to a status directory.
 With --triage, moves an item from the parent directory into the dungeon.
 With --triage and --to-docs, routes an item to an existing campaign-root docs/<subdirectory>.
+With --workitem, resolves a campaign workitem from anywhere and moves its directory
+into the workitem type's local dungeon.
 Moves are always auto-committed so dungeon history remains auditable.
 
 Statuses: completed, archived, someday
@@ -32,7 +34,8 @@ Examples:
   camp dungeon move stale-doc completed          Move dungeon item to completed
   camp dungeon move old-project --triage         Move parent item into dungeon root
   camp dungeon move old-project archived --triage Move parent item directly to archived
-  camp dungeon move stale-note.md --triage --to-docs architecture/api Route to docs subdirectory`,
+  camp dungeon move stale-note.md --triage --to-docs architecture/api Route to docs subdirectory
+  camp dungeon move feature-slug archived --workitem Move workitem directory to its local archive`,
 	Args: cobra.RangeArgs(1, 2),
 	Annotations: map[string]string{
 		"agent_allowed": "true",
@@ -47,6 +50,7 @@ func init() {
 	flags := dungeonMoveCmd.Flags()
 	flags.Bool("triage", false, "Move from parent directory (not from dungeon root)")
 	flags.String("to-docs", "", "Route triage item into an existing campaign-root docs/<subdir> (requires --triage)")
+	flags.Bool("workitem", false, "Resolve item as a campaign workitem and move its directory to the local dungeon")
 }
 
 func runDungeonMove(cmd *cobra.Command, args []string) error {
@@ -54,6 +58,7 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 
 	triageMode, _ := cmd.Flags().GetBool("triage")
 	toDocs, _ := cmd.Flags().GetString("to-docs")
+	workitemMode, _ := cmd.Flags().GetBool("workitem")
 
 	itemName := args[0]
 	status := ""
@@ -68,6 +73,20 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 		if status != "" {
 			return fmt.Errorf("status argument cannot be combined with --to-docs; use either a dungeon status or --to-docs <subdir>")
 		}
+	}
+
+	if workitemMode {
+		if triageMode {
+			return fmt.Errorf("--workitem cannot be combined with --triage because workitem mode resolves the source directory itself")
+		}
+		if toDocs != "" {
+			return fmt.Errorf("--workitem cannot be combined with --to-docs")
+		}
+		move, err := moveWorkitemToDungeon(ctx, cmd, itemName, status)
+		if err != nil {
+			return err
+		}
+		return commitDungeonMove(ctx, move)
 	}
 
 	cmdCtx, err := resolveDungeonCommandContext(ctx)
@@ -138,8 +157,18 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 		destinationPaths = []string{targetPath}
 	}
 
-	files := commit.NormalizeFiles(cmdCtx.CampaignRoot, destinationPaths...)
-	preStaged, err := stageTrackedMoveSourceDeletions(ctx, cmdCtx.CampaignRoot, sourcePaths)
+	return commitDungeonMove(ctx, &dungeonMoveCommit{
+		Config:           cmdCtx.Config,
+		CampaignRoot:     cmdCtx.CampaignRoot,
+		Description:      description,
+		SourcePaths:      sourcePaths,
+		DestinationPaths: destinationPaths,
+	})
+}
+
+func commitDungeonMove(ctx context.Context, move *dungeonMoveCommit) error {
+	files := commit.NormalizeFiles(move.CampaignRoot, move.DestinationPaths...)
+	preStaged, err := stageTrackedMoveSourceDeletions(ctx, move.CampaignRoot, move.SourcePaths)
 	if err != nil {
 		fmt.Printf("%s Move was applied on disk, but staging the source deletion failed.\n", ui.WarningIcon())
 		fmt.Printf("%s %v\n", ui.WarningIcon(), err)
@@ -147,11 +176,11 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 	}
 	result := commit.Crawl(ctx, commit.CrawlOptions{
 		Options: commit.Options{
-			CampaignRoot: cmdCtx.CampaignRoot,
-			CampaignID:   cmdCtx.Config.ID,
+			CampaignRoot: move.CampaignRoot,
+			CampaignID:   move.Config.ID,
 			PreStaged:    preStaged,
 		},
-		Description: strings.TrimSpace(description),
+		Description: strings.TrimSpace(move.Description),
 		Files:       files,
 	})
 	if result.Committed {

--- a/cmd/camp/dungeon/workitem_move.go
+++ b/cmd/camp/dungeon/workitem_move.go
@@ -1,0 +1,233 @@
+package dungeon
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	intdungeon "github.com/Obedience-Corp/camp/internal/dungeon"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+type dungeonMoveCommit struct {
+	Config           *config.CampaignConfig
+	CampaignRoot     string
+	Description      string
+	SourcePaths      []string
+	DestinationPaths []string
+}
+
+type resolvedWorkitemDungeonTarget struct {
+	Item        wkitem.WorkItem
+	ItemName    string
+	ParentPath  string
+	DungeonPath string
+	SourcePath  string
+}
+
+func moveWorkitemToDungeon(ctx context.Context, cmd *cobra.Command, target, status string) (*dungeonMoveCommit, error) {
+	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	resolver := paths.NewResolverFromConfig(campaignRoot, cfg)
+	items, err := wkitem.Discover(ctx, campaignRoot, resolver)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "discovering work items")
+	}
+
+	item, err := selectWorkitemDungeonTarget(campaignRoot, items, target)
+	if err != nil {
+		return nil, err
+	}
+
+	resolved, err := resolveWorkitemDungeonTarget(campaignRoot, item)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateWorkitemDungeonStatus(status); err != nil {
+		return nil, wrapDungeonMoveError(err, resolved.ItemName, status)
+	}
+
+	svc := intdungeon.NewService(campaignRoot, resolved.DungeonPath)
+	initResult, err := svc.Init(ctx, intdungeon.InitOptions{})
+	if err != nil {
+		return nil, camperrors.Wrap(err, "initializing workitem dungeon")
+	}
+
+	destinationPaths := append([]string{}, initResult.CreatedFiles...)
+	var targetPath string
+	if status == "" {
+		if err := svc.MoveToDungeon(ctx, resolved.ItemName, resolved.ParentPath); err != nil {
+			return nil, wrapDungeonMoveError(err, resolved.ItemName, "dungeon")
+		}
+		targetPath = filepath.Join(resolved.DungeonPath, resolved.ItemName)
+	} else {
+		var moveErr error
+		targetPath, moveErr = svc.MoveToDungeonStatus(ctx, resolved.ItemName, resolved.ParentPath, status)
+		if moveErr != nil {
+			return nil, wrapDungeonMoveError(moveErr, resolved.ItemName, status)
+		}
+	}
+	destinationPaths = append(destinationPaths, targetPath)
+
+	src := relFromRoot(campaignRoot, resolved.SourcePath)
+	dst := relFromRoot(campaignRoot, targetPath)
+	fmt.Printf("%s Moved %s (%s → %s)\n", ui.SuccessIcon(), resolved.ItemName, src, dst)
+	invalidateDungeonWorkitemNavigationCache(cmd, campaignRoot)
+
+	description := fmt.Sprintf("Triage workitem %s → %s", resolved.ItemName, dst)
+	return &dungeonMoveCommit{
+		Config:           cfg,
+		CampaignRoot:     campaignRoot,
+		Description:      description,
+		SourcePaths:      []string{resolved.SourcePath},
+		DestinationPaths: destinationPaths,
+	}, nil
+}
+
+func validateWorkitemDungeonStatus(status string) error {
+	if status == "" {
+		return nil
+	}
+	if status == "." || status == ".." || strings.Contains(status, "/") || strings.Contains(status, "\\") {
+		return camperrors.Wrap(intdungeon.ErrInvalidStatus, status)
+	}
+	return nil
+}
+
+func selectWorkitemDungeonTarget(campaignRoot string, items []wkitem.WorkItem, target string) (wkitem.WorkItem, error) {
+	raw := strings.TrimSpace(target)
+	if raw == "" {
+		return wkitem.WorkItem{}, fmt.Errorf("workitem target must not be empty")
+	}
+
+	matchStages := []struct {
+		name  string
+		match func(wkitem.WorkItem) bool
+	}{
+		{
+			name: "stable id",
+			match: func(item wkitem.WorkItem) bool {
+				return item.StableID != "" && item.StableID == raw
+			},
+		},
+		{
+			name: "relative path",
+			match: func(item wkitem.WorkItem) bool {
+				return normalizeWorkitemTargetPath(campaignRoot, raw) == normalizeRelativeWorkitemPath(item.RelativePath)
+			},
+		},
+		{
+			name: "slug",
+			match: func(item wkitem.WorkItem) bool {
+				return filepath.Base(item.RelativePath) == raw
+			},
+		},
+	}
+
+	for _, stage := range matchStages {
+		matches := matchingWorkitems(items, stage.match)
+		if len(matches) == 1 {
+			return matches[0], nil
+		}
+		if len(matches) > 1 {
+			return wkitem.WorkItem{}, fmt.Errorf("workitem target %q is ambiguous by %s; matches: %s", raw, stage.name, formatWorkitemMatches(matches))
+		}
+	}
+
+	return wkitem.WorkItem{}, fmt.Errorf("workitem %q not found; run 'camp workitem --json' to inspect available workitems", raw)
+}
+
+func matchingWorkitems(items []wkitem.WorkItem, match func(wkitem.WorkItem) bool) []wkitem.WorkItem {
+	matches := make([]wkitem.WorkItem, 0, 1)
+	seen := map[string]bool{}
+	for _, item := range items {
+		if !match(item) {
+			continue
+		}
+		key := item.Key
+		if key == "" {
+			key = item.RelativePath
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		matches = append(matches, item)
+	}
+	return matches
+}
+
+func normalizeWorkitemTargetPath(campaignRoot, target string) string {
+	cleaned := strings.TrimSpace(target)
+	if cleaned == "" {
+		return ""
+	}
+	if filepath.IsAbs(cleaned) {
+		if rel, err := filepath.Rel(campaignRoot, cleaned); err == nil {
+			cleaned = rel
+		}
+	}
+	return normalizeRelativeWorkitemPath(cleaned)
+}
+
+func normalizeRelativeWorkitemPath(path string) string {
+	cleaned := filepath.Clean(path)
+	if cleaned == "." {
+		return ""
+	}
+	cleaned = strings.TrimPrefix(cleaned, "."+string(filepath.Separator))
+	return filepath.ToSlash(cleaned)
+}
+
+func resolveWorkitemDungeonTarget(campaignRoot string, item wkitem.WorkItem) (*resolvedWorkitemDungeonTarget, error) {
+	if item.ItemKind != wkitem.ItemKindDirectory {
+		return nil, fmt.Errorf("workitem %q resolves to %s, but only directory workitems under workflow/<type>/<slug> can be moved with --workitem", item.RelativePath, item.ItemKind)
+	}
+
+	rel := normalizeRelativeWorkitemPath(item.RelativePath)
+	parts := strings.Split(rel, "/")
+	if len(parts) != 3 || parts[0] != "workflow" || parts[1] == "" || parts[2] == "" || parts[1] == "dungeon" || parts[2] == "dungeon" {
+		return nil, fmt.Errorf("workitem %q is not under workflow/<type>/<slug>; only directory workitems under workflow/<type>/<slug> can be moved with --workitem", item.RelativePath)
+	}
+
+	parentRel := filepath.FromSlash(strings.Join(parts[:2], "/"))
+	itemName := parts[2]
+	parentPath := filepath.Join(campaignRoot, parentRel)
+	dungeonPath := filepath.Join(parentPath, "dungeon")
+
+	return &resolvedWorkitemDungeonTarget{
+		Item:        item,
+		ItemName:    itemName,
+		ParentPath:  parentPath,
+		DungeonPath: dungeonPath,
+		SourcePath:  filepath.Join(parentPath, itemName),
+	}, nil
+}
+
+func formatWorkitemMatches(matches []wkitem.WorkItem) string {
+	paths := make([]string, 0, len(matches))
+	for _, item := range matches {
+		paths = append(paths, item.RelativePath)
+	}
+	sort.Strings(paths)
+	return strings.Join(paths, ", ")
+}
+
+func invalidateDungeonWorkitemNavigationCache(cmd *cobra.Command, campaignRoot string) {
+	if err := navindex.Delete(campaignRoot); err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: failed to invalidate navigation cache: %v\n", err)
+	}
+}

--- a/cmd/camp/dungeon/workitem_move.go
+++ b/cmd/camp/dungeon/workitem_move.go
@@ -56,10 +56,6 @@ func moveWorkitemToDungeon(ctx context.Context, cmd *cobra.Command, target, stat
 		return nil, err
 	}
 
-	if err := validateWorkitemDungeonStatus(status); err != nil {
-		return nil, wrapDungeonMoveError(err, resolved.ItemName, status)
-	}
-
 	svc := intdungeon.NewService(campaignRoot, resolved.DungeonPath)
 	initResult, err := svc.Init(ctx, intdungeon.InitOptions{})
 	if err != nil {
@@ -97,16 +93,6 @@ func moveWorkitemToDungeon(ctx context.Context, cmd *cobra.Command, target, stat
 	}, nil
 }
 
-func validateWorkitemDungeonStatus(status string) error {
-	if status == "" {
-		return nil
-	}
-	if status == "." || status == ".." || strings.Contains(status, "/") || strings.Contains(status, "\\") {
-		return camperrors.Wrap(intdungeon.ErrInvalidStatus, status)
-	}
-	return nil
-}
-
 func selectWorkitemDungeonTarget(campaignRoot string, items []wkitem.WorkItem, target string) (wkitem.WorkItem, error) {
 	raw := strings.TrimSpace(target)
 	if raw == "" {
@@ -120,7 +106,7 @@ func selectWorkitemDungeonTarget(campaignRoot string, items []wkitem.WorkItem, t
 		{
 			name: "stable id",
 			match: func(item wkitem.WorkItem) bool {
-				return item.StableID != "" && item.StableID == raw
+				return item.StableID == raw
 			},
 		},
 		{
@@ -228,6 +214,6 @@ func formatWorkitemMatches(matches []wkitem.WorkItem) string {
 
 func invalidateDungeonWorkitemNavigationCache(cmd *cobra.Command, campaignRoot string) {
 	if err := navindex.Delete(campaignRoot); err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "warning: failed to invalidate navigation cache: %v\n", err)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s failed to invalidate navigation cache: %v\n", ui.WarningIcon(), err)
 	}
 }

--- a/cmd/camp/dungeon/workitem_move_test.go
+++ b/cmd/camp/dungeon/workitem_move_test.go
@@ -1,0 +1,129 @@
+package dungeon
+
+import (
+	"strings"
+	"testing"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+func TestSelectWorkitemDungeonTarget(t *testing.T) {
+	items := []wkitem.WorkItem{
+		{
+			Key:          "feature:workflow/feature/foo",
+			StableID:     "feature-foo-fixed",
+			RelativePath: "workflow/feature/foo",
+			ItemKind:     wkitem.ItemKindDirectory,
+		},
+		{
+			Key:          "bug:workflow/bug/foo",
+			StableID:     "bug-foo-fixed",
+			RelativePath: "workflow/bug/foo",
+			ItemKind:     wkitem.ItemKindDirectory,
+		},
+	}
+
+	tests := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{
+			name:   "stable id",
+			target: "feature-foo-fixed",
+			want:   "workflow/feature/foo",
+		},
+		{
+			name:   "relative path",
+			target: "./workflow/bug/foo/",
+			want:   "workflow/bug/foo",
+		},
+		{
+			name:   "absolute path",
+			target: "/campaign/workflow/feature/foo",
+			want:   "workflow/feature/foo",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := selectWorkitemDungeonTarget("/campaign", items, tc.target)
+			if err != nil {
+				t.Fatalf("selectWorkitemDungeonTarget() error = %v", err)
+			}
+			if got.RelativePath != tc.want {
+				t.Fatalf("RelativePath = %q, want %q", got.RelativePath, tc.want)
+			}
+		})
+	}
+}
+
+func TestSelectWorkitemDungeonTarget_AmbiguousSlug(t *testing.T) {
+	items := []wkitem.WorkItem{
+		{Key: "feature:workflow/feature/foo", RelativePath: "workflow/feature/foo"},
+		{Key: "bug:workflow/bug/foo", RelativePath: "workflow/bug/foo"},
+	}
+
+	_, err := selectWorkitemDungeonTarget("/campaign", items, "foo")
+	if err == nil {
+		t.Fatal("expected ambiguity error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"ambiguous",
+		"workflow/bug/foo",
+		"workflow/feature/foo",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("expected error to contain %q, got: %s", want, msg)
+		}
+	}
+}
+
+func TestResolveWorkitemDungeonTarget(t *testing.T) {
+	item := wkitem.WorkItem{
+		RelativePath: "workflow/feature/foo",
+		ItemKind:     wkitem.ItemKindDirectory,
+	}
+
+	got, err := resolveWorkitemDungeonTarget("/campaign", item)
+	if err != nil {
+		t.Fatalf("resolveWorkitemDungeonTarget() error = %v", err)
+	}
+
+	if got.ItemName != "foo" {
+		t.Fatalf("ItemName = %q, want foo", got.ItemName)
+	}
+	if got.ParentPath != "/campaign/workflow/feature" {
+		t.Fatalf("ParentPath = %q", got.ParentPath)
+	}
+	if got.DungeonPath != "/campaign/workflow/feature/dungeon" {
+		t.Fatalf("DungeonPath = %q", got.DungeonPath)
+	}
+	if got.SourcePath != "/campaign/workflow/feature/foo" {
+		t.Fatalf("SourcePath = %q", got.SourcePath)
+	}
+}
+
+func TestResolveWorkitemDungeonTarget_RejectsUnsupportedItems(t *testing.T) {
+	tests := []wkitem.WorkItem{
+		{
+			RelativePath: ".campaign/intents/active/foo.md",
+			ItemKind:     wkitem.ItemKindFile,
+		},
+		{
+			RelativePath: "festivals/active/demo",
+			ItemKind:     wkitem.ItemKindDirectory,
+		},
+	}
+
+	for _, item := range tests {
+		_, err := resolveWorkitemDungeonTarget("/campaign", item)
+		if err == nil {
+			t.Fatalf("expected unsupported item error for %+v", item)
+		}
+		if !strings.Contains(err.Error(), "workflow/<type>/<slug>") {
+			t.Fatalf("expected workflow path guidance, got: %s", err)
+		}
+	}
+}

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -993,6 +993,8 @@ Move items within the dungeon or from the parent directory into the dungeon.
 Without --triage, moves an item already in the dungeon root to a status directory.
 With --triage, moves an item from the parent directory into the dungeon.
 With --triage and --to-docs, routes an item to an existing campaign-root docs/<subdirectory>.
+With --workitem, resolves a campaign workitem from anywhere and moves its directory
+into the workitem type's local dungeon.
 Moves are always auto-committed so dungeon history remains auditable.
 
 Statuses: completed, archived, someday
@@ -1003,6 +1005,7 @@ Examples:
   camp dungeon move old-project --triage         Move parent item into dungeon root
   camp dungeon move old-project archived --triage Move parent item directly to archived
   camp dungeon move stale-note.md --triage --to-docs architecture/api Route to docs subdirectory
+  camp dungeon move feature-slug archived --workitem Move workitem directory to its local archive
 
 ```
 camp dungeon move <item> [status] [flags]
@@ -1014,6 +1017,7 @@ camp dungeon move <item> [status] [flags]
   -h, --help             help for move
       --to-docs string   Route triage item into an existing campaign-root docs/<subdir> (requires --triage)
       --triage           Move from parent directory (not from dungeon root)
+      --workitem         Resolve item as a campaign workitem and move its directory to the local dungeon
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_dungeon_move.md
+++ b/docs/cli-reference/camp_dungeon_move.md
@@ -9,6 +9,8 @@ Move items within the dungeon or from the parent directory into the dungeon.
 Without --triage, moves an item already in the dungeon root to a status directory.
 With --triage, moves an item from the parent directory into the dungeon.
 With --triage and --to-docs, routes an item to an existing campaign-root docs/<subdirectory>.
+With --workitem, resolves a campaign workitem from anywhere and moves its directory
+into the workitem type's local dungeon.
 Moves are always auto-committed so dungeon history remains auditable.
 
 Statuses: completed, archived, someday
@@ -19,6 +21,7 @@ Examples:
   camp dungeon move old-project --triage         Move parent item into dungeon root
   camp dungeon move old-project archived --triage Move parent item directly to archived
   camp dungeon move stale-note.md --triage --to-docs architecture/api Route to docs subdirectory
+  camp dungeon move feature-slug archived --workitem Move workitem directory to its local archive
 
 ```
 camp dungeon move <item> [status] [flags]
@@ -30,6 +33,7 @@ camp dungeon move <item> [status] [flags]
   -h, --help             help for move
       --to-docs string   Route triage item into an existing campaign-root docs/<subdir> (requires --triage)
       --triage           Move from parent directory (not from dungeon root)
+      --workitem         Resolve item as a campaign workitem and move its directory to the local dungeon
 ```
 
 ### Options inherited from parent commands

--- a/tests/integration/dungeon_test.go
+++ b/tests/integration/dungeon_test.go
@@ -469,6 +469,105 @@ func TestDungeonMove_TriageDirectToStatusWithCommit(t *testing.T) {
 	assert.Regexp(t, `(?m)^A\tdungeon/archived/[0-9]{4}-[0-9]{2}-[0-9]{2}/stale-doc\.md$`, diff)
 }
 
+func TestDungeonMove_WorkitemBySlugToStatus(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupDungeonCampaign(t, tc, "dmove-workitem-slug")
+
+	output, err := tc.RunCampInDir(path,
+		"workitem", "create", "demo-feature",
+		"--type", "feature",
+		"--title", "Demo feature",
+		"--id", "feature-demo-fixed",
+	)
+	require.NoError(t, err, "workitem create should succeed: %s", output)
+
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+path+" && git add . && git commit -m 'add workitem'")
+	require.NoError(t, err)
+
+	output, err = tc.RunCampInDir(path, "dungeon", "move", "demo-feature", "archived", "--workitem")
+	require.NoError(t, err, "workitem dungeon move should succeed: %s", output)
+	assert.Contains(t, output, "Moved demo-feature")
+	assert.Contains(t, output, "workflow/feature/demo-feature")
+	assert.Contains(t, output, "workflow/feature/dungeon/archived")
+	assert.Contains(t, output, "Committed", "should auto-commit")
+
+	exists, err := checkDatedDungeonStatusItemExists(tc, path+"/workflow/feature/dungeon/archived", "demo-feature")
+	require.NoError(t, err)
+	assert.True(t, exists, "workitem directory should be in local archived dungeon")
+
+	exists, err = tc.CheckDirExists(path + "/workflow/feature/demo-feature")
+	require.NoError(t, err)
+	assert.False(t, exists, "source workitem directory should be gone")
+
+	statusOutput, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git status --porcelain")
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(statusOutput), "git status should be clean after workitem dungeon move")
+
+	diff := assertLastDungeonMoveCommit(t, tc, path, "Triage workitem demo-feature", "D\tworkflow/feature/demo-feature/.workitem")
+	assert.Contains(t, diff, "workflow/feature/dungeon/OBEY.md")
+	assert.Contains(t, diff, "workflow/feature/dungeon/archived/.gitkeep")
+	assert.Regexp(t, `(?m)^A\tworkflow/feature/dungeon/archived/[0-9]{4}-[0-9]{2}-[0-9]{2}/demo-feature/.workitem$`, diff)
+}
+
+func TestDungeonMove_WorkitemByIDToLocalDungeonRootFromAnywhere(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupDungeonCampaign(t, tc, "dmove-workitem-id")
+
+	output, err := tc.RunCampInDir(path,
+		"workitem", "create", "id-target",
+		"--type", "bug",
+		"--title", "ID target",
+		"--id", "bug-id-target-fixed",
+	)
+	require.NoError(t, err, "workitem create should succeed: %s", output)
+	_, _, err = tc.ExecCommand("sh", "-c", "mkdir -p "+path+"/docs && cd "+path+" && git add . && git commit -m 'add id workitem'")
+	require.NoError(t, err)
+
+	output, err = tc.RunCampInDir(path+"/docs", "dungeon", "move", "bug-id-target-fixed", "--workitem")
+	require.NoError(t, err, "workitem dungeon root move should succeed: %s", output)
+	assert.Contains(t, output, "Moved id-target")
+	assert.Contains(t, output, "workflow/bug/dungeon/id-target")
+
+	exists, err := tc.CheckDirExists(path + "/workflow/bug/dungeon/id-target")
+	require.NoError(t, err)
+	assert.True(t, exists, "workitem should move into its local dungeon root")
+
+	exists, err = tc.CheckDirExists(path + "/workflow/bug/id-target")
+	require.NoError(t, err)
+	assert.False(t, exists, "source workitem directory should be gone")
+
+	statusOutput, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git status --porcelain")
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(statusOutput), "git status should be clean after workitem dungeon root move")
+}
+
+func TestDungeonMove_WorkitemByRelativePath(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupDungeonCampaign(t, tc, "dmove-workitem-path")
+
+	output, err := tc.RunCampInDir(path,
+		"workitem", "create", "path-target",
+		"--type", "chore",
+		"--title", "Path target",
+	)
+	require.NoError(t, err, "workitem create should succeed: %s", output)
+	_, _, err = tc.ExecCommand("sh", "-c", "mkdir -p "+path+"/docs && cd "+path+" && git add . && git commit -m 'add path workitem'")
+	require.NoError(t, err)
+
+	output, err = tc.RunCampInDir(path+"/docs", "dungeon", "move", "workflow/chore/path-target", "archived", "--workitem")
+	require.NoError(t, err, "workitem relative path move should succeed: %s", output)
+	assert.Contains(t, output, "Moved path-target")
+	assert.Contains(t, output, "workflow/chore/dungeon/archived")
+
+	exists, err := checkDatedDungeonStatusItemExists(tc, path+"/workflow/chore/dungeon/archived", "path-target")
+	require.NoError(t, err)
+	assert.True(t, exists, "workitem should move by relative path into its local archived dungeon")
+
+	exists, err = tc.CheckDirExists(path + "/workflow/chore/path-target")
+	require.NoError(t, err)
+	assert.False(t, exists, "source workitem directory should be gone")
+}
+
 func TestDungeonMove_TriageToDocsDestination(t *testing.T) {
 	tc := GetSharedContainer(t)
 	path := setupDungeonCampaign(t, tc, "dmove-triage-docs")


### PR DESCRIPTION
## Summary
- add `camp dungeon move --workitem` for moving `workflow/<type>/<slug>` workitems into their local dungeon from anywhere
- resolve workitem targets by stable id, relative path, or slug, with ambiguity checks
- initialize local dungeon scaffold and include scaffold/move files in the existing dungeon auto-commit path
- document the new flag and add unit/integration coverage

## Tests
- `go test ./cmd/camp/dungeon`
- `go test ./cmd/camp/dungeon ./internal/dungeon ./internal/workitem`
- `go test -tags=integration ./tests/integration -run 'TestDungeonMove_Workitem|TestDungeonMove_TriageDirectToStatusWithCommit' -count=1`\n- `go test ./...`\n- `git diff --check`