### PR TITLE
feat(promote): add camp promote for workitem dungeon-status moves

### DIFF
--- a/cmd/camp/dungeon/context.go
+++ b/cmd/camp/dungeon/context.go
@@ -50,7 +50,7 @@ func resolveDungeonCommandContext(ctx context.Context) (*dungeonCommandContext, 
 	}, nil
 }
 
-func relFromRoot(root, target string) string {
+func RelFromRoot(root, target string) string {
 	rel, err := filepath.Rel(root, target)
 	if err != nil || rel == "" {
 		return target

--- a/cmd/camp/dungeon/crawl.go
+++ b/cmd/camp/dungeon/crawl.go
@@ -62,8 +62,8 @@ func runDungeonCrawl(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	svc := intdungeon.NewService(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath)
-	relParent := relFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.ParentPath)
-	relDungeon := relFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath)
+	relParent := RelFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.ParentPath)
+	relDungeon := RelFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath)
 
 	// Determine modes
 	runTriage, runInner := triageFlag, innerFlag

--- a/cmd/camp/dungeon/list.go
+++ b/cmd/camp/dungeon/list.go
@@ -68,8 +68,8 @@ func runDungeonList(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	svc := intdungeon.NewService(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath)
-	dungeonRel := relFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath)
-	parentRel := relFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.ParentPath)
+	dungeonRel := RelFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath)
+	parentRel := RelFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.ParentPath)
 
 	if triageMode {
 		items, err := svc.ListParentItems(ctx, cmdCtx.Dungeon.ParentPath)

--- a/cmd/camp/dungeon/move.go
+++ b/cmd/camp/dungeon/move.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -166,13 +168,21 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 	})
 }
 
-func CommitDungeonMove(ctx context.Context, move *DungeonMoveCommit) error {
+type DungeonMoveCommitOutcome struct {
+	StagingErr error
+	Committed  bool
+	NoChanges  bool
+	Message    string
+	CommitErr  error
+}
+
+func StageAndCommitDungeonMove(ctx context.Context, move *DungeonMoveCommit) *DungeonMoveCommitOutcome {
+	outcome := &DungeonMoveCommitOutcome{}
 	files := commit.NormalizeFiles(move.CampaignRoot, move.DestinationPaths...)
 	preStaged, err := stageTrackedMoveSourceDeletions(ctx, move.CampaignRoot, move.SourcePaths)
 	if err != nil {
-		fmt.Printf("%s Move was applied on disk, but staging the source deletion failed.\n", ui.WarningIcon())
-		fmt.Printf("%s %v\n", ui.WarningIcon(), err)
-		return camperrors.Wrap(err, "staging move source deletions")
+		outcome.StagingErr = err
+		return outcome
 	}
 	result := commit.Crawl(ctx, commit.CrawlOptions{
 		Options: commit.Options{
@@ -183,19 +193,44 @@ func CommitDungeonMove(ctx context.Context, move *DungeonMoveCommit) error {
 		Description: strings.TrimSpace(move.Description),
 		Files:       files,
 	})
-	if result.Committed {
-		fmt.Printf("%s %s\n", ui.SuccessIcon(), result.Message)
-	} else if result.NoChanges {
-		fmt.Printf("%s %s\n", ui.InfoIcon(), result.Message)
-	} else if result.Err != nil {
-		fmt.Printf("%s Move was applied on disk, but auto-commit failed.\n", ui.WarningIcon())
-		fmt.Printf("%s %v\n", ui.WarningIcon(), result.Err)
-		return camperrors.Wrap(result.Err, "auto-committing dungeon move")
-	} else if result.Message != "" {
-		fmt.Printf("%s %s\n", ui.InfoIcon(), result.Message)
-	}
+	outcome.Committed = result.Committed
+	outcome.NoChanges = result.NoChanges
+	outcome.Message = result.Message
+	outcome.CommitErr = result.Err
+	return outcome
+}
 
+func PrintDungeonMoveOutcome(w io.Writer, outcome *DungeonMoveCommitOutcome) {
+	switch {
+	case outcome.StagingErr != nil:
+		fmt.Fprintf(w, "%s Move was applied on disk, but staging the source deletion failed.\n", ui.WarningIcon())
+		fmt.Fprintf(w, "%s %v\n", ui.WarningIcon(), outcome.StagingErr)
+	case outcome.Committed:
+		fmt.Fprintf(w, "%s %s\n", ui.SuccessIcon(), outcome.Message)
+	case outcome.CommitErr != nil:
+		fmt.Fprintf(w, "%s Move was applied on disk, but auto-commit failed.\n", ui.WarningIcon())
+		fmt.Fprintf(w, "%s %v\n", ui.WarningIcon(), outcome.CommitErr)
+	case outcome.NoChanges:
+		fmt.Fprintf(w, "%s %s\n", ui.InfoIcon(), outcome.Message)
+	case outcome.Message != "":
+		fmt.Fprintf(w, "%s %s\n", ui.InfoIcon(), outcome.Message)
+	}
+}
+
+func (o *DungeonMoveCommitOutcome) Err() error {
+	if o.StagingErr != nil {
+		return camperrors.Wrap(o.StagingErr, "staging move source deletions")
+	}
+	if o.CommitErr != nil {
+		return camperrors.Wrap(o.CommitErr, "auto-committing dungeon move")
+	}
 	return nil
+}
+
+func CommitDungeonMove(ctx context.Context, move *DungeonMoveCommit) error {
+	outcome := StageAndCommitDungeonMove(ctx, move)
+	PrintDungeonMoveOutcome(os.Stdout, outcome)
+	return outcome.Err()
 }
 
 func stageTrackedMoveSourceDeletions(ctx context.Context, campaignRoot string, sourcePaths []string) ([]string, error) {

--- a/cmd/camp/dungeon/move.go
+++ b/cmd/camp/dungeon/move.go
@@ -86,7 +86,7 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		return commitDungeonMove(ctx, move)
+		return CommitDungeonMove(ctx, move)
 	}
 
 	cmdCtx, err := resolveDungeonCommandContext(ctx)
@@ -105,8 +105,8 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return wrapDungeonDocsRouteError(err, itemName, toDocs)
 			}
-			src := filepath.Join(relFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.ParentPath), itemName)
-			dst := relFromRoot(cmdCtx.CampaignRoot, targetPath)
+			src := filepath.Join(RelFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.ParentPath), itemName)
+			dst := RelFromRoot(cmdCtx.CampaignRoot, targetPath)
 			fmt.Printf("%s Moved %s (%s → %s)\n", ui.SuccessIcon(), itemName, src, dst)
 			description = fmt.Sprintf("Route %s → %s", itemName, dst)
 			sourcePaths = []string{filepath.Join(cmdCtx.Dungeon.ParentPath, itemName)}
