### PR TITLE
fix(CW0003 seq-01): atomic config writes + links RMW lock + workflow doctor stale walk

### DIFF
--- a/docs/OBEY.md
+++ b/docs/OBEY.md
@@ -25,3 +25,31 @@ docs/
 - Use Markdown for all documentation
 - Keep documentation close to the code it describes
 - Update docs when code changes
+
+## Narrative References
+
+Hand-authored references that explain concepts beyond the per-command
+auto-generated CLI reference.
+
+- [campaign-directory-reference.md](campaign-directory-reference.md)
+- [campaign-settings-files.md](campaign-settings-files.md)
+- [workflow-reference.md](workflow-reference.md) — custom workflow surface
+  (`camp workflow create/list/show/doctor/sync` and `shortcut add`).
+- [workitem-link-reference.md](workitem-link-reference.md) — link registry,
+  `lnk_*` IDs, resolver tiers, broken-link recovery.
+- [workitem-commit-reference.md](workitem-commit-reference.md) — scoped
+  workitem commits, staging matrix, refusal mode, cross-repo query, tag
+  grammar.
+- [SHORTCUTS.md](SHORTCUTS.md)
+- [shell-integration.md](shell-integration.md)
+- [leverage-score.md](leverage-score.md)
+
+## Migrations
+
+Operator-facing rollout notes for behavior changes that affect existing
+campaigns.
+
+- [migrations/dungeon-behavior-upgrade-2026-03.md](migrations/dungeon-behavior-upgrade-2026-03.md)
+- [migrations/intent-path-targeting-upgrade-2026-03.md](migrations/intent-path-targeting-upgrade-2026-03.md)
+- [migrations/workitem-v1alpha6-2026-05.md](migrations/workitem-v1alpha6-2026-05.md) —
+  `.workitem` schema bump (added `ref` and `quest_id`).

--- a/docs/campaign-directory-reference.md
+++ b/docs/campaign-directory-reference.md
@@ -33,6 +33,9 @@ After `camp init`, the directory usually looks like this:
 │   ├── allowlist.json
 │   ├── fresh.yaml
 │   └── jumps.yaml
+├── workitems/              # link registry + current selection
+│   ├── links.yaml
+│   └── current.yaml
 ├── skills/
 │   ├── camp-navigation/
 │   ├── camp-projects/
@@ -115,6 +118,28 @@ Important:
 
 - quests are long-lived working contexts, not the same thing as festivals
 - there is no required `.active` file; multiple quests can exist simultaneously
+
+### `.campaign/workitems/`
+
+Workitem link registry and per-machine current selection, written by
+`camp workitem link`, `camp workitem unlink`, and `camp workitem current`.
+
+Files:
+
+- `links.yaml` is the shared link registry. It stores `lnk_*` entries that
+  bind a workitem to its targets (festival, project, custom workflow item).
+  This file is intended to be committed.
+- `current.yaml` is the per-machine record of the currently selected
+  workitem. It is intended to be machine-local state.
+
+See [workitem-link-reference.md](workitem-link-reference.md) for the
+registry concept, resolver tiers, and recovery paths.
+
+Known issue, pending fix (CW0003-links-02): `current.yaml` is not yet
+covered by the `.campaign/.gitignore` scaffold and can be committed by
+mistake. Until the gitignore update lands, add `workitems/current.yaml` to
+the campaign-local ignore set after `camp init`, or avoid committing it
+with `git restore --staged .campaign/workitems/current.yaml` before commits.
 
 ### `.campaign/settings/`
 

--- a/docs/campaign-settings-files.md
+++ b/docs/campaign-settings-files.md
@@ -136,6 +136,11 @@ It stores:
 Navigation paths and shortcuts do not live here anymore; those live in
 `.campaign/settings/jumps.yaml`.
 
+`camp workflow create <type>` adds a concept entry under `concepts:` for
+the workflow type. The entry name is the workflow type slug and the path
+points to `workflow/<type>/`. Use `--replace` to overwrite a concept entry
+that already exists under the same name.
+
 ### `.campaign/settings/jumps.yaml`
 
 Campaign-local navigation settings.
@@ -171,6 +176,12 @@ Notes:
   jumps in memory and try to save the file back to disk.
 - `camp init --repair` preserves user-defined shortcuts and adds missing
   built-in shortcuts.
+- `camp workflow create <type>` adds a shortcut entry under `shortcuts:` for
+  the workflow type. The default key is the workflow type slug and the path
+  points to `workflow/<type>/`. Use `--shortcut <key>` to override the key
+  and `--replace` to overwrite an existing shortcut at the same key.
+- `camp workflow shortcut add` and `camp workflow sync` write shortcut
+  entries the same way and target the same file.
 
 See [SHORTCUTS.md](SHORTCUTS.md) for shortcut-specific details.
 

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -329,14 +329,15 @@ camp commit [flags]
 ### Options
 
 ```
-  -a, --all              Stage all changes before committing (default true)
-      --amend            Amend the previous commit
-      --auto-write       Run configured commit message writer
-  -h, --help             help for commit
-      --include-refs     Include submodule ref changes when staging at campaign root
-  -m, --message string   Commit message (required unless --auto-write)
-  -p, --project string   Operate on a specific project/submodule path
-      --sub              Operate on the submodule detected from current directory
+  -a, --all               Stage all changes before committing (default true)
+      --amend             Amend the previous commit
+      --auto-write        Run configured commit message writer
+  -h, --help              help for commit
+      --include-refs      Include submodule ref changes when staging at campaign root
+  -m, --message string    Commit message (required unless --auto-write)
+  -p, --project string    Operate on a specific project/submodule path
+      --sub               Operate on the submodule detected from current directory
+      --workitem string   explicit workitem selector for the commit tag (overrides cwd-based resolution)
 ```
 
 ### Options inherited from parent commands
@@ -2694,13 +2695,14 @@ camp project commit [flags]
 ### Options
 
 ```
-  -a, --all              Stage all changes (default true)
-      --amend            Amend the previous commit
-      --auto-write       Run configured commit message writer
-  -h, --help             help for commit
-  -m, --message string   Commit message (required unless --auto-write)
-  -p, --project string   Project name (auto-detected from cwd if not specified)
-      --sync             Sync submodule ref at campaign root after commit (opt-in)
+  -a, --all               Stage all changes (default true)
+      --amend             Amend the previous commit
+      --auto-write        Run configured commit message writer
+  -h, --help              help for commit
+  -m, --message string    Commit message (required unless --auto-write)
+  -p, --project string    Project name (auto-detected from cwd if not specified)
+      --sync              Sync submodule ref at campaign root after commit (opt-in)
+      --workitem string   explicit workitem selector for the commit tag (overrides cwd-based resolution)
 ```
 
 ### Options inherited from parent commands
@@ -3547,6 +3549,48 @@ camp project worktree remove <name> [flags]
   -f, --force            Force removal even with uncommitted changes
   -h, --help             help for remove
   -p, --project string   Project name (auto-detected from cwd if not specified)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp promote
+
+Promote the workitem at cwd to a dungeon status
+
+### Synopsis
+
+Promote the directory-style workitem containing the current working
+directory to a named status. Status directories live under the workitem
+type's local dungeon (workflow/<type>/dungeon/<status>/); outside the
+dungeon a workitem is treated as active.
+
+Run this from anywhere inside workflow/<type>/<slug>/. The workitem
+boundary is detected from cwd. The status argument is the destination
+directory name (e.g., completed, archived, someday) - no need to spell
+out "dungeon/".
+
+Examples:
+  camp promote completed   Shelve the workitem to its local dungeon/completed
+  camp promote archived    Move to dungeon/archived
+  camp promote someday     Move to dungeon/someday
+
+```
+camp promote <status> [flags]
+```
+
+### Options
+
+```
+  -h, --help        help for promote
+      --json        Output result as JSON
+      --no-commit   Skip auto-commit after promotion
 ```
 
 ### Options inherited from parent commands
