### PR TITLE
feat(workitem): workitem link registry — links/current/resolve/doctor (CW0003 slice 2)

### DIFF
--- a/internal/commands/workitem/current.go
+++ b/internal/commands/workitem/current.go
@@ -1,0 +1,111 @@
+package workitem
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+func newCurrentCommand() *cobra.Command {
+	var clear, jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "current [selector]",
+		Short: "Get, set, or clear the local current workitem",
+		Args:  cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			selectorArg := ""
+			if len(args) == 1 {
+				selectorArg = args[0]
+			}
+			return runCurrent(cmd.Context(), cmd, selectorArg, clear, jsonOut)
+		},
+	}
+	cmd.Flags().BoolVar(&clear, "clear", false, "remove the local current.yaml selection")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a structured JSON result")
+	return cmd
+}
+
+func runCurrent(ctx context.Context, cmd *cobra.Command, selectorArg string, clear, jsonOut bool) error {
+	_, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	switch {
+	case clear:
+		if selectorArg != "" {
+			return camperrors.NewValidation("clear", "--clear and a selector are mutually exclusive", nil)
+		}
+		if err := links.SaveCurrent(ctx, root, nil); err != nil {
+			return err
+		}
+		if jsonOut {
+			return emitCurrentJSON(cmd.OutOrStdout(), nil, true)
+		}
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), "cleared current workitem")
+		return err
+
+	case selectorArg != "":
+		wi, err := resolveSelector(ctx, root, selectorArg, false)
+		if err != nil {
+			return err
+		}
+		cur := &links.Current{
+			Version:    links.CurrentSchemaVersion,
+			WorkitemID: wi.StableID,
+			SelectedAt: time.Now().UTC().Truncate(time.Second),
+		}
+		if wi.StableID == "" {
+			cur.WorkitemID = wi.Key
+		}
+		if err := links.SaveCurrent(ctx, root, cur); err != nil {
+			return err
+		}
+		if jsonOut {
+			return emitCurrentJSON(cmd.OutOrStdout(), cur, false)
+		}
+		_, err = fmt.Fprintf(cmd.OutOrStdout(), "set current workitem: %s\n", cur.WorkitemID)
+		return err
+
+	default:
+		cur, err := links.LoadCurrent(ctx, root)
+		if err != nil {
+			return err
+		}
+		if jsonOut {
+			return emitCurrentJSON(cmd.OutOrStdout(), cur, false)
+		}
+		if cur == nil {
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), "no current workitem")
+			return err
+		}
+		_, err = fmt.Fprintf(cmd.OutOrStdout(),
+			"current workitem: %s (selected %s)\n",
+			cur.WorkitemID, cur.SelectedAt.Format(time.RFC3339))
+		return err
+	}
+}
+
+func emitCurrentJSON(w io.Writer, cur *links.Current, cleared bool) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(struct {
+		SchemaVersion string         `json:"schema_version"`
+		GeneratedAt   time.Time      `json:"generated_at"`
+		Cleared       bool           `json:"cleared"`
+		Current       *links.Current `json:"current"`
+	}{
+		SchemaVersion: links.CurrentSchemaVersion,
+		GeneratedAt:   time.Now().UTC(),
+		Cleared:       cleared,
+		Current:       cur,
+	})
+}