@@ -115,10 +115,10 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 			// Triage directly to a status directory
 			targetPath, err := svc.MoveToDungeonStatus(ctx, itemName, cmdCtx.Dungeon.ParentPath, status)
 			if err != nil {
-				return wrapDungeonMoveError(err, itemName, status)
+				return WrapDungeonMoveError(err, itemName, status)
 			}
-			src := filepath.Join(relFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.ParentPath), itemName)
-			dst := relFromRoot(cmdCtx.CampaignRoot, targetPath)
+			src := filepath.Join(RelFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.ParentPath), itemName)
+			dst := RelFromRoot(cmdCtx.CampaignRoot, targetPath)
 			fmt.Printf("%s Moved %s (%s → %s)\n", ui.SuccessIcon(), itemName, src, dst)
 			description = fmt.Sprintf("Triage %s → dungeon/%s", itemName, status)
 			sourcePaths = []string{filepath.Join(cmdCtx.Dungeon.ParentPath, itemName)}
@@ -126,10 +126,10 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 		} else {
 			// Triage to dungeon root
 			if err := svc.MoveToDungeon(ctx, itemName, cmdCtx.Dungeon.ParentPath); err != nil {
-				return wrapDungeonMoveError(err, itemName, "dungeon")
+				return WrapDungeonMoveError(err, itemName, "dungeon")
 			}
-			src := filepath.Join(relFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.ParentPath), itemName)
-			dst := filepath.Join(relFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath), itemName)
+			src := filepath.Join(RelFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.ParentPath), itemName)
+			dst := filepath.Join(RelFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath), itemName)
 			fmt.Printf("%s Moved %s (%s → %s)\n", ui.SuccessIcon(), itemName, src, dst)
 			description = fmt.Sprintf("Triage %s → dungeon", itemName)
 			sourcePaths = []string{filepath.Join(cmdCtx.Dungeon.ParentPath, itemName)}
@@ -142,10 +142,10 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 		}
 		targetPath, err := svc.MoveToStatus(ctx, itemName, status)
 		if err != nil {
-			return wrapDungeonMoveError(err, itemName, status)
+			return WrapDungeonMoveError(err, itemName, status)
 		}
-		src := filepath.Join(relFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath), itemName)
-		dst := relFromRoot(cmdCtx.CampaignRoot, targetPath)
+		src := filepath.Join(RelFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath), itemName)
+		dst := RelFromRoot(cmdCtx.CampaignRoot, targetPath)
 		fmt.Printf("%s Moved %s (%s → %s)\n", ui.SuccessIcon(), itemName, src, dst)
 
 		relDir, relErr := filepath.Rel(cmdCtx.CampaignRoot, cmdCtx.Dungeon.ParentPath)
@@ -157,7 +157,7 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 		destinationPaths = []string{targetPath}
 	}
 