@@ -4981,6 +5025,201 @@ camp version [flags]
 ```
 ---
 
+## camp workflow
+
+Manage workflow collections
+
+### Synopsis
+
+Manage workflow collections.
+
+A workflow collection is a campaign directory under workflow/<type>/ with
+navigation config and workitem type support.
+
+### Options
+
+```
+  -h, --help   help for workflow
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workflow create
+
+Create a custom workflow collection
+
+```
+camp workflow create <type> [flags]
+```
+
+### Options
+
+```
+      --dry-run           report planned writes without modifying the filesystem
+  -h, --help              help for create
+      --json              emit a structured JSON result
+      --replace           replace an existing shortcut or concept with the same name
+      --shortcut string   navigation shortcut for this workflow
+      --title string      human-readable workflow title
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workflow doctor
+
+Report workflow surface inconsistencies
+
+```
+camp workflow doctor [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for doctor
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workflow list
+
+List user-created workflow collections
+
+```
+camp workflow list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workflow shortcut
+
+Manage navigation shortcuts for workflow collections
+
+### Options
+
+```
+  -h, --help   help for shortcut
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workflow shortcut add
+
+Attach a navigation shortcut to an existing workflow
+
+```
+camp workflow shortcut add <type> <key> [flags]
+```
+
+### Options
+
+```
+  -h, --help      help for add
+      --json      emit a structured JSON result
+      --replace   replace an existing shortcut with the same name
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workflow show
+
+Show a workflow collection's config and recent workitems
+
+```
+camp workflow show <type> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workflow sync
+
+Repair auto-fixable doctor findings
+
+```
+camp workflow sync [flags]
+```
+
+### Options
+
+```
+      --apply   perform writes (default: report only)
+  -h, --help    help for sync
+      --json    emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
 ## camp workitem
 
 View active campaign work items
@@ -5037,8 +5276,91 @@ camp workitem adopt <dir> [flags]
 ```
   -h, --help           help for adopt
       --id string      override the generated id
+      --quest string   capture quest_id from this quest (defaults to CAMP_QUEST env var if set)
       --title string   human-readable title
       --type string    workitem type (feature, bug, chore, or custom) (default "feature")
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workitem commit
+
+Commit changes scoped to the resolved workitem
+
+### Synopsis
+
+Stage and commit changes belonging to a resolved workitem.
+
+The staging plan is computed from the resolver context (cwd-aware, with
+explicit positional <selector> or --project overrides) and printed to stderr
+before the commit runs. The plan never silently widens to "git add ." at the
+campaign root.
+
+See internal/commands/workitem/COMMIT_DESIGN.md for the full staging matrix
+and flag precedence.
+
+```
+camp workitem commit [selector] [flags]
+```
+
+### Options
+
+```
+      --dry-run                     print the staging plan and exit without committing
+      --exclude stringArray         path to remove from the staging plan (repeatable)
+  -h, --help                        help for commit
+      --include stringArray         additional path to stage (repeatable; relative to repo root)
+      --include-submodule-pointer   include dirty project submodule pointers in the plan
+      --json                        emit the staging plan and commit result as JSON on stdout
+  -m, --message string              commit message (required unless --dry-run)
+      --project string              force project-repo context by name (skips resolver)
+      --staged                      commit whatever is already in the git index
+      --workitem string             explicit workitem selector (overrides cwd-based resolution)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workitem commits
+
+List commits referencing a workitem across linked repos
+
+### Synopsis
+
+Search the campaign root and every linked project/repo/worktree/festival
+repo for commits whose campaign tag references this workitem's ref.
+
+Default sort: most recent first across all repos. Use --json for structured
+output. Repos that are not git checkouts or that fail their git log invocation
+are reported under "errors" in JSON mode; table mode warns on stderr when
+repo queries fail.
+
+```
+camp workitem commits [selector] [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for commits
+      --json              emit JSON instead of the default table
+      --limit int         maximum commits to return (default 100)
+      --offset int        number of commits to skip (after sorting)
+      --ref string        query by workitem ref directly (e.g. WI-abc123) — skips resolver
+      --workitem string   alias for the positional <selector>
 ```
 
 ### Options inherited from parent commands
@@ -5064,8 +5386,170 @@ camp workitem create <slug> [flags]
       --dir string     parent dir override (default: workflow/<type>)
   -h, --help           help for create
       --id string      override the generated id
+      --quest string   capture quest_id from this quest (defaults to CAMP_QUEST env var if set)
       --title string   human-readable title
       --type string    workitem type (feature, bug, chore, or custom) (default "feature")
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workitem current
+
+Get, set, or clear the local current workitem
+
+```
+camp workitem current [selector] [flags]
+```
+
+### Options
+
+```
+      --clear   remove the local current.yaml selection
+  -h, --help    help for current
+      --json    emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workitem doctor
+
+Report workitem link-registry health issues
+
+```
+camp workitem doctor [flags]
+```
+
+### Options
+
+```
+      --fix    auto-repair findings tagged auto_fixable
+  -h, --help   help for doctor
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workitem link
+
+Attach a workitem to a project, festival, worktree, or campaign path
+
+```
+camp workitem link <selector> [path] [flags]
+```
+
+### Options
+
+```
+      --allow-missing     allow the workitem and scope target to not exist (migrations)
+      --cwd               use current working directory as the scope
+      --festival string   festival id or relative path under festivals/
+  -h, --help              help for link
+      --json              emit a structured JSON result
+      --project string    project name (matches projects/<name>)
+      --replace           replace an existing primary link on the same scope
+      --role string       primary | related | blocked_by | supersedes (default "primary")
+      --worktree string   worktree relative path under projects/worktrees/
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workitem links
+
+List workitem links
+
+```
+camp workitem links [selector] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for links
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workitem resolve
+
+Print the workitem the current context resolves to (read-only)
+
+```
+camp workitem resolve [flags]
+```
+
+### Options
+
+```
+      --explain           print the tier-by-tier resolution trace
+      --festival string   festival id for the festival tier
+  -h, --help              help for resolve
+      --json              emit a structured JSON result
+      --workitem string   explicit workitem selector (overrides cwd-based detection)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workitem unlink
+
+Remove one or more workitem links
+
+```
+camp workitem unlink [selector] [path] [flags]
+```
+
+### Options
+
+```
+      --all               remove every link matching the selector
+      --festival string   festival scope filter
+  -h, --help              help for unlink
+      --id string         remove the link with this lnk_ id
+      --json              emit a structured JSON result
+      --project string    project scope filter
+      --worktree string   worktree scope filter
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp.md
+++ b/docs/cli-reference/camp.md
@@ -69,6 +69,7 @@ camp [flags]
 * [camp pins](camp_pins.md)	 - List all pinned directories
 * [camp plugins](camp_plugins.md)	 - List discovered camp plugins on PATH
 * [camp project](camp_project.md)	 - Manage campaign projects
+* [camp promote](camp_promote.md)	 - Promote the workitem at cwd to a dungeon status
 * [camp pull](camp_pull.md)	 - Pull latest changes from remote
 * [camp push](camp_push.md)	 - Push campaign changes to remote
 * [camp refs-sync](camp_refs-sync.md)	 - Sync submodule ref pointers in campaign root
@@ -88,4 +89,5 @@ camp [flags]
 * [camp unpin](camp_unpin.md)	 - Remove a saved pin
 * [camp unregister](camp_unregister.md)	 - Remove campaign from registry
 * [camp version](camp_version.md)	 - Show version information
+* [camp workflow](camp_workflow.md)	 - Manage workflow collections
 * [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/docs/cli-reference/camp_commit.md
+++ b/docs/cli-reference/camp_commit.md
@@ -31,14 +31,15 @@ camp commit [flags]
 ### Options
 
 ```
-  -a, --all              Stage all changes before committing (default true)
-      --amend            Amend the previous commit
-      --auto-write       Run configured commit message writer
-  -h, --help             help for commit
-      --include-refs     Include submodule ref changes when staging at campaign root
-  -m, --message string   Commit message (required unless --auto-write)
-  -p, --project string   Operate on a specific project/submodule path
-      --sub              Operate on the submodule detected from current directory
+  -a, --all               Stage all changes before committing (default true)
+      --amend             Amend the previous commit
+      --auto-write        Run configured commit message writer
+  -h, --help              help for commit
+      --include-refs      Include submodule ref changes when staging at campaign root
+  -m, --message string    Commit message (required unless --auto-write)
+  -p, --project string    Operate on a specific project/submodule path
+      --sub               Operate on the submodule detected from current directory
+      --workitem string   explicit workitem selector for the commit tag (overrides cwd-based resolution)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_project_commit.md
+++ b/docs/cli-reference/camp_project_commit.md
@@ -24,13 +24,14 @@ camp project commit [flags]
 ### Options
 
 ```
-  -a, --all              Stage all changes (default true)
-      --amend            Amend the previous commit
-      --auto-write       Run configured commit message writer
-  -h, --help             help for commit
-  -m, --message string   Commit message (required unless --auto-write)
-  -p, --project string   Project name (auto-detected from cwd if not specified)
-      --sync             Sync submodule ref at campaign root after commit (opt-in)
+  -a, --all               Stage all changes (default true)
+      --amend             Amend the previous commit
+      --auto-write        Run configured commit message writer
+  -h, --help              help for commit
+  -m, --message string    Commit message (required unless --auto-write)
+  -p, --project string    Project name (auto-detected from cwd if not specified)
+      --sync              Sync submodule ref at campaign root after commit (opt-in)
+      --workitem string   explicit workitem selector for the commit tag (overrides cwd-based resolution)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_promote.md
+++ b/docs/cli-reference/camp_promote.md
@@ -1,0 +1,44 @@
+## camp promote
+
+Promote the workitem at cwd to a dungeon status
+
+### Synopsis
+
+Promote the directory-style workitem containing the current working
+directory to a named status. Status directories live under the workitem
+type's local dungeon (workflow/<type>/dungeon/<status>/); outside the
+dungeon a workitem is treated as active.
+
+Run this from anywhere inside workflow/<type>/<slug>/. The workitem
+boundary is detected from cwd. The status argument is the destination
+directory name (e.g., completed, archived, someday) - no need to spell
+out "dungeon/".
+
+Examples:
+  camp promote completed   Shelve the workitem to its local dungeon/completed
+  camp promote archived    Move to dungeon/archived
+  camp promote someday     Move to dungeon/someday
+
+```
+camp promote <status> [flags]
+```
+
+### Options
+
+```
+  -h, --help        help for promote
+      --json        Output result as JSON
+      --no-commit   Skip auto-commit after promotion
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces

--- a/docs/cli-reference/camp_workflow.md
+++ b/docs/cli-reference/camp_workflow.md
@@ -1,0 +1,34 @@
+## camp workflow
+
+Manage workflow collections
+
+### Synopsis
+
+Manage workflow collections.
+
+A workflow collection is a campaign directory under workflow/<type>/ with
+navigation config and workitem type support.
+
+### Options
+
+```
+  -h, --help   help for workflow
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
+* [camp workflow create](camp_workflow_create.md)	 - Create a custom workflow collection
+* [camp workflow doctor](camp_workflow_doctor.md)	 - Report workflow surface inconsistencies
+* [camp workflow list](camp_workflow_list.md)	 - List user-created workflow collections
+* [camp workflow shortcut](camp_workflow_shortcut.md)	 - Manage navigation shortcuts for workflow collections
+* [camp workflow show](camp_workflow_show.md)	 - Show a workflow collection's config and recent workitems
+* [camp workflow sync](camp_workflow_sync.md)	 - Repair auto-fixable doctor findings

--- a/docs/cli-reference/camp_workflow_create.md
+++ b/docs/cli-reference/camp_workflow_create.md
@@ -1,0 +1,30 @@
+## camp workflow create
+
+Create a custom workflow collection
+
+```
+camp workflow create <type> [flags]
+```
+
+### Options
+
+```
+      --dry-run           report planned writes without modifying the filesystem
+  -h, --help              help for create
+      --json              emit a structured JSON result
+      --replace           replace an existing shortcut or concept with the same name
+      --shortcut string   navigation shortcut for this workflow
+      --title string      human-readable workflow title
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workflow](camp_workflow.md)	 - Manage workflow collections

--- a/docs/cli-reference/camp_workflow_doctor.md
+++ b/docs/cli-reference/camp_workflow_doctor.md
@@ -1,0 +1,26 @@
+## camp workflow doctor
+
+Report workflow surface inconsistencies
+
+```
+camp workflow doctor [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for doctor
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workflow](camp_workflow.md)	 - Manage workflow collections

--- a/docs/cli-reference/camp_workflow_list.md
+++ b/docs/cli-reference/camp_workflow_list.md
@@ -1,0 +1,26 @@
+## camp workflow list
+
+List user-created workflow collections
+
+```
+camp workflow list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workflow](camp_workflow.md)	 - Manage workflow collections

--- a/docs/cli-reference/camp_workflow_shortcut.md
+++ b/docs/cli-reference/camp_workflow_shortcut.md
@@ -1,0 +1,22 @@
+## camp workflow shortcut
+
+Manage navigation shortcuts for workflow collections
+
+### Options
+
+```
+  -h, --help   help for shortcut
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workflow](camp_workflow.md)	 - Manage workflow collections
+* [camp workflow shortcut add](camp_workflow_shortcut_add.md)	 - Attach a navigation shortcut to an existing workflow

--- a/docs/cli-reference/camp_workflow_shortcut_add.md
+++ b/docs/cli-reference/camp_workflow_shortcut_add.md
@@ -1,0 +1,27 @@
+## camp workflow shortcut add
+
+Attach a navigation shortcut to an existing workflow
+
+```
+camp workflow shortcut add <type> <key> [flags]
+```
+
+### Options
+
+```
+  -h, --help      help for add
+      --json      emit a structured JSON result
+      --replace   replace an existing shortcut with the same name
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workflow shortcut](camp_workflow_shortcut.md)	 - Manage navigation shortcuts for workflow collections

--- a/docs/cli-reference/camp_workflow_show.md
+++ b/docs/cli-reference/camp_workflow_show.md
@@ -1,0 +1,26 @@
+## camp workflow show
+
+Show a workflow collection's config and recent workitems
+
+```
+camp workflow show <type> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workflow](camp_workflow.md)	 - Manage workflow collections

--- a/docs/cli-reference/camp_workflow_sync.md
+++ b/docs/cli-reference/camp_workflow_sync.md
@@ -1,0 +1,27 @@
+## camp workflow sync
+
+Repair auto-fixable doctor findings
+
+```
+camp workflow sync [flags]
+```
+
+### Options
+
+```
+      --apply   perform writes (default: report only)
+  -h, --help    help for sync
+      --json    emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workflow](camp_workflow.md)	 - Manage workflow collections

--- a/docs/cli-reference/camp_workitem.md
+++ b/docs/cli-reference/camp_workitem.md
@@ -44,4 +44,12 @@ camp workitem [flags]
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
 * [camp workitem adopt](camp_workitem_adopt.md)	 - Attach .workitem metadata to an existing directory
+* [camp workitem commit](camp_workitem_commit.md)	 - Commit changes scoped to the resolved workitem
+* [camp workitem commits](camp_workitem_commits.md)	 - List commits referencing a workitem across linked repos
 * [camp workitem create](camp_workitem_create.md)	 - Create a new workitem with v1 minimum metadata
+* [camp workitem current](camp_workitem_current.md)	 - Get, set, or clear the local current workitem
+* [camp workitem doctor](camp_workitem_doctor.md)	 - Report workitem link-registry health issues
+* [camp workitem link](camp_workitem_link.md)	 - Attach a workitem to a project, festival, worktree, or campaign path
+* [camp workitem links](camp_workitem_links.md)	 - List workitem links
+* [camp workitem resolve](camp_workitem_resolve.md)	 - Print the workitem the current context resolves to (read-only)
+* [camp workitem unlink](camp_workitem_unlink.md)	 - Remove one or more workitem links

--- a/docs/cli-reference/camp_workitem_adopt.md
+++ b/docs/cli-reference/camp_workitem_adopt.md
@@ -11,6 +11,7 @@ camp workitem adopt <dir> [flags]
 ```
   -h, --help           help for adopt
       --id string      override the generated id
+      --quest string   capture quest_id from this quest (defaults to CAMP_QUEST env var if set)
       --title string   human-readable title
       --type string    workitem type (feature, bug, chore, or custom) (default "feature")
 ```

