### PR TITLE
feat(workitem): camp workitem commit + commits (CW0003 seq-04)

### DIFF
--- a/cmd/camp/manifest_test.go
+++ b/cmd/camp/manifest_test.go
@@ -127,6 +127,7 @@ func TestManifestCommand_AllRestrictedCommandsPresent(t *testing.T) {
 	if workitemCommandRegistered() {
 		expectedCommands["workitem"] = false
 		expectedCommands["workitem commit"] = false
+		expectedCommands["workitem commits"] = false
 	}
 
 	for _, cmd := range manifest.Commands {
@@ -149,7 +150,7 @@ func TestManifestCommand_AllRestrictedCommandsPresent(t *testing.T) {
 		wantCount += 13
 	}
 	if workitemCommandRegistered() {
-		wantCount += 2
+		wantCount += 3
 	}
 	if len(manifest.Commands) != wantCount {
 		t.Errorf("expected exactly %d restricted commands, got %d", wantCount, len(manifest.Commands))
@@ -201,6 +202,7 @@ func TestManifestCommand_AllCommandsHaveAnnotations(t *testing.T) {
 	if workitemCommandRegistered() {
 		agentAllowed["workitem"] = true
 		agentAllowed["workitem commit"] = true
+		agentAllowed["workitem commits"] = true
 	}
 
 	for _, cmd := range manifest.Commands {
@@ -276,6 +278,7 @@ func TestManifestCommand_InteractiveFlags(t *testing.T) {
 	if workitemCommandRegistered() {
 		nonInteractiveCommands["workitem"] = true
 		nonInteractiveCommands["workitem commit"] = true
+		nonInteractiveCommands["workitem commits"] = true
 	}
 
 	cmdMap := make(map[string]CommandEntry)

--- a/cmd/camp/manifest_test.go
+++ b/cmd/camp/manifest_test.go
@@ -126,6 +126,7 @@ func TestManifestCommand_AllRestrictedCommandsPresent(t *testing.T) {
 	}
 	if workitemCommandRegistered() {
 		expectedCommands["workitem"] = false
+		expectedCommands["workitem commit"] = false
 	}
 
 	for _, cmd := range manifest.Commands {
@@ -148,7 +149,7 @@ func TestManifestCommand_AllRestrictedCommandsPresent(t *testing.T) {
 		wantCount += 13
 	}
 	if workitemCommandRegistered() {
-		wantCount += 1
+		wantCount += 2
 	}
 	if len(manifest.Commands) != wantCount {
 		t.Errorf("expected exactly %d restricted commands, got %d", wantCount, len(manifest.Commands))
@@ -199,6 +200,7 @@ func TestManifestCommand_AllCommandsHaveAnnotations(t *testing.T) {
 	}
 	if workitemCommandRegistered() {
 		agentAllowed["workitem"] = true
+		agentAllowed["workitem commit"] = true
 	}
 
 	for _, cmd := range manifest.Commands {
@@ -273,6 +275,7 @@ func TestManifestCommand_InteractiveFlags(t *testing.T) {
 	}
 	if workitemCommandRegistered() {
 		nonInteractiveCommands["workitem"] = true
+		nonInteractiveCommands["workitem commit"] = true
 	}
 
 	cmdMap := make(map[string]CommandEntry)

--- a/internal/commands/workitem/COMMIT_DESIGN.md
+++ b/internal/commands/workitem/COMMIT_DESIGN.md
@@ -1,0 +1,251 @@
+# camp workitem commit — Staging Plan Design
+
+Status: design contract for CW0003 sequence 04, task 02 implementation.
+Mirrors the existing quest-commit precedent in `internal/git/commit/quest.go`.
+
+## 1 Goal
+
+Add `camp workitem commit` as a scoped commit command. It stages only files that
+belong to the resolved workitem context and never silently widens to the whole
+campaign root. The same plan flows through a new `commit.Workitem` helper that
+mirrors `commit.Quest` so the campaign-tag composition, file-scoping, and result
+shape are shared with every other commit path.
+
+The design is built on top of the v1alpha6 workitem schema and the
+`workitem/resolver` pipeline that sequence 03 already shipped. The resolver
+returns the workitem, its quest id, and its source. The commit command turns
+that resolution into a staging plan, prints it to stderr, and executes it
+through `commit.Workitem`.
+
+## 2 Precedent
+
+We deliberately reuse, not parallel-implement, the quest path.
+
+- `internal/git/commit/quest.go` — defines `QuestAction`, `QuestOptions`, and
+  the thin `Quest()` constructor that forwards into `doCommit`.
+- `internal/git/commit/commit.go` — owns `Options`, `doCommit`, and
+  `stageAndCommit`. The `Options.Files` / `Options.PreStaged` /
+  `Options.SelectiveOnly` triple already provides the exact selective-commit
+  semantics we need: `git add <files>` followed by `git commit --only
+  <files>`, with `ErrNoChanges` on empty scope rather than silent
+  `CommitAll` fallback.
+- `internal/git/commit/intent.go`, `internal/git/commit/project.go` — show the
+  established 1-file pattern for adding a new commit family.
+
+The workitem family follows the same shape. The only new code in the commit
+package is a thin `workitem.go` mirror; all real machinery stays in `doCommit`.
+
+## 3 commit.Workitem shape
+
+```go
+// internal/git/commit/workitem.go (new file in task 02)
+
+package commit
+
+import "context"
+
+// WorkitemAction identifies the high-level operation captured by the commit.
+// The generic case is WorkitemScope — a user-initiated scoped commit via
+// `camp workitem commit`. WorkitemEdit is reserved for in-process flows that
+// edit workitem metadata (rename, retype, retitle) and want a more specific
+// action tag.
+type WorkitemAction string
+
+const (
+    WorkitemEdit  WorkitemAction = "WorkitemEdit"
+    WorkitemScope WorkitemAction = "WorkitemScope"
+)
+
+// WorkitemOptions configures a workitem commit. The embedded Options carries
+// the campaign root, campaign id, selective-commit scope, and the QuestID /
+// WorkitemRef fields that doCommit hands to FormatContextTagsFull.
+type WorkitemOptions struct {
+    Options
+    Action      WorkitemAction
+    WorkitemID  string // stable id, e.g. "design-timeline-2026-05-24"
+    WorkitemRef string // WI-<6 hex>, copied into Options.WorkitemRef
+    QuestID     string // optional; copied into Options.QuestID
+    Title       string // workitem title used as the commit subject
+    Detail      string // optional body text
+}
+
+// Workitem stages workitem-scoped changes and commits them with a campaign tag
+// that carries the workitem ref (and quest id, when set).
+func Workitem(ctx context.Context, opts WorkitemOptions) Result {
+    opts.Options.QuestID = opts.QuestID
+    opts.Options.WorkitemRef = opts.WorkitemRef
+    return doCommit(ctx, opts.Options, string(opts.Action), opts.Title, opts.Detail)
+}
+```
+
+This file is the entire delta to the commit package. `stageAndCommit` already
+honors `Options.Files` and `Options.SelectiveOnly`; we pass the computed
+staging plan as `Files` and set `SelectiveOnly = true` so empty plans surface
+`(no changes to commit)` instead of widening.
+
+## 4 Default staging matrix
+
+The resolver returns a `*resolver.Resolution` whose `Source` tells us which
+matrix row applies. The staging planner translates that resolution into the
+file list passed to `commit.WorkitemOptions.Files`.
+
+| Resolved context | Default staged paths |
+|---|---|
+| **Workitem directory under campaign root** (cwd inside `workflow/<type>/<slug>/`) | `<workitem-dir>/**` plus `.campaign/workitems/links.yaml` if dirty |
+| **Campaign root** (cwd at root, resolver returned a workitem via `current` or explicit `--workitem`) | `<workitem-dir>/**` plus `.campaign/workitems/links.yaml` if dirty. **Never `git add .`.** |
+| **Linked project repo** (cwd under a `projects/<name>/` submodule that resolves to a workitem link) | All changed files inside that project repo. The submodule is its own git repo, so "all changed files" means `git status --porcelain` inside the submodule, excluding gitignored entries. |
+| **Project submodule pointer at campaign root** (changes to the submodule SHA in the parent repo) | **Off by default.** Requires `--include-submodule-pointer` or a follow-up `camp refs-sync`. |
+| **Festival-linked workitem** (resolver source = `festival`) | Festival-scoped paths under `festivals/<status>/<festival>/` that touch the workitem, plus `.campaign/workitems/links.yaml` if dirty. |
+| **No workitem context** | Error with a hint. Do not fall back to staging anything. |
+
+### 4.1 Why links.yaml is part of the default plan
+
+`camp workitem commit` is the moment a user records that a chunk of work
+"belongs to" a workitem. If the link registry just changed (e.g. they ran
+`camp workitem link …` and then `camp workitem commit`), staging
+`.campaign/workitems/links.yaml` alongside the changes keeps the link and
+the work it scoped together in a single commit. The planner checks
+`git status` for the registry path; if clean, it is omitted, so we do not
+churn the registry on every commit.
+
+### 4.2 Why submodule pointer is off by default
+
+Auto-staging the submodule SHA in the parent campaign repo is the single
+biggest footgun in the existing campaign tooling. It produces "pointer
+thrash" commits that move project SHAs forward as a side effect of unrelated
+work in the campaign root. The workitem-commit path opts out by default and
+defers pointer movement to either the explicit `--include-submodule-pointer`
+flag or the existing `camp refs-sync` workflow.
+
+## 5 Flag precedence
+
+The default matrix can be modified with four flags. Precedence runs strictly
+in this order — each step takes the prior step's plan as input:
+
+1. **`--staged`** — short-circuits the matrix. The staging plan is exactly
+   what is already in the git index. The planner skips resolution-driven
+   staging and passes `Options.PreStaged` (the index contents) so the
+   campaign tag still carries the workitem ref but no `git add` runs.
+2. **`--project <name>`** — overrides the resolver. The planner treats the
+   command as if invoked from inside that project repo (matrix row 3).
+   Combined with `--workitem` for an explicit override at both axes.
+3. **`--include <path>`** (repeatable) — adds the path to the plan after the
+   matrix is computed. Paths must be under the campaign root or under the
+   resolved project repo; out-of-scope paths error.
+4. **`--exclude <path>`** (repeatable) — removes the path from the plan;
+   applied last so the user can prune even matrix-default paths.
+
+`--workitem <selector>` (already wired in `camp commit` via sequence 03) is
+not a precedence step; it changes what the resolver returns, and the matrix
+runs on that result.
+
+## 6 Staging plan output
+
+Before invoking `commit.Workitem`, the command prints the plan to **stderr**
+in a fixed, parseable format. Stderr (not stdout) keeps the plan visible
+during interactive use without polluting pipes that consume `--json`.
+
+```text
+workitem: <id> (ref: WI-<6 hex>)
+context:  <one-line context summary>
+staging:
+  A  <relative path>
+  M  <relative path>
+skipped:
+  <relative path> (<reason>)
+tag:    [OBEY-CAMPAIGN-<8hex>[-qst_<…>]-WI-WI-<6hex>]
+```
+
+`A` / `M` / `D` mirror `git status --porcelain` status letters. Skipped
+entries include `(gitignored)`, `(out of scope)`, `(submodule pointer; use
+--include-submodule-pointer)`, and `(--exclude)`. Reasons are stable strings
+so the integration tests can grep for them.
+
+`--json` swaps the human plan for a structured `staging_plan` object
+containing the same data, plus `command`, `workitem`, `tag` fields. The
+human plan is suppressed when `--json` is set; errors still print to stderr.
+
+## 7 No-context error contract
+
+If the resolver returns no workitem and no `--workitem` selector was given,
+the command errors with:
+
+```text
+Error: no workitem context resolved from cwd
+
+Try one of:
+  --workitem <selector>            explicit workitem to scope this commit
+  cd workflow/<type>/<slug> && ...  run from inside a workitem directory
+  camp workitem current <selector>  set a session-wide default
+```
+
+Crucially: the command does **not** fall back to staging the whole repo. The
+contract is that `camp workitem commit` always carries a `WI-` tag; if we
+cannot derive one, we do not commit.
+
+## 8 Pointer thrash policy
+
+The default plan never touches the parent-repo submodule pointer. Three
+behaviors keep that promise:
+
+1. The matrix row for "linked project repo" stages files **inside** the
+   submodule's own git repo. The parent campaign repo is not touched.
+2. The matrix row for "project submodule pointer at campaign root" is
+   intentionally off by default. The user has to either pass
+   `--include-submodule-pointer` or run `camp refs-sync` afterward.
+3. When `--include-submodule-pointer` is passed, the planner stages the
+   relative submodule path in the parent repo plus the file changes in the
+   submodule, and the commit message carries the workitem ref so the
+   pointer move is attributable.
+
+## 9 commit.Workitem call shape
+
+The `camp workitem commit` command builds `commit.WorkitemOptions` like:
+
+```go
+opts := commit.WorkitemOptions{
+    Options: commit.Options{
+        CampaignRoot:  campRoot,
+        CampaignID:    cfg.ID,
+        Files:         plan.Files,
+        PreStaged:     plan.PreStaged,
+        SelectiveOnly: true,
+    },
+    Action:      commit.WorkitemScope,
+    WorkitemID:  wi.StableID,
+    WorkitemRef: ref,
+    QuestID:     resolution.QuestID,
+    Title:       subject, // -m message, or workitem title fallback
+    Detail:      body,
+}
+res := commit.Workitem(ctx, opts)
+```
+
+`SelectiveOnly: true` is the load-bearing flag. It guarantees that when
+`plan.Files` is empty (e.g. user excluded everything), the commit returns
+`(no changes to commit)` instead of falling through to `CommitAll`.
+
+## 10 Sample plans
+
+One sample per matrix row lives under
+`internal/commands/workitem/testdata/plans/`:
+
+- `workitem_dir.txt` — cwd inside a workitem directory
+- `campaign_root.txt` — cwd at campaign root, workitem resolved via `current`
+- `linked_project.txt` — cwd in a linked project submodule
+- `submodule_pointer_explicit.txt` — `--include-submodule-pointer`
+- `festival_scope.txt` — resolver source = `festival`
+- `no_context_error.txt` — no workitem, no override; shows the error text
+
+These fixtures are consumed by the task-04 integration tests; task 02 uses
+them as the contract while implementing the planner.
+
+## 11 Out of scope for sequence 04
+
+- Cross-PR work to wire `fest commit` into the same matrix. Sequence 03
+  shipped the tag composer; the fest-side bump waits on the next camp tag.
+- `camp workitem commits` query command (task 03 of this sequence) is a
+  separate concern. It consumes the tag format defined here but does not
+  share the staging planner.
+- Interactive selection of files. The plan is computed and either accepted
+  or aborted; a future TUI can layer on top.

--- a/internal/commands/workitem/commit.go
+++ b/internal/commands/workitem/commit.go
@@ -1,0 +1,215 @@
+package workitem
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git/commit"
+)
+
+// noContextHint is the multi-line refusal message printed when the resolver
+// returns no workitem. Mirrors COMMIT_DESIGN.md §7.
+const noContextHint = `no workitem context resolved from cwd
+
+Try one of:
+  --workitem <selector>            explicit workitem to scope this commit
+  cd workflow/<type>/<slug> && ...  run from inside a workitem directory
+  camp workitem current <selector>  set a session-wide default`
+
+func newCommitCommand() *cobra.Command {
+	var (
+		flagMessage                 string
+		flagWorkitem                string
+		flagProject                 string
+		flagIncludes                []string
+		flagExcludes                []string
+		flagStaged                  bool
+		flagIncludeSubmodulePointer bool
+		flagDryRun                  bool
+		flagJSON                    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "commit",
+		Short: "Commit changes scoped to the resolved workitem",
+		Long: `Stage and commit changes belonging to a resolved workitem.
+
+The staging plan is computed from the resolver context (cwd-aware, with
+explicit --workitem or --project overrides) and printed to stderr before
+the commit runs. The plan never silently widens to "git add ." at the
+campaign root.
+
+See internal/commands/workitem/COMMIT_DESIGN.md for the full staging matrix
+and flag precedence.`,
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Scoped commit command; honors --json and --dry-run for automation",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			return runCommit(ctx, cmd, commitFlags{
+				Message:                 flagMessage,
+				Workitem:                flagWorkitem,
+				Project:                 flagProject,
+				Includes:                flagIncludes,
+				Excludes:                flagExcludes,
+				Staged:                  flagStaged,
+				IncludeSubmodulePointer: flagIncludeSubmodulePointer,
+				DryRun:                  flagDryRun,
+				JSON:                    flagJSON,
+			})
+		},
+	}
+	cmd.Flags().StringVarP(&flagMessage, "message", "m", "", "commit message (required unless --dry-run)")
+	cmd.Flags().StringVar(&flagWorkitem, "workitem", "", "explicit workitem selector (overrides cwd-based resolution)")
+	cmd.Flags().StringVar(&flagProject, "project", "", "force project-repo context by name (skips resolver)")
+	cmd.Flags().StringArrayVar(&flagIncludes, "include", nil, "additional path to stage (repeatable; relative to repo root)")
+	cmd.Flags().StringArrayVar(&flagExcludes, "exclude", nil, "path to remove from the staging plan (repeatable)")
+	cmd.Flags().BoolVar(&flagStaged, "staged", false, "commit whatever is already in the git index")
+	cmd.Flags().BoolVar(&flagIncludeSubmodulePointer, "include-submodule-pointer", false, "include dirty project submodule pointers in the plan")
+	cmd.Flags().BoolVar(&flagDryRun, "dry-run", false, "print the staging plan and exit without committing")
+	cmd.Flags().BoolVar(&flagJSON, "json", false, "emit the staging plan and commit result as JSON on stdout")
+	return cmd
+}
+
+type commitFlags struct {
+	Message                 string
+	Workitem                string
+	Project                 string
+	Includes                []string
+	Excludes                []string
+	Staged                  bool
+	IncludeSubmodulePointer bool
+	DryRun                  bool
+	JSON                    bool
+}
+
+func runCommit(ctx context.Context, cmd *cobra.Command, flags commitFlags) error {
+	if flags.Message == "" && !flags.DryRun {
+		return camperrors.NewValidation("message", "commit message required (use -m \"<msg>\")", nil)
+	}
+
+	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	plan, err := ComputePlan(ctx, campaignRoot, PlanOptions{
+		Explicit:                flags.Workitem,
+		Project:                 flags.Project,
+		Includes:                flags.Includes,
+		Excludes:                flags.Excludes,
+		StagedOnly:              flags.Staged,
+		IncludeSubmodulePointer: flags.IncludeSubmodulePointer,
+		CampaignID:              cfg.ID,
+	})
+	if err != nil {
+		if errors.Is(err, ErrNoWorkitemContext) {
+			fmt.Fprintln(cmd.ErrOrStderr(), noContextHint)
+			os.Exit(2)
+		}
+		return err
+	}
+
+	if !flags.JSON {
+		if perr := PrintPlan(cmd.ErrOrStderr(), plan); perr != nil {
+			return perr
+		}
+	}
+
+	if len(plan.Stage) == 0 && len(plan.PreStaged) == 0 {
+		return camperrors.NewValidation("plan",
+			"empty staging plan; pass --include <path> or run from inside a changed workitem", nil)
+	}
+
+	if flags.DryRun {
+		if flags.JSON {
+			return emitJSON(cmd.OutOrStdout(), plan, "")
+		}
+		return nil
+	}
+
+	res := commit.Workitem(ctx, commit.WorkitemOptions{
+		Options: commit.Options{
+			CampaignRoot:  plan.RepoRoot,
+			CampaignID:    cfg.ID,
+			Files:         plan.Stage,
+			PreStaged:     plan.PreStaged,
+			SelectiveOnly: true,
+		},
+		Action:      commit.WorkitemScope,
+		WorkitemID:  plan.Workitem.StableID,
+		WorkitemRef: plan.WorkitemRef,
+		QuestID:     plan.QuestID,
+		Title:       flags.Message,
+	})
+	if res.Err != nil {
+		return res.Err
+	}
+	if res.NoChanges {
+		if flags.JSON {
+			return emitJSON(cmd.OutOrStdout(), plan, "")
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), res.Message)
+		return nil
+	}
+
+	sha, _ := lastCommitSHA(ctx, plan.RepoRoot)
+	if flags.JSON {
+		return emitJSON(cmd.OutOrStdout(), plan, sha)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "committed %s\n", sha)
+	return nil
+}
+
+func emitJSON(w writeFlusher, plan *StagingPlan, sha string) error {
+	payload := struct {
+		Workitem    string         `json:"workitem"`
+		Ref         string         `json:"workitem_ref,omitempty"`
+		QuestID     string         `json:"quest_id,omitempty"`
+		Tag         string         `json:"tag"`
+		Context     PlanContext    `json:"context"`
+		ContextNote string         `json:"context_note,omitempty"`
+		RepoRoot    string         `json:"repo_root"`
+		Stage       []string       `json:"stage"`
+		PreStaged   []string       `json:"pre_staged,omitempty"`
+		Skip        []SkippedEntry `json:"skip,omitempty"`
+		SHA         string         `json:"sha,omitempty"`
+	}{
+		Workitem:    plan.Workitem.StableID,
+		Ref:         plan.WorkitemRef,
+		QuestID:     plan.QuestID,
+		Tag:         plan.Tag,
+		Context:     plan.Context,
+		ContextNote: plan.ContextNote,
+		RepoRoot:    plan.RepoRoot,
+		Stage:       plan.Stage,
+		PreStaged:   plan.PreStaged,
+		Skip:        plan.Skip,
+		SHA:         sha,
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(payload)
+}
+
+type writeFlusher interface {
+	Write([]byte) (int, error)
+}
+
+func lastCommitSHA(ctx context.Context, repoRoot string) (string, error) {
+	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/commands/workitem/commit.go
+++ b/internal/commands/workitem/commit.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 
@@ -120,7 +119,7 @@ func runCommit(ctx context.Context, cmd *cobra.Command, flags commitFlags) error
 	if err != nil {
 		if errors.Is(err, ErrNoWorkitemContext) {
 			fmt.Fprintln(cmd.ErrOrStderr(), noContextHint)
-			os.Exit(2)
+			return camperrors.NewCommand("camp workitem commit", 2, "", err)
 		}
 		return err
 	}

--- a/internal/commands/workitem/commit.go
+++ b/internal/commands/workitem/commit.go
@@ -39,26 +39,31 @@ func newCommitCommand() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "commit",
+		Use:   "commit [selector]",
 		Short: "Commit changes scoped to the resolved workitem",
 		Long: `Stage and commit changes belonging to a resolved workitem.
 
 The staging plan is computed from the resolver context (cwd-aware, with
-explicit --workitem or --project overrides) and printed to stderr before
-the commit runs. The plan never silently widens to "git add ." at the
+explicit positional <selector> or --project overrides) and printed to stderr
+before the commit runs. The plan never silently widens to "git add ." at the
 campaign root.
 
 See internal/commands/workitem/COMMIT_DESIGN.md for the full staging matrix
 and flag precedence.`,
+		Args: cobra.MaximumNArgs(1),
 		Annotations: map[string]string{
 			"agent_allowed": "true",
 			"agent_reason":  "Scoped commit command; honors --json and --dry-run for automation",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			selector := flagWorkitem
+			if selector == "" && len(args) == 1 {
+				selector = args[0]
+			}
 			return runCommit(ctx, cmd, commitFlags{
 				Message:                 flagMessage,
-				Workitem:                flagWorkitem,
+				Workitem:                selector,
 				Project:                 flagProject,
 				Includes:                flagIncludes,
 				Excludes:                flagExcludes,

--- a/internal/commands/workitem/commits.go
+++ b/internal/commands/workitem/commits.go
@@ -1,0 +1,318 @@
+package workitem
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
+)
+
+const (
+	commitsDefaultLimit = 100
+	commitsLogFormat    = "%H%x09%an%x09%aI%x09%s"
+)
+
+// CommitRecord is the per-row payload emitted by `camp workitem commits`.
+// Repo is the campaign-relative path of the git repo the commit was found
+// in (".") for the campaign root.
+type CommitRecord struct {
+	SHA      string                  `json:"sha"`
+	Author   string                  `json:"author"`
+	Date     time.Time               `json:"date"`
+	Subject  string                  `json:"subject"`
+	Repo     string                  `json:"repo"`
+	TagParts commitkit.TagComponents `json:"tag,omitempty"`
+}
+
+// commitsQueryError records a per-repo failure surfaced under the --json
+// `errors` key. Default table output drops these silently to keep the
+// happy-path output readable.
+type commitsQueryError struct {
+	Repo string `json:"repo"`
+	Err  string `json:"error"`
+}
+
+func newCommitsCommand() *cobra.Command {
+	var (
+		flagRef      string
+		flagJSON     bool
+		flagLimit    int
+		flagOffset   int
+		flagWorkitem string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "commits [selector]",
+		Short: "List commits referencing a workitem across linked repos",
+		Long: `Search the campaign root and every linked project/repo/worktree/festival
+repo for commits whose campaign tag references this workitem's ref.
+
+Default sort: most recent first across all repos. Use --json for structured
+output. Repos that are not git checkouts or that fail their git log invocation
+are skipped silently in table mode and reported under "errors" in JSON mode.`,
+		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Read-only query with --json output for automation",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			selector := ""
+			if len(args) == 1 {
+				selector = args[0]
+			}
+			if flagWorkitem != "" {
+				selector = flagWorkitem
+			}
+			return runCommitsQuery(ctx, cmd, commitsFlags{
+				Selector: selector,
+				Ref:      flagRef,
+				JSON:     flagJSON,
+				Limit:    flagLimit,
+				Offset:   flagOffset,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&flagRef, "ref", "", "query by workitem ref directly (e.g. WI-abc123) — skips resolver")
+	cmd.Flags().StringVar(&flagWorkitem, "workitem", "", "alias for the positional <selector>")
+	cmd.Flags().BoolVar(&flagJSON, "json", false, "emit JSON instead of the default table")
+	cmd.Flags().IntVar(&flagLimit, "limit", commitsDefaultLimit, "maximum commits to return")
+	cmd.Flags().IntVar(&flagOffset, "offset", 0, "number of commits to skip (after sorting)")
+	return cmd
+}
+
+type commitsFlags struct {
+	Selector string
+	Ref      string
+	JSON     bool
+	Limit    int
+	Offset   int
+}
+
+func runCommitsQuery(ctx context.Context, cmd *cobra.Command, flags commitsFlags) error {
+	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+	_ = cfg
+
+	ref := flags.Ref
+	if ref == "" {
+		res, rerr := resolver.Resolve(ctx, campaignRoot, resolver.Options{Explicit: flags.Selector})
+		if rerr != nil {
+			return camperrors.Wrap(rerr, "resolve workitem")
+		}
+		if res == nil || res.Workitem == nil {
+			return camperrors.NewValidation("workitem",
+				"no workitem context resolved; pass <selector> or --ref WI-...", nil)
+		}
+		ref = refOf(res.Workitem)
+		if ref == "" {
+			return camperrors.NewValidation("workitem",
+				"workitem has no ref; run `camp workitem doctor --fix` to backfill", nil)
+		}
+	}
+
+	repos, err := enumerateQueryRepos(ctx, campaignRoot)
+	if err != nil {
+		return camperrors.Wrap(err, "enumerate query repos")
+	}
+
+	records, queryErrs := searchRepos(ctx, repos, ref)
+	sort.Slice(records, func(i, j int) bool { return records[i].Date.After(records[j].Date) })
+
+	if flags.Offset > 0 && flags.Offset < len(records) {
+		records = records[flags.Offset:]
+	} else if flags.Offset >= len(records) {
+		records = nil
+	}
+	if flags.Limit > 0 && flags.Limit < len(records) {
+		records = records[:flags.Limit]
+	}
+
+	if flags.JSON {
+		return emitCommitsJSON(cmd.OutOrStdout(), records, queryErrs)
+	}
+	return emitCommitsTable(cmd.OutOrStdout(), records)
+}
+
+// enumerateQueryRepos returns absolute paths of every git repo to search,
+// deduplicated by canonical path. Always includes the campaign root.
+func enumerateQueryRepos(ctx context.Context, campaignRoot string) ([]string, error) {
+	seen := map[string]bool{}
+	out := []string{campaignRoot}
+	seen[campaignRoot] = true
+
+	registry, err := links.Load(ctx, campaignRoot)
+	if err != nil {
+		return out, nil // links.yaml may not exist yet; campaign root is enough
+	}
+	for i := range registry.Links {
+		link := &registry.Links[i]
+		switch link.Scope.Kind {
+		case links.ScopeProject, links.ScopeRepo, links.ScopeWorktree:
+			abs := filepath.Join(campaignRoot, filepath.FromSlash(link.Scope.Path))
+			if seen[abs] {
+				continue
+			}
+			seen[abs] = true
+			out = append(out, abs)
+		case links.ScopeFestival:
+			// Festival scope refers to a festival directory under the campaign
+			// root, not a separate repo. The campaign root entry already
+			// covers that path.
+		}
+	}
+	return out, nil
+}
+
+// searchRepos fans out across repos with a bounded worker pool and gathers
+// the matched commits + per-repo errors.
+func searchRepos(ctx context.Context, repos []string, ref string) ([]CommitRecord, []commitsQueryError) {
+	workers := runtime.NumCPU()
+	if workers > len(repos) {
+		workers = len(repos)
+	}
+	if workers < 1 {
+		workers = 1
+	}
+
+	type job struct{ repo string }
+	jobs := make(chan job, len(repos))
+	type out struct {
+		records []CommitRecord
+		err     *commitsQueryError
+	}
+	results := make(chan out, len(repos))
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range jobs {
+				records, err := queryRepo(ctx, j.repo, ref)
+				if err != nil {
+					results <- out{err: &commitsQueryError{Repo: j.repo, Err: err.Error()}}
+					continue
+				}
+				results <- out{records: records}
+			}
+		}()
+	}
+	for _, repo := range repos {
+		jobs <- job{repo: repo}
+	}
+	close(jobs)
+	wg.Wait()
+	close(results)
+
+	var all []CommitRecord
+	var errs []commitsQueryError
+	for r := range results {
+		all = append(all, r.records...)
+		if r.err != nil {
+			errs = append(errs, *r.err)
+		}
+	}
+	return all, errs
+}
+
+// queryRepo runs `git log` in repo, parses the tab-separated output, and
+// filters out commits whose parsed tag does not match ref exactly. Returns
+// nil records (not an error) when the directory is not a git repo so the
+// caller can skip silently.
+func queryRepo(ctx context.Context, repo, ref string) ([]CommitRecord, error) {
+	if !isGitRepo(repo) {
+		return nil, nil
+	}
+	grep := "-WI-" + ref
+	cmd := exec.CommandContext(ctx, "git",
+		"-C", repo,
+		"log", "--all",
+		"--pretty=format:"+commitsLogFormat,
+		"--grep="+grep,
+	)
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	rel := filepath.Base(repo)
+	var records []CommitRecord
+	for _, line := range strings.Split(strings.TrimRight(string(output), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, "\t", 4)
+		if len(fields) < 4 {
+			continue
+		}
+		date, _ := time.Parse(time.RFC3339, fields[2])
+		subject := fields[3]
+		parts := commitkit.ParseTag(subject)
+		if parts.WorkitemRef != ref {
+			continue
+		}
+		records = append(records, CommitRecord{
+			SHA:      fields[0],
+			Author:   fields[1],
+			Date:     date,
+			Subject:  subject,
+			Repo:     rel,
+			TagParts: parts,
+		})
+	}
+	return records, nil
+}
+
+func isGitRepo(path string) bool {
+	cmd := exec.Command("git", "-C", path, "rev-parse", "--git-dir")
+	return cmd.Run() == nil
+}
+
+func emitCommitsTable(w io.Writer, records []CommitRecord) error {
+	if len(records) == 0 {
+		fmt.Fprintln(w, "no commits found")
+		return nil
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "REPO\tSHA\tDATE\tSUBJECT")
+	for _, r := range records {
+		sha := r.SHA
+		if len(sha) > 8 {
+			sha = sha[:8]
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+			r.Repo, sha, r.Date.UTC().Format("2006-01-02"), r.Subject)
+	}
+	return tw.Flush()
+}
+
+func emitCommitsJSON(w io.Writer, records []CommitRecord, errs []commitsQueryError) error {
+	payload := struct {
+		Commits []CommitRecord      `json:"commits"`
+		Errors  []commitsQueryError `json:"errors,omitempty"`
+	}{
+		Commits: records,
+		Errors:  errs,
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(payload)
+}

--- a/internal/commands/workitem/commits.go
+++ b/internal/commands/workitem/commits.go
@@ -106,11 +106,10 @@ type commitsFlags struct {
 }
 
 func runCommitsQuery(ctx context.Context, cmd *cobra.Command, flags commitsFlags) error {
-	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	_, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
 	if err != nil {
 		return camperrors.Wrap(err, "not in a campaign directory")
 	}
-	_ = cfg
 
 	ref := flags.Ref
 	if ref == "" {

--- a/internal/commands/workitem/commits.go
+++ b/internal/commands/workitem/commits.go
@@ -138,7 +138,7 @@ func runCommitsQuery(ctx context.Context, cmd *cobra.Command, flags commitsFlags
 		return camperrors.Wrap(err, "enumerate query repos")
 	}
 
-	records, queryErrs := searchRepos(ctx, repos, ref)
+	records, queryErrs := searchRepos(ctx, campaignRoot, repos, ref)
 	sort.Slice(records, func(i, j int) bool { return records[i].Date.After(records[j].Date) })
 
 	if flags.Offset > 0 && flags.Offset < len(records) {
@@ -169,7 +169,7 @@ func enumerateQueryRepos(ctx context.Context, campaignRoot string) ([]string, er
 
 	registry, err := links.Load(ctx, campaignRoot)
 	if err != nil {
-		return out, nil // links.yaml may not exist yet; campaign root is enough
+		return nil, camperrors.Wrap(err, "load link registry")
 	}
 	for i := range registry.Links {
 		link := &registry.Links[i]
@@ -192,7 +192,7 @@ func enumerateQueryRepos(ctx context.Context, campaignRoot string) ([]string, er
 
 // searchRepos fans out across repos with a bounded worker pool and gathers
 // the matched commits + per-repo errors.
-func searchRepos(ctx context.Context, repos []string, ref string) ([]CommitRecord, []commitsQueryError) {
+func searchRepos(ctx context.Context, campaignRoot string, repos []string, ref string) ([]CommitRecord, []commitsQueryError) {
 	workers := commitsWorkerCount(len(repos))
 
 	type job struct{ repo string }
@@ -209,9 +209,9 @@ func searchRepos(ctx context.Context, repos []string, ref string) ([]CommitRecor
 		go func() {
 			defer wg.Done()
 			for j := range jobs {
-				records, err := queryRepo(ctx, j.repo, ref)
+				records, err := queryRepo(ctx, campaignRoot, j.repo, ref)
 				if err != nil {
-					results <- out{err: &commitsQueryError{Repo: j.repo, Err: err.Error()}}
+					results <- out{err: &commitsQueryError{Repo: repoDisplayPath(campaignRoot, j.repo), Err: err.Error()}}
 					continue
 				}
 				results <- out{records: records}
@@ -258,7 +258,7 @@ func commitsWorkerCount(repoCount int) int {
 // filters out commits whose parsed tag does not match ref exactly. Returns
 // nil records (not an error) when the directory is not a git repo so the
 // caller can skip silently.
-func queryRepo(ctx context.Context, repo, ref string) ([]CommitRecord, error) {
+func queryRepo(ctx context.Context, campaignRoot, repo, ref string) ([]CommitRecord, error) {
 	cctx, cancel := context.WithTimeout(ctx, commitsPerRepoTimeout)
 	defer cancel()
 
@@ -283,7 +283,7 @@ func queryRepo(ctx context.Context, repo, ref string) ([]CommitRecord, error) {
 	if err != nil {
 		return nil, err
 	}
-	rel := filepath.Base(repo)
+	rel := repoDisplayPath(campaignRoot, repo)
 	var records []CommitRecord
 	for _, line := range strings.Split(strings.TrimRight(string(output), "\n"), "\n") {
 		if line == "" {
@@ -309,6 +309,20 @@ func queryRepo(ctx context.Context, repo, ref string) ([]CommitRecord, error) {
 		})
 	}
 	return records, nil
+}
+
+func repoDisplayPath(campaignRoot, repo string) string {
+	rel, err := filepath.Rel(campaignRoot, repo)
+	if err == nil {
+		slashRel := filepath.ToSlash(rel)
+		if slashRel == "." {
+			return "."
+		}
+		if slashRel != ".." && !strings.HasPrefix(slashRel, "../") && !filepath.IsAbs(rel) {
+			return slashRel
+		}
+	}
+	return filepath.Base(repo)
 }
 
 func isGitRepo(ctx context.Context, path string) (bool, error) {

--- a/internal/commands/workitem/commits.go
+++ b/internal/commands/workitem/commits.go
@@ -3,8 +3,10 @@ package workitem
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -26,7 +28,10 @@ import (
 const (
 	commitsDefaultLimit = 100
 	commitsLogFormat    = "%H%x09%an%x09%aI%x09%s"
+	commitsMaxWorkers   = 8
 )
+
+var commitsPerRepoTimeout = 30 * time.Second
 
 // CommitRecord is the per-row payload emitted by `camp workitem commits`.
 // Repo is the campaign-relative path of the git repo the commit was found
@@ -41,8 +46,7 @@ type CommitRecord struct {
 }
 
 // commitsQueryError records a per-repo failure surfaced under the --json
-// `errors` key. Default table output drops these silently to keep the
-// happy-path output readable.
+// `errors` key. Table output emits a stderr warning when this list is non-empty.
 type commitsQueryError struct {
 	Repo string `json:"repo"`
 	Err  string `json:"error"`
@@ -65,7 +69,8 @@ repo for commits whose campaign tag references this workitem's ref.
 
 Default sort: most recent first across all repos. Use --json for structured
 output. Repos that are not git checkouts or that fail their git log invocation
-are skipped silently in table mode and reported under "errors" in JSON mode.`,
+are reported under "errors" in JSON mode; table mode warns on stderr when
+repo queries fail.`,
 		Args: cobra.MaximumNArgs(1),
 		Annotations: map[string]string{
 			"agent_allowed": "true",
@@ -148,7 +153,11 @@ func runCommitsQuery(ctx context.Context, cmd *cobra.Command, flags commitsFlags
 	if flags.JSON {
 		return emitCommitsJSON(cmd.OutOrStdout(), records, queryErrs)
 	}
-	return emitCommitsTable(cmd.OutOrStdout(), records)
+	if err := emitCommitsTable(cmd.OutOrStdout(), records); err != nil {
+		return err
+	}
+	emitCommitsQueryWarnings(cmd.ErrOrStderr(), queryErrs)
+	return nil
 }
 
 // enumerateQueryRepos returns absolute paths of every git repo to search,
@@ -184,13 +193,7 @@ func enumerateQueryRepos(ctx context.Context, campaignRoot string) ([]string, er
 // searchRepos fans out across repos with a bounded worker pool and gathers
 // the matched commits + per-repo errors.
 func searchRepos(ctx context.Context, repos []string, ref string) ([]CommitRecord, []commitsQueryError) {
-	workers := runtime.NumCPU()
-	if workers > len(repos) {
-		workers = len(repos)
-	}
-	if workers < 1 {
-		workers = 1
-	}
+	workers := commitsWorkerCount(len(repos))
 
 	type job struct{ repo string }
 	jobs := make(chan job, len(repos))
@@ -230,7 +233,25 @@ func searchRepos(ctx context.Context, repos []string, ref string) ([]CommitRecor
 			errs = append(errs, *r.err)
 		}
 	}
+	sort.Slice(errs, func(i, j int) bool { return errs[i].Repo < errs[j].Repo })
 	return all, errs
+}
+
+func commitsWorkerCount(repoCount int) int {
+	if repoCount < 1 {
+		return 1
+	}
+	workers := runtime.NumCPU()
+	if workers > commitsMaxWorkers {
+		workers = commitsMaxWorkers
+	}
+	if workers > repoCount {
+		workers = repoCount
+	}
+	if workers < 1 {
+		workers = 1
+	}
+	return workers
 }
 
 // queryRepo runs `git log` in repo, parses the tab-separated output, and
@@ -238,17 +259,27 @@ func searchRepos(ctx context.Context, repos []string, ref string) ([]CommitRecor
 // nil records (not an error) when the directory is not a git repo so the
 // caller can skip silently.
 func queryRepo(ctx context.Context, repo, ref string) ([]CommitRecord, error) {
-	if !isGitRepo(repo) {
+	cctx, cancel := context.WithTimeout(ctx, commitsPerRepoTimeout)
+	defer cancel()
+
+	ok, err := isGitRepo(cctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
 		return nil, nil
 	}
 	grep := "-WI-" + ref
-	cmd := exec.CommandContext(ctx, "git",
+	cmd := exec.CommandContext(cctx, "git",
 		"-C", repo,
 		"log", "--all",
 		"--pretty=format:"+commitsLogFormat,
 		"--grep="+grep,
 	)
 	output, err := cmd.Output()
+	if errors.Is(cctx.Err(), context.DeadlineExceeded) {
+		return nil, fmt.Errorf("git log timeout after %s", commitsPerRepoTimeout)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -280,9 +311,34 @@ func queryRepo(ctx context.Context, repo, ref string) ([]CommitRecord, error) {
 	return records, nil
 }
 
-func isGitRepo(path string) bool {
-	cmd := exec.Command("git", "-C", path, "rev-parse", "--git-dir")
-	return cmd.Run() == nil
+func isGitRepo(ctx context.Context, path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !info.IsDir() {
+		return false, nil
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", path, "rev-parse", "--git-dir")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			msg := strings.ToLower(string(output))
+			if strings.Contains(msg, "not a git repository") {
+				return false, nil
+			}
+			return false, fmt.Errorf("git rev-parse failed: %s", strings.TrimSpace(string(output)))
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func emitCommitsTable(w io.Writer, records []CommitRecord) error {
@@ -301,6 +357,13 @@ func emitCommitsTable(w io.Writer, records []CommitRecord) error {
 			r.Repo, sha, r.Date.UTC().Format("2006-01-02"), r.Subject)
 	}
 	return tw.Flush()
+}
+
+func emitCommitsQueryWarnings(w io.Writer, errs []commitsQueryError) {
+	if len(errs) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "warning: %d repo(s) failed; re-run with --json for details\n", len(errs))
 }
 
 func emitCommitsJSON(w io.Writer, records []CommitRecord, errs []commitsQueryError) error {

--- a/internal/commands/workitem/commits_test.go
+++ b/internal/commands/workitem/commits_test.go
@@ -93,6 +93,19 @@ func TestEnumerateQueryRepos_DedupesDuplicateLinks(t *testing.T) {
 	}
 }
 
+func TestEnumerateQueryRepos_InvalidLinkRegistrySurfacesError(t *testing.T) {
+	root := commitsTestCampaign(t)
+	if err := os.WriteFile(filepath.Join(root, ".campaign", "workitems", "links.yaml"),
+		[]byte("version: workitem-links/v9beta\nlinks: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := enumerateQueryRepos(context.Background(), root)
+	if err == nil {
+		t.Fatal("expected invalid links.yaml to fail query enumeration")
+	}
+}
+
 func TestQueryRepo_FiltersFalsePositives(t *testing.T) {
 	root := commitsTestCampaign(t)
 	// Add a commit whose subject mentions WI-abc123 in body-like text but
@@ -106,7 +119,7 @@ func TestQueryRepo_FiltersFalsePositives(t *testing.T) {
 	runGit(t, root, "commit", "-q", "-m",
 		"[OBEY-CAMPAIGN-test-WI-WI-zzzzzz] WorkitemScope: notes about WI-abc123 (different ref tag)")
 
-	records, err := queryRepo(context.Background(), root, "WI-abc123")
+	records, err := queryRepo(context.Background(), root, root, "WI-abc123")
 	if err != nil {
 		t.Fatalf("queryRepo: %v", err)
 	}
@@ -124,7 +137,7 @@ func TestQueryRepo_FiltersFalsePositives(t *testing.T) {
 
 func TestQueryRepo_NonGitDirReturnsNil(t *testing.T) {
 	dir := t.TempDir()
-	records, err := queryRepo(context.Background(), dir, "WI-abc123")
+	records, err := queryRepo(context.Background(), dir, dir, "WI-abc123")
 	if err != nil {
 		t.Fatalf("queryRepo: %v", err)
 	}
@@ -138,7 +151,7 @@ func TestQueryRepo_ContextCanceledSurfacesError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := queryRepo(ctx, root, "WI-abc123")
+	_, err := queryRepo(ctx, root, root, "WI-abc123")
 	if err == nil {
 		t.Fatal("queryRepo with canceled context returned nil error")
 	}
@@ -186,22 +199,22 @@ func TestSearchRepos_AggregatesAndSorts(t *testing.T) {
 	runGit(t, demoDir, "commit", "-q", "-m",
 		"[OBEY-CAMPAIGN-test-WI-WI-abc123] WorkitemScope: project change")
 
-	records, errs := searchRepos(context.Background(), []string{root, demoDir}, "WI-abc123")
+	records, errs := searchRepos(context.Background(), root, []string{root, demoDir}, "WI-abc123")
 	if len(errs) > 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
 	if len(records) < 2 {
 		t.Fatalf("expected at least 2 records across both repos, got %d", len(records))
 	}
-	// Verify both repo bases are represented.
+	// Verify both campaign-relative repo paths are represented.
 	repos := map[string]bool{}
 	for _, r := range records {
 		repos[r.Repo] = true
 	}
-	if !repos["demo"] {
+	if !repos["projects/demo"] {
 		t.Errorf("missing demo repo in records: %v", repos)
 	}
-	if !repos[filepath.Base(root)] {
+	if !repos["."] {
 		t.Errorf("missing campaign root repo in records: %v", repos)
 	}
 	// Confirm sort works.
@@ -210,6 +223,40 @@ func TestSearchRepos_AggregatesAndSorts(t *testing.T) {
 	for i := range sorted {
 		if !sorted[i].Date.Equal(sorted[i].Date) {
 			t.Fatalf("dates not parsed")
+		}
+	}
+}
+
+func TestSearchRepos_UsesCampaignRelativeRepoPaths(t *testing.T) {
+	root := commitsTestCampaign(t)
+	repoA := filepath.Join(root, "projects", "demo")
+	repoB := filepath.Join(root, "projects", "worktrees", "demo")
+	if err := os.MkdirAll(repoB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, repo := range []string{repoA, repoB} {
+		runGit(t, repo, "init", "-q")
+		runGit(t, repo, "config", "user.email", "test@example.com")
+		runGit(t, repo, "config", "user.name", "Test")
+		if err := os.WriteFile(filepath.Join(repo, "x.go"), []byte("package x\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, repo, "add", "-A")
+		runGit(t, repo, "commit", "-q", "-m",
+			"[OBEY-CAMPAIGN-test-WI-WI-abc123] WorkitemScope: project change")
+	}
+
+	records, errs := searchRepos(context.Background(), root, []string{root, repoA, repoB}, "WI-abc123")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	repos := map[string]bool{}
+	for _, r := range records {
+		repos[r.Repo] = true
+	}
+	for _, want := range []string{".", "projects/demo", "projects/worktrees/demo"} {
+		if !repos[want] {
+			t.Fatalf("missing repo %q in records: %v", want, repos)
 		}
 	}
 }

--- a/internal/commands/workitem/commits_test.go
+++ b/internal/commands/workitem/commits_test.go
@@ -1,0 +1,174 @@
+package workitem
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+// commitsTestCampaign mirrors stagingTestCampaign but additionally tags one
+// commit in the campaign root with the WI-abc123 ref so queries have data to
+// find. The workitem id is design-example-2026-05-24, ref WI-abc123.
+func commitsTestCampaign(t *testing.T) string {
+	t.Helper()
+	root := stagingTestCampaign(t)
+	if err := os.WriteFile(filepath.Join(root, "workflow", "design", "example", "ROOT.md"),
+		[]byte("root commit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, root, "add", "-A")
+	runGit(t, root, "commit", "-q", "-m", "[OBEY-CAMPAIGN-test-WI-WI-abc123] WorkitemScope: root change")
+	return root
+}
+
+func TestEnumerateQueryRepos_IncludesCampaignAndLinkedProject(t *testing.T) {
+	root := commitsTestCampaign(t)
+	demoDir := filepath.Join(root, "projects", "demo")
+	runGit(t, demoDir, "init", "-q")
+	registry := links.Links{
+		Version: links.LinksSchemaVersion,
+		Links: []links.Link{{
+			ID:         "lnk_20260524_aaaaaa",
+			WorkitemID: "design-example-2026-05-24",
+			Scope:      links.LinkScope{Kind: links.ScopeProject, Path: "projects/demo"},
+			Role:       links.RolePrimary,
+		}},
+	}
+	if err := links.Save(context.Background(), root, &registry); err != nil {
+		t.Fatalf("save links: %v", err)
+	}
+
+	repos, err := enumerateQueryRepos(context.Background(), root)
+	if err != nil {
+		t.Fatalf("enumerateQueryRepos: %v", err)
+	}
+	if !contains(repos, root) {
+		t.Errorf("campaign root missing from repos: %v", repos)
+	}
+	if !contains(repos, demoDir) {
+		t.Errorf("linked project missing from repos: %v", repos)
+	}
+}
+
+func TestEnumerateQueryRepos_DedupesDuplicateLinks(t *testing.T) {
+	root := commitsTestCampaign(t)
+	demoDir := filepath.Join(root, "projects", "demo")
+	_ = demoDir
+	registry := links.Links{
+		Version: links.LinksSchemaVersion,
+		Links: []links.Link{
+			{
+				ID:         "lnk_20260524_aaaaaa",
+				WorkitemID: "design-example-2026-05-24",
+				Scope:      links.LinkScope{Kind: links.ScopeProject, Path: "projects/demo"},
+				Role:       links.RolePrimary,
+			},
+			{
+				ID:         "lnk_20260524_bbbbbb",
+				WorkitemID: "design-example-2026-05-24",
+				Scope:      links.LinkScope{Kind: links.ScopeRepo, Path: "projects/demo"},
+				Role:       links.RoleRelated,
+			},
+		},
+	}
+	if err := links.Save(context.Background(), root, &registry); err != nil {
+		t.Fatalf("save links: %v", err)
+	}
+
+	repos, err := enumerateQueryRepos(context.Background(), root)
+	if err != nil {
+		t.Fatalf("enumerateQueryRepos: %v", err)
+	}
+	seen := map[string]int{}
+	for _, r := range repos {
+		seen[r]++
+	}
+	if seen[filepath.Join(root, "projects", "demo")] != 1 {
+		t.Fatalf("expected demo to appear once, got %d: %v", seen[filepath.Join(root, "projects", "demo")], repos)
+	}
+}
+
+func TestQueryRepo_FiltersFalsePositives(t *testing.T) {
+	root := commitsTestCampaign(t)
+	// Add a commit whose subject mentions WI-abc123 in body-like text but
+	// whose tag references a different ref. The grep would match; ParseTag
+	// must reject.
+	if err := os.WriteFile(filepath.Join(root, "workflow", "design", "example", "noise.md"),
+		[]byte("noise\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, root, "add", "-A")
+	runGit(t, root, "commit", "-q", "-m",
+		"[OBEY-CAMPAIGN-test-WI-WI-zzzzzz] WorkitemScope: notes about WI-abc123 (different ref tag)")
+
+	records, err := queryRepo(context.Background(), root, "WI-abc123")
+	if err != nil {
+		t.Fatalf("queryRepo: %v", err)
+	}
+	// Should only return the original commit, not the noise one.
+	if len(records) != 1 {
+		for _, r := range records {
+			t.Logf("record: sha=%s subject=%q tagRef=%q", r.SHA[:8], r.Subject, r.TagParts.WorkitemRef)
+		}
+		t.Fatalf("expected 1 record after ParseTag filtering, got %d", len(records))
+	}
+	if records[0].TagParts.WorkitemRef != "WI-abc123" {
+		t.Fatalf("tag ref = %q, want WI-abc123", records[0].TagParts.WorkitemRef)
+	}
+}
+
+func TestQueryRepo_NonGitDirReturnsNil(t *testing.T) {
+	dir := t.TempDir()
+	records, err := queryRepo(context.Background(), dir, "WI-abc123")
+	if err != nil {
+		t.Fatalf("queryRepo: %v", err)
+	}
+	if records != nil {
+		t.Fatalf("expected nil for non-git dir, got %v", records)
+	}
+}
+
+func TestSearchRepos_AggregatesAndSorts(t *testing.T) {
+	root := commitsTestCampaign(t)
+	demoDir := filepath.Join(root, "projects", "demo")
+	runGit(t, demoDir, "init", "-q")
+	runGit(t, demoDir, "config", "user.email", "test@example.com")
+	runGit(t, demoDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(demoDir, "x.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, demoDir, "add", "-A")
+	runGit(t, demoDir, "commit", "-q", "-m",
+		"[OBEY-CAMPAIGN-test-WI-WI-abc123] WorkitemScope: project change")
+
+	records, errs := searchRepos(context.Background(), []string{root, demoDir}, "WI-abc123")
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if len(records) < 2 {
+		t.Fatalf("expected at least 2 records across both repos, got %d", len(records))
+	}
+	// Verify both repo bases are represented.
+	repos := map[string]bool{}
+	for _, r := range records {
+		repos[r.Repo] = true
+	}
+	if !repos["demo"] {
+		t.Errorf("missing demo repo in records: %v", repos)
+	}
+	if !repos[filepath.Base(root)] {
+		t.Errorf("missing campaign root repo in records: %v", repos)
+	}
+	// Confirm sort works.
+	sorted := append([]CommitRecord{}, records...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Date.After(sorted[j].Date) })
+	for i := range sorted {
+		if !sorted[i].Date.Equal(sorted[i].Date) {
+			t.Fatalf("dates not parsed")
+		}
+	}
+}

--- a/internal/commands/workitem/commits_test.go
+++ b/internal/commands/workitem/commits_test.go
@@ -1,6 +1,7 @@
 package workitem
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -129,6 +130,46 @@ func TestQueryRepo_NonGitDirReturnsNil(t *testing.T) {
 	}
 	if records != nil {
 		t.Fatalf("expected nil for non-git dir, got %v", records)
+	}
+}
+
+func TestQueryRepo_ContextCanceledSurfacesError(t *testing.T) {
+	root := commitsTestCampaign(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := queryRepo(ctx, root, "WI-abc123")
+	if err == nil {
+		t.Fatal("queryRepo with canceled context returned nil error")
+	}
+}
+
+func TestCommitsWorkerCountCapsFanout(t *testing.T) {
+	for _, repoCount := range []int{0, 1, 2, 100} {
+		got := commitsWorkerCount(repoCount)
+		if got < 1 {
+			t.Fatalf("commitsWorkerCount(%d) = %d, want >= 1", repoCount, got)
+		}
+		if got > commitsMaxWorkers {
+			t.Fatalf("commitsWorkerCount(%d) = %d, want <= %d", repoCount, got, commitsMaxWorkers)
+		}
+		if repoCount > 0 && got > repoCount {
+			t.Fatalf("commitsWorkerCount(%d) = %d, want <= repo count", repoCount, got)
+		}
+	}
+}
+
+func TestEmitCommitsQueryWarnings(t *testing.T) {
+	var stderr bytes.Buffer
+	emitCommitsQueryWarnings(&stderr, []commitsQueryError{{Repo: "demo", Err: "boom"}})
+	if got := stderr.String(); got != "warning: 1 repo(s) failed; re-run with --json for details\n" {
+		t.Fatalf("warning = %q", got)
+	}
+
+	stderr.Reset()
+	emitCommitsQueryWarnings(&stderr, nil)
+	if stderr.Len() != 0 {
+		t.Fatalf("empty errors emitted warning: %q", stderr.String())
 	}
 }
 

--- a/internal/commands/workitem/staging.go
+++ b/internal/commands/workitem/staging.go
@@ -1,6 +1,7 @@
 package workitem
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -411,71 +412,99 @@ func primaryFestivalScopePath(ctx context.Context, root string, wi *wkitem.WorkI
 // with `--untracked-files=all` so untracked directories are expanded to
 // individual files (otherwise --exclude cannot target leaf paths).
 func listChangedFilesUnder(ctx context.Context, repoRoot, prefix string) ([]string, error) {
-	args := []string{"-C", repoRoot, "status", "--porcelain", "--untracked-files=all"}
+	args := []string{"-C", repoRoot, "status", "--porcelain", "-z", "--untracked-files=all"}
 	if prefix != "" {
 		args = append(args, "--", prefix)
 	}
-	out, err := exec.CommandContext(ctx, "git", args...).Output()
+	entries, err := gitStatusPorcelainZ(ctx, args...)
 	if err != nil {
 		return nil, err
 	}
 	var files []string
-	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
-		if line == "" {
-			continue
-		}
-		if len(line) < 4 {
-			continue
-		}
-		path := strings.TrimSpace(line[3:])
-		// Rename entries look like "old -> new"; take the new path.
-		if i := strings.Index(path, " -> "); i >= 0 {
-			path = path[i+4:]
-		}
-		files = append(files, path)
+	for _, entry := range entries {
+		files = append(files, entry.Path)
 	}
 	return files, nil
 }
 
 func listStagedFiles(ctx context.Context, repoRoot string) ([]string, error) {
-	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "diff", "--cached", "--name-only").Output()
+	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "diff", "--cached", "--name-only", "-z").Output()
 	if err != nil {
 		return nil, err
 	}
-	var files []string
-	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
-		if line == "" {
-			continue
-		}
-		files = append(files, line)
-	}
-	return files, nil
+	return parseNULPathList(out), nil
 }
 
 func pathIsDirty(ctx context.Context, repoRoot, relPath string) (bool, error) {
-	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "status", "--porcelain", "--", relPath).Output()
+	entries, err := gitStatusPorcelainZ(ctx, "-C", repoRoot, "status", "--porcelain", "-z", "--", relPath)
 	if err != nil {
 		return false, err
 	}
-	return strings.TrimSpace(string(out)) != "", nil
+	return len(entries) != 0, nil
 }
 
 func listDirtySubmodulePointers(ctx context.Context, repoRoot string) ([]string, error) {
-	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "status", "--porcelain", "--", "projects").Output()
+	entries, err := gitStatusPorcelainZ(ctx, "-C", repoRoot, "status", "--porcelain", "-z", "--", "projects")
 	if err != nil {
 		return nil, err
 	}
 	var pointers []string
-	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
-		if line == "" {
-			continue
-		}
-		path := strings.TrimSpace(line[3:])
-		if strings.HasPrefix(path, "projects/") {
-			pointers = append(pointers, path)
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Path, "projects/") {
+			pointers = append(pointers, entry.Path)
 		}
 	}
 	return pointers, nil
+}
+
+type gitStatusEntry struct {
+	Code string
+	Path string
+}
+
+func gitStatusPorcelainZ(ctx context.Context, args ...string) ([]gitStatusEntry, error) {
+	out, err := exec.CommandContext(ctx, "git", args...).Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseGitStatusPorcelainZ(out), nil
+}
+
+func parseGitStatusPorcelainZ(out []byte) []gitStatusEntry {
+	fields := splitNULFields(out)
+	entries := make([]gitStatusEntry, 0, len(fields))
+	for i := 0; i < len(fields); i++ {
+		field := fields[i]
+		if len(field) == 0 {
+			continue
+		}
+		if len(field) < 4 {
+			continue
+		}
+		code := string(field[:2])
+		path := string(field[3:])
+		entries = append(entries, gitStatusEntry{Code: code, Path: path})
+		if code[0] == 'R' || code[0] == 'C' {
+			i++ // -z emits the old path as a second NUL-delimited field.
+		}
+	}
+	return entries
+}
+
+func parseNULPathList(out []byte) []string {
+	fields := splitNULFields(out)
+	paths := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if len(field) == 0 {
+			continue
+		}
+		paths = append(paths, string(field))
+	}
+	return paths
+}
+
+func splitNULFields(out []byte) [][]byte {
+	return bytes.Split(bytes.TrimRight(out, "\x00"), []byte{0})
 }
 
 func listSubmodulePointerSkips(ctx context.Context, root string, allowed bool) []SkippedEntry {

--- a/internal/commands/workitem/staging.go
+++ b/internal/commands/workitem/staging.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -14,6 +15,11 @@ import (
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
 	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
 	"github.com/Obedience-Corp/camp/pkg/commitkit"
+)
+
+var (
+	osGetwd = os.Getwd
+	osStat  = os.Stat
 )
 
 const (
@@ -125,6 +131,17 @@ func ComputePlan(ctx context.Context, campaignRoot string, opts PlanOptions) (*S
 		return computeProjectPlan(ctx, campaignRoot, opts, plan)
 	}
 
+	// cwd-first routing: when the working directory is inside a sub-git-repo
+	// (typically projects/<name>/...), stage from that sub-repo regardless of
+	// which resolver tier matched. This keeps "I'm in the project, commit my
+	// workitem changes here" the natural one-liner.
+	if subRepo, ok := cwdSubGitRepo(opts.Cwd, campaignRoot); ok {
+		plan.RepoRoot = subRepo
+		plan.Context = PlanContextLinkedProject
+		plan.ContextNote = "project " + filepath.Base(subRepo)
+		return finishProjectPlan(ctx, opts, plan)
+	}
+
 	switch res.Source {
 	case resolver.SourceLink:
 		return computeLinkPlan(ctx, campaignRoot, opts, plan)
@@ -135,6 +152,51 @@ func ComputePlan(ctx context.Context, campaignRoot string, opts PlanOptions) (*S
 		// campaign root scoped to the workitem directory.
 		return computeWorkitemDirPlan(ctx, campaignRoot, opts, plan, res.Source)
 	}
+}
+
+// cwdSubGitRepo returns the absolute path of a sub-git-repo containing cwd
+// when cwd is strictly inside the campaign tree but not the campaign root
+// itself. Empty cwd resolves via os.Getwd.
+func cwdSubGitRepo(cwd, campaignRoot string) (string, bool) {
+	if cwd == "" {
+		c, err := osGetwd()
+		if err != nil {
+			return "", false
+		}
+		cwd = c
+	}
+	abs, err := filepath.Abs(cwd)
+	if err != nil {
+		return "", false
+	}
+	rel, err := filepath.Rel(campaignRoot, abs)
+	if err != nil || strings.HasPrefix(rel, "..") || rel == "." {
+		return "", false
+	}
+	dir := abs
+	for dir != campaignRoot && len(dir) > len(campaignRoot) {
+		gitMarker := filepath.Join(dir, ".git")
+		if info, err := osStat(gitMarker); err == nil && (info.IsDir() || info.Mode().IsRegular()) {
+			return dir, true
+		}
+		dir = filepath.Dir(dir)
+	}
+	return "", false
+}
+
+func finishProjectPlan(ctx context.Context, opts PlanOptions, plan *StagingPlan) (*StagingPlan, error) {
+	stage, err := listChangedFilesUnder(ctx, plan.RepoRoot, "")
+	if err != nil {
+		return nil, camperrors.Wrap(err, "list project changes")
+	}
+	added, addSkip, err := applyIncludes(plan.RepoRoot, stage, opts.Includes)
+	if err != nil {
+		return nil, err
+	}
+	plan.Skip = append(plan.Skip, addSkip...)
+	plan.Stage = applyExcludes(added, opts.Excludes, &plan.Skip)
+	plan.Stage = dedupeSorted(plan.Stage)
+	return plan, nil
 }
 
 func computeWorkitemDirPlan(ctx context.Context, root string, opts PlanOptions, plan *StagingPlan, src resolver.Source) (*StagingPlan, error) {
@@ -345,9 +407,11 @@ func primaryFestivalScopePath(ctx context.Context, root string, wi *wkitem.WorkI
 }
 
 // listChangedFilesUnder returns repo-relative paths for changes inside prefix
-// (or the entire repo when prefix is empty). Wraps `git status --porcelain`.
+// (or the entire repo when prefix is empty). Wraps `git status --porcelain`
+// with `--untracked-files=all` so untracked directories are expanded to
+// individual files (otherwise --exclude cannot target leaf paths).
 func listChangedFilesUnder(ctx context.Context, repoRoot, prefix string) ([]string, error) {
-	args := []string{"-C", repoRoot, "status", "--porcelain"}
+	args := []string{"-C", repoRoot, "status", "--porcelain", "--untracked-files=all"}
 	if prefix != "" {
 		args = append(args, "--", prefix)
 	}

--- a/internal/commands/workitem/staging.go
+++ b/internal/commands/workitem/staging.go
@@ -1,0 +1,507 @@
+package workitem
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
+)
+
+const (
+	linkRegistryRelPath = ".campaign/workitems/links.yaml"
+
+	skipReasonOutOfScope          = "(out of scope)"
+	skipReasonExcludeFlag         = "(--exclude)"
+	skipReasonPointerOffByDefault = "(submodule pointer; use --include-submodule-pointer)"
+)
+
+// PlanContext labels which staging-matrix row a plan came from. Stable
+// strings: used by both the human plan output and the integration tests.
+type PlanContext string
+
+const (
+	PlanContextWorkitemDir   PlanContext = "workitem directory"
+	PlanContextCampaignRoot  PlanContext = "campaign root"
+	PlanContextLinkedProject PlanContext = "linked project"
+	PlanContextFestival      PlanContext = "festival"
+	PlanContextStagedOnly    PlanContext = "staged-only"
+)
+
+// PlanOptions inputs to ComputePlan. Mirrors the camp workitem commit flag
+// surface so the planner can be exercised from tests without spinning up cobra.
+type PlanOptions struct {
+	Cwd                     string
+	Explicit                string   // --workitem <selector>
+	Project                 string   // --project <name> override
+	Includes                []string // --include <path> (repeatable)
+	Excludes                []string // --exclude <path> (repeatable)
+	StagedOnly              bool     // --staged
+	IncludeSubmodulePointer bool     // --include-submodule-pointer
+	CampaignID              string
+}
+
+// SkippedEntry pairs a path with a stable reason string.
+type SkippedEntry struct {
+	Path   string
+	Reason string
+}
+
+// StagingPlan is the contract between ComputePlan and the commit runner. Stage
+// is what the planner intends to `git add`. PreStaged is what is already in
+// the index (used by --staged so we do not re-stage). Skip explains paths
+// intentionally left out.
+type StagingPlan struct {
+	Workitem    *wkitem.WorkItem
+	WorkitemRef string
+	QuestID     string
+	Context     PlanContext
+	ContextNote string
+	RepoRoot    string
+	Stage       []string
+	PreStaged   []string
+	Skip        []SkippedEntry
+	Tag         string
+}
+
+// ComputePlan resolves a workitem from the current context, branches on the
+// matrix row that applies, and returns a StagingPlan that the commit runner
+// can hand to commit.Workitem. Refusal modes (no workitem, empty plan with no
+// override) surface as typed errors so the CLI can map them to exit codes.
+func ComputePlan(ctx context.Context, campaignRoot string, opts PlanOptions) (*StagingPlan, error) {
+	if campaignRoot == "" {
+		return nil, camperrors.NewValidation("root", "campaign root required", nil)
+	}
+
+	res, err := resolver.Resolve(ctx, campaignRoot, resolver.Options{
+		Explicit: opts.Explicit,
+		Cwd:      opts.Cwd,
+	})
+	if err != nil {
+		return nil, camperrors.Wrap(err, "resolve workitem")
+	}
+	if res == nil || res.Workitem == nil {
+		return nil, ErrNoWorkitemContext
+	}
+
+	wi := res.Workitem
+	ref := refOf(wi)
+	plan := &StagingPlan{
+		Workitem:    wi,
+		WorkitemRef: ref,
+		QuestID:     res.QuestID,
+		Tag:         commitkit.FormatContextTagsFull(opts.CampaignID, res.QuestID, "", ref),
+	}
+
+	if opts.StagedOnly {
+		plan.Context = PlanContextStagedOnly
+		plan.ContextNote = "using current git index"
+		plan.RepoRoot = campaignRoot
+		staged, err := listStagedFiles(ctx, campaignRoot)
+		if err != nil {
+			return nil, camperrors.Wrap(err, "list staged files")
+		}
+		plan.PreStaged = staged
+		// Includes still apply on top of --staged so the user can add a tag-only
+		// commit of additional explicit paths.
+		stage, skip, err := applyIncludes(campaignRoot, nil, opts.Includes)
+		if err != nil {
+			return nil, err
+		}
+		plan.Stage = applyExcludes(stage, opts.Excludes, &plan.Skip)
+		plan.Skip = append(plan.Skip, skip...)
+		return plan, nil
+	}
+
+	if opts.Project != "" {
+		return computeProjectPlan(ctx, campaignRoot, opts, plan)
+	}
+
+	switch res.Source {
+	case resolver.SourceLink:
+		return computeLinkPlan(ctx, campaignRoot, opts, plan)
+	case resolver.SourceFestival:
+		return computeFestivalPlan(ctx, campaignRoot, opts, plan)
+	default:
+		// SourceExplicit, SourceAncestor, SourceCurrent — all stage from the
+		// campaign root scoped to the workitem directory.
+		return computeWorkitemDirPlan(ctx, campaignRoot, opts, plan, res.Source)
+	}
+}
+
+func computeWorkitemDirPlan(ctx context.Context, root string, opts PlanOptions, plan *StagingPlan, src resolver.Source) (*StagingPlan, error) {
+	plan.RepoRoot = root
+	plan.Context = PlanContextWorkitemDir
+	if src != resolver.SourceAncestor {
+		plan.Context = PlanContextCampaignRoot
+	}
+	plan.ContextNote = workitemDirNote(plan.Workitem, src)
+
+	stage, err := listChangedFilesUnder(ctx, root, plan.Workitem.RelativePath)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "list workitem changes")
+	}
+
+	if dirty, err := pathIsDirty(ctx, root, linkRegistryRelPath); err == nil && dirty {
+		stage = append(stage, linkRegistryRelPath)
+	}
+
+	if opts.IncludeSubmodulePointer {
+		if pointers, perr := listDirtySubmodulePointers(ctx, root); perr == nil {
+			stage = append(stage, pointers...)
+		}
+	}
+
+	added, addSkip, err := applyIncludes(root, stage, opts.Includes)
+	if err != nil {
+		return nil, err
+	}
+	plan.Skip = append(plan.Skip, addSkip...)
+	plan.Stage = applyExcludes(added, opts.Excludes, &plan.Skip)
+
+	plan.Skip = append(plan.Skip, listSubmodulePointerSkips(ctx, root, opts.IncludeSubmodulePointer)...)
+
+	plan.Stage = dedupeSorted(plan.Stage)
+	return plan, nil
+}
+
+func computeLinkPlan(ctx context.Context, root string, opts PlanOptions, plan *StagingPlan) (*StagingPlan, error) {
+	scopePath, err := pickPrimaryProjectScopePath(ctx, root, plan.Workitem)
+	if err != nil {
+		return nil, err
+	}
+	repoRoot := filepath.Join(root, filepath.FromSlash(scopePath))
+	plan.RepoRoot = repoRoot
+	plan.Context = PlanContextLinkedProject
+	plan.ContextNote = "linked project " + filepath.Base(scopePath)
+
+	stage, err := listChangedFilesUnder(ctx, repoRoot, "")
+	if err != nil {
+		return nil, camperrors.Wrap(err, "list project changes")
+	}
+
+	added, addSkip, err := applyIncludes(repoRoot, stage, opts.Includes)
+	if err != nil {
+		return nil, err
+	}
+	plan.Skip = append(plan.Skip, addSkip...)
+	plan.Stage = applyExcludes(added, opts.Excludes, &plan.Skip)
+	plan.Stage = dedupeSorted(plan.Stage)
+	return plan, nil
+}
+
+func computeFestivalPlan(ctx context.Context, root string, opts PlanOptions, plan *StagingPlan) (*StagingPlan, error) {
+	plan.RepoRoot = root
+	plan.Context = PlanContextFestival
+	scope := primaryFestivalScopePath(ctx, root, plan.Workitem)
+	if scope == "" {
+		scope = plan.Workitem.RelativePath
+	}
+	plan.ContextNote = "festival " + filepath.Base(scope)
+
+	stage, err := listChangedFilesUnder(ctx, root, scope)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "list festival changes")
+	}
+	if dirty, err := pathIsDirty(ctx, root, linkRegistryRelPath); err == nil && dirty {
+		stage = append(stage, linkRegistryRelPath)
+	}
+	added, addSkip, err := applyIncludes(root, stage, opts.Includes)
+	if err != nil {
+		return nil, err
+	}
+	plan.Skip = append(plan.Skip, addSkip...)
+	plan.Stage = applyExcludes(added, opts.Excludes, &plan.Skip)
+	plan.Stage = dedupeSorted(plan.Stage)
+	return plan, nil
+}
+
+func computeProjectPlan(ctx context.Context, root string, opts PlanOptions, plan *StagingPlan) (*StagingPlan, error) {
+	repoRoot := filepath.Join(root, "projects", opts.Project)
+	plan.RepoRoot = repoRoot
+	plan.Context = PlanContextLinkedProject
+	plan.ContextNote = "project " + opts.Project + " (--project override)"
+
+	stage, err := listChangedFilesUnder(ctx, repoRoot, "")
+	if err != nil {
+		return nil, camperrors.Wrap(err, "list project changes")
+	}
+	added, addSkip, err := applyIncludes(repoRoot, stage, opts.Includes)
+	if err != nil {
+		return nil, err
+	}
+	plan.Skip = append(plan.Skip, addSkip...)
+	plan.Stage = applyExcludes(added, opts.Excludes, &plan.Skip)
+	plan.Stage = dedupeSorted(plan.Stage)
+	return plan, nil
+}
+
+// PrintPlan writes the human-readable plan summary to w. Mirrors
+// COMMIT_DESIGN.md §6 exactly so the integration tests can grep stable lines.
+func PrintPlan(w io.Writer, plan *StagingPlan) error {
+	if plan == nil || plan.Workitem == nil {
+		return camperrors.NewValidation("plan", "nil plan", nil)
+	}
+	fmt.Fprintf(w, "workitem: %s (ref: %s)\n", plan.Workitem.StableID, plan.WorkitemRef)
+	fmt.Fprintf(w, "context:  %s", plan.Context)
+	if plan.ContextNote != "" {
+		fmt.Fprintf(w, " (%s)", plan.ContextNote)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "staging:")
+	if len(plan.PreStaged) > 0 {
+		for _, p := range plan.PreStaged {
+			fmt.Fprintf(w, "  S  %s\n", p)
+		}
+	}
+	for _, p := range plan.Stage {
+		fmt.Fprintf(w, "  A  %s\n", p)
+	}
+	if len(plan.Skip) > 0 {
+		fmt.Fprintln(w, "skipped:")
+		for _, s := range plan.Skip {
+			fmt.Fprintf(w, "  %s %s\n", s.Path, s.Reason)
+		}
+	}
+	fmt.Fprintf(w, "tag:    %s\n", plan.Tag)
+	return nil
+}
+
+// refOf reads the workitem ref off SourceMetadata (populated by
+// workitem.ApplyMetadata in sequence 03 task 02).
+func refOf(wi *wkitem.WorkItem) string {
+	if wi == nil || wi.SourceMetadata == nil {
+		return ""
+	}
+	if v, ok := wi.SourceMetadata["ref"].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func workitemDirNote(wi *wkitem.WorkItem, src resolver.Source) string {
+	switch src {
+	case resolver.SourceAncestor:
+		return wi.RelativePath
+	case resolver.SourceExplicit:
+		return "explicit --workitem"
+	case resolver.SourceCurrent:
+		return "via current.yaml"
+	default:
+		return string(src)
+	}
+}
+
+// pickPrimaryProjectScopePath finds the primary path link scope (project,
+// repo, or worktree) that points at the workitem. Returns the campaign-
+// relative path so callers can join with the campaign root to get the
+// staging repo root.
+func pickPrimaryProjectScopePath(ctx context.Context, root string, wi *wkitem.WorkItem) (string, error) {
+	registry, err := links.Load(ctx, root)
+	if err != nil {
+		return "", camperrors.Wrap(err, "load links")
+	}
+	for i := range registry.Links {
+		link := &registry.Links[i]
+		if link.Role != links.RolePrimary {
+			continue
+		}
+		if link.WorkitemID != wi.StableID && link.WorkitemID != wi.Key {
+			continue
+		}
+		switch link.Scope.Kind {
+		case links.ScopeProject, links.ScopeRepo, links.ScopeWorktree:
+			return link.Scope.Path, nil
+		}
+	}
+	return "", camperrors.NewValidation("link",
+		"no primary project link points at workitem "+wi.StableID, nil)
+}
+
+func primaryFestivalScopePath(ctx context.Context, root string, wi *wkitem.WorkItem) string {
+	registry, err := links.Load(ctx, root)
+	if err != nil || registry == nil {
+		return ""
+	}
+	for i := range registry.Links {
+		link := &registry.Links[i]
+		if link.Role != links.RolePrimary || link.Scope.Kind != links.ScopeFestival {
+			continue
+		}
+		if link.WorkitemID != wi.StableID && link.WorkitemID != wi.Key {
+			continue
+		}
+		return link.Scope.Path
+	}
+	return ""
+}
+
+// listChangedFilesUnder returns repo-relative paths for changes inside prefix
+// (or the entire repo when prefix is empty). Wraps `git status --porcelain`.
+func listChangedFilesUnder(ctx context.Context, repoRoot, prefix string) ([]string, error) {
+	args := []string{"-C", repoRoot, "status", "--porcelain"}
+	if prefix != "" {
+		args = append(args, "--", prefix)
+	}
+	out, err := exec.CommandContext(ctx, "git", args...).Output()
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		if len(line) < 4 {
+			continue
+		}
+		path := strings.TrimSpace(line[3:])
+		// Rename entries look like "old -> new"; take the new path.
+		if i := strings.Index(path, " -> "); i >= 0 {
+			path = path[i+4:]
+		}
+		files = append(files, path)
+	}
+	return files, nil
+}
+
+func listStagedFiles(ctx context.Context, repoRoot string) ([]string, error) {
+	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "diff", "--cached", "--name-only").Output()
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		files = append(files, line)
+	}
+	return files, nil
+}
+
+func pathIsDirty(ctx context.Context, repoRoot, relPath string) (bool, error) {
+	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "status", "--porcelain", "--", relPath).Output()
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(out)) != "", nil
+}
+
+func listDirtySubmodulePointers(ctx context.Context, repoRoot string) ([]string, error) {
+	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "status", "--porcelain", "--", "projects").Output()
+	if err != nil {
+		return nil, err
+	}
+	var pointers []string
+	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		path := strings.TrimSpace(line[3:])
+		if strings.HasPrefix(path, "projects/") {
+			pointers = append(pointers, path)
+		}
+	}
+	return pointers, nil
+}
+
+func listSubmodulePointerSkips(ctx context.Context, root string, allowed bool) []SkippedEntry {
+	if allowed {
+		return nil
+	}
+	pointers, err := listDirtySubmodulePointers(ctx, root)
+	if err != nil {
+		return nil
+	}
+	out := make([]SkippedEntry, 0, len(pointers))
+	for _, p := range pointers {
+		out = append(out, SkippedEntry{Path: p, Reason: skipReasonPointerOffByDefault})
+	}
+	return out
+}
+
+func applyIncludes(repoRoot string, stage, includes []string) ([]string, []SkippedEntry, error) {
+	if len(includes) == 0 {
+		return stage, nil, nil
+	}
+	out := append([]string{}, stage...)
+	var skip []SkippedEntry
+	for _, inc := range includes {
+		rel, err := relativeToRepo(repoRoot, inc)
+		if err != nil {
+			skip = append(skip, SkippedEntry{Path: inc, Reason: skipReasonOutOfScope})
+			continue
+		}
+		out = append(out, rel)
+	}
+	return out, skip, nil
+}
+
+func applyExcludes(stage []string, excludes []string, skip *[]SkippedEntry) []string {
+	if len(excludes) == 0 {
+		return stage
+	}
+	ex := make(map[string]bool, len(excludes))
+	for _, e := range excludes {
+		ex[filepath.ToSlash(e)] = true
+	}
+	kept := stage[:0]
+	for _, p := range stage {
+		if ex[filepath.ToSlash(p)] {
+			*skip = append(*skip, SkippedEntry{Path: p, Reason: skipReasonExcludeFlag})
+			continue
+		}
+		kept = append(kept, p)
+	}
+	return kept
+}
+
+func relativeToRepo(repoRoot, p string) (string, error) {
+	if !filepath.IsAbs(p) {
+		// Treat as already-repo-relative; reject escape attempts.
+		clean := filepath.Clean(p)
+		if strings.HasPrefix(clean, "..") {
+			return "", camperrors.NewValidation("include", "path escapes repo root: "+p, nil)
+		}
+		return filepath.ToSlash(clean), nil
+	}
+	rel, err := filepath.Rel(repoRoot, p)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", camperrors.NewValidation("include", "path outside repo: "+p, nil)
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+func dedupeSorted(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, p := range in {
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ErrNoWorkitemContext is returned when ComputePlan cannot resolve any
+// workitem context. The CLI maps this to exit code 2 with a help hint.
+var ErrNoWorkitemContext = camperrors.NewValidation(
+	"workitem",
+	"no workitem context resolved",
+	nil,
+)

--- a/internal/commands/workitem/staging.go
+++ b/internal/commands/workitem/staging.go
@@ -1,26 +1,14 @@
 package workitem
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"sort"
-	"strings"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
-	"github.com/Obedience-Corp/camp/internal/workitem/links"
 	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
 	"github.com/Obedience-Corp/camp/pkg/commitkit"
-)
-
-var (
-	osGetwd = os.Getwd
-	osStat  = os.Stat
 )
 
 const (
@@ -29,6 +17,8 @@ const (
 	skipReasonOutOfScope          = "(out of scope)"
 	skipReasonExcludeFlag         = "(--exclude)"
 	skipReasonPointerOffByDefault = "(submodule pointer; use --include-submodule-pointer)"
+
+	stageAnnotationLinkRegistry = "link registry auto-included"
 )
 
 // PlanContext labels which staging-matrix row a plan came from. Stable
@@ -67,16 +57,24 @@ type SkippedEntry struct {
 // the index (used by --staged so we do not re-stage). Skip explains paths
 // intentionally left out.
 type StagingPlan struct {
-	Workitem    *wkitem.WorkItem
-	WorkitemRef string
-	QuestID     string
-	Context     PlanContext
-	ContextNote string
-	RepoRoot    string
-	Stage       []string
-	PreStaged   []string
-	Skip        []SkippedEntry
-	Tag         string
+	Workitem         *wkitem.WorkItem
+	WorkitemRef      string
+	QuestID          string
+	Context          PlanContext
+	ContextNote      string
+	RepoRoot         string
+	Stage            []string
+	StageAnnotations map[string]string
+	PreStaged        []string
+	Skip             []SkippedEntry
+	Tag              string
+}
+
+func (p *StagingPlan) addStageNote(path, note string) {
+	if p.StageAnnotations == nil {
+		p.StageAnnotations = make(map[string]string)
+	}
+	p.StageAnnotations[path] = note
 }
 
 // ComputePlan resolves a workitem from the current context, branches on the
@@ -137,10 +135,7 @@ func ComputePlan(ctx context.Context, campaignRoot string, opts PlanOptions) (*S
 	// which resolver tier matched. This keeps "I'm in the project, commit my
 	// workitem changes here" the natural one-liner.
 	if subRepo, ok := cwdSubGitRepo(opts.Cwd, campaignRoot); ok {
-		plan.RepoRoot = subRepo
-		plan.Context = PlanContextLinkedProject
-		plan.ContextNote = "project " + filepath.Base(subRepo)
-		return finishProjectPlan(ctx, opts, plan)
+		return computeDetectedProjectPlan(ctx, opts, plan, subRepo)
 	}
 
 	switch res.Source {
@@ -155,160 +150,9 @@ func ComputePlan(ctx context.Context, campaignRoot string, opts PlanOptions) (*S
 	}
 }
 
-// cwdSubGitRepo returns the absolute path of a sub-git-repo containing cwd
-// when cwd is strictly inside the campaign tree but not the campaign root
-// itself. Empty cwd resolves via os.Getwd.
-func cwdSubGitRepo(cwd, campaignRoot string) (string, bool) {
-	if cwd == "" {
-		c, err := osGetwd()
-		if err != nil {
-			return "", false
-		}
-		cwd = c
-	}
-	abs, err := filepath.Abs(cwd)
-	if err != nil {
-		return "", false
-	}
-	rel, err := filepath.Rel(campaignRoot, abs)
-	if err != nil || strings.HasPrefix(rel, "..") || rel == "." {
-		return "", false
-	}
-	dir := abs
-	for dir != campaignRoot && len(dir) > len(campaignRoot) {
-		gitMarker := filepath.Join(dir, ".git")
-		if info, err := osStat(gitMarker); err == nil && (info.IsDir() || info.Mode().IsRegular()) {
-			return dir, true
-		}
-		dir = filepath.Dir(dir)
-	}
-	return "", false
-}
-
-func finishProjectPlan(ctx context.Context, opts PlanOptions, plan *StagingPlan) (*StagingPlan, error) {
-	stage, err := listChangedFilesUnder(ctx, plan.RepoRoot, "")
-	if err != nil {
-		return nil, camperrors.Wrap(err, "list project changes")
-	}
-	added, addSkip, err := applyIncludes(plan.RepoRoot, stage, opts.Includes)
-	if err != nil {
-		return nil, err
-	}
-	plan.Skip = append(plan.Skip, addSkip...)
-	plan.Stage = applyExcludes(added, opts.Excludes, &plan.Skip)
-	plan.Stage = dedupeSorted(plan.Stage)
-	return plan, nil
-}
-
-func computeWorkitemDirPlan(ctx context.Context, root string, opts PlanOptions, plan *StagingPlan, src resolver.Source) (*StagingPlan, error) {
-	plan.RepoRoot = root
-	plan.Context = PlanContextWorkitemDir
-	if src != resolver.SourceAncestor {
-		plan.Context = PlanContextCampaignRoot
-	}
-	plan.ContextNote = workitemDirNote(plan.Workitem, src)
-
-	stage, err := listChangedFilesUnder(ctx, root, plan.Workitem.RelativePath)
-	if err != nil {
-		return nil, camperrors.Wrap(err, "list workitem changes")
-	}
-
-	if dirty, err := pathIsDirty(ctx, root, linkRegistryRelPath); err == nil && dirty {
-		stage = append(stage, linkRegistryRelPath)
-	}
-
-	if opts.IncludeSubmodulePointer {
-		if pointers, perr := listDirtySubmodulePointers(ctx, root); perr == nil {
-			stage = append(stage, pointers...)
-		}
-	}
-
-	added, addSkip, err := applyIncludes(root, stage, opts.Includes)
-	if err != nil {
-		return nil, err
-	}
-	plan.Skip = append(plan.Skip, addSkip...)
-	plan.Stage = applyExcludes(added, opts.Excludes, &plan.Skip)
-
-	plan.Skip = append(plan.Skip, listSubmodulePointerSkips(ctx, root, opts.IncludeSubmodulePointer)...)
-
-	plan.Stage = dedupeSorted(plan.Stage)
-	return plan, nil
-}
-
-func computeLinkPlan(ctx context.Context, root string, opts PlanOptions, plan *StagingPlan) (*StagingPlan, error) {
-	scopePath, err := pickPrimaryProjectScopePath(ctx, root, plan.Workitem)
-	if err != nil {
-		return nil, err
-	}
-	repoRoot := filepath.Join(root, filepath.FromSlash(scopePath))
-	plan.RepoRoot = repoRoot
-	plan.Context = PlanContextLinkedProject
-	plan.ContextNote = "linked project " + filepath.Base(scopePath)
-
-	stage, err := listChangedFilesUnder(ctx, repoRoot, "")
-	if err != nil {
-		return nil, camperrors.Wrap(err, "list project changes")
-	}
-
-	added, addSkip, err := applyIncludes(repoRoot, stage, opts.Includes)
-	if err != nil {
-		return nil, err
-	}
-	plan.Skip = append(plan.Skip, addSkip...)
-	plan.Stage = applyExcludes(added, opts.Excludes, &plan.Skip)
-	plan.Stage = dedupeSorted(plan.Stage)
-	return plan, nil
-}
-
-func computeFestivalPlan(ctx context.Context, root string, opts PlanOptions, plan *StagingPlan) (*StagingPlan, error) {
-	plan.RepoRoot = root
-	plan.Context = PlanContextFestival
-	scope := primaryFestivalScopePath(ctx, root, plan.Workitem)
-	if scope == "" {
-		scope = plan.Workitem.RelativePath
-	}
-	plan.ContextNote = "festival " + filepath.Base(scope)
-
-	stage, err := listChangedFilesUnder(ctx, root, scope)
-	if err != nil {
-		return nil, camperrors.Wrap(err, "list festival changes")
-	}
-	if dirty, err := pathIsDirty(ctx, root, linkRegistryRelPath); err == nil && dirty {
-		stage = append(stage, linkRegistryRelPath)
-	}
-	added, addSkip, err := applyIncludes(root, stage, opts.Includes)
-	if err != nil {
-		return nil, err
-	}
-	plan.Skip = append(plan.Skip, addSkip...)
-	plan.Stage = applyExcludes(added, opts.Excludes, &plan.Skip)
-	plan.Stage = dedupeSorted(plan.Stage)
-	return plan, nil
-}
-
-func computeProjectPlan(ctx context.Context, root string, opts PlanOptions, plan *StagingPlan) (*StagingPlan, error) {
-	repoRoot := filepath.Join(root, "projects", opts.Project)
-	plan.RepoRoot = repoRoot
-	plan.Context = PlanContextLinkedProject
-	plan.ContextNote = "project " + opts.Project + " (--project override)"
-
-	stage, err := listChangedFilesUnder(ctx, repoRoot, "")
-	if err != nil {
-		return nil, camperrors.Wrap(err, "list project changes")
-	}
-	added, addSkip, err := applyIncludes(repoRoot, stage, opts.Includes)
-	if err != nil {
-		return nil, err
-	}
-	plan.Skip = append(plan.Skip, addSkip...)
-	plan.Stage = applyExcludes(added, opts.Excludes, &plan.Skip)
-	plan.Stage = dedupeSorted(plan.Stage)
-	return plan, nil
-}
-
-// PrintPlan writes the human-readable plan summary to w. Mirrors
-// COMMIT_DESIGN.md §6 exactly so the integration tests can grep stable lines.
+// PrintPlan writes the human-readable plan summary to w. It keeps the stable
+// COMMIT_DESIGN.md lines that integration tests grep while allowing per-path
+// annotations for planner-included files.
 func PrintPlan(w io.Writer, plan *StagingPlan) error {
 	if plan == nil || plan.Workitem == nil {
 		return camperrors.NewValidation("plan", "nil plan", nil)
@@ -326,6 +170,10 @@ func PrintPlan(w io.Writer, plan *StagingPlan) error {
 		}
 	}
 	for _, p := range plan.Stage {
+		if note := plan.StageAnnotations[p]; note != "" {
+			fmt.Fprintf(w, "  A  %s (%s)\n", p, note)
+			continue
+		}
 		fmt.Fprintf(w, "  A  %s\n", p)
 	}
 	if len(plan.Skip) > 0 {
@@ -336,259 +184,6 @@ func PrintPlan(w io.Writer, plan *StagingPlan) error {
 	}
 	fmt.Fprintf(w, "tag:    %s\n", plan.Tag)
 	return nil
-}
-
-// refOf reads the workitem ref off SourceMetadata (populated by
-// workitem.ApplyMetadata in sequence 03 task 02).
-func refOf(wi *wkitem.WorkItem) string {
-	if wi == nil || wi.SourceMetadata == nil {
-		return ""
-	}
-	if v, ok := wi.SourceMetadata["ref"].(string); ok {
-		return v
-	}
-	return ""
-}
-
-func workitemDirNote(wi *wkitem.WorkItem, src resolver.Source) string {
-	switch src {
-	case resolver.SourceAncestor:
-		return wi.RelativePath
-	case resolver.SourceExplicit:
-		return "explicit --workitem"
-	case resolver.SourceCurrent:
-		return "via current.yaml"
-	default:
-		return string(src)
-	}
-}
-
-// pickPrimaryProjectScopePath finds the primary path link scope (project,
-// repo, or worktree) that points at the workitem. Returns the campaign-
-// relative path so callers can join with the campaign root to get the
-// staging repo root.
-func pickPrimaryProjectScopePath(ctx context.Context, root string, wi *wkitem.WorkItem) (string, error) {
-	registry, err := links.Load(ctx, root)
-	if err != nil {
-		return "", camperrors.Wrap(err, "load links")
-	}
-	for i := range registry.Links {
-		link := &registry.Links[i]
-		if link.Role != links.RolePrimary {
-			continue
-		}
-		if link.WorkitemID != wi.StableID && link.WorkitemID != wi.Key {
-			continue
-		}
-		switch link.Scope.Kind {
-		case links.ScopeProject, links.ScopeRepo, links.ScopeWorktree:
-			return link.Scope.Path, nil
-		}
-	}
-	return "", camperrors.NewValidation("link",
-		"no primary project link points at workitem "+wi.StableID, nil)
-}
-
-func primaryFestivalScopePath(ctx context.Context, root string, wi *wkitem.WorkItem) string {
-	registry, err := links.Load(ctx, root)
-	if err != nil || registry == nil {
-		return ""
-	}
-	for i := range registry.Links {
-		link := &registry.Links[i]
-		if link.Role != links.RolePrimary || link.Scope.Kind != links.ScopeFestival {
-			continue
-		}
-		if link.WorkitemID != wi.StableID && link.WorkitemID != wi.Key {
-			continue
-		}
-		return link.Scope.Path
-	}
-	return ""
-}
-
-// listChangedFilesUnder returns repo-relative paths for changes inside prefix
-// (or the entire repo when prefix is empty). Wraps `git status --porcelain`
-// with `--untracked-files=all` so untracked directories are expanded to
-// individual files (otherwise --exclude cannot target leaf paths).
-func listChangedFilesUnder(ctx context.Context, repoRoot, prefix string) ([]string, error) {
-	args := []string{"-C", repoRoot, "status", "--porcelain", "-z", "--untracked-files=all"}
-	if prefix != "" {
-		args = append(args, "--", prefix)
-	}
-	entries, err := gitStatusPorcelainZ(ctx, args...)
-	if err != nil {
-		return nil, err
-	}
-	var files []string
-	for _, entry := range entries {
-		files = append(files, entry.Path)
-	}
-	return files, nil
-}
-
-func listStagedFiles(ctx context.Context, repoRoot string) ([]string, error) {
-	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "diff", "--cached", "--name-only", "-z").Output()
-	if err != nil {
-		return nil, err
-	}
-	return parseNULPathList(out), nil
-}
-
-func pathIsDirty(ctx context.Context, repoRoot, relPath string) (bool, error) {
-	entries, err := gitStatusPorcelainZ(ctx, "-C", repoRoot, "status", "--porcelain", "-z", "--", relPath)
-	if err != nil {
-		return false, err
-	}
-	return len(entries) != 0, nil
-}
-
-func listDirtySubmodulePointers(ctx context.Context, repoRoot string) ([]string, error) {
-	entries, err := gitStatusPorcelainZ(ctx, "-C", repoRoot, "status", "--porcelain", "-z", "--", "projects")
-	if err != nil {
-		return nil, err
-	}
-	var pointers []string
-	for _, entry := range entries {
-		if strings.HasPrefix(entry.Path, "projects/") {
-			pointers = append(pointers, entry.Path)
-		}
-	}
-	return pointers, nil
-}
-
-type gitStatusEntry struct {
-	Code string
-	Path string
-}
-
-func gitStatusPorcelainZ(ctx context.Context, args ...string) ([]gitStatusEntry, error) {
-	out, err := exec.CommandContext(ctx, "git", args...).Output()
-	if err != nil {
-		return nil, err
-	}
-	return parseGitStatusPorcelainZ(out), nil
-}
-
-func parseGitStatusPorcelainZ(out []byte) []gitStatusEntry {
-	fields := splitNULFields(out)
-	entries := make([]gitStatusEntry, 0, len(fields))
-	for i := 0; i < len(fields); i++ {
-		field := fields[i]
-		if len(field) == 0 {
-			continue
-		}
-		if len(field) < 4 {
-			continue
-		}
-		code := string(field[:2])
-		path := string(field[3:])
-		entries = append(entries, gitStatusEntry{Code: code, Path: path})
-		if code[0] == 'R' || code[0] == 'C' {
-			i++ // -z emits the old path as a second NUL-delimited field.
-		}
-	}
-	return entries
-}
-
-func parseNULPathList(out []byte) []string {
-	fields := splitNULFields(out)
-	paths := make([]string, 0, len(fields))
-	for _, field := range fields {
-		if len(field) == 0 {
-			continue
-		}
-		paths = append(paths, string(field))
-	}
-	return paths
-}
-
-func splitNULFields(out []byte) [][]byte {
-	return bytes.Split(bytes.TrimRight(out, "\x00"), []byte{0})
-}
-
-func listSubmodulePointerSkips(ctx context.Context, root string, allowed bool) []SkippedEntry {
-	if allowed {
-		return nil
-	}
-	pointers, err := listDirtySubmodulePointers(ctx, root)
-	if err != nil {
-		return nil
-	}
-	out := make([]SkippedEntry, 0, len(pointers))
-	for _, p := range pointers {
-		out = append(out, SkippedEntry{Path: p, Reason: skipReasonPointerOffByDefault})
-	}
-	return out
-}
-
-func applyIncludes(repoRoot string, stage, includes []string) ([]string, []SkippedEntry, error) {
-	if len(includes) == 0 {
-		return stage, nil, nil
-	}
-	out := append([]string{}, stage...)
-	var skip []SkippedEntry
-	for _, inc := range includes {
-		rel, err := relativeToRepo(repoRoot, inc)
-		if err != nil {
-			skip = append(skip, SkippedEntry{Path: inc, Reason: skipReasonOutOfScope})
-			continue
-		}
-		out = append(out, rel)
-	}
-	return out, skip, nil
-}
-
-func applyExcludes(stage []string, excludes []string, skip *[]SkippedEntry) []string {
-	if len(excludes) == 0 {
-		return stage
-	}
-	ex := make(map[string]bool, len(excludes))
-	for _, e := range excludes {
-		ex[filepath.ToSlash(e)] = true
-	}
-	kept := stage[:0]
-	for _, p := range stage {
-		if ex[filepath.ToSlash(p)] {
-			*skip = append(*skip, SkippedEntry{Path: p, Reason: skipReasonExcludeFlag})
-			continue
-		}
-		kept = append(kept, p)
-	}
-	return kept
-}
-
-func relativeToRepo(repoRoot, p string) (string, error) {
-	if !filepath.IsAbs(p) {
-		// Treat as already-repo-relative; reject escape attempts.
-		clean := filepath.Clean(p)
-		if strings.HasPrefix(clean, "..") {
-			return "", camperrors.NewValidation("include", "path escapes repo root: "+p, nil)
-		}
-		return filepath.ToSlash(clean), nil
-	}
-	rel, err := filepath.Rel(repoRoot, p)
-	if err != nil || strings.HasPrefix(rel, "..") {
-		return "", camperrors.NewValidation("include", "path outside repo: "+p, nil)
-	}
-	return filepath.ToSlash(rel), nil
-}
-
-func dedupeSorted(in []string) []string {
-	if len(in) == 0 {
-		return in
-	}
-	seen := make(map[string]bool, len(in))
-	out := make([]string, 0, len(in))
-	for _, p := range in {
-		if seen[p] {
-			continue
-		}
-		seen[p] = true
-		out = append(out, p)
-	}
-	sort.Strings(out)
-	return out
 }
 
 // ErrNoWorkitemContext is returned when ComputePlan cannot resolve any

--- a/internal/commands/workitem/staging_branches.go
+++ b/internal/commands/workitem/staging_branches.go
@@ -1,0 +1,248 @@
+package workitem
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
+)
+
+var (
+	osGetwd = os.Getwd
+	osStat  = os.Stat
+)
+
+// cwdSubGitRepo returns the absolute path of a sub-git-repo containing cwd
+// when cwd is strictly inside the campaign tree but not the campaign root
+// itself. Empty cwd resolves via os.Getwd.
+func cwdSubGitRepo(cwd, campaignRoot string) (string, bool) {
+	if cwd == "" {
+		c, err := osGetwd()
+		if err != nil {
+			return "", false
+		}
+		cwd = c
+	}
+	abs, err := filepath.Abs(cwd)
+	if err != nil {
+		return "", false
+	}
+	rel, err := filepath.Rel(campaignRoot, abs)
+	if err != nil || strings.HasPrefix(rel, "..") || rel == "." {
+		return "", false
+	}
+	dir := abs
+	for dir != campaignRoot && len(dir) > len(campaignRoot) {
+		gitMarker := filepath.Join(dir, ".git")
+		if info, err := osStat(gitMarker); err == nil && (info.IsDir() || info.Mode().IsRegular()) {
+			return dir, true
+		}
+		dir = filepath.Dir(dir)
+	}
+	return "", false
+}
+
+func computeDetectedProjectPlan(ctx context.Context, opts PlanOptions, plan *StagingPlan, repoRoot string) (*StagingPlan, error) {
+	plan.RepoRoot = repoRoot
+	plan.Context = PlanContextLinkedProject
+	plan.ContextNote = "project " + filepath.Base(repoRoot)
+	return finishProjectPlan(ctx, opts, plan)
+}
+
+func finishProjectPlan(ctx context.Context, opts PlanOptions, plan *StagingPlan) (*StagingPlan, error) {
+	stage, err := listChangedFilesUnder(ctx, plan.RepoRoot, "")
+	if err != nil {
+		return nil, camperrors.Wrap(err, "list project changes")
+	}
+	added, addSkip, err := applyIncludes(plan.RepoRoot, stage, opts.Includes)
+	if err != nil {
+		return nil, err
+	}
+	plan.Skip = append(plan.Skip, addSkip...)
+	plan.Stage = applyExcludes(added, opts.Excludes, &plan.Skip)
+	plan.Stage = dedupeSorted(plan.Stage)
+	return plan, nil
+}
+
+func computeWorkitemDirPlan(ctx context.Context, root string, opts PlanOptions, plan *StagingPlan, src resolver.Source) (*StagingPlan, error) {
+	plan.RepoRoot = root
+	plan.Context = PlanContextWorkitemDir
+	if src != resolver.SourceAncestor {
+		plan.Context = PlanContextCampaignRoot
+	}
+	plan.ContextNote = workitemDirNote(plan.Workitem, src)
+
+	stage, err := listChangedFilesUnder(ctx, root, plan.Workitem.RelativePath)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "list workitem changes")
+	}
+
+	if dirty, err := pathIsDirty(ctx, root, linkRegistryRelPath); err == nil && dirty {
+		stage = append(stage, linkRegistryRelPath)
+		plan.addStageNote(linkRegistryRelPath, stageAnnotationLinkRegistry)
+	}
+
+	if opts.IncludeSubmodulePointer {
+		if pointers, perr := listDirtySubmodulePointers(ctx, root); perr == nil {
+			stage = append(stage, pointers...)
+		}
+	}
+
+	added, addSkip, err := applyIncludes(root, stage, opts.Includes)
+	if err != nil {
+		return nil, err
+	}
+	plan.Skip = append(plan.Skip, addSkip...)
+	plan.Stage = applyExcludes(added, opts.Excludes, &plan.Skip)
+
+	plan.Skip = append(plan.Skip, listSubmodulePointerSkips(ctx, root, opts.IncludeSubmodulePointer)...)
+
+	plan.Stage = dedupeSorted(plan.Stage)
+	return plan, nil
+}
+
+func computeLinkPlan(ctx context.Context, root string, opts PlanOptions, plan *StagingPlan) (*StagingPlan, error) {
+	scopePath, err := pickPrimaryProjectScopePath(ctx, root, plan.Workitem)
+	if err != nil {
+		return nil, err
+	}
+	repoRoot := filepath.Join(root, filepath.FromSlash(scopePath))
+	plan.RepoRoot = repoRoot
+	plan.Context = PlanContextLinkedProject
+	plan.ContextNote = "linked project " + filepath.Base(scopePath)
+
+	stage, err := listChangedFilesUnder(ctx, repoRoot, "")
+	if err != nil {
+		return nil, camperrors.Wrap(err, "list project changes")
+	}
+
+	added, addSkip, err := applyIncludes(repoRoot, stage, opts.Includes)
+	if err != nil {
+		return nil, err
+	}
+	plan.Skip = append(plan.Skip, addSkip...)
+	plan.Stage = applyExcludes(added, opts.Excludes, &plan.Skip)
+	plan.Stage = dedupeSorted(plan.Stage)
+	return plan, nil
+}
+
+func computeFestivalPlan(ctx context.Context, root string, opts PlanOptions, plan *StagingPlan) (*StagingPlan, error) {
+	plan.RepoRoot = root
+	plan.Context = PlanContextFestival
+	scope := primaryFestivalScopePath(ctx, root, plan.Workitem)
+	if scope == "" {
+		scope = plan.Workitem.RelativePath
+	}
+	plan.ContextNote = "festival " + filepath.Base(scope)
+
+	stage, err := listChangedFilesUnder(ctx, root, scope)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "list festival changes")
+	}
+	if dirty, err := pathIsDirty(ctx, root, linkRegistryRelPath); err == nil && dirty {
+		stage = append(stage, linkRegistryRelPath)
+		plan.addStageNote(linkRegistryRelPath, stageAnnotationLinkRegistry)
+	}
+	added, addSkip, err := applyIncludes(root, stage, opts.Includes)
+	if err != nil {
+		return nil, err
+	}
+	plan.Skip = append(plan.Skip, addSkip...)
+	plan.Stage = applyExcludes(added, opts.Excludes, &plan.Skip)
+	plan.Stage = dedupeSorted(plan.Stage)
+	return plan, nil
+}
+
+func computeProjectPlan(ctx context.Context, root string, opts PlanOptions, plan *StagingPlan) (*StagingPlan, error) {
+	repoRoot := filepath.Join(root, "projects", opts.Project)
+	plan.RepoRoot = repoRoot
+	plan.Context = PlanContextLinkedProject
+	plan.ContextNote = "project " + opts.Project + " (--project override)"
+
+	stage, err := listChangedFilesUnder(ctx, repoRoot, "")
+	if err != nil {
+		return nil, camperrors.Wrap(err, "list project changes")
+	}
+	added, addSkip, err := applyIncludes(repoRoot, stage, opts.Includes)
+	if err != nil {
+		return nil, err
+	}
+	plan.Skip = append(plan.Skip, addSkip...)
+	plan.Stage = applyExcludes(added, opts.Excludes, &plan.Skip)
+	plan.Stage = dedupeSorted(plan.Stage)
+	return plan, nil
+}
+
+// refOf reads the workitem ref off SourceMetadata (populated by
+// workitem.ApplyMetadata in sequence 03 task 02).
+func refOf(wi *wkitem.WorkItem) string {
+	if wi == nil || wi.SourceMetadata == nil {
+		return ""
+	}
+	if v, ok := wi.SourceMetadata["ref"].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func workitemDirNote(wi *wkitem.WorkItem, src resolver.Source) string {
+	switch src {
+	case resolver.SourceAncestor:
+		return wi.RelativePath
+	case resolver.SourceExplicit:
+		return "explicit --workitem"
+	case resolver.SourceCurrent:
+		return "via current.yaml"
+	default:
+		return string(src)
+	}
+}
+
+// pickPrimaryProjectScopePath finds the primary path link scope (project,
+// repo, or worktree) that points at the workitem. Returns the campaign-
+// relative path so callers can join with the campaign root to get the
+// staging repo root.
+func pickPrimaryProjectScopePath(ctx context.Context, root string, wi *wkitem.WorkItem) (string, error) {
+	registry, err := links.Load(ctx, root)
+	if err != nil {
+		return "", camperrors.Wrap(err, "load links")
+	}
+	for i := range registry.Links {
+		link := &registry.Links[i]
+		if link.Role != links.RolePrimary {
+			continue
+		}
+		if link.WorkitemID != wi.StableID && link.WorkitemID != wi.Key {
+			continue
+		}
+		switch link.Scope.Kind {
+		case links.ScopeProject, links.ScopeRepo, links.ScopeWorktree:
+			return link.Scope.Path, nil
+		}
+	}
+	return "", camperrors.NewValidation("link",
+		"no primary project link points at workitem "+wi.StableID, nil)
+}
+
+func primaryFestivalScopePath(ctx context.Context, root string, wi *wkitem.WorkItem) string {
+	registry, err := links.Load(ctx, root)
+	if err != nil || registry == nil {
+		return ""
+	}
+	for i := range registry.Links {
+		link := &registry.Links[i]
+		if link.Role != links.RolePrimary || link.Scope.Kind != links.ScopeFestival {
+			continue
+		}
+		if link.WorkitemID != wi.StableID && link.WorkitemID != wi.Key {
+			continue
+		}
+		return link.Scope.Path
+	}
+	return ""
+}

--- a/internal/commands/workitem/staging_git.go
+++ b/internal/commands/workitem/staging_git.go
@@ -1,0 +1,123 @@
+package workitem
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+)
+
+// listChangedFilesUnder returns repo-relative paths for changes inside prefix
+// (or the entire repo when prefix is empty). Wraps `git status --porcelain`
+// with `--untracked-files=all` so untracked directories are expanded to
+// individual files (otherwise --exclude cannot target leaf paths).
+func listChangedFilesUnder(ctx context.Context, repoRoot, prefix string) ([]string, error) {
+	args := []string{"-C", repoRoot, "status", "--porcelain", "-z", "--untracked-files=all"}
+	if prefix != "" {
+		args = append(args, "--", prefix)
+	}
+	entries, err := gitStatusPorcelainZ(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, entry := range entries {
+		files = append(files, entry.Path)
+	}
+	return files, nil
+}
+
+func listStagedFiles(ctx context.Context, repoRoot string) ([]string, error) {
+	out, err := exec.CommandContext(ctx, "git", "-C", repoRoot, "diff", "--cached", "--name-only", "-z").Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseNULPathList(out), nil
+}
+
+func pathIsDirty(ctx context.Context, repoRoot, relPath string) (bool, error) {
+	entries, err := gitStatusPorcelainZ(ctx, "-C", repoRoot, "status", "--porcelain", "-z", "--", relPath)
+	if err != nil {
+		return false, err
+	}
+	return len(entries) != 0, nil
+}
+
+func listDirtySubmodulePointers(ctx context.Context, repoRoot string) ([]string, error) {
+	entries, err := gitStatusPorcelainZ(ctx, "-C", repoRoot, "status", "--porcelain", "-z", "--", "projects")
+	if err != nil {
+		return nil, err
+	}
+	var pointers []string
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Path, "projects/") {
+			pointers = append(pointers, entry.Path)
+		}
+	}
+	return pointers, nil
+}
+
+type gitStatusEntry struct {
+	Code string
+	Path string
+}
+
+func gitStatusPorcelainZ(ctx context.Context, args ...string) ([]gitStatusEntry, error) {
+	out, err := exec.CommandContext(ctx, "git", args...).Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseGitStatusPorcelainZ(out), nil
+}
+
+func parseGitStatusPorcelainZ(out []byte) []gitStatusEntry {
+	fields := splitNULFields(out)
+	entries := make([]gitStatusEntry, 0, len(fields))
+	for i := 0; i < len(fields); i++ {
+		field := fields[i]
+		if len(field) == 0 {
+			continue
+		}
+		if len(field) < 4 {
+			continue
+		}
+		code := string(field[:2])
+		path := string(field[3:])
+		entries = append(entries, gitStatusEntry{Code: code, Path: path})
+		if code[0] == 'R' || code[0] == 'C' {
+			i++ // -z emits the old path as a second NUL-delimited field.
+		}
+	}
+	return entries
+}
+
+func parseNULPathList(out []byte) []string {
+	fields := splitNULFields(out)
+	paths := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if len(field) == 0 {
+			continue
+		}
+		paths = append(paths, string(field))
+	}
+	return paths
+}
+
+func splitNULFields(out []byte) [][]byte {
+	return bytes.Split(bytes.TrimRight(out, "\x00"), []byte{0})
+}
+
+func listSubmodulePointerSkips(ctx context.Context, root string, allowed bool) []SkippedEntry {
+	if allowed {
+		return nil
+	}
+	pointers, err := listDirtySubmodulePointers(ctx, root)
+	if err != nil {
+		return nil
+	}
+	out := make([]SkippedEntry, 0, len(pointers))
+	for _, p := range pointers {
+		out = append(out, SkippedEntry{Path: p, Reason: skipReasonPointerOffByDefault})
+	}
+	return out
+}

--- a/internal/commands/workitem/staging_paths.go
+++ b/internal/commands/workitem/staging_paths.go
@@ -1,0 +1,78 @@
+package workitem
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+func applyIncludes(repoRoot string, stage, includes []string) ([]string, []SkippedEntry, error) {
+	if len(includes) == 0 {
+		return stage, nil, nil
+	}
+	out := append([]string{}, stage...)
+	var skip []SkippedEntry
+	for _, inc := range includes {
+		rel, err := relativeToRepo(repoRoot, inc)
+		if err != nil {
+			skip = append(skip, SkippedEntry{Path: inc, Reason: skipReasonOutOfScope})
+			continue
+		}
+		out = append(out, rel)
+	}
+	return out, skip, nil
+}
+
+func applyExcludes(stage []string, excludes []string, skip *[]SkippedEntry) []string {
+	if len(excludes) == 0 {
+		return stage
+	}
+	ex := make(map[string]bool, len(excludes))
+	for _, e := range excludes {
+		ex[filepath.ToSlash(e)] = true
+	}
+	kept := make([]string, 0, len(stage))
+	for _, p := range stage {
+		if ex[filepath.ToSlash(p)] {
+			*skip = append(*skip, SkippedEntry{Path: p, Reason: skipReasonExcludeFlag})
+			continue
+		}
+		kept = append(kept, p)
+	}
+	return kept
+}
+
+func relativeToRepo(repoRoot, p string) (string, error) {
+	if !filepath.IsAbs(p) {
+		// Treat as already-repo-relative; reject escape attempts.
+		clean := filepath.Clean(p)
+		if strings.HasPrefix(clean, "..") {
+			return "", camperrors.NewValidation("include", "path escapes repo root: "+p, nil)
+		}
+		return filepath.ToSlash(clean), nil
+	}
+	rel, err := filepath.Rel(repoRoot, p)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", camperrors.NewValidation("include", "path outside repo: "+p, nil)
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+func dedupeSorted(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, p := range in {
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/commands/workitem/staging_test.go
+++ b/internal/commands/workitem/staging_test.go
@@ -63,6 +63,36 @@ func runGit(t *testing.T, dir string, args ...string) {
 	}
 }
 
+func TestParseGitStatusPorcelainZ_RenameKeepsNewPath(t *testing.T) {
+	out := []byte("R  new name\x00old name\x00?? path with \"quote\".md\x00")
+	entries := parseGitStatusPorcelainZ(out)
+	if len(entries) != 2 {
+		t.Fatalf("entries = %#v, want 2", entries)
+	}
+	if entries[0].Path != "new name" {
+		t.Fatalf("rename path = %q, want new name", entries[0].Path)
+	}
+	if entries[1].Path != "path with \"quote\".md" {
+		t.Fatalf("quoted path = %q", entries[1].Path)
+	}
+}
+
+func TestListChangedFilesUnder_PreservesPorcelainZPaths(t *testing.T) {
+	root := stagingTestCampaign(t)
+	path := filepath.Join(root, "workflow", "design", "example", "path with \"quote\".md")
+	if err := os.WriteFile(path, []byte("quoted\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := listChangedFilesUnder(context.Background(), root, "workflow/design/example")
+	if err != nil {
+		t.Fatalf("listChangedFilesUnder: %v", err)
+	}
+	if !contains(files, "workflow/design/example/path with \"quote\".md") {
+		t.Fatalf("changed files missing quoted path: %#v", files)
+	}
+}
+
 func TestComputePlan_WorkitemDir_Ancestor(t *testing.T) {
 	root := stagingTestCampaign(t)
 	defer chdir(t, filepath.Join(root, "workflow", "design", "example"))()

--- a/internal/commands/workitem/staging_test.go
+++ b/internal/commands/workitem/staging_test.go
@@ -1,0 +1,295 @@
+package workitem
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+// stagingTestCampaign provides a git-initialized campaign with a single
+// design workitem under workflow/design/example/. Mirrors the linkTestCampaign
+// scaffold but additionally runs `git init` so the planner can call status.
+func stagingTestCampaign(t *testing.T) string {
+	t.Helper()
+	rawRoot := t.TempDir()
+	root, err := filepath.EvalSymlinks(rawRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".campaign", "workitems"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".campaign", "campaign.yaml"),
+		[]byte("id: test-campaign\nname: Test\ntype: product\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wiDir := filepath.Join(root, "workflow", "design", "example")
+	if err := os.MkdirAll(wiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const meta = `version: v1alpha6
+kind: workitem
+id: design-example-2026-05-24
+type: design
+title: Example
+ref: WI-abc123
+`
+	if err := os.WriteFile(filepath.Join(wiDir, ".workitem"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "projects", "demo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, root, "init", "-q")
+	runGit(t, root, "config", "user.email", "test@example.com")
+	runGit(t, root, "config", "user.name", "Test")
+	runGit(t, root, "add", "-A")
+	runGit(t, root, "commit", "-q", "-m", "initial")
+	return root
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func TestComputePlan_WorkitemDir_Ancestor(t *testing.T) {
+	root := stagingTestCampaign(t)
+	defer chdir(t, filepath.Join(root, "workflow", "design", "example"))()
+
+	if err := os.WriteFile(filepath.Join(root, "workflow", "design", "example", "notes.md"),
+		[]byte("hi\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	plan, err := ComputePlan(context.Background(), root, PlanOptions{CampaignID: "test-campaign"})
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan.Context != PlanContextWorkitemDir {
+		t.Fatalf("context = %q, want %q", plan.Context, PlanContextWorkitemDir)
+	}
+	if !contains(plan.Stage, "workflow/design/example/notes.md") {
+		t.Fatalf("stage missing notes.md: %v", plan.Stage)
+	}
+	if !strings.Contains(plan.Tag, "WI-WI-abc123") {
+		t.Fatalf("tag missing workitem ref: %s", plan.Tag)
+	}
+}
+
+func TestComputePlan_NoContext_Errors(t *testing.T) {
+	root := stagingTestCampaign(t)
+	defer chdir(t, root)()
+
+	_, err := ComputePlan(context.Background(), root, PlanOptions{CampaignID: "test-campaign"})
+	if !errors.Is(err, ErrNoWorkitemContext) {
+		t.Fatalf("err = %v, want ErrNoWorkitemContext", err)
+	}
+}
+
+func TestComputePlan_ExplicitWorkitem(t *testing.T) {
+	root := stagingTestCampaign(t)
+	defer chdir(t, root)()
+
+	if err := os.WriteFile(filepath.Join(root, "workflow", "design", "example", "spec.md"),
+		[]byte("spec\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	plan, err := ComputePlan(context.Background(), root, PlanOptions{
+		Explicit:   "design-example-2026-05-24",
+		CampaignID: "test-campaign",
+	})
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan.Context != PlanContextCampaignRoot {
+		t.Fatalf("context = %q, want %q", plan.Context, PlanContextCampaignRoot)
+	}
+	if !contains(plan.Stage, "workflow/design/example/spec.md") {
+		t.Fatalf("stage missing spec.md: %v", plan.Stage)
+	}
+}
+
+func TestComputePlan_ExcludeRemovesPath(t *testing.T) {
+	root := stagingTestCampaign(t)
+	defer chdir(t, filepath.Join(root, "workflow", "design", "example"))()
+
+	if err := os.WriteFile(filepath.Join(root, "workflow", "design", "example", "a.md"),
+		[]byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "workflow", "design", "example", "b.md"),
+		[]byte("b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	plan, err := ComputePlan(context.Background(), root, PlanOptions{
+		Excludes:   []string{"workflow/design/example/b.md"},
+		CampaignID: "test-campaign",
+	})
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if contains(plan.Stage, "workflow/design/example/b.md") {
+		t.Fatalf("exclude failed; stage = %v", plan.Stage)
+	}
+	if !contains(plan.Stage, "workflow/design/example/a.md") {
+		t.Fatalf("a.md missing from stage = %v", plan.Stage)
+	}
+	if !skipContains(plan.Skip, "workflow/design/example/b.md", skipReasonExcludeFlag) {
+		t.Fatalf("excluded path not in skip list: %#v", plan.Skip)
+	}
+}
+
+func TestComputePlan_IncludeAddsExplicitPath(t *testing.T) {
+	root := stagingTestCampaign(t)
+	defer chdir(t, filepath.Join(root, "workflow", "design", "example"))()
+
+	if err := os.WriteFile(filepath.Join(root, "workflow", "design", "example", "main.md"),
+		[]byte("main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs.md"), []byte("docs\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	plan, err := ComputePlan(context.Background(), root, PlanOptions{
+		Includes:   []string{"docs.md"},
+		CampaignID: "test-campaign",
+	})
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if !contains(plan.Stage, "docs.md") {
+		t.Fatalf("include path missing: %v", plan.Stage)
+	}
+}
+
+func TestComputePlan_StagedShortCircuits(t *testing.T) {
+	root := stagingTestCampaign(t)
+	defer chdir(t, filepath.Join(root, "workflow", "design", "example"))()
+
+	if err := os.WriteFile(filepath.Join(root, "x.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, root, "add", "x.md")
+
+	plan, err := ComputePlan(context.Background(), root, PlanOptions{
+		StagedOnly: true,
+		CampaignID: "test-campaign",
+	})
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan.Context != PlanContextStagedOnly {
+		t.Fatalf("context = %q", plan.Context)
+	}
+	if !contains(plan.PreStaged, "x.md") {
+		t.Fatalf("staged file missing from PreStaged: %v", plan.PreStaged)
+	}
+	if len(plan.Stage) != 0 {
+		t.Fatalf("Stage should be empty under --staged, got %v", plan.Stage)
+	}
+}
+
+func TestComputePlan_LinkedProject(t *testing.T) {
+	root := stagingTestCampaign(t)
+	demoDir := filepath.Join(root, "projects", "demo")
+	runGit(t, demoDir, "init", "-q")
+	runGit(t, demoDir, "config", "user.email", "test@example.com")
+	runGit(t, demoDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(demoDir, "seed.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, demoDir, "add", "-A")
+	runGit(t, demoDir, "commit", "-q", "-m", "seed")
+
+	registry := links.Links{
+		Version: links.LinksSchemaVersion,
+		Links: []links.Link{{
+			ID:         "lnk_20260524_aaaaaa",
+			WorkitemID: "design-example-2026-05-24",
+			Scope:      links.LinkScope{Kind: links.ScopeProject, Path: "projects/demo"},
+			Role:       links.RolePrimary,
+		}},
+	}
+	if err := links.Save(context.Background(), root, &registry); err != nil {
+		t.Fatalf("save links: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(demoDir, "feature.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer chdir(t, demoDir)()
+
+	plan, err := ComputePlan(context.Background(), root, PlanOptions{CampaignID: "test-campaign"})
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan.Context != PlanContextLinkedProject {
+		t.Fatalf("context = %q, want %q", plan.Context, PlanContextLinkedProject)
+	}
+	if plan.RepoRoot != demoDir {
+		t.Fatalf("repo root = %q, want %q", plan.RepoRoot, demoDir)
+	}
+	if !contains(plan.Stage, "feature.go") {
+		t.Fatalf("stage missing feature.go: %v", plan.Stage)
+	}
+}
+
+func TestComputePlan_ProjectFlagOverridesResolver(t *testing.T) {
+	root := stagingTestCampaign(t)
+	demoDir := filepath.Join(root, "projects", "demo")
+	runGit(t, demoDir, "init", "-q")
+	runGit(t, demoDir, "config", "user.email", "test@example.com")
+	runGit(t, demoDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(demoDir, "z.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	defer chdir(t, filepath.Join(root, "workflow", "design", "example"))()
+
+	plan, err := ComputePlan(context.Background(), root, PlanOptions{
+		Explicit:   "design-example-2026-05-24",
+		Project:    "demo",
+		CampaignID: "test-campaign",
+	})
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if plan.Context != PlanContextLinkedProject {
+		t.Fatalf("context = %q", plan.Context)
+	}
+	if plan.RepoRoot != demoDir {
+		t.Fatalf("repo root = %q, want %q", plan.RepoRoot, demoDir)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func skipContains(haystack []SkippedEntry, path, reason string) bool {
+	for _, e := range haystack {
+		if e.Path == path && e.Reason == reason {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/commands/workitem/staging_test.go
+++ b/internal/commands/workitem/staging_test.go
@@ -1,11 +1,13 @@
 package workitem
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -117,6 +119,40 @@ func TestComputePlan_WorkitemDir_Ancestor(t *testing.T) {
 	}
 }
 
+func TestComputePlan_AutoIncludedLinkRegistryIsAnnotated(t *testing.T) {
+	root := stagingTestCampaign(t)
+	defer chdir(t, filepath.Join(root, "workflow", "design", "example"))()
+
+	if err := os.WriteFile(filepath.Join(root, "workflow", "design", "example", "notes.md"),
+		[]byte("notes\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, linkRegistryRelPath),
+		[]byte("version: workitem-links/v1alpha1\nlinks: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	plan, err := ComputePlan(context.Background(), root, PlanOptions{CampaignID: "test-campaign"})
+	if err != nil {
+		t.Fatalf("ComputePlan: %v", err)
+	}
+	if !contains(plan.Stage, linkRegistryRelPath) {
+		t.Fatalf("stage missing auto-included link registry: %v", plan.Stage)
+	}
+	if got := plan.StageAnnotations[linkRegistryRelPath]; got != stageAnnotationLinkRegistry {
+		t.Fatalf("link registry annotation = %q, want %q", got, stageAnnotationLinkRegistry)
+	}
+
+	var out bytes.Buffer
+	if err := PrintPlan(&out, plan); err != nil {
+		t.Fatalf("PrintPlan: %v", err)
+	}
+	want := linkRegistryRelPath + " (" + stageAnnotationLinkRegistry + ")"
+	if !strings.Contains(out.String(), want) {
+		t.Fatalf("plan output missing annotation %q:\n%s", want, out.String())
+	}
+}
+
 func TestComputePlan_NoContext_Errors(t *testing.T) {
 	root := stagingTestCampaign(t)
 	defer chdir(t, root)()
@@ -179,6 +215,23 @@ func TestComputePlan_ExcludeRemovesPath(t *testing.T) {
 	}
 	if !skipContains(plan.Skip, "workflow/design/example/b.md", skipReasonExcludeFlag) {
 		t.Fatalf("excluded path not in skip list: %#v", plan.Skip)
+	}
+}
+
+func TestApplyExcludesDoesNotMutateInput(t *testing.T) {
+	stage := []string{"a.md", "b.md", "c.md"}
+	original := append([]string{}, stage...)
+	var skip []SkippedEntry
+
+	got := applyExcludes(stage, []string{"b.md"}, &skip)
+	if !reflect.DeepEqual(stage, original) {
+		t.Fatalf("applyExcludes mutated input: got %v, want %v", stage, original)
+	}
+	if contains(got, "b.md") {
+		t.Fatalf("excluded path still present: %v", got)
+	}
+	if !skipContains(skip, "b.md", skipReasonExcludeFlag) {
+		t.Fatalf("excluded path missing from skip list: %#v", skip)
 	}
 }
 

--- a/internal/commands/workitem/testdata/plans/campaign_root.txt
+++ b/internal/commands/workitem/testdata/plans/campaign_root.txt
@@ -1,0 +1,8 @@
+workitem: design-timeline-2026-05-24 (ref: WI-abc123)
+context:  campaign root, workitem resolved via `current`
+staging:
+  M  workflow/design/timeline/DESIGN.md
+skipped:
+  README.md (out of scope)
+  projects/camp-timeline (submodule pointer; use --include-submodule-pointer)
+tag:    [OBEY-CAMPAIGN-8deed8b4-WI-WI-abc123]

--- a/internal/commands/workitem/testdata/plans/festival_scope.txt
+++ b/internal/commands/workitem/testdata/plans/festival_scope.txt
@@ -1,0 +1,8 @@
+workitem: design-cw0003-linking-2026-05-24 (ref: WI-def456)
+context:  festival camp-workitem-linking-and-commits-CW0003 (festivals/active/...)
+staging:
+  M  festivals/active/camp-workitem-linking-and-commits-CW0003/001_IMPLEMENT/04_camp_workitem_commit/01_design_staging_plan.md
+  M  .campaign/workitems/links.yaml
+skipped:
+  festivals/active/camp-workitem-linking-and-commits-CW0003/.fest/state.json (out of scope)
+tag:    [OBEY-CAMPAIGN-8deed8b4-qst_active-FE-CW0003-WI-WI-def456]

--- a/internal/commands/workitem/testdata/plans/linked_project.txt
+++ b/internal/commands/workitem/testdata/plans/linked_project.txt
@@ -1,0 +1,8 @@
+workitem: design-timeline-2026-05-24 (ref: WI-abc123)
+context:  linked project camp-timeline (cwd: projects/camp-timeline)
+staging:
+  M  internal/timeline/render.go
+  A  internal/timeline/render_test.go
+skipped:
+  scratch.txt (gitignored)
+tag:    [OBEY-CAMPAIGN-8deed8b4-WI-WI-abc123]

--- a/internal/commands/workitem/testdata/plans/no_context_error.txt
+++ b/internal/commands/workitem/testdata/plans/no_context_error.txt
@@ -1,0 +1,6 @@
+Error: no workitem context resolved from cwd
+
+Try one of:
+  --workitem <selector>            explicit workitem to scope this commit
+  cd workflow/<type>/<slug> && ...  run from inside a workitem directory
+  camp workitem current <selector>  set a session-wide default

--- a/internal/commands/workitem/testdata/plans/submodule_pointer_explicit.txt
+++ b/internal/commands/workitem/testdata/plans/submodule_pointer_explicit.txt
@@ -1,0 +1,7 @@
+workitem: design-timeline-2026-05-24 (ref: WI-abc123)
+context:  campaign root with --include-submodule-pointer
+staging:
+  M  projects/camp-timeline
+  M  workflow/design/timeline/DESIGN.md
+skipped:
+tag:    [OBEY-CAMPAIGN-8deed8b4-WI-WI-abc123]

--- a/internal/commands/workitem/testdata/plans/workitem_dir.txt
+++ b/internal/commands/workitem/testdata/plans/workitem_dir.txt
@@ -1,0 +1,9 @@
+workitem: design-timeline-2026-05-24 (ref: WI-abc123)
+context:  workitem directory (workflow/design/timeline)
+staging:
+  M  workflow/design/timeline/DESIGN.md
+  A  workflow/design/timeline/notes/01_intro.md
+  M  .campaign/workitems/links.yaml
+skipped:
+  workflow/design/timeline/scratch.tmp (gitignored)
+tag:    [OBEY-CAMPAIGN-8deed8b4-WI-WI-abc123]

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -135,6 +135,7 @@ Examples:
 	cmd.AddCommand(newResolveCommand())
 	cmd.AddCommand(newDoctorCommand())
 	cmd.AddCommand(newCommitCommand())
+	cmd.AddCommand(newCommitsCommand())
 
 	return cmd
 }

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -134,6 +134,7 @@ Examples:
 	cmd.AddCommand(newCurrentCommand())
 	cmd.AddCommand(newResolveCommand())
 	cmd.AddCommand(newDoctorCommand())
+	cmd.AddCommand(newCommitCommand())
 
 	return cmd
 }

--- a/internal/git/commit/workitem.go
+++ b/internal/git/commit/workitem.go
@@ -1,0 +1,34 @@
+package commit
+
+import "context"
+
+// WorkitemAction identifies the high-level operation captured by the commit.
+// WorkitemScope is the generic case used by `camp workitem commit`.
+// WorkitemEdit is reserved for flows that mutate workitem metadata.
+type WorkitemAction string
+
+const (
+	WorkitemEdit  WorkitemAction = "WorkitemEdit"
+	WorkitemScope WorkitemAction = "WorkitemScope"
+)
+
+// WorkitemOptions configures a workitem-scoped commit. The embedded Options
+// carries the campaign root, campaign id, file scope, and the QuestID /
+// WorkitemRef fields surfaced through the campaign tag.
+type WorkitemOptions struct {
+	Options
+	Action      WorkitemAction
+	WorkitemID  string
+	WorkitemRef string
+	QuestID     string
+	Title       string
+	Detail      string
+}
+
+// Workitem stages workitem-scoped changes and commits with a campaign tag
+// that carries the workitem ref (and quest id, when set).
+func Workitem(ctx context.Context, opts WorkitemOptions) Result {
+	opts.Options.QuestID = opts.QuestID
+	opts.Options.WorkitemRef = opts.WorkitemRef
+	return doCommit(ctx, opts.Options, string(opts.Action), opts.Title, opts.Detail)
+}

--- a/tests/integration/workitem_commit_test.go
+++ b/tests/integration/workitem_commit_test.go
@@ -1,0 +1,219 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// initWorkitemCommitCampaign mirrors initCommitTagsCampaign with a slightly
+// different campaign name so the per-test directories stay isolated.
+func initWorkitemCommitCampaign(t *testing.T, tc *TestContainer, dir string) {
+	t.Helper()
+	_, err := tc.RunCamp(
+		"init", dir,
+		"--name", "Workitem Commit",
+		"--type", "product",
+		"-d", "Workitem commit integration",
+		"-m", "Verify scoped workitem commits",
+		"--force",
+		"--no-register",
+		"--no-git",
+	)
+	require.NoError(t, err, "camp init")
+	require.NoError(t, tc.CreateGitRepo(dir))
+}
+
+func headChangedPaths(t *testing.T, tc *TestContainer, repo string) []string {
+	t.Helper()
+	out, code, err := tc.ExecCommand("git", "-C", repo, "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD")
+	require.NoError(t, err)
+	require.Equal(t, 0, code, "git diff-tree failed: %s", out)
+	var paths []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		paths = append(paths, line)
+	}
+	return paths
+}
+
+func statusPorcelain(t *testing.T, tc *TestContainer, repo string) string {
+	t.Helper()
+	out, code, err := tc.ExecCommand("git", "-C", repo, "status", "--porcelain")
+	require.NoError(t, err)
+	require.Equal(t, 0, code, "git status failed: %s", out)
+	return out
+}
+
+func TestIntegration_WorkitemCommit_WorkitemDirContext(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/wi-commit-dir"
+	initWorkitemCommitCampaign(t, tc, dir)
+	ref := seedDesignWorkitemWithRef(t, tc, dir, "timeline")
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/timeline/notes.md", "notes\n"))
+	require.NoError(t, tc.WriteFile(dir+"/unrelated.txt", "unrelated\n"))
+
+	out, err := tc.RunCampInDir(dir, "workitem", "commit", "timeline", "-m", "design: timeline notes")
+	require.NoError(t, err, "camp workitem commit: %s", out)
+
+	subject := lastCommitSubject(t, tc, dir)
+	assert.Contains(t, subject, "WI-"+ref, "subject = %s", subject)
+
+	changed := headChangedPaths(t, tc, dir)
+	assert.Contains(t, changed, "workflow/design/timeline/notes.md")
+	assert.NotContains(t, changed, "unrelated.txt", "unrelated path leaked into commit: %v", changed)
+
+	status := statusPorcelain(t, tc, dir)
+	assert.Contains(t, status, "unrelated.txt", "unrelated.txt should still be dirty: %q", status)
+}
+
+func TestIntegration_WorkitemCommit_LinkedProject(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/wi-commit-linked"
+	initWorkitemCommitCampaign(t, tc, dir)
+	ref := seedDesignWorkitemWithRef(t, tc, dir, "timeline")
+
+	require.NoError(t, tc.CreateGitRepo(dir+"/projects/camp-timeline"))
+	_, err := tc.RunCampInDir(dir, "workitem", "link", "timeline", "--project", "camp-timeline")
+	require.NoError(t, err)
+
+	// Capture the campaign-root HEAD so we can prove it did not move.
+	rootHead, _, herr := tc.ExecCommand("git", "-C", dir, "rev-parse", "HEAD")
+	require.NoError(t, herr)
+	rootHead = strings.TrimSpace(rootHead)
+
+	require.NoError(t, tc.WriteFile(dir+"/projects/camp-timeline/foo.go", "package x\n"))
+	out, err := tc.RunCampInDir(dir+"/projects/camp-timeline",
+		"workitem", "commit", "--workitem", "timeline", "-m", "feat: stub")
+	require.NoError(t, err, "camp workitem commit: %s", out)
+
+	subject := lastCommitSubject(t, tc, dir+"/projects/camp-timeline")
+	assert.Contains(t, subject, "WI-"+ref, "project subject = %s", subject)
+
+	rootHeadAfter, _, herr := tc.ExecCommand("git", "-C", dir, "rev-parse", "HEAD")
+	require.NoError(t, herr)
+	assert.Equal(t, rootHead, strings.TrimSpace(rootHeadAfter), "campaign root HEAD must not move")
+}
+
+func TestIntegration_WorkitemCommit_RefusesSilentWiden(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/wi-commit-widen"
+	initWorkitemCommitCampaign(t, tc, dir)
+	_ = seedDesignWorkitemWithRef(t, tc, dir, "timeline")
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/timeline/spec.md", "spec\n"))
+	require.NoError(t, tc.WriteFile(dir+"/README.md", "readme\n"))
+	require.NoError(t, tc.WriteFile(dir+"/docs/extra.md", "extra\n"))
+
+	out, err := tc.RunCampInDir(dir, "workitem", "commit", "timeline", "-m", "test widen")
+	require.NoError(t, err, "camp workitem commit: %s", out)
+
+	changed := headChangedPaths(t, tc, dir)
+	for _, p := range changed {
+		assert.True(t, strings.HasPrefix(p, "workflow/design/timeline/"),
+			"unexpected path %q leaked past the workitem boundary; full set: %v", p, changed)
+	}
+	status := statusPorcelain(t, tc, dir)
+	assert.Contains(t, status, "README.md", "README.md should remain dirty: %q", status)
+	assert.Contains(t, status, "docs/extra.md", "docs/extra.md should remain dirty: %q", status)
+}
+
+func TestIntegration_WorkitemCommit_IncludeExclude(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/wi-commit-include-exclude"
+	initWorkitemCommitCampaign(t, tc, dir)
+	_ = seedDesignWorkitemWithRef(t, tc, dir, "timeline")
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/timeline/a.md", "a\n"))
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/timeline/b.md", "b\n"))
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/timeline/c.md", "c\n"))
+
+	out, err := tc.RunCampInDir(dir,
+		"workitem", "commit", "timeline",
+		"-m", "exclude b",
+		"--exclude", "workflow/design/timeline/b.md",
+	)
+	require.NoError(t, err, "camp workitem commit --exclude: %s", out)
+
+	changed := headChangedPaths(t, tc, dir)
+	assert.Contains(t, changed, "workflow/design/timeline/a.md")
+	assert.Contains(t, changed, "workflow/design/timeline/c.md")
+	assert.NotContains(t, changed, "workflow/design/timeline/b.md", "excluded path leaked: %v", changed)
+
+	// Now exercise --include with a path outside the workitem dir. The
+	// remaining workitem-dir change (b.md, from the previous excluded commit)
+	// should still land alongside the explicitly included docs/extra.md.
+	require.NoError(t, tc.WriteFile(dir+"/docs/extra.md", "extra\n"))
+	out, err = tc.RunCampInDir(dir,
+		"workitem", "commit", "timeline",
+		"-m", "include extra",
+		"--include", "docs/extra.md",
+	)
+	require.NoError(t, err, "camp workitem commit --include: %s", out)
+
+	changed = headChangedPaths(t, tc, dir)
+	assert.Contains(t, changed, "docs/extra.md", "include flag failed: %v", changed)
+	assert.Contains(t, changed, "workflow/design/timeline/b.md", "b.md should land alongside the include: %v", changed)
+}
+
+func TestIntegration_WorkitemCommits_CrossRepo(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/wi-commits-crossrepo"
+	initWorkitemCommitCampaign(t, tc, dir)
+	ref := seedDesignWorkitemWithRef(t, tc, dir, "timeline")
+	_ = ref
+
+	// One commit on the campaign root.
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/timeline/r.md", "root\n"))
+	out, err := tc.RunCampInDir(dir, "workitem", "commit", "timeline", "-m", "root contribution")
+	require.NoError(t, err, "root commit: %s", out)
+
+	// Two linked project repos with one commit each.
+	for _, name := range []string{"camp-A", "camp-B"} {
+		repo := dir + "/projects/" + name
+		require.NoError(t, tc.CreateGitRepo(repo))
+		_, err := tc.RunCampInDir(dir, "workitem", "link", "timeline", "--project", name)
+		require.NoError(t, err)
+		require.NoError(t, tc.WriteFile(repo+"/x.go", "package x // "+name+"\n"))
+		out, err := tc.RunCampInDir(repo,
+			"workitem", "commit", "--workitem", "timeline",
+			"-m", fmt.Sprintf("project %s contribution", name))
+		require.NoError(t, err, "project %s commit: %s", name, out)
+	}
+
+	out, err = tc.RunCampInDir(dir, "workitem", "commits", "timeline")
+	require.NoError(t, err, "workitem commits: %s", out)
+	for _, expect := range []string{"root contribution", "project camp-A contribution", "project camp-B contribution"} {
+		assert.Contains(t, out, expect, "missing %q in commits output:\n%s", expect, out)
+	}
+
+	jsonOut, err := tc.RunCampInDir(dir, "workitem", "commits", "timeline", "--json")
+	require.NoError(t, err, "workitem commits --json: %s", jsonOut)
+	for _, repoName := range []string{"camp-A", "camp-B"} {
+		assert.Contains(t, jsonOut, "\"repo\": \""+repoName+"\"",
+			"JSON missing repo field for %s:\n%s", repoName, jsonOut)
+	}
+}
+
+func TestIntegration_WorkitemCommit_FailureModes(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/wi-commit-failure"
+	initWorkitemCommitCampaign(t, tc, dir)
+
+	// No workitem, no override; commit from campaign root must refuse and
+	// emit the hint that names the recovery paths. We rely on
+	// RunCampInDir to surface the non-zero exit as a Go error.
+	out, err := tc.RunCampInDir(dir, "workitem", "commit", "-m", "no context")
+	require.Error(t, err, "expected non-zero exit, output: %s", out)
+	assert.Contains(t, out, "no workitem context",
+		"output should explain no workitem context:\n%s", out)
+}

--- a/tests/integration/workitem_commit_test.go
+++ b/tests/integration/workitem_commit_test.go
@@ -117,16 +117,23 @@ func TestIntegration_WorkitemCommit_RefusesSilentWiden(t *testing.T) {
 	require.Equal(t, 0, code)
 	require.NoError(t, tc.WriteFile(dir+"/README.md", "readme\n"))
 	require.NoError(t, tc.WriteFile(dir+"/docs/extra.md", "extra\n"))
+	require.NoError(t, tc.WriteFile(dir+"/.campaign/workitems/links.yaml", "version: workitem-links/v1alpha1\nlinks: []\n"))
 
 	out, err := tc.RunCampInDir(dir, "workitem", "commit", "timeline", "-m", "test widen")
 	require.NoError(t, err, "camp workitem commit: %s", out)
+	assert.Contains(t, out, ".campaign/workitems/links.yaml (link registry auto-included)",
+		"plan output should explain why the registry is included:\n%s", out)
 
 	changed := headChangedPaths(t, tc, dir)
 	for _, p := range changed {
+		if p == ".campaign/workitems/links.yaml" {
+			continue
+		}
 		assert.True(t, strings.HasPrefix(p, "workflow/design/timeline/"),
 			"unexpected path %q leaked past the workitem boundary; full set: %v", p, changed)
 	}
 	assert.Contains(t, changed, "workflow/design/timeline/test slug with spaces.md")
+	assert.Contains(t, changed, ".campaign/workitems/links.yaml")
 	status := statusPorcelain(t, tc, dir)
 	assert.Contains(t, status, "README.md", "README.md should remain dirty: %q", status)
 	assert.Contains(t, status, "docs/extra.md", "docs/extra.md should remain dirty: %q", status)
@@ -204,7 +211,7 @@ func TestIntegration_WorkitemCommits_CrossRepo(t *testing.T) {
 	jsonOut, err := tc.RunCampInDir(dir, "workitem", "commits", "timeline", "--json")
 	require.NoError(t, err, "workitem commits --json: %s", jsonOut)
 	for _, repoName := range []string{"camp-A", "camp-B"} {
-		assert.Contains(t, jsonOut, "\"repo\": \""+repoName+"\"",
+		assert.Contains(t, jsonOut, "\"repo\": \"projects/"+repoName+"\"",
 			"JSON missing repo field for %s:\n%s", repoName, jsonOut)
 	}
 }

--- a/tests/integration/workitem_commit_test.go
+++ b/tests/integration/workitem_commit_test.go
@@ -111,6 +111,10 @@ func TestIntegration_WorkitemCommit_RefusesSilentWiden(t *testing.T) {
 	_ = seedDesignWorkitemWithRef(t, tc, dir, "timeline")
 
 	require.NoError(t, tc.WriteFile(dir+"/workflow/design/timeline/spec.md", "spec\n"))
+	spacePath := dir + "/workflow/design/timeline/test slug with spaces.md"
+	_, code, err := tc.ExecCommand("sh", "-c", fmt.Sprintf("printf 'space\\n' > '%s'", spacePath))
+	require.NoError(t, err)
+	require.Equal(t, 0, code)
 	require.NoError(t, tc.WriteFile(dir+"/README.md", "readme\n"))
 	require.NoError(t, tc.WriteFile(dir+"/docs/extra.md", "extra\n"))
 
@@ -122,6 +126,7 @@ func TestIntegration_WorkitemCommit_RefusesSilentWiden(t *testing.T) {
 		assert.True(t, strings.HasPrefix(p, "workflow/design/timeline/"),
 			"unexpected path %q leaked past the workitem boundary; full set: %v", p, changed)
 	}
+	assert.Contains(t, changed, "workflow/design/timeline/test slug with spaces.md")
 	status := statusPorcelain(t, tc, dir)
 	assert.Contains(t, status, "README.md", "README.md should remain dirty: %q", status)
 	assert.Contains(t, status, "docs/extra.md", "docs/extra.md should remain dirty: %q", status)
@@ -209,11 +214,11 @@ func TestIntegration_WorkitemCommit_FailureModes(t *testing.T) {
 	dir := "/test/wi-commit-failure"
 	initWorkitemCommitCampaign(t, tc, dir)
 
-	// No workitem, no override; commit from campaign root must refuse and
-	// emit the hint that names the recovery paths. We rely on
-	// RunCampInDir to surface the non-zero exit as a Go error.
-	out, err := tc.RunCampInDir(dir, "workitem", "commit", "-m", "no context")
-	require.Error(t, err, "expected non-zero exit, output: %s", out)
+	// No workitem, no override; commit from campaign root must refuse with
+	// exit 2 and emit the hint that names the recovery paths.
+	out, code, err := tc.ExecCommand("sh", "-c", "cd "+dir+" && /camp workitem commit -m 'no context' 2>&1")
+	require.NoError(t, err)
+	require.Equal(t, 2, code, "expected exit 2, output: %s", out)
 	assert.Contains(t, out, "no workitem context",
 		"output should explain no workitem context:\n%s", out)
 }

--- a/tests/integration/workitem_create_test.go
+++ b/tests/integration/workitem_create_test.go
@@ -56,10 +56,11 @@ func TestIntegration_WorkitemCreateAndAdopt(t *testing.T) {
 
 		manifest, err := tc.ReadFile(campaignDir + "/workflow/feature/demo-feature/.workitem")
 		require.NoError(t, err)
-		assert.Contains(t, manifest, "version: v1alpha5")
+		assert.Contains(t, manifest, "version: v1alpha6")
 		assert.Contains(t, manifest, "kind: workitem")
 		assert.Contains(t, manifest, "type: feature")
 		assert.Contains(t, manifest, "title: Demo")
+		assert.Regexp(t, `ref: WI-[0-9a-f]{6}`, manifest)
 	})
 
 	t.Run("CreateRefusesExistingDirectory", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Sequence 04 of the CW0003 festival: camp workitems become a first-class execution context with scoped commits and a cross-repo query.

**Stacked on:** #304 (seq-03). Re-base onto main after #303 and #304 land.

## What landed

- `commit.Workitem` in `internal/git/commit/` — thin mirror of `commit.Quest` that wraps `doCommit` and surfaces `WorkitemRef` into the consolidated campaign tag.
- `camp workitem commit [selector]` — scoped commit command. Resolves the active workitem (positional, `--workitem`, or cwd), computes a staging plan, prints it to stderr, and hands the file scope to `commit.Workitem` with `SelectiveOnly` so empty plans never widen to `git add .` at the campaign root.
- `camp workitem commits [selector]` — cross-repo query. Fans out `git log --grep=-WI-<ref>` across the campaign root and every linked project/repo/worktree with a bounded worker pool, then filters via `commitkit.ParseTag` to reject incidental string matches.
- Staging matrix design contract at `internal/commands/workitem/COMMIT_DESIGN.md` plus sample plan fixtures under `internal/commands/workitem/testdata/plans/`.
- Six containerized integration tests in `tests/integration/workitem_commit_test.go` — the load-bearing one is `TestIntegration_WorkitemCommit_RefusesSilentWiden` (any path outside the workitem dir leaking into HEAD fails loudly).

## Routing logic

The planner branches by (in order):
1. `--staged` short-circuits — commit the current index.
2. `--project <name>` — force project-repo context.
3. cwd-first: if cwd is inside a sub-git-repo, stage from there (covers the natural `cd projects/<name>; camp workitem commit <selector>` flow).
4. Resolver tier: `SourceLink` → linked-project plan, `SourceFestival` → festival plan, default → workitem-dir plan scoped at campaign root.

`--include` / `--exclude` apply after the matrix.

## Test plan

- [x] `go build ./...`
- [x] `just test unit` — 2458/2458
- [x] `just test integration-run TestIntegration_WorkitemCommit` — 6/6