--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -1,0 +1,310 @@
+package workitem
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	"github.com/Obedience-Corp/camp/internal/quest"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+// Doctor finding codes (dotted-domain form). Stable strings; consumers
+// dispatch on them.
+const (
+	codeBrokenLink       = "workitem.link.broken"
+	codeBrokenScope      = "workitem.scope.broken"
+	codeOutOfBounds      = "workitem.scope.out-of-bounds"
+	codeDuplicatePrimary = "workitem.link.duplicate-primary"
+	codeSchemaViolation  = "workitem.schema.violation"
+	codeCurrentMissing   = "workitem.current.missing"
+)
+
+const (
+	docSeverityError   = "error"
+	docSeverityWarning = "warning"
+	docSeverityInfo    = "info"
+)
+
+type docFinding struct {
+	Code        string `json:"code"`
+	Severity    string `json:"severity"`
+	Target      string `json:"target,omitempty"`
+	Message     string `json:"message"`
+	FixHint     string `json:"fix_hint,omitempty"`
+	AutoFixable bool   `json:"auto_fixable"`
+}
+
+// errDoctorIssues triggers a non-zero exit from cobra after we have already
+// emitted findings.
+var errDoctorIssues = camperrors.NewValidation("doctor", "doctor reported error-severity findings", nil)
+
+func newDoctorCommand() *cobra.Command {
+	var jsonOut, fix bool
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Report workitem link-registry health issues",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDoctor(cmd.Context(), cmd, jsonOut, fix)
+		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a structured JSON result")
+	cmd.Flags().BoolVar(&fix, "fix", false, "auto-repair findings tagged auto_fixable")
+	return cmd
+}
+
+func runDoctor(ctx context.Context, cmd *cobra.Command, jsonOut, fix bool) error {
+	_, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+	registry, err := links.Load(ctx, root)
+	if err != nil {
+		return err
+	}
+
+	knownIDs, err := workitemIDsOnDisk(ctx, root)
+	if err != nil {
+		return err
+	}
+
+	findings := collectWorkitemFindings(ctx, root, registry, knownIDs)
+	if fix {
+		applied := autoFixWorkitemFindings(ctx, root, registry, findings)
+		if applied > 0 {
+			if err := links.Save(ctx, root, registry); err != nil {
+				return err
+			}
+			// Re-run findings after fixes for an accurate post-fix report.
+			knownIDs, _ = workitemIDsOnDisk(ctx, root)
+			findings = collectWorkitemFindings(ctx, root, registry, knownIDs)
+		}
+	}
+
+	if jsonOut {
+		if err := emitDocJSON(cmd.OutOrStdout(), findings); err != nil {
+			return err
+		}
+	} else {
+		emitDocHuman(cmd.OutOrStdout(), findings)
+	}
+
+	if hasErrorFinding(findings) {
+		return errDoctorIssues
+	}
+	return nil
+}
+
+func collectWorkitemFindings(ctx context.Context, root string, registry *links.Links, knownIDs map[string]struct{}) []docFinding {
+	var findings []docFinding
+
+	// Schema-level validation.
+	for _, v := range links.Validate(ctx, registry, links.ValidateOptions{
+		CampaignRoot: root,
+		WorkitemIDs:  nil, // existence is checked below as a separate finding
+	}) {
+		findings = append(findings, docFinding{
+			Code:     codeSchemaViolation,
+			Severity: docSeverityError,
+			Target:   targetForLinkID(v.LinkID),
+			Message:  v.Field + ": " + v.Message,
+		})
+	}
+
+	primarySeen := make(map[string]string)
+	for _, link := range registry.Links {
+		if _, known := knownIDs[link.WorkitemID]; !known {
+			findings = append(findings, docFinding{
+				Code:        codeBrokenLink,
+				Severity:    docSeverityError,
+				Target:      "link:" + link.ID,
+				Message:     "workitem_id " + link.WorkitemID + " is not present on disk",
+				FixHint:     "auto-fix removes the link",
+				AutoFixable: true,
+			})
+		}
+		if !scopeTargetExists(root, link.Scope.Path) {
+			findings = append(findings, docFinding{
+				Code:        codeBrokenScope,
+				Severity:    docSeverityError,
+				Target:      "link:" + link.ID,
+				Message:     "scope path " + link.Scope.Path + " does not exist",
+				FixHint:     "remove the link or restore the directory; auto-fix removes the link",
+				AutoFixable: true,
+			})
+		}
+		if err := quest.ValidateLinkPath(root, link.Scope.Path); err != nil && errors.Is(err, camperrors.ErrInvalidInput) {
+			findings = append(findings, docFinding{
+				Code:     codeOutOfBounds,
+				Severity: docSeverityError,
+				Target:   "link:" + link.ID,
+				Message:  "scope path " + link.Scope.Path + " escapes the campaign root",
+			})
+		}
+		if link.Role == links.RolePrimary {
+			key := string(link.Scope.Kind) + "::" + link.Scope.Path
+			if other, dup := primarySeen[key]; dup {
+				findings = append(findings, docFinding{
+					Code:     codeDuplicatePrimary,
+					Severity: docSeverityError,
+					Target:   "scope:" + key,
+					Message:  "primary links " + other + " and " + link.ID + " collide on the same scope",
+				})
+			} else {
+				primarySeen[key] = link.ID
+			}
+		}
+	}
+
+	cur, err := links.LoadCurrent(ctx, root)
+	if err == nil && cur != nil {
+		if _, known := knownIDs[cur.WorkitemID]; !known {
+			findings = append(findings, docFinding{
+				Code:        codeCurrentMissing,
+				Severity:    docSeverityWarning,
+				Target:      "current:" + cur.WorkitemID,
+				Message:     "current.yaml points at workitem " + cur.WorkitemID + " which is not present on disk",
+				FixHint:     "auto-fix removes current.yaml",
+				AutoFixable: true,
+			})
+		}
+	}
+
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Code != findings[j].Code {
+			return findings[i].Code < findings[j].Code
+		}
+		return findings[i].Target < findings[j].Target
+	})
+	return findings
+}
+
+func autoFixWorkitemFindings(ctx context.Context, root string, registry *links.Links, findings []docFinding) int {
+	applied := 0
+	for _, f := range findings {
+		if !f.AutoFixable {
+			continue
+		}
+		switch f.Code {
+		case codeBrokenLink, codeBrokenScope:
+			id := strings.TrimPrefix(f.Target, "link:")
+			if registry.RemoveLinkByID(id) {
+				applied++
+			}
+		case codeCurrentMissing:
+			if err := links.SaveCurrent(ctx, root, nil); err == nil {
+				applied++
+			}
+		}
+	}
+	return applied
+}
+
+func targetForLinkID(linkID string) string {
+	if linkID == "" {
+		return "registry"
+	}
+	return "link:" + linkID
+}
+
+func scopeTargetExists(root, scopePath string) bool {
+	if scopePath == "" {
+		return false
+	}
+	abs := filepath.Join(root, filepath.FromSlash(scopePath))
+	_, err := os.Stat(abs)
+	if err == nil {
+		return true
+	}
+	return !errors.Is(err, fs.ErrNotExist)
+}
+
+func workitemIDsOnDisk(ctx context.Context, root string) (map[string]struct{}, error) {
+	cfg, err := config.LoadCampaignConfig(ctx, root)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "load campaign config")
+	}
+	resolver := paths.NewResolverFromConfig(root, cfg)
+	items, err := wkitem.Discover(ctx, root, resolver)
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		if item.StableID != "" {
+			set[item.StableID] = struct{}{}
+		}
+	}
+	return set, nil
+}
+
+func hasErrorFinding(findings []docFinding) bool {
+	for _, f := range findings {
+		if f.Severity == docSeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+func emitDocHuman(w io.Writer, findings []docFinding) {
+	if len(findings) == 0 {
+		fmt.Fprintln(w, "doctor: 0 findings")
+		return
+	}
+	fmt.Fprintf(w, "doctor: %d finding(s)\n", len(findings))
+	for _, f := range findings {
+		fmt.Fprintf(w, "  [%s] %s %s — %s\n", f.Severity, f.Code, f.Target, f.Message)
+		if f.FixHint != "" {
+			fmt.Fprintln(w, "    hint: "+f.FixHint)
+		}
+	}
+}
+
+func emitDocJSON(w io.Writer, findings []docFinding) error {
+	if findings == nil {
+		findings = []docFinding{}
+	}
+	out := struct {
+		SchemaVersion string       `json:"schema_version"`
+		GeneratedAt   time.Time    `json:"generated_at"`
+		Findings      []docFinding `json:"findings"`
+		ErrorCount    int          `json:"error_count"`
+		WarningCount  int          `json:"warning_count"`
+		InfoCount     int          `json:"info_count"`
+	}{
+		SchemaVersion: "workitem-doctor/v1alpha1",
+		GeneratedAt:   time.Now().UTC(),
+		Findings:      findings,
+	}
+	for _, f := range findings {
+		switch f.Severity {
+		case docSeverityError:
+			out.ErrorCount++
+		case docSeverityWarning:
+			out.WarningCount++
+		case docSeverityInfo:
+			out.InfoCount++
+		}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}

--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -26,12 +26,13 @@ import (
 // Doctor finding codes (dotted-domain form). Stable strings; consumers
 // dispatch on them.
 const (
-	codeBrokenLink       = "workitem.link.broken"
-	codeBrokenScope      = "workitem.scope.broken"
-	codeOutOfBounds      = "workitem.scope.out-of-bounds"
-	codeDuplicatePrimary = "workitem.link.duplicate-primary"
-	codeSchemaViolation  = "workitem.schema.violation"
-	codeCurrentMissing   = "workitem.current.missing"
+	codeBrokenLink         = "workitem.link.broken"
+	codeBrokenScope        = "workitem.scope.broken"
+	codeOutOfBounds        = "workitem.scope.out-of-bounds"
+	codeScopeUnvalidatable = "workitem.scope.unvalidatable"
+	codeDuplicatePrimary   = "workitem.link.duplicate-primary"
+	codeSchemaViolation    = "workitem.schema.violation"
+	codeCurrentMissing     = "workitem.current.missing"
 )
 
 const (
@@ -140,7 +141,8 @@ func collectWorkitemFindings(ctx context.Context, root string, registry *links.L
 				AutoFixable: true,
 			})
 		}
-		if !scopeTargetExists(root, link.Scope.Path) {
+		scopeMissing := !scopeTargetExists(root, link.Scope.Path)
+		if scopeMissing {
 			findings = append(findings, docFinding{
 				Code:        codeBrokenScope,
 				Severity:    docSeverityError,
@@ -150,13 +152,23 @@ func collectWorkitemFindings(ctx context.Context, root string, registry *links.L
 				AutoFixable: true,
 			})
 		}
-		if err := quest.ValidateLinkPath(root, link.Scope.Path); err != nil && errors.Is(err, camperrors.ErrInvalidInput) {
-			findings = append(findings, docFinding{
-				Code:     codeOutOfBounds,
-				Severity: docSeverityError,
-				Target:   "link:" + link.ID,
-				Message:  "scope path " + link.Scope.Path + " escapes the campaign root",
-			})
+		if err := quest.ValidateLinkPath(root, link.Scope.Path); err != nil {
+			switch {
+			case errors.Is(err, camperrors.ErrInvalidInput):
+				findings = append(findings, docFinding{
+					Code:     codeOutOfBounds,
+					Severity: docSeverityError,
+					Target:   "link:" + link.ID,
+					Message:  "scope path " + link.Scope.Path + " escapes the campaign root",
+				})
+			case !scopeMissing:
+				findings = append(findings, docFinding{
+					Code:     codeScopeUnvalidatable,
+					Severity: docSeverityError,
+					Target:   "link:" + link.ID,
+					Message:  "scope path " + link.Scope.Path + " could not be validated: " + err.Error(),
+				})
+			}
 		}
 		if link.Role == links.RolePrimary {
 			key := string(link.Scope.Kind) + "::" + link.Scope.Path

--- a/internal/commands/workitem/link.go
+++ b/internal/commands/workitem/link.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/user"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -117,7 +119,7 @@ func runLink(ctx context.Context, cmd *cobra.Command, opts linkOptions) error {
 		Scope:       *scope,
 		Role:        role,
 		CreatedAt:   time.Now().UTC().Truncate(time.Second),
-		CreatedBy:   "camp_workitem_link",
+		CreatedBy:   defaultCreatedBy(),
 	}
 	if err := registry.AddLink(link, opts.Replace); err != nil {
 		return err
@@ -141,6 +143,26 @@ func runLink(ctx context.Context, cmd *cobra.Command, opts linkOptions) error {
 		return emitLinkJSON(cmd.OutOrStdout(), link)
 	}
 	return emitLinkHuman(cmd.OutOrStdout(), link)
+}
+
+var createdBySanitizer = regexp.MustCompile(`[^A-Za-z0-9_-]+`)
+
+func defaultCreatedBy() string {
+	if u, err := user.Current(); err == nil && u.Username != "" {
+		if sanitized := sanitizeCreatedBy(u.Username); sanitized != "" {
+			return sanitized
+		}
+	}
+	return "camp_workitem_link"
+}
+
+func sanitizeCreatedBy(value string) string {
+	sanitized := createdBySanitizer.ReplaceAllString(value, "-")
+	sanitized = strings.Trim(sanitized, "-")
+	if len(sanitized) > 64 {
+		sanitized = sanitized[:64]
+	}
+	return sanitized
 }
 
 func resolveSelector(ctx context.Context, root, query string, allowMissing bool) (*wkitem.WorkItem, error) {

--- a/internal/commands/workitem/link.go
+++ b/internal/commands/workitem/link.go
@@ -1,0 +1,293 @@
+package workitem
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/quest"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/selector"
+)
+
+func newLinkCommand() *cobra.Command {
+	var (
+		project, festival, worktree string
+		useCwd, replace             bool
+		allowMissing, jsonOut       bool
+		role                        string
+	)
+	cmd := &cobra.Command{
+		Use:   "link <selector> [path]",
+		Short: "Attach a workitem to a project, festival, worktree, or campaign path",
+		Args:  cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			explicitPath := ""
+			if len(args) == 2 {
+				explicitPath = args[1]
+			}
+			return runLink(cmd.Context(), cmd, linkOptions{
+				Selector:     args[0],
+				ExplicitPath: explicitPath,
+				Project:      project,
+				Festival:     festival,
+				Worktree:     worktree,
+				UseCwd:       useCwd,
+				Role:         role,
+				Replace:      replace,
+				AllowMissing: allowMissing,
+				JSON:         jsonOut,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&project, "project", "", "project name (matches projects/<name>)")
+	cmd.Flags().StringVar(&festival, "festival", "", "festival id or relative path under festivals/")
+	cmd.Flags().StringVar(&worktree, "worktree", "", "worktree relative path under projects/worktrees/")
+	cmd.Flags().BoolVar(&useCwd, "cwd", false, "use current working directory as the scope")
+	cmd.Flags().StringVar(&role, "role", string(links.RolePrimary), "primary | related | blocked_by | supersedes")
+	cmd.Flags().BoolVar(&replace, "replace", false, "replace an existing primary link on the same scope")
+	cmd.Flags().BoolVar(&allowMissing, "allow-missing", false, "allow the workitem and scope target to not exist (migrations)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a structured JSON result")
+	return cmd
+}
+
+type linkOptions struct {
+	Selector     string
+	ExplicitPath string
+	Project      string
+	Festival     string
+	Worktree     string
+	UseCwd       bool
+	Role         string
+	Replace      bool
+	AllowMissing bool
+	JSON         bool
+}
+
+func runLink(ctx context.Context, cmd *cobra.Command, opts linkOptions) error {
+	_, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	if opts.Role == "" {
+		opts.Role = string(links.RolePrimary)
+	}
+	role := links.Role(opts.Role)
+	if !isValidRole(role) {
+		return camperrors.NewValidation("role",
+			"invalid role "+opts.Role+" (expected primary|related|blocked_by|supersedes)", nil)
+	}
+
+	wi, err := resolveSelector(ctx, root, opts.Selector, opts.AllowMissing)
+	if err != nil {
+		return err
+	}
+
+	scope, err := resolveLinkScope(root, opts)
+	if err != nil {
+		return err
+	}
+
+	if !opts.AllowMissing {
+		if err := quest.ValidateLinkPath(root, scope.Path); err != nil {
+			return camperrors.Wrap(err, "scope path")
+		}
+	}
+
+	registry, err := links.Load(ctx, root)
+	if err != nil {
+		return err
+	}
+
+	link := links.Link{
+		ID:          generateLinkID(),
+		WorkitemID:  workitemIDForLink(wi, opts),
+		WorkitemKey: workitemKeyForLink(wi),
+		Scope:       *scope,
+		Role:        role,
+		CreatedAt:   time.Now().UTC().Truncate(time.Second),
+		CreatedBy:   "camp_workitem_link",
+	}
+	if err := registry.AddLink(link, opts.Replace); err != nil {
+		return err
+	}
+
+	knownIDs := workitemIDSetFromMaybeNil(wi, opts.AllowMissing)
+	if errs := links.Validate(ctx, registry, links.ValidateOptions{
+		CampaignRoot: root,
+		WorkitemIDs:  knownIDs,
+		AllowMissing: opts.AllowMissing,
+		Now:          link.CreatedAt,
+	}); len(errs) > 0 {
+		return camperrors.NewValidation(errs[0].Field, errs[0].Message, nil)
+	}
+
+	if err := links.Save(ctx, root, registry); err != nil {
+		return err
+	}
+
+	if opts.JSON {
+		return emitLinkJSON(cmd.OutOrStdout(), link)
+	}
+	return emitLinkHuman(cmd.OutOrStdout(), link)
+}
+
+func resolveSelector(ctx context.Context, root, query string, allowMissing bool) (*wkitem.WorkItem, error) {
+	if allowMissing && (strings.HasPrefix(query, "lnk_") == false) {
+		// Even with --allow-missing, try the resolver first; if it fails,
+		// synthesize a minimal WorkItem so the link can still be saved.
+		if wi, err := selector.Resolve(ctx, root, query, selector.ResolveOptions{}); err == nil {
+			return wi, nil
+		}
+		return &wkitem.WorkItem{
+			Key:      query,
+			StableID: query,
+		}, nil
+	}
+	return selector.Resolve(ctx, root, query, selector.ResolveOptions{})
+}
+
+func resolveLinkScope(root string, opts linkOptions) (*links.LinkScope, error) {
+	chosen := 0
+	for _, v := range []string{opts.Project, opts.Festival, opts.Worktree, opts.ExplicitPath} {
+		if v != "" {
+			chosen++
+		}
+	}
+	if opts.UseCwd {
+		chosen++
+	}
+	if chosen == 0 {
+		return nil, camperrors.NewValidation("scope",
+			"must specify one of --project, --festival, --worktree, --cwd, or a path argument", nil)
+	}
+	if chosen > 1 {
+		return nil, camperrors.NewValidation("scope",
+			"--project, --festival, --worktree, --cwd, and the path argument are mutually exclusive", nil)
+	}
+
+	switch {
+	case opts.Project != "":
+		return &links.LinkScope{Kind: links.ScopeProject, Path: filepath.ToSlash(filepath.Join("projects", opts.Project))}, nil
+	case opts.Festival != "":
+		path := opts.Festival
+		if !strings.HasPrefix(path, "festivals/") {
+			path = filepath.ToSlash(filepath.Join("festivals", "active", path))
+		}
+		return &links.LinkScope{Kind: links.ScopeFestival, Path: path}, nil
+	case opts.Worktree != "":
+		path := opts.Worktree
+		if !strings.HasPrefix(path, "projects/worktrees/") {
+			path = filepath.ToSlash(filepath.Join("projects", "worktrees", opts.Worktree))
+		}
+		return &links.LinkScope{Kind: links.ScopeWorktree, Path: path}, nil
+	case opts.UseCwd:
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, camperrors.Wrap(err, "get cwd")
+		}
+		rel, err := filepath.Rel(root, cwd)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			return nil, camperrors.NewValidation("scope",
+				"current directory is outside the campaign root", nil)
+		}
+		rel = filepath.ToSlash(rel)
+		return &links.LinkScope{Kind: inferScopeKind(rel), Path: rel}, nil
+	default: // explicit path
+		path := filepath.ToSlash(opts.ExplicitPath)
+		return &links.LinkScope{Kind: inferScopeKind(path), Path: path}, nil
+	}
+}
+
+func inferScopeKind(rel string) links.ScopeKind {
+	switch {
+	case strings.HasPrefix(rel, "projects/worktrees/"):
+		return links.ScopeWorktree
+	case strings.HasPrefix(rel, "projects/"):
+		return links.ScopeProject
+	case strings.HasPrefix(rel, "festivals/"):
+		return links.ScopeFestival
+	default:
+		return links.ScopeCampaignPath
+	}
+}
+
+func workitemIDForLink(wi *wkitem.WorkItem, opts linkOptions) string {
+	if wi.StableID != "" {
+		return wi.StableID
+	}
+	if opts.AllowMissing {
+		return opts.Selector
+	}
+	return wi.Key
+}
+
+func workitemKeyForLink(wi *wkitem.WorkItem) string {
+	return wi.Key
+}
+
+func workitemIDSetFromMaybeNil(wi *wkitem.WorkItem, allowMissing bool) map[string]struct{} {
+	if allowMissing {
+		return nil
+	}
+	if wi == nil || wi.StableID == "" {
+		return nil
+	}
+	return map[string]struct{}{wi.StableID: {}}
+}
+
+func emitLinkHuman(w io.Writer, link links.Link) error {
+	_, err := fmt.Fprintf(w,
+		"linked %s -> %s:%s (role %s, id %s)\n",
+		link.WorkitemID, link.Scope.Kind, link.Scope.Path, link.Role, link.ID)
+	return err
+}
+
+func emitLinkJSON(w io.Writer, link links.Link) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(struct {
+		SchemaVersion string     `json:"schema_version"`
+		GeneratedAt   time.Time  `json:"generated_at"`
+		Link          links.Link `json:"link"`
+	}{
+		SchemaVersion: links.LinksSchemaVersion,
+		GeneratedAt:   time.Now().UTC(),
+		Link:          link,
+	})
+}
+
+func generateLinkID() string {
+	// Local-only ID generator: yyyymmdd + 6 hex bytes of randomness.
+	// crypto/rand keeps the per-day collision domain wide.
+	var b [3]byte
+	if _, err := readRand(b[:]); err != nil {
+		// In the unlikely case of rand failure, fall back to a time-derived
+		// suffix so we still produce a valid ID rather than abort the link.
+		return fmt.Sprintf("lnk_%s_%06x",
+			time.Now().UTC().Format("20060102"),
+			time.Now().UnixNano()&0xffffff)
+	}
+	return fmt.Sprintf("lnk_%s_%02x%02x%02x",
+		time.Now().UTC().Format("20060102"), b[0], b[1], b[2])
+}
+
+func isValidRole(r links.Role) bool {
+	for _, valid := range links.ValidRoles {
+		if r == valid {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/commands/workitem/link_rand.go
+++ b/internal/commands/workitem/link_rand.go
@@ -1,0 +1,7 @@
+package workitem
+
+import "crypto/rand"
+
+// readRand is a seam so tests can inject deterministic randomness if needed.
+// Default reads from crypto/rand.
+var readRand = func(b []byte) (int, error) { return rand.Read(b) }

--- a/internal/commands/workitem/link_test.go
+++ b/internal/commands/workitem/link_test.go
@@ -1,0 +1,402 @@
+package workitem
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+// linkTestCampaign builds a minimal campaign with one design workitem at
+// workflow/design/example/.workitem so the selector resolver can find it.
+func linkTestCampaign(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".campaign"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".campaign", "campaign.yaml"),
+		[]byte("id: test-campaign\nname: Test\ntype: product\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wiDir := filepath.Join(root, "workflow", "design", "example")
+	if err := os.MkdirAll(wiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const meta = `version: v1alpha5
+kind: workitem
+id: design-example-2026-05-24
+type: design
+title: Example
+`
+	if err := os.WriteFile(filepath.Join(wiDir, ".workitem"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "projects", "demo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func chdir(t *testing.T, dir string) func() {
+	t.Helper()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	return func() {
+		if err := os.Chdir(old); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}
+}
+
+func newCmd() *cobra.Command {
+	c := &cobra.Command{}
+	c.SetOut(&bytes.Buffer{})
+	c.SetErr(&bytes.Buffer{})
+	return c
+}
+
+func TestLink_HappyPath(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := newCmd()
+	if err := runLink(context.Background(), cmd, linkOptions{
+		Selector: "design-example-2026-05-24",
+		Project:  "demo",
+	}); err != nil {
+		t.Fatalf("runLink: %v", err)
+	}
+
+	registry, err := links.Load(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(registry.Links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(registry.Links))
+	}
+	link := registry.Links[0]
+	if link.WorkitemID != "design-example-2026-05-24" {
+		t.Fatalf("workitem_id = %q", link.WorkitemID)
+	}
+	if link.Scope.Kind != links.ScopeProject || link.Scope.Path != "projects/demo" {
+		t.Fatalf("scope = %#v", link.Scope)
+	}
+	if link.Role != links.RolePrimary {
+		t.Fatalf("role = %s", link.Role)
+	}
+}
+
+func TestLink_MissingSelectorErrors(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := newCmd()
+	err := runLink(context.Background(), cmd, linkOptions{
+		Selector: "no-such-workitem",
+		Project:  "demo",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing selector")
+	}
+	if !strings.Contains(err.Error(), "no workitem matched") {
+		t.Fatalf("err = %v, expected 'no workitem matched'", err)
+	}
+}
+
+func TestLink_AmbiguousSelector(t *testing.T) {
+	root := linkTestCampaign(t)
+	// Add a second design workitem with the same slug to trigger ambiguity on
+	// the slug-match path.
+	otherDir := filepath.Join(root, "workflow", "design", "duplicate-slug")
+	if err := os.MkdirAll(otherDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const otherMeta = `version: v1alpha5
+kind: workitem
+id: design-duplicate-2026-05-24
+type: design
+title: Duplicate
+`
+	if err := os.WriteFile(filepath.Join(otherDir, ".workitem"), []byte(otherMeta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	restore := chdir(t, root)
+	defer restore()
+
+	// Use a fuzzy-style ambiguous selector that matches slug exactness on
+	// neither but matches multiple via key. "design" matches both via key
+	// when AllowFuzzy is on — but selector default has fuzzy off, so it
+	// should fall to ErrNotFound here. Construct a real ambiguity instead:
+	// create two workitems sharing the same slug, then look up by slug.
+	thirdDir := filepath.Join(root, "workflow", "design", "shared")
+	fourthDir := filepath.Join(root, "workflow", "explore", "shared")
+	for _, dir := range []string{thirdDir, fourthDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		meta := "version: v1alpha5\nkind: workitem\nid: " +
+			filepath.Base(dir) + "-" + filepath.Base(filepath.Dir(dir)) +
+			"-2026-05-24\ntype: " + filepath.Base(filepath.Dir(dir)) + "\n"
+		if err := os.WriteFile(filepath.Join(dir, ".workitem"), []byte(meta), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cmd := newCmd()
+	err := runLink(context.Background(), cmd, linkOptions{
+		Selector: "shared",
+		Project:  "demo",
+	})
+	if err == nil {
+		t.Fatal("expected error for ambiguous selector")
+	}
+	if !strings.Contains(err.Error(), "multiple workitems") {
+		t.Fatalf("err = %v, want multiple-match message", err)
+	}
+}
+
+func TestLink_DuplicatePrimaryRequiresReplace(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := newCmd()
+	if err := runLink(context.Background(), cmd, linkOptions{
+		Selector: "design-example-2026-05-24",
+		Project:  "demo",
+	}); err != nil {
+		t.Fatalf("first link: %v", err)
+	}
+	if err := runLink(context.Background(), cmd, linkOptions{
+		Selector: "design-example-2026-05-24",
+		Project:  "demo",
+	}); err == nil {
+		t.Fatal("expected collision without --replace")
+	}
+	if err := runLink(context.Background(), cmd, linkOptions{
+		Selector: "design-example-2026-05-24",
+		Project:  "demo",
+		Replace:  true,
+	}); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	registry, err := links.Load(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(registry.Links) != 1 {
+		t.Fatalf("expected 1 link after replace, got %d", len(registry.Links))
+	}
+}
+
+func TestLink_JSONShape(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	if err := runLink(context.Background(), cmd, linkOptions{
+		Selector: "design-example-2026-05-24",
+		Project:  "demo",
+		JSON:     true,
+	}); err != nil {
+		t.Fatalf("runLink: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\nraw=%s", err, stdout.String())
+	}
+	if payload["schema_version"] != links.LinksSchemaVersion {
+		t.Fatalf("schema_version = %v", payload["schema_version"])
+	}
+}
+
+func TestUnlink_RemovesByID(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := newCmd()
+	if err := runLink(context.Background(), cmd, linkOptions{
+		Selector: "design-example-2026-05-24",
+		Project:  "demo",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	registry, err := links.Load(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	linkID := registry.Links[0].ID
+
+	if err := runUnlink(context.Background(), cmd, unlinkOptions{ID: linkID}); err != nil {
+		t.Fatalf("runUnlink: %v", err)
+	}
+	after, err := links.Load(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after.Links) != 0 {
+		t.Fatalf("expected 0 links after unlink, got %d", len(after.Links))
+	}
+}
+
+func TestUnlink_RoundTripBySelector(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := newCmd()
+	if err := runLink(context.Background(), cmd, linkOptions{
+		Selector: "design-example-2026-05-24",
+		Project:  "demo",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := runUnlink(context.Background(), cmd, unlinkOptions{
+		Selector:     "design-example-2026-05-24",
+		ExplicitPath: "projects/demo",
+	}); err != nil {
+		t.Fatalf("runUnlink: %v", err)
+	}
+	after, err := links.Load(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after.Links) != 0 {
+		t.Fatalf("expected 0 links after selector-based unlink, got %d", len(after.Links))
+	}
+}
+
+func TestLinks_ListEmptyAndFiltered(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := newCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	if err := runLinks(context.Background(), cmd, "", false); err != nil {
+		t.Fatalf("runLinks empty: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "no links") {
+		t.Fatalf("empty output = %q", stdout.String())
+	}
+
+	if err := runLink(context.Background(), cmd, linkOptions{
+		Selector: "design-example-2026-05-24",
+		Project:  "demo",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	cmd.SetOut(&stdout)
+	if err := runLinks(context.Background(), cmd, "design-example-2026-05-24", false); err != nil {
+		t.Fatalf("runLinks filtered: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "design-example-2026-05-24") {
+		t.Fatalf("filtered output missing workitem id: %q", stdout.String())
+	}
+}
+
+func TestCurrent_SetGetClear(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := newCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := runCurrent(context.Background(), cmd, "", false, false); err != nil {
+		t.Fatalf("runCurrent empty get: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "no current workitem") {
+		t.Fatalf("empty get output = %q", stdout.String())
+	}
+
+	stdout.Reset()
+	cmd.SetOut(&stdout)
+	if err := runCurrent(context.Background(), cmd, "design-example-2026-05-24", false, false); err != nil {
+		t.Fatalf("runCurrent set: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "set current workitem") {
+		t.Fatalf("set output = %q", stdout.String())
+	}
+
+	stdout.Reset()
+	cmd.SetOut(&stdout)
+	if err := runCurrent(context.Background(), cmd, "", false, false); err != nil {
+		t.Fatalf("runCurrent get: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "design-example-2026-05-24") {
+		t.Fatalf("get output = %q", stdout.String())
+	}
+
+	stdout.Reset()
+	cmd.SetOut(&stdout)
+	if err := runCurrent(context.Background(), cmd, "", true, false); err != nil {
+		t.Fatalf("runCurrent clear: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "cleared") {
+		t.Fatalf("clear output = %q", stdout.String())
+	}
+
+	// Verify file is gone.
+	if _, err := os.Stat(filepath.Join(root, ".campaign", "workitems", "current.yaml")); !os.IsNotExist(err) {
+		t.Fatalf("current.yaml should not exist after --clear: err=%v", err)
+	}
+}
+
+func TestLink_CwdInfersScope(t *testing.T) {
+	root := linkTestCampaign(t)
+	// Run from inside projects/demo so --cwd picks it up as scope.
+	cwd := filepath.Join(root, "projects", "demo")
+	restore := chdir(t, cwd)
+	defer restore()
+
+	cmd := newCmd()
+	if err := runLink(context.Background(), cmd, linkOptions{
+		Selector: "design-example-2026-05-24",
+		UseCwd:   true,
+	}); err != nil {
+		t.Fatalf("runLink --cwd: %v", err)
+	}
+	registry, err := links.Load(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(registry.Links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(registry.Links))
+	}
+	if registry.Links[0].Scope.Kind != links.ScopeProject {
+		t.Fatalf("scope.kind = %s, want project", registry.Links[0].Scope.Kind)
+	}
+	if registry.Links[0].Scope.Path != "projects/demo" {
+		t.Fatalf("scope.path = %q", registry.Links[0].Scope.Path)
+	}
+}
+
+// Sanity: link save loads the same campaign config the resolver uses.
+var _ = config.LoadCampaignConfig

--- a/internal/commands/workitem/link_test.go
+++ b/internal/commands/workitem/link_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
 )
 
@@ -397,6 +396,3 @@ func TestLink_CwdInfersScope(t *testing.T) {
 		t.Fatalf("scope.path = %q", registry.Links[0].Scope.Path)
 	}
 }
-
-// Sanity: link save loads the same campaign config the resolver uses.
-var _ = config.LoadCampaignConfig

--- a/internal/commands/workitem/link_test.go
+++ b/internal/commands/workitem/link_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/selector"
 )
 
 // linkTestCampaign builds a minimal campaign with one design workitem at
@@ -98,6 +100,19 @@ func TestLink_HappyPath(t *testing.T) {
 	if link.Role != links.RolePrimary {
 		t.Fatalf("role = %s", link.Role)
 	}
+	if link.CreatedBy == "" {
+		t.Fatalf("created_by must not be empty")
+	}
+}
+
+func TestSanitizeCreatedBy(t *testing.T) {
+	if got := sanitizeCreatedBy("DOMAIN\\Lance Rogers!"); got != "DOMAIN-Lance-Rogers" {
+		t.Fatalf("sanitizeCreatedBy = %q", got)
+	}
+	long := strings.Repeat("a", 70)
+	if got := sanitizeCreatedBy(long); len(got) != 64 {
+		t.Fatalf("sanitizeCreatedBy length = %d, want 64", len(got))
+	}
 }
 
 func TestLink_MissingSelectorErrors(t *testing.T) {
@@ -115,6 +130,9 @@ func TestLink_MissingSelectorErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no workitem matched") {
 		t.Fatalf("err = %v, expected 'no workitem matched'", err)
+	}
+	if !errors.Is(err, selector.ErrSelectorNotFound) {
+		t.Fatalf("err = %v, want ErrSelectorNotFound", err)
 	}
 }
 
@@ -167,6 +185,9 @@ title: Duplicate
 	}
 	if !strings.Contains(err.Error(), "multiple workitems") {
 		t.Fatalf("err = %v, want multiple-match message", err)
+	}
+	if !errors.Is(err, selector.ErrSelectorAmbiguous) {
+		t.Fatalf("err = %v, want ErrSelectorAmbiguous", err)
 	}
 }
 
@@ -315,6 +336,64 @@ func TestLinks_ListEmptyAndFiltered(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "design-example-2026-05-24") {
 		t.Fatalf("filtered output missing workitem id: %q", stdout.String())
+	}
+}
+
+func TestLinks_FilteredOutputIsSorted(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	for _, dir := range []string{"projects/a", "projects/z"} {
+		if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(dir)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".campaign", "workitems"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	raw := `version: workitem-links/v1alpha1
+links:
+  - id: lnk_20260524_ffffff
+    workitem_id: design-example-2026-05-24
+    workitem_key: design:workflow/design/example
+    scope:
+      kind: project
+      path: projects/z
+    role: related
+    created_at: 2026-05-24T19:00:00Z
+    created_by: test
+  - id: lnk_20260524_aaaaaa
+    workitem_id: design-example-2026-05-24
+    workitem_key: design:workflow/design/example
+    scope:
+      kind: project
+      path: projects/a
+    role: related
+    created_at: 2026-05-24T19:00:00Z
+    created_by: test
+`
+	if err := os.WriteFile(filepath.Join(root, ".campaign", "workitems", "links.yaml"), []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newCmd()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	if err := runLinks(context.Background(), cmd, "design-example-2026-05-24", true); err != nil {
+		t.Fatalf("runLinks filtered json: %v", err)
+	}
+	var payload struct {
+		Links []links.Link `json:"links"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\nraw=%s", err, stdout.String())
+	}
+	if len(payload.Links) != 2 {
+		t.Fatalf("links len = %d, want 2", len(payload.Links))
+	}
+	if payload.Links[0].Scope.Path != "projects/a" || payload.Links[1].Scope.Path != "projects/z" {
+		t.Fatalf("filtered links not sorted: %#v", payload.Links)
 	}
 }
 

--- a/internal/commands/workitem/links.go
+++ b/internal/commands/workitem/links.go
@@ -44,6 +44,7 @@ func runLinks(ctx context.Context, cmd *cobra.Command, selectorArg string, jsonO
 		return err
 	}
 
+	registry.Sort()
 	filtered := registry.Links
 	if selectorArg != "" {
 		wi, err := resolveSelector(ctx, root, selectorArg, false)
@@ -59,7 +60,6 @@ func runLinks(ctx context.Context, cmd *cobra.Command, selectorArg string, jsonO
 		filtered = matched
 	}
 
-	registry.Sort()
 	if jsonOut {
 		return emitLinksJSON(cmd.OutOrStdout(), filtered)
 	}

--- a/internal/commands/workitem/links.go
+++ b/internal/commands/workitem/links.go
@@ -1,0 +1,99 @@
+package workitem
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+func newLinksCommand() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "links [selector]",
+		Short: "List workitem links",
+		Args:  cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			selectorArg := ""
+			if len(args) == 1 {
+				selectorArg = args[0]
+			}
+			return runLinks(cmd.Context(), cmd, selectorArg, jsonOut)
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a structured JSON result")
+	return cmd
+}
+
+func runLinks(ctx context.Context, cmd *cobra.Command, selectorArg string, jsonOut bool) error {
+	_, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	registry, err := links.Load(ctx, root)
+	if err != nil {
+		return err
+	}
+
+	filtered := registry.Links
+	if selectorArg != "" {
+		wi, err := resolveSelector(ctx, root, selectorArg, false)
+		if err != nil {
+			return err
+		}
+		var matched []links.Link
+		for _, link := range registry.Links {
+			if link.WorkitemID == wi.StableID {
+				matched = append(matched, link)
+			}
+		}
+		filtered = matched
+	}
+
+	registry.Sort()
+	if jsonOut {
+		return emitLinksJSON(cmd.OutOrStdout(), filtered)
+	}
+	return emitLinksHuman(cmd.OutOrStdout(), filtered)
+}
+
+func emitLinksHuman(w io.Writer, list []links.Link) error {
+	if len(list) == 0 {
+		_, err := fmt.Fprintln(w, "no links")
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "LINK_ID\tWORKITEM\tSCOPE\tROLE\tCREATED")
+	for _, link := range list {
+		fmt.Fprintf(tw, "%s\t%s\t%s:%s\t%s\t%s\n",
+			link.ID, link.WorkitemID, link.Scope.Kind, link.Scope.Path,
+			link.Role, link.CreatedAt.Format(time.RFC3339))
+	}
+	return tw.Flush()
+}
+
+func emitLinksJSON(w io.Writer, list []links.Link) error {
+	if list == nil {
+		list = []links.Link{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(struct {
+		SchemaVersion string       `json:"schema_version"`
+		GeneratedAt   time.Time    `json:"generated_at"`
+		Links         []links.Link `json:"links"`
+	}{
+		SchemaVersion: links.LinksSchemaVersion,
+		GeneratedAt:   time.Now().UTC(),
+		Links:         list,
+	})
+}

--- a/internal/commands/workitem/resolve.go
+++ b/internal/commands/workitem/resolve.go
@@ -1,0 +1,123 @@
+package workitem
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
+)
+
+func newResolveCommand() *cobra.Command {
+	var (
+		explicit, festival string
+		jsonOut, explain   bool
+	)
+	cmd := &cobra.Command{
+		Use:   "resolve",
+		Short: "Print the workitem the current context resolves to (read-only)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runResolve(cmd.Context(), cmd, resolveOptions{
+				Explicit:   explicit,
+				FestivalID: festival,
+				JSON:       jsonOut,
+				Explain:    explain,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&explicit, "workitem", "", "explicit workitem selector (overrides cwd-based detection)")
+	cmd.Flags().StringVar(&festival, "festival", "", "festival id for the festival tier")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a structured JSON result")
+	cmd.Flags().BoolVar(&explain, "explain", false, "print the tier-by-tier resolution trace")
+	return cmd
+}
+
+type resolveOptions struct {
+	Explicit   string
+	FestivalID string
+	JSON       bool
+	Explain    bool
+}
+
+func runResolve(ctx context.Context, cmd *cobra.Command, opts resolveOptions) error {
+	_, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+	res, err := resolver.Resolve(ctx, root, resolver.Options{
+		Explicit:   opts.Explicit,
+		FestivalID: opts.FestivalID,
+	})
+	if err != nil {
+		return err
+	}
+	if opts.JSON {
+		return emitResolveJSON(cmd.OutOrStdout(), res)
+	}
+	return emitResolveHuman(cmd.OutOrStdout(), res, opts.Explain)
+}
+
+func emitResolveHuman(w io.Writer, res *resolver.Resolution, explain bool) error {
+	if explain {
+		for _, step := range res.Trace {
+			detail := step.Detail
+			if detail != "" {
+				detail = " — " + detail
+			}
+			if _, err := fmt.Fprintf(w, "  [%s] %s%s\n", step.Tier, step.Result, detail); err != nil {
+				return err
+			}
+		}
+	}
+	if res.Workitem == nil {
+		_, err := fmt.Fprintln(w, "no workitem context")
+		return err
+	}
+	quest := "-"
+	if res.QuestID != "" {
+		quest = res.QuestID
+	}
+	_, err := fmt.Fprintf(w,
+		"workitem: %s (source: %s, quest: %s)\n",
+		identityOf(res.Workitem), res.Source, quest)
+	return err
+}
+
+func emitResolveJSON(w io.Writer, res *resolver.Resolution) error {
+	if res.Trace == nil {
+		res.Trace = []resolver.TraceStep{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(struct {
+		SchemaVersion string               `json:"schema_version"`
+		GeneratedAt   time.Time            `json:"generated_at"`
+		Resolution    *resolver.Resolution `json:"resolution"`
+	}{
+		SchemaVersion: "workitem-resolve/v1alpha1",
+		GeneratedAt:   time.Now().UTC(),
+		Resolution:    res,
+	})
+}
+
+func identityOf(wi *wkitem.WorkItem) string {
+	if wi == nil {
+		return ""
+	}
+	if wi.StableID != "" {
+		return wi.StableID
+	}
+	if wi.Key != "" {
+		return wi.Key
+	}
+	return strings.TrimSpace(wi.Title)
+}

--- a/internal/commands/workitem/resolve_test.go
+++ b/internal/commands/workitem/resolve_test.go
@@ -57,6 +57,23 @@ func TestResolve_AncestorTier(t *testing.T) {
 	}
 }
 
+func TestResolve_AncestorTierWithSymlinkedCwd(t *testing.T) {
+	root := linkTestCampaign(t)
+	linkRoot := filepath.Join(t.TempDir(), "campaign-link")
+	if err := os.Symlink(root, linkRoot); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	cwd := filepath.Join(linkRoot, "workflow", "design", "example")
+
+	res, err := resolver.Resolve(context.Background(), root, resolver.Options{Cwd: cwd})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Source != resolver.SourceAncestor {
+		t.Fatalf("source = %s, want ancestor; trace=%v", res.Source, res.Trace)
+	}
+}
+
 func TestResolve_LinkTier(t *testing.T) {
 	root := linkTestCampaign(t)
 	restore := chdir(t, root)
@@ -78,6 +95,37 @@ func TestResolve_LinkTier(t *testing.T) {
 	}
 	if res.Source != resolver.SourceLink {
 		t.Fatalf("source = %s, want link; trace=%v", res.Source, res.Trace)
+	}
+}
+
+func TestResolve_BrokenPrimaryLinkDoesNotFallThrough(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	if err := runLink(context.Background(), newCmd(), linkOptions{
+		Selector: "design-example-2026-05-24",
+		Project:  "demo",
+	}); err != nil {
+		t.Fatalf("seed link: %v", err)
+	}
+	if err := links.SaveCurrent(context.Background(), root, &links.Current{
+		Version:    links.CurrentSchemaVersion,
+		WorkitemID: "design-example-2026-05-24",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(root, "workflow", "design", "example")); err != nil {
+		t.Fatal(err)
+	}
+
+	cwd := filepath.Join(root, "projects", "demo")
+	_, err := resolver.Resolve(context.Background(), root, resolver.Options{Cwd: cwd})
+	if err == nil {
+		t.Fatal("expected broken primary link to fail instead of falling through")
+	}
+	if !strings.Contains(err.Error(), "primary link") {
+		t.Fatalf("err = %v, want primary link context", err)
 	}
 }
 

--- a/internal/commands/workitem/resolve_test.go
+++ b/internal/commands/workitem/resolve_test.go
@@ -1,0 +1,324 @@
+package workitem
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
+)
+
+func TestResolve_NoneWhenEmpty(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := newCmd()
+	if err := runResolve(context.Background(), cmd, resolveOptions{}); err != nil {
+		t.Fatalf("runResolve: %v", err)
+	}
+}
+
+func TestResolve_ExplicitTierWins(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	res, err := resolver.Resolve(context.Background(), root, resolver.Options{
+		Explicit: "design-example-2026-05-24",
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Source != resolver.SourceExplicit {
+		t.Fatalf("source = %s, want explicit", res.Source)
+	}
+}
+
+func TestResolve_AncestorTier(t *testing.T) {
+	root := linkTestCampaign(t)
+	cwd := filepath.Join(root, "workflow", "design", "example")
+	restore := chdir(t, cwd)
+	defer restore()
+
+	res, err := resolver.Resolve(context.Background(), root, resolver.Options{Cwd: cwd})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Source != resolver.SourceAncestor {
+		t.Fatalf("source = %s, want ancestor; trace=%v", res.Source, res.Trace)
+	}
+}
+
+func TestResolve_LinkTier(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	// Create a primary link on projects/demo, then resolve from inside it.
+	cmd := newCmd()
+	if err := runLink(context.Background(), cmd, linkOptions{
+		Selector: "design-example-2026-05-24",
+		Project:  "demo",
+	}); err != nil {
+		t.Fatalf("seed link: %v", err)
+	}
+
+	cwd := filepath.Join(root, "projects", "demo")
+	res, err := resolver.Resolve(context.Background(), root, resolver.Options{Cwd: cwd})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Source != resolver.SourceLink {
+		t.Fatalf("source = %s, want link; trace=%v", res.Source, res.Trace)
+	}
+}
+
+func TestResolve_AncestorBeatsLink(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	// Create link, then cd into the workitem dir (ancestor tier should fire).
+	if err := runLink(context.Background(), newCmd(), linkOptions{
+		Selector: "design-example-2026-05-24",
+		Project:  "demo",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	cwd := filepath.Join(root, "workflow", "design", "example")
+	res, err := resolver.Resolve(context.Background(), root, resolver.Options{Cwd: cwd})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Source != resolver.SourceAncestor {
+		t.Fatalf("ancestor must beat link; got source=%s trace=%v", res.Source, res.Trace)
+	}
+}
+
+func TestResolve_CurrentTierFallback(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cur := &links.Current{
+		Version:    links.CurrentSchemaVersion,
+		WorkitemID: "design-example-2026-05-24",
+	}
+	if err := links.SaveCurrent(context.Background(), root, cur); err != nil {
+		t.Fatal(err)
+	}
+	// cd to a path with no .workitem ancestor and no link match.
+	otherDir := filepath.Join(root, "docs")
+	if err := os.MkdirAll(otherDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := resolver.Resolve(context.Background(), root, resolver.Options{Cwd: otherDir})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Source != resolver.SourceCurrent {
+		t.Fatalf("source = %s, want current; trace=%v", res.Source, res.Trace)
+	}
+}
+
+func TestResolve_FestivalTier(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	festDir := filepath.Join(root, "festivals", "active", "CT0001")
+	if err := os.MkdirAll(festDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := runLink(context.Background(), newCmd(), linkOptions{
+		Selector: "design-example-2026-05-24",
+		Festival: "CT0001",
+	}); err != nil {
+		t.Fatalf("seed festival link: %v", err)
+	}
+
+	// cwd is the campaign root, no ancestor, no path-link match.
+	res, err := resolver.Resolve(context.Background(), root, resolver.Options{
+		Cwd:        root,
+		FestivalID: "CT0001",
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Source != resolver.SourceFestival {
+		t.Fatalf("source = %s, want festival; trace=%v", res.Source, res.Trace)
+	}
+}
+
+func TestResolve_NoneSource(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	otherDir := filepath.Join(root, "docs")
+	if err := os.MkdirAll(otherDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	res, err := resolver.Resolve(context.Background(), root, resolver.Options{Cwd: otherDir})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.Source != resolver.SourceNone {
+		t.Fatalf("source = %s, want none; trace=%v", res.Source, res.Trace)
+	}
+}
+
+func TestResolve_JSONShape(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	if err := runResolve(context.Background(), cmd, resolveOptions{
+		Explicit: "design-example-2026-05-24",
+		JSON:     true,
+	}); err != nil {
+		t.Fatalf("runResolve --json: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\nraw=%s", err, stdout.String())
+	}
+	if payload["schema_version"] != "workitem-resolve/v1alpha1" {
+		t.Fatalf("schema_version = %v", payload["schema_version"])
+	}
+}
+
+func TestDoctor_CleanWhenNoLinks(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := newCmd()
+	if err := runDoctor(context.Background(), cmd, false, false); err != nil {
+		t.Fatalf("doctor clean: %v", err)
+	}
+}
+
+func TestDoctor_BrokenLinkIsError(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	if err := runLink(context.Background(), newCmd(), linkOptions{
+		Selector: "design-example-2026-05-24",
+		Project:  "demo",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Remove the workitem directory entirely; the link is now orphaned.
+	if err := os.RemoveAll(filepath.Join(root, "workflow", "design", "example")); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	err := runDoctor(context.Background(), cmd, false, false)
+	if err == nil {
+		t.Fatal("expected doctor to report error-severity findings")
+	}
+	if !strings.Contains(stdout.String(), codeBrokenLink) {
+		t.Fatalf("expected %s finding in stdout, got %q", codeBrokenLink, stdout.String())
+	}
+}
+
+func TestDoctor_FixRemovesOrphanLink(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	if err := runLink(context.Background(), newCmd(), linkOptions{
+		Selector: "design-example-2026-05-24",
+		Project:  "demo",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(root, "workflow", "design", "example")); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newCmd()
+	if err := runDoctor(context.Background(), cmd, false, true); err != nil {
+		t.Fatalf("doctor --fix should clear after auto-repair: %v", err)
+	}
+	registry, err := links.Load(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(registry.Links) != 0 {
+		t.Fatalf("expected 0 links after --fix, got %d", len(registry.Links))
+	}
+}
+
+func TestDoctor_CurrentMissingIsWarning(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cur := &links.Current{
+		Version:    links.CurrentSchemaVersion,
+		WorkitemID: "design-gone-2026-05-24",
+	}
+	if err := links.SaveCurrent(context.Background(), root, cur); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	if err := runDoctor(context.Background(), cmd, false, false); err != nil {
+		t.Fatalf("warning-only should exit 0: %v", err)
+	}
+	if !strings.Contains(stdout.String(), codeCurrentMissing) {
+		t.Fatalf("expected %s finding, got %q", codeCurrentMissing, stdout.String())
+	}
+}
+
+func TestDoctor_JSONShape(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	if err := runLink(context.Background(), newCmd(), linkOptions{
+		Selector: "design-example-2026-05-24",
+		Project:  "demo",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(filepath.Join(root, "workflow", "design", "example")); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	_ = runDoctor(context.Background(), cmd, true, false)
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\nraw=%s", err, stdout.String())
+	}
+	if int(payload["error_count"].(float64)) < 1 {
+		t.Fatalf("error_count = %v, want >= 1", payload["error_count"])
+	}
+}

--- a/internal/commands/workitem/unlink.go
+++ b/internal/commands/workitem/unlink.go
@@ -1,0 +1,193 @@
+package workitem
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+func newUnlinkCommand() *cobra.Command {
+	var (
+		id, project, festival, worktree string
+		all, jsonOut                    bool
+	)
+	cmd := &cobra.Command{
+		Use:   "unlink [selector] [path]",
+		Short: "Remove one or more workitem links",
+		Args:  cobra.RangeArgs(0, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			selectorArg := ""
+			path := ""
+			if len(args) >= 1 {
+				selectorArg = args[0]
+			}
+			if len(args) == 2 {
+				path = args[1]
+			}
+			return runUnlink(cmd.Context(), cmd, unlinkOptions{
+				ID:           id,
+				Selector:     selectorArg,
+				ExplicitPath: path,
+				Project:      project,
+				Festival:     festival,
+				Worktree:     worktree,
+				All:          all,
+				JSON:         jsonOut,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&id, "id", "", "remove the link with this lnk_ id")
+	cmd.Flags().StringVar(&project, "project", "", "project scope filter")
+	cmd.Flags().StringVar(&festival, "festival", "", "festival scope filter")
+	cmd.Flags().StringVar(&worktree, "worktree", "", "worktree scope filter")
+	cmd.Flags().BoolVar(&all, "all", false, "remove every link matching the selector")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a structured JSON result")
+	return cmd
+}
+
+type unlinkOptions struct {
+	ID           string
+	Selector     string
+	ExplicitPath string
+	Project      string
+	Festival     string
+	Worktree     string
+	All          bool
+	JSON         bool
+}
+
+func runUnlink(ctx context.Context, cmd *cobra.Command, opts unlinkOptions) error {
+	_, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+	registry, err := links.Load(ctx, root)
+	if err != nil {
+		return err
+	}
+
+	removed := []links.Link{}
+	switch {
+	case opts.ID != "":
+		link, ok := registry.FindByID(opts.ID)
+		if !ok {
+			return camperrors.NewValidation("id", "no link with id "+opts.ID, nil)
+		}
+		removed = append(removed, *link)
+		registry.RemoveLinkByID(opts.ID)
+
+	case opts.Selector != "":
+		wi, err := resolveSelector(ctx, root, opts.Selector, false)
+		if err != nil {
+			return err
+		}
+		matches := matchUnlinkCandidates(registry, wi.StableID, opts)
+		if len(matches) == 0 {
+			return camperrors.NewValidation("selector",
+				"no links matched selector "+opts.Selector, nil)
+		}
+		if len(matches) > 1 && !opts.All {
+			return camperrors.NewValidation("selector",
+				fmt.Sprintf("selector matched %d links; pass --all to remove every match or --id to pick one", len(matches)), nil)
+		}
+		for _, link := range matches {
+			registry.RemoveLinkByID(link.ID)
+			removed = append(removed, link)
+		}
+
+	default:
+		return camperrors.NewValidation("selector",
+			"must provide --id or a selector to unlink", nil)
+	}
+
+	if err := links.Save(ctx, root, registry); err != nil {
+		return err
+	}
+
+	if opts.JSON {
+		return emitUnlinkJSON(cmd.OutOrStdout(), removed)
+	}
+	return emitUnlinkHuman(cmd.OutOrStdout(), removed)
+}
+
+func matchUnlinkCandidates(registry *links.Links, workitemID string, opts unlinkOptions) []links.Link {
+	scopeFilter, useScope := unlinkScopeFilter(opts)
+	var out []links.Link
+	for _, link := range registry.Links {
+		if link.WorkitemID != workitemID {
+			continue
+		}
+		if useScope {
+			if link.Scope.Kind != scopeFilter.Kind || link.Scope.Path != scopeFilter.Path {
+				continue
+			}
+		}
+		out = append(out, link)
+	}
+	return out
+}
+
+func unlinkScopeFilter(opts unlinkOptions) (links.LinkScope, bool) {
+	switch {
+	case opts.Project != "":
+		return links.LinkScope{Kind: links.ScopeProject, Path: "projects/" + opts.Project}, true
+	case opts.Festival != "":
+		path := opts.Festival
+		if !strings.HasPrefix(path, "festivals/") {
+			path = "festivals/active/" + path
+		}
+		return links.LinkScope{Kind: links.ScopeFestival, Path: path}, true
+	case opts.Worktree != "":
+		path := opts.Worktree
+		if !strings.HasPrefix(path, "projects/worktrees/") {
+			path = "projects/worktrees/" + opts.Worktree
+		}
+		return links.LinkScope{Kind: links.ScopeWorktree, Path: path}, true
+	case opts.ExplicitPath != "":
+		return links.LinkScope{Kind: inferScopeKind(opts.ExplicitPath), Path: opts.ExplicitPath}, true
+	}
+	return links.LinkScope{}, false
+}
+
+func emitUnlinkHuman(w io.Writer, removed []links.Link) error {
+	if len(removed) == 0 {
+		_, err := fmt.Fprintln(w, "no links removed")
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "removed %d link(s)\n", len(removed)); err != nil {
+		return err
+	}
+	for _, link := range removed {
+		if _, err := fmt.Fprintf(w, "  %s  %s -> %s:%s\n",
+			link.ID, link.WorkitemID, link.Scope.Kind, link.Scope.Path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func emitUnlinkJSON(w io.Writer, removed []links.Link) error {
+	if removed == nil {
+		removed = []links.Link{}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(struct {
+		SchemaVersion string       `json:"schema_version"`
+		GeneratedAt   time.Time    `json:"generated_at"`
+		Removed       []links.Link `json:"removed"`
+	}{
+		SchemaVersion: links.LinksSchemaVersion,
+		GeneratedAt:   time.Now().UTC(),
+		Removed:       removed,
+	})
+}

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -128,6 +128,10 @@ Examples:
 
 	cmd.AddCommand(newCreateCommand())
 	cmd.AddCommand(newAdoptCommand())
+	cmd.AddCommand(newLinkCommand())
+	cmd.AddCommand(newUnlinkCommand())
+	cmd.AddCommand(newLinksCommand())
+	cmd.AddCommand(newCurrentCommand())
 
 	return cmd
 }

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -132,6 +132,8 @@ Examples:
 	cmd.AddCommand(newUnlinkCommand())
 	cmd.AddCommand(newLinksCommand())
 	cmd.AddCommand(newCurrentCommand())
+	cmd.AddCommand(newResolveCommand())
+	cmd.AddCommand(newDoctorCommand())
 
 	return cmd
 }

--- a/internal/fsutil/lock.go
+++ b/internal/fsutil/lock.go
@@ -1,0 +1,86 @@
+package fsutil
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+const (
+	defaultLockTimeout = 5 * time.Second
+	staleLockAfter     = 30 * time.Second
+	lockRetryDelay     = 20 * time.Millisecond
+)
+
+// AcquireFileLock takes an exclusive lock on lockPath via O_CREATE|O_EXCL.
+// The returned release closure removes the lock file. Locks older than 30s
+// are treated as stale and removed before retrying.
+func AcquireFileLock(ctx context.Context, lockPath string) (func(), error) {
+	deadline := time.Now().Add(defaultLockTimeout)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		release, acquired, err := tryAcquireFileLock(lockPath)
+		if err != nil {
+			return nil, err
+		}
+		if acquired {
+			return release, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, camperrors.Wrap(camperrors.ErrTimeout,
+				"timeout acquiring lock at "+lockPath+" (another camp invocation holds it?)")
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(lockRetryDelay):
+		}
+	}
+}
+
+func tryAcquireFileLock(lockPath string) (func(), bool, error) {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err == nil {
+		_ = f.Close()
+		released := false
+		return func() {
+			if released {
+				return
+			}
+			released = true
+			_ = os.Remove(lockPath)
+		}, true, nil
+	}
+	if !errors.Is(err, fs.ErrExist) {
+		return nil, false, camperrors.Wrap(err, "acquire lock")
+	}
+	if removed, err := removeStaleLock(lockPath); err != nil {
+		return nil, false, err
+	} else if removed {
+		return nil, false, nil
+	}
+	return nil, false, nil
+}
+
+func removeStaleLock(lockPath string) (bool, error) {
+	info, err := os.Stat(lockPath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return true, nil
+	}
+	if err != nil {
+		return false, camperrors.Wrap(err, "stat lock")
+	}
+	if time.Since(info.ModTime()) <= staleLockAfter {
+		return false, nil
+	}
+	if err := os.Remove(lockPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return false, camperrors.Wrap(err, "remove stale lock")
+	}
+	return true, nil
+}

--- a/internal/fsutil/lock_test.go
+++ b/internal/fsutil/lock_test.go
@@ -1,0 +1,60 @@
+package fsutil
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+func TestAcquireFileLock_RemovesStaleLock(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "links.yaml.lock")
+	if err := os.WriteFile(lockPath, []byte("orphaned"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	staleTime := time.Now().Add(-(staleLockAfter + time.Second))
+	if err := os.Chtimes(lockPath, staleTime, staleTime); err != nil {
+		t.Fatal(err)
+	}
+
+	release, err := AcquireFileLock(context.Background(), lockPath)
+	if err != nil {
+		t.Fatalf("AcquireFileLock stale lock: %v", err)
+	}
+	release()
+}
+
+func TestAcquireFileLock_ContextCancellation(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "links.yaml.lock")
+	if err := os.WriteFile(lockPath, []byte("held"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := AcquireFileLock(ctx, lockPath)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("AcquireFileLock canceled error = %v, want context.Canceled", err)
+	}
+}
+
+func TestAcquireFileLock_TimeoutIsCategorized(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "links.yaml.lock")
+	if err := os.WriteFile(lockPath, []byte("held"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	_, err := AcquireFileLock(ctx, lockPath)
+	if err == nil {
+		t.Fatal("expected lock acquisition error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, camperrors.ErrTimeout) {
+		t.Fatalf("AcquireFileLock timeout error = %v, want deadline or ErrTimeout", err)
+	}
+}

--- a/internal/workitem/links/SCHEMA.md
+++ b/internal/workitem/links/SCHEMA.md
@@ -1,0 +1,375 @@
+# Workitem link registry — schema
+
+Sequence: `001_IMPLEMENT/02_workitem_link_registry`
+Festival: `camp-workitem-linking-and-commits-CW0003`
+Source design: [`workflow/design/workitem-linking-commit-tracking/02-workitem-linking-model.md`](../../../../workflow/design/workitem-linking-commit-tracking/02-workitem-linking-model.md)
+Sibling implementation: [`projects/camp/internal/quest/link.go`](../../quest/link.go)
+
+This document is the v1 contract for the workitem link registry. It freezes
+the schemas, scope kinds, roles, resolution priority, safety bounds, and link
+ID format before any production code is written. Subsequent tasks (02–08 of
+this sequence) implement against this contract.
+
+---
+
+## 1. Files
+
+| Path | Committed? | Purpose |
+|---|---|---|
+| `.campaign/workitems/links.yaml` | yes | Durable workitem-to-scope relationships. Schema in §2. |
+| `.campaign/workitems/current.yaml` | **no — gitignored** | The user's locally selected active workitem. Schema in §3. |
+
+Both files live under `.campaign/workitems/`. The directory is created on
+first write by `camp workitem link` / `camp workitem current`. Pre-existing
+campaigns without either file behave as "no links, no current"; see §10
+(migration).
+
+### 1.1 Gitignore policy for `current.yaml`
+
+`current.yaml` carries the user's per-machine context selection — what they
+were working on when they last ran `camp workitem current <id>`. Committing
+it would force the entire team to share one active workitem, which is the
+opposite of what the file is for. It must be gitignored.
+
+Implementation: `camp init` writes a campaign-root `.gitignore` template.
+Sequence-02 task 02 adds `.campaign/workitems/current.yaml` to that template
+and runs a one-time migration on existing campaigns (append the line if
+absent and the file does not already ignore it transitively).
+
+The team can opt-in to sharing `current.yaml` by removing the line manually;
+this is documented but not surfaced as a CLI flag.
+
+---
+
+## 2. `links.yaml` schema
+
+```yaml
+version: workitem-links/v1alpha1
+links:
+  - id: lnk_20260524_ab12cd
+    workitem_id: design-camp-timeline-2026-05-19
+    workitem_key: design:workflow/design/camp-timeline
+    scope:
+      kind: project
+      path: projects/camp-timeline
+    role: primary
+    created_at: 2026-05-24T19:00:00Z
+    created_by: camp_workitem_link
+```
+
+### 2.1 Top-level fields
+
+| Field | Required | Type | Notes |
+|---|---|---|---|
+| `version` | yes | string literal `workitem-links/v1alpha1` | Schema version. Loader rejects unknown versions with a wrapped `camperrors.ErrInvalidInput`. Future versions migrate forward at load time. |
+| `links` | yes | sequence of `Link` | May be empty (`[]`). Empty file with only `version` is valid and represents "no links". |
+
+### 2.2 `Link` fields
+
+| Field | Required | Type | Validation |
+|---|---|---|---|
+| `id` | yes | string, format `lnk_<yyyymmdd>_<6 lowercase hex>` | Globally unique per campaign. Generated at create time, never changed. See §4. |
+| `workitem_id` | yes | string | Stable `.workitem` `id` field. Matched against existing workitems unless `--allow-missing`. Max 200 chars. |
+| `workitem_key` | optional | string | Human-readable convenience key (e.g. `design:workflow/design/foo`). Derived at create time; not authoritative — `workitem_id` wins on mismatch. Loader recomputes from `workitem_id` if missing. |
+| `scope` | yes | nested object | See §2.3. |
+| `role` | yes | enum | One of `primary`, `related`, `blocked_by`, `supersedes`. See §6. |
+| `created_at` | yes | RFC 3339 UTC timestamp | Set at create time. Stored as `time.Time` in Go. |
+| `created_by` | yes | string | Free-form provenance. Default `camp_workitem_link` from CLI. Allowed chars: `[A-Za-z0-9_-]`, max 64. |
+
+### 2.3 `scope` fields
+
+| Field | Required | Type | Validation |
+|---|---|---|---|
+| `kind` | yes | enum | One of `project`, `repo`, `campaign_path`, `festival`, `worktree`. See §5. |
+| `path` | yes | string | Campaign-relative path, forward-slash-normalized, no leading `/`. Validated via `quest.ValidateLinkPath` (campaign-root containment + target existence). Max 4096 chars. |
+
+The `scope` object is the unique key for primary-link collision detection.
+`(scope.kind, scope.path, role=primary)` may exist at most once per campaign;
+duplicates are rejected unless `--replace`. Non-primary roles (`related`,
+`blocked_by`, `supersedes`) have no uniqueness constraint.
+
+### 2.4 Sort order on disk
+
+Links are written in stable order: ascending `scope.kind`, then ascending
+`scope.path`, then ascending `created_at`. This keeps diffs minimal under
+churn and makes review predictable. Loader does not require this order; it
+is enforced only by the writer.
+
+---
+
+## 3. `current.yaml` schema
+
+```yaml
+version: workitem-current/v1alpha1
+workitem_id: design-camp-timeline-2026-05-19
+selected_at: 2026-05-24T19:30:00Z
+```
+
+| Field | Required | Type | Validation |
+|---|---|---|---|
+| `version` | yes | string literal `workitem-current/v1alpha1` | Schema version. |
+| `workitem_id` | yes | string | Same validation as `links[].workitem_id`. Cleared by `camp workitem current --clear`, which deletes the file. |
+| `selected_at` | yes | RFC 3339 UTC timestamp | Set on every write. |
+
+`current.yaml` is a single document, not a list. Setting a new current
+overwrites the file atomically (write-temp + rename). Clearing removes it.
+
+The file is intentionally small and self-contained so a stale or
+half-written copy is easy to spot and recover from manually.
+
+---
+
+## 4. Link ID format
+
+```
+lnk_<yyyymmdd>_<6 lowercase hex>
+```
+
+- `yyyymmdd` is the UTC date the link was created.
+- `<6 lowercase hex>` is 24 bits of `crypto/rand`-sourced randomness.
+- Regex: `^lnk_[0-9]{8}_[0-9a-f]{6}$` (exactly 22 characters).
+
+Rationale:
+
+- The date prefix is human-scannable in YAML and survives sorting.
+- 24 bits of randomness is ample for the per-day collision domain (~16M
+  values per day) and keeps IDs short.
+- The `lnk_` prefix is reserved for this kind; collisions with workitem
+  `id`s (no prefix or `<type>-<slug>-<date>` form) and quest `id`s
+  (`qst_<...>`) are impossible.
+
+Collision handling: on `crypto/rand` collision (single-process, after retry
+loop of up to 32 attempts) the create call returns
+`camperrors.NewValidation("id", ...)` — same shape as the workitem create
+collision-retry path in `internal/commands/workitem/create.go`.
+
+---
+
+## 5. Scope kinds
+
+| Kind | Path resolves to | Example |
+|---|---|---|
+| `project` | Campaign project or submodule path under `projects/` | `projects/camp-timeline` |
+| `repo` | A git repository root that may not be registered as a project | `vendor/external-repo` |
+| `campaign_path` | Any path under the campaign root that does not fit a more specific kind | `workflow/design/timeline-spike` |
+| `festival` | A festival path under `festivals/active/`, `festivals/ready/`, etc. | `festivals/active/camp-timeline-CT0001` |
+| `worktree` | A project worktree path under `projects/worktrees/` | `projects/worktrees/camp@feat-x` |
+
+Kind validation:
+
+- Loader rejects unknown kinds with `camperrors.ErrInvalidInput`.
+- Writer normalizes `path` to forward slashes and strips trailing `/`.
+- Kind detection from a raw path (for CLI ergonomics like `camp workitem
+  link <id> --cwd`) reuses the rules embedded in
+  `quest.DetectLinkType` where they overlap, with workitem-specific
+  extensions for `worktree` (under `projects/worktrees/`) and the
+  catch-all `campaign_path`. The detection logic lives in
+  `internal/workitem/links/scope.go` — `quest.DetectLinkType` is not
+  modified, since it returns the quest type vocabulary, not the workitem
+  scope vocabulary.
+
+Kind-to-path constraints (enforced at create time):
+
+| Kind | Required path prefix | Notes |
+|---|---|---|
+| `project` | `projects/` | Must not be under `projects/worktrees/`. |
+| `worktree` | `projects/worktrees/` | |
+| `festival` | `festivals/` | |
+| `repo` | (none) | Must contain a `.git/` directory or file. |
+| `campaign_path` | (none) | Catch-all; rejected if it matches a more specific kind unless `--force-kind`. |
+
+---
+
+## 6. Roles
+
+| Role | Routing meaning | Uniqueness |
+|---|---|---|
+| `primary` | The active workitem for `(scope.kind, scope.path)`. Commit wrappers pick this up. | At most one per scope. |
+| `related` | Context only. Visible in `camp workitem links`. Not auto-selected for commits. | Unlimited per scope. |
+| `blocked_by` | Pure metadata. May influence future doctor/sync checks. | Unlimited. |
+| `supersedes` | Pure metadata. Lets a newer workitem claim an older one's history. | Unlimited. |
+
+Role transitions: there is no explicit transition API in v1. To change a
+link's role, callers remove and re-add. This keeps the data model
+append-mostly and predictable for review.
+
+---
+
+## 7. Resolution priority
+
+Commit wrappers and `camp workitem resolve` use this deterministic order
+(first match wins):
+
+1. Explicit `--workitem` flag.
+2. Nearest ancestor directory containing a `.workitem` marker file.
+3. `primary` link from `links.yaml` whose `scope.path` is the longest
+   prefix of the current working directory (campaign-relative).
+4. `primary` link whose `scope.kind` is `festival` and whose path is the
+   active festival (when `fest link --show` resolves a festival).
+5. `current.yaml`'s `workitem_id`.
+6. No workitem context — commit wrappers proceed without a workitem tag.
+
+```mermaid
+flowchart TD
+    Start[Resolve workitem context] --> Explicit{--workitem set?}
+    Explicit -->|yes| UseExplicit[Use explicit workitem]
+    Explicit -->|no| Ancestor{Inside .workitem dir?}
+    Ancestor -->|yes| UseAncestor[Use nearest .workitem]
+    Ancestor -->|no| PathLink{Path link primary?}
+    PathLink -->|yes| UseLink[Use linked workitem]
+    PathLink -->|no| FestLink{Festival link primary?}
+    FestLink -->|yes| UseFestival[Use festival-linked workitem]
+    FestLink -->|no| Current{current.yaml set?}
+    Current -->|yes| UseCurrent[Use current workitem]
+    Current -->|no| None[No workitem context]
+```
+
+Notes:
+
+- "Longest prefix" at step 3 lets a deep path link (e.g.
+  `projects/camp-timeline/internal/api`) win over a shorter sibling link
+  (`projects/camp-timeline`) when both exist.
+- Step 4 reuses the `fest link --show` resolver — workitem links do not
+  reimplement festival detection.
+- Resolution is read-only. It never mutates `current.yaml` even if a higher
+  priority resolves; the local current selection persists across cwd
+  changes by design.
+
+---
+
+## 8. Safety bounds
+
+| Check | When enforced | Failure mode |
+|---|---|---|
+| Campaign-root containment for `scope.path` | Create + load | `camperrors.ErrInvalidInput` via `quest.ValidateLinkPath` |
+| Target exists for `scope.path` | Create | `camperrors.ErrNotFound` via `quest.ValidateLinkPath`. Skipped under `--allow-missing` for migrations. |
+| Workitem exists with `workitem_id` | Create | `camperrors.ErrNotFound`. Skipped under `--allow-missing`. |
+| Duplicate `(scope.kind, scope.path, role=primary)` | Create | `camperrors.NewValidation("scope", ...)`. Overridable with `--replace`. |
+| `version` field present and known | Load | Returns wrapped `camperrors.ErrInvalidInput`; loader does not silently coerce. |
+| `id` matches `^lnk_[0-9]{8}_[0-9a-f]{6}$` | Load + create | `camperrors.NewValidation("id", ...)`. |
+| Rename/move preservation | N/A (built-in) | Links key on `workitem_id` (the stable id). Moving the workitem directory does not change `id`, so links survive. `camp workitem doctor` detects orphaned `id`s (no matching `.workitem` on disk) and reports a finding. |
+
+### 8.1 Atomicity
+
+`links.yaml` writes use write-temp-plus-rename (the same pattern as
+`internal/commands/workitem/create.go::atomicWriteFile`). Readers always
+see either the old or the new full file; never a partial.
+
+`current.yaml` follows the same pattern.
+
+### 8.2 Concurrent writes
+
+v1 does not lock `links.yaml`. Two concurrent `camp workitem link`
+invocations could last-writer-wins. This matches every other YAML config
+file in the repo (`.campaign/campaign.yaml`, `.campaign/settings/jumps.yaml`)
+and is acceptable for the workitem use case (single-user CLI).
+Documenting the limitation here so it does not surprise reviewers.
+
+---
+
+## 9. Validation rule table
+
+Single table the implementation tests against. Each row is one assertion in
+`internal/workitem/links/validation_test.go` (sequence-02 task 02).
+
+| Field | Rule |
+|---|---|
+| `version` | Must equal `workitem-links/v1alpha1`. Missing or unknown → reject. |
+| `links` | May be empty. Each element validated per below. |
+| `links[].id` | Required, matches `^lnk_[0-9]{8}_[0-9a-f]{6}$`, unique within the file. |
+| `links[].workitem_id` | Required, 1–200 chars, validated via `pathsafe.ValidateSegment` (same slug-safe rules as `.workitem` ids). |
+| `links[].workitem_key` | Optional, no validation; loader recomputes if absent. |
+| `links[].scope.kind` | Required, one of the §5 enum values. |
+| `links[].scope.path` | Required, 1–4096 chars, no leading `/`, no `..`, passes `quest.ValidateLinkPath`, satisfies kind-prefix table in §5. |
+| `links[].role` | Required, one of `primary`, `related`, `blocked_by`, `supersedes`. |
+| `links[].created_at` | Required, RFC 3339 UTC, not in the future (>5min skew → warn, not reject; >24h skew → reject). |
+| `links[].created_by` | Required, matches `^[A-Za-z0-9_-]{1,64}$`. |
+| `current.version` | Must equal `workitem-current/v1alpha1`. |
+| `current.workitem_id` | Required, same rules as `links[].workitem_id`. |
+| `current.selected_at` | Required, RFC 3339 UTC, same skew tolerance as `created_at`. |
+
+Validation errors return wrapped `camperrors.NewValidation` so the CLI
+surfaces a field name and a one-line message. No `fmt.Errorf`.
+
+---
+
+## 10. Migration
+
+Pre-existing campaigns have no `.campaign/workitems/` directory at all.
+This must continue to work end-to-end:
+
+1. `camp workitem resolve` returns "no workitem context" (resolution step 6)
+   instead of erroring on the missing files.
+2. `camp workitem links` prints "no links" and exits 0.
+3. `camp workitem doctor` does **not** flag missing `links.yaml` or
+   `current.yaml` as findings. Missing files are the documented zero state,
+   not a problem.
+4. The first `camp workitem link` creates the directory via `os.MkdirAll`.
+
+No automatic file creation at campaign-init time. The directory only
+appears once the user explicitly creates a link or sets a current.
+
+---
+
+## 11. Quest cross-reference
+
+Workitem links and quest links share the campaign-root containment validator
+but are otherwise separate first-class registries:
+
+| Concern | Quest links | Workitem links |
+|---|---|---|
+| File | `.campaign/quests/<dir>/quest.yaml` | `.campaign/workitems/links.yaml` |
+| Owner package | `internal/quest/` | `internal/workitem/links/` (new) |
+| Shape | `{Path, Type, AddedAt}` | `{ID, WorkitemID, Scope{Kind, Path}, Role, CreatedAt, CreatedBy}` |
+| Add/remove API | `quest.AddLink/RemoveLink` (operate on `Quest`) | `links.Add/Remove` (operate on `Links`, defined in task 02) |
+| Path validator | `quest.ValidateLinkPath` | **same** — reused directly |
+| Type detection | `quest.DetectLinkType` | Workitem-specific — see §5 |
+
+`internal/quest/link.go` is **not** modified by this sequence. The workitem
+link package imports `quest.ValidateLinkPath` and uses it as-is.
+
+### 11.1 `quest_id` on `.workitem`
+
+Sequence 03 task 01 adds an optional `quest_id` field to the `.workitem`
+schema at version `v1alpha6`. The flow:
+
+- At workitem create/adopt time, `camp` calls `quest.Service.ResolveContext`.
+- If a quest resolves, its `id` is written into `.workitem.quest_id`.
+- If no quest resolves, the field is omitted (legacy workitems remain
+  byte-identical).
+
+The link registry itself does not carry `quest_id`. It belongs on the
+workitem, not the link, because a workitem has one quest at most while a
+workitem can have many links.
+
+---
+
+## 12. Examples
+
+Full examples live at `testdata/`:
+
+- [`testdata/example_links.yaml`](testdata/example_links.yaml) — every
+  scope kind and role represented.
+- [`testdata/example_current.yaml`](testdata/example_current.yaml) — a
+  populated `current.yaml`.
+
+These fixtures are loaded by the unit tests in task 02 to assert the
+loader-writer round-trip.
+
+---
+
+## 13. Open questions (out of scope, tracked here)
+
+1. **Stable cross-machine `created_by` identity.** Currently `created_by`
+   is a free-form provenance string. If the team wants per-user audit
+   later, we will need to plumb a real identity source (`git config
+   user.email`?) and define normalization rules. v1 leaves this as
+   free-form on purpose.
+2. **Link expiration.** No `expires_at` field in v1. Doctor handles
+   orphaned-by-deletion via the missing-`.workitem` check. If teams want
+   time-based expiry, add it at v1beta1.
+3. **Quest-link auto-mirror.** Whether creating a workitem link should
+   also create a quest link (or vice-versa) is deliberately not specified
+   in v1. The two registries stay independent; cross-references happen
+   only via `.workitem.quest_id` (§11.1) and the commit-tag composition
+   in sequence 03.

--- a/internal/workitem/links/SCHEMA.md
+++ b/internal/workitem/links/SCHEMA.md
@@ -282,7 +282,7 @@ Single table the implementation tests against. Each row is one assertion in
 | `links[].scope.kind` | Required, one of the §5 enum values. |
 | `links[].scope.path` | Required, 1–4096 chars, no leading `/`, no `..`, passes `quest.ValidateLinkPath`, satisfies kind-prefix table in §5. |
 | `links[].role` | Required, one of `primary`, `related`, `blocked_by`, `supersedes`. |
-| `links[].created_at` | Required, RFC 3339 UTC, not in the future (>5min skew → warn, not reject; >24h skew → reject). |
+| `links[].created_at` | Required, RFC 3339 UTC, not more than 24h from the local clock. |
 | `links[].created_by` | Required, matches `^[A-Za-z0-9_-]{1,64}$`. |
 | `current.version` | Must equal `workitem-current/v1alpha1`. |
 | `current.workitem_id` | Required, same rules as `links[].workitem_id`. |

--- a/internal/workitem/links/links_test.go
+++ b/internal/workitem/links/links_test.go
@@ -1,0 +1,457 @@
+package links
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// seedScopeTargets creates every directory referenced by the example fixtures
+// so quest.ValidateLinkPath does not error on path-existence checks. This
+// keeps each test self-contained: no shared state between fixtures and the
+// campaign root.
+func seedScopeTargets(t *testing.T, root string, links *Links) {
+	t.Helper()
+	for _, link := range links.Links {
+		full := filepath.Join(root, filepath.FromSlash(link.Scope.Path))
+		if err := os.MkdirAll(full, 0o755); err != nil {
+			t.Fatalf("seed %s: %v", full, err)
+		}
+		if link.Scope.Kind == ScopeRepo {
+			if err := os.MkdirAll(filepath.Join(full, ".git"), 0o755); err != nil {
+				t.Fatalf("seed git dir: %v", err)
+			}
+		}
+	}
+}
+
+func loadFixture(t *testing.T, name string) *Links {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var out Links
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	return &out
+}
+
+func TestLoad_MissingFileReturnsEmpty(t *testing.T) {
+	root := t.TempDir()
+	got, err := Load(context.Background(), root)
+	if err != nil {
+		t.Fatalf("Load missing: %v", err)
+	}
+	if got == nil || got.Version != LinksSchemaVersion {
+		t.Fatalf("missing file should return Empty(), got %#v", got)
+	}
+	if len(got.Links) != 0 {
+		t.Fatalf("expected empty Links slice, got %d", len(got.Links))
+	}
+}
+
+func TestLoadCurrent_MissingFileReturnsNil(t *testing.T) {
+	root := t.TempDir()
+	got, err := LoadCurrent(context.Background(), root)
+	if err != nil {
+		t.Fatalf("LoadCurrent missing: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("missing current.yaml should return nil, got %#v", got)
+	}
+}
+
+func TestLoad_RejectsUnknownVersion(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".campaign", "workitems"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "version: workitem-links/v9beta\nlinks: []\n"
+	if err := os.WriteFile(LinksPath(root), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(context.Background(), root)
+	if err == nil {
+		t.Fatal("expected error for unknown version")
+	}
+	if !strings.Contains(err.Error(), "schema version") {
+		t.Fatalf("error should mention schema version, got %v", err)
+	}
+}
+
+func TestSaveLoadRoundTrip_ExampleLinksFixture(t *testing.T) {
+	root := t.TempDir()
+	in := loadFixture(t, "example_links.yaml")
+	seedScopeTargets(t, root, in)
+
+	if err := Save(context.Background(), root, in); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := Load(context.Background(), root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(got.Links) != len(in.Links) {
+		t.Fatalf("link count mismatch: got %d, want %d", len(got.Links), len(in.Links))
+	}
+	for _, expected := range in.Links {
+		found, ok := got.FindByID(expected.ID)
+		if !ok {
+			t.Fatalf("link %s missing after round-trip", expected.ID)
+		}
+		if found.WorkitemID != expected.WorkitemID {
+			t.Fatalf("workitem_id mismatch for %s: got %q, want %q",
+				expected.ID, found.WorkitemID, expected.WorkitemID)
+		}
+		if found.Scope != expected.Scope {
+			t.Fatalf("scope mismatch for %s: got %#v, want %#v",
+				expected.ID, found.Scope, expected.Scope)
+		}
+		if found.Role != expected.Role {
+			t.Fatalf("role mismatch for %s: got %s, want %s",
+				expected.ID, found.Role, expected.Role)
+		}
+		if !found.CreatedAt.Equal(expected.CreatedAt) {
+			t.Fatalf("created_at mismatch for %s: got %v, want %v",
+				expected.ID, found.CreatedAt, expected.CreatedAt)
+		}
+	}
+}
+
+func TestSave_ByteStableTwiceInARow(t *testing.T) {
+	root := t.TempDir()
+	in := loadFixture(t, "example_links.yaml")
+	seedScopeTargets(t, root, in)
+
+	if err := Save(context.Background(), root, in); err != nil {
+		t.Fatalf("Save 1: %v", err)
+	}
+	first, err := os.ReadFile(LinksPath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded, err := Load(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Save(context.Background(), root, reloaded); err != nil {
+		t.Fatalf("Save 2: %v", err)
+	}
+	second, err := os.ReadFile(LinksPath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(first, second) {
+		t.Fatalf("save→load→save not byte-stable.\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+func TestSaveLoadCurrent_RoundTrip(t *testing.T) {
+	root := t.TempDir()
+	cur := &Current{
+		Version:    CurrentSchemaVersion,
+		WorkitemID: "design-camp-timeline-2026-05-19",
+		SelectedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	if err := SaveCurrent(context.Background(), root, cur); err != nil {
+		t.Fatalf("SaveCurrent: %v", err)
+	}
+	got, err := LoadCurrent(context.Background(), root)
+	if err != nil {
+		t.Fatalf("LoadCurrent: %v", err)
+	}
+	if got.WorkitemID != cur.WorkitemID {
+		t.Fatalf("workitem_id mismatch: %q vs %q", got.WorkitemID, cur.WorkitemID)
+	}
+	if !got.SelectedAt.Equal(cur.SelectedAt) {
+		t.Fatalf("selected_at mismatch")
+	}
+
+	// SaveCurrent(nil) clears the file.
+	if err := SaveCurrent(context.Background(), root, nil); err != nil {
+		t.Fatalf("SaveCurrent nil: %v", err)
+	}
+	if got, err := LoadCurrent(context.Background(), root); err != nil || got != nil {
+		t.Fatalf("after clear, LoadCurrent = %v, %v; want nil, nil", got, err)
+	}
+}
+
+// makeValidLink builds a minimal valid Link for unit tests.
+func makeValidLink(t *testing.T, root string) Link {
+	t.Helper()
+	full := filepath.Join(root, "projects", "demo")
+	if err := os.MkdirAll(full, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return Link{
+		ID:         genLinkID(t),
+		WorkitemID: "design-demo-2026-05-24",
+		Scope:      LinkScope{Kind: ScopeProject, Path: "projects/demo"},
+		Role:       RolePrimary,
+		CreatedAt:  time.Now().UTC().Truncate(time.Second),
+		CreatedBy:  "test",
+	}
+}
+
+func genLinkID(t *testing.T) string {
+	t.Helper()
+	var b [3]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf("lnk_%s_%s", time.Now().UTC().Format("20060102"), hex.EncodeToString(b[:]))
+}
+
+func TestValidate_EveryRule(t *testing.T) {
+	root := t.TempDir()
+	good := makeValidLink(t, root)
+
+	cases := []struct {
+		name      string
+		mutate    func(*Link)
+		wantField string
+	}{
+		{"missing id", func(l *Link) { l.ID = "" }, "id"},
+		{"bad id format", func(l *Link) { l.ID = "not-a-link-id" }, "id"},
+		{"missing workitem_id", func(l *Link) { l.WorkitemID = "" }, "workitem_id"},
+		{"unknown scope kind", func(l *Link) { l.Scope.Kind = "nope" }, "scope.kind"},
+		{"missing scope path", func(l *Link) { l.Scope.Path = "" }, "scope.path"},
+		{"leading slash path", func(l *Link) { l.Scope.Path = "/abs/path" }, "scope.path"},
+		{"parent escape path", func(l *Link) { l.Scope.Path = "projects/../etc/passwd" }, "scope.path"},
+		{"unknown role", func(l *Link) { l.Role = "boss" }, "role"},
+		{"missing created_at", func(l *Link) { l.CreatedAt = time.Time{} }, "created_at"},
+		{"missing created_by", func(l *Link) { l.CreatedBy = "" }, "created_by"},
+		{"bad created_by chars", func(l *Link) { l.CreatedBy = "spaces are bad" }, "created_by"},
+		{"project kind under worktrees", func(l *Link) {
+			l.Scope.Kind = ScopeProject
+			l.Scope.Path = "projects/worktrees/demo"
+		}, "scope.path"},
+		{"worktree kind outside worktrees", func(l *Link) {
+			l.Scope.Kind = ScopeWorktree
+			l.Scope.Path = "projects/demo"
+		}, "scope.path"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			link := good
+			tc.mutate(&link)
+			l := &Links{Version: LinksSchemaVersion, Links: []Link{link}}
+			errs := Validate(context.Background(), l, ValidateOptions{CampaignRoot: root})
+			found := false
+			for _, e := range errs {
+				if e.Field == tc.wantField {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("expected error on field %q, got %v", tc.wantField, errs)
+			}
+		})
+	}
+}
+
+func TestValidate_DuplicatePrimary(t *testing.T) {
+	root := t.TempDir()
+	a := makeValidLink(t, root)
+	b := makeValidLink(t, root) // same scope.path, same role
+	b.WorkitemID = "design-other-2026-05-24"
+	l := &Links{Version: LinksSchemaVersion, Links: []Link{a, b}}
+	errs := Validate(context.Background(), l, ValidateOptions{CampaignRoot: root})
+	found := false
+	for _, e := range errs {
+		if e.Field == "role" && strings.Contains(e.Message, "duplicate primary") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected duplicate-primary finding, got %v", errs)
+	}
+}
+
+func TestValidate_HappyPath(t *testing.T) {
+	root := t.TempDir()
+	link := makeValidLink(t, root)
+	l := &Links{Version: LinksSchemaVersion, Links: []Link{link}}
+	errs := Validate(context.Background(), l, ValidateOptions{CampaignRoot: root})
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %v", errs)
+	}
+}
+
+func TestValidate_WorkitemIDMustExistWhenSetProvided(t *testing.T) {
+	root := t.TempDir()
+	link := makeValidLink(t, root)
+	known := map[string]struct{}{"something-else": {}}
+	l := &Links{Version: LinksSchemaVersion, Links: []Link{link}}
+	errs := Validate(context.Background(), l, ValidateOptions{
+		CampaignRoot: root,
+		WorkitemIDs:  known,
+	})
+	found := false
+	for _, e := range errs {
+		if e.Field == "workitem_id" && strings.Contains(e.Message, "no workitem with id") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected workitem_id missing finding, got %v", errs)
+	}
+
+	// AllowMissing suppresses the check.
+	errs = Validate(context.Background(), l, ValidateOptions{
+		CampaignRoot: root,
+		WorkitemIDs:  known,
+		AllowMissing: true,
+	})
+	for _, e := range errs {
+		if e.Field == "workitem_id" && strings.Contains(e.Message, "no workitem with id") {
+			t.Fatalf("AllowMissing should suppress the workitem-existence check; got %v", errs)
+		}
+	}
+}
+
+func TestAddLink_DuplicatePrimaryRequiresReplace(t *testing.T) {
+	l := &Links{Version: LinksSchemaVersion, Links: []Link{}}
+	scope := LinkScope{Kind: ScopeProject, Path: "projects/demo"}
+	a := Link{
+		ID:         "lnk_20260524_aaaaaa",
+		WorkitemID: "design-a-2026-05-24",
+		Scope:      scope,
+		Role:       RolePrimary,
+		CreatedAt:  time.Now().UTC(),
+		CreatedBy:  "test",
+	}
+	b := a
+	b.ID = "lnk_20260524_bbbbbb"
+	b.WorkitemID = "design-b-2026-05-24"
+
+	if err := l.AddLink(a, false); err != nil {
+		t.Fatalf("AddLink a: %v", err)
+	}
+	if err := l.AddLink(b, false); err == nil {
+		t.Fatal("expected primary collision without replace")
+	}
+	if err := l.AddLink(b, true); err != nil {
+		t.Fatalf("AddLink b with replace: %v", err)
+	}
+	if len(l.Links) != 1 {
+		t.Fatalf("replace should leave exactly one link, got %d", len(l.Links))
+	}
+	if l.Links[0].ID != b.ID {
+		t.Fatalf("replace should keep new link, got %s", l.Links[0].ID)
+	}
+}
+
+func TestSave_ConcurrentInvocationsDoNotCorrupt(t *testing.T) {
+	root := t.TempDir()
+	if err := Save(context.Background(), root, Empty()); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "projects", "demo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	const workers = 2
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			link := makeValidLink(t, root)
+			link.ID = fmt.Sprintf("lnk_20260524_%06x", i+0xabcd00)
+			link.Role = RoleRelated // avoid primary collisions between workers
+			existing, err := Load(context.Background(), root)
+			if err != nil {
+				errs <- err
+				return
+			}
+			_ = existing.AddLink(link, false)
+			errs <- Save(context.Background(), root, existing)
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for e := range errs {
+		if e != nil {
+			t.Fatalf("concurrent Save: %v", e)
+		}
+	}
+
+	got, err := Load(context.Background(), root)
+	if err != nil {
+		t.Fatalf("Load after concurrent: %v", err)
+	}
+	// At least one link present (one of the writers won the last-writer-wins
+	// race); the file is valid YAML and parses cleanly.
+	if len(got.Links) == 0 {
+		t.Fatal("expected at least one link after concurrent saves")
+	}
+}
+
+func TestSave_RandomRoundTripStability(t *testing.T) {
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		root := t.TempDir()
+		l := generateRandomLinks(t, root, 1+i%5)
+
+		if err := Save(context.Background(), root, l); err != nil {
+			t.Fatalf("iter %d Save: %v", i, err)
+		}
+		first, err := os.ReadFile(LinksPath(root))
+		if err != nil {
+			t.Fatal(err)
+		}
+		reloaded, err := Load(context.Background(), root)
+		if err != nil {
+			t.Fatalf("iter %d Load: %v", i, err)
+		}
+		if err := Save(context.Background(), root, reloaded); err != nil {
+			t.Fatalf("iter %d resave: %v", i, err)
+		}
+		second, err := os.ReadFile(LinksPath(root))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(first, second) {
+			t.Fatalf("iter %d round-trip not byte-stable", i)
+		}
+	}
+}
+
+func generateRandomLinks(t *testing.T, root string, n int) *Links {
+	t.Helper()
+	l := Empty()
+	for i := 0; i < n; i++ {
+		path := fmt.Sprintf("projects/demo-%03d", i)
+		if err := os.MkdirAll(filepath.Join(root, path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		l.Links = append(l.Links, Link{
+			ID:         fmt.Sprintf("lnk_20260524_%06x", i),
+			WorkitemID: fmt.Sprintf("design-demo-%d-2026-05-24", i),
+			Scope:      LinkScope{Kind: ScopeProject, Path: path},
+			Role:       RolePrimary,
+			CreatedAt:  time.Date(2026, 5, 24, 12, i%60, i%60, 0, time.UTC),
+			CreatedBy:  "test",
+		})
+	}
+	return l
+}

--- a/internal/workitem/links/load.go
+++ b/internal/workitem/links/load.go
@@ -1,0 +1,92 @@
+package links
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// linksDir returns `<root>/.campaign/workitems/`.
+func linksDir(root string) string {
+	return filepath.Join(root, ".campaign", "workitems")
+}
+
+// LinksPath returns the absolute path to `links.yaml` for a campaign root.
+func LinksPath(root string) string {
+	return filepath.Join(linksDir(root), "links.yaml")
+}
+
+// CurrentPath returns the absolute path to `current.yaml` for a campaign root.
+func CurrentPath(root string) string {
+	return filepath.Join(linksDir(root), "current.yaml")
+}
+
+// Load reads `links.yaml` and returns the registry. A missing file is the
+// documented zero state — Load returns Empty(), no error. Malformed YAML or
+// an unknown schema version returns a wrapped error.
+func Load(ctx context.Context, root string) (*Links, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(LinksPath(root))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return Empty(), nil
+		}
+		return nil, camperrors.Wrap(err, "read links.yaml")
+	}
+
+	var out Links
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		return nil, camperrors.Wrap(err, "parse links.yaml")
+	}
+	if out.Version == "" {
+		return nil, newValidation("version", "links.yaml is missing the version field")
+	}
+	if out.Version != LinksSchemaVersion {
+		return nil, newValidation("version",
+			"unknown links.yaml schema version "+out.Version+
+				"; this build understands "+LinksSchemaVersion)
+	}
+	if out.Links == nil {
+		out.Links = []Link{}
+	}
+	return &out, nil
+}
+
+// LoadCurrent reads `current.yaml` and returns the selection. A missing file
+// returns nil, nil.
+func LoadCurrent(ctx context.Context, root string) (*Current, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(CurrentPath(root))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, camperrors.Wrap(err, "read current.yaml")
+	}
+
+	var out Current
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		return nil, camperrors.Wrap(err, "parse current.yaml")
+	}
+	if out.Version == "" {
+		return nil, newValidation("version", "current.yaml is missing the version field")
+	}
+	if out.Version != CurrentSchemaVersion {
+		return nil, newValidation("version",
+			"unknown current.yaml schema version "+out.Version+
+				"; this build understands "+CurrentSchemaVersion)
+	}
+	return &out, nil
+}

--- a/internal/workitem/links/save.go
+++ b/internal/workitem/links/save.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io/fs"
 	"os"
-	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -45,7 +44,7 @@ func Save(ctx context.Context, root string, links *Links) error {
 		return camperrors.Wrap(err, "create links dir")
 	}
 
-	release, err := acquireFileLock(ctx, path+".lock")
+	release, err := fsutil.AcquireFileLock(ctx, path+".lock")
 	if err != nil {
 		return err
 	}
@@ -85,7 +84,7 @@ func SaveCurrent(ctx context.Context, root string, c *Current) error {
 		return camperrors.Wrap(err, "create links dir")
 	}
 
-	release, err := acquireFileLock(ctx, path+".lock")
+	release, err := fsutil.AcquireFileLock(ctx, path+".lock")
 	if err != nil {
 		return err
 	}
@@ -111,40 +110,4 @@ func marshalYAML(value any) ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
-}
-
-// acquireFileLock takes an exclusive lock on lockPath via O_CREATE|O_EXCL.
-// The returned release closure removes the lock file. Cross-platform; does
-// not depend on flock(2). Times out after 5s with a wrapped error.
-func acquireFileLock(ctx context.Context, lockPath string) (func(), error) {
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
-		if err == nil {
-			_ = f.Close()
-			released := false
-			return func() {
-				if released {
-					return
-				}
-				released = true
-				_ = os.Remove(lockPath)
-			}, nil
-		}
-		if !errors.Is(err, fs.ErrExist) {
-			return nil, camperrors.Wrap(err, "acquire lock")
-		}
-		if time.Now().After(deadline) {
-			return nil, camperrors.Wrap(camperrors.ErrInvalidInput,
-				"timeout acquiring lock at "+lockPath+" (another camp invocation holds it?)")
-		}
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(20 * time.Millisecond):
-		}
-	}
 }

--- a/internal/workitem/links/save.go
+++ b/internal/workitem/links/save.go
@@ -1,0 +1,150 @@
+package links
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+)
+
+// Save writes the registry to `links.yaml` under a file lock. Links are
+// sorted in place before marshaling so the on-disk order is stable across
+// runs.
+//
+// The directory `.campaign/workitems/` is created on demand. Writes are
+// atomic via fsutil.WriteFileAtomically.
+func Save(ctx context.Context, root string, links *Links) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if links == nil {
+		return newValidation("links", "cannot save nil Links")
+	}
+	if links.Version == "" {
+		links.Version = LinksSchemaVersion
+	}
+	if links.Links == nil {
+		links.Links = []Link{}
+	}
+	links.Sort()
+
+	data, err := marshalYAML(links)
+	if err != nil {
+		return camperrors.Wrap(err, "marshal links.yaml")
+	}
+
+	path := LinksPath(root)
+	if err := os.MkdirAll(linksDir(root), 0o755); err != nil {
+		return camperrors.Wrap(err, "create links dir")
+	}
+
+	release, err := acquireFileLock(ctx, path+".lock")
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	if err := fsutil.WriteFileAtomically(path, data, 0o644); err != nil {
+		return camperrors.Wrap(err, "write links.yaml")
+	}
+	return nil
+}
+
+// SaveCurrent writes `current.yaml` under a file lock. Passing nil clears
+// the file (removes it from disk); the directory is left in place.
+func SaveCurrent(ctx context.Context, root string, c *Current) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	path := CurrentPath(root)
+
+	if c == nil {
+		if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return camperrors.Wrap(err, "remove current.yaml")
+		}
+		return nil
+	}
+
+	if c.Version == "" {
+		c.Version = CurrentSchemaVersion
+	}
+
+	data, err := marshalYAML(c)
+	if err != nil {
+		return camperrors.Wrap(err, "marshal current.yaml")
+	}
+
+	if err := os.MkdirAll(linksDir(root), 0o755); err != nil {
+		return camperrors.Wrap(err, "create links dir")
+	}
+
+	release, err := acquireFileLock(ctx, path+".lock")
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	if err := fsutil.WriteFileAtomically(path, data, 0o644); err != nil {
+		return camperrors.Wrap(err, "write current.yaml")
+	}
+	return nil
+}
+
+// marshalYAML encodes value as YAML with 2-space indent and a trailing
+// newline.
+func marshalYAML(value any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(value); err != nil {
+		_ = enc.Close()
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// acquireFileLock takes an exclusive lock on lockPath via O_CREATE|O_EXCL.
+// The returned release closure removes the lock file. Cross-platform; does
+// not depend on flock(2). Times out after 5s with a wrapped error.
+func acquireFileLock(ctx context.Context, lockPath string) (func(), error) {
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+		if err == nil {
+			_ = f.Close()
+			released := false
+			return func() {
+				if released {
+					return
+				}
+				released = true
+				_ = os.Remove(lockPath)
+			}, nil
+		}
+		if !errors.Is(err, fs.ErrExist) {
+			return nil, camperrors.Wrap(err, "acquire lock")
+		}
+		if time.Now().After(deadline) {
+			return nil, camperrors.Wrap(camperrors.ErrInvalidInput,
+				"timeout acquiring lock at "+lockPath+" (another camp invocation holds it?)")
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}

--- a/internal/workitem/links/testdata/example_current.yaml
+++ b/internal/workitem/links/testdata/example_current.yaml
@@ -1,0 +1,3 @@
+version: workitem-current/v1alpha1
+workitem_id: design-camp-timeline-2026-05-19
+selected_at: 2026-05-24T19:30:00Z

--- a/internal/workitem/links/testdata/example_links.yaml
+++ b/internal/workitem/links/testdata/example_links.yaml
@@ -1,0 +1,81 @@
+version: workitem-links/v1alpha1
+links:
+  - id: lnk_20260524_ab12cd
+    workitem_id: design-camp-timeline-2026-05-19
+    workitem_key: design:workflow/design/camp-timeline
+    scope:
+      kind: project
+      path: projects/camp-timeline
+    role: primary
+    created_at: 2026-05-24T19:00:00Z
+    created_by: camp_workitem_link
+
+  - id: lnk_20260524_ef34gh
+    workitem_id: design-camp-timeline-2026-05-19
+    workitem_key: design:workflow/design/camp-timeline
+    scope:
+      kind: campaign_path
+      path: workflow/design/camp-timeline
+    role: primary
+    created_at: 2026-05-24T19:00:05Z
+    created_by: camp_workitem_link
+
+  - id: lnk_20260524_aa11bb
+    workitem_id: feature-festival-app-bootstrap-2026-05-24
+    workitem_key: feature:workflow/feature/festival-app-bootstrap
+    scope:
+      kind: repo
+      path: vendor/festival-app
+    role: primary
+    created_at: 2026-05-24T20:14:00Z
+    created_by: camp_workitem_link
+
+  - id: lnk_20260524_22ccdd
+    workitem_id: design-camp-timeline-2026-05-19
+    workitem_key: design:workflow/design/camp-timeline
+    scope:
+      kind: festival
+      path: festivals/active/camp-timeline-CT0001
+    role: primary
+    created_at: 2026-05-24T20:30:00Z
+    created_by: camp_workitem_link
+
+  - id: lnk_20260524_55eeff
+    workitem_id: chore-cleanup-2026-05-20
+    workitem_key: chore:workflow/chore/cleanup
+    scope:
+      kind: worktree
+      path: projects/worktrees/camp@feat-link-registry
+    role: primary
+    created_at: 2026-05-24T21:00:00Z
+    created_by: camp_workitem_link
+
+  - id: lnk_20260524_66aaff
+    workitem_id: design-camp-timeline-2026-05-19
+    workitem_key: design:workflow/design/camp-timeline
+    scope:
+      kind: project
+      path: projects/festival-app
+    role: related
+    created_at: 2026-05-24T21:05:00Z
+    created_by: camp_workitem_link
+
+  - id: lnk_20260524_77bb00
+    workitem_id: design-camp-timeline-2026-05-19
+    workitem_key: design:workflow/design/camp-timeline
+    scope:
+      kind: campaign_path
+      path: workflow/design/older-timeline-spike
+    role: blocked_by
+    created_at: 2026-05-24T21:10:00Z
+    created_by: camp_workitem_link
+
+  - id: lnk_20260524_88cc11
+    workitem_id: design-camp-timeline-2026-05-19
+    workitem_key: design:workflow/design/camp-timeline
+    scope:
+      kind: campaign_path
+      path: workflow/design/legacy-timeline-2025
+    role: supersedes
+    created_at: 2026-05-24T21:15:00Z
+    created_by: camp_workitem_link

--- a/internal/workitem/links/types.go
+++ b/internal/workitem/links/types.go
@@ -1,0 +1,181 @@
+// Package links implements the workitem link registry at
+// `.campaign/workitems/links.yaml` plus the local `current.yaml` selection.
+//
+// Contract: see SCHEMA.md. Types in this file mirror that schema. Validation
+// rules live in validate.go. Persistence (with file locking and atomic
+// rename) lives in load.go / save.go. The package reuses
+// `internal/quest/link.go::ValidateLinkPath` for campaign-root containment.
+package links
+
+import (
+	"sort"
+	"time"
+)
+
+// Schema versions are immutable strings persisted in YAML.
+const (
+	LinksSchemaVersion   = "workitem-links/v1alpha1"
+	CurrentSchemaVersion = "workitem-current/v1alpha1"
+)
+
+// LinkIDPattern is the regex form of a link ID: `lnk_<yyyymmdd>_<6 hex>`.
+// Implementations parse and emit only this form.
+const LinkIDPattern = `^lnk_[0-9]{8}_[0-9a-f]{6}$`
+
+// ScopeKind enumerates the scope a link can attach to.
+type ScopeKind string
+
+const (
+	ScopeProject      ScopeKind = "project"
+	ScopeRepo         ScopeKind = "repo"
+	ScopeCampaignPath ScopeKind = "campaign_path"
+	ScopeFestival     ScopeKind = "festival"
+	ScopeWorktree     ScopeKind = "worktree"
+)
+
+// ValidScopeKinds is the enumerable set; iteration order is deterministic.
+var ValidScopeKinds = []ScopeKind{
+	ScopeProject, ScopeRepo, ScopeCampaignPath, ScopeFestival, ScopeWorktree,
+}
+
+// Role enumerates the role a link plays in commit routing.
+type Role string
+
+const (
+	RolePrimary    Role = "primary"
+	RoleRelated    Role = "related"
+	RoleBlockedBy  Role = "blocked_by"
+	RoleSupersedes Role = "supersedes"
+)
+
+// ValidRoles is the enumerable set; iteration order is deterministic.
+var ValidRoles = []Role{RolePrimary, RoleRelated, RoleBlockedBy, RoleSupersedes}
+
+// LinkScope is the target of a link.
+type LinkScope struct {
+	Kind ScopeKind `yaml:"kind"`
+	Path string    `yaml:"path"`
+}
+
+// Link is one workitem-to-scope relationship.
+type Link struct {
+	ID          string    `yaml:"id"`
+	WorkitemID  string    `yaml:"workitem_id"`
+	WorkitemKey string    `yaml:"workitem_key,omitempty"`
+	Scope       LinkScope `yaml:"scope"`
+	Role        Role      `yaml:"role"`
+	CreatedAt   time.Time `yaml:"created_at"`
+	CreatedBy   string    `yaml:"created_by"`
+}
+
+// Links is the top-level registry persisted to `links.yaml`.
+type Links struct {
+	Version string `yaml:"version"`
+	Links   []Link `yaml:"links"`
+}
+
+// Current is the top-level shape persisted to `current.yaml`.
+type Current struct {
+	Version    string    `yaml:"version"`
+	WorkitemID string    `yaml:"workitem_id"`
+	SelectedAt time.Time `yaml:"selected_at"`
+}
+
+// FindByID returns the link with the matching id and true; otherwise nil, false.
+func (l *Links) FindByID(id string) (*Link, bool) {
+	for i := range l.Links {
+		if l.Links[i].ID == id {
+			return &l.Links[i], true
+		}
+	}
+	return nil, false
+}
+
+// FindByScope returns every link whose scope matches the given kind+path.
+// The slice is a new allocation; callers may mutate it without affecting the
+// underlying registry.
+func (l *Links) FindByScope(kind ScopeKind, path string) []Link {
+	var out []Link
+	for _, link := range l.Links {
+		if link.Scope.Kind == kind && link.Scope.Path == path {
+			out = append(out, link)
+		}
+	}
+	return out
+}
+
+// PrimaryForScope returns the primary link for (kind, path) and true, or
+// nil, false if none is set.
+func (l *Links) PrimaryForScope(kind ScopeKind, path string) (*Link, bool) {
+	for i := range l.Links {
+		link := &l.Links[i]
+		if link.Role == RolePrimary && link.Scope.Kind == kind && link.Scope.Path == path {
+			return link, true
+		}
+	}
+	return nil, false
+}
+
+// AddLink appends link to the registry.
+//
+//   - If a primary link already exists for (link.Scope, RolePrimary) and the
+//     incoming link's role is primary, the call returns a ValidationError
+//     unless replace is true. With replace, the existing primary is removed
+//     before append.
+//   - If a link with the same ID already exists, the call returns a
+//     ValidationError unconditionally — IDs are append-only.
+//   - Non-primary roles have no uniqueness constraint.
+func (l *Links) AddLink(link Link, replace bool) error {
+	if _, found := l.FindByID(link.ID); found {
+		return newValidation("id", "duplicate link id: "+link.ID)
+	}
+	if link.Role == RolePrimary {
+		if existing, ok := l.PrimaryForScope(link.Scope.Kind, link.Scope.Path); ok {
+			if !replace {
+				return newValidation("scope",
+					"primary link already exists for "+string(link.Scope.Kind)+":"+link.Scope.Path+
+						" (id "+existing.ID+"); use --replace to override")
+			}
+			_ = l.RemoveLinkByID(existing.ID)
+		}
+	}
+	l.Links = append(l.Links, link)
+	return nil
+}
+
+// RemoveLinkByID drops the link with the given id. Returns true if a link
+// was removed, false if no match was found.
+func (l *Links) RemoveLinkByID(id string) bool {
+	for i := range l.Links {
+		if l.Links[i].ID == id {
+			l.Links = append(l.Links[:i], l.Links[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// Sort orders links by (scope.kind, scope.path, created_at, id) in place.
+// The writer calls Sort before marshaling to keep diffs minimal.
+func (l *Links) Sort() {
+	sort.SliceStable(l.Links, func(i, j int) bool {
+		a, b := l.Links[i], l.Links[j]
+		if a.Scope.Kind != b.Scope.Kind {
+			return a.Scope.Kind < b.Scope.Kind
+		}
+		if a.Scope.Path != b.Scope.Path {
+			return a.Scope.Path < b.Scope.Path
+		}
+		if !a.CreatedAt.Equal(b.CreatedAt) {
+			return a.CreatedAt.Before(b.CreatedAt)
+		}
+		return a.ID < b.ID
+	})
+}
+
+// Empty returns a freshly-initialized Links with the current schema version
+// and a non-nil, empty Links slice (so YAML marshals as `links: []` rather
+// than `links: null`).
+func Empty() *Links {
+	return &Links{Version: LinksSchemaVersion, Links: []Link{}}
+}

--- a/internal/workitem/links/validate.go
+++ b/internal/workitem/links/validate.go
@@ -1,0 +1,229 @@
+package links
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/pathsafe"
+	"github.com/Obedience-Corp/camp/internal/quest"
+)
+
+// ValidationError captures one rule failure. Validate returns a slice; the
+// CLI surface promotes the slice to a single wrapped camperrors error.
+type ValidationError struct {
+	LinkID  string // empty for top-level errors
+	Field   string
+	Message string
+}
+
+func (e ValidationError) Error() string {
+	if e.LinkID == "" {
+		return fmt.Sprintf("validation error on %s: %s", e.Field, e.Message)
+	}
+	return fmt.Sprintf("validation error on %s (link %s): %s", e.Field, e.LinkID, e.Message)
+}
+
+// ValidateOptions controls which checks Validate performs.
+type ValidateOptions struct {
+	// CampaignRoot enables filesystem-backed checks (path containment, target
+	// existence). Required for the safety bounds documented in SCHEMA.md §8.
+	CampaignRoot string
+
+	// AllowMissing skips the "scope.path target must exist" check. Used by
+	// migrations.
+	AllowMissing bool
+
+	// WorkitemIDs is the set of known workitem ids on disk. When non-nil
+	// Validate ensures each link.workitem_id is in the set. Pass nil to skip
+	// (used by tests that don't have a campaign on disk).
+	WorkitemIDs map[string]struct{}
+
+	// Now is the reference time for created_at skew checks. Defaults to
+	// time.Now() if zero.
+	Now time.Time
+}
+
+var linkIDRegex = regexp.MustCompile(LinkIDPattern)
+
+const (
+	maxClockSkewWarn   = 5 * time.Minute
+	maxClockSkewReject = 24 * time.Hour
+	maxCreatedByLen    = 64
+	maxWorkitemIDLen   = 200
+	maxScopePathLen    = 4096
+)
+
+var createdByRegex = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+
+// Validate returns the list of rule failures for a links registry. An empty
+// slice means the registry is valid. Errors are returned in the order
+// fields appear in SCHEMA.md §9.
+func Validate(ctx context.Context, l *Links, opts ValidateOptions) []ValidationError {
+	if err := ctx.Err(); err != nil {
+		return []ValidationError{{Field: "context", Message: err.Error()}}
+	}
+	if l == nil {
+		return []ValidationError{{Field: "links", Message: "nil registry"}}
+	}
+
+	var errs []ValidationError
+	if l.Version != LinksSchemaVersion {
+		errs = append(errs, ValidationError{
+			Field:   "version",
+			Message: "expected " + LinksSchemaVersion + ", got " + l.Version,
+		})
+	}
+
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	seenIDs := make(map[string]struct{}, len(l.Links))
+	primaryKey := func(s LinkScope) string { return string(s.Kind) + "::" + s.Path }
+	seenPrimary := make(map[string]string, len(l.Links))
+
+	for _, link := range l.Links {
+		errs = append(errs, validateOneLink(link, opts, now, seenIDs, seenPrimary, primaryKey)...)
+	}
+	return errs
+}
+
+func validateOneLink(link Link, opts ValidateOptions, now time.Time,
+	seenIDs map[string]struct{}, seenPrimary map[string]string,
+	primaryKey func(LinkScope) string,
+) []ValidationError {
+	var errs []ValidationError
+	addErr := func(field, msg string) {
+		errs = append(errs, ValidationError{LinkID: link.ID, Field: field, Message: msg})
+	}
+
+	if link.ID == "" {
+		addErr("id", "required")
+	} else if !linkIDRegex.MatchString(link.ID) {
+		addErr("id", "must match "+LinkIDPattern)
+	} else if _, dup := seenIDs[link.ID]; dup {
+		addErr("id", "duplicate id within registry")
+	} else {
+		seenIDs[link.ID] = struct{}{}
+	}
+
+	if link.WorkitemID == "" {
+		addErr("workitem_id", "required")
+	} else if len(link.WorkitemID) > maxWorkitemIDLen {
+		addErr("workitem_id", fmt.Sprintf("must be at most %d chars", maxWorkitemIDLen))
+	} else if err := pathsafe.ValidateSegment("workitem_id", link.WorkitemID); err != nil {
+		addErr("workitem_id", err.Error())
+	} else if opts.WorkitemIDs != nil {
+		if _, known := opts.WorkitemIDs[link.WorkitemID]; !known && !opts.AllowMissing {
+			addErr("workitem_id", "no workitem with id "+link.WorkitemID+" found on disk")
+		}
+	}
+
+	if !isValidScopeKind(link.Scope.Kind) {
+		addErr("scope.kind", "unknown scope kind: "+string(link.Scope.Kind))
+	}
+	if link.Scope.Path == "" {
+		addErr("scope.path", "required")
+	} else if len(link.Scope.Path) > maxScopePathLen {
+		addErr("scope.path", fmt.Sprintf("must be at most %d chars", maxScopePathLen))
+	} else if strings.HasPrefix(link.Scope.Path, "/") {
+		addErr("scope.path", "must be campaign-relative (no leading /)")
+	} else if strings.Contains(link.Scope.Path, "..") {
+		addErr("scope.path", "must not contain ..")
+	} else if opts.CampaignRoot != "" && !opts.AllowMissing {
+		if err := quest.ValidateLinkPath(opts.CampaignRoot, link.Scope.Path); err != nil {
+			addErr("scope.path", err.Error())
+		}
+	}
+	if msg, ok := checkKindPathPrefix(link.Scope); !ok {
+		addErr("scope.path", msg)
+	}
+
+	if !isValidRole(link.Role) {
+		addErr("role", "unknown role: "+string(link.Role))
+	} else if link.Role == RolePrimary {
+		key := primaryKey(link.Scope)
+		if otherID, dup := seenPrimary[key]; dup {
+			addErr("role", "duplicate primary for scope "+string(link.Scope.Kind)+":"+link.Scope.Path+
+				" (also id "+otherID+")")
+		} else {
+			seenPrimary[key] = link.ID
+		}
+	}
+
+	if link.CreatedAt.IsZero() {
+		addErr("created_at", "required")
+	} else {
+		skew := now.Sub(link.CreatedAt)
+		if skew < 0 {
+			skew = -skew
+		}
+		if skew > maxClockSkewReject {
+			addErr("created_at", "more than 24h from now (possible clock skew or wrong year)")
+		}
+	}
+
+	if link.CreatedBy == "" {
+		addErr("created_by", "required")
+	} else if len(link.CreatedBy) > maxCreatedByLen {
+		addErr("created_by", fmt.Sprintf("must be at most %d chars", maxCreatedByLen))
+	} else if !createdByRegex.MatchString(link.CreatedBy) {
+		addErr("created_by", "must match [A-Za-z0-9_-]+")
+	}
+
+	return errs
+}
+
+func isValidScopeKind(k ScopeKind) bool {
+	for _, valid := range ValidScopeKinds {
+		if k == valid {
+			return true
+		}
+	}
+	return false
+}
+
+func isValidRole(r Role) bool {
+	for _, valid := range ValidRoles {
+		if r == valid {
+			return true
+		}
+	}
+	return false
+}
+
+// checkKindPathPrefix enforces the kind-to-path table in SCHEMA.md §5.
+// Returns (errorMessage, ok). ok=true means the scope is acceptable.
+func checkKindPathPrefix(s LinkScope) (string, bool) {
+	switch s.Kind {
+	case ScopeProject:
+		if !strings.HasPrefix(s.Path, "projects/") {
+			return "scope kind project requires path under projects/", false
+		}
+		if strings.HasPrefix(s.Path, "projects/worktrees/") {
+			return "scope kind project must not be under projects/worktrees/ (use kind worktree)", false
+		}
+	case ScopeWorktree:
+		if !strings.HasPrefix(s.Path, "projects/worktrees/") {
+			return "scope kind worktree requires path under projects/worktrees/", false
+		}
+	case ScopeFestival:
+		if !strings.HasPrefix(s.Path, "festivals/") {
+			return "scope kind festival requires path under festivals/", false
+		}
+	case ScopeRepo, ScopeCampaignPath:
+		// No prefix constraint.
+	}
+	return "", true
+}
+
+// newValidation wraps a single field/message into the package error type
+// used throughout the loader/saver code.
+func newValidation(field, message string) error {
+	return camperrors.NewValidation(field, message, nil)
+}

--- a/internal/workitem/links/validate.go
+++ b/internal/workitem/links/validate.go
@@ -50,7 +50,6 @@ type ValidateOptions struct {
 var linkIDRegex = regexp.MustCompile(LinkIDPattern)
 
 const (
-	maxClockSkewWarn   = 5 * time.Minute
 	maxClockSkewReject = 24 * time.Hour
 	maxCreatedByLen    = 64
 	maxWorkitemIDLen   = 200

--- a/internal/workitem/resolver/resolver.go
+++ b/internal/workitem/resolver/resolver.go
@@ -1,0 +1,313 @@
+// Package resolver implements the deterministic workitem-context resolution
+// pipeline documented in `internal/workitem/links/SCHEMA.md` §7. It is the
+// single source of truth for "which workitem should this commit/operation
+// count toward?" and is imported by commit wrappers in sequence 03 and the
+// `camp workitem resolve` and `camp workitem doctor` commands.
+package resolver
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/selector"
+)
+
+// Source identifies which resolution tier produced a result.
+type Source string
+
+const (
+	SourceExplicit Source = "explicit"
+	SourceAncestor Source = "ancestor"
+	SourceLink     Source = "link"
+	SourceFestival Source = "festival"
+	SourceCurrent  Source = "current"
+	SourceNone     Source = "none"
+)
+
+// Options inputs to Resolve. Cwd defaults to os.Getwd() when empty.
+type Options struct {
+	Explicit   string
+	Cwd        string
+	FestivalID string
+	AllowFuzzy bool
+}
+
+// TraceStep records what one tier of the resolver did. Surfaced via --json
+// and --explain so debugging "why did this resolve to X?" is mechanical.
+type TraceStep struct {
+	Tier   Source `json:"tier"`
+	Result string `json:"result"`           // "match" | "miss" | "skip" | "error"
+	Detail string `json:"detail,omitempty"` // human-readable note
+}
+
+// Resolution is what Resolve returns.
+type Resolution struct {
+	Workitem *workitem.WorkItem `json:"workitem,omitempty"`
+	Source   Source             `json:"source"`
+	Reason   string             `json:"reason"`
+	QuestID  string             `json:"quest_id,omitempty"`
+	Trace    []TraceStep        `json:"trace"`
+}
+
+// Resolve runs the six-tier pipeline and returns the first match (or a
+// Resolution with Source=none when no tier matches).
+func Resolve(ctx context.Context, root string, opts Options) (*Resolution, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	cwd := opts.Cwd
+	if cwd == "" {
+		c, err := os.Getwd()
+		if err != nil {
+			return nil, camperrors.Wrap(err, "get cwd")
+		}
+		cwd = c
+	}
+	if abs, err := filepath.Abs(cwd); err == nil {
+		cwd = abs
+	}
+
+	result := &Resolution{Source: SourceNone, Reason: "no tier matched"}
+
+	if wi, step := resolveExplicit(ctx, root, opts); wi != nil {
+		result.Workitem = wi
+		result.Source = SourceExplicit
+		result.Reason = "explicit --workitem flag"
+		result.QuestID = questIDOf(wi)
+		result.Trace = append(result.Trace, step)
+		return result, nil
+	} else {
+		result.Trace = append(result.Trace, step)
+	}
+
+	if wi, step := resolveAncestor(ctx, root, cwd); wi != nil {
+		result.Workitem = wi
+		result.Source = SourceAncestor
+		result.Reason = "nearest ancestor .workitem"
+		result.QuestID = questIDOf(wi)
+		result.Trace = append(result.Trace, step)
+		return result, nil
+	} else {
+		result.Trace = append(result.Trace, step)
+	}
+
+	if wi, step := resolveLink(ctx, root, cwd); wi != nil {
+		result.Workitem = wi
+		result.Source = SourceLink
+		result.Reason = step.Detail
+		result.QuestID = questIDOf(wi)
+		result.Trace = append(result.Trace, step)
+		return result, nil
+	} else {
+		result.Trace = append(result.Trace, step)
+	}
+
+	if wi, step := resolveFestival(ctx, root, opts.FestivalID); wi != nil {
+		result.Workitem = wi
+		result.Source = SourceFestival
+		result.Reason = step.Detail
+		result.QuestID = questIDOf(wi)
+		result.Trace = append(result.Trace, step)
+		return result, nil
+	} else {
+		result.Trace = append(result.Trace, step)
+	}
+
+	if wi, step := resolveCurrent(ctx, root); wi != nil {
+		result.Workitem = wi
+		result.Source = SourceCurrent
+		result.Reason = step.Detail
+		result.QuestID = questIDOf(wi)
+		result.Trace = append(result.Trace, step)
+		return result, nil
+	} else {
+		result.Trace = append(result.Trace, step)
+	}
+
+	result.Trace = append(result.Trace, TraceStep{Tier: SourceNone, Result: "match", Detail: "no workitem context"})
+	return result, nil
+}
+
+func resolveExplicit(ctx context.Context, root string, opts Options) (*workitem.WorkItem, TraceStep) {
+	if opts.Explicit == "" {
+		return nil, TraceStep{Tier: SourceExplicit, Result: "skip", Detail: "no --workitem flag"}
+	}
+	wi, err := selector.Resolve(ctx, root, opts.Explicit, selector.ResolveOptions{AllowFuzzy: opts.AllowFuzzy})
+	if err != nil {
+		return nil, TraceStep{Tier: SourceExplicit, Result: "error", Detail: err.Error()}
+	}
+	return wi, TraceStep{Tier: SourceExplicit, Result: "match", Detail: wi.Key}
+}
+
+func resolveAncestor(ctx context.Context, root, cwd string) (*workitem.WorkItem, TraceStep) {
+	if cwd == "" || root == "" {
+		return nil, TraceStep{Tier: SourceAncestor, Result: "skip", Detail: "no cwd"}
+	}
+	dir := cwd
+	for {
+		markerPath := filepath.Join(dir, workitem.MetadataFilename)
+		if info, err := os.Stat(markerPath); err == nil && !info.IsDir() {
+			rel, _ := filepath.Rel(root, dir)
+			wi, err := selector.Resolve(ctx, root, filepath.ToSlash(rel), selector.ResolveOptions{})
+			if err == nil {
+				return wi, TraceStep{Tier: SourceAncestor, Result: "match", Detail: filepath.ToSlash(rel)}
+			}
+		}
+		if dir == root || dir == filepath.Dir(dir) {
+			break
+		}
+		dir = filepath.Dir(dir)
+		// Guard: don't walk above the campaign root.
+		if !strings.HasPrefix(dir, root) {
+			break
+		}
+	}
+	return nil, TraceStep{Tier: SourceAncestor, Result: "miss", Detail: "no .workitem found between cwd and campaign root"}
+}
+
+func resolveLink(ctx context.Context, root, cwd string) (*workitem.WorkItem, TraceStep) {
+	registry, err := links.Load(ctx, root)
+	if err != nil {
+		return nil, TraceStep{Tier: SourceLink, Result: "error", Detail: err.Error()}
+	}
+	rel, err := filepath.Rel(root, cwd)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return nil, TraceStep{Tier: SourceLink, Result: "skip", Detail: "cwd outside campaign root"}
+	}
+	relSlash := filepath.ToSlash(rel)
+
+	var best *links.Link
+	bestLen := -1
+	for i := range registry.Links {
+		link := &registry.Links[i]
+		if link.Role != links.RolePrimary {
+			continue
+		}
+		switch link.Scope.Kind {
+		case links.ScopeProject, links.ScopeRepo, links.ScopeCampaignPath, links.ScopeWorktree:
+		default:
+			continue
+		}
+		scopePath := strings.TrimRight(link.Scope.Path, "/")
+		if !pathMatchesPrefix(relSlash, scopePath) {
+			continue
+		}
+		if len(scopePath) > bestLen {
+			best = link
+			bestLen = len(scopePath)
+		}
+	}
+	if best == nil {
+		return nil, TraceStep{Tier: SourceLink, Result: "miss", Detail: "no primary path link covers cwd"}
+	}
+	wi, err := selector.Resolve(ctx, root, best.WorkitemID, selector.ResolveOptions{})
+	if err != nil {
+		// Workitem on disk vanished; surface as a tier miss with a note —
+		// doctor will report the same condition as broken-link.
+		return nil, TraceStep{
+			Tier:   SourceLink,
+			Result: "error",
+			Detail: "primary link " + best.ID + " points to missing workitem " + best.WorkitemID,
+		}
+	}
+	return wi, TraceStep{
+		Tier:   SourceLink,
+		Result: "match",
+		Detail: "via link " + best.ID + " on " + string(best.Scope.Kind) + ":" + best.Scope.Path,
+	}
+}
+
+func resolveFestival(ctx context.Context, root, festivalID string) (*workitem.WorkItem, TraceStep) {
+	if festivalID == "" {
+		return nil, TraceStep{Tier: SourceFestival, Result: "skip", Detail: "no festival id"}
+	}
+	registry, err := links.Load(ctx, root)
+	if err != nil {
+		return nil, TraceStep{Tier: SourceFestival, Result: "error", Detail: err.Error()}
+	}
+	for i := range registry.Links {
+		link := &registry.Links[i]
+		if link.Role != links.RolePrimary || link.Scope.Kind != links.ScopeFestival {
+			continue
+		}
+		if !festivalScopeMatches(link.Scope.Path, festivalID) {
+			continue
+		}
+		wi, err := selector.Resolve(ctx, root, link.WorkitemID, selector.ResolveOptions{})
+		if err == nil {
+			return wi, TraceStep{
+				Tier:   SourceFestival,
+				Result: "match",
+				Detail: "via link " + link.ID + " on festival " + link.Scope.Path,
+			}
+		}
+	}
+	return nil, TraceStep{Tier: SourceFestival, Result: "miss", Detail: "no festival link matches " + festivalID}
+}
+
+func resolveCurrent(ctx context.Context, root string) (*workitem.WorkItem, TraceStep) {
+	cur, err := links.LoadCurrent(ctx, root)
+	if err != nil {
+		return nil, TraceStep{Tier: SourceCurrent, Result: "error", Detail: err.Error()}
+	}
+	if cur == nil {
+		return nil, TraceStep{Tier: SourceCurrent, Result: "skip", Detail: "no current.yaml"}
+	}
+	wi, err := selector.Resolve(ctx, root, cur.WorkitemID, selector.ResolveOptions{})
+	if err != nil {
+		return nil, TraceStep{Tier: SourceCurrent, Result: "error", Detail: err.Error()}
+	}
+	return wi, TraceStep{Tier: SourceCurrent, Result: "match", Detail: "via current.yaml"}
+}
+
+func pathMatchesPrefix(cwdRel, scopePath string) bool {
+	if cwdRel == scopePath {
+		return true
+	}
+	return strings.HasPrefix(cwdRel, scopePath+"/")
+}
+
+func festivalScopeMatches(scopePath, festivalID string) bool {
+	if scopePath == festivalID {
+		return true
+	}
+	base := filepath.Base(scopePath)
+	return base == festivalID
+}
+
+// questIDOf returns the workitem's quest id, or "" if the field is not set.
+// The QuestID field is added in sequence 03 task 01; this helper hides the
+// access so sequences 02 callers do not break when the field is empty.
+func questIDOf(wi *workitem.WorkItem) string {
+	if wi == nil {
+		return ""
+	}
+	// QuestID lives on Metadata, not WorkItem. WorkItem.SourceMetadata may
+	// carry it as a hint surfaced by the discoverer; check there first.
+	// Until sequence 03 plumbs it through, this stays a no-op.
+	if wi.SourceMetadata == nil {
+		return ""
+	}
+	if v, ok := wi.SourceMetadata["quest_id"]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// fsExists is a tiny helper used by tests.
+func fsExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil || !errors.Is(err, fs.ErrNotExist)
+}
+
+var _ = fsExists

--- a/internal/workitem/resolver/resolver.go
+++ b/internal/workitem/resolver/resolver.go
@@ -7,6 +7,7 @@ package resolver
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -61,6 +62,12 @@ func Resolve(ctx context.Context, root string, opts Options) (*Resolution, error
 		return nil, err
 	}
 
+	var err error
+	root, err = canonicalPath(root)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "resolve campaign root")
+	}
+
 	cwd := opts.Cwd
 	if cwd == "" {
 		c, err := os.Getwd()
@@ -69,85 +76,89 @@ func Resolve(ctx context.Context, root string, opts Options) (*Resolution, error
 		}
 		cwd = c
 	}
-	if abs, err := filepath.Abs(cwd); err == nil {
-		cwd = abs
+	cwd, err = canonicalPath(cwd)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "resolve cwd")
 	}
 
 	result := &Resolution{Source: SourceNone, Reason: "no tier matched"}
-
-	if wi, step := resolveExplicit(ctx, root, opts); wi != nil {
-		result.Workitem = wi
-		result.Source = SourceExplicit
-		result.Reason = "explicit --workitem flag"
-		result.QuestID = questIDOf(wi)
-		result.Trace = append(result.Trace, step)
-		return result, nil
-	} else {
-		result.Trace = append(result.Trace, step)
+	tiers := []resolveTier{
+		{SourceExplicit, func() (*workitem.WorkItem, TraceStep, error) {
+			return resolveExplicit(ctx, root, opts)
+		}, "explicit --workitem flag"},
+		{SourceAncestor, func() (*workitem.WorkItem, TraceStep, error) {
+			return resolveAncestor(ctx, root, cwd)
+		}, "nearest ancestor .workitem"},
+		{SourceLink, func() (*workitem.WorkItem, TraceStep, error) {
+			return resolveLink(ctx, root, cwd)
+		}, ""},
+		{SourceFestival, func() (*workitem.WorkItem, TraceStep, error) {
+			return resolveFestival(ctx, root, opts.FestivalID)
+		}, ""},
+		{SourceCurrent, func() (*workitem.WorkItem, TraceStep, error) {
+			return resolveCurrent(ctx, root)
+		}, ""},
 	}
-
-	if wi, step := resolveAncestor(ctx, root, cwd); wi != nil {
-		result.Workitem = wi
-		result.Source = SourceAncestor
-		result.Reason = "nearest ancestor .workitem"
-		result.QuestID = questIDOf(wi)
+	for _, tier := range tiers {
+		wi, step, err := tier.fn()
 		result.Trace = append(result.Trace, step)
-		return result, nil
-	} else {
-		result.Trace = append(result.Trace, step)
-	}
-
-	if wi, step := resolveLink(ctx, root, cwd); wi != nil {
-		result.Workitem = wi
-		result.Source = SourceLink
-		result.Reason = step.Detail
-		result.QuestID = questIDOf(wi)
-		result.Trace = append(result.Trace, step)
-		return result, nil
-	} else {
-		result.Trace = append(result.Trace, step)
-	}
-
-	if wi, step := resolveFestival(ctx, root, opts.FestivalID); wi != nil {
-		result.Workitem = wi
-		result.Source = SourceFestival
-		result.Reason = step.Detail
-		result.QuestID = questIDOf(wi)
-		result.Trace = append(result.Trace, step)
-		return result, nil
-	} else {
-		result.Trace = append(result.Trace, step)
-	}
-
-	if wi, step := resolveCurrent(ctx, root); wi != nil {
-		result.Workitem = wi
-		result.Source = SourceCurrent
-		result.Reason = step.Detail
-		result.QuestID = questIDOf(wi)
-		result.Trace = append(result.Trace, step)
-		return result, nil
-	} else {
-		result.Trace = append(result.Trace, step)
+		if err != nil {
+			return nil, err
+		}
+		if wi != nil {
+			result.Workitem = wi
+			result.Source = tier.source
+			result.Reason = firstNonEmpty(tier.reason, step.Detail)
+			result.QuestID = questIDOf(wi)
+			return result, nil
+		}
 	}
 
 	result.Trace = append(result.Trace, TraceStep{Tier: SourceNone, Result: "match", Detail: "no workitem context"})
 	return result, nil
 }
 
-func resolveExplicit(ctx context.Context, root string, opts Options) (*workitem.WorkItem, TraceStep) {
+type resolveTier struct {
+	source Source
+	fn     func() (*workitem.WorkItem, TraceStep, error)
+	reason string
+}
+
+func canonicalPath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err == nil {
+		return resolved, nil
+	}
+	return abs, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func resolveExplicit(ctx context.Context, root string, opts Options) (*workitem.WorkItem, TraceStep, error) {
 	if opts.Explicit == "" {
-		return nil, TraceStep{Tier: SourceExplicit, Result: "skip", Detail: "no --workitem flag"}
+		return nil, TraceStep{Tier: SourceExplicit, Result: "skip", Detail: "no --workitem flag"}, nil
 	}
 	wi, err := selector.Resolve(ctx, root, opts.Explicit, selector.ResolveOptions{AllowFuzzy: opts.AllowFuzzy})
 	if err != nil {
-		return nil, TraceStep{Tier: SourceExplicit, Result: "error", Detail: err.Error()}
+		return nil, TraceStep{Tier: SourceExplicit, Result: "error", Detail: err.Error()}, nil
 	}
-	return wi, TraceStep{Tier: SourceExplicit, Result: "match", Detail: wi.Key}
+	return wi, TraceStep{Tier: SourceExplicit, Result: "match", Detail: wi.Key}, nil
 }
 
-func resolveAncestor(ctx context.Context, root, cwd string) (*workitem.WorkItem, TraceStep) {
+func resolveAncestor(ctx context.Context, root, cwd string) (*workitem.WorkItem, TraceStep, error) {
 	if cwd == "" || root == "" {
-		return nil, TraceStep{Tier: SourceAncestor, Result: "skip", Detail: "no cwd"}
+		return nil, TraceStep{Tier: SourceAncestor, Result: "skip", Detail: "no cwd"}, nil
 	}
 	dir := cwd
 	for {
@@ -156,29 +167,28 @@ func resolveAncestor(ctx context.Context, root, cwd string) (*workitem.WorkItem,
 			rel, _ := filepath.Rel(root, dir)
 			wi, err := selector.Resolve(ctx, root, filepath.ToSlash(rel), selector.ResolveOptions{})
 			if err == nil {
-				return wi, TraceStep{Tier: SourceAncestor, Result: "match", Detail: filepath.ToSlash(rel)}
+				return wi, TraceStep{Tier: SourceAncestor, Result: "match", Detail: filepath.ToSlash(rel)}, nil
 			}
 		}
 		if dir == root || dir == filepath.Dir(dir) {
 			break
 		}
 		dir = filepath.Dir(dir)
-		// Guard: don't walk above the campaign root.
-		if !strings.HasPrefix(dir, root) {
+		if pathOutside(root, dir) {
 			break
 		}
 	}
-	return nil, TraceStep{Tier: SourceAncestor, Result: "miss", Detail: "no .workitem found between cwd and campaign root"}
+	return nil, TraceStep{Tier: SourceAncestor, Result: "miss", Detail: "no .workitem found between cwd and campaign root"}, nil
 }
 
-func resolveLink(ctx context.Context, root, cwd string) (*workitem.WorkItem, TraceStep) {
+func resolveLink(ctx context.Context, root, cwd string) (*workitem.WorkItem, TraceStep, error) {
 	registry, err := links.Load(ctx, root)
 	if err != nil {
-		return nil, TraceStep{Tier: SourceLink, Result: "error", Detail: err.Error()}
+		return nil, TraceStep{Tier: SourceLink, Result: "error", Detail: err.Error()}, nil
 	}
 	rel, err := filepath.Rel(root, cwd)
-	if err != nil || strings.HasPrefix(rel, "..") {
-		return nil, TraceStep{Tier: SourceLink, Result: "skip", Detail: "cwd outside campaign root"}
+	if err != nil || relOutsideRoot(rel) {
+		return nil, TraceStep{Tier: SourceLink, Result: "skip", Detail: "cwd outside campaign root"}, nil
 	}
 	relSlash := filepath.ToSlash(rel)
 
@@ -204,32 +214,35 @@ func resolveLink(ctx context.Context, root, cwd string) (*workitem.WorkItem, Tra
 		}
 	}
 	if best == nil {
-		return nil, TraceStep{Tier: SourceLink, Result: "miss", Detail: "no primary path link covers cwd"}
+		return nil, TraceStep{Tier: SourceLink, Result: "miss", Detail: "no primary path link covers cwd"}, nil
 	}
 	wi, err := selector.Resolve(ctx, root, best.WorkitemID, selector.ResolveOptions{})
 	if err != nil {
-		// Workitem on disk vanished; surface as a tier miss with a note —
-		// doctor will report the same condition as broken-link.
-		return nil, TraceStep{
+		detail := "primary link " + best.ID + " points to missing workitem " + best.WorkitemID
+		if !errors.Is(err, selector.ErrSelectorNotFound) {
+			detail = "primary link " + best.ID + " could not resolve workitem " + best.WorkitemID + ": " + err.Error()
+		}
+		step := TraceStep{
 			Tier:   SourceLink,
 			Result: "error",
-			Detail: "primary link " + best.ID + " points to missing workitem " + best.WorkitemID,
+			Detail: detail,
 		}
+		return nil, step, camperrors.NewValidation("workitem_link", detail, err)
 	}
 	return wi, TraceStep{
 		Tier:   SourceLink,
 		Result: "match",
 		Detail: "via link " + best.ID + " on " + string(best.Scope.Kind) + ":" + best.Scope.Path,
-	}
+	}, nil
 }
 
-func resolveFestival(ctx context.Context, root, festivalID string) (*workitem.WorkItem, TraceStep) {
+func resolveFestival(ctx context.Context, root, festivalID string) (*workitem.WorkItem, TraceStep, error) {
 	if festivalID == "" {
-		return nil, TraceStep{Tier: SourceFestival, Result: "skip", Detail: "no festival id"}
+		return nil, TraceStep{Tier: SourceFestival, Result: "skip", Detail: "no festival id"}, nil
 	}
 	registry, err := links.Load(ctx, root)
 	if err != nil {
-		return nil, TraceStep{Tier: SourceFestival, Result: "error", Detail: err.Error()}
+		return nil, TraceStep{Tier: SourceFestival, Result: "error", Detail: err.Error()}, nil
 	}
 	for i := range registry.Links {
 		link := &registry.Links[i]
@@ -245,25 +258,25 @@ func resolveFestival(ctx context.Context, root, festivalID string) (*workitem.Wo
 				Tier:   SourceFestival,
 				Result: "match",
 				Detail: "via link " + link.ID + " on festival " + link.Scope.Path,
-			}
+			}, nil
 		}
 	}
-	return nil, TraceStep{Tier: SourceFestival, Result: "miss", Detail: "no festival link matches " + festivalID}
+	return nil, TraceStep{Tier: SourceFestival, Result: "miss", Detail: "no festival link matches " + festivalID}, nil
 }
 
-func resolveCurrent(ctx context.Context, root string) (*workitem.WorkItem, TraceStep) {
+func resolveCurrent(ctx context.Context, root string) (*workitem.WorkItem, TraceStep, error) {
 	cur, err := links.LoadCurrent(ctx, root)
 	if err != nil {
-		return nil, TraceStep{Tier: SourceCurrent, Result: "error", Detail: err.Error()}
+		return nil, TraceStep{Tier: SourceCurrent, Result: "error", Detail: err.Error()}, nil
 	}
 	if cur == nil {
-		return nil, TraceStep{Tier: SourceCurrent, Result: "skip", Detail: "no current.yaml"}
+		return nil, TraceStep{Tier: SourceCurrent, Result: "skip", Detail: "no current.yaml"}, nil
 	}
 	wi, err := selector.Resolve(ctx, root, cur.WorkitemID, selector.ResolveOptions{})
 	if err != nil {
-		return nil, TraceStep{Tier: SourceCurrent, Result: "error", Detail: err.Error()}
+		return nil, TraceStep{Tier: SourceCurrent, Result: "error", Detail: err.Error()}, nil
 	}
-	return wi, TraceStep{Tier: SourceCurrent, Result: "match", Detail: "via current.yaml"}
+	return wi, TraceStep{Tier: SourceCurrent, Result: "match", Detail: "via current.yaml"}, nil
 }
 
 func pathMatchesPrefix(cwdRel, scopePath string) bool {
@@ -271,6 +284,15 @@ func pathMatchesPrefix(cwdRel, scopePath string) bool {
 		return true
 	}
 	return strings.HasPrefix(cwdRel, scopePath+"/")
+}
+
+func pathOutside(root, dir string) bool {
+	rel, err := filepath.Rel(root, dir)
+	return err != nil || relOutsideRoot(rel)
+}
+
+func relOutsideRoot(rel string) bool {
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel)
 }
 
 func festivalScopeMatches(scopePath, festivalID string) bool {
@@ -301,4 +323,3 @@ func questIDOf(wi *workitem.WorkItem) string {
 	}
 	return ""
 }
-

--- a/internal/workitem/resolver/resolver.go
+++ b/internal/workitem/resolver/resolver.go
@@ -7,8 +7,6 @@ package resolver
 
 import (
 	"context"
-	"errors"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -304,10 +302,3 @@ func questIDOf(wi *workitem.WorkItem) string {
 	return ""
 }
 
-// fsExists is a tiny helper used by tests.
-func fsExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil || !errors.Is(err, fs.ErrNotExist)
-}
-
-var _ = fsExists

--- a/internal/workitem/selector/selector.go
+++ b/internal/workitem/selector/selector.go
@@ -23,11 +23,16 @@ type ResolveOptions struct {
 	AllowFuzzy bool
 }
 
+var (
+	ErrSelectorAmbiguous = camperrors.NewValidation("selector", "ambiguous", nil)
+	ErrSelectorNotFound  = camperrors.NewValidation("selector", "not found", nil)
+)
+
 // Resolve looks up a workitem by query. It returns:
 //   - the matched workitem when exactly one workitem matches the highest
 //     priority that produced any match;
-//   - a wrapped ErrAmbiguous when multiple workitems tie at that priority;
-//   - a wrapped ErrNotFound when nothing matches.
+//   - a wrapped ErrSelectorAmbiguous when multiple workitems tie at that priority;
+//   - a wrapped ErrSelectorNotFound when nothing matches.
 //
 // Resolution order:
 //  1. exact stable .workitem id
@@ -109,8 +114,8 @@ func ambiguous(query, stage string, matches []workitem.WorkItem) error {
 		keys = append(keys, m.Key)
 	}
 	sort.Strings(keys)
-	return camperrors.NewValidation("selector",
-		"selector "+query+" matched "+stage+" against multiple workitems: "+strings.Join(keys, ", "), nil)
+	return camperrors.Wrap(ErrSelectorAmbiguous,
+		"selector "+query+" matched "+stage+" against multiple workitems: "+strings.Join(keys, ", "))
 }
 
 func notFound(query string, items []workitem.WorkItem) error {
@@ -119,7 +124,7 @@ func notFound(query string, items []workitem.WorkItem) error {
 	if len(suggestions) > 0 {
 		msg += "; did you mean: " + strings.Join(suggestions, ", ")
 	}
-	return camperrors.NewValidation("selector", msg, nil)
+	return camperrors.Wrap(ErrSelectorNotFound, msg)
 }
 
 func nearMatches(query string, items []workitem.WorkItem, limit int) []string {

--- a/internal/workitem/selector/selector.go
+++ b/internal/workitem/selector/selector.go
@@ -1,0 +1,140 @@
+// Package selector resolves user-supplied workitem selector strings to a
+// concrete WorkItem. The resolution order is documented in SCHEMA.md and
+// followed strictly so CLI ergonomics stay predictable.
+package selector
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	"github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+// ResolveOptions tunes selector resolution.
+type ResolveOptions struct {
+	// AllowFuzzy enables title/key substring matching when no exact match is
+	// found. Reserved for interactive callers; commit-path resolvers should
+	// leave this false.
+	AllowFuzzy bool
+}
+
+// Resolve looks up a workitem by query. It returns:
+//   - the matched workitem when exactly one workitem matches the highest
+//     priority that produced any match;
+//   - a wrapped ErrAmbiguous when multiple workitems tie at that priority;
+//   - a wrapped ErrNotFound when nothing matches.
+//
+// Resolution order:
+//  1. exact stable .workitem id
+//  2. exact key (`<type>:<path>`)
+//  3. exact RelativePath
+//  4. exact directory-base slug
+//  5. fuzzy substring on key or title (only when opts.AllowFuzzy)
+func Resolve(ctx context.Context, root string, query string, opts ResolveOptions) (*workitem.WorkItem, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, camperrors.NewValidation("selector", "selector must not be empty", nil)
+	}
+
+	items, err := discover(ctx, root)
+	if err != nil {
+		return nil, err
+	}
+
+	type matcher struct {
+		name string
+		eq   func(workitem.WorkItem) bool
+	}
+	matchers := []matcher{
+		{"id", func(w workitem.WorkItem) bool { return w.StableID != "" && w.StableID == query }},
+		{"key", func(w workitem.WorkItem) bool { return strings.EqualFold(w.Key, query) }},
+		{"path", func(w workitem.WorkItem) bool { return w.RelativePath == strings.TrimRight(query, "/") }},
+		{"slug", func(w workitem.WorkItem) bool { return strings.EqualFold(filepath.Base(w.RelativePath), query) }},
+	}
+	for _, m := range matchers {
+		var matched []workitem.WorkItem
+		for _, item := range items {
+			if m.eq(item) {
+				matched = append(matched, item)
+			}
+		}
+		if len(matched) == 1 {
+			return &matched[0], nil
+		}
+		if len(matched) > 1 {
+			return nil, ambiguous(query, m.name, matched)
+		}
+	}
+
+	if opts.AllowFuzzy {
+		lower := strings.ToLower(query)
+		var matched []workitem.WorkItem
+		for _, item := range items {
+			if strings.Contains(strings.ToLower(item.Key), lower) ||
+				strings.Contains(strings.ToLower(item.Title), lower) {
+				matched = append(matched, item)
+			}
+		}
+		if len(matched) == 1 {
+			return &matched[0], nil
+		}
+		if len(matched) > 1 {
+			return nil, ambiguous(query, "fuzzy", matched)
+		}
+	}
+
+	return nil, notFound(query, items)
+}
+
+func discover(ctx context.Context, root string) ([]workitem.WorkItem, error) {
+	cfg, err := config.LoadCampaignConfig(ctx, root)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "load campaign config")
+	}
+	resolver := paths.NewResolverFromConfig(root, cfg)
+	return workitem.Discover(ctx, root, resolver)
+}
+
+func ambiguous(query, stage string, matches []workitem.WorkItem) error {
+	keys := make([]string, 0, len(matches))
+	for _, m := range matches {
+		keys = append(keys, m.Key)
+	}
+	sort.Strings(keys)
+	return camperrors.NewValidation("selector",
+		"selector "+query+" matched "+stage+" against multiple workitems: "+strings.Join(keys, ", "), nil)
+}
+
+func notFound(query string, items []workitem.WorkItem) error {
+	suggestions := nearMatches(query, items, 3)
+	msg := "no workitem matched selector " + query
+	if len(suggestions) > 0 {
+		msg += "; did you mean: " + strings.Join(suggestions, ", ")
+	}
+	return camperrors.NewValidation("selector", msg, nil)
+}
+
+func nearMatches(query string, items []workitem.WorkItem, limit int) []string {
+	lower := strings.ToLower(query)
+	scored := make([][2]string, 0, len(items))
+	for _, item := range items {
+		base := strings.ToLower(filepath.Base(item.RelativePath))
+		if strings.Contains(base, lower) {
+			scored = append(scored, [2]string{base, item.Key})
+		}
+	}
+	sort.Slice(scored, func(i, j int) bool { return scored[i][0] < scored[j][0] })
+	out := make([]string, 0, limit)
+	for i := 0; i < len(scored) && i < limit; i++ {
+		out = append(out, scored[i][1])
+	}
+	return out
+}

--- a/tests/integration/workitem_links_test.go
+++ b/tests/integration/workitem_links_test.go
@@ -1,0 +1,253 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const linksCampaignDir = "/test/workitem-links"
+
+func initLinksCampaign(t *testing.T, tc *TestContainer, dir string) {
+	t.Helper()
+	_, err := tc.RunCamp(
+		"init", dir,
+		"--name", "Workitem Links",
+		"--type", "product",
+		"-d", "Workitem link integration",
+		"-m", "Verify link surface",
+		"--force",
+		"--no-register",
+		"--no-git",
+	)
+	require.NoError(t, err, "camp init should succeed")
+}
+
+func seedDesignWorkitem(t *testing.T, tc *TestContainer, dir, slug string) {
+	t.Helper()
+	out, err := tc.RunCampInDir(dir, "workitem", "create", slug, "--type", "design", "--title", slug)
+	require.NoError(t, err, "workitem create: %s", out)
+}
+
+func seedProject(t *testing.T, tc *TestContainer, dir, name string) {
+	t.Helper()
+	_, _, err := tc.ExecCommand("mkdir", "-p", dir+"/projects/"+name)
+	require.NoError(t, err)
+}
+
+func TestIntegration_LinkLifecycle(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := linksCampaignDir
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "camp-timeline")
+	seedDesignWorkitem(t, tc, dir, "timeline")
+
+	out, err := tc.RunCampInDir(dir,
+		"workitem", "link", "timeline", "--project", "camp-timeline")
+	require.NoError(t, err, "workitem link: %s", out)
+	assert.Contains(t, out, "linked")
+
+	linksYAML, err := tc.ReadFile(dir + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, linksYAML, "version: workitem-links/v1alpha1")
+	assert.Contains(t, linksYAML, "projects/camp-timeline")
+
+	out, err = tc.RunCampInDir(dir, "workitem", "links")
+	require.NoError(t, err, "links: %s", out)
+	assert.Contains(t, out, "camp-timeline")
+
+	out, err = tc.RunCampInDir(dir,
+		"workitem", "unlink", "timeline", "projects/camp-timeline")
+	require.NoError(t, err, "unlink: %s", out)
+
+	out, err = tc.RunCampInDir(dir, "workitem", "links")
+	require.NoError(t, err, "links post-unlink: %s", out)
+	assert.Contains(t, out, "no links")
+}
+
+func TestIntegration_ResolverTiers(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/resolver-tiers"
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "camp-timeline")
+	seedDesignWorkitem(t, tc, dir, "timeline")
+
+	// Tier 1 (explicit): wins always.
+	out, err := tc.RunCampInDir(dir,
+		"workitem", "resolve", "--workitem", "timeline", "--json")
+	require.NoError(t, err, "resolve --workitem: %s", out)
+	src, _ := extractResolveSource(t, out)
+	assert.Equal(t, "explicit", src, "explicit tier should win")
+
+	// Tier 2 (ancestor): cd into workitem directory.
+	out, err = tc.RunCampInDir(dir+"/workflow/design/timeline",
+		"workitem", "resolve", "--json")
+	require.NoError(t, err)
+	src, _ = extractResolveSource(t, out)
+	assert.Equal(t, "ancestor", src)
+
+	// Tier 3 (link): create a link, cd into linked project.
+	_, err = tc.RunCampInDir(dir,
+		"workitem", "link", "timeline", "--project", "camp-timeline")
+	require.NoError(t, err)
+	out, err = tc.RunCampInDir(dir+"/projects/camp-timeline",
+		"workitem", "resolve", "--json")
+	require.NoError(t, err)
+	src, _ = extractResolveSource(t, out)
+	assert.Equal(t, "link", src)
+
+	// Tier 4 (festival): seed festival dir + festival-scoped link.
+	_, _, err = tc.ExecCommand("mkdir", "-p", dir+"/festivals/active/CT0001")
+	require.NoError(t, err)
+	_, err = tc.RunCampInDir(dir,
+		"workitem", "link", "timeline", "--festival", "CT0001")
+	require.NoError(t, err)
+	out, err = tc.RunCampInDir(dir,
+		"workitem", "resolve", "--festival", "CT0001", "--json")
+	require.NoError(t, err)
+	src, _ = extractResolveSource(t, out)
+	assert.Equal(t, "festival", src, "festival tier should win when explicit/ancestor/link miss")
+
+	// Tier 5 (current): clear other links, set current, resolve from docs/.
+	_, err = tc.RunCampInDir(dir, "workitem", "unlink", "timeline", "--all")
+	require.NoError(t, err)
+	_, err = tc.RunCampInDir(dir, "workitem", "current", "timeline")
+	require.NoError(t, err)
+	_, _, err = tc.ExecCommand("mkdir", "-p", dir+"/docs")
+	require.NoError(t, err)
+	out, err = tc.RunCampInDir(dir+"/docs", "workitem", "resolve", "--json")
+	require.NoError(t, err)
+	src, _ = extractResolveSource(t, out)
+	assert.Equal(t, "current", src)
+
+	// Tier 6 (none): clear current.
+	_, err = tc.RunCampInDir(dir, "workitem", "current", "--clear")
+	require.NoError(t, err)
+	out, err = tc.RunCampInDir(dir+"/docs", "workitem", "resolve", "--json")
+	require.NoError(t, err)
+	src, _ = extractResolveSource(t, out)
+	assert.Equal(t, "none", src)
+}
+
+func TestIntegration_ResolverQuestID(t *testing.T) {
+	// quest_id propagation lands in sequence 03 task 01. Until then the
+	// .workitem file has no quest_id field, so the resolver returns empty.
+	// Keep the test as a placeholder so the contract reappears once the
+	// dependency ships.
+	t.Skip("quest_id field on .workitem is delivered by sequence 03 task 01")
+}
+
+func TestIntegration_DoctorBrokenLinks(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/doctor-broken"
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "camp-timeline")
+	seedDesignWorkitem(t, tc, dir, "timeline")
+	_, err := tc.RunCampInDir(dir,
+		"workitem", "link", "timeline", "--project", "camp-timeline")
+	require.NoError(t, err)
+
+	// 1. Delete the workitem -> broken-link.
+	_, _, err = tc.ExecCommand("rm", "-rf", dir+"/workflow/design/timeline")
+	require.NoError(t, err)
+	out, err := tc.RunCampInDir(dir, "workitem", "doctor")
+	require.Error(t, err, "doctor must exit non-zero on errors: %s", out)
+	assert.Contains(t, out, "workitem.link.broken")
+
+	// 2. Replace scope.path with ../escape -> out-of-bounds via schema-violation.
+	_, _, err = tc.ExecCommand("sh", "-c",
+		"sed -i 's|projects/camp-timeline|../escape|' "+dir+"/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	out, _ = tc.RunCampInDir(dir, "workitem", "doctor")
+	// Note: doctor surfaces either out-of-bounds or schema.violation depending on
+	// which validator catches it first; assert at least one of them is present.
+	assert.True(t,
+		strings.Contains(out, "workitem.scope.out-of-bounds") || strings.Contains(out, "workitem.schema.violation"),
+		"expected out-of-bounds or schema violation finding in: %s", out)
+
+	// 3. Corrupt YAML -> error from Load surfaces via wrapped error (not a
+	// finding — the registry won't load at all).
+	require.NoError(t, tc.WriteFile(dir+"/.campaign/workitems/links.yaml", "not: yaml: ::\n"))
+	out, err = tc.RunCampInDir(dir, "workitem", "doctor")
+	require.Error(t, err, "corrupt YAML must error: %s", out)
+
+	// 4. Rebuild a valid registry and add a duplicate primary by hand.
+	require.NoError(t, tc.WriteFile(dir+"/.campaign/workitems/links.yaml", `version: workitem-links/v1alpha1
+links:
+  - id: lnk_20260524_aaaaaa
+    workitem_id: design-timeline-2026-05-24
+    workitem_key: design:workflow/design/timeline
+    scope:
+      kind: project
+      path: projects/camp-timeline
+    role: primary
+    created_at: 2026-05-24T19:00:00Z
+    created_by: test
+  - id: lnk_20260524_bbbbbb
+    workitem_id: design-other-2026-05-24
+    workitem_key: design:workflow/design/other
+    scope:
+      kind: project
+      path: projects/camp-timeline
+    role: primary
+    created_at: 2026-05-24T19:01:00Z
+    created_by: test
+`))
+	out, err = tc.RunCampInDir(dir, "workitem", "doctor")
+	require.Error(t, err)
+	assert.Contains(t, out, "workitem.link.duplicate-primary")
+
+	// 5. stale-quest-id requires the quest_id field shipped by sequence 03;
+	// this assertion is deferred to that sequence's integration tests.
+}
+
+func TestIntegration_DoctorFix(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/doctor-fix"
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "camp-timeline")
+	seedDesignWorkitem(t, tc, dir, "timeline")
+	_, err := tc.RunCampInDir(dir,
+		"workitem", "link", "timeline", "--project", "camp-timeline")
+	require.NoError(t, err)
+
+	// Orphan the workitem.
+	_, _, err = tc.ExecCommand("rm", "-rf", dir+"/workflow/design/timeline")
+	require.NoError(t, err)
+
+	// Pre-fix: doctor reports broken-link and exits non-zero.
+	_, err = tc.RunCampInDir(dir, "workitem", "doctor")
+	require.Error(t, err)
+
+	// Fix: should clear the orphan link.
+	out, err := tc.RunCampInDir(dir, "workitem", "doctor", "--fix")
+	require.NoError(t, err, "doctor --fix should clear: %s", out)
+
+	// Re-run: doctor should be clean.
+	out, err = tc.RunCampInDir(dir, "workitem", "doctor")
+	require.NoError(t, err, "post-fix doctor should be clean: %s", out)
+
+	// Links file no longer references the orphan.
+	linksYAML, err := tc.ReadFile(dir + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.NotContains(t, linksYAML, "timeline")
+}
+
+// extractResolveSource pulls .resolution.source out of a resolve --json
+// payload. Returns the source string and the full resolution payload for
+// downstream assertions.
+func extractResolveSource(t *testing.T, raw string) (string, map[string]any) {
+	t.Helper()
+	var envelope struct {
+		Resolution map[string]any `json:"resolution"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(raw), &envelope), "raw=%s", raw)
+	src, _ := envelope.Resolution["source"].(string)
+	return src, envelope.Resolution
+}


### PR DESCRIPTION
## Summary

Sequence 02 of the CW0003 festival. Ships the v1alpha1 workitem link registry and the user-facing command surface that consumes it. Branch-of-origin/main, independent of sequence 01 (PR #302).

### What lands

- **`internal/workitem/links/SCHEMA.md`** — frozen v1alpha1 contract. `links.yaml` and `current.yaml` schemas, scope kinds, roles, six-tier resolution priority, safety bounds, validation rules, link ID format, migration policy, and the quest cross-reference. Two example fixtures under `testdata/`.
- **`internal/workitem/links/`** — typed registry with `Load`, `Save`, `LoadCurrent`, `SaveCurrent`, `AddLink/RemoveLinkByID/FindByID/FindByScope/PrimaryForScope/Sort`, and `Validate`. YAML round-trip is byte-stable; saves are atomic under a cross-platform O_CREATE|O_EXCL file lock with a 5s timeout. Reuses `internal/quest/link.go::ValidateLinkPath` for campaign-root containment (no parallel implementation).
- **`internal/workitem/selector/`** — selector resolver. Order: stable `.workitem` id → key (`<type>:<path>`) → relative path → directory slug → optional fuzzy. Returns wrapped validation errors with candidate lists on ambiguity and near-match suggestions on not-found.
- **`internal/workitem/resolver/`** — deterministic six-tier context resolver (`explicit` → `ancestor` → `link` → `festival` → `current` → `none`) used by `camp workitem resolve` and the sequence-03 commit wrappers. Carries a per-tier `Trace[]` for `--json --explain` debugging and a `QuestID` field that stays empty until sequence 03 plumbs it.
- **CLI surface** under `internal/commands/workitem/`:
  - `camp workitem link <selector> [path]` with `--project`, `--festival`, `--worktree`, `--cwd`, `--role`, `--replace`, `--allow-missing`, `--json`
  - `camp workitem unlink` with `--id`, scope filters, and `--all`
  - `camp workitem links [selector]` with table + `--json`
  - `camp workitem current [selector] | --clear` with `--json`
  - `camp workitem resolve [--workitem] [--festival] [--json] [--explain]`
  - `camp workitem doctor [--json] [--fix]` reporting `workitem.link.broken`, `workitem.scope.broken`, `workitem.scope.out-of-bounds`, `workitem.link.duplicate-primary`, `workitem.schema.violation`, `workitem.current.missing`

## Test plan

- [x] `go test ./...` clean across the camp module
- [x] Unit coverage: `internal/workitem/links` 75.6%, `internal/commands/workitem` 39.3% (workitem command surface includes pre-existing TUI code not covered by these tests)
- [x] Round-trip and validation: every fixture loads, saves, reloads byte-identical; 100-iteration random round-trip; every SCHEMA.md §9 rule has positive + negative cases; 2-goroutine concurrent save preserves file integrity
- [x] Resolver: every tier exercised, ancestor-beats-link precedence verified, JSON shape asserted
- [x] Doctor: every finding code triggered, `--fix` round-trip verified
- [x] Containerized integration tests pass (`just test integration-run TestIntegration_LinkLifecycle | TestIntegration_Resolver | TestIntegration_Doctor`)

## Notes for reviewers

- `TestIntegration_ResolverQuestID` and the `stale-quest-id` doctor check are intentionally skipped/deferred. They depend on sequence 03 task 01 adding `quest_id` to the `.workitem` schema; the test files keep the contracts in place so they reappear once the dependency lands.
- `SCHEMA.md` §13 lists the open questions tracked out of this sequence (stable cross-machine `created_by` identity, time-based expiry, quest-link auto-mirror).
- `current.yaml` is meant to be gitignored. The gitignore policy is documented in §1.1; the actual `camp init` `.gitignore` template update is deferred to sequence 03 (it touches the same template).