### PR TITLE
feat(workitem): ref + quest_id schema, doctor backfill, tag composition (CW0003 slice 3 part 1)

### DIFF
--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -169,7 +169,8 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	if commitAutoWrite {
 		fmt.Println(ui.Info("Writing commit message..."))
 		var hookErr error
-		message, hookErr = commitkit.AutoWriteCommitMessage(ctx, campRoot, target.Path)
+		extraEnv := workitemEnvForCommit(ctx, campRoot, commitWorkitem)
+		message, hookErr = commitkit.AutoWriteCommitMessageWithEnv(ctx, campRoot, target.Path, extraEnv)
 		if hookErr != nil {
 			return hookErr
 		}

--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -48,6 +48,7 @@ var (
 	commitProject     string
 	commitIncludeRefs bool
 	commitAutoWrite   bool
+	commitWorkitem    string
 )
 
 func init() {
@@ -58,6 +59,7 @@ func init() {
 	commitCmd.Flags().StringVarP(&commitProject, "project", "p", "", "Operate on a specific project/submodule path")
 	commitCmd.Flags().BoolVar(&commitIncludeRefs, "include-refs", false, "Include submodule ref changes when staging at campaign root")
 	commitCmd.Flags().BoolVar(&commitAutoWrite, "auto-write", false, "Run configured commit message writer")
+	commitCmd.Flags().StringVar(&commitWorkitem, "workitem", "", "explicit workitem selector for the commit tag (overrides cwd-based resolution)")
 
 	rootCmd.AddCommand(commitCmd)
 	commitCmd.GroupID = "git"
@@ -173,9 +175,12 @@ func runCommit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Prepend campaign tag (graceful degradation if config unavailable)
+	// Prepend campaign tag (graceful degradation if config unavailable).
+	// Resolves the active workitem (and any captured quest) so the tag
+	// includes WI-<ref> when one is in context.
 	if cfg, cfgErr := config.LoadCampaignConfig(ctx, campRoot); cfgErr == nil {
-		message = git.PrependCampaignTag(cfg.ID, message)
+		questID, workitemRef := resolveCommitContext(ctx, campRoot, commitWorkitem)
+		message = commitkit.PrependContextTagsFull(cfg.ID, questID, "", workitemRef, message)
 	}
 
 	// Perform commit

--- a/cmd/camp/commit_workitem.go
+++ b/cmd/camp/commit_workitem.go
@@ -5,6 +5,7 @@ import (
 
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
 )
 
 // resolveCommitContext runs the workitem resolver against the campaign root
@@ -34,4 +35,17 @@ func workitemRefFor(wi *wkitem.WorkItem) string {
 		return v
 	}
 	return ""
+}
+
+// workitemEnvForCommit resolves the active workitem and returns the
+// CAMP_WORKITEM_* env vars for the auto-write hook. Returns nil when no
+// workitem context resolves so the hook sees no leaked vars.
+func workitemEnvForCommit(ctx context.Context, campaignRoot, explicit string) []string {
+	res, err := resolver.Resolve(ctx, campaignRoot, resolver.Options{
+		Explicit: explicit,
+	})
+	if err != nil || res == nil || res.Workitem == nil {
+		return nil
+	}
+	return commitkit.WorkitemEnv(res.Workitem, campaignRoot)
 }

--- a/cmd/camp/commit_workitem.go
+++ b/cmd/camp/commit_workitem.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
+)
+
+// resolveCommitContext runs the workitem resolver against the campaign root
+// and returns the captured quest id and ref for inclusion in the commit
+// tag. Resolution failures are non-fatal: empty strings are returned so the
+// caller can still produce a quest- and workitem-free tag.
+//
+// explicit, when non-empty, is the user-supplied --workitem selector.
+func resolveCommitContext(ctx context.Context, campaignRoot, explicit string) (questID, workitemRef string) {
+	res, err := resolver.Resolve(ctx, campaignRoot, resolver.Options{
+		Explicit: explicit,
+	})
+	if err != nil || res == nil || res.Workitem == nil {
+		return "", ""
+	}
+	return res.QuestID, workitemRefFor(res.Workitem)
+}
+
+// workitemRefFor returns the ref carried on the resolved workitem's
+// SourceMetadata, or empty if none was captured (e.g. v1alpha5 workitems
+// that have not yet been backfilled).
+func workitemRefFor(wi *wkitem.WorkItem) string {
+	if wi == nil || wi.SourceMetadata == nil {
+		return ""
+	}
+	if v, ok := wi.SourceMetadata["ref"].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/cmd/camp/commit_workitem_test.go
+++ b/cmd/camp/commit_workitem_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+func TestWorkitemRefFor_HandlesNilAndEmpty(t *testing.T) {
+	if got := workitemRefFor(nil); got != "" {
+		t.Fatalf("nil workitem: got %q, want empty", got)
+	}
+	if got := workitemRefFor(&workitem.WorkItem{}); got != "" {
+		t.Fatalf("empty SourceMetadata: got %q, want empty", got)
+	}
+	wi := &workitem.WorkItem{
+		SourceMetadata: map[string]any{"ref": "WI-abcdef"},
+	}
+	if got := workitemRefFor(wi); got != "WI-abcdef" {
+		t.Fatalf("got %q, want WI-abcdef", got)
+	}
+}
+
+func TestResolveCommitContext_GracefulOutsideCampaign(t *testing.T) {
+	tmp := t.TempDir()
+	// Set a working directory outside any campaign so the resolver returns
+	// (none, none).
+	cur, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(cur) }()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	questID, ref := resolveCommitContext(context.Background(), filepath.Join(tmp, "no-campaign"), "")
+	if questID != "" || ref != "" {
+		t.Fatalf("expected empty strings for non-campaign root, got quest=%q ref=%q", questID, ref)
+	}
+}

--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -42,6 +42,7 @@ var (
 	projectCommitAmend     bool
 	projectCommitSync      bool
 	projectCommitAutoWrite bool
+	projectCommitWorkitem  string
 )
 
 func init() {
@@ -51,6 +52,7 @@ func init() {
 	projectCommitCmd.Flags().BoolVar(&projectCommitAmend, "amend", false, "Amend the previous commit")
 	projectCommitCmd.Flags().BoolVar(&projectCommitSync, "sync", false, "Sync submodule ref at campaign root after commit (opt-in)")
 	projectCommitCmd.Flags().BoolVar(&projectCommitAutoWrite, "auto-write", false, "Run configured commit message writer")
+	projectCommitCmd.Flags().StringVar(&projectCommitWorkitem, "workitem", "", "explicit workitem selector for the commit tag (overrides cwd-based resolution)")
 
 	if err := projectCommitCmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjectName); err != nil {
 		panic(err)
@@ -147,9 +149,12 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Prepend campaign tag (graceful degradation if config unavailable)
+	// Prepend campaign tag (graceful degradation if config unavailable).
+	// Resolves the active workitem so the tag includes WI-<ref> when the
+	// project is linked.
 	if cfg != nil {
-		message = git.PrependCampaignTag(cfg.ID, message)
+		questID, workitemRef := resolveProjectCommitContext(ctx, campRoot, projectCommitWorkitem)
+		message = commitkit.PrependContextTagsFull(cfg.ID, questID, "", workitemRef, message)
 	}
 
 	// Commit

--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -143,7 +143,8 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 	if projectCommitAutoWrite {
 		fmt.Println(ui.Info("Writing commit message..."))
 		var hookErr error
-		message, hookErr = commitkit.AutoWriteCommitMessage(ctx, campRoot, resolvedPath)
+		extraEnv := workitemEnvForProjectCommit(ctx, campRoot, projectCommitWorkitem)
+		message, hookErr = commitkit.AutoWriteCommitMessageWithEnv(ctx, campRoot, resolvedPath, extraEnv)
 		if hookErr != nil {
 			return hookErr
 		}

--- a/cmd/camp/project/commit_workitem.go
+++ b/cmd/camp/project/commit_workitem.go
@@ -1,0 +1,35 @@
+package project
+
+import (
+	"context"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
+)
+
+// resolveProjectCommitContext runs the workitem resolver against the
+// campaign root and returns the captured quest id and ref for inclusion in
+// the project-commit tag. Resolution failures are non-fatal: empty strings
+// are returned so callers can still produce a quest- and workitem-free tag.
+//
+// explicit, when non-empty, is the user-supplied --workitem selector and
+// short-circuits the cwd-based resolution.
+func resolveProjectCommitContext(ctx context.Context, campaignRoot, explicit string) (questID, workitemRef string) {
+	res, err := resolver.Resolve(ctx, campaignRoot, resolver.Options{
+		Explicit: explicit,
+	})
+	if err != nil || res == nil || res.Workitem == nil {
+		return "", ""
+	}
+	return res.QuestID, workitemRefFor(res.Workitem)
+}
+
+func workitemRefFor(wi *wkitem.WorkItem) string {
+	if wi == nil || wi.SourceMetadata == nil {
+		return ""
+	}
+	if v, ok := wi.SourceMetadata["ref"].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/cmd/camp/project/commit_workitem.go
+++ b/cmd/camp/project/commit_workitem.go
@@ -5,6 +5,7 @@ import (
 
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
 )
 
 // resolveProjectCommitContext runs the workitem resolver against the
@@ -32,4 +33,17 @@ func workitemRefFor(wi *wkitem.WorkItem) string {
 		return v
 	}
 	return ""
+}
+
+// workitemEnvForProjectCommit resolves the active workitem and returns the
+// CAMP_WORKITEM_* env vars for the auto-write hook. Returns nil when no
+// workitem context resolves.
+func workitemEnvForProjectCommit(ctx context.Context, campaignRoot, explicit string) []string {
+	res, err := resolver.Resolve(ctx, campaignRoot, resolver.Options{
+		Explicit: explicit,
+	})
+	if err != nil || res == nil || res.Workitem == nil {
+		return nil
+	}
+	return commitkit.WorkitemEnv(res.Workitem, campaignRoot)
 }

--- a/internal/commands/workitem/adopt.go
+++ b/internal/commands/workitem/adopt.go
@@ -15,28 +15,29 @@ import (
 )
 
 func newAdoptCommand() *cobra.Command {
-	var typeFlag, title, idOverride string
+	var typeFlag, title, idOverride, questSelector string
 	cmd := &cobra.Command{
 		Use:   "adopt <dir>",
 		Short: "Attach .workitem metadata to an existing directory",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			return runAdopt(ctx, cmd, args[0], typeFlag, title, idOverride)
+			return runAdopt(ctx, cmd, args[0], typeFlag, title, idOverride, questSelector)
 		},
 	}
 	cmd.Flags().StringVar(&typeFlag, "type", "feature", "workitem type (feature, bug, chore, or custom)")
 	cmd.Flags().StringVar(&title, "title", "", "human-readable title")
 	cmd.Flags().StringVar(&idOverride, "id", "", "override the generated id")
+	cmd.Flags().StringVar(&questSelector, "quest", "", "capture quest_id from this quest (defaults to CAMP_QUEST env var if set)")
 	return cmd
 }
 
-func runAdopt(ctx context.Context, cmd *cobra.Command, dir, typeFlag, title, idOverride string) error {
+func runAdopt(ctx context.Context, cmd *cobra.Command, dir, typeFlag, title, idOverride, questSelector string) error {
 	if err := validateSlug(typeFlag); err != nil {
 		return camperrors.NewValidation("type", "invalid type slug: "+err.Error(), nil)
 	}
 
-	_, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
 	if err != nil {
 		return camperrors.Wrap(err, "not in a campaign directory")
 	}
@@ -74,12 +75,20 @@ func runAdopt(ctx context.Context, cmd *cobra.Command, dir, typeFlag, title, idO
 		return err
 	}
 
+	ref, err := deriveUniqueRef(ctx, campaignRoot, cfg, id)
+	if err != nil {
+		return err
+	}
+	questID := resolveQuestIDForCreate(ctx, cmd, campaignRoot, questSelector)
+
 	meta := wkitem.Metadata{
 		Version: wkitem.WorkitemSchemaVersion,
 		Kind:    "workitem",
 		ID:      id,
 		Type:    typeFlag,
 		Title:   title,
+		Ref:     ref,
+		QuestID: questID,
 	}
 	buf, err := yaml.Marshal(&meta)
 	if err != nil {
@@ -92,8 +101,12 @@ func runAdopt(ctx context.Context, cmd *cobra.Command, dir, typeFlag, title, idO
 	// workflow/type parent mtime watched by passive cache staleness checks.
 	invalidateNavigationCache(cmd, campaignRoot)
 
+	questLine := ""
+	if questID != "" {
+		questLine = fmt.Sprintf("  quest: %s\n", questID)
+	}
 	fmt.Fprintf(cmd.OutOrStdout(),
-		"adopted %s\n  id: %s\n  type: %s\n",
-		rel, id, typeFlag)
+		"adopted %s\n  id: %s\n  ref: %s\n  type: %s\n%s",
+		rel, id, ref, typeFlag, questLine)
 	return nil
 }

--- a/internal/commands/workitem/create.go
+++ b/internal/commands/workitem/create.go
@@ -21,24 +21,25 @@ import (
 )
 
 func newCreateCommand() *cobra.Command {
-	var typeFlag, title, idOverride, dirOverride string
+	var typeFlag, title, idOverride, dirOverride, questSelector string
 	cmd := &cobra.Command{
 		Use:   "create <slug>",
 		Short: "Create a new workitem with v1 minimum metadata",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			return runCreate(ctx, cmd, args[0], typeFlag, title, idOverride, dirOverride)
+			return runCreate(ctx, cmd, args[0], typeFlag, title, idOverride, dirOverride, questSelector)
 		},
 	}
 	cmd.Flags().StringVar(&typeFlag, "type", "feature", "workitem type (feature, bug, chore, or custom)")
 	cmd.Flags().StringVar(&title, "title", "", "human-readable title")
 	cmd.Flags().StringVar(&idOverride, "id", "", "override the generated id")
 	cmd.Flags().StringVar(&dirOverride, "dir", "", "parent dir override (default: workflow/<type>)")
+	cmd.Flags().StringVar(&questSelector, "quest", "", "capture quest_id from this quest (defaults to CAMP_QUEST env var if set)")
 	return cmd
 }
 
-func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, idOverride, dirOverride string) error {
+func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, idOverride, dirOverride, questSelector string) error {
 	if err := validateSlug(slug); err != nil {
 		return err
 	}
@@ -46,7 +47,7 @@ func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, i
 		return camperrors.NewValidation("type", "invalid type slug: "+err.Error(), nil)
 	}
 
-	_, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
 	if err != nil {
 		return camperrors.Wrap(err, "not in a campaign directory")
 	}
@@ -73,12 +74,20 @@ func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, i
 		return camperrors.Wrap(err, "create directory")
 	}
 
+	ref, err := deriveUniqueRef(ctx, campaignRoot, cfg, id)
+	if err != nil {
+		return err
+	}
+	questID := resolveQuestIDForCreate(ctx, cmd, campaignRoot, questSelector)
+
 	meta := wkitem.Metadata{
 		Version: wkitem.WorkitemSchemaVersion,
 		Kind:    "workitem",
 		ID:      id,
 		Type:    typeFlag,
 		Title:   title,
+		Ref:     ref,
+		QuestID: questID,
 	}
 	buf, err := yaml.Marshal(&meta)
 	if err != nil {
@@ -90,9 +99,13 @@ func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, i
 	invalidateNavigationCache(cmd, campaignRoot)
 
 	rel := filepath.Join(parent, slug)
+	questLine := ""
+	if questID != "" {
+		questLine = fmt.Sprintf("  quest: %s\n", questID)
+	}
 	fmt.Fprintf(cmd.OutOrStdout(),
-		"created %s\n  id: %s\n  type: %s\nnext: cd %s && fest create workflow %s\n",
-		rel, id, typeFlag, rel, slug)
+		"created %s\n  id: %s\n  ref: %s\n  type: %s\n%snext: cd %s && fest create workflow %s\n",
+		rel, id, ref, typeFlag, questLine, rel, slug)
 	return nil
 }
 

--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -34,6 +34,7 @@ const (
 	codeSchemaViolation    = "workitem.schema.violation"
 	codeCurrentMissing     = "workitem.current.missing"
 	codeMissingRefField    = "workitem.ref.missing"
+	codeWorkitemScanFailed = "workitem.scan.failed"
 )
 
 const (
@@ -89,7 +90,7 @@ func runDoctor(ctx context.Context, cmd *cobra.Command, jsonOut, fix bool) error
 
 	findings := collectWorkitemFindings(ctx, root, registry, knownIDs)
 	if fix {
-		applied := autoFixWorkitemFindings(ctx, root, registry, findings)
+		applied := autoFixWorkitemFindings(ctx, root, registry, findings, cmd.ErrOrStderr())
 		if applied > 0 {
 			if err := links.Save(ctx, root, registry); err != nil {
 				return err
@@ -190,7 +191,14 @@ func collectWorkitemFindings(ctx context.Context, root string, registry *links.L
 	// the order in which DeriveUnique fills collisions during --fix is
 	// deterministic.
 	missingRefPaths, err := workitemPathsMissingRef(ctx, root)
-	if err == nil {
+	if err != nil {
+		findings = append(findings, docFinding{
+			Code:     codeWorkitemScanFailed,
+			Severity: docSeverityError,
+			Target:   "workitem-tree",
+			Message:  "could not scan workitems for ref backfill: " + err.Error(),
+		})
+	} else {
 		for _, rel := range missingRefPaths {
 			findings = append(findings, docFinding{
 				Code:        codeMissingRefField,
@@ -226,8 +234,9 @@ func collectWorkitemFindings(ctx context.Context, root string, registry *links.L
 	return findings
 }
 
-func autoFixWorkitemFindings(ctx context.Context, root string, registry *links.Links, findings []docFinding) int {
+func autoFixWorkitemFindings(ctx context.Context, root string, registry *links.Links, findings []docFinding, errw io.Writer) int {
 	applied := 0
+	needsRefBackfill := false
 	for _, f := range findings {
 		if !f.AutoFixable {
 			continue
@@ -243,10 +252,15 @@ func autoFixWorkitemFindings(ctx context.Context, root string, registry *links.L
 				applied++
 			}
 		case codeMissingRefField:
-			rel := strings.TrimPrefix(f.Target, "workitem:")
-			if backfillRef(ctx, root, rel) == nil {
-				applied++
-			}
+			needsRefBackfill = true
+		}
+	}
+	if needsRefBackfill {
+		n, err := backfillMissingRefs(ctx, root)
+		applied += n
+		if err != nil {
+			fmt.Fprintf(errw, "warning: backfill refs: %v\n", err)
+			return applied
 		}
 	}
 	return applied

--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -33,6 +33,7 @@ const (
 	codeDuplicatePrimary   = "workitem.link.duplicate-primary"
 	codeSchemaViolation    = "workitem.schema.violation"
 	codeCurrentMissing     = "workitem.current.missing"
+	codeMissingRefField    = "workitem.ref.missing"
 )
 
 const (
@@ -185,6 +186,23 @@ func collectWorkitemFindings(ctx context.Context, root string, registry *links.L
 		}
 	}
 
+	// Workitems missing the ref field added in v1alpha6. Sorted by path so
+	// the order in which DeriveUnique fills collisions during --fix is
+	// deterministic.
+	missingRefPaths, err := workitemPathsMissingRef(ctx, root)
+	if err == nil {
+		for _, rel := range missingRefPaths {
+			findings = append(findings, docFinding{
+				Code:        codeMissingRefField,
+				Severity:    docSeverityWarning,
+				Target:      "workitem:" + rel,
+				Message:     "workitem at " + rel + " is missing the ref field added in v1alpha6",
+				FixHint:     "run camp workitem doctor --fix to backfill",
+				AutoFixable: true,
+			})
+		}
+	}
+
 	cur, err := links.LoadCurrent(ctx, root)
 	if err == nil && cur != nil {
 		if _, known := knownIDs[cur.WorkitemID]; !known {
@@ -222,6 +240,11 @@ func autoFixWorkitemFindings(ctx context.Context, root string, registry *links.L
 			}
 		case codeCurrentMissing:
 			if err := links.SaveCurrent(ctx, root, nil); err == nil {
+				applied++
+			}
+		case codeMissingRefField:
+			rel := strings.TrimPrefix(f.Target, "workitem:")
+			if backfillRef(ctx, root, rel) == nil {
 				applied++
 			}
 		}

--- a/internal/commands/workitem/doctor_ref_backfill.go
+++ b/internal/commands/workitem/doctor_ref_backfill.go
@@ -1,0 +1,167 @@
+package workitem
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+// workitemPathsMissingRef discovers every workitem on disk and returns the
+// campaign-relative paths to those whose .workitem marker has no ref field.
+// Paths are sorted lexicographically so DeriveUnique's collision retry has
+// deterministic input ordering during a doctor --fix pass.
+func workitemPathsMissingRef(ctx context.Context, root string) ([]string, error) {
+	cfg, err := config.LoadCampaignConfig(ctx, root)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "load campaign config")
+	}
+	resolver := paths.NewResolverFromConfig(root, cfg)
+	items, err := wkitem.Discover(ctx, root, resolver)
+	if err != nil {
+		return nil, err
+	}
+	var missing []string
+	for _, item := range items {
+		ref, _ := item.SourceMetadata["ref"].(string)
+		if ref != "" {
+			continue
+		}
+		missing = append(missing, item.RelativePath)
+	}
+	sort.Strings(missing)
+	return missing, nil
+}
+
+// backfillRef rewrites the .workitem at relPath to include a derived ref
+// field, computed via DeriveUnique against every other workitem's existing
+// ref (rescanned fresh to avoid stale snapshots in long-running doctor
+// passes). All other fields and YAML key order are preserved by mutating
+// only the parsed mapping in place.
+func backfillRef(ctx context.Context, root, relPath string) error {
+	abs := filepath.Join(root, filepath.FromSlash(relPath), wkitem.MetadataFilename)
+	raw, err := os.ReadFile(abs)
+	if err != nil {
+		return camperrors.Wrapf(err, "read %s", abs)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return camperrors.Wrapf(err, "parse %s", abs)
+	}
+
+	id, ok := lookupScalar(&doc, "id")
+	if !ok {
+		return camperrors.NewValidation("id", "missing id in "+abs, nil)
+	}
+	if existing, ok := lookupScalar(&doc, "ref"); ok && existing != "" {
+		// Another concurrent process already filled it in. No-op.
+		return nil
+	}
+
+	existingRefs, err := refsExcludingPath(ctx, root, relPath)
+	if err != nil {
+		return err
+	}
+	ref := wkitem.DeriveUnique(id, existingRefs)
+
+	if err := insertScalarAfter(&doc, "id", "ref", ref); err != nil {
+		return err
+	}
+
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return camperrors.Wrap(err, "marshal updated workitem")
+	}
+	return fsutil.WriteFileAtomically(abs, out, 0o644)
+}
+
+func refsExcludingPath(ctx context.Context, root, skipRel string) (map[string]bool, error) {
+	cfg, err := config.LoadCampaignConfig(ctx, root)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "load campaign config")
+	}
+	resolver := paths.NewResolverFromConfig(root, cfg)
+	items, err := wkitem.Discover(ctx, root, resolver)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]bool, len(items))
+	for _, item := range items {
+		if item.RelativePath == skipRel {
+			continue
+		}
+		ref, _ := item.SourceMetadata["ref"].(string)
+		if ref != "" {
+			out[ref] = true
+		}
+	}
+	return out, nil
+}
+
+// lookupScalar finds the scalar value of `key` in a top-level mapping
+// document. Returns (value, true) on hit; ("", false) when the document is
+// not a mapping or the key is absent.
+func lookupScalar(doc *yaml.Node, key string) (string, bool) {
+	root := mappingRoot(doc)
+	if root == nil {
+		return "", false
+	}
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		k := root.Content[i]
+		v := root.Content[i+1]
+		if k.Kind == yaml.ScalarNode && k.Value == key && v.Kind == yaml.ScalarNode {
+			return v.Value, true
+		}
+	}
+	return "", false
+}
+
+// insertScalarAfter inserts {key: value} immediately after the mapping pair
+// whose key equals `after`. If `after` is missing, the new pair is appended
+// at the end. This keeps the on-disk diff minimal for backfills.
+func insertScalarAfter(doc *yaml.Node, after, key, value string) error {
+	root := mappingRoot(doc)
+	if root == nil {
+		return camperrors.NewValidation("doc", "top-level YAML is not a mapping", nil)
+	}
+	insertAt := len(root.Content)
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		k := root.Content[i]
+		if k.Kind == yaml.ScalarNode && k.Value == after {
+			insertAt = i + 2
+			break
+		}
+	}
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
+	valueNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+
+	updated := make([]*yaml.Node, 0, len(root.Content)+2)
+	updated = append(updated, root.Content[:insertAt]...)
+	updated = append(updated, keyNode, valueNode)
+	updated = append(updated, root.Content[insertAt:]...)
+	root.Content = updated
+	return nil
+}
+
+func mappingRoot(doc *yaml.Node) *yaml.Node {
+	if doc == nil {
+		return nil
+	}
+	root := doc
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
+		root = root.Content[0]
+	}
+	if root.Kind != yaml.MappingNode {
+		return nil
+	}
+	return root
+}

--- a/internal/commands/workitem/doctor_ref_backfill.go
+++ b/internal/commands/workitem/doctor_ref_backfill.go
@@ -42,12 +42,76 @@ func workitemPathsMissingRef(ctx context.Context, root string) ([]string, error)
 }
 
 // backfillRef rewrites the .workitem at relPath to include a derived ref
-// field, computed via DeriveUnique against every other workitem's existing
-// ref (rescanned fresh to avoid stale snapshots in long-running doctor
-// passes). All other fields and YAML key order are preserved by mutating
-// only the parsed mapping in place.
+// field. All other fields and YAML key order are preserved by mutating only
+// the parsed mapping in place.
 func backfillRef(ctx context.Context, root, relPath string) error {
+	existingRefs, err := refsExcludingPath(ctx, root, relPath)
+	if err != nil {
+		return err
+	}
+	id, err := workitemIDAtPath(root, relPath)
+	if err != nil {
+		return err
+	}
+	ref, err := wkitem.DeriveUnique(ctx, id, existingRefs)
+	if err != nil {
+		return err
+	}
+	return backfillRefWithRef(ctx, root, relPath, ref)
+}
+
+func backfillMissingRefs(ctx context.Context, root string) (int, error) {
+	cfg, err := config.LoadCampaignConfig(ctx, root)
+	if err != nil {
+		return 0, camperrors.Wrap(err, "load campaign config")
+	}
+	resolver := paths.NewResolverFromConfig(root, cfg)
+	items, err := wkitem.Discover(ctx, root, resolver)
+	if err != nil {
+		return 0, err
+	}
+
+	existingRefs := make(map[string]bool, len(items))
+	var pending []wkitem.WorkItem
+	for _, item := range items {
+		ref, _ := item.SourceMetadata["ref"].(string)
+		if ref != "" {
+			existingRefs[ref] = true
+			continue
+		}
+		pending = append(pending, item)
+	}
+	sort.Slice(pending, func(i, j int) bool {
+		return pending[i].RelativePath < pending[j].RelativePath
+	})
+
+	applied := 0
+	for _, item := range pending {
+		if err := ctx.Err(); err != nil {
+			return applied, err
+		}
+		ref, err := wkitem.DeriveUnique(ctx, item.StableID, existingRefs)
+		if err != nil {
+			return applied, err
+		}
+		existingRefs[ref] = true
+		if err := backfillRefWithRef(ctx, root, item.RelativePath, ref); err != nil {
+			return applied, err
+		}
+		applied++
+	}
+	return applied, nil
+}
+
+func backfillRefWithRef(ctx context.Context, root, relPath, ref string) error {
 	abs := filepath.Join(root, filepath.FromSlash(relPath), wkitem.MetadataFilename)
+
+	release, err := fsutil.AcquireFileLock(ctx, abs+".lock")
+	if err != nil {
+		return err
+	}
+	defer release()
+
 	raw, err := os.ReadFile(abs)
 	if err != nil {
 		return camperrors.Wrapf(err, "read %s", abs)
@@ -58,20 +122,13 @@ func backfillRef(ctx context.Context, root, relPath string) error {
 		return camperrors.Wrapf(err, "parse %s", abs)
 	}
 
-	id, ok := lookupScalar(&doc, "id")
-	if !ok {
+	if _, ok := lookupScalar(&doc, "id"); !ok {
 		return camperrors.NewValidation("id", "missing id in "+abs, nil)
 	}
 	if existing, ok := lookupScalar(&doc, "ref"); ok && existing != "" {
 		// Another concurrent process already filled it in. No-op.
 		return nil
 	}
-
-	existingRefs, err := refsExcludingPath(ctx, root, relPath)
-	if err != nil {
-		return err
-	}
-	ref := wkitem.DeriveUnique(id, existingRefs)
 
 	if err := insertScalarAfter(&doc, "id", "ref", ref); err != nil {
 		return err
@@ -82,6 +139,23 @@ func backfillRef(ctx context.Context, root, relPath string) error {
 		return camperrors.Wrap(err, "marshal updated workitem")
 	}
 	return fsutil.WriteFileAtomically(abs, out, 0o644)
+}
+
+func workitemIDAtPath(root, relPath string) (string, error) {
+	abs := filepath.Join(root, filepath.FromSlash(relPath), wkitem.MetadataFilename)
+	raw, err := os.ReadFile(abs)
+	if err != nil {
+		return "", camperrors.Wrapf(err, "read %s", abs)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return "", camperrors.Wrapf(err, "parse %s", abs)
+	}
+	id, ok := lookupScalar(&doc, "id")
+	if !ok {
+		return "", camperrors.NewValidation("id", "missing id in "+abs, nil)
+	}
+	return id, nil
 }
 
 func refsExcludingPath(ctx context.Context, root, skipRel string) (map[string]bool, error) {
@@ -136,9 +210,15 @@ func insertScalarAfter(doc *yaml.Node, after, key, value string) error {
 	insertAt := len(root.Content)
 	for i := 0; i+1 < len(root.Content); i += 2 {
 		k := root.Content[i]
+		v := root.Content[i+1]
+		if k.Kind == yaml.ScalarNode && k.Value == key {
+			v.Kind = yaml.ScalarNode
+			v.Tag = "!!str"
+			v.Value = value
+			return nil
+		}
 		if k.Kind == yaml.ScalarNode && k.Value == after {
 			insertAt = i + 2
-			break
 		}
 	}
 	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}

--- a/internal/commands/workitem/doctor_ref_test.go
+++ b/internal/commands/workitem/doctor_ref_test.go
@@ -83,10 +83,13 @@ func TestDoctor_FixBackfillsRefAndPreservesFields(t *testing.T) {
 		t.Fatalf("ref %q != Derive(id) %q", meta.Ref, expected)
 	}
 
-	// Title text from the legacy fixture should survive byte-identical to the
-	// original (other than the inserted ref line) — verify by string contains.
-	if !strings.Contains(string(after), "title: Legacy legacy") {
-		t.Fatalf("title field clobbered:\n%s", after)
+	expectedBytes := strings.Replace(string(before),
+		"id: design-legacy-2026-05-24\n",
+		"id: design-legacy-2026-05-24\nref: "+meta.Ref+"\n",
+		1,
+	)
+	if string(after) != expectedBytes {
+		t.Fatalf("backfill diff was not minimal\nwant:\n%s\ngot:\n%s", expectedBytes, after)
 	}
 
 	// Re-run doctor: no missing-ref findings remain.
@@ -97,6 +100,44 @@ func TestDoctor_FixBackfillsRefAndPreservesFields(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), codeMissingRefField) {
 		t.Fatalf("missing-ref finding still present after --fix:\n%s", stdout.String())
+	}
+}
+
+func TestDoctor_FixUpdatesEmptyRefWithoutDuplicateKey(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	dir := filepath.Join(root, "workflow", "design", "empty-ref")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "version: v1alpha5\nkind: workitem\nid: design-empty-ref-2026-05-24\n" +
+		"ref: \"\"\ntype: design\ntitle: Empty Ref\n"
+	if err := os.WriteFile(filepath.Join(dir, ".workitem"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := runDoctor(context.Background(), cmd, false, true); err != nil {
+		t.Fatalf("doctor --fix: %v", err)
+	}
+
+	after, err := os.ReadFile(filepath.Join(dir, ".workitem"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count := strings.Count(string(after), "\nref:"); count != 1 {
+		t.Fatalf("ref key count = %d, want 1\n%s", count, after)
+	}
+	meta, err := wkitem.LoadMetadata(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Ref == "" {
+		t.Fatalf("empty ref was not backfilled:\n%s", after)
 	}
 }
 

--- a/internal/commands/workitem/doctor_ref_test.go
+++ b/internal/commands/workitem/doctor_ref_test.go
@@ -1,0 +1,139 @@
+package workitem
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+func writeLegacyWorkitem(t *testing.T, root, slug string) {
+	t.Helper()
+	dir := filepath.Join(root, "workflow", "design", slug)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "version: v1alpha5\nkind: workitem\nid: design-" + slug + "-2026-05-24\n" +
+		"type: design\ntitle: Legacy " + slug + "\n"
+	if err := os.WriteFile(filepath.Join(dir, ".workitem"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDoctor_MissingRefIsWarning(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	writeLegacyWorkitem(t, root, "legacy")
+
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	if err := runDoctor(context.Background(), cmd, false, false); err != nil {
+		t.Fatalf("doctor should exit 0 for warnings only: %v", err)
+	}
+	if !strings.Contains(stdout.String(), codeMissingRefField) {
+		t.Fatalf("expected %s finding, got %q", codeMissingRefField, stdout.String())
+	}
+}
+
+func TestDoctor_FixBackfillsRefAndPreservesFields(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	writeLegacyWorkitem(t, root, "legacy")
+	beforePath := filepath.Join(root, "workflow", "design", "legacy", ".workitem")
+	before, err := os.ReadFile(beforePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := runDoctor(context.Background(), cmd, false, true); err != nil {
+		t.Fatalf("doctor --fix: %v", err)
+	}
+
+	after, err := os.ReadFile(beforePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	meta, err := wkitem.LoadMetadata(context.Background(), filepath.Dir(beforePath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Ref == "" {
+		t.Fatalf("ref was not backfilled\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+	if meta.ID == "" || meta.Type == "" || meta.Title == "" {
+		t.Fatalf("backfill clobbered preserved fields: %#v", meta)
+	}
+	if expected := wkitem.Derive(meta.ID); meta.Ref != expected {
+		t.Fatalf("ref %q != Derive(id) %q", meta.Ref, expected)
+	}
+
+	// Title text from the legacy fixture should survive byte-identical to the
+	// original (other than the inserted ref line) — verify by string contains.
+	if !strings.Contains(string(after), "title: Legacy legacy") {
+		t.Fatalf("title field clobbered:\n%s", after)
+	}
+
+	// Re-run doctor: no missing-ref findings remain.
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	if err := runDoctor(context.Background(), cmd, false, false); err != nil {
+		t.Fatalf("post-fix doctor: %v", err)
+	}
+	if strings.Contains(stdout.String(), codeMissingRefField) {
+		t.Fatalf("missing-ref finding still present after --fix:\n%s", stdout.String())
+	}
+}
+
+func TestDoctor_FixHandlesCollisionsAcrossManyWorkitems(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	// Three legacy workitems with very similar IDs to exercise the
+	// collision-retry path in DeriveUnique. They cannot actually hash-collide
+	// (sha256 is too wide for that on three inputs), but this test pins
+	// down the contract that --fix produces a unique ref per workitem and
+	// the registry stays internally consistent.
+	for _, slug := range []string{"alpha", "beta", "gamma"} {
+		writeLegacyWorkitem(t, root, slug)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := runDoctor(context.Background(), cmd, false, true); err != nil {
+		t.Fatalf("doctor --fix: %v", err)
+	}
+
+	seen := map[string]string{}
+	for _, slug := range []string{"alpha", "beta", "gamma"} {
+		meta, err := wkitem.LoadMetadata(context.Background(),
+			filepath.Join(root, "workflow", "design", slug))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if meta.Ref == "" {
+			t.Fatalf("%s: ref was not backfilled", slug)
+		}
+		if other, dup := seen[meta.Ref]; dup {
+			t.Fatalf("ref collision: %s and %s both got %q", slug, other, meta.Ref)
+		}
+		seen[meta.Ref] = slug
+	}
+}

--- a/internal/commands/workitem/ref_quest.go
+++ b/internal/commands/workitem/ref_quest.go
@@ -1,0 +1,43 @@
+package workitem
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	"github.com/Obedience-Corp/camp/internal/quest"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+// deriveUniqueRef enumerates existing workitem refs and returns a fresh ref
+// for id that does not collide with any of them.
+func deriveUniqueRef(ctx context.Context, campaignRoot string, cfg *config.CampaignConfig, id string) (string, error) {
+	resolver := paths.NewResolverFromConfig(campaignRoot, cfg)
+	items, err := wkitem.Discover(ctx, campaignRoot, resolver)
+	if err != nil {
+		return "", camperrors.Wrap(err, "scan existing refs")
+	}
+	existing := wkitem.RefsFromWorkitems(items)
+	return wkitem.DeriveUnique(id, existing), nil
+}
+
+// resolveQuestIDForCreate calls quest.ResolveContext to capture the active
+// quest's id at workitem-create time. Quest resolution failures are
+// non-fatal: the function returns "" and emits a one-line warning on
+// stderr. This keeps the quest-agnostic behavior intact for users who do
+// not run quests.
+func resolveQuestIDForCreate(ctx context.Context, cmd *cobra.Command, campaignRoot, explicit string) string {
+	q, err := quest.ResolveContext(ctx, campaignRoot, explicit)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: quest resolution failed: %v\n", err)
+		return ""
+	}
+	if q == nil {
+		return ""
+	}
+	return q.ID
+}

--- a/internal/commands/workitem/ref_quest.go
+++ b/internal/commands/workitem/ref_quest.go
@@ -22,7 +22,7 @@ func deriveUniqueRef(ctx context.Context, campaignRoot string, cfg *config.Campa
 		return "", camperrors.Wrap(err, "scan existing refs")
 	}
 	existing := wkitem.RefsFromWorkitems(items)
-	return wkitem.DeriveUnique(id, existing), nil
+	return wkitem.DeriveUnique(ctx, id, existing)
 }
 
 // resolveQuestIDForCreate calls quest.ResolveContext to capture the active

--- a/internal/commands/workitem/ref_quest_test.go
+++ b/internal/commands/workitem/ref_quest_test.go
@@ -1,0 +1,154 @@
+package workitem
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+// refQuestTestCampaign builds a minimal campaign root.
+func refQuestTestCampaign(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".campaign"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".campaign", "campaign.yaml"),
+		[]byte("id: test\nname: Test\ntype: product\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func loadMarker(t *testing.T, path string) wkitem.Metadata {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var meta wkitem.Metadata
+	if err := yaml.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	return meta
+}
+
+func TestRunCreate_WritesRefAndOmitsQuestWhenNoneActive(t *testing.T) {
+	root := refQuestTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+	// Ensure no CAMP_QUEST env var leaks into the test.
+	t.Setenv("CAMP_QUEST", "")
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(os.Stdout)
+	cmd.SetErr(os.Stderr)
+
+	if err := runCreate(context.Background(), cmd, "alpha", "design", "Alpha", "", "", ""); err != nil {
+		t.Fatalf("runCreate: %v", err)
+	}
+	meta := loadMarker(t, filepath.Join(root, "workflow", "design", "alpha", ".workitem"))
+	if meta.Version != wkitem.WorkitemSchemaVersion {
+		t.Fatalf("version = %q, want %q", meta.Version, wkitem.WorkitemSchemaVersion)
+	}
+	if meta.Ref == "" {
+		t.Fatal("expected ref to be set on create")
+	}
+	if !strings.HasPrefix(meta.Ref, "WI-") || len(meta.Ref) != 9 {
+		t.Fatalf("ref %q has unexpected shape", meta.Ref)
+	}
+	if meta.QuestID != "" {
+		t.Fatalf("expected empty quest_id with no active quest, got %q", meta.QuestID)
+	}
+	if meta.ID != "design-alpha-"+meta.ID[len("design-alpha-"):] {
+		t.Fatalf("id = %q (sanity check)", meta.ID)
+	}
+	if expected := wkitem.Derive(meta.ID); meta.Ref != expected {
+		t.Fatalf("ref %q != Derive(id) %q", meta.Ref, expected)
+	}
+}
+
+func TestRunCreate_RefsAreUniqueAcrossWorkitems(t *testing.T) {
+	root := refQuestTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+	t.Setenv("CAMP_QUEST", "")
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(os.Stdout)
+	cmd.SetErr(os.Stderr)
+
+	for _, slug := range []string{"alpha", "beta", "gamma"} {
+		if err := runCreate(context.Background(), cmd, slug, "design", slug, "", "", ""); err != nil {
+			t.Fatalf("runCreate %s: %v", slug, err)
+		}
+	}
+	seen := make(map[string]bool)
+	for _, slug := range []string{"alpha", "beta", "gamma"} {
+		meta := loadMarker(t, filepath.Join(root, "workflow", "design", slug, ".workitem"))
+		if seen[meta.Ref] {
+			t.Fatalf("duplicate ref across workitems: %q", meta.Ref)
+		}
+		seen[meta.Ref] = true
+	}
+}
+
+func TestRunAdopt_WritesRef(t *testing.T) {
+	root := refQuestTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+	t.Setenv("CAMP_QUEST", "")
+
+	adoptDir := filepath.Join(root, "workflow", "design", "legacy")
+	if err := os.MkdirAll(adoptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(os.Stdout)
+	cmd.SetErr(os.Stderr)
+	if err := runAdopt(context.Background(), cmd, "workflow/design/legacy", "design", "Legacy", "", ""); err != nil {
+		t.Fatalf("runAdopt: %v", err)
+	}
+	meta := loadMarker(t, filepath.Join(adoptDir, ".workitem"))
+	if meta.Ref == "" {
+		t.Fatal("expected ref on adopt")
+	}
+	if expected := wkitem.Derive(meta.ID); meta.Ref != expected {
+		t.Fatalf("ref %q != Derive(id) %q", meta.Ref, expected)
+	}
+}
+
+func TestLoadMetadata_LegacyV1Alpha5StillLoads(t *testing.T) {
+	root := refQuestTestCampaign(t)
+	dir := filepath.Join(root, "workflow", "design", "legacy")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const legacy = `version: v1alpha5
+kind: workitem
+id: design-legacy-2026-05-24
+type: design
+title: Legacy
+`
+	if err := os.WriteFile(filepath.Join(dir, ".workitem"), []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta, err := wkitem.LoadMetadata(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("LoadMetadata legacy: %v", err)
+	}
+	if meta == nil || meta.Version != "v1alpha5" {
+		t.Fatalf("legacy load returned %#v", meta)
+	}
+	if meta.Ref != "" || meta.QuestID != "" {
+		t.Fatalf("legacy meta should have empty Ref/QuestID, got %#v", meta)
+	}
+}

--- a/internal/git/campaign_tag.go
+++ b/internal/git/campaign_tag.go
@@ -30,6 +30,9 @@ func FormatContextTagsFull(campaignID, questID, festRef, workitemRef string) str
 		parts = append(parts, "FE-"+festRef)
 	}
 	if workitemRef != "" {
+		if !strings.HasPrefix(workitemRef, "WI-") {
+			workitemRef = "WI-" + workitemRef
+		}
 		// Workitem refs already carry the WI- prefix per
 		// internal/workitem/ref.go::Derive. Embed verbatim so the bracket
 		// reads `WI-WI-abcdef`, matching the documented tag grammar.
@@ -88,6 +91,10 @@ var tagShellRegex = regexp.MustCompile(`\[OBEY-CAMPAIGN-([^\]]+)\]`)
 
 // ParseTag extracts the components of a campaign tag from a commit subject.
 // Returns a zero-valued TagComponents when no tag is present.
+//
+// ParseTag assumes quest IDs match `qst_[0-9]+_[a-z0-9]+` per
+// internal/quest/slug.go. If that alphabet is extended to include "-",
+// update indexOfNextPrefix and add adversarial quest-id cases.
 //
 // Two-stage parse: regex strips the bracket and the OBEY-CAMPAIGN prefix,
 // then the inner string is walked once to peel off quest, festival, and

--- a/internal/git/campaign_tag.go
+++ b/internal/git/campaign_tag.go
@@ -1,27 +1,53 @@
 package git
 
-import "fmt"
+import (
+	"regexp"
+	"strings"
+)
 
 const campaignTagMaxIDLen = 8
+
+// FormatContextTagsFull composes the consolidated campaign tag from any
+// subset of the four components. Component order inside the bracket is
+// fixed: campaign id, then quest id (qst_<...>), then festival ref
+// (FE-<ref>), then workitem ref (WI-<ref>). Absent components are
+// omitted entirely; their separators do not appear in the output.
+//
+// Returns "" when campaignID is empty (no tag without a campaign).
+func FormatContextTagsFull(campaignID, questID, festRef, workitemRef string) string {
+	if campaignID == "" {
+		return ""
+	}
+	shortID := campaignID
+	if len(shortID) > campaignTagMaxIDLen {
+		shortID = shortID[:campaignTagMaxIDLen]
+	}
+	parts := []string{"OBEY-CAMPAIGN", shortID}
+	if questID != "" {
+		parts = append(parts, questID)
+	}
+	if festRef != "" {
+		parts = append(parts, "FE-"+festRef)
+	}
+	if workitemRef != "" {
+		// Workitem refs already carry the WI- prefix per
+		// internal/workitem/ref.go::Derive. Embed verbatim so the bracket
+		// reads `WI-WI-abcdef`, matching the documented tag grammar.
+		parts = append(parts, "WI-"+workitemRef)
+	}
+	return "[" + strings.Join(parts, "-") + "]"
+}
 
 // FormatCampaignTag returns the "[OBEY-CAMPAIGN-{id}]" prefix string.
 // If a questID is provided, it is appended inside the same bracket:
 // "[OBEY-CAMPAIGN-{id}-{questID}]".
 // Truncates campaignID to 8 characters. Returns empty string if campaignID is empty.
 func FormatCampaignTag(campaignID string, questID ...string) string {
-	if campaignID == "" {
-		return ""
+	qid := ""
+	if len(questID) > 0 {
+		qid = questID[0]
 	}
-
-	shortID := campaignID
-	if len(shortID) > campaignTagMaxIDLen {
-		shortID = shortID[:campaignTagMaxIDLen]
-	}
-
-	if len(questID) > 0 && questID[0] != "" {
-		return fmt.Sprintf("[OBEY-CAMPAIGN-%s-%s]", shortID, questID[0])
-	}
-	return fmt.Sprintf("[OBEY-CAMPAIGN-%s]", shortID)
+	return FormatContextTagsFull(campaignID, qid, "", "")
 }
 
 // PrependCampaignTag prepends the campaign tag to a commit message.
@@ -33,7 +59,7 @@ func PrependCampaignTag(campaignID, message string) string {
 // FormatContextTags returns the combined campaign/quest tag prefix string.
 // When questID is non-empty, produces "[OBEY-CAMPAIGN-{id}-{questID}]".
 func FormatContextTags(campaignID, questID string) string {
-	return FormatCampaignTag(campaignID, questID)
+	return FormatContextTagsFull(campaignID, questID, "", "")
 }
 
 // PrependContextTags prepends the campaign and optional quest tag to a message.
@@ -43,4 +69,92 @@ func PrependContextTags(campaignID, questID, message string) string {
 		return message
 	}
 	return tag + " " + message
+}
+
+// TagComponents are the parsed pieces of a `[OBEY-CAMPAIGN-...]` tag.
+// Empty fields indicate the component was absent.
+type TagComponents struct {
+	CampaignID  string // short form, max 8 chars
+	QuestID     string
+	FestRef     string
+	WorkitemRef string // includes the leading "WI-" prefix (e.g. "WI-abcdef")
+}
+
+// tagShellRegex captures everything between `[OBEY-CAMPAIGN-` and `]`. The
+// inner contents are split component-by-component in ParseTag so the parser
+// can disambiguate `FE-<ref>` and `WI-<ref>` without relying on regex
+// lookahead (which RE2 does not support).
+var tagShellRegex = regexp.MustCompile(`\[OBEY-CAMPAIGN-([^\]]+)\]`)
+
+// ParseTag extracts the components of a campaign tag from a commit subject.
+// Returns a zero-valued TagComponents when no tag is present.
+//
+// Two-stage parse: regex strips the bracket and the OBEY-CAMPAIGN prefix,
+// then the inner string is walked once to peel off quest, festival, and
+// workitem segments in their fixed order. Each peeled segment is anchored
+// on its prefix (`qst_`, `FE-`, `WI-`); whatever is left between the
+// previous prefix and the next belongs to the previous segment. This
+// matches FormatContextTagsFull's grammar exactly.
+func ParseTag(subject string) TagComponents {
+	m := tagShellRegex.FindStringSubmatch(subject)
+	if m == nil {
+		return TagComponents{}
+	}
+	inner := m[1]
+	// First segment is always the campaign id.
+	rest := inner
+	out := TagComponents{}
+	idEnd := strings.Index(rest, "-")
+	if idEnd < 0 {
+		out.CampaignID = rest
+		return out
+	}
+	out.CampaignID = rest[:idEnd]
+	rest = rest[idEnd+1:]
+
+	// rest may now contain: [qst_<...>-][FE-<ref>-][WI-<ref>]
+	for rest != "" {
+		switch {
+		case strings.HasPrefix(rest, "qst_"):
+			end := indexOfNextPrefix(rest)
+			out.QuestID = rest[:end]
+			rest = trimLeadingSeparator(rest[end:])
+		case strings.HasPrefix(rest, "FE-"):
+			payload := rest[len("FE-"):]
+			end := indexOfNextPrefix(payload)
+			out.FestRef = payload[:end]
+			rest = trimLeadingSeparator(payload[end:])
+		case strings.HasPrefix(rest, "WI-"):
+			// Workitem refs in tags are emitted as `WI-<ref>` where the ref
+			// itself already starts with `WI-`. Keep the stored ref in its
+			// canonical form so the caller does not have to re-add the prefix.
+			payload := rest[len("WI-"):]
+			out.WorkitemRef = payload
+			rest = ""
+		default:
+			// Unknown trailing content — return what we have rather than guess.
+			rest = ""
+		}
+	}
+	return out
+}
+
+// indexOfNextPrefix returns the byte offset of the next known segment
+// prefix (`-FE-` or `-WI-`) inside s, or len(s) if none is found.
+func indexOfNextPrefix(s string) int {
+	candidates := []string{"-FE-", "-WI-"}
+	best := len(s)
+	for _, p := range candidates {
+		if idx := strings.Index(s, p); idx >= 0 && idx < best {
+			best = idx
+		}
+	}
+	return best
+}
+
+func trimLeadingSeparator(s string) string {
+	if strings.HasPrefix(s, "-") {
+		return s[1:]
+	}
+	return s
 }

--- a/internal/git/campaign_tag_full_test.go
+++ b/internal/git/campaign_tag_full_test.go
@@ -61,6 +61,11 @@ func TestFormatContextTagsFull_AllCombinations(t *testing.T) {
 			campaign: "8deed8b4abcdef", workitem: "WI-abcdef",
 			want: "[OBEY-CAMPAIGN-8deed8b4-WI-WI-abcdef]",
 		},
+		{
+			name:     "workitem ref normalized",
+			campaign: "8deed8b4", workitem: "abcdef",
+			want: "[OBEY-CAMPAIGN-8deed8b4-WI-WI-abcdef]",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -94,8 +99,8 @@ func TestFormatCampaignTag_BackwardCompat(t *testing.T) {
 
 func TestParseTag_KnownCombinations(t *testing.T) {
 	cases := []struct {
-		subject                                              string
-		wantCampaign, wantQuest, wantFest, wantWorkitem      string
+		subject                                         string
+		wantCampaign, wantQuest, wantFest, wantWorkitem string
 	}{
 		{
 			subject:      "[OBEY-CAMPAIGN-8deed8b4] feat: thing",

--- a/internal/git/campaign_tag_full_test.go
+++ b/internal/git/campaign_tag_full_test.go
@@ -1,0 +1,185 @@
+package git
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+)
+
+func TestFormatContextTagsFull_AllCombinations(t *testing.T) {
+	cases := []struct {
+		name                                  string
+		campaign, quest, fest, workitem, want string
+	}{
+		{
+			name:     "empty campaign returns empty",
+			campaign: "", quest: "qst_abc", fest: "CW0003", workitem: "WI-abcdef",
+			want: "",
+		},
+		{
+			name:     "campaign only",
+			campaign: "8deed8b4",
+			want:     "[OBEY-CAMPAIGN-8deed8b4]",
+		},
+		{
+			name:     "campaign + quest",
+			campaign: "8deed8b4", quest: "qst_abc",
+			want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc]",
+		},
+		{
+			name:     "campaign + festival",
+			campaign: "8deed8b4", fest: "CW0003",
+			want: "[OBEY-CAMPAIGN-8deed8b4-FE-CW0003]",
+		},
+		{
+			name:     "campaign + workitem",
+			campaign: "8deed8b4", workitem: "WI-abcdef",
+			want: "[OBEY-CAMPAIGN-8deed8b4-WI-WI-abcdef]",
+		},
+		{
+			name:     "campaign + quest + festival",
+			campaign: "8deed8b4", quest: "qst_abc", fest: "CW0003",
+			want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc-FE-CW0003]",
+		},
+		{
+			name:     "campaign + quest + workitem",
+			campaign: "8deed8b4", quest: "qst_abc", workitem: "WI-abcdef",
+			want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc-WI-WI-abcdef]",
+		},
+		{
+			name:     "campaign + festival + workitem",
+			campaign: "8deed8b4", fest: "CW0003", workitem: "WI-abcdef",
+			want: "[OBEY-CAMPAIGN-8deed8b4-FE-CW0003-WI-WI-abcdef]",
+		},
+		{
+			name:     "all four components",
+			campaign: "8deed8b4", quest: "qst_abc", fest: "CW0003", workitem: "WI-abcdef",
+			want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc-FE-CW0003-WI-WI-abcdef]",
+		},
+		{
+			name:     "campaign id truncated to 8 chars",
+			campaign: "8deed8b4abcdef", workitem: "WI-abcdef",
+			want: "[OBEY-CAMPAIGN-8deed8b4-WI-WI-abcdef]",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatContextTagsFull(tc.campaign, tc.quest, tc.fest, tc.workitem)
+			if got != tc.want {
+				t.Fatalf("FormatContextTagsFull = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatCampaignTag_BackwardCompat(t *testing.T) {
+	cases := []struct {
+		campaign, quest, want string
+	}{
+		{campaign: "8deed8b4", want: "[OBEY-CAMPAIGN-8deed8b4]"},
+		{campaign: "8deed8b4", quest: "qst_abc", want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc]"},
+	}
+	for _, tc := range cases {
+		var got string
+		if tc.quest == "" {
+			got = FormatCampaignTag(tc.campaign)
+		} else {
+			got = FormatCampaignTag(tc.campaign, tc.quest)
+		}
+		if got != tc.want {
+			t.Fatalf("FormatCampaignTag back-compat broke: got %q, want %q", got, tc.want)
+		}
+	}
+}
+
+func TestParseTag_KnownCombinations(t *testing.T) {
+	cases := []struct {
+		subject                                              string
+		wantCampaign, wantQuest, wantFest, wantWorkitem      string
+	}{
+		{
+			subject:      "[OBEY-CAMPAIGN-8deed8b4] feat: thing",
+			wantCampaign: "8deed8b4",
+		},
+		{
+			subject:      "[OBEY-CAMPAIGN-8deed8b4-qst_abc] message",
+			wantCampaign: "8deed8b4", wantQuest: "qst_abc",
+		},
+		{
+			subject:      "[OBEY-CAMPAIGN-8deed8b4-FE-CW0003] feat: ...",
+			wantCampaign: "8deed8b4", wantFest: "CW0003",
+		},
+		{
+			subject:      "[OBEY-CAMPAIGN-8deed8b4-WI-WI-abcdef] x",
+			wantCampaign: "8deed8b4", wantWorkitem: "WI-abcdef",
+		},
+		{
+			subject:      "[OBEY-CAMPAIGN-8deed8b4-qst_abc-FE-CW0003-WI-WI-abcdef] all",
+			wantCampaign: "8deed8b4", wantQuest: "qst_abc", wantFest: "CW0003", wantWorkitem: "WI-abcdef",
+		},
+		{
+			subject:      "no tag here at all",
+			wantCampaign: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.subject, func(t *testing.T) {
+			got := ParseTag(tc.subject)
+			if got.CampaignID != tc.wantCampaign {
+				t.Fatalf("CampaignID = %q, want %q", got.CampaignID, tc.wantCampaign)
+			}
+			if got.QuestID != tc.wantQuest {
+				t.Fatalf("QuestID = %q, want %q", got.QuestID, tc.wantQuest)
+			}
+			if got.FestRef != tc.wantFest {
+				t.Fatalf("FestRef = %q, want %q", got.FestRef, tc.wantFest)
+			}
+			if got.WorkitemRef != tc.wantWorkitem {
+				t.Fatalf("WorkitemRef = %q, want %q", got.WorkitemRef, tc.wantWorkitem)
+			}
+		})
+	}
+}
+
+func TestParseTag_RoundTripProperty(t *testing.T) {
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		campaign := randHex(t, 4)
+		quest := ""
+		fest := ""
+		workitem := ""
+		if i%2 == 0 {
+			quest = "qst_" + randHex(t, 3)
+		}
+		if i%3 == 0 {
+			fest = "CW" + randHex(t, 2)
+		}
+		if i%5 == 0 {
+			workitem = "WI-" + randHex(t, 3)
+		}
+
+		tag := FormatContextTagsFull(campaign, quest, fest, workitem)
+		got := ParseTag(tag)
+		if got.CampaignID != campaign {
+			t.Fatalf("iter %d: campaign round-trip broke: %q -> %q", i, campaign, got.CampaignID)
+		}
+		if got.QuestID != quest {
+			t.Fatalf("iter %d: quest round-trip broke: %q -> %q (tag %q)", i, quest, got.QuestID, tag)
+		}
+		if got.FestRef != fest {
+			t.Fatalf("iter %d: fest round-trip broke: %q -> %q (tag %q)", i, fest, got.FestRef, tag)
+		}
+		if got.WorkitemRef != workitem {
+			t.Fatalf("iter %d: workitem round-trip broke: %q -> %q (tag %q)", i, workitem, got.WorkitemRef, tag)
+		}
+	}
+}
+
+func randHex(t *testing.T, n int) string {
+	t.Helper()
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/git/commit/commit.go
+++ b/internal/git/commit/commit.go
@@ -21,6 +21,7 @@ type Options struct {
 	CampaignRoot  string   // Path to campaign root
 	CampaignID    string   // Campaign ID (truncated to 8 chars)
 	QuestID       string   // Optional quest ID for additive commit context
+	WorkitemRef   string   // Optional workitem ref (WI-<6 hex>) for additive commit context
 	Files         []string // If set, stage only these paths instead of everything
 	PreStaged     []string // Paths already staged (included in --only commit scope, not re-staged)
 	SelectiveOnly bool     // When true, never fall back to CommitAll; no-op if Files is empty
@@ -43,7 +44,7 @@ func doCommit(ctx context.Context, opts Options, action, subject, description st
 	}
 
 	commitMsg := fmt.Sprintf("%s %s: %s",
-		git.FormatContextTags(opts.CampaignID, opts.QuestID),
+		git.FormatContextTagsFull(opts.CampaignID, opts.QuestID, "", opts.WorkitemRef),
 		action,
 		subject,
 	)

--- a/internal/workitem/merge.go
+++ b/internal/workitem/merge.go
@@ -20,5 +20,16 @@ func ApplyMetadata(item WorkItem, md *Metadata) (WorkItem, error) {
 	if md.Title != "" {
 		item.Title = md.Title
 	}
+	if md.Ref != "" || md.QuestID != "" {
+		if item.SourceMetadata == nil {
+			item.SourceMetadata = make(map[string]any)
+		}
+		if md.Ref != "" {
+			item.SourceMetadata["ref"] = md.Ref
+		}
+		if md.QuestID != "" {
+			item.SourceMetadata["quest_id"] = md.QuestID
+		}
+	}
 	return item, nil
 }

--- a/internal/workitem/metadata.go
+++ b/internal/workitem/metadata.go
@@ -14,13 +14,17 @@ import (
 
 const MetadataFilename = ".workitem"
 
-const WorkitemSchemaVersion = "v1alpha5"
+const WorkitemSchemaVersion = "v1alpha6"
 
 const MetadataKind = "workitem"
 
+// acceptedWorkitemVersions are loadable .workitem schema versions. v1alpha4
+// and v1alpha5 are accepted for backward compatibility; v1alpha6 is the
+// current shape and gains the Ref and QuestID fields.
 var acceptedWorkitemVersions = map[string]bool{
 	"v1alpha4": true,
 	"v1alpha5": true,
+	"v1alpha6": true,
 }
 
 type Metadata struct {
@@ -30,6 +34,14 @@ type Metadata struct {
 	Type      string `yaml:"type"`
 	Title     string `yaml:"title,omitempty"`
 	CreatedBy string `yaml:"created_by,omitempty"`
+	// Ref is a deterministic short reference for commit-message embedding.
+	// Format: WI-<6 lowercase hex>. Added in v1alpha6; absent on legacy
+	// workitems and backfilled by `camp workitem doctor --fix`.
+	Ref string `yaml:"ref,omitempty"`
+	// QuestID is the id of the quest active when this workitem was created
+	// or adopted. Empty when no quest resolved (no --quest flag and no
+	// CAMP_QUEST env var). Added in v1alpha6.
+	QuestID string `yaml:"quest_id,omitempty"`
 }
 
 // LoadMetadata reads .workitem from dir on the host filesystem.

--- a/internal/workitem/metadata.go
+++ b/internal/workitem/metadata.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -90,7 +91,8 @@ func LoadMetadataFS(ctx context.Context, fsys fs.FS, path string) (*Metadata, er
 func validateMetadata(m *Metadata) error {
 	if !acceptedWorkitemVersions[m.Version] {
 		return camperrors.NewValidation("version",
-			"unsupported .workitem schema version (got "+m.Version+", supported: v1alpha4, v1alpha5); update .workitem `version:` to "+WorkitemSchemaVersion, nil)
+			"unsupported .workitem schema version (got "+m.Version+", supported: "+
+				strings.Join(supportedWorkitemVersions(), ", ")+"); update .workitem `version:` to "+WorkitemSchemaVersion, nil)
 	}
 	if m.Kind != MetadataKind {
 		return camperrors.NewValidation("kind",
@@ -103,4 +105,13 @@ func validateMetadata(m *Metadata) error {
 		return camperrors.NewValidation("type", "required field type is empty", nil)
 	}
 	return nil
+}
+
+func supportedWorkitemVersions() []string {
+	versions := make([]string, 0, len(acceptedWorkitemVersions))
+	for version := range acceptedWorkitemVersions {
+		versions = append(versions, version)
+	}
+	sort.Strings(versions)
+	return versions
 }

--- a/internal/workitem/metadata_test.go
+++ b/internal/workitem/metadata_test.go
@@ -105,6 +105,16 @@ title: T
 			wantSubstr: "update .workitem `version:` to " + WorkitemSchemaVersion,
 		},
 		{
+			name: "wrong version lists current supported version",
+			body: `version: v1alpha3
+kind: workitem
+id: x
+type: design
+title: T
+`,
+			wantSubstr: "v1alpha6",
+		},
+		{
 			name: "wrong kind",
 			body: `version: v1alpha4
 kind: festival

--- a/internal/workitem/ref.go
+++ b/internal/workitem/ref.go
@@ -1,13 +1,18 @@
 package workitem
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 
 // RefPrefix is the literal prefix every workitem `ref` carries.
 const RefPrefix = "WI-"
+
+const maxRefCollisionRetries = 1 << 24
 
 // Derive returns the canonical ref for a workitem id. The shape is stable:
 // "WI-" plus the first 6 lowercase hex chars of sha256(id). Same id always
@@ -26,17 +31,24 @@ func Derive(id string) string {
 // The existing map is read-only; DeriveUnique does not insert into it.
 // Callers should add the returned ref to their existing set before deriving
 // another to keep the no-collision invariant.
-func DeriveUnique(id string, existing map[string]bool) string {
+func DeriveUnique(ctx context.Context, id string, existing map[string]bool) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	candidate := Derive(id)
 	if !existing[candidate] {
-		return candidate
+		return candidate, nil
 	}
-	for n := 1; ; n++ {
+	for n := 1; n <= maxRefCollisionRetries; n++ {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
 		candidate = Derive(fmt.Sprintf("%s#%d", id, n))
 		if !existing[candidate] {
-			return candidate
+			return candidate, nil
 		}
 	}
+	return "", camperrors.NewValidation("ref", "ref space exhausted for id "+id, nil)
 }
 
 // RefsFromWorkitems returns the set of refs already in use across the

--- a/internal/workitem/ref.go
+++ b/internal/workitem/ref.go
@@ -1,0 +1,54 @@
+package workitem
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// RefPrefix is the literal prefix every workitem `ref` carries.
+const RefPrefix = "WI-"
+
+// Derive returns the canonical ref for a workitem id. The shape is stable:
+// "WI-" plus the first 6 lowercase hex chars of sha256(id). Same id always
+// yields the same ref; this is the reason the field is safe to recompute
+// during migrations and doctor backfills.
+func Derive(id string) string {
+	sum := sha256.Sum256([]byte(id))
+	return RefPrefix + hex.EncodeToString(sum[:])[:6]
+}
+
+// DeriveUnique returns a ref guaranteed not to collide with the keys of
+// existing. On collision, the function re-rolls by hashing `id#1`, `id#2`,
+// ... until a free slot is found. Returns the deterministic Derive(id)
+// result whenever the original is already unique.
+//
+// The existing map is read-only; DeriveUnique does not insert into it.
+// Callers should add the returned ref to their existing set before deriving
+// another to keep the no-collision invariant.
+func DeriveUnique(id string, existing map[string]bool) string {
+	candidate := Derive(id)
+	if !existing[candidate] {
+		return candidate
+	}
+	for n := 1; ; n++ {
+		candidate = Derive(fmt.Sprintf("%s#%d", id, n))
+		if !existing[candidate] {
+			return candidate
+		}
+	}
+}
+
+// RefsFromWorkitems returns the set of refs already in use across the
+// provided WorkItem slice. Use this to seed DeriveUnique.
+func RefsFromWorkitems(items []WorkItem) map[string]bool {
+	out := make(map[string]bool, len(items))
+	for _, item := range items {
+		ref, ok := item.SourceMetadata["ref"].(string)
+		if !ok || ref == "" {
+			continue
+		}
+		out[ref] = true
+	}
+	return out
+}

--- a/internal/workitem/ref_test.go
+++ b/internal/workitem/ref_test.go
@@ -1,6 +1,8 @@
 package workitem
 
 import (
+	"context"
+	"errors"
 	"regexp"
 	"strings"
 	"testing"
@@ -34,7 +36,10 @@ func TestDerive_DifferentIDsDifferentRefs(t *testing.T) {
 func TestDeriveUnique_NoCollisionReturnsBase(t *testing.T) {
 	id := "design-foo-2026-05-24"
 	base := Derive(id)
-	got := DeriveUnique(id, map[string]bool{})
+	got, err := DeriveUnique(context.Background(), id, map[string]bool{})
+	if err != nil {
+		t.Fatalf("DeriveUnique: %v", err)
+	}
 	if got != base {
 		t.Fatalf("DeriveUnique with empty existing should equal Derive: got %q, base %q", got, base)
 	}
@@ -44,7 +49,10 @@ func TestDeriveUnique_AvoidsCollision(t *testing.T) {
 	id := "design-foo-2026-05-24"
 	base := Derive(id)
 	existing := map[string]bool{base: true}
-	got := DeriveUnique(id, existing)
+	got, err := DeriveUnique(context.Background(), id, existing)
+	if err != nil {
+		t.Fatalf("DeriveUnique: %v", err)
+	}
 	if got == base {
 		t.Fatalf("DeriveUnique returned the colliding base ref: %q", got)
 	}
@@ -63,9 +71,21 @@ func TestDeriveUnique_HandlesMultipleCollisions(t *testing.T) {
 		Derive(id + "#1"): true,
 		Derive(id + "#2"): true,
 	}
-	got := DeriveUnique(id, existing)
+	got, err := DeriveUnique(context.Background(), id, existing)
+	if err != nil {
+		t.Fatalf("DeriveUnique: %v", err)
+	}
 	if existing[got] {
 		t.Fatalf("DeriveUnique returned a colliding ref: %q", got)
+	}
+}
+
+func TestDeriveUnique_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := DeriveUnique(ctx, "design-foo-2026-05-24", map[string]bool{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("DeriveUnique error = %v, want context.Canceled", err)
 	}
 }
 

--- a/internal/workitem/ref_test.go
+++ b/internal/workitem/ref_test.go
@@ -1,0 +1,87 @@
+package workitem
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var refPattern = regexp.MustCompile(`^WI-[0-9a-f]{6}$`)
+
+func TestDerive_Deterministic(t *testing.T) {
+	id := "design-foo-2026-05-24"
+	first := Derive(id)
+	second := Derive(id)
+	if first != second {
+		t.Fatalf("Derive(%q) is non-deterministic: %q vs %q", id, first, second)
+	}
+	if !refPattern.MatchString(first) {
+		t.Fatalf("Derive(%q) = %q does not match %s", id, first, refPattern)
+	}
+	if !strings.HasPrefix(first, RefPrefix) {
+		t.Fatalf("Derive(%q) = %q does not have %q prefix", id, first, RefPrefix)
+	}
+}
+
+func TestDerive_DifferentIDsDifferentRefs(t *testing.T) {
+	a := Derive("design-foo-2026-05-24")
+	b := Derive("design-bar-2026-05-24")
+	if a == b {
+		t.Fatalf("Derive collided across different inputs: %q == %q", a, b)
+	}
+}
+
+func TestDeriveUnique_NoCollisionReturnsBase(t *testing.T) {
+	id := "design-foo-2026-05-24"
+	base := Derive(id)
+	got := DeriveUnique(id, map[string]bool{})
+	if got != base {
+		t.Fatalf("DeriveUnique with empty existing should equal Derive: got %q, base %q", got, base)
+	}
+}
+
+func TestDeriveUnique_AvoidsCollision(t *testing.T) {
+	id := "design-foo-2026-05-24"
+	base := Derive(id)
+	existing := map[string]bool{base: true}
+	got := DeriveUnique(id, existing)
+	if got == base {
+		t.Fatalf("DeriveUnique returned the colliding base ref: %q", got)
+	}
+	if existing[got] {
+		t.Fatalf("DeriveUnique returned a ref still in the existing set: %q", got)
+	}
+	if !refPattern.MatchString(got) {
+		t.Fatalf("DeriveUnique result %q does not match %s", got, refPattern)
+	}
+}
+
+func TestDeriveUnique_HandlesMultipleCollisions(t *testing.T) {
+	id := "design-foo-2026-05-24"
+	existing := map[string]bool{
+		Derive(id):        true,
+		Derive(id + "#1"): true,
+		Derive(id + "#2"): true,
+	}
+	got := DeriveUnique(id, existing)
+	if existing[got] {
+		t.Fatalf("DeriveUnique returned a colliding ref: %q", got)
+	}
+}
+
+func TestRefsFromWorkitems(t *testing.T) {
+	items := []WorkItem{
+		{SourceMetadata: map[string]any{"ref": "WI-aaaaaa"}},
+		{SourceMetadata: map[string]any{"ref": "WI-bbbbbb"}},
+		{SourceMetadata: map[string]any{}},          // no ref
+		{SourceMetadata: nil},                       // nil metadata
+		{SourceMetadata: map[string]any{"ref": ""}}, // empty ref
+	}
+	set := RefsFromWorkitems(items)
+	if len(set) != 2 {
+		t.Fatalf("expected 2 refs, got %d (%v)", len(set), set)
+	}
+	if !set["WI-aaaaaa"] || !set["WI-bbbbbb"] {
+		t.Fatalf("missing expected refs: %v", set)
+	}
+}

--- a/internal/workitem/testdata/workitem_full.yaml
+++ b/internal/workitem/testdata/workitem_full.yaml
@@ -1,4 +1,4 @@
-version: v1alpha5
+version: v1alpha6
 kind: workitem
 
 id: design-thin-start-workflow-ladder-2026-04-25

--- a/pkg/commitkit/autowrite.go
+++ b/pkg/commitkit/autowrite.go
@@ -61,6 +61,16 @@ func LoadCommitMessageHook(ctx context.Context, campaignRoot string) (*CommitMes
 
 // AutoWriteCommitMessage runs the configured commit message hook from repoPath.
 func AutoWriteCommitMessage(ctx context.Context, campaignRoot, repoPath string) (string, error) {
+	return AutoWriteCommitMessageWithEnv(ctx, campaignRoot, repoPath, nil)
+}
+
+// AutoWriteCommitMessageWithEnv is AutoWriteCommitMessage with extra
+// environment variables passed to the hook subprocess. extraEnv entries are
+// appended to os.Environ() — they take precedence on duplicate keys.
+//
+// Use commitkit.WorkitemEnv (and any future *Env helpers) to build the
+// extraEnv slice so the variable contract stays in one place.
+func AutoWriteCommitMessageWithEnv(ctx context.Context, campaignRoot, repoPath string, extraEnv []string) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
@@ -70,12 +80,18 @@ func AutoWriteCommitMessage(ctx context.Context, campaignRoot, repoPath string) 
 		return "", err
 	}
 
-	return RunCommitMessageCommand(ctx, repoPath, hook.Command)
+	return RunCommitMessageCommandWithEnv(ctx, repoPath, hook.Command, extraEnv)
 }
 
 // RunCommitMessageCommand executes command exactly as configured from repoPath
 // and returns trimmed stdout as the raw commit message.
 func RunCommitMessageCommand(ctx context.Context, repoPath, command string) (string, error) {
+	return RunCommitMessageCommandWithEnv(ctx, repoPath, command, nil)
+}
+
+// RunCommitMessageCommandWithEnv is RunCommitMessageCommand with extra
+// environment variables passed to the subprocess (appended to os.Environ()).
+func RunCommitMessageCommandWithEnv(ctx context.Context, repoPath, command string, extraEnv []string) (string, error) {
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
@@ -88,6 +104,9 @@ func RunCommitMessageCommand(ctx context.Context, repoPath, command string) (str
 	name, args := shellCommand(command)
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = repoPath
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/pkg/commitkit/commitkit.go
+++ b/pkg/commitkit/commitkit.go
@@ -42,6 +42,34 @@ func PrependCampaignTag(campaignID, message string) string {
 	return git.PrependCampaignTag(campaignID, message)
 }
 
+// TagComponents is the parsed form of a campaign tag. Re-exported from
+// internal/git so callers do not need to import the internal package.
+type TagComponents = git.TagComponents
+
+// FormatContextTagsFull composes the consolidated campaign tag from any
+// subset of (campaign id, quest id, festival ref, workitem ref). Component
+// order is fixed: campaign → quest → festival → workitem.
+func FormatContextTagsFull(campaignID, questID, festRef, workitemRef string) string {
+	return git.FormatContextTagsFull(campaignID, questID, festRef, workitemRef)
+}
+
+// PrependContextTagsFull prepends the consolidated campaign tag to a commit
+// message. If campaignID is empty, returns the message unchanged (no tag
+// without a campaign).
+func PrependContextTagsFull(campaignID, questID, festRef, workitemRef, message string) string {
+	tag := FormatContextTagsFull(campaignID, questID, festRef, workitemRef)
+	if tag == "" {
+		return message
+	}
+	return tag + " " + message
+}
+
+// ParseTag extracts the components of a campaign tag from a commit subject.
+// Returns a zero-valued TagComponents when no tag is present.
+func ParseTag(subject string) TagComponents {
+	return git.ParseTag(subject)
+}
+
 // DetectCampaign finds the campaign root by walking up from the current
 // working directory. Returns the campaign ID string from the campaign's
 // config, or an error if the working directory is not inside a campaign.

--- a/pkg/commitkit/commitkit_tags_test.go
+++ b/pkg/commitkit/commitkit_tags_test.go
@@ -1,0 +1,47 @@
+package commitkit_test
+
+import (
+	"testing"
+
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
+)
+
+func TestPrependContextTagsFull(t *testing.T) {
+	cases := []struct {
+		name                                            string
+		campaign, quest, fest, workitem, msg, want      string
+	}{
+		{
+			name:     "no campaign returns message unchanged",
+			campaign: "", quest: "qst_x", fest: "CW0003", workitem: "WI-abcdef",
+			msg: "hello", want: "hello",
+		},
+		{
+			name:     "campaign only",
+			campaign: "8deed8b4", msg: "feat: thing",
+			want: "[OBEY-CAMPAIGN-8deed8b4] feat: thing",
+		},
+		{
+			name:     "all four components",
+			campaign: "8deed8b4", quest: "qst_abc", fest: "CW0003", workitem: "WI-abcdef",
+			msg: "full",
+			want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc-FE-CW0003-WI-WI-abcdef] full",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := commitkit.PrependContextTagsFull(tc.campaign, tc.quest, tc.fest, tc.workitem, tc.msg)
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCommitkit_ParseTag_RoundTrip(t *testing.T) {
+	tag := commitkit.PrependContextTagsFull("8deed8b4", "qst_abc", "CW0003", "WI-abcdef", "subject")
+	got := commitkit.ParseTag(tag)
+	if got.CampaignID != "8deed8b4" || got.QuestID != "qst_abc" || got.FestRef != "CW0003" || got.WorkitemRef != "WI-abcdef" {
+		t.Fatalf("parse round-trip broke: %#v", got)
+	}
+}

--- a/pkg/commitkit/workitem_env.go
+++ b/pkg/commitkit/workitem_env.go
@@ -1,0 +1,50 @@
+package commitkit
+
+import (
+	"path/filepath"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+// WorkitemEnv builds the CAMP_WORKITEM_* environment variables that the
+// auto-write commit-message hook receives. Returns nil when wi is nil so the
+// caller's "no workitem context" branch is just `append(env, nil...)`.
+//
+// The CAMP_WORKITEM_PATH value is campaign-relative when campaignRoot is
+// non-empty and the workitem is inside it; otherwise it falls back to the
+// raw path.
+//
+// CAMP_WORKITEM_QUEST_ID is emitted only when the workitem carries a
+// non-empty quest_id, matching the SCHEMA.md "absent when unset" contract.
+func WorkitemEnv(wi *wkitem.WorkItem, campaignRoot string) []string {
+	if wi == nil {
+		return nil
+	}
+	path := wi.RelativePath
+	if campaignRoot != "" {
+		if rel, err := filepath.Rel(campaignRoot, filepath.Join(campaignRoot, wi.RelativePath)); err == nil {
+			path = filepath.ToSlash(rel)
+		}
+	}
+	env := []string{
+		"CAMP_WORKITEM_ID=" + wi.StableID,
+		"CAMP_WORKITEM_REF=" + sourceMetaString(wi, "ref"),
+		"CAMP_WORKITEM_TYPE=" + string(wi.WorkflowType),
+		"CAMP_WORKITEM_TITLE=" + wi.Title,
+		"CAMP_WORKITEM_PATH=" + path,
+	}
+	if questID := sourceMetaString(wi, "quest_id"); questID != "" {
+		env = append(env, "CAMP_WORKITEM_QUEST_ID="+questID)
+	}
+	return env
+}
+
+func sourceMetaString(wi *wkitem.WorkItem, key string) string {
+	if wi == nil || wi.SourceMetadata == nil {
+		return ""
+	}
+	if v, ok := wi.SourceMetadata[key].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/pkg/commitkit/workitem_env_test.go
+++ b/pkg/commitkit/workitem_env_test.go
@@ -1,0 +1,92 @@
+package commitkit_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
+)
+
+func TestWorkitemEnv_NilReturnsNil(t *testing.T) {
+	if got := commitkit.WorkitemEnv(nil, "/campaign"); got != nil {
+		t.Fatalf("WorkitemEnv(nil) = %v, want nil", got)
+	}
+}
+
+func TestWorkitemEnv_AllFiveBaseVarsPresent(t *testing.T) {
+	wi := &workitem.WorkItem{
+		StableID:     "design-timeline-2026-05-24",
+		WorkflowType: workitem.WorkflowTypeDesign,
+		Title:        "Timeline",
+		RelativePath: "workflow/design/timeline",
+		SourceMetadata: map[string]any{
+			"ref": "WI-abcdef",
+		},
+	}
+	got := commitkit.WorkitemEnv(wi, "/campaign")
+	want := map[string]string{
+		"CAMP_WORKITEM_ID":    "design-timeline-2026-05-24",
+		"CAMP_WORKITEM_REF":   "WI-abcdef",
+		"CAMP_WORKITEM_TYPE":  "design",
+		"CAMP_WORKITEM_TITLE": "Timeline",
+		"CAMP_WORKITEM_PATH":  "workflow/design/timeline",
+	}
+	for k, wantValue := range want {
+		gotValue, ok := envValue(got, k)
+		if !ok {
+			t.Fatalf("missing %s in env: %v", k, got)
+		}
+		if gotValue != wantValue {
+			t.Fatalf("%s = %q, want %q", k, gotValue, wantValue)
+		}
+	}
+	if _, ok := envValue(got, "CAMP_WORKITEM_QUEST_ID"); ok {
+		t.Fatalf("CAMP_WORKITEM_QUEST_ID should be absent without quest_id: %v", got)
+	}
+}
+
+func TestWorkitemEnv_QuestIDPresentWhenSet(t *testing.T) {
+	wi := &workitem.WorkItem{
+		StableID:     "design-timeline-2026-05-24",
+		WorkflowType: workitem.WorkflowTypeDesign,
+		Title:        "Timeline",
+		RelativePath: "workflow/design/timeline",
+		SourceMetadata: map[string]any{
+			"ref":      "WI-abcdef",
+			"quest_id": "qst_active",
+		},
+	}
+	got := commitkit.WorkitemEnv(wi, "/campaign")
+	v, ok := envValue(got, "CAMP_WORKITEM_QUEST_ID")
+	if !ok {
+		t.Fatalf("expected CAMP_WORKITEM_QUEST_ID, got %v", got)
+	}
+	if v != "qst_active" {
+		t.Fatalf("CAMP_WORKITEM_QUEST_ID = %q, want qst_active", v)
+	}
+}
+
+func TestWorkitemEnv_EmptyOptionalFieldsRetainKey(t *testing.T) {
+	wi := &workitem.WorkItem{
+		StableID:     "design-x-2026-05-24",
+		WorkflowType: workitem.WorkflowTypeDesign,
+		RelativePath: "workflow/design/x",
+		// Title intentionally empty
+		SourceMetadata: map[string]any{"ref": "WI-aaaaaa"},
+	}
+	got := commitkit.WorkitemEnv(wi, "/campaign")
+	v, ok := envValue(got, "CAMP_WORKITEM_TITLE")
+	if !ok || v != "" {
+		t.Fatalf("expected CAMP_WORKITEM_TITLE with empty value, got %v", got)
+	}
+}
+
+func envValue(env []string, key string) (string, bool) {
+	for _, e := range env {
+		if strings.HasPrefix(e, key+"=") {
+			return e[len(key)+1:], true
+		}
+	}
+	return "", false
+}

--- a/tests/integration/commit_tags_test.go
+++ b/tests/integration/commit_tags_test.go
@@ -1,0 +1,190 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func initCommitTagsCampaign(t *testing.T, tc *TestContainer, dir string) {
+	t.Helper()
+	_, err := tc.RunCamp(
+		"init", dir,
+		"--name", "Commit Tags",
+		"--type", "product",
+		"-d", "Commit tags integration",
+		"-m", "Verify commit tag composition",
+		"--force",
+		"--no-register",
+		"--no-git",
+	)
+	require.NoError(t, err, "camp init")
+	// Make the campaign root a git repo so commits actually run.
+	require.NoError(t, tc.CreateGitRepo(dir))
+}
+
+func seedDesignWorkitemWithRef(t *testing.T, tc *TestContainer, dir, slug string) string {
+	t.Helper()
+	out, err := tc.RunCampInDir(dir, "workitem", "create", slug, "--type", "design", "--title", slug)
+	require.NoError(t, err, "workitem create: %s", out)
+	// Pull the ref out of the create output: "  ref: WI-<6 hex>".
+	var ref string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "ref:") {
+			ref = strings.TrimSpace(strings.TrimPrefix(line, "ref:"))
+			break
+		}
+	}
+	require.NotEmpty(t, ref, "ref missing from create output: %s", out)
+	return ref
+}
+
+func lastCommitSubject(t *testing.T, tc *TestContainer, repoPath string) string {
+	t.Helper()
+	out, code, err := tc.ExecCommand("git", "-C", repoPath, "log", "-1", "--pretty=%s")
+	require.NoError(t, err)
+	require.Equal(t, 0, code, "git log failed: %s", out)
+	return strings.TrimSpace(out)
+}
+
+func TestIntegration_CommitTags_CampCommit(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/commit-tags-camp"
+	initCommitTagsCampaign(t, tc, dir)
+	ref := seedDesignWorkitemWithRef(t, tc, dir, "timeline")
+
+	// Stage the workitem dir creation into git so there is something to commit.
+	_, _, err := tc.ExecCommand("git", "-C", dir, "add", "-A")
+	require.NoError(t, err)
+
+	wiDir := dir + "/workflow/design/timeline"
+	out, err := tc.RunCampInDir(wiDir, "commit", "-m", "design: timeline contract")
+	require.NoError(t, err, "camp commit: %s", out)
+
+	subject := lastCommitSubject(t, tc, dir)
+	assert.Contains(t, subject, "WI-"+ref, "subject should include WI-<ref>: %s", subject)
+	assert.Contains(t, subject, "design: timeline contract", "subject = %s", subject)
+}
+
+func TestIntegration_CommitTags_CampPCommit(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/commit-tags-p"
+	initCommitTagsCampaign(t, tc, dir)
+	ref := seedDesignWorkitemWithRef(t, tc, dir, "timeline")
+
+	// Create a project repo and link the workitem to it.
+	require.NoError(t, tc.CreateGitRepo(dir+"/projects/camp-timeline"))
+	_, err := tc.RunCampInDir(dir, "workitem", "link", "timeline", "--project", "camp-timeline")
+	require.NoError(t, err)
+
+	// Touch a file in the project and commit via camp p commit.
+	require.NoError(t, tc.WriteFile(dir+"/projects/camp-timeline/foo.go", "package x\n"))
+	out, err := tc.RunCampInDir(dir+"/projects/camp-timeline",
+		"p", "commit", "-m", "feat: stub")
+	require.NoError(t, err, "camp p commit: %s", out)
+
+	subject := lastCommitSubject(t, tc, dir+"/projects/camp-timeline")
+	assert.Contains(t, subject, "WI-"+ref, "subject should include WI-<ref>: %s", subject)
+	assert.Contains(t, subject, "feat: stub", "subject = %s", subject)
+}
+
+func TestIntegration_CommitTags_NoContext(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/commit-tags-no-context"
+	initCommitTagsCampaign(t, tc, dir)
+	// No workitems, no links — commit from a docs/ dir should produce a tag
+	// without any WI- segment.
+	require.NoError(t, tc.WriteFile(dir+"/docs/notes.md", "hi\n"))
+	_, _, err := tc.ExecCommand("git", "-C", dir, "add", "-A")
+	require.NoError(t, err)
+
+	out, err := tc.RunCampInDir(dir+"/docs", "commit", "-m", "chore: cleanup")
+	require.NoError(t, err, "camp commit: %s", out)
+
+	subject := lastCommitSubject(t, tc, dir)
+	assert.NotContains(t, subject, "WI-", "no-context commit must not include WI-: %s", subject)
+	assert.NotContains(t, subject, "qst_", "no-context commit must not include qst_: %s", subject)
+	assert.Regexp(t, `^\[OBEY-CAMPAIGN-[0-9a-f]{1,8}\]`, subject,
+		"subject should still carry the campaign tag: %s", subject)
+}
+
+func TestIntegration_CommitTags_ExplicitOverride(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/commit-tags-override"
+	initCommitTagsCampaign(t, tc, dir)
+	_ = seedDesignWorkitemWithRef(t, tc, dir, "ambient")
+	ref := seedDesignWorkitemWithRef(t, tc, dir, "override-target")
+
+	// Commit from a path NOT under either workitem; pass --workitem explicitly.
+	require.NoError(t, tc.WriteFile(dir+"/docs/r.md", "explicit\n"))
+	_, _, err := tc.ExecCommand("git", "-C", dir, "add", "-A")
+	require.NoError(t, err)
+
+	out, err := tc.RunCampInDir(dir+"/docs",
+		"commit", "-m", "doc: explicit", "--workitem", "override-target")
+	require.NoError(t, err, "camp commit --workitem: %s", out)
+
+	subject := lastCommitSubject(t, tc, dir)
+	assert.Contains(t, subject, "WI-"+ref, "explicit override should win: %s", subject)
+}
+
+func TestIntegration_AutoWriteEnv(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/commit-tags-autowrite"
+	initCommitTagsCampaign(t, tc, dir)
+	_ = seedDesignWorkitemWithRef(t, tc, dir, "envtest")
+
+	// Drop a tiny hook script that dumps env and prints a fixed message.
+	// Using a script keeps the campaign.yaml YAML simple (no nested quoting).
+	require.NoError(t, tc.WriteFile("/tmp/commit_hook.sh",
+		"#!/bin/sh\nenv | grep '^CAMP_WORKITEM_' > /tmp/env_dump\necho 'auto: from hook'\n"))
+	_, _, scriptErr := tc.ExecCommand("chmod", "+x", "/tmp/commit_hook.sh")
+	require.NoError(t, scriptErr)
+
+	// Append the hooks section to the existing campaign.yaml so other
+	// required fields (id, name, type, etc.) are not clobbered.
+	hookYAML := "\nhooks:\n  commit_message:\n    command: /tmp/commit_hook.sh\n"
+	_, _, hookErr := tc.ExecCommand("sh", "-c",
+		"cat >> "+dir+"/.campaign/campaign.yaml <<EOF"+hookYAML+"EOF")
+	require.NoError(t, hookErr)
+	_, _, addErr := tc.ExecCommand("git", "-C", dir, "add", "-A")
+	require.NoError(t, addErr)
+
+	wiDir := dir + "/workflow/design/envtest"
+	out, err := tc.RunCampInDir(wiDir, "commit", "--auto-write")
+	require.NoError(t, err, "camp commit --auto-write: %s", out)
+
+	dump, err := tc.ReadFile("/tmp/env_dump")
+	require.NoError(t, err, "env dump should exist")
+	for _, key := range []string{
+		"CAMP_WORKITEM_ID=",
+		"CAMP_WORKITEM_REF=WI-",
+		"CAMP_WORKITEM_TYPE=design",
+		"CAMP_WORKITEM_TITLE=envtest",
+		"CAMP_WORKITEM_PATH=workflow/design/envtest",
+	} {
+		assert.Contains(t, dump, key, "env dump missing %s:\n%s", key, dump)
+	}
+
+	subject := lastCommitSubject(t, tc, dir)
+	assert.Contains(t, subject, "auto: from hook", "commit subject should come from hook: %s", subject)
+}
+
+// fest commit and fest-side workitem resolution are deferred until camp is
+// re-tagged with commitkit.PrependContextTagsFull and
+// AutoWriteCommitMessageWithEnv. Skipped tests stay in tree so the contract
+// reappears once the dependency lands.
+
+func TestIntegration_CommitTags_FestCommit(t *testing.T) {
+	t.Skip("fest-side wiring deferred: requires fest go.mod bump to a camp release containing commitkit.PrependContextTagsFull")
+}
+
+func TestIntegration_CommitTags_QuestAndWorkitem(t *testing.T) {
+	t.Skip("quest context capture is camp-side, but the assertion currently requires the fest commit path; revisit after the camp release")
+}


### PR DESCRIPTION
## Summary

Sequence 03 of the CW0003 festival, **tasks 01–03**. Stacked on top of PR #303 (seq 02). Adds the `.workitem` schema bump that the rest of the sequence relies on, the doctor backfill for legacy workitems, and the full consolidated-tag composer in `internal/git`/`pkg/commitkit`.

### Tasks landed

**Task 01 — `.workitem` schema → v1alpha6.** New optional fields `ref` (deterministic `WI-<6 hex>` derived from id via `internal/workitem/ref.go::Derive`/`DeriveUnique`) and `quest_id` (captured at create/adopt time via `quest.ResolveContext`). v1alpha4/v1alpha5 markers still load without error. `camp workitem create` and `camp workitem adopt` both gain a `--quest` flag and surface a `ref:` line (plus optional `quest:` line) in their output.

**Task 02 — doctor backfills missing refs.** New finding code `workitem.ref.missing` (severity `warning`, `auto_fixable: true`). `camp workitem doctor --fix` rewrites each refless workitem in place via `yaml.Node` so all other fields and the existing key order are preserved; the `ref` lands immediately after `id` for minimal diffs. Backfill uses `DeriveUnique` against the currently-on-disk ref set (rescanned per fix, not stale-snapshotted) for collision avoidance. `ApplyMetadata` extended to surface `Ref`/`QuestID` into `WorkItem.SourceMetadata` so post-fix re-checks see the new values.

**Task 03 — consolidated tag composer.** `git.FormatContextTagsFull(campaignID, questID, festRef, workitemRef)` composes `[OBEY-CAMPAIGN-{cid}[-{qst}][-FE-{ref}][-WI-WI-{ref}]]`. Component order is fixed; absent components are omitted entirely. `FormatCampaignTag`/`FormatContextTags` now delegate so existing callers keep byte-identical output. `git.ParseTag(subject)` returns `TagComponents{CampaignID, QuestID, FestRef, WorkitemRef}` via a two-stage parser (RE2 strips the bracket; a small state machine peels the inner string on the known prefixes — clean disambiguation of `FE-<ref>-WI-<ref>` from `FE-<hyphenated ref>` without lookahead). `commitkit.PrependContextTagsFull` and `commitkit.ParseTag` re-export the helpers for both camp and fest consumers.

## Stacking note

This PR depends on PR #303 (sequence 02). Merging order:
1. PR #302 (sequence 01 — workflow surface)
2. PR #303 (sequence 02 — link registry)
3. PR #304 (this one — sequence 03 schema + doctor + tag)
4. Sequence 03 task 04+ (wiring the new tag into camp/fest commit wrappers) ships as a follow-up

## Test plan

- [x] `go test ./...` clean across the camp module
- [x] `internal/workitem/ref.go` — 5 unit tests (determinism, uniqueness, collision retry, helper)
- [x] `internal/commands/workitem/ref_quest_test.go` — create writes ref + omits quest_id when none active, three sequential creates produce unique refs, adopt writes ref, legacy v1alpha5 still loads
- [x] `internal/commands/workitem/doctor_ref_test.go` — backfill on legacy workitem clears the finding, preserves all other fields, handles multiple workitems without ref collision
- [x] `internal/git/campaign_tag_full_test.go` — every combo of present/absent components, parser on each known shape, backward-compat for `FormatCampaignTag` one-arg and two-arg forms, 100-iteration property round-trip
- [x] `pkg/commitkit/commitkit_tags_test.go` — `PrependContextTagsFull` matrix + parse-round-trip smoke
- [x] `internal/workitem/testdata/workitem_full.yaml` fixture bumped to v1alpha6 to match the new schema constant; `TestLoadMetadata_FullFixture` updated accordingly

## Notes for reviewers

- The two-stage tag parser in `internal/git/campaign_tag.go::ParseTag` is the riskiest piece. The property test exercises 100 random combinations; if a future component is added (e.g. `BR-<branch>`), the state machine needs a new arm.
- `ApplyMetadata` (`internal/workitem/merge.go`) now writes to `SourceMetadata` when `Ref` or `QuestID` is present. This is additive — existing readers that don't look at those keys are unaffected — but it does change the `SourceMetadata` shape for v1alpha6 workitems.
- The `workitem.ref.missing` doctor check runs on every invocation. On a fresh `camp` install with no v1alpha5 workitems the check is a no-op; on a campaign migrating from v1alpha5, expect one warning per legacy workitem until `--fix` is run.