--- a/docs/cli-reference/camp_workitem_commit.md
+++ b/docs/cli-reference/camp_workitem_commit.md
@@ -1,0 +1,46 @@
+## camp workitem commit
+
+Commit changes scoped to the resolved workitem
+
+### Synopsis
+
+Stage and commit changes belonging to a resolved workitem.
+
+The staging plan is computed from the resolver context (cwd-aware, with
+explicit positional <selector> or --project overrides) and printed to stderr
+before the commit runs. The plan never silently widens to "git add ." at the
+campaign root.
+
+See internal/commands/workitem/COMMIT_DESIGN.md for the full staging matrix
+and flag precedence.
+
+```
+camp workitem commit [selector] [flags]
+```
+
+### Options
+
+```
+      --dry-run                     print the staging plan and exit without committing
+      --exclude stringArray         path to remove from the staging plan (repeatable)
+  -h, --help                        help for commit
+      --include stringArray         additional path to stage (repeatable; relative to repo root)
+      --include-submodule-pointer   include dirty project submodule pointers in the plan
+      --json                        emit the staging plan and commit result as JSON on stdout
+  -m, --message string              commit message (required unless --dry-run)
+      --project string              force project-repo context by name (skips resolver)
+      --staged                      commit whatever is already in the git index
+      --workitem string             explicit workitem selector (overrides cwd-based resolution)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/docs/cli-reference/camp_workitem_commits.md
+++ b/docs/cli-reference/camp_workitem_commits.md
@@ -1,0 +1,40 @@
+## camp workitem commits
+
+List commits referencing a workitem across linked repos
+
+### Synopsis
+
+Search the campaign root and every linked project/repo/worktree/festival
+repo for commits whose campaign tag references this workitem's ref.
+
+Default sort: most recent first across all repos. Use --json for structured
+output. Repos that are not git checkouts or that fail their git log invocation
+are reported under "errors" in JSON mode; table mode warns on stderr when
+repo queries fail.
+
+```
+camp workitem commits [selector] [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for commits
+      --json              emit JSON instead of the default table
+      --limit int         maximum commits to return (default 100)
+      --offset int        number of commits to skip (after sorting)
+      --ref string        query by workitem ref directly (e.g. WI-abc123) — skips resolver
+      --workitem string   alias for the positional <selector>
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/docs/cli-reference/camp_workitem_create.md
+++ b/docs/cli-reference/camp_workitem_create.md
@@ -12,6 +12,7 @@ camp workitem create <slug> [flags]
       --dir string     parent dir override (default: workflow/<type>)
   -h, --help           help for create
       --id string      override the generated id
+      --quest string   capture quest_id from this quest (defaults to CAMP_QUEST env var if set)
       --title string   human-readable title
       --type string    workitem type (feature, bug, chore, or custom) (default "feature")
 ```

--- a/docs/cli-reference/camp_workitem_current.md
+++ b/docs/cli-reference/camp_workitem_current.md
@@ -1,0 +1,27 @@
+## camp workitem current
+
+Get, set, or clear the local current workitem
+
+```
+camp workitem current [selector] [flags]
+```
+
+### Options
+
+```
+      --clear   remove the local current.yaml selection
+  -h, --help    help for current
+      --json    emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/docs/cli-reference/camp_workitem_doctor.md
+++ b/docs/cli-reference/camp_workitem_doctor.md
@@ -1,0 +1,27 @@
+## camp workitem doctor
+
+Report workitem link-registry health issues
+
+```
+camp workitem doctor [flags]
+```
+
+### Options
+
+```
+      --fix    auto-repair findings tagged auto_fixable
+  -h, --help   help for doctor
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/docs/cli-reference/camp_workitem_link.md
+++ b/docs/cli-reference/camp_workitem_link.md
@@ -1,0 +1,33 @@
+## camp workitem link
+
+Attach a workitem to a project, festival, worktree, or campaign path
+
+```
+camp workitem link <selector> [path] [flags]
+```
+
+### Options
+
+```
+      --allow-missing     allow the workitem and scope target to not exist (migrations)
+      --cwd               use current working directory as the scope
+      --festival string   festival id or relative path under festivals/
+  -h, --help              help for link
+      --json              emit a structured JSON result
+      --project string    project name (matches projects/<name>)
+      --replace           replace an existing primary link on the same scope
+      --role string       primary | related | blocked_by | supersedes (default "primary")
+      --worktree string   worktree relative path under projects/worktrees/
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/docs/cli-reference/camp_workitem_links.md
+++ b/docs/cli-reference/camp_workitem_links.md
@@ -1,0 +1,26 @@
+## camp workitem links
+
+List workitem links
+
+```
+camp workitem links [selector] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for links
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/docs/cli-reference/camp_workitem_resolve.md
+++ b/docs/cli-reference/camp_workitem_resolve.md
@@ -1,0 +1,29 @@
+## camp workitem resolve
+
+Print the workitem the current context resolves to (read-only)
+
+```
+camp workitem resolve [flags]
+```
+
+### Options
+
+```
+      --explain           print the tier-by-tier resolution trace
+      --festival string   festival id for the festival tier
+  -h, --help              help for resolve
+      --json              emit a structured JSON result
+      --workitem string   explicit workitem selector (overrides cwd-based detection)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/docs/cli-reference/camp_workitem_unlink.md
+++ b/docs/cli-reference/camp_workitem_unlink.md
@@ -1,0 +1,31 @@
+## camp workitem unlink
+
+Remove one or more workitem links
+
+```
+camp workitem unlink [selector] [path] [flags]
+```
+
+### Options
+
+```
+      --all               remove every link matching the selector
+      --festival string   festival scope filter
+  -h, --help              help for unlink
+      --id string         remove the link with this lnk_ id
+      --json              emit a structured JSON result
+      --project string    project scope filter
+      --worktree string   worktree scope filter
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/docs/migrations/workitem-v1alpha6-2026-05.md
+++ b/docs/migrations/workitem-v1alpha6-2026-05.md
@@ -1,0 +1,179 @@
+# Workitem `.workitem` Schema v1alpha6 Upgrade Guide (May 2026)
+
+This note covers the v1alpha6 schema bump delivered by the CW0003 festival
+(workitem linking and commit tracking) and the operator-visible rollout
+behavior.
+
+## Scope
+
+The rollout covers a single metadata schema change:
+
+1. `.workitem` files now use `version: v1alpha6`.
+2. Two new fields are introduced.
+   - `ref` is mandatory on newly created workitems and follows the format
+     `WI-<6 lowercase hex>`. It is the deterministic short reference embedded
+     in commit messages.
+   - `quest_id` is optional. It captures the quest active when the workitem
+     was created or adopted (via `--quest` or the `CAMP_QUEST` env var).
+
+## Why
+
+The CW0003 design promotes scoped workitem commits and a campaign-local link
+registry. Commit-message tags must carry a compact, stable workitem reference
+that is unique within a campaign, and adopted workitems should record the
+quest context that produced them.
+
+Design reference: `workflow/design/workitem-linking-commit-tracking/` in
+`obey-campaign` (notably `02-workitem-linking-model.md` and
+`03-commit-tracking-and-scoped-commits.md`).
+
+## What Changed
+
+### Schema
+
+The accepted set is now `v1alpha4`, `v1alpha5`, and `v1alpha6`. New workitems
+written by `camp workitem create` and `camp workitem adopt` emit v1alpha6.
+
+```yaml
+version: v1alpha6
+kind: workitem
+id: feature-CW0003-payments
+type: feature
+title: Payments rebuild
+created_by: lance
+ref: WI-a1b2c3
+quest_id: q-2026-05-launch
+```
+
+Sample diff from v1alpha5 to v1alpha6 for an existing file:
+
+```diff
+-version: v1alpha5
++version: v1alpha6
+ kind: workitem
+ id: feature-CW0003-payments
+ type: feature
+ title: Payments rebuild
+ created_by: lance
++ref: WI-a1b2c3
++quest_id: q-2026-05-launch
+```
+
+### Reader Compatibility
+
+`v1alpha4` and `v1alpha5` `.workitem` files remain readable.
+
+- `LoadMetadata` accepts all three versions through `acceptedWorkitemVersions`
+  in `internal/workitem/metadata.go`.
+- Legacy workitems load with empty `ref` and empty `quest_id`.
+
+### Commit-Path Behavior For Legacy Workitems
+
+When `camp workitem commit` (or `camp p commit` running inside a workitem
+context) operates on a legacy workitem that has no `ref`, the commit-message
+tag is still emitted, but the `WI-` segment is omitted from the trailer. The
+resulting tag therefore identifies the festival or context but not the
+specific workitem.
+
+Operator impact: legacy workitems should be backfilled via doctor before
+relying on the commit history for per-workitem aggregation. See known issues
+below.
+
+## Migration Path
+
+The supported workflow for upgrading an existing campaign:
+
+1. Run `camp workitem doctor` to enumerate workitems with missing `ref` (and
+   any other metadata drift).
+2. Run `camp workitem doctor --fix` to backfill `ref` values into the
+   matching `.workitem` files. Backfilled refs are deterministic for the
+   given workitem id and unique within the campaign.
+3. Re-run `camp workitem doctor` to confirm no missing-ref workitems remain.
+
+After backfill, subsequent commits emit fully-qualified tags including the
+`WI-<ref>` segment.
+
+## Known Issues — Pending Fix
+
+The CW0003 review captured several open defects on the v1alpha6 surface.
+These are tracked in the festival findings under
+`festivals/active/camp-workitem-linking-and-commits-CW0003/`. Until they
+land, operators should be aware of the following.
+
+### Doctor reports false positives on intents and festivals
+
+Finding `CW0003-format-01`: `camp workitem doctor` flags non-workitem
+artifacts (intents and festivals) as missing-ref. In real repos this can
+generate dozens of false positives (52 observed on the obey-campaign
+workspace).
+
+Workaround: when reading doctor output, treat entries outside the workitem
+status directories as advisory and ignore them. Apply `--fix` only when the
+queue is dominated by genuine workitem entries (see next item).
+
+### Doctor `--fix` aborts the queue on the first per-item error
+
+Finding `CW0003-format-06`: `camp workitem doctor --fix` stops processing on
+the first per-item failure rather than continuing and reporting a summary at
+the end. A single malformed `.workitem` can prevent backfill of every later
+workitem in the same run.
+
+Workaround: when `--fix` aborts, address the reported workitem in isolation
+(hand-edit or remove the offending file), then re-run `--fix`. Iterate until
+the queue completes.
+
+### Validator does not enforce the `WI-<6 hex>` shape on hand-edited markers
+
+Finding `CW0003-format-02`: `validateMetadata` accepts any non-empty string
+for `ref`. Hand-edited markers with malformed values (wrong prefix, wrong
+length, non-hex characters, embedded whitespace) load successfully and the
+junk reference propagates into commit-message tags and git history.
+
+Workaround: only set `ref` via `camp workitem doctor --fix` or by letting
+`camp workitem create` derive it. Treat hand-editing the `ref` field as
+unsupported until validator coverage lands.
+
+### Commit-path silently drops the `WI-` segment for legacy workitems
+
+Finding `CW0003-format-13`: when a workitem has no `ref`, the commit-path
+emits a tag without the workitem segment rather than refusing or warning.
+The behavior is intentional for read-side compatibility but is silent, so
+operators who expect every commit to carry a workitem reference will not
+notice the gap.
+
+Workaround: run `camp workitem doctor --fix` ahead of any campaign-wide
+commit history audit, and confirm via `camp workitem doctor` that the
+backfill is complete before relying on tag aggregation.
+
+## Compatibility Expectations
+
+- All three accepted schema versions (`v1alpha4`, `v1alpha5`, `v1alpha6`)
+  load successfully.
+- Writes default to v1alpha6 in `camp workitem create` and `camp workitem
+  adopt`.
+- Legacy workitems remain usable; their commit tags omit the workitem
+  segment until backfilled.
+- `camp workitem commit` and `camp p commit` continue to function against
+  legacy workitems with the documented silent-omission caveat.
+
+## Reference Links
+
+CLI reference:
+
+- `docs/cli-reference/camp_workitem_create.md`
+- `docs/cli-reference/camp_workitem_adopt.md`
+- `docs/cli-reference/camp_workitem_doctor.md`
+- `docs/cli-reference/camp_workitem_commit.md`
+
+Narrative reference (CW0003):
+
+- `docs/workitem-link-reference.md`
+- `docs/workitem-commit-reference.md`
+- `docs/workflow-reference.md`
+
+Source:
+
+- `internal/workitem/metadata.go` (schema definition and accepted version
+  set)
+- `internal/commands/workitem/doctor_ref.go` (backfill path used by
+  `doctor --fix`)

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -1,0 +1,450 @@
+# Workflow Collections Reference
+
+A **workflow collection** is a user-defined directory tree under `workflow/<type>/`
+in the campaign root. It groups workitems of a single type (`research`, `feature`,
+`bug`, etc.) and wires them into camp's navigation and completion systems via a
+shortcut key and a concept entry.
+
+## Concept boundaries
+
+Two unrelated things share the word "workflow" in camp. This document covers
+only the workitem-collection workflow surface. The other meaning, the per-workitem
+state machine driven by `camp flow` and `.workflow.yaml`, is unrelated.
+
+| Term | Location | What it is |
+|---|---|---|
+| Workflow collection (this doc) | `workflow/<type>/` | User-created collection of workitems of one type, with navigation config |
+| Flow status | `.workflow.yaml` per workitem | Per-workitem lifecycle state machine, owned by `camp flow` |
+
+A workflow collection is not:
+
+- a workitem (a single tracked unit of work)
+- an intent (a raw idea captured under `.campaign/intents/`)
+- a festival (a structured multi-phase project plan)
+- a project (a git submodule registered under `projects/`)
+
+Use `camp workflow create` when you want to group a set of workitems under a
+named type, navigate to them with a shortcut, and have camp surface them in tab
+completion.
+
+---
+
+## Lifecycle walkthrough
+
+### 1. Create
+
+```
+camp workflow create research --shortcut re --title "Research"
+```
+
+Output on first run:
+
+```
+created workflow/research
+  shortcut: re -> workflow/research/
+  workitem type: research
+  status dirs: inbox/, active/, ready/, dungeon/completed/, dungeon/archived/, dungeon/someday/
+next: camp workitem create <slug> --type research
+```
+
+What `create` writes:
+
+```
+workflow/research/
+├── OBEY.md
+├── inbox/
+│   └── .gitkeep
+├── active/
+│   └── .gitkeep
+├── ready/
+│   └── .gitkeep
+└── dungeon/
+    ├── completed/
+    │   └── .gitkeep
+    ├── archived/
+    │   └── .gitkeep
+    └── someday/
+        └── .gitkeep
+```
+
+It also writes two config entries:
+
+- `.campaign/settings/jumps.yaml` — shortcut `re -> workflow/research/`
+- `.campaign/campaign.yaml` — concept `research -> workflow/research/`
+
+Rerunning with the same arguments exits 0 with `no changes for workflow research`.
+Rerunning with a different shortcut key fails unless `--replace` is set.
+
+See [camp workflow create](cli-reference/camp_workflow_create.md) for the full
+flag reference.
+
+### 2. List
+
+```
+camp workflow list
+```
+
+```
+TYPE        SHORTCUT  ITEMS  UPDATED
+research    re        4      2026-05-20T14:32:00Z
+feature     fe        12     2026-05-22T09:01:00Z
+```
+
+Lists every user-created workflow collection. Builtin types (`intent`, `design`,
+`explore`, `festival`, `code_reviews`, `pipelines`) are excluded. Entries come
+from the union of concepts listed in `campaign.yaml` and directories present on
+disk under `workflow/`. The workitem count is the number of `.workitem` marker
+files found under the type directory.
+
+See [camp workflow list](cli-reference/camp_workflow_list.md).
+
+### 3. Inspect
+
+```
+camp workflow show research
+```
+
+```
+workflow: research
+  title: Research
+  path: workflow/research/
+  shortcut: re -> workflow/research/
+  has_concept: true
+  has_dir: true
+  workitems: 4
+recent:
+  2026-05-20T14:32:00Z  workflow/research/active/rate-limiting
+  2026-05-18T11:00:00Z  workflow/research/active/auth-design
+```
+
+See [camp workflow show](cli-reference/camp_workflow_show.md).
+
+### 4. Add a shortcut later
+
+If you skipped `--shortcut` at creation time, or want a second shortcut pointing
+at the same collection:
+
+```
+camp workflow shortcut add research res
+```
+
+This reuses the same upsert logic as `create`. Use `--replace` if the key already
+points elsewhere.
+
+See [camp workflow shortcut add](cli-reference/camp_workflow_shortcut_add.md).
+
+### 5. Check consistency
+
+```
+camp workflow doctor
+```
+
+Doctor is read-only. It checks the config and filesystem for inconsistencies and
+reports findings with stable dotted-domain codes.
+
+```
+doctor: 2 finding(s)
+  [error] workflow.shortcut.missing-target shortcut:re — shortcut "re" points to missing workflow/research/
+    hint: remove the shortcut from .campaign/settings/jumps.yaml or restore the directory; auto-fix removes the shortcut
+  [warning] workflow.dir.missing-concept dir:workflow/feature/ — workflow workflow/feature/ has no concept entry
+    hint: auto-fix adds a concept entry derived from the directory name
+```
+
+Exit code is 0 when all findings are `info` or `warning`. Exit code 2 when any
+finding has severity `error`.
+
+See [camp workflow doctor](cli-reference/camp_workflow_doctor.md).
+
+### 6. Repair
+
+```
+camp workflow sync
+```
+
+Sync is dry-run by default. It plans the auto-fixable subset of doctor findings
+and prints what it would do. Pass `--apply` to write:
+
+```
+camp workflow sync --apply
+```
+
+```
+sync: applied 2 / 2 auto-fixable findings
+  fixed workflow.shortcut.missing-target (re)
+  fixed workflow.dir.missing-concept (workflow/feature/)
+```
+
+See [camp workflow sync](cli-reference/camp_workflow_sync.md).
+
+---
+
+## Plan/apply model
+
+`camp workflow create` separates work into two phases:
+
+1. **Plan phase.** No writes. Checks which directories, `.gitkeep` files,
+   `OBEY.md`, shortcut entry, and concept entry are missing or would change.
+   Classifies each as `create`, `update`, `skip-exists`, or `no-op`.
+
+2. **Apply phase.** Iterates the plan and writes.
+
+`--dry-run` runs the plan phase only and exits without writing.
+
+`camp workflow sync` uses the same model with its default inverted: dry-run is
+the default and `--apply` triggers writes.
+
+### Known issues
+
+**CW0003-workflow-01 (major).** The `--dry-run` human output does not emit
+per-action lines. The design contract (DESIGN.md §4.1) specifies one line per
+planned write with a `create / skip-exists / update / no-op` verb. The
+implementation prints a summary block that is identical whether the scaffold dirs
+already exist or not. The `createPlan` struct carries all the data needed for the
+per-line form; the renderer does not use it.
+
+Workaround: use `--json --dry-run` to get the plan fields programmatically
+(`workflow_dir`, `status_dirs`, `obey_written`, `shortcut.no_change`,
+`concept.no_change`, `no_changes`).
+
+---
+
+## Status scaffold
+
+`camp workflow create` writes seven status directories under `workflow/<type>/`.
+These mirror the layout of `.campaign/intents/`.
+
+| Directory | Purpose |
+|---|---|
+| `inbox/` | Newly captured workitems not yet triaged |
+| `active/` | In-progress workitems |
+| `ready/` | Workitems ready to start |
+| `dungeon/completed/` | Finished |
+| `dungeon/archived/` | Shelved, preserved |
+| `dungeon/someday/` | Deprioritized |
+
+Each directory contains a `.gitkeep` file so git tracks empty directories and
+the paths are available after a clean checkout.
+
+`camp workitem create --type <T>` currently places new items at
+`workflow/<T>/<slug>/`, not inside `inbox/`. Placement in status directories
+requires manual `mv` until a follow-up sequence changes the default.
+
+`discover_custom_workflows.go` skips dot-prefixed names inside the type
+directory. The `.gitkeep` files are therefore invisible to workitem discovery.
+Directories named `inbox`, `active`, `ready`, and `dungeon` are visible to the
+walker but skipped because they have no `.workitem` marker.
+
+### Known issues
+
+**CW0003-workflow-03 (major).** The scaffold writes (`MkdirAll` per directory,
+`WriteFile` per `.gitkeep`) are followed by separate `SaveJumpsConfig` and
+`SaveCampaignConfig` calls. There is no rollback between them. A write failure
+mid-apply leaves the on-disk scaffold intact but the config partially updated
+(e.g. shortcut written, concept not written). `camp workflow doctor` detects
+the resulting inconsistency; `camp workflow sync --apply` is the recovery path.
+
+---
+
+## JSON output
+
+All subcommands accept `--json`. Output goes to stdout as a single JSON document.
+The top-level `schema_version` field is `"workflow/v1"` for all responses.
+Warnings from cache-invalidation failures still go to stderr as plain text.
+
+### `create` schema
+
+```json
+{
+  "schema_version": "workflow/v1",
+  "generated_at": "2026-05-25T03:30:00Z",
+  "type": "research",
+  "title": "Research",
+  "workflow_dir": "workflow/research/",
+  "status_dirs": ["inbox/", "active/", "ready/", "dungeon/completed/", "dungeon/archived/", "dungeon/someday/"],
+  "obey_written": true,
+  "shortcut": {"key": "re", "path": "workflow/research/", "replaced": false, "no_change": false},
+  "concept": {"name": "research", "path": "workflow/research/", "replaced": false, "no_change": false},
+  "replaced": [],
+  "no_changes": false,
+  "dry_run": false,
+  "applied": true
+}
+```
+
+`obey_written` is `true` only when `OBEY.md` was actually written; `false` when
+it was already present. `no_changes` is `true` when every action was a no-op.
+`applied` is `!dry_run`.
+
+### `list` schema (as-built)
+
+```json
+{
+  "schema_version": "workflow/v1",
+  "generated_at": "...",
+  "workflows": [
+    {
+      "type": "research",
+      "path": "workflow/research/",
+      "shortcut": "re",
+      "workitem_count": 4,
+      "has_concept": true,
+      "has_dir": true,
+      "has_shortcut": true,
+      "last_modified": "2026-05-20T14:32:00Z"
+    }
+  ]
+}
+```
+
+### `show` schema (as-built)
+
+```json
+{
+  "schema_version": "workflow/v1",
+  "generated_at": "...",
+  "type": "research",
+  "title": "Research",
+  "path": "workflow/research/",
+  "shortcut": "re",
+  "shortcut_path": "workflow/research/",
+  "has_concept": true,
+  "has_dir": true,
+  "has_shortcut": true,
+  "workitem_count": 4,
+  "recent": [
+    {"slug": "rate-limiting", "path": "workflow/research/active/rate-limiting", "modified": "..."}
+  ]
+}
+```
+
+### `doctor` schema
+
+```json
+{
+  "schema_version": "workflow/v1",
+  "generated_at": "...",
+  "findings": [
+    {
+      "code": "workflow.shortcut.missing-target",
+      "severity": "error",
+      "target": "shortcut:re",
+      "message": "shortcut \"re\" points to missing workflow/research/",
+      "fix_hint": "remove the shortcut from .campaign/settings/jumps.yaml or restore the directory; auto-fix removes the shortcut",
+      "auto_fixable": true
+    }
+  ],
+  "error_count": 1,
+  "warning_count": 0,
+  "info_count": 0
+}
+```
+
+### `sync` schema
+
+```json
+{
+  "schema_version": "workflow/v1",
+  "generated_at": "...",
+  "findings": [...],
+  "planned": [{"finding": {...}, "kind": "remove_shortcut", "target": "re"}],
+  "applied": [{"finding": {...}, "kind": "remove_shortcut", "target": "re"}],
+  "apply": true
+}
+```
+
+### Known issues
+
+**CW0003-workflow-07 (minor).** The `list` JSON shape differs from DESIGN.md §6.1.
+The as-built v1 omits `title`, `has_scaffold`, and `workitem_count_capped`. It
+adds `has_concept`, `has_dir`, `has_shortcut`, and `last_modified`. There is no
+walk cap; a type directory with a large number of workitems blocks on enumeration.
+
+**CW0003-workflow-08 (minor).** The `show` JSON shape differs from DESIGN.md §6.2.
+The as-built v1 omits the `scaffold` object (per-directory present/missing booleans)
+and `obey_first_line`. These fields are defined by the design but not yet emitted.
+
+The fields above are the actual v1 contract. Consumers should not assume fields
+promised in DESIGN.md but not listed here are present.
+
+---
+
+## Doctor finding codes
+
+Finding codes are stable dotted-domain strings. Consumers may dispatch on them.
+
+| Code | Severity | Trigger |
+|---|---|---|
+| `workflow.shortcut.missing-target` | error | Shortcut points to a non-existent `workflow/<type>/` directory |
+| `workflow.concept.missing-dir` | error | Concept entry references a missing `workflow/<type>/` directory |
+| `workflow.shortcut.duplicate` | error | Two shortcut keys normalize to the same value |
+| `workflow.dir.missing-concept` | warning | Workflow directory exists but no concept entry references it |
+| `workflow.cache.stale` | warning | Nav index `BuildTime` predates the workflow root's mtime |
+| `workflow.dir.missing-shortcut` | info | Workflow directory has a concept but no shortcut |
+
+Each finding carries `code`, `severity`, `target`, `message`, `fix_hint`, and
+`auto_fixable`. Doctor sorts findings by code then by target.
+
+`--fix` is not implemented. Passing an unknown flag errors via cobra.
+Use `camp workflow sync --apply` to apply auto-fixable findings.
+
+### Sync action kinds
+
+`camp workflow sync` maps auto-fixable findings to action kinds:
+
+| Finding code | Action kind |
+|---|---|
+| `workflow.shortcut.missing-target` | `remove_shortcut` |
+| `workflow.concept.missing-dir` | `remove_concept` |
+| `workflow.dir.missing-concept` | `add_concept` |
+| `workflow.shortcut.duplicate` | `deduplicate_shortcut` |
+| `workflow.cache.stale` | `delete_nav_cache` |
+
+`workflow.dir.missing-shortcut` is not auto-fixable because it requires the user
+to choose a shortcut key.
+
+When deduplicating, sync keeps the normalized (lowercase) form of the key, not
+the lexicographically first variant.
+
+### Known issues
+
+**CW0003-workflow-10 (minor).** The `fix_hint` text for
+`workflow.shortcut.duplicate` reads "auto-fix keeps the lexicographically first
+variant." The actual behavior is to keep the normalized (lowercase) key and
+remove case variants. The hint is wrong; the behavior is correct.
+
+---
+
+## Idempotency
+
+`camp workflow create` is idempotent. Rerunning with identical arguments on an
+already-created collection exits 0, writes nothing, and prints
+`no changes for workflow <type>`. In JSON mode, `no_changes: true` and
+`applied: false`.
+
+Rerunning with a different shortcut key or title fails unless `--replace` is
+set. A partial scaffold (some directories present, some missing) is completed on
+rerun: only the missing pieces are created.
+
+`camp workflow sync` with no arguments is always read-only and always exits 0.
+
+---
+
+## Builtin type exclusions
+
+The following names are reserved and excluded from user workflow enumeration
+even if a directory or concept entry exists for them:
+
+`intent`, `design`, `explore`, `festival`, `code_reviews`, `pipelines`
+
+---
+
+## Related pages
+
+- [camp workflow](cli-reference/camp_workflow.md) — command group overview
+- [camp workflow create](cli-reference/camp_workflow_create.md) — flag reference
+- [camp workflow list](cli-reference/camp_workflow_list.md) — flag reference
+- [camp workflow show](cli-reference/camp_workflow_show.md) — flag reference
+- [camp workflow shortcut add](cli-reference/camp_workflow_shortcut_add.md) — flag reference
+- [camp workflow doctor](cli-reference/camp_workflow_doctor.md) — flag reference
+- [camp workflow sync](cli-reference/camp_workflow_sync.md) — flag reference
+- [Campaign directory reference](campaign-directory-reference.md) — `.campaign/` layout including `jumps.yaml` and `campaign.yaml`

--- a/docs/workitem-commit-reference.md
+++ b/docs/workitem-commit-reference.md
@@ -1,0 +1,376 @@
+# Workitem Commit Reference
+
+Narrative reference for `camp workitem commit`, `camp workitem commits`, the
+staging matrix, and the commit tag grammar. For flag syntax and defaults, see
+the auto-generated CLI reference:
+
+- [`docs/cli-reference/camp_workitem_commit.md`](cli-reference/camp_workitem_commit.md)
+- [`docs/cli-reference/camp_workitem_commits.md`](cli-reference/camp_workitem_commits.md)
+
+---
+
+## Why scoped workitem commits exist
+
+`camp commit` and `camp p commit` stamp every commit with a campaign tag but
+do not restrict which files they stage. Either command can accidentally widen
+scope to unrelated paths.
+
+`camp workitem commit` adds a second constraint: the staging plan is derived
+from the resolved workitem context and never silently falls back to
+`git add .`. The commit carries a `WI-<ref>` segment in its campaign tag so
+history queries can later retrieve all commits that belong to a specific
+workitem across every linked repo.
+
+---
+
+## Staging matrix
+
+When `camp workitem commit` runs, `ComputePlan` selects exactly one matrix row
+based on the resolved context. Flag evaluation runs in this order before the
+matrix:
+
+1. `--staged` — short-circuits; skips the matrix entirely (see Known issues).
+2. `--project <name>` — overrides the resolver; treats the command as if
+   invoked from inside `projects/<name>/`.
+3. Matrix routing by resolved source (see table below).
+4. `--include` — adds paths on top of the matrix result.
+5. `--exclude` — removes paths from the plan; applied last.
+
+| Context label | When it applies | Default staged paths |
+|---|---|---|
+| `workitem directory` | cwd is inside `workflow/<type>/<slug>/` (ancestor match) | Changed files under `<workitem-dir>/` plus `.campaign/workitems/links.yaml` when dirty |
+| `campaign root` | cwd at campaign root; workitem resolved via `current.yaml` or explicit `--workitem` | Same as above — never `git add .` |
+| `linked project` | cwd is inside a sub-git-repo under the campaign tree (cwd-first detection), or resolver source is `SourceLink` | All changed files in that project's git repo |
+| `festival` | resolver source is `SourceFestival` | Changed files under the festival scope path plus `.campaign/workitems/links.yaml` when dirty |
+| `staged-only` | `--staged` flag is set | Whatever is already in the git index of the campaign root |
+
+The link registry (`.campaign/workitems/links.yaml`) is auto-included in the
+`workitem directory` and `festival` rows when it is dirty. This keeps a link
+registration and the work it scoped in a single atomic commit.
+
+Submodule pointer changes in the parent campaign repo are excluded by default
+from every row. Pass `--include-submodule-pointer` to include them, or use
+`camp refs-sync` afterward.
+
+### cwd-first sub-git-repo detection
+
+Before consulting the resolver source, `ComputePlan` calls `cwdSubGitRepo`
+to check whether the current working directory is inside a sub-git-repo (a
+nested `.git` marker under the campaign root). When detection succeeds, that
+project repo is used as the staging root regardless of how the resolver found
+the workitem. This is the mechanism behind "I'm in the project, commit my
+workitem changes here."
+
+---
+
+## `camp workitem commit [selector]`
+
+```
+camp workitem commit [selector] [flags]
+```
+
+### Selector forms
+
+The workitem to scope can be specified as:
+
+- a slug (`timeline-redesign-2026-05`)
+- a stable ID (`design-timeline-redesign-2026-05`)
+- a workitem ref (`WI-abc123`)
+- a festival ref (`camp-workitem-linking-and-commits-CW0003`)
+- an `lnk_`-prefixed link ID
+
+Both the positional `[selector]` and `--workitem <selector>` accept these
+forms. When both are present, `--workitem` wins. When neither is provided,
+the resolver falls back to cwd and `current.yaml`.
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `-m, --message` | Commit message. Required unless `--dry-run`. |
+| `--workitem` | Explicit workitem selector (overrides cwd-based resolution). |
+| `--project` | Force project-repo context by name (skips resolver). |
+| `--include` | Additional path to stage (repeatable; literal, relative to repo root). |
+| `--exclude` | Path to remove from the staging plan (repeatable; exact match). |
+| `--staged` | Commit whatever is already in the git index. |
+| `--include-submodule-pointer` | Include dirty project submodule pointers in the plan. |
+| `--dry-run` | Print the staging plan and exit without committing. |
+| `--json` | Emit staging plan and commit result as JSON on stdout. |
+
+`--include` and `--exclude` accept literal paths only. Glob patterns are not
+expanded; a pattern that does not match any real path either passes through
+silently to `git add` (include) or has no effect (exclude). See Known issues.
+
+### Plan output
+
+Before committing, the plan is printed to stderr in a stable format:
+
+```text
+workitem: <stable-id> (ref: WI-<6 hex>)
+context:  <matrix row label> (<context note>)
+staging:
+  S  <already-staged path>
+  A  <path to stage>
+  A  <path> (link registry auto-included)
+skipped:
+  <path> (out of scope)
+  <path> (submodule pointer; use --include-submodule-pointer)
+  <path> (--exclude)
+tag:    [OBEY-CAMPAIGN-<8hex>[-qst_<...>][-WI-WI-<6hex>]]
+```
+
+`S` marks files already in the index (from `--staged` mode). `A` marks files
+the planner will stage. Under `--json`, this plan is suppressed on stderr and
+emitted as structured JSON on stdout instead.
+
+### Refusal mode
+
+When no workitem can be resolved and no `--workitem` flag was given,
+`camp workitem commit` exits with code 2 and prints:
+
+```text
+no workitem context resolved from cwd
+
+Try one of:
+  --workitem <selector>            explicit workitem to scope this commit
+  cd workflow/<type>/<slug> && ...  run from inside a workitem directory
+  camp workitem current <selector>  set a session-wide default
+```
+
+The command never falls back to staging the whole repo. A `WI-` tag in the
+commit is mandatory; if one cannot be derived, the commit does not happen.
+
+---
+
+## `camp workitem commits [selector]`
+
+```
+camp workitem commits [selector] [flags]
+```
+
+A read-only query that retrieves all commits attributed to a workitem ref
+across the campaign root and every linked project, worktree, and repo
+registered in the link registry.
+
+### Repo enumeration
+
+`enumerateQueryRepos` always includes the campaign root. It then loads the
+link registry and adds every entry whose scope kind is `project`, `repo`, or
+`worktree`. Festival-scoped entries are intentionally excluded because
+festival paths live under the campaign root, which is already included. The
+help text's mention of "festival repo" refers to this coverage, not a
+separate enumeration.
+
+Repos are searched concurrently under a bounded worker pool capped at
+`min(runtime.NumCPU(), 8)` workers. Each repo call has a per-repo timeout of
+30 seconds. Repos that are not git checkouts return silently (no error). Repos
+that fail the `git log` invocation are captured in the error list.
+
+### Candidate filtering
+
+Each repo is queried with `git log --grep="-WI-<ref>"` to narrow candidates
+cheaply. Every candidate commit subject is then parsed through
+`commitkit.ParseTag` to verify the `WorkitemRef` field matches exactly. This
+two-pass approach avoids committing to a full log scan for every repo while
+still rejecting subjects that contain the grep pattern in non-tag positions.
+
+See Known issues for the unanchored-regex limitation in `ParseTag`.
+
+### Flags
+
+| Flag | Description |
+|---|---|
+| `--ref` | Query by workitem ref directly (e.g. `WI-abc123`). Skips the resolver. |
+| `--workitem` | Alias for the positional `<selector>`. |
+| `--limit` | Maximum commits to return (default 100). |
+| `--offset` | Number of commits to skip after sorting. |
+| `--json` | Emit JSON instead of the default table. |
+
+Results are sorted newest first across all repos before `--limit` and
+`--offset` are applied.
+
+### Table output
+
+```
+REPO    SHA       DATE        SUBJECT
+.       a1b2c3d4  2026-05-25  [OBEY-CAMPAIGN-abc-WI-WI-def123] feat: ...
+projects/camp  e5f6a7b8  2026-05-24  [OBEY-CAMPAIGN-abc-WI-WI-def123] fix: ...
+```
+
+Per-repo errors are reported on stderr as a summary warning. Under `--json`,
+they appear in the `errors` array.
+
+---
+
+## Commit tag grammar
+
+Every commit produced by `camp workitem commit` (and `camp commit` / `camp p
+commit` when run in a workitem context) carries a tag with this structure:
+
+```
+[OBEY-CAMPAIGN-<campaign-id>[-<quest-id>][-FE-<festival-ref>][-WI-WI-<workitem-ref>]]
+```
+
+Segment rules:
+
+- All four components appear in fixed order inside the bracket. Absent
+  components are omitted entirely; their separators do not appear.
+- `<campaign-id>` is the first 8 hex characters of the campaign UUID.
+- `<quest-id>` matches `qst_<digits>_<alphanum>` when a quest is active.
+- `<festival-ref>` is the festival slug when the commit is scoped to a
+  festival workitem.
+- `<workitem-ref>` is the canonical `WI-<6 lowercase hex>` ref. Because the
+  ref already starts with `WI-`, the segment marker adds a second `WI-`,
+  producing the `WI-WI-` double prefix. This is intentional. The segment
+  marker and the ref are distinct: flattening to a single prefix breaks the
+  parser's segment-boundary detection (see `indexOfNextPrefix` in
+  `internal/git/campaign_tag.go`).
+
+Concrete examples:
+
+```
+[OBEY-CAMPAIGN-2736169c] feat: no workitem
+[OBEY-CAMPAIGN-2736169c-WI-WI-861089] fix: workitem only
+[OBEY-CAMPAIGN-2736169c-qst_1_alpha-WI-WI-861089] fix: with quest
+[OBEY-CAMPAIGN-2736169c-FE-CW0003-WI-WI-861089] feat: festival + workitem
+```
+
+The full composer is `FormatContextTagsFull` in
+`internal/git/campaign_tag.go`. The public re-export is
+`commitkit.FormatContextTagsFull` in `pkg/commitkit/`.
+
+### ParseTag
+
+`ParseTag(subject string) TagComponents` reverses the grammar. It returns a
+zero-valued `TagComponents` when no tag is present in the subject. The four
+fields of `TagComponents` are `CampaignID`, `QuestID`, `FestRef`, and
+`WorkitemRef` (the last includes its `WI-` prefix, e.g. `"WI-861089"`).
+
+The parse contract is designed for subjects produced by `FormatContextTagsFull`.
+For known parser bugs, see Known issues below.
+
+---
+
+## JSON output schemas
+
+### `camp workitem commit --json`
+
+Emitted on stdout. Pretty-printed with two-space indent.
+
+| Field | Type | Notes |
+|---|---|---|
+| `workitem` | string | Stable workitem ID |
+| `workitem_ref` | string | `WI-<6 hex>`, omitted when empty |
+| `quest_id` | string | omitted when empty |
+| `tag` | string | Full campaign tag as it appears in the commit subject |
+| `context` | string | Matrix row label (e.g. `"linked project"`) |
+| `context_note` | string | Detail within the row (e.g. `"project camp"`), omitted when empty |
+| `repo_root` | string | Absolute path of the git repo the commit targeted |
+| `stage` | []string | Paths passed to `git add` |
+| `pre_staged` | []string | Paths already in the index (from `--staged`), omitted when empty |
+| `skip` | []object | Each entry has `path` and `reason` strings, omitted when empty |
+| `sha` | string | Commit SHA after a successful commit; empty on `--dry-run` or no-changes |
+
+Note: `schema_version` is absent from the current payload. See Known issues
+(`CW0003-commit-10`).
+
+### `camp workitem commits --json`
+
+Emitted on stdout. Pretty-printed with two-space indent.
+
+| Field | Type | Notes |
+|---|---|---|
+| `commits` | []CommitRecord | Sorted newest first, post-limit/offset |
+| `errors` | []object | Per-repo failures; each entry has `repo` and `error` strings; omitted when empty |
+
+Each `CommitRecord`:
+
+| Field | Type | Notes |
+|---|---|---|
+| `sha` | string | Full commit SHA |
+| `author` | string | Author name |
+| `date` | string | RFC 3339 timestamp |
+| `subject` | string | Full commit subject line |
+| `repo` | string | Campaign-relative path of the repo (`"."` for campaign root) |
+| `tag` | object | Parsed `TagComponents` (fields: `CampaignID`, `QuestID`, `FestRef`, `WorkitemRef`) |
+
+Note: `schema_version` is absent from the current payload. See Known issues
+(`CW0003-commit-10`).
+
+---
+
+## Failure modes
+
+| Error | Meaning | Recovery |
+|---|---|---|
+| `commit message required` | `-m` was not passed and `--dry-run` is not set | Add `-m "message"` |
+| `no workitem context resolved from cwd` (exit 2) | Resolver found no workitem; no `--workitem` given | Use `--workitem <selector>`, navigate into the workitem directory, or set `camp workitem current` |
+| `empty staging plan` | The plan has no files to commit | Check that the workitem directory has uncommitted changes, or pass `--include <path>` |
+| `no workitem context resolved; pass <selector> or --ref WI-...` | `commits` command received no selector and no workitem is resolved | Pass a selector or `--ref WI-<hex>` directly |
+| `workitem has no ref; run camp workitem doctor --fix` | The resolved workitem pre-dates v1alpha6 and has no `ref` field | Run `camp workitem doctor --fix` to backfill |
+| `not in a campaign directory` | Command run outside any campaign root | Navigate to the campaign root or a subdirectory |
+| Per-repo query failure (table: stderr warning; JSON: `errors[]`) | `git log` in a linked repo timed out or failed | Check that the repo is accessible; re-run with `--json` for the error detail |
+
+---
+
+## Known issues
+
+The following findings are open at the reviewed commit (`642504f`) and have
+not yet been merged as fixes. They are cited by ID for tracking.
+
+**`CW0003-commit-02`** — `runCommit` returns the raw error from
+`commit.Workitem` without wrapping it with the `"commit workitem"` operation
+context. Additionally, `lastCommitSHA` errors are silently swallowed
+(`sha, _ := ...`); when the SHA lookup fails after a successful commit, the
+JSON payload emits `"sha": ""` with no indication of why.
+
+**`CW0003-commit-03`** — `cwdSubGitRepo` does not call
+`filepath.EvalSymlinks` on either the current working directory or the
+campaign root before computing `filepath.Rel`. On macOS, campaign roots under
+symlinked paths (e.g. `/var/folders/...` resolving to `/private/var/...`)
+cause the prefix comparison to fail, so `cwdSubGitRepo` returns false and
+the plan routes to the campaign root instead of the project submodule the
+user is actually inside. The cwd-first routing promise from the staging
+matrix silently breaks for affected users.
+
+**`CW0003-commit-10`** — Both `--json` payloads (`commit` and `commits`) are
+missing a `schema_version` field. Both commands carry `"agent_allowed":
+"true"` in their Cobra annotations, meaning agent tooling is expected to
+depend on these payloads. Any future field rename is a silent break with no
+version signal for consumers.
+
+**`CW0003-commit-14`** — `--staged` always uses `campaignRoot` as the staging
+repo root and reads from the campaign repo's index. If `camp workitem commit
+--staged` is run from inside `projects/foo/`, the submodule's index is
+ignored. The cwd-first detection (`cwdSubGitRepo`) is bypassed in the
+`--staged` branch.
+
+**`CW0003-format-02`** — `validateMetadata` does not validate the shape of
+the `ref` or `quest_id` fields on load. A hand-edited `.workitem` marker with
+a malformed `ref` value propagates through the staging plan and into the
+commit tag without rejection.
+
+**`CW0003-format-03`** — `tagShellRegex` is unanchored
+(`\[OBEY-CAMPAIGN-([^\]]+)\]` with no `^`). `ParseTag` matches a campaign
+tag appearing anywhere in the subject string, not only at position 0. A
+revert subject like `Revert "[OBEY-CAMPAIGN-abc] feat: X"` or a commit body
+that contains a sample tag will produce false-positive parse results. The
+`commits` command's candidate filter (`ParseTag(subject).WorkitemRef != ref`)
+inherits this behavior.
+
+**`CW0003-format-04`** — `ParseTag` silently merges junk segments into
+adjacent fields when a tag contains unknown segments, duplicate segments, or
+content between known prefixes. Examples: a second `FE-` segment overwrites
+the first; an unknown leading segment causes the parser to abandon the
+remainder of the inner string, silently dropping a valid `WI-` segment that
+follows. Downstream consumers receive plausible-looking but wrong
+`TagComponents` with no indication that parsing degraded.
+
+**`CW0003-format-13`** — (Design note, not yet a named finding in the review
+index.) The `FormatContextTagsFull` composer silently omits the `WI-` segment
+when `workitemRef` is empty. Commits produced by `camp commit` or `camp p
+commit` outside a workitem context carry no `WI-` segment. This is correct
+behavior, but callers that pass a workitem ref derived from v1alpha5 metadata
+(which has no `ref` field) will silently produce a tag with no workitem
+attribution. Run `camp workitem doctor --fix` to backfill refs before relying
+on tag-based history queries.

--- a/docs/workitem-link-reference.md
+++ b/docs/workitem-link-reference.md
@@ -1,0 +1,318 @@
+# Workitem Link Registry Reference
+
+The workitem link registry connects a workitem to one or more scopes in the campaign, such as a project directory, festival, or worktree. Once a link exists, commit wrappers (`camp workitem commit`, `fest commit`, `camp p commit`) can automatically tag commits with the workitem reference without requiring the `--workitem` flag on every invocation.
+
+Without a link, a workitem is passive state: it exists in `.campaign/workitems/` and tracks work, but it has no connection to the places where that work happens. A link is what makes the registry actionable.
+
+**Scenario.** You are working on a design workitem at `workflow/design/api-refactor` and want every commit you make under `projects/myrepo` to carry `WI-api-refactor-2026-05-20` in its message automatically. Run:
+
+```
+camp workitem link api-refactor-2026-05-20 --project myrepo
+```
+
+From that point forward, any commit made from within `projects/myrepo` resolves to that workitem through the link registry, and the commit wrapper appends the `WI-<ref>` segment.
+
+---
+
+## Link ID Format
+
+Every link is assigned an ID at creation time:
+
+```
+lnk_<yyyymmdd>_<6 lowercase hex>
+```
+
+Example IDs: `lnk_20260524_ab12cd`, `lnk_20260524_ef3401`.
+
+The date component is the UTC date the link was created. The six-character suffix is sourced from `crypto/rand`. The full ID is always exactly 22 characters and matches `^lnk_[0-9]{8}_[0-9a-f]{6}$`.
+
+IDs are immutable once created. The registry spec (SCHEMA.md §4) defines a retry-on-collision loop of up to 32 attempts for the rare case where a newly generated ID collides with an existing one. **Known issue `CW0003-links-01`:** the retry loop is not yet implemented. A collision currently surfaces as a hard error rather than being transparently retried. At normal usage volumes (hundreds of links per campaign) a collision is extremely unlikely, but the contract is not yet met.
+
+---
+
+## Persistence
+
+### `links.yaml`
+
+The durable link registry lives at:
+
+```
+<campaign-root>/.campaign/workitems/links.yaml
+```
+
+This file should be committed to the campaign repository. It records all workitem-to-scope relationships and is the shared source of truth for all users of the campaign.
+
+Schema version: `workitem-links/v1alpha1`. The loader rejects unknown versions with a validation error. Full field-level schema documentation is in [`internal/workitem/links/SCHEMA.md`](../internal/workitem/links/SCHEMA.md).
+
+The file is created on first `camp workitem link` invocation. A missing file is the valid zero state: all commands treat it as "no links."
+
+Writes are atomic (write-temp-plus-rename). Two concurrent `camp workitem link` invocations use a file lock during the write phase, but the read-modify-write window is not locked. **Known issue `CW0003-links-06`:** a concurrent read before a locked write means last-writer-wins in multi-terminal or multi-agent scenarios. In the single-user CLI case this is unlikely to cause data loss, but the window exists.
+
+### `current.yaml`
+
+The locally selected active workitem lives at:
+
+```
+<campaign-root>/.campaign/workitems/current.yaml
+```
+
+This file is per-machine state. It should not be committed to git. The SCHEMA.md §1.1 specifies that `camp init` writes `.campaign/workitems/current.yaml` to the campaign `.gitignore`. **Known issue `CW0003-links-02`:** the gitignore entry is not yet written by `camp init`. Until this is resolved, `current.yaml` will appear as an untracked file in `git status` and can be accidentally staged.
+
+**Workaround until `CW0003-links-02` lands:** add the following line to `.campaign/.gitignore` manually:
+
+```
+workitems/current.yaml
+```
+
+`current.yaml` contains a single workitem selection. Setting a new current overwrites the file atomically. `--clear` removes the file.
+
+---
+
+## Scope Kinds
+
+A link's `scope` specifies what area of the campaign the workitem is attached to.
+
+| Kind | Path resolves to | Example path |
+|---|---|---|
+| `project` | A project or submodule under `projects/` | `projects/myrepo` |
+| `repo` | A git repository root not registered as a project | `vendor/external` |
+| `campaign_path` | Any campaign-relative path (catch-all) | `workflow/design/spike` |
+| `festival` | A festival path under `festivals/` | `festivals/active/myrepo-MR0001` |
+| `worktree` | A project worktree under `projects/worktrees/` | `projects/worktrees/myrepo@feat-x` |
+
+Paths are campaign-relative, forward-slash-normalized, and validated to be contained within the campaign root.
+
+---
+
+## Roles
+
+| Role | Meaning |
+|---|---|
+| `primary` | Active workitem for the scope. Commit wrappers pick this up automatically. At most one primary per `(scope.kind, scope.path)`. |
+| `related` | Context only. Shown in `camp workitem links`. Not used for commit routing. |
+| `blocked_by` | Metadata only. May influence future doctor checks. |
+| `supersedes` | Metadata only. Lets a newer workitem claim an older one's history. |
+
+To change a link's role, remove and re-add it. There is no in-place role transition.
+
+---
+
+## Resolver Tiers
+
+When a commit wrapper or `camp workitem resolve` needs to determine the active workitem, it consults these tiers in order. The first match wins.
+
+1. Explicit `--workitem <selector>` flag.
+2. Nearest ancestor directory containing a `.workitem` marker file.
+3. Primary link in `links.yaml` whose `scope.path` is the longest prefix of the current working directory (campaign-relative).
+4. Primary link whose `scope.kind` is `festival` and whose path matches the supplied festival ID.
+5. `current.yaml` workitem selection.
+6. No workitem context. Commit wrappers proceed without a `WI-` tag.
+
+Tier 3 uses longest-prefix matching: a link on `projects/myrepo/internal/api` wins over one on `projects/myrepo` when both exist and `cwd` is under the deeper path.
+
+Resolution is read-only. It never mutates `current.yaml`.
+
+**Known issue `CW0003-links-03`:** when a primary link exists at tier 3 but its `workitem_id` no longer resolves on disk (workitem moved or deleted), the resolver returns an error and exits 1 instead of falling through to tier 4 or tier 5. The intended behavior is to record the tier as a miss and continue. Until this is fixed, an orphaned primary link will block commit wrappers operating from within that scope. Use `camp workitem doctor --fix` to remove the broken link, or `--workitem <id>` to override for a single operation.
+
+**Known issue `CW0003-links-13` (proposed):** resolver fall-through behavior for broken links at tiers 4 and 5 may have similar propagation gaps. Under investigation.
+
+---
+
+## Commands
+
+### `camp workitem link`
+
+Attach a workitem to a scope.
+
+```
+camp workitem link <selector> [flags]
+```
+
+Scope is specified via exactly one of:
+
+| Flag | Resolves to |
+|---|---|
+| `--project <name>` | `projects/<name>` |
+| `--festival <id>` | Festival path under `festivals/` |
+| `--worktree <path>` | Path under `projects/worktrees/` |
+| `--cwd` | Current working directory (campaign-relative) |
+
+Note: `--project` takes a project name, not an absolute path. `--project myrepo` resolves to `projects/myrepo`.
+
+Additional flags:
+
+- `--role primary|related|blocked_by|supersedes` (default `primary`)
+- `--replace` overrides an existing primary link on the same scope
+- `--allow-missing` skips existence checks on the workitem and scope target (useful for migrations)
+- `--json` emits structured output
+
+On success, the command prints the new `lnk_` ID and the resolved scope.
+
+See [cli-reference/camp\_workitem\_link.md](cli-reference/camp_workitem_link.md).
+
+### `camp workitem unlink`
+
+Remove one or more links.
+
+```
+camp workitem unlink [selector] [flags]
+```
+
+Remove by ID:
+
+```
+camp workitem unlink --id lnk_20260524_ab12cd
+```
+
+Remove by workitem and scope:
+
+```
+camp workitem unlink my-workitem-id --project myrepo
+```
+
+Use `--all` when multiple links match the selector and you want to remove all of them. Without `--all`, an ambiguous match returns an error.
+
+See [cli-reference/camp\_workitem\_unlink.md](cli-reference/camp_workitem_unlink.md).
+
+### `camp workitem links`
+
+List links, optionally filtered by workitem selector.
+
+```
+camp workitem links [selector] [flags]
+```
+
+Output is sorted by `(scope.kind, scope.path, created_at, id)`. An empty registry prints "no links" and exits 0.
+
+`--json` emits the full link list as a structured envelope.
+
+See [cli-reference/camp\_workitem\_links.md](cli-reference/camp_workitem_links.md).
+
+### `camp workitem current`
+
+Get, set, or clear the local current workitem.
+
+```
+camp workitem current [selector] [flags]
+```
+
+With no arguments, prints the currently selected workitem (or "none" if `current.yaml` is absent).
+
+With a selector, writes the resolved workitem to `current.yaml`:
+
+```
+camp workitem current my-workitem-id
+```
+
+`--clear` removes `current.yaml` entirely.
+
+`current.yaml` is per-machine. See the gitignore note under [Persistence](#persistence).
+
+See [cli-reference/camp\_workitem\_current.md](cli-reference/camp_workitem_current.md).
+
+### `camp workitem resolve`
+
+Print the workitem the current context resolves to, without mutating any state.
+
+```
+camp workitem resolve [flags]
+```
+
+`--explain` prints the tier-by-tier trace showing which tiers matched, missed, or were skipped. Useful for debugging unexpected resolution.
+
+`--workitem <selector>` tests explicit resolution. `--festival <id>` supplies a festival ID for tier 4.
+
+`--json` emits the `Resolution` struct including `source`, `reason`, and the full `trace` array.
+
+See [cli-reference/camp\_workitem\_resolve.md](cli-reference/camp_workitem_resolve.md).
+
+### `camp workitem doctor`
+
+Report health issues in the link registry.
+
+```
+camp workitem doctor [flags]
+```
+
+Doctor checks for:
+
+- Links whose `workitem_id` no longer resolves on disk (orphaned workitem).
+- Links whose `scope.path` no longer exists on disk (orphaned scope).
+- Duplicate primary links for the same scope.
+- `current.yaml` pointing to a workitem that no longer exists.
+- Schema violations in `links.yaml` or `current.yaml`.
+
+`--fix` auto-removes findings tagged `auto_fixable`. This includes broken links and a stale `current.yaml`. The fix is applied in one pass before re-checking.
+
+`--json` emits structured finding output.
+
+**Known issue `CW0003-links-12` (proposed):** when `links.yaml` is corrupt enough to prevent loading, doctor may itself fail rather than reporting the corruption as a finding. Until this is addressed, see [Recovery](#recovery) below.
+
+See [cli-reference/camp\_workitem\_doctor.md](cli-reference/camp_workitem_doctor.md).
+
+---
+
+## Happy Path Walkthrough
+
+```
+# 1. Create or locate a workitem.
+camp workitem create --title "API refactor" --type feature
+
+# 2. Link it to the project you are working in.
+camp workitem link api-refactor-2026-05-20 --project myrepo
+
+# 3. Confirm the link.
+camp workitem links api-refactor-2026-05-20
+
+# 4. Optionally set it as current for other contexts.
+camp workitem current api-refactor-2026-05-20
+
+# 5. Check what the resolver sees from inside the project.
+cd projects/myrepo
+camp workitem resolve --explain
+
+# 6. Commits from within projects/myrepo now carry WI-<ref> automatically.
+camp workitem commit -m "refactor connection pool"
+
+# 7. When the work is done, remove the link.
+camp workitem unlink --id lnk_20260524_ab12cd
+```
+
+---
+
+## Recovery
+
+### Corrupt `links.yaml`
+
+If `links.yaml` is corrupt (truncated, invalid YAML, wrong version field), all commands that load the registry will fail with a validation or parse error. This includes `doctor`.
+
+Recovery options:
+
+- If the file is in git: `git restore .campaign/workitems/links.yaml`
+- If not in git or the committed version is also bad: `rm .campaign/workitems/links.yaml`. The registry returns to zero state (no links). Re-create links manually.
+
+**Known issue `CW0003-links-12` (proposed):** doctor does not yet produce a structured finding for a registry that fails to load; it fails with an error instead. Manual recovery is required until that lands.
+
+### Stale `current.yaml`
+
+If `current.yaml` is corrupt, `camp workitem current` and the resolver will fail at tier 5. Remove the file:
+
+```
+rm .campaign/workitems/current.yaml
+```
+
+This returns tier 5 to "skip" state. No links are affected.
+
+---
+
+## Known Issues
+
+| ID | Severity | Summary |
+|---|---|---|
+| `CW0003-links-01` | major | ID generation retry loop is missing. A collision returns an error instead of re-rolling. |
+| `CW0003-links-02` | major | `current.yaml` is not added to `.campaign/.gitignore` by `camp init`. Workaround: add `workitems/current.yaml` to `.campaign/.gitignore` manually. |
+| `CW0003-links-03` | major | Resolver hard-errors on a broken primary link instead of falling through to lower tiers. |
+| `CW0003-links-04` | major | The canonical `testdata/example_links.yaml` fixture contains an invalid ID (`ef34gh` is not hex) and fails its own schema validation. |
+| `CW0003-links-06` | minor | Read-modify-write window in `link` and `unlink` is not locked. Concurrent invocations can silently overwrite each other. |
+| `CW0003-links-12` | proposed | Doctor wedges on an unloadable registry instead of reporting the corruption as a finding. |
+| `CW0003-links-13` | proposed | Resolver fall-through behavior for broken links at tiers 4 and 5 may propagate the same hard-error pattern as `CW0003-links-03`. |

--- a/internal/commands/workflow/doctor.go
+++ b/internal/commands/workflow/doctor.go
@@ -81,7 +81,7 @@ func runDoctor(ctx context.Context, cmd *cobra.Command, jsonOut bool) error {
 		return camperrors.Wrap(err, "not in a campaign directory")
 	}
 
-	findings, err := collectFindings(campaignRoot, cfg)
+	findings, err := collectFindings(ctx, campaignRoot, cfg)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func runDoctor(ctx context.Context, cmd *cobra.Command, jsonOut bool) error {
 	return nil
 }
 
-func collectFindings(campaignRoot string, cfg *config.CampaignConfig) ([]finding, error) {
+func collectFindings(ctx context.Context, campaignRoot string, cfg *config.CampaignConfig) ([]finding, error) {
 	var findings []finding
 
 	shortcuts := cfg.Shortcuts()
@@ -225,7 +225,7 @@ func collectFindings(campaignRoot string, cfg *config.CampaignConfig) ([]finding
 
 	// workflow.cache.stale: nav cache mtime older than newest workflow dir
 	// mtime.
-	if stale, err := isNavCacheStaleForWorkflow(campaignRoot); err != nil {
+	if stale, err := isNavCacheStaleForWorkflow(ctx, campaignRoot); err != nil {
 		return nil, err
 	} else if stale {
 		findings = append(findings, finding{
@@ -247,23 +247,48 @@ func collectFindings(campaignRoot string, cfg *config.CampaignConfig) ([]finding
 	return findings, nil
 }
 
-func isNavCacheStaleForWorkflow(campaignRoot string) (bool, error) {
+const maxWorkflowWalkEntries = 10_000
+
+func isNavCacheStaleForWorkflow(ctx context.Context, campaignRoot string) (bool, error) {
 	idx, err := navindex.Load(campaignRoot)
-	if err != nil {
-		return false, nil
-	}
-	if idx == nil {
+	if err != nil || idx == nil {
 		return false, nil
 	}
 	workflowRoot := filepath.Join(campaignRoot, "workflow")
-	info, err := os.Stat(workflowRoot)
-	if err != nil {
+	if _, err := os.Stat(workflowRoot); err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return false, nil
 		}
 		return false, camperrors.Wrap(err, "stat workflow root")
 	}
-	return info.ModTime().After(idx.BuildTime), nil
+
+	stale := false
+	entries := 0
+	walkErr := filepath.WalkDir(workflowRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		entries++
+		if entries > maxWorkflowWalkEntries {
+			return filepath.SkipAll
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil
+		}
+		if info.ModTime().After(idx.BuildTime) {
+			stale = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if walkErr != nil && !errors.Is(walkErr, filepath.SkipAll) {
+		return false, camperrors.Wrap(walkErr, "walk workflow tree")
+	}
+	return stale, nil
 }
 
 func hasErrorFindings(findings []finding) bool {

--- a/internal/commands/workflow/doctor_cache_test.go
+++ b/internal/commands/workflow/doctor_cache_test.go
@@ -1,0 +1,56 @@
+package workflow
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
+)
+
+func TestIsNavCacheStaleForWorkflow_FreshCacheNotStale(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "workflow", "research"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "workflow", "research", "OBEY.md"),
+		[]byte("hi\n"), 0o644))
+
+	idx := &navindex.Index{BuildTime: time.Now().Add(time.Hour)}
+	require.NoError(t, navindex.Save(idx, root))
+
+	stale, err := isNavCacheStaleForWorkflow(context.Background(), root)
+	require.NoError(t, err)
+	assert.False(t, stale, "future-dated cache must not be flagged stale")
+}
+
+func TestIsNavCacheStaleForWorkflow_TouchedDeepFileTriggersStale(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "workflow", "research", "compare-llms")
+	require.NoError(t, os.MkdirAll(deep, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(deep, ".workitem"), []byte("id: x\n"), 0o644))
+
+	idx := &navindex.Index{BuildTime: time.Now().Add(-time.Hour)}
+	require.NoError(t, navindex.Save(idx, root))
+
+	touched := time.Now()
+	require.NoError(t, os.Chtimes(filepath.Join(deep, ".workitem"), touched, touched))
+
+	stale, err := isNavCacheStaleForWorkflow(context.Background(), root)
+	require.NoError(t, err)
+	assert.True(t, stale, "mtime on deep .workitem newer than cache build must mark stale")
+}
+
+func TestIsNavCacheStaleForWorkflow_NoWorkflowDirNotStale(t *testing.T) {
+	root := t.TempDir()
+	idx := &navindex.Index{BuildTime: time.Now()}
+	require.NoError(t, navindex.Save(idx, root))
+
+	stale, err := isNavCacheStaleForWorkflow(context.Background(), root)
+	require.NoError(t, err)
+	assert.False(t, stale, "missing workflow/ tree must not be flagged stale")
+}

--- a/internal/commands/workflow/sync.go
+++ b/internal/commands/workflow/sync.go
@@ -53,7 +53,7 @@ func runSync(ctx context.Context, cmd *cobra.Command, apply, jsonOut bool) error
 		return camperrors.Wrap(err, "not in a campaign directory")
 	}
 
-	findings, err := collectFindings(campaignRoot, cfg)
+	findings, err := collectFindings(ctx, campaignRoot, cfg)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -78,27 +78,32 @@ func runDoctor(ctx context.Context, cmd *cobra.Command, jsonOut, fix bool) error
 	if err != nil {
 		return camperrors.Wrap(err, "not in a campaign directory")
 	}
-	registry, err := links.Load(ctx, root)
-	if err != nil {
-		return err
-	}
-
 	knownIDs, err := workitemIDsOnDisk(ctx, root)
 	if err != nil {
 		return err
 	}
 
-	findings := collectWorkitemFindings(ctx, root, registry, knownIDs)
+	var findings []docFinding
 	if fix {
-		applied := autoFixWorkitemFindings(ctx, root, registry, findings, cmd.ErrOrStderr())
-		if applied > 0 {
-			if err := links.Save(ctx, root, registry); err != nil {
-				return err
+		err = links.WithLock(ctx, root, func(registry *links.Links) error {
+			findings = collectWorkitemFindings(ctx, root, registry, knownIDs)
+			applied := autoFixWorkitemFindings(ctx, root, registry, findings, cmd.ErrOrStderr())
+			if applied == 0 {
+				return links.ErrSkipSave
 			}
-			// Re-run findings after fixes for an accurate post-fix report.
 			knownIDs, _ = workitemIDsOnDisk(ctx, root)
 			findings = collectWorkitemFindings(ctx, root, registry, knownIDs)
+			return nil
+		})
+		if err != nil {
+			return err
 		}
+	} else {
+		registry, err := links.Load(ctx, root)
+		if err != nil {
+			return err
+		}
+		findings = collectWorkitemFindings(ctx, root, registry, knownIDs)
 	}
 
 	if jsonOut {

--- a/internal/commands/workitem/link.go
+++ b/internal/commands/workitem/link.go
@@ -107,11 +107,6 @@ func runLink(ctx context.Context, cmd *cobra.Command, opts linkOptions) error {
 		}
 	}
 
-	registry, err := links.Load(ctx, root)
-	if err != nil {
-		return err
-	}
-
 	link := links.Link{
 		ID:          generateLinkID(),
 		WorkitemID:  workitemIDForLink(wi, opts),
@@ -121,21 +116,23 @@ func runLink(ctx context.Context, cmd *cobra.Command, opts linkOptions) error {
 		CreatedAt:   time.Now().UTC().Truncate(time.Second),
 		CreatedBy:   defaultCreatedBy(),
 	}
-	if err := registry.AddLink(link, opts.Replace); err != nil {
-		return err
-	}
 
-	knownIDs := workitemIDSetFromMaybeNil(wi, opts.AllowMissing)
-	if errs := links.Validate(ctx, registry, links.ValidateOptions{
-		CampaignRoot: root,
-		WorkitemIDs:  knownIDs,
-		AllowMissing: opts.AllowMissing,
-		Now:          link.CreatedAt,
-	}); len(errs) > 0 {
-		return camperrors.NewValidation(errs[0].Field, errs[0].Message, nil)
-	}
-
-	if err := links.Save(ctx, root, registry); err != nil {
+	err = links.WithLock(ctx, root, func(registry *links.Links) error {
+		if err := registry.AddLink(link, opts.Replace); err != nil {
+			return err
+		}
+		knownIDs := workitemIDSetFromMaybeNil(wi, opts.AllowMissing)
+		if errs := links.Validate(ctx, registry, links.ValidateOptions{
+			CampaignRoot: root,
+			WorkitemIDs:  knownIDs,
+			AllowMissing: opts.AllowMissing,
+			Now:          link.CreatedAt,
+		}); len(errs) > 0 {
+			return camperrors.NewValidation(errs[0].Field, errs[0].Message, nil)
+		}
+		return nil
+	})
+	if err != nil {
 		return err
 	}
 

--- a/internal/commands/workitem/unlink.go
+++ b/internal/commands/workitem/unlink.go
@@ -70,46 +70,43 @@ func runUnlink(ctx context.Context, cmd *cobra.Command, opts unlinkOptions) erro
 	if err != nil {
 		return camperrors.Wrap(err, "not in a campaign directory")
 	}
-	registry, err := links.Load(ctx, root)
-	if err != nil {
-		return err
-	}
-
 	removed := []links.Link{}
-	switch {
-	case opts.ID != "":
-		link, ok := registry.FindByID(opts.ID)
-		if !ok {
-			return camperrors.NewValidation("id", "no link with id "+opts.ID, nil)
-		}
-		removed = append(removed, *link)
-		registry.RemoveLinkByID(opts.ID)
+	err = links.WithLock(ctx, root, func(registry *links.Links) error {
+		switch {
+		case opts.ID != "":
+			link, ok := registry.FindByID(opts.ID)
+			if !ok {
+				return camperrors.NewValidation("id", "no link with id "+opts.ID, nil)
+			}
+			removed = append(removed, *link)
+			registry.RemoveLinkByID(opts.ID)
 
-	case opts.Selector != "":
-		wi, err := resolveSelector(ctx, root, opts.Selector, false)
-		if err != nil {
-			return err
-		}
-		matches := matchUnlinkCandidates(registry, wi.StableID, opts)
-		if len(matches) == 0 {
+		case opts.Selector != "":
+			wi, err := resolveSelector(ctx, root, opts.Selector, false)
+			if err != nil {
+				return err
+			}
+			matches := matchUnlinkCandidates(registry, wi.StableID, opts)
+			if len(matches) == 0 {
+				return camperrors.NewValidation("selector",
+					"no links matched selector "+opts.Selector, nil)
+			}
+			if len(matches) > 1 && !opts.All {
+				return camperrors.NewValidation("selector",
+					fmt.Sprintf("selector matched %d links; pass --all to remove every match or --id to pick one", len(matches)), nil)
+			}
+			for _, link := range matches {
+				registry.RemoveLinkByID(link.ID)
+				removed = append(removed, link)
+			}
+
+		default:
 			return camperrors.NewValidation("selector",
-				"no links matched selector "+opts.Selector, nil)
+				"must provide --id or a selector to unlink", nil)
 		}
-		if len(matches) > 1 && !opts.All {
-			return camperrors.NewValidation("selector",
-				fmt.Sprintf("selector matched %d links; pass --all to remove every match or --id to pick one", len(matches)), nil)
-		}
-		for _, link := range matches {
-			registry.RemoveLinkByID(link.ID)
-			removed = append(removed, link)
-		}
-
-	default:
-		return camperrors.NewValidation("selector",
-			"must provide --id or a selector to unlink", nil)
-	}
-
-	if err := links.Save(ctx, root, registry); err != nil {
+		return nil
+	})
+	if err != nil {
 		return err
 	}
 

--- a/internal/config/campaign.go
+++ b/internal/config/campaign.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
 )
 
 // CampaignConfigFile is the name of the campaign configuration file.
@@ -142,7 +143,7 @@ func SaveCampaignConfig(ctx context.Context, campaignRoot string, cfg *CampaignC
 		data = append(data, commentedHooksPlaceholder()...)
 	}
 
-	if err := os.WriteFile(configPath, data, 0644); err != nil {
+	if err := fsutil.WriteFileAtomically(configPath, data, 0o644); err != nil {
 		return camperrors.Wrap(err, "failed to write campaign config")
 	}
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
 )
 
 const legacyIntentsPath = "workflow/intents/"
@@ -102,7 +103,7 @@ func SaveJumpsConfig(ctx context.Context, campaignRoot string, cfg *JumpsConfig)
 		return camperrors.Wrap(err, "failed to marshal jumps config")
 	}
 
-	if err := os.WriteFile(configPath, data, 0644); err != nil {
+	if err := fsutil.WriteFileAtomically(configPath, data, 0o644); err != nil {
 		return camperrors.Wrap(err, "failed to write jumps config")
 	}
 

--- a/internal/workitem/links/links_test.go
+++ b/internal/workitem/links/links_test.go
@@ -368,7 +368,7 @@ func TestSave_ConcurrentInvocationsDoNotCorrupt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	const workers = 2
+	const workers = 20
 	var wg sync.WaitGroup
 	errs := make(chan error, workers)
 	for i := 0; i < workers; i++ {
@@ -377,21 +377,18 @@ func TestSave_ConcurrentInvocationsDoNotCorrupt(t *testing.T) {
 			defer wg.Done()
 			link := makeValidLink(t, root)
 			link.ID = fmt.Sprintf("lnk_20260524_%06x", i+0xabcd00)
-			link.Role = RoleRelated // avoid primary collisions between workers
-			existing, err := Load(context.Background(), root)
-			if err != nil {
-				errs <- err
-				return
-			}
-			_ = existing.AddLink(link, false)
-			errs <- Save(context.Background(), root, existing)
+			link.Role = RoleRelated
+			err := WithLock(context.Background(), root, func(registry *Links) error {
+				return registry.AddLink(link, false)
+			})
+			errs <- err
 		}(i)
 	}
 	wg.Wait()
 	close(errs)
 	for e := range errs {
 		if e != nil {
-			t.Fatalf("concurrent Save: %v", e)
+			t.Fatalf("concurrent WithLock: %v", e)
 		}
 	}
 
@@ -399,10 +396,18 @@ func TestSave_ConcurrentInvocationsDoNotCorrupt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load after concurrent: %v", err)
 	}
-	// At least one link present (one of the writers won the last-writer-wins
-	// race); the file is valid YAML and parses cleanly.
-	if len(got.Links) == 0 {
-		t.Fatal("expected at least one link after concurrent saves")
+	if len(got.Links) != workers {
+		t.Fatalf("expected %d links after concurrent WithLock writers, got %d", workers, len(got.Links))
+	}
+	seen := make(map[string]bool, workers)
+	for _, l := range got.Links {
+		seen[l.ID] = true
+	}
+	for i := 0; i < workers; i++ {
+		id := fmt.Sprintf("lnk_20260524_%06x", i+0xabcd00)
+		if !seen[id] {
+			t.Errorf("missing link %s after concurrent writers", id)
+		}
 	}
 }
 

--- a/internal/workitem/links/load.go
+++ b/internal/workitem/links/load.go
@@ -31,6 +31,13 @@ func CurrentPath(root string) string {
 // documented zero state — Load returns Empty(), no error. Malformed YAML or
 // an unknown schema version returns a wrapped error.
 func Load(ctx context.Context, root string) (*Links, error) {
+	return loadLocked(ctx, root)
+}
+
+// loadLocked is the unexported peer of Load used by WithLock. It does not
+// acquire links.yaml.lock; callers that need locked Load-Mutate-Save use
+// WithLock instead.
+func loadLocked(ctx context.Context, root string) (*Links, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/workitem/links/save.go
+++ b/internal/workitem/links/save.go
@@ -23,6 +23,25 @@ func Save(ctx context.Context, root string, links *Links) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	path := LinksPath(root)
+	if err := os.MkdirAll(linksDir(root), 0o755); err != nil {
+		return camperrors.Wrap(err, "create links dir")
+	}
+	release, err := fsutil.AcquireFileLock(ctx, path+".lock")
+	if err != nil {
+		return err
+	}
+	defer release()
+	return saveLocked(ctx, root, links)
+}
+
+// saveLocked marshals and writes the registry assuming the caller already
+// holds links.yaml.lock. WithLock uses this so the Load->Mutate->Save window
+// runs under a single lock acquisition.
+func saveLocked(ctx context.Context, root string, links *Links) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if links == nil {
 		return newValidation("links", "cannot save nil Links")
 	}
@@ -38,23 +57,47 @@ func Save(ctx context.Context, root string, links *Links) error {
 	if err != nil {
 		return camperrors.Wrap(err, "marshal links.yaml")
 	}
+	if err := fsutil.WriteFileAtomically(LinksPath(root), data, 0o644); err != nil {
+		return camperrors.Wrap(err, "write links.yaml")
+	}
+	return nil
+}
 
-	path := LinksPath(root)
+// WithLock holds links.yaml.lock for the full Load-Mutate-Save transaction
+// so concurrent callers cannot silently drop each other's writes. fn receives
+// the loaded registry; mutations are persisted on success. If fn returns
+// ErrSkipSave the save is skipped (use this for "no-op after inspection").
+func WithLock(ctx context.Context, root string, fn func(*Links) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(linksDir(root), 0o755); err != nil {
 		return camperrors.Wrap(err, "create links dir")
 	}
-
+	path := LinksPath(root)
 	release, err := fsutil.AcquireFileLock(ctx, path+".lock")
 	if err != nil {
 		return err
 	}
 	defer release()
 
-	if err := fsutil.WriteFileAtomically(path, data, 0o644); err != nil {
-		return camperrors.Wrap(err, "write links.yaml")
+	registry, err := loadLocked(ctx, root)
+	if err != nil {
+		return err
 	}
-	return nil
+	if err := fn(registry); err != nil {
+		if errors.Is(err, ErrSkipSave) {
+			return nil
+		}
+		return err
+	}
+	return saveLocked(ctx, root, registry)
 }
+
+// ErrSkipSave signals to WithLock that the registry should not be persisted
+// after the transaction. Use it when an inspection-only fn determines no
+// mutation is needed.
+var ErrSkipSave = errors.New("links: skip save")
 
 // SaveCurrent writes `current.yaml` under a file lock. Passing nil clears
 // the file (removes it from disk); the directory is left in place.

--- a/tests/integration/workflow_atomic_writes_test.go
+++ b/tests/integration/workflow_atomic_writes_test.go
@@ -3,6 +3,7 @@
 package integration
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,5 +24,58 @@ func TestIntegration_WorkflowConfigSave_NoTempLeftover(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, out, ".tmp-",
 		"WriteFileAtomically should not leave .tmp-* files after a successful save")
+}
+
+// TestIntegration_WorkflowConfigSaveAtomic_ENOSPC proves SaveJumpsConfig
+// honors the atomic-write contract: when the rename step fails, the original
+// file is preserved and no tmp residue is left behind.
+//
+// The CW0003 spec called for an ENOSPC trigger via tmpfs bind-mount, which
+// requires container privileges we do not grant. We get the same atomicity
+// signal by replacing the destination file with a non-empty directory, which
+// makes os.Rename fail with EISDIR/ENOTEMPTY on every Linux kernel.
+func TestIntegration_WorkflowConfigSaveAtomic_ENOSPC(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/workflow-atomic-enospc"
+	initWorkflowCampaign(t, tc, dir)
+
+	jumpsPath := dir + "/.campaign/settings/jumps.yaml"
+	_, err := tc.ReadFile(jumpsPath)
+	if err != nil {
+		_, err = tc.RunCampInDir(dir, "workflow", "create", "research",
+			"--shortcut", "re", "--title", "Research")
+		require.NoError(t, err)
+	}
+	baseline, err := tc.ReadFile(jumpsPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, baseline)
+
+	_, _, err = tc.ExecCommand("sh", "-c",
+		"rm -f "+jumpsPath+" && mkdir -p "+jumpsPath+"/blocker && touch "+jumpsPath+"/blocker/marker")
+	require.NoError(t, err)
+
+	out, runErr := tc.RunCampInDir(dir, "workflow", "create", "design",
+		"--shortcut", "de", "--title", "Design")
+	require.Error(t, runErr, "expected atomic-save failure when destination is a non-empty directory; got: %s", out)
+	assert.True(t,
+		strings.Contains(out, "failed to write") ||
+			strings.Contains(out, "directory not empty") ||
+			strings.Contains(out, "is a directory") ||
+			strings.Contains(out, "file exists"),
+		"expected atomic-write error surface, got: %s", out)
+
+	_, exit, err := tc.ExecCommand("test", "-d", jumpsPath)
+	require.NoError(t, err)
+	assert.Equal(t, 0, exit, "destination must remain a directory (failed rename did not tunnel through)")
+
+	_, exit, err = tc.ExecCommand("test", "-f", jumpsPath+"/blocker/marker")
+	require.NoError(t, err)
+	assert.Equal(t, 0, exit, "marker inside destination dir must survive failed save (no clobber)")
+
+	leftovers, _, err := tc.ExecCommand("sh", "-c",
+		"ls "+dir+"/.campaign/settings/ 2>/dev/null | (grep 'jumps.yaml.tmp-' || true) | wc -l | tr -d ' '")
+	require.NoError(t, err)
+	assert.Equal(t, "0", strings.TrimSpace(leftovers),
+		"atomic write must clean up tmp file on rename failure; found leftover tmp files: %s", leftovers)
 }
 

--- a/tests/integration/workflow_atomic_writes_test.go
+++ b/tests/integration/workflow_atomic_writes_test.go
@@ -1,0 +1,27 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_WorkflowConfigSave_NoTempLeftover(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/workflow-atomic-leftover"
+	initWorkflowCampaign(t, tc, dir)
+
+	out, err := tc.RunCampInDir(dir, "workflow", "create", "research",
+		"--shortcut", "re", "--title", "Research")
+	require.NoError(t, err, "workflow create: %s", out)
+
+	out, _, err = tc.ExecCommand("sh", "-c",
+		"ls -A "+dir+"/.campaign/settings/ "+dir+"/.campaign/")
+	require.NoError(t, err)
+	assert.NotContains(t, out, ".tmp-",
+		"WriteFileAtomically should not leave .tmp-* files after a successful save")
+}
+

--- a/tests/integration/workitem_link_concurrent_test.go
+++ b/tests/integration/workitem_link_concurrent_test.go
@@ -29,7 +29,7 @@ func TestIntegration_LinkConcurrentNoLoss(t *testing.T) {
 		"--type", "design", "--title", "shared")
 	require.NoError(t, err, "create shared: %s", out)
 
-	const n = 10
+	const n = 20
 	for i := 0; i < n; i++ {
 		_, _, err = tc.ExecCommand("mkdir", "-p", fmt.Sprintf("%s/projects/proj-%02d", dir, i))
 		require.NoError(t, err)

--- a/tests/integration/workitem_link_concurrent_test.go
+++ b/tests/integration/workitem_link_concurrent_test.go
@@ -1,0 +1,69 @@
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_LinkConcurrentNoLoss(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/workitem-link-concurrent"
+
+	_, err := tc.RunCamp(
+		"init", dir,
+		"--name", "Link Concurrent",
+		"--type", "product",
+		"-d", "Concurrent link race",
+		"-m", "Verify WithLock holds RMW",
+		"--force", "--no-register", "--no-git",
+	)
+	require.NoError(t, err)
+
+	out, err := tc.RunCampInDir(dir, "workitem", "create", "shared",
+		"--type", "design", "--title", "shared")
+	require.NoError(t, err, "create shared: %s", out)
+
+	const n = 10
+	for i := 0; i < n; i++ {
+		_, _, err = tc.ExecCommand("mkdir", "-p", fmt.Sprintf("%s/projects/proj-%02d", dir, i))
+		require.NoError(t, err)
+	}
+
+	var script strings.Builder
+	script.WriteString("set -e; cd " + dir + "; pids=\"\"; ")
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&script,
+			"/camp workitem link shared --project proj-%02d --role related >/tmp/link-%02d.out 2>&1 & pids=\"$pids $!\"; ",
+			i, i)
+	}
+	script.WriteString("for p in $pids; do wait $p || exit $?; done")
+
+	out, _, err = tc.ExecCommand("sh", "-c", script.String())
+	logsOut, _, _ := tc.ExecCommand("sh", "-c",
+		"for f in /tmp/link-*.out; do echo \"=== $f ===\"; cat \"$f\"; done")
+	if err != nil {
+		t.Fatalf("concurrent link script failed: %s\n%s", out, logsOut)
+	}
+	t.Logf("per-invocation logs:\n%s", logsOut)
+
+	listOut, err := tc.RunCampInDir(dir, "workitem", "links")
+	require.NoError(t, err, "links list: %s", listOut)
+	t.Logf("links list:\n%s", listOut)
+
+	for i := 0; i < n; i++ {
+		project := fmt.Sprintf("proj-%02d", i)
+		assert.Contains(t, listOut, project,
+			"link to %s missing from registry after concurrent race", project)
+	}
+
+	linksYAML, err := tc.ReadFile(dir + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	count := strings.Count(linksYAML, "id: lnk_")
+	assert.Equal(t, n, count, "expected %d links in registry, found %d:\n%s", n, count, linksYAML)
+}


### PR DESCRIPTION
Closes 4 merge-blocking findings from CW0003 Phase 002 (REVIEW). First sequence of Phase 003 (FIX_BLOCKERS).

## Findings closed

- **`CW0003-workflow-03`** — Multi-file config writes non-atomic. `SaveJumpsConfig` / `SaveCampaignConfig` now go through `fsutil.WriteFileAtomically`.
- **`CW0003-workflow-13` (proposed)** — Raw `os.WriteFile` on `jumps.yaml` / `campaign.yaml`. Closed by the same swap.
- **`CW0003-links-06`** — Last-writer-wins RMW window on `links.yaml`. New `links.WithLock(ctx, root, fn)` holds the lock across the full Load -> Mutate -> Save transaction. 3 RMW call sites migrated (link, unlink, doctor --fix).
- **`CW0003-workflow-02`** — `workflow.cache.stale` mtime check missed most real staleness. Replaced single-dir `os.Stat` with bounded recursive walk (`maxWorkflowWalkEntries = 10_000`). `collectFindings` and the helper now take `ctx` (incidental chip at `CW0003-workflow-04`).

## Test evidence

- New unit tests in `internal/commands/workflow/doctor_cache_test.go` cover fresh / touched-deep / missing-workflow-tree paths.
- New containerized integration tests:
  - `TestIntegration_WorkflowConfigSave_NoTempLeftover` — asserts atomic-write codepath runs cleanly with no `.tmp-*` leftovers.
  - `TestIntegration_LinkConcurrentNoLoss` — 10-way concurrent `camp workitem link` race, asserts all 10 links land in the registry.
- All existing tests pass: `internal/config/...`, `internal/workitem/links/...`, `internal/commands/workitem/...`, `internal/commands/workflow/...`.

## Target

Targets `feat/workflow-surface-CW0003` (the integrated trunk), NOT `main`. Trunk merges to main after Phase 003 closes all 5 sequences and `COMPLETENESS_MEMO.md` reissues GO.

## Festival tracking

Festival: `camp-workitem-linking-and-commits-CW0003` / Phase 003 / sequence 01 (`atomic_config_writes`). Commit body cites each closed finding ID.