-	return commitDungeonMove(ctx, &dungeonMoveCommit{
+	return CommitDungeonMove(ctx, &DungeonMoveCommit{
 		Config:           cmdCtx.Config,
 		CampaignRoot:     cmdCtx.CampaignRoot,
 		Description:      description,
@@ -166,7 +166,7 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 	})
 }
 
-func commitDungeonMove(ctx context.Context, move *dungeonMoveCommit) error {
+func CommitDungeonMove(ctx context.Context, move *DungeonMoveCommit) error {
 	files := commit.NormalizeFiles(move.CampaignRoot, move.DestinationPaths...)
 	preStaged, err := stageTrackedMoveSourceDeletions(ctx, move.CampaignRoot, move.SourcePaths)
 	if err != nil {
@@ -216,7 +216,7 @@ func stageTrackedMoveSourceDeletions(ctx context.Context, campaignRoot string, s
 	return tracked, nil
 }
 
-func wrapDungeonMoveError(err error, itemName, status string) error {
+func WrapDungeonMoveError(err error, itemName, status string) error {
 	switch {
 	case errors.Is(err, intdungeon.ErrAlreadyExists):
 		return fmt.Errorf(

--- a/cmd/camp/dungeon/move_test.go
+++ b/cmd/camp/dungeon/move_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestWrapDungeonMoveError_InvalidItemPath(t *testing.T) {
-	err := wrapDungeonMoveError(intdungeon.ErrInvalidItemPath, "../secret.md", "archived")
+	err := WrapDungeonMoveError(intdungeon.ErrInvalidItemPath, "../secret.md", "archived")
 	if err == nil {
-		t.Fatal("wrapDungeonMoveError should return an error")
+		t.Fatal("WrapDungeonMoveError should return an error")
 	}
 	if !errors.Is(err, intdungeon.ErrInvalidItemPath) {
 		t.Fatalf("expected wrapped ErrInvalidItemPath, got: %v", err)

--- a/cmd/camp/dungeon/workitem_move.go
+++ b/cmd/camp/dungeon/workitem_move.go
@@ -18,7 +18,7 @@ import (
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
 
-type dungeonMoveCommit struct {
+type DungeonMoveCommit struct {
 	Config           *config.CampaignConfig
 	CampaignRoot     string
 	Description      string
@@ -34,7 +34,7 @@ type resolvedWorkitemDungeonTarget struct {
 	SourcePath  string
 }
 
-func moveWorkitemToDungeon(ctx context.Context, cmd *cobra.Command, target, status string) (*dungeonMoveCommit, error) {
+func moveWorkitemToDungeon(ctx context.Context, cmd *cobra.Command, target, status string) (*DungeonMoveCommit, error) {
 	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
 	if err != nil {
 		return nil, camperrors.Wrap(err, "not in a campaign directory")
@@ -66,25 +66,25 @@ func moveWorkitemToDungeon(ctx context.Context, cmd *cobra.Command, target, stat
 	var targetPath string
 	if status == "" {
 		if err := svc.MoveToDungeon(ctx, resolved.ItemName, resolved.ParentPath); err != nil {
-			return nil, wrapDungeonMoveError(err, resolved.ItemName, "dungeon")
+			return nil, WrapDungeonMoveError(err, resolved.ItemName, "dungeon")
 		}
 		targetPath = filepath.Join(resolved.DungeonPath, resolved.ItemName)
 	} else {
 		var moveErr error
 		targetPath, moveErr = svc.MoveToDungeonStatus(ctx, resolved.ItemName, resolved.ParentPath, status)
 		if moveErr != nil {
-			return nil, wrapDungeonMoveError(moveErr, resolved.ItemName, status)
+			return nil, WrapDungeonMoveError(moveErr, resolved.ItemName, status)
 		}
 	}
 	destinationPaths = append(destinationPaths, targetPath)
 
-	src := relFromRoot(campaignRoot, resolved.SourcePath)
-	dst := relFromRoot(campaignRoot, targetPath)
+	src := RelFromRoot(campaignRoot, resolved.SourcePath)
+	dst := RelFromRoot(campaignRoot, targetPath)
 	fmt.Printf("%s Moved %s (%s → %s)\n", ui.SuccessIcon(), resolved.ItemName, src, dst)
 	invalidateDungeonWorkitemNavigationCache(cmd, campaignRoot)
 
 	description := fmt.Sprintf("Triage workitem %s → %s", resolved.ItemName, dst)
-	return &dungeonMoveCommit{
+	return &DungeonMoveCommit{
 		Config:           cfg,
 		CampaignRoot:     campaignRoot,
 		Description:      description,

--- a/cmd/camp/manifest_test.go
+++ b/cmd/camp/manifest_test.go
@@ -99,6 +99,7 @@ func TestManifestCommand_AllRestrictedCommandsPresent(t *testing.T) {
 		"dungeon list":  false,
 		"dungeon move":  false,
 		"intent crawl":  false,
+		"promote":       false,
 		"skills link":   false,
 		"skills status": false,
 		"skills unlink": false,
@@ -139,9 +140,9 @@ func TestManifestCommand_AllRestrictedCommandsPresent(t *testing.T) {
 		}
 	}
 
-	wantCount := 17
+	wantCount := 18
 	if flowCommandsRegistered() {
-		wantCount = 20
+		wantCount = 21
 	}
 	if questCommandsRegistered() {
 		wantCount += 13
@@ -173,6 +174,7 @@ func TestManifestCommand_AllCommandsHaveAnnotations(t *testing.T) {
 		"create":        true,
 		"dungeon list":  true,
 		"dungeon move":  true,
+		"promote":       true,
 		"switch":        true,
 		"skills link":   true,
 		"skills status": true,

--- a/cmd/camp/promote/detect.go
+++ b/cmd/camp/promote/detect.go
@@ -1,0 +1,91 @@
+package promote
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/dungeon/statuspath"
+)
+
+type WorkitemLocation struct {
+	Type        string
+	Slug        string
+	ParentPath  string
+	SourcePath  string
+	DungeonPath string
+	InDungeon   bool
+	Status      string
+}
+
+func detectWorkitemFromCwd(campaignRoot, cwd string) (*WorkitemLocation, error) {
+	rel, err := filepath.Rel(campaignRoot, cwd)
+	if err != nil {
+		return nil, fmt.Errorf("resolving cwd relative to campaign root: %w", err)
+	}
+	rel = filepath.ToSlash(filepath.Clean(rel))
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return nil, fmt.Errorf("cwd %q is not under campaign root %q", cwd, campaignRoot)
+	}
+	if rel == "." {
+		return nil, fmt.Errorf("not inside a workitem; cwd is at the campaign root")
+	}
+
+	parts := strings.Split(rel, "/")
+	if parts[0] != "workflow" {
+		return nil, fmt.Errorf("not inside a workitem; cwd must be under workflow/<type>/<slug>/")
+	}
+	if len(parts) < 3 {
+		return nil, fmt.Errorf("not inside a workitem; cwd is at workflow root, expected workflow/<type>/<slug>/")
+	}
+	typeName := parts[1]
+	if typeName == "" || typeName == "dungeon" {
+		return nil, fmt.Errorf("not inside a workitem; %q is not a valid workflow type", typeName)
+	}
+
+	if parts[2] != "dungeon" {
+		slug := parts[2]
+		parentRel := filepath.Join("workflow", typeName)
+		sourceRel := filepath.Join("workflow", typeName, slug)
+		dungeonRel := filepath.Join("workflow", typeName, "dungeon")
+		return &WorkitemLocation{
+			Type:        typeName,
+			Slug:        slug,
+			ParentPath:  filepath.Join(campaignRoot, parentRel),
+			SourcePath:  filepath.Join(campaignRoot, sourceRel),
+			DungeonPath: filepath.Join(campaignRoot, dungeonRel),
+		}, nil
+	}
+
+	if len(parts) < 5 {
+		return nil, fmt.Errorf("not inside a workitem; cwd is at workflow/%s/dungeon[/...] without a slug", typeName)
+	}
+	status := parts[3]
+	if status == "" {
+		return nil, fmt.Errorf("not inside a workitem; cwd is at the dungeon root")
+	}
+
+	var slug string
+	var parentRel string
+	if statuspath.IsDateDir(parts[4]) {
+		if len(parts) < 6 || parts[5] == "" {
+			return nil, fmt.Errorf("not inside a workitem; cwd is at workflow/%s/dungeon/%s/%s without a slug", typeName, status, parts[4])
+		}
+		slug = parts[5]
+		parentRel = filepath.Join("workflow", typeName, "dungeon", status, parts[4])
+	} else {
+		slug = parts[4]
+		parentRel = filepath.Join("workflow", typeName, "dungeon", status)
+	}
+
+	dungeonRel := filepath.Join("workflow", typeName, "dungeon")
+	return &WorkitemLocation{
+		Type:        typeName,
+		Slug:        slug,
+		ParentPath:  filepath.Join(campaignRoot, parentRel),
+		SourcePath:  filepath.Join(campaignRoot, parentRel, slug),
+		DungeonPath: filepath.Join(campaignRoot, dungeonRel),
+		InDungeon:   true,
+		Status:      status,
+	}, nil
+}

--- a/cmd/camp/promote/detect_test.go
+++ b/cmd/camp/promote/detect_test.go
@@ -1,0 +1,169 @@
+package promote
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDetectWorkitemFromCwd(t *testing.T) {
+	const root = "/campaign"
+
+	tests := []struct {
+		name      string
+		cwd       string
+		wantErr   string
+		wantType  string
+		wantSlug  string
+		wantSrc   string
+		wantPar   string
+		wantDun   string
+		wantIn    bool
+		wantStat  string
+	}{
+		{
+			name:     "active workitem root",
+			cwd:      "/campaign/workflow/design/myslug",
+			wantType: "design",
+			wantSlug: "myslug",
+			wantSrc:  "/campaign/workflow/design/myslug",
+			wantPar:  "/campaign/workflow/design",
+			wantDun:  "/campaign/workflow/design/dungeon",
+		},
+		{
+			name:     "active workitem subdir",
+			cwd:      "/campaign/workflow/design/myslug/notes",
+			wantType: "design",
+			wantSlug: "myslug",
+			wantSrc:  "/campaign/workflow/design/myslug",
+			wantPar:  "/campaign/workflow/design",
+			wantDun:  "/campaign/workflow/design/dungeon",
+		},
+		{
+			name:     "active workitem deep subdir",
+			cwd:      "/campaign/workflow/explore/topic/a/b/c",
+			wantType: "explore",
+			wantSlug: "topic",
+			wantSrc:  "/campaign/workflow/explore/topic",
+			wantPar:  "/campaign/workflow/explore",
+			wantDun:  "/campaign/workflow/explore/dungeon",
+		},
+		{
+			name:     "dungeon legacy flat layout",
+			cwd:      "/campaign/workflow/design/dungeon/completed/oldslug",
+			wantType: "design",
+			wantSlug: "oldslug",
+			wantSrc:  "/campaign/workflow/design/dungeon/completed/oldslug",
+			wantPar:  "/campaign/workflow/design/dungeon/completed",
+			wantDun:  "/campaign/workflow/design/dungeon",
+			wantIn:   true,
+			wantStat: "completed",
+		},
+		{
+			name:     "dungeon dated layout",
+			cwd:      "/campaign/workflow/design/dungeon/archived/2026-05-22/oldslug",
+			wantType: "design",
+			wantSlug: "oldslug",
+			wantSrc:  "/campaign/workflow/design/dungeon/archived/2026-05-22/oldslug",
+			wantPar:  "/campaign/workflow/design/dungeon/archived/2026-05-22",
+			wantDun:  "/campaign/workflow/design/dungeon",
+			wantIn:   true,
+			wantStat: "archived",
+		},
+		{
+			name:     "dungeon dated subdir",
+			cwd:      "/campaign/workflow/design/dungeon/someday/2026-05-22/oldslug/notes",
+			wantType: "design",
+			wantSlug: "oldslug",
+			wantSrc:  "/campaign/workflow/design/dungeon/someday/2026-05-22/oldslug",
+			wantPar:  "/campaign/workflow/design/dungeon/someday/2026-05-22",
+			wantDun:  "/campaign/workflow/design/dungeon",
+			wantIn:   true,
+			wantStat: "someday",
+		},
+		{
+			name:    "cwd at campaign root",
+			cwd:     "/campaign",
+			wantErr: "not inside a workitem",
+		},
+		{
+			name:    "cwd outside campaign root",
+			cwd:     "/somewhere/else",
+			wantErr: "not under campaign root",
+		},
+		{
+			name:    "cwd outside workflow",
+			cwd:     "/campaign/docs/handbook",
+			wantErr: "must be under workflow",
+		},
+		{
+			name:    "cwd at workflow root",
+			cwd:     "/campaign/workflow",
+			wantErr: "not inside a workitem",
+		},
+		{
+			name:    "cwd at workflow type root",
+			cwd:     "/campaign/workflow/design",
+			wantErr: "not inside a workitem",
+		},
+		{
+			name:    "workflow/dungeon as type",
+			cwd:     "/campaign/workflow/dungeon/whatever",
+			wantErr: "not a valid workflow type",
+		},
+		{
+			name:    "dungeon root no status",
+			cwd:     "/campaign/workflow/design/dungeon",
+			wantErr: "without a slug",
+		},
+		{
+			name:    "dungeon status no slug",
+			cwd:     "/campaign/workflow/design/dungeon/completed",
+			wantErr: "without a slug",
+		},
+		{
+			name:    "dungeon date dir no slug",
+			cwd:     "/campaign/workflow/design/dungeon/completed/2026-05-22",
+			wantErr: "without a slug",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := detectWorkitemFromCwd(root, tc.cwd)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil (result=%+v)", tc.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Type != tc.wantType {
+				t.Errorf("Type=%q want %q", got.Type, tc.wantType)
+			}
+			if got.Slug != tc.wantSlug {
+				t.Errorf("Slug=%q want %q", got.Slug, tc.wantSlug)
+			}
+			if filepath.ToSlash(got.SourcePath) != tc.wantSrc {
+				t.Errorf("SourcePath=%q want %q", got.SourcePath, tc.wantSrc)
+			}
+			if filepath.ToSlash(got.ParentPath) != tc.wantPar {
+				t.Errorf("ParentPath=%q want %q", got.ParentPath, tc.wantPar)
+			}
+			if filepath.ToSlash(got.DungeonPath) != tc.wantDun {
+				t.Errorf("DungeonPath=%q want %q", got.DungeonPath, tc.wantDun)
+			}
+			if got.InDungeon != tc.wantIn {
+				t.Errorf("InDungeon=%v want %v", got.InDungeon, tc.wantIn)
+			}
+			if got.Status != tc.wantStat {
+				t.Errorf("Status=%q want %q", got.Status, tc.wantStat)
+			}
+		})
+	}
+}

--- a/cmd/camp/promote/promote.go
+++ b/cmd/camp/promote/promote.go
@@ -3,6 +3,7 @@ package promote
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -49,11 +50,14 @@ func init() {
 }
 
 type promoteResult struct {
-	Slug   string `json:"slug"`
-	Type   string `json:"type"`
-	Status string `json:"status"`
-	From   string `json:"from"`
-	To     string `json:"to"`
+	Slug          string   `json:"slug"`
+	Type          string   `json:"type"`
+	Status        string   `json:"status"`
+	From          string   `json:"from"`
+	To            string   `json:"to"`
+	Committed     bool     `json:"committed"`
+	CommitMessage string   `json:"commit_message,omitempty"`
+	Warnings      []string `json:"warnings,omitempty"`
 }
 
 func runPromote(cmd *cobra.Command, args []string) error {
@@ -62,6 +66,10 @@ func runPromote(cmd *cobra.Command, args []string) error {
 
 	noCommit, _ := cmd.Flags().GetBool("no-commit")
 	jsonOut, _ := cmd.Flags().GetBool("json")
+
+	if status == "active" {
+		return fmt.Errorf("promote cannot target %q: %q is not a dungeon status (outside the dungeon a workitem is already active); restoring workitems out of dungeon is not supported by promote", status, status)
+	}
 
 	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
 	if err != nil {
@@ -101,45 +109,57 @@ func runPromote(cmd *cobra.Command, args []string) error {
 		return dungeoncmd.WrapDungeonMoveError(err, loc.Slug, status)
 	}
 
-	src := dungeoncmd.RelFromRoot(campaignRoot, loc.SourcePath)
-	dst := dungeoncmd.RelFromRoot(campaignRoot, targetPath)
+	result := promoteResult{
+		Slug:   loc.Slug,
+		Type:   loc.Type,
+		Status: status,
+		From:   filepath.ToSlash(dungeoncmd.RelFromRoot(campaignRoot, loc.SourcePath)),
+		To:     filepath.ToSlash(dungeoncmd.RelFromRoot(campaignRoot, targetPath)),
+	}
+
+	stdout := cmd.OutOrStdout()
+	textOut := stdout
+	if jsonOut {
+		textOut = io.Discard
+	}
+
+	if !jsonOut {
+		fmt.Fprintf(stdout, "%s Promoted %s (%s → %s)\n", ui.SuccessIcon(), loc.Slug, result.From, result.To)
+	}
+
+	if navErr := navindex.Delete(campaignRoot); navErr != nil {
+		msg := fmt.Sprintf("failed to invalidate navigation cache: %v", navErr)
+		if jsonOut {
+			result.Warnings = append(result.Warnings, msg)
+		} else {
+			fmt.Fprintf(stdout, "%s %s\n", ui.WarningIcon(), msg)
+		}
+	}
+
+	var commitErr error
+	if !noCommit {
+		destinationPaths := append([]string{}, initResult.CreatedFiles...)
+		destinationPaths = append(destinationPaths, targetPath)
+		description := fmt.Sprintf("Promote workitem %s → %s", loc.Slug, result.To)
+
+		outcome := dungeoncmd.StageAndCommitDungeonMove(ctx, &dungeoncmd.DungeonMoveCommit{
+			Config:           cfg,
+			CampaignRoot:     campaignRoot,
+			Description:      description,
+			SourcePaths:      []string{loc.SourcePath},
+			DestinationPaths: destinationPaths,
+		})
+		dungeoncmd.PrintDungeonMoveOutcome(textOut, outcome)
+		result.Committed = outcome.Committed
+		result.CommitMessage = outcome.Message
+		commitErr = outcome.Err()
+	}
 
 	if jsonOut {
-		out := promoteResult{
-			Slug:   loc.Slug,
-			Type:   loc.Type,
-			Status: status,
-			From:   filepath.ToSlash(src),
-			To:     filepath.ToSlash(dst),
-		}
-		if err := json.NewEncoder(cmd.OutOrStdout()).Encode(out); err != nil {
+		if err := json.NewEncoder(stdout).Encode(result); err != nil {
 			return camperrors.Wrap(err, "encoding JSON output")
 		}
-	} else {
-		fmt.Fprintf(cmd.OutOrStdout(), "%s Promoted %s (%s → %s)\n", ui.SuccessIcon(), loc.Slug, src, dst)
 	}
 
-	invalidatePromoteNavCache(cmd, campaignRoot)
-
-	if noCommit {
-		return nil
-	}
-
-	destinationPaths := append([]string{}, initResult.CreatedFiles...)
-	destinationPaths = append(destinationPaths, targetPath)
-	description := fmt.Sprintf("Promote workitem %s → %s", loc.Slug, dst)
-
-	return dungeoncmd.CommitDungeonMove(ctx, &dungeoncmd.DungeonMoveCommit{
-		Config:           cfg,
-		CampaignRoot:     campaignRoot,
-		Description:      description,
-		SourcePaths:      []string{loc.SourcePath},
-		DestinationPaths: destinationPaths,
-	})
-}
-
-func invalidatePromoteNavCache(cmd *cobra.Command, campaignRoot string) {
-	if err := navindex.Delete(campaignRoot); err != nil {
-		fmt.Fprintf(cmd.OutOrStdout(), "%s failed to invalidate navigation cache: %v\n", ui.WarningIcon(), err)
-	}
+	return commitErr
 }

--- a/cmd/camp/promote/promote.go
+++ b/cmd/camp/promote/promote.go
@@ -1,0 +1,145 @@
+package promote
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	dungeoncmd "github.com/Obedience-Corp/camp/cmd/camp/dungeon"
+	"github.com/Obedience-Corp/camp/internal/config"
+	intdungeon "github.com/Obedience-Corp/camp/internal/dungeon"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
+	"github.com/Obedience-Corp/camp/internal/ui"
+)
+
+var Cmd = &cobra.Command{
+	Use:     "promote <status>",
+	Short:   "Promote the workitem at cwd to a dungeon status",
+	GroupID: "planning",
+	Long: `Promote the directory-style workitem containing the current working
+directory to a named status. Status directories live under the workitem
+type's local dungeon (workflow/<type>/dungeon/<status>/); outside the
+dungeon a workitem is treated as active.
+
+Run this from anywhere inside workflow/<type>/<slug>/. The workitem
+boundary is detected from cwd. The status argument is the destination
+directory name (e.g., completed, archived, someday) - no need to spell
+out "dungeon/".
+
+Examples:
+  camp promote completed   Shelve the workitem to its local dungeon/completed
+  camp promote archived    Move to dungeon/archived
+  camp promote someday     Move to dungeon/someday`,
+	Args: cobra.ExactArgs(1),
+	Annotations: map[string]string{
+		"agent_allowed": "true",
+		"agent_reason":  "Non-interactive promotion of the workitem at cwd to a dungeon status",
+	},
+	RunE: runPromote,
+}
+
+func init() {
+	flags := Cmd.Flags()
+	flags.Bool("no-commit", false, "Skip auto-commit after promotion")
+	flags.Bool("json", false, "Output result as JSON")
+}
+
+type promoteResult struct {
+	Slug   string `json:"slug"`
+	Type   string `json:"type"`
+	Status string `json:"status"`
+	From   string `json:"from"`
+	To     string `json:"to"`
+}
+
+func runPromote(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	status := args[0]
+
+	noCommit, _ := cmd.Flags().GetBool("no-commit")
+	jsonOut, _ := cmd.Flags().GetBool("json")
+
+	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return camperrors.Wrap(err, "getting current directory")
+	}
+
+	loc, err := detectWorkitemFromCwd(campaignRoot, cwd)
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Stat(loc.SourcePath)
+	if err != nil {
+		return camperrors.Wrapf(err, "stat workitem %s", loc.SourcePath)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("workitem %s is not a directory; promote only handles directory-style workitems", dungeoncmd.RelFromRoot(campaignRoot, loc.SourcePath))
+	}
+
+	if loc.InDungeon && loc.Status == status {
+		return fmt.Errorf("workitem %q is already at status %q", loc.Slug, status)
+	}
+
+	svc := intdungeon.NewService(campaignRoot, loc.DungeonPath)
+	initResult, err := svc.Init(ctx, intdungeon.InitOptions{})
+	if err != nil {
+		return camperrors.Wrap(err, "initializing workitem dungeon")
+	}
+
+	targetPath, err := svc.MoveToDungeonStatus(ctx, loc.Slug, loc.ParentPath, status)
+	if err != nil {
+		return dungeoncmd.WrapDungeonMoveError(err, loc.Slug, status)
+	}
+
+	src := dungeoncmd.RelFromRoot(campaignRoot, loc.SourcePath)
+	dst := dungeoncmd.RelFromRoot(campaignRoot, targetPath)
+
+	if jsonOut {
+		out := promoteResult{
+			Slug:   loc.Slug,
+			Type:   loc.Type,
+			Status: status,
+			From:   filepath.ToSlash(src),
+			To:     filepath.ToSlash(dst),
+		}
+		if err := json.NewEncoder(cmd.OutOrStdout()).Encode(out); err != nil {
+			return camperrors.Wrap(err, "encoding JSON output")
+		}
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s Promoted %s (%s → %s)\n", ui.SuccessIcon(), loc.Slug, src, dst)
+	}
+
+	invalidatePromoteNavCache(cmd, campaignRoot)
+
+	if noCommit {
+		return nil
+	}
+
+	destinationPaths := append([]string{}, initResult.CreatedFiles...)
+	destinationPaths = append(destinationPaths, targetPath)
+	description := fmt.Sprintf("Promote workitem %s → %s", loc.Slug, dst)
+
+	return dungeoncmd.CommitDungeonMove(ctx, &dungeoncmd.DungeonMoveCommit{
+		Config:           cfg,
+		CampaignRoot:     campaignRoot,
+		Description:      description,
+		SourcePaths:      []string{loc.SourcePath},
+		DestinationPaths: destinationPaths,
+	})
+}
+
+func invalidatePromoteNavCache(cmd *cobra.Command, campaignRoot string) {
+	if err := navindex.Delete(campaignRoot); err != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "%s failed to invalidate navigation cache: %v\n", ui.WarningIcon(), err)
+	}
+}

--- a/cmd/camp/root.go
+++ b/cmd/camp/root.go
@@ -15,6 +15,7 @@ import (
 	leveragepkg "github.com/Obedience-Corp/camp/cmd/camp/leverage"
 	navigationpkg "github.com/Obedience-Corp/camp/cmd/camp/navigation"
 	projectpkg "github.com/Obedience-Corp/camp/cmd/camp/project"
+	promotepkg "github.com/Obedience-Corp/camp/cmd/camp/promote"
 	refspkg "github.com/Obedience-Corp/camp/cmd/camp/refs"
 	registrypkg "github.com/Obedience-Corp/camp/cmd/camp/registry"
 	skillspkg "github.com/Obedience-Corp/camp/cmd/camp/skills"
@@ -201,6 +202,7 @@ func init() {
 	rootCmd.AddCommand(projectpkg.Cmd)
 	rootCmd.AddCommand(dungeonpkg.Cmd)
 	rootCmd.AddCommand(intentpkg.Cmd)
+	rootCmd.AddCommand(promotepkg.Cmd)
 	rootCmd.AddCommand(leveragepkg.Cmd)
 	rootCmd.AddCommand(worktreespkg.Cmd)
 	rootCmd.AddCommand(refspkg.Cmd)

--- a/tests/integration/promote_workitem_test.go
+++ b/tests/integration/promote_workitem_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -143,6 +144,68 @@ func TestPromote_AlreadyAtStatus(t *testing.T) {
 	output, err := tc.RunCampInDir(currentDir, "promote", "completed")
 	require.Error(t, err, "re-promote to same status should fail")
 	assert.Contains(t, output+err.Error(), "already at status")
+}
+
+func TestPromote_ActiveRejected(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupPromoteWorkitem(t, tc, "promote-active-rejected", "design", "feature-a")
+
+	output, err := tc.RunCampInDir(path+"/workflow/design/feature-a", "promote", "active")
+	require.Error(t, err, "promote active should fail")
+	assert.Contains(t, output+err.Error(), "not a dungeon status")
+
+	exists, err := tc.CheckDirExists(path + "/workflow/design/feature-a")
+	require.NoError(t, err)
+	assert.True(t, exists, "workitem should remain in active location")
+
+	exists, err = tc.CheckDirExists(path + "/workflow/design/dungeon/active")
+	require.NoError(t, err)
+	assert.False(t, exists, "no dungeon/active directory should be created")
+}
+
+func TestPromote_JsonOutput(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupPromoteWorkitem(t, tc, "promote-json", "design", "feature-j")
+
+	output, err := tc.RunCampInDir(path+"/workflow/design/feature-j", "promote", "completed", "--json")
+	require.NoError(t, err, "promote --json should succeed: %s", output)
+
+	trimmed := strings.TrimSpace(output)
+	require.NotEmpty(t, trimmed, "JSON output should not be empty")
+
+	var result struct {
+		Slug          string   `json:"slug"`
+		Type          string   `json:"type"`
+		Status        string   `json:"status"`
+		From          string   `json:"from"`
+		To            string   `json:"to"`
+		Committed     bool     `json:"committed"`
+		CommitMessage string   `json:"commit_message"`
+		Warnings      []string `json:"warnings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(trimmed), &result), "JSON output must be a single parseable object: %s", output)
+
+	assert.Equal(t, "feature-j", result.Slug)
+	assert.Equal(t, "design", result.Type)
+	assert.Equal(t, "completed", result.Status)
+	assert.Equal(t, "workflow/design/feature-j", result.From)
+	assert.Contains(t, result.To, "workflow/design/dungeon/completed/")
+	assert.True(t, result.Committed, "commit should have succeeded")
+	assert.NotEmpty(t, result.CommitMessage, "commit message should be set")
+}
+
+func TestPromote_JsonOutputNoCommit(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupPromoteWorkitem(t, tc, "promote-json-no-commit", "design", "feature-k")
+
+	output, err := tc.RunCampInDir(path+"/workflow/design/feature-k", "promote", "someday", "--json", "--no-commit")
+	require.NoError(t, err, "promote --json --no-commit should succeed: %s", output)
+
+	var result struct {
+		Committed bool `json:"committed"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &result), "JSON output must parse: %s", output)
+	assert.False(t, result.Committed, "committed should be false with --no-commit")
 }
 
 func TestPromote_NoCommit(t *testing.T) {

--- a/tests/integration/promote_workitem_test.go
+++ b/tests/integration/promote_workitem_test.go
@@ -1,0 +1,167 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupPromoteWorkitem(t *testing.T, tc *TestContainer, name, wkType, slug string) string {
+	t.Helper()
+	path := setupDungeonCampaign(t, tc, name)
+
+	output, err := tc.RunCampInDir(path,
+		"workitem", "create", slug,
+		"--type", wkType,
+		"--title", slug,
+		"--id", wkType+"-"+slug+"-fixed",
+	)
+	require.NoError(t, err, "workitem create should succeed: %s", output)
+
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+path+" && git add . && git commit -m 'add workitem'")
+	require.NoError(t, err, "initial commit should succeed")
+
+	return path
+}
+
+func TestPromote_FromActive(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupPromoteWorkitem(t, tc, "promote-from-active", "design", "feature-x")
+
+	wkDir := path + "/workflow/design/feature-x"
+	output, err := tc.RunCampInDir(wkDir, "promote", "completed")
+	require.NoError(t, err, "promote from active should succeed: %s", output)
+
+	assert.Contains(t, output, "Promoted feature-x")
+	assert.Contains(t, output, "workflow/design/feature-x")
+	assert.Contains(t, output, "workflow/design/dungeon/completed")
+	assert.Contains(t, output, "Committed", "should auto-commit")
+
+	exists, err := checkDatedDungeonStatusItemExists(tc, path+"/workflow/design/dungeon/completed", "feature-x")
+	require.NoError(t, err)
+	assert.True(t, exists, "workitem should be in dated dungeon/completed")
+
+	exists, err = tc.CheckDirExists(path + "/workflow/design/feature-x")
+	require.NoError(t, err)
+	assert.False(t, exists, "source workitem directory should be gone")
+
+	statusOutput, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git status --porcelain")
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(statusOutput), "git status should be clean after promote")
+}
+
+func TestPromote_FromSubdir(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupPromoteWorkitem(t, tc, "promote-from-subdir", "design", "feature-y")
+
+	_, _, err := tc.ExecCommand("sh", "-c", "mkdir -p "+path+"/workflow/design/feature-y/notes/deep")
+	require.NoError(t, err)
+
+	output, err := tc.RunCampInDir(path+"/workflow/design/feature-y/notes/deep", "promote", "archived")
+	require.NoError(t, err, "promote from deep subdir should succeed: %s", output)
+
+	assert.Contains(t, output, "Promoted feature-y")
+	assert.Contains(t, output, "workflow/design/dungeon/archived")
+
+	exists, err := checkDatedDungeonStatusItemExists(tc, path+"/workflow/design/dungeon/archived", "feature-y")
+	require.NoError(t, err)
+	assert.True(t, exists, "workitem should be in dated dungeon/archived")
+}
+
+func TestPromote_BetweenDungeonStatuses(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupPromoteWorkitem(t, tc, "promote-between-statuses", "design", "feature-z")
+
+	_, err := tc.RunCampInDir(path+"/workflow/design/feature-z", "promote", "completed")
+	require.NoError(t, err)
+
+	findOutput, _, err := tc.ExecCommand(
+		"find",
+		path+"/workflow/design/dungeon/completed",
+		"-mindepth", "2", "-maxdepth", "2",
+		"-name", "feature-z", "-type", "d",
+	)
+	require.NoError(t, err)
+	currentDir := strings.TrimSpace(findOutput)
+	require.NotEmpty(t, currentDir, "should have found dated dungeon dir for feature-z")
+
+	output, err := tc.RunCampInDir(currentDir, "promote", "archived")
+	require.NoError(t, err, "promote between dungeon statuses should succeed: %s", output)
+
+	assert.Contains(t, output, "Promoted feature-z")
+	assert.Contains(t, output, "workflow/design/dungeon/archived")
+
+	exists, err := checkDatedDungeonStatusItemExists(tc, path+"/workflow/design/dungeon/archived", "feature-z")
+	require.NoError(t, err)
+	assert.True(t, exists, "workitem should be in dated dungeon/archived after second promote")
+
+	exists, err = tc.CheckDirExists(currentDir)
+	require.NoError(t, err)
+	assert.False(t, exists, "previous dungeon location should be empty")
+}
+
+func TestPromote_NotInWorkitem(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupDungeonCampaign(t, tc, "promote-not-in-workitem")
+
+	output, err := tc.RunCampInDir(path, "promote", "completed")
+	require.Error(t, err, "promote outside workitem should fail")
+	assert.Contains(t, output+err.Error(), "not inside a workitem")
+}
+
+func TestPromote_InvalidStatus(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupPromoteWorkitem(t, tc, "promote-invalid-status", "design", "feature-q")
+
+	output, err := tc.RunCampInDir(path+"/workflow/design/feature-q", "promote", "foo/bar")
+	require.Error(t, err, "promote with invalid status should fail")
+	assert.Contains(t, output+err.Error(), "invalid status")
+}
+
+func TestPromote_AlreadyAtStatus(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupPromoteWorkitem(t, tc, "promote-already-at-status", "design", "feature-r")
+
+	_, err := tc.RunCampInDir(path+"/workflow/design/feature-r", "promote", "completed")
+	require.NoError(t, err)
+
+	findOutput, _, err := tc.ExecCommand(
+		"find",
+		path+"/workflow/design/dungeon/completed",
+		"-mindepth", "2", "-maxdepth", "2",
+		"-name", "feature-r", "-type", "d",
+	)
+	require.NoError(t, err)
+	currentDir := strings.TrimSpace(findOutput)
+	require.NotEmpty(t, currentDir)
+
+	output, err := tc.RunCampInDir(currentDir, "promote", "completed")
+	require.Error(t, err, "re-promote to same status should fail")
+	assert.Contains(t, output+err.Error(), "already at status")
+}
+
+func TestPromote_NoCommit(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupPromoteWorkitem(t, tc, "promote-no-commit", "design", "feature-s")
+
+	headBefore := strings.TrimSpace(tc.GitOutput(t, path, "rev-parse", "HEAD"))
+
+	output, err := tc.RunCampInDir(path+"/workflow/design/feature-s", "promote", "someday", "--no-commit")
+	require.NoError(t, err, "promote --no-commit should succeed: %s", output)
+
+	exists, err := checkDatedDungeonStatusItemExists(tc, path+"/workflow/design/dungeon/someday", "feature-s")
+	require.NoError(t, err)
+	assert.True(t, exists, "workitem should still be moved on disk")
+
+	headAfter := strings.TrimSpace(tc.GitOutput(t, path, "rev-parse", "HEAD"))
+	assert.Equal(t, headBefore, headAfter, "no new commit should be created with --no-commit")
+
+	statusOutput, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git status --porcelain")
+	require.NoError(t, err)
+	assert.NotEmpty(t, strings.TrimSpace(statusOutput), "filesystem move should appear in git status")
+}


### PR DESCRIPTION
## Summary
- New top-level `camp promote <status>` command for directory-style workitems under `workflow/<type>/`.
- Detects the workitem from cwd (walks up from anywhere inside it); no stable-ID / slug arg needed.
- No `--dungeon` flag: status directories live under the workitem-local dungeon, so naming them implies dungeon. Outside dungeon = active.
- Handles both active workitems (`workflow/<type>/<slug>`) and already-dungeoned workitems (`workflow/<type>/dungeon/<status>[/<date>]/<slug>`), so the same verb promotes between dungeon statuses.
- Flags `--no-commit` and `--json` mirror `fest promote`.

## Why
Festivals and intents already have ergonomic single-verb promotion. Generic workitems under `workflow/` only had `camp dungeon move --workitem <id> <status>` (verbose, requires stable-ID/path/slug) or `camp flow move` (slug-only, no cross-surface resolution). This fills the gap with the most common case: \"I'm in this workitem; shelve it.\"

## Scope (intentional)
- `workflow/` workitems only — festivals and intents have their own promote.
- Directory-style workitems only — matches PR #300 constraint.
- Out of scope: bringing items back out of dungeon (`promote active`), workflow-config validation, shared fest/camp promote package.

## Implementation
- `cmd/camp/promote/detect.go` — pure path-based detection of the workitem boundary. Recognizes legacy flat dungeon layout and dated dungeon layout (via `statuspath.IsDateDir`).
- `cmd/camp/promote/promote.go` — cobra command, calls `intdungeon.Service.MoveToDungeonStatus`, invalidates nav cache, commits via shared helper.
- `cmd/camp/dungeon/` — exported the move/commit helpers (`DungeonMoveCommit`, `CommitDungeonMove`, `WrapDungeonMoveError`, `RelFromRoot`) so promote can reuse the existing pipeline without duplication.
- Registered as agent-allowed in the camp restricted-commands manifest.

## Tests
- `go test ./cmd/camp/promote/...` — 15 table-driven unit tests for `detectWorkitemFromCwd` covering active, subdir, dated/legacy dungeon, and all error cases.
- `go test -tags=integration ./tests/integration -run 'TestPromote_'` — 7 containerized tests: FromActive, FromSubdir, BetweenDungeonStatuses, NotInWorkitem, InvalidStatus, AlreadyAtStatus, NoCommit.
- `go test ./...` — full unit suite green (incl. manifest tests updated for the new entry).
- `go test -tags=integration ./tests/integration -run 'TestPromote_|TestDungeonMove_'` — promote + PR #300 dungeon tests both green; no regression in the shared helpers.

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass
- [x] No regression in existing dungeon move tests
- [ ] Manual smoke: `cd workflow/design/<slug> && camp promote someday`