### PR TITLE
fix(CW0003 seq-02): doctor + tag grammar + workflow dry-run (10 findings)

### DIFF
--- a/cmd/camp/commit_workitem.go
+++ b/cmd/camp/commit_workitem.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"os"
 
+	workitemcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
 	"github.com/Obedience-Corp/camp/pkg/commitkit"
@@ -14,12 +16,23 @@ import (
 // caller can still produce a quest- and workitem-free tag.
 //
 // explicit, when non-empty, is the user-supplied --workitem selector.
+//
+// When the resolved workitem is a directory-kind item with no `ref` field
+// (pre-v1alpha6), the ref is auto-backfilled into the .workitem marker on
+// disk so future commits inherit it. A stderr warning notifies the user.
 func resolveCommitContext(ctx context.Context, campaignRoot, explicit string) (questID, workitemRef string) {
 	res, err := resolver.Resolve(ctx, campaignRoot, resolver.Options{
 		Explicit: explicit,
 	})
 	if err != nil || res == nil || res.Workitem == nil {
 		return "", ""
+	}
+	ref, ensureErr := workitemcmd.EnsureRefForCommit(ctx, campaignRoot, res.Workitem, os.Stderr)
+	if ensureErr != nil {
+		return res.QuestID, workitemRefFor(res.Workitem)
+	}
+	if ref != "" {
+		return res.QuestID, ref
 	}
 	return res.QuestID, workitemRefFor(res.Workitem)
 }

--- a/internal/commands/workflow/create_emit.go
+++ b/internal/commands/workflow/create_emit.go
@@ -25,17 +25,86 @@ func emitCreateHuman(cmd *cobra.Command, plan *createPlan, opts createOptions) e
 
 	if opts.DryRun {
 		fmt.Fprintf(w, "plan: create %s\n", strings.TrimRight(plan.WorkflowRel, "/"))
-	} else {
-		fmt.Fprintf(w, "created %s\n", strings.TrimRight(plan.WorkflowRel, "/"))
+		for _, line := range planActionLines(plan) {
+			fmt.Fprintf(w, "  %s\n", line)
+		}
+		fmt.Fprintln(w, "dry run: nothing written. re-run without --dry-run to apply.")
+		return nil
 	}
+
+	fmt.Fprintf(w, "created %s\n", strings.TrimRight(plan.WorkflowRel, "/"))
 	fmt.Fprintf(w, "  shortcut: %s -> %s\n", plan.Shortcut.Key, plan.WorkflowRel)
 	fmt.Fprintf(w, "  workitem type: %s\n", plan.Type)
 	fmt.Fprintf(w, "  status dirs: %s\n", strings.Join(statusDirsForOutput(), ", "))
 	fmt.Fprintf(w, "next: camp workitem create <slug> --type %s\n", plan.Type)
-	if opts.DryRun {
-		fmt.Fprintln(w, "dry run: nothing written. re-run without --dry-run to apply.")
-	}
 	return nil
+}
+
+func planActionLines(plan *createPlan) []string {
+	var lines []string
+	rel := strings.TrimRight(plan.WorkflowRel, "/")
+
+	if plan.WorkflowDirCreate {
+		lines = append(lines, "create dir "+rel+"/")
+	} else {
+		lines = append(lines, "skip-exists dir "+rel+"/")
+	}
+
+	for _, sub := range statusDirs {
+		dir := rel + "/" + sub + "/"
+		missing := false
+		for _, m := range plan.MissingStatusDirs {
+			if m == sub {
+				missing = true
+				break
+			}
+		}
+		if missing {
+			lines = append(lines, "create dir "+dir)
+		} else {
+			lines = append(lines, "skip-exists dir "+dir)
+		}
+		gitkeepMissing := false
+		for _, m := range plan.MissingGitKeeps {
+			if m == sub {
+				gitkeepMissing = true
+				break
+			}
+		}
+		if gitkeepMissing {
+			lines = append(lines, "create file "+dir+".gitkeep")
+		}
+	}
+
+	if plan.OBEYWrite {
+		lines = append(lines, "create file "+rel+"/OBEY.md")
+	} else {
+		lines = append(lines, "skip-exists file "+rel+"/OBEY.md")
+	}
+
+	switch {
+	case plan.Shortcut.NoChange:
+		lines = append(lines, "no-op shortcut "+plan.Shortcut.Key+" -> "+plan.Shortcut.Path)
+	case plan.Shortcut.Replaced:
+		lines = append(lines, "update shortcut "+plan.Shortcut.Key+" -> "+plan.Shortcut.Path+" (was "+plan.Shortcut.Existing+")")
+	default:
+		lines = append(lines, "create shortcut "+plan.Shortcut.Key+" -> "+plan.Shortcut.Path)
+	}
+
+	switch {
+	case plan.Concept.NoChange:
+		lines = append(lines, "no-op concept "+plan.Concept.Name+" -> "+plan.Concept.Path)
+	case plan.Concept.Replaced:
+		lines = append(lines, "update concept "+plan.Concept.Name+" -> "+plan.Concept.Path+" (was "+plan.Concept.Existing+")")
+	default:
+		lines = append(lines, "create concept "+plan.Concept.Name+" -> "+plan.Concept.Path)
+	}
+
+	for _, key := range plan.Replaced {
+		lines = append(lines, "remove shortcut "+key+" (replaced under --replace)")
+	}
+
+	return lines
 }
 
 func emitCreateJSON(cmd *cobra.Command, plan *createPlan, opts createOptions) error {

--- a/internal/commands/workflow/doctor.go
+++ b/internal/commands/workflow/doctor.go
@@ -218,7 +218,7 @@ func collectFindings(campaignRoot string, cfg *config.CampaignConfig) ([]finding
 			Severity:    severityError,
 			Target:      "shortcut:" + normalized,
 			Message:     fmt.Sprintf("duplicate shortcut keys normalize to %q: %s", normalized, strings.Join(dupes, ", ")),
-			FixHint:     "manually consolidate the entries in .campaign/settings/jumps.yaml; auto-fix keeps the normalized (canonical-case) variant when present, otherwise the lexicographically first variant",
+			FixHint:     "manually consolidate the entries in .campaign/settings/jumps.yaml; auto-fix keeps the normalized (lowercase) form when present, otherwise the lexicographically first variant",
 			AutoFixable: true,
 		})
 	}

--- a/internal/commands/workflow/doctor.go
+++ b/internal/commands/workflow/doctor.go
@@ -218,7 +218,7 @@ func collectFindings(campaignRoot string, cfg *config.CampaignConfig) ([]finding
 			Severity:    severityError,
 			Target:      "shortcut:" + normalized,
 			Message:     fmt.Sprintf("duplicate shortcut keys normalize to %q: %s", normalized, strings.Join(dupes, ", ")),
-			FixHint:     "manually consolidate the entries in .campaign/settings/jumps.yaml; auto-fix keeps the lexicographically first variant",
+			FixHint:     "manually consolidate the entries in .campaign/settings/jumps.yaml; auto-fix keeps the normalized (canonical-case) variant when present, otherwise the lexicographically first variant",
 			AutoFixable: true,
 		})
 	}

--- a/internal/commands/workitem/commit.go
+++ b/internal/commands/workitem/commit.go
@@ -124,6 +124,10 @@ func runCommit(ctx context.Context, cmd *cobra.Command, flags commitFlags) error
 		return err
 	}
 
+	for _, w := range plan.Warnings {
+		fmt.Fprintln(cmd.ErrOrStderr(), "warning: "+w)
+	}
+
 	if !flags.JSON {
 		if perr := PrintPlan(cmd.ErrOrStderr(), plan); perr != nil {
 			return perr

--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -91,7 +91,10 @@ func runDoctor(ctx context.Context, cmd *cobra.Command, jsonOut, fix bool) error
 				AutoFixable: true,
 			}
 			if jsonOut {
-				return emitDocJSON(cmd.OutOrStdout(), []docFinding{parseFinding})
+				if jerr := emitDocJSON(cmd.OutOrStdout(), []docFinding{parseFinding}); jerr != nil {
+					return jerr
+				}
+				return errDoctorIssues
 			}
 			emitDocHuman(cmd.OutOrStdout(), []docFinding{parseFinding})
 			return camperrors.Wrap(err, "load links registry")

--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -35,6 +35,7 @@ const (
 	codeCurrentMissing     = "workitem.current.missing"
 	codeMissingRefField    = "workitem.ref.missing"
 	codeWorkitemScanFailed = "workitem.scan.failed"
+	codeRegistryParseError = "workitem.registry.parse-error"
 )
 
 const (
@@ -80,7 +81,34 @@ func runDoctor(ctx context.Context, cmd *cobra.Command, jsonOut, fix bool) error
 	}
 	registry, err := links.Load(ctx, root)
 	if err != nil {
-		return err
+		if !fix {
+			parseFinding := docFinding{
+				Code:        codeRegistryParseError,
+				Severity:    docSeverityError,
+				Target:      "registry:links.yaml",
+				Message:     "links.yaml cannot be parsed: " + err.Error(),
+				FixHint:     "run `camp workitem doctor --fix` to quarantine the broken file and bootstrap an empty registry",
+				AutoFixable: true,
+			}
+			if jsonOut {
+				return emitDocJSON(cmd.OutOrStdout(), []docFinding{parseFinding})
+			}
+			emitDocHuman(cmd.OutOrStdout(), []docFinding{parseFinding})
+			return camperrors.Wrap(err, "load links registry")
+		}
+		quarantined, qerr := links.QuarantineBroken(ctx, root)
+		if qerr != nil {
+			return camperrors.Wrap(qerr, "quarantine broken registry")
+		}
+		if quarantined != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(),
+				"quarantined broken links.yaml to %s; bootstrapped empty registry\n",
+				quarantined)
+		}
+		registry, err = links.Load(ctx, root)
+		if err != nil {
+			return camperrors.Wrap(err, "reload after quarantine")
+		}
 	}
 
 	knownIDs, err := workitemIDsOnDisk(ctx, root)
@@ -256,8 +284,11 @@ func autoFixWorkitemFindings(ctx context.Context, root string, registry *links.L
 		}
 	}
 	if needsRefBackfill {
-		n, err := backfillMissingRefs(ctx, root)
+		n, failures, err := backfillMissingRefs(ctx, root)
 		applied += n
+		for _, f := range failures {
+			fmt.Fprintf(errw, "warning: backfill ref for %s: %v\n", f.RelativePath, f.Err)
+		}
 		if err != nil {
 			fmt.Fprintf(errw, "warning: backfill refs: %v\n", err)
 			return applied

--- a/internal/commands/workitem/doctor_ref_backfill.go
+++ b/internal/commands/workitem/doctor_ref_backfill.go
@@ -15,10 +15,23 @@ import (
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
 
+// hasWorkitemMarker reports whether the campaign-relative path holds a
+// `.workitem` marker on disk. Backfill targets only paths with markers;
+// intent .md files and festival directories have their own metadata and
+// must not be flagged as "missing ref".
+func hasWorkitemMarker(root, relPath string) bool {
+	markerPath := filepath.Join(root, filepath.FromSlash(relPath), wkitem.MetadataFilename)
+	info, err := os.Stat(markerPath)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
 // workitemPathsMissingRef discovers every workitem on disk and returns the
-// campaign-relative paths to those whose .workitem marker has no ref field.
-// Paths are sorted lexicographically so DeriveUnique's collision retry has
-// deterministic input ordering during a doctor --fix pass.
+// campaign-relative paths to those whose .workitem marker exists and has no
+// ref field. Paths are sorted lexicographically so DeriveUnique's collision
+// retry has deterministic input ordering during a doctor --fix pass.
 func workitemPathsMissingRef(ctx context.Context, root string) ([]string, error) {
 	cfg, err := config.LoadCampaignConfig(ctx, root)
 	if err != nil {
@@ -31,6 +44,9 @@ func workitemPathsMissingRef(ctx context.Context, root string) ([]string, error)
 	}
 	var missing []string
 	for _, item := range items {
+		if !hasWorkitemMarker(root, item.RelativePath) {
+			continue
+		}
 		ref, _ := item.SourceMetadata["ref"].(string)
 		if ref != "" {
 			continue
@@ -41,20 +57,28 @@ func workitemPathsMissingRef(ctx context.Context, root string) ([]string, error)
 	return missing, nil
 }
 
-func backfillMissingRefs(ctx context.Context, root string) (int, error) {
+type backfillFailure struct {
+	RelativePath string
+	Err          error
+}
+
+func backfillMissingRefs(ctx context.Context, root string) (int, []backfillFailure, error) {
 	cfg, err := config.LoadCampaignConfig(ctx, root)
 	if err != nil {
-		return 0, camperrors.Wrap(err, "load campaign config")
+		return 0, nil, camperrors.Wrap(err, "load campaign config")
 	}
 	resolver := paths.NewResolverFromConfig(root, cfg)
 	items, err := wkitem.Discover(ctx, root, resolver)
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 
 	existingRefs := make(map[string]bool, len(items))
 	var pending []wkitem.WorkItem
 	for _, item := range items {
+		if !hasWorkitemMarker(root, item.RelativePath) {
+			continue
+		}
 		ref, _ := item.SourceMetadata["ref"].(string)
 		if ref != "" {
 			existingRefs[ref] = true
@@ -67,21 +91,24 @@ func backfillMissingRefs(ctx context.Context, root string) (int, error) {
 	})
 
 	applied := 0
+	var failures []backfillFailure
 	for _, item := range pending {
 		if err := ctx.Err(); err != nil {
-			return applied, err
+			return applied, failures, err
 		}
 		ref, err := wkitem.DeriveUnique(ctx, item.StableID, existingRefs)
 		if err != nil {
-			return applied, err
+			failures = append(failures, backfillFailure{RelativePath: item.RelativePath, Err: err})
+			continue
+		}
+		if err := backfillRefWithRef(ctx, root, item.RelativePath, ref); err != nil {
+			failures = append(failures, backfillFailure{RelativePath: item.RelativePath, Err: err})
+			continue
 		}
 		existingRefs[ref] = true
-		if err := backfillRefWithRef(ctx, root, item.RelativePath, ref); err != nil {
-			return applied, err
-		}
 		applied++
 	}
-	return applied, nil
+	return applied, failures, nil
 }
 
 func backfillRefWithRef(ctx context.Context, root, relPath, ref string) error {

--- a/internal/commands/workitem/resolve_test.go
+++ b/internal/commands/workitem/resolve_test.go
@@ -98,7 +98,7 @@ func TestResolve_LinkTier(t *testing.T) {
 	}
 }
 
-func TestResolve_BrokenPrimaryLinkDoesNotFallThrough(t *testing.T) {
+func TestResolve_BrokenPrimaryLinkFallsThroughToLowerTier(t *testing.T) {
 	root := linkTestCampaign(t)
 	restore := chdir(t, root)
 	defer restore()
@@ -120,12 +120,22 @@ func TestResolve_BrokenPrimaryLinkDoesNotFallThrough(t *testing.T) {
 	}
 
 	cwd := filepath.Join(root, "projects", "demo")
-	_, err := resolver.Resolve(context.Background(), root, resolver.Options{Cwd: cwd})
-	if err == nil {
-		t.Fatal("expected broken primary link to fail instead of falling through")
+	res, err := resolver.Resolve(context.Background(), root, resolver.Options{Cwd: cwd})
+	if err != nil {
+		t.Fatalf("resolver should not error on broken primary link, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "primary link") {
-		t.Fatalf("err = %v, want primary link context", err)
+	if res == nil {
+		t.Fatal("expected non-nil result")
+	}
+	sawError := false
+	for _, step := range res.Trace {
+		if step.Result == "error" {
+			sawError = true
+			break
+		}
+	}
+	if !sawError {
+		t.Fatalf("expected an error trace step from the broken link tier, got %#v", res.Trace)
 	}
 }
 

--- a/internal/commands/workitem/staging.go
+++ b/internal/commands/workitem/staging.go
@@ -68,6 +68,7 @@ type StagingPlan struct {
 	PreStaged        []string
 	Skip             []SkippedEntry
 	Tag              string
+	Warnings         []string
 }
 
 func (p *StagingPlan) addStageNote(path, note string) {
@@ -104,6 +105,10 @@ func ComputePlan(ctx context.Context, campaignRoot string, opts PlanOptions) (*S
 		WorkitemRef: ref,
 		QuestID:     res.QuestID,
 		Tag:         commitkit.FormatContextTagsFull(opts.CampaignID, res.QuestID, "", ref),
+	}
+	if ref == "" && wi != nil {
+		plan.Warnings = append(plan.Warnings,
+			"workitem "+wi.Key+" has no ref field (pre-v1alpha6); commit tag will omit the WI- segment. Run `camp workitem doctor --fix` to backfill.")
 	}
 
 	if opts.StagedOnly {

--- a/internal/commands/workitem/staging.go
+++ b/internal/commands/workitem/staging.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
@@ -44,6 +45,7 @@ type PlanOptions struct {
 	StagedOnly              bool     // --staged
 	IncludeSubmodulePointer bool     // --include-submodule-pointer
 	CampaignID              string
+	Stderr                  io.Writer // for warning lines from ref backfill (default: os.Stderr)
 }
 
 // SkippedEntry pairs a path with a stable reason string.
@@ -99,14 +101,21 @@ func ComputePlan(ctx context.Context, campaignRoot string, opts PlanOptions) (*S
 	}
 
 	wi := res.Workitem
-	ref := refOf(wi)
+	errw := opts.Stderr
+	if errw == nil {
+		errw = os.Stderr
+	}
+	ref, err := ensureRefForCommit(ctx, campaignRoot, wi, errw)
+	if err != nil {
+		return nil, err
+	}
 	plan := &StagingPlan{
 		Workitem:    wi,
 		WorkitemRef: ref,
 		QuestID:     res.QuestID,
 		Tag:         commitkit.FormatContextTagsFull(opts.CampaignID, res.QuestID, "", ref),
 	}
-	if ref == "" && wi != nil {
+	if ref == "" && wi != nil && wi.ItemKind == wkitem.ItemKindDirectory && wi.StableID != "" {
 		plan.Warnings = append(plan.Warnings,
 			"workitem "+wi.Key+" has no ref field (pre-v1alpha6); commit tag will omit the WI- segment. Run `camp workitem doctor --fix` to backfill.")
 	}

--- a/internal/commands/workitem/staging_branches.go
+++ b/internal/commands/workitem/staging_branches.go
@@ -2,11 +2,15 @@ package workitem
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/paths"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
 	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
@@ -188,6 +192,57 @@ func refOf(wi *wkitem.WorkItem) string {
 		return v
 	}
 	return ""
+}
+
+// EnsureRefForCommit is the exported entry point for the commit path. See
+// ensureRefForCommit.
+func EnsureRefForCommit(ctx context.Context, root string, wi *wkitem.WorkItem, errw io.Writer) (string, error) {
+	return ensureRefForCommit(ctx, root, wi, errw)
+}
+
+// ensureRefForCommit returns the workitem's ref, auto-backfilling the
+// .workitem marker on disk if the field is empty and the workitem is a
+// directory-kind item with a stable id. Intents/festivals and unresolved
+// workitems return "" with no side effect. Failures during backfill fall
+// back to "" with a louder stderr warning so the commit can still proceed
+// without a WI- segment.
+func ensureRefForCommit(ctx context.Context, root string, wi *wkitem.WorkItem, errw io.Writer) (string, error) {
+	if wi == nil {
+		return "", nil
+	}
+	if wi.ItemKind != wkitem.ItemKindDirectory || wi.StableID == "" {
+		return "", nil
+	}
+	if v := refOf(wi); v != "" {
+		return v, nil
+	}
+	cfg, err := config.LoadCampaignConfig(ctx, root)
+	if err != nil {
+		return "", camperrors.Wrap(err, "load campaign config for ref backfill")
+	}
+	resolver := paths.NewResolverFromConfig(root, cfg)
+	items, err := wkitem.Discover(ctx, root, resolver)
+	if err != nil {
+		return "", camperrors.Wrap(err, "discover for ref collision set")
+	}
+	existing := wkitem.RefsFromWorkitems(items)
+	ref, err := wkitem.DeriveUnique(ctx, wi.StableID, existing)
+	if err != nil {
+		fmt.Fprintf(errw,
+			"warning: could not derive ref for %s: %v; committing without WI segment\n",
+			wi.RelativePath, err)
+		return "", nil
+	}
+	if err := backfillRefWithRef(ctx, root, wi.RelativePath, ref); err != nil {
+		fmt.Fprintf(errw,
+			"warning: could not backfill ref for %s: %v; committing without WI segment\n",
+			wi.RelativePath, err)
+		return "", nil
+	}
+	fmt.Fprintf(errw,
+		"warning: backfilled missing ref for %s -> %s; commit the .workitem update with your next change\n",
+		wi.RelativePath, ref)
+	return ref, nil
 }
 
 func workitemDirNote(wi *wkitem.WorkItem, src resolver.Source) string {

--- a/internal/git/campaign_tag.go
+++ b/internal/git/campaign_tag.go
@@ -87,7 +87,14 @@ type TagComponents struct {
 // inner contents are split component-by-component in ParseTag so the parser
 // can disambiguate `FE-<ref>` and `WI-<ref>` without relying on regex
 // lookahead (which RE2 does not support).
-var tagShellRegex = regexp.MustCompile(`\[OBEY-CAMPAIGN-([^\]]+)\]`)
+//
+// The leading guard `(?:^|[^"])` rejects matches where the tag opens
+// immediately after a quote character. This blocks the Revert-subject
+// false-positive (git emits `Revert "<original subject>"` and if the
+// original subject was prepended with a tag, the quoted form would
+// otherwise match). Tags at start of line or preceded by whitespace
+// continue to match.
+var tagShellRegex = regexp.MustCompile(`(?m)(?:^|[^"])\[OBEY-CAMPAIGN-([^\]]+)\]`)
 
 // ParseTag extracts the components of a campaign tag from a commit subject.
 // Returns a zero-valued TagComponents when no tag is present.
@@ -139,8 +146,15 @@ func ParseTag(subject string) TagComponents {
 			out.WorkitemRef = payload
 			rest = ""
 		default:
-			// Unknown trailing content — return what we have rather than guess.
-			rest = ""
+			// Unknown segment — skip past it and keep parsing so a later
+			// well-formed segment (e.g. WI-WI-<ref>) is still recovered
+			// instead of being silently dropped.
+			next := indexOfNextPrefix(rest)
+			if next == 0 || next >= len(rest) {
+				rest = ""
+				continue
+			}
+			rest = trimLeadingSeparator(rest[next:])
 		}
 	}
 	return out

--- a/internal/git/campaign_tag.go
+++ b/internal/git/campaign_tag.go
@@ -95,6 +95,22 @@ var leadingTagRegex = regexp.MustCompile(`^\[OBEY-CAMPAIGN-([^\]]+)\]`)
 // use this in ParseTag; the contract there is "leading tag only".
 var tagBodyScanRegex = regexp.MustCompile(`\[OBEY-CAMPAIGN-([^\]]+)\]`)
 
+var (
+	tagWorkitemRefRe = regexp.MustCompile(`^WI-[0-9a-f]{6}$`)
+	tagQuestIDRe     = regexp.MustCompile(`^qst_[A-Za-z0-9_]{1,40}$`)
+	tagFestRefRe     = regexp.MustCompile(`^[A-Za-z0-9]{1,32}$`)
+)
+
+// TagParseWarning records a degraded parse: a component whose shape check
+// failed (and was zeroed out) or an unknown segment encountered between
+// known prefixes. ParseTagDetailed returns these so callers can decide
+// whether to log, surface, or treat as a hard error.
+type TagParseWarning struct {
+	Field  string
+	Value  string
+	Reason string
+}
+
 // ParseTag extracts the components of a campaign tag from a commit subject.
 // Returns a zero-valued TagComponents when no tag is present.
 //
@@ -113,72 +129,102 @@ var tagBodyScanRegex = regexp.MustCompile(`\[OBEY-CAMPAIGN-([^\]]+)\]`)
 // previous prefix and the next belongs to the previous segment. This
 // matches FormatContextTagsFull's grammar exactly.
 func ParseTag(subject string) TagComponents {
+	tc, _ := ParseTagDetailed(subject)
+	return tc
+}
+
+// ParseTagDetailed is the warnings-aware peer of ParseTag. It continues
+// scanning past unknown segments, applies shape checks to extracted
+// component values, zeros out failures, and records each fixup in the
+// returned warnings slice.
+func ParseTagDetailed(subject string) (TagComponents, []TagParseWarning) {
 	m := leadingTagRegex.FindStringSubmatch(subject)
 	if m == nil {
-		return TagComponents{}
+		return TagComponents{}, nil
 	}
 	inner := m[1]
-	// First segment is always the campaign id.
-	rest := inner
-	out := TagComponents{}
-	idEnd := strings.Index(rest, "-")
-	if idEnd < 0 {
-		out.CampaignID = rest
-		return out
-	}
-	out.CampaignID = rest[:idEnd]
-	rest = rest[idEnd+1:]
+	var warnings []TagParseWarning
 
-	// rest may now contain: [qst_<...>-][FE-<ref>-][WI-<ref>]
+	idEnd := strings.Index(inner, "-")
+	if idEnd < 0 {
+		return TagComponents{CampaignID: inner}, nil
+	}
+	out := TagComponents{CampaignID: inner[:idEnd]}
+	rest := inner[idEnd+1:]
+
 	for rest != "" {
 		switch {
 		case strings.HasPrefix(rest, "qst_"):
-			end := indexOfNextPrefix(rest)
-			out.QuestID = rest[:end]
-			rest = trimLeadingSeparator(rest[end:])
+			seg, after := splitAtDash(rest)
+			if !tagQuestIDRe.MatchString(seg) {
+				warnings = append(warnings, TagParseWarning{
+					Field: "quest_id", Value: seg,
+					Reason: "shape check failed (want qst_<id>)",
+				})
+			} else if out.QuestID != "" {
+				warnings = append(warnings, TagParseWarning{
+					Field: "quest_id", Value: seg,
+					Reason: "duplicate quest_id segment",
+				})
+			} else {
+				out.QuestID = seg
+			}
+			rest = after
 		case strings.HasPrefix(rest, "FE-"):
 			payload := rest[len("FE-"):]
-			end := indexOfNextPrefix(payload)
-			out.FestRef = payload[:end]
-			rest = trimLeadingSeparator(payload[end:])
+			seg, after := splitAtDash(payload)
+			if !tagFestRefRe.MatchString(seg) {
+				warnings = append(warnings, TagParseWarning{
+					Field: "fest_ref", Value: seg,
+					Reason: "shape check failed (want <PREFIX><4 digits>)",
+				})
+			} else if out.FestRef != "" {
+				warnings = append(warnings, TagParseWarning{
+					Field: "fest_ref", Value: seg,
+					Reason: "duplicate fest_ref segment",
+				})
+			} else {
+				out.FestRef = seg
+			}
+			rest = after
 		case strings.HasPrefix(rest, "WI-"):
-			// Workitem refs in tags are emitted as `WI-<ref>` where the ref
-			// itself already starts with `WI-`. Keep the stored ref in its
-			// canonical form so the caller does not have to re-add the prefix.
+			// Per the tag grammar, WI- is always the last segment, so the
+			// rest of the payload IS the workitem ref. Anything that does
+			// not match the canonical shape is rejected wholesale rather
+			// than peeled apart into multiple unknown segments.
 			payload := rest[len("WI-"):]
-			out.WorkitemRef = payload
+			if !tagWorkitemRefRe.MatchString(payload) {
+				warnings = append(warnings, TagParseWarning{
+					Field: "workitem_ref", Value: payload,
+					Reason: "shape check failed (want WI-<6 hex>)",
+				})
+			} else if out.WorkitemRef != "" {
+				warnings = append(warnings, TagParseWarning{
+					Field: "workitem_ref", Value: payload,
+					Reason: "duplicate workitem_ref segment",
+				})
+			} else {
+				out.WorkitemRef = payload
+			}
 			rest = ""
 		default:
-			// Unknown segment — skip past it and keep parsing so a later
-			// well-formed segment (e.g. WI-WI-<ref>) is still recovered
-			// instead of being silently dropped.
-			next := indexOfNextPrefix(rest)
-			if next == 0 || next >= len(rest) {
-				rest = ""
-				continue
-			}
-			rest = trimLeadingSeparator(rest[next:])
+			seg, after := splitAtDash(rest)
+			warnings = append(warnings, TagParseWarning{
+				Field: "unknown", Value: seg,
+				Reason: "unknown segment between known prefixes",
+			})
+			rest = after
 		}
 	}
-	return out
+	return out, warnings
 }
 
-// indexOfNextPrefix returns the byte offset of the next known segment
-// prefix (`-FE-` or `-WI-`) inside s, or len(s) if none is found.
-func indexOfNextPrefix(s string) int {
-	candidates := []string{"-FE-", "-WI-"}
-	best := len(s)
-	for _, p := range candidates {
-		if idx := strings.Index(s, p); idx >= 0 && idx < best {
-			best = idx
-		}
+// splitAtDash returns the substring up to the next "-" and the remainder
+// after the dash. If no dash is present, returns (s, "").
+func splitAtDash(s string) (string, string) {
+	if i := strings.Index(s, "-"); i >= 0 {
+		return s[:i], s[i+1:]
 	}
-	return best
+	return s, ""
 }
 
-func trimLeadingSeparator(s string) string {
-	if strings.HasPrefix(s, "-") {
-		return s[1:]
-	}
-	return s
-}

--- a/internal/git/campaign_tag.go
+++ b/internal/git/campaign_tag.go
@@ -83,21 +83,24 @@ type TagComponents struct {
 	WorkitemRef string // includes the leading "WI-" prefix (e.g. "WI-abcdef")
 }
 
-// tagShellRegex captures everything between `[OBEY-CAMPAIGN-` and `]`. The
-// inner contents are split component-by-component in ParseTag so the parser
-// can disambiguate `FE-<ref>` and `WI-<ref>` without relying on regex
-// lookahead (which RE2 does not support).
-//
-// The leading guard `(?:^|[^"])` rejects matches where the tag opens
-// immediately after a quote character. This blocks the Revert-subject
-// false-positive (git emits `Revert "<original subject>"` and if the
-// original subject was prepended with a tag, the quoted form would
-// otherwise match). Tags at start of line or preceded by whitespace
-// continue to match.
-var tagShellRegex = regexp.MustCompile(`(?m)(?:^|[^"])\[OBEY-CAMPAIGN-([^\]]+)\]`)
+// leadingTagRegex anchors the tag match to the start of the subject. This is
+// the contract ParseTag enforces: a tag is only what FormatContextTagsFull
+// produces at position 0. Embedded mentions in revert subjects, code
+// samples, or appended notes are intentionally ignored.
+var leadingTagRegex = regexp.MustCompile(`^\[OBEY-CAMPAIGN-([^\]]+)\]`)
+
+// tagBodyScanRegex is the unanchored form, retained for callers that
+// intentionally scan commit bodies for tag mentions (e.g. body-grep paths
+// that surface "this commit references campaign X" attributions). Do NOT
+// use this in ParseTag; the contract there is "leading tag only".
+var tagBodyScanRegex = regexp.MustCompile(`\[OBEY-CAMPAIGN-([^\]]+)\]`)
 
 // ParseTag extracts the components of a campaign tag from a commit subject.
 // Returns a zero-valued TagComponents when no tag is present.
+//
+// ParseTag matches only the leading bracket; embedded mentions in revert
+// subjects or code samples are intentionally ignored. Callers that need
+// body-grep semantics must use tagBodyScanRegex directly.
 //
 // ParseTag assumes quest IDs match `qst_[0-9]+_[a-z0-9]+` per
 // internal/quest/slug.go. If that alphabet is extended to include "-",
@@ -110,7 +113,7 @@ var tagShellRegex = regexp.MustCompile(`(?m)(?:^|[^"])\[OBEY-CAMPAIGN-([^\]]+)\]
 // previous prefix and the next belongs to the previous segment. This
 // matches FormatContextTagsFull's grammar exactly.
 func ParseTag(subject string) TagComponents {
-	m := tagShellRegex.FindStringSubmatch(subject)
+	m := leadingTagRegex.FindStringSubmatch(subject)
 	if m == nil {
 		return TagComponents{}
 	}

--- a/internal/git/campaign_tag_full_test.go
+++ b/internal/git/campaign_tag_full_test.go
@@ -126,6 +126,18 @@ func TestParseTag_KnownCombinations(t *testing.T) {
 			subject:      "no tag here at all",
 			wantCampaign: "",
 		},
+		{
+			subject:      `Revert "[OBEY-CAMPAIGN-8deed8b4-WI-WI-fake01] feat: x"`,
+			wantCampaign: "",
+		},
+		{
+			subject:      `chore: backport "[OBEY-CAMPAIGN-8deed8b4-FE-CW0003] feat: y" from main`,
+			wantCampaign: "",
+		},
+		{
+			subject:      "[OBEY-CAMPAIGN-8deed8b4-BOGUS-WI-WI-abcdef] x",
+			wantCampaign: "8deed8b4", wantWorkitem: "WI-abcdef",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.subject, func(t *testing.T) {

--- a/internal/git/campaign_tag_full_test.go
+++ b/internal/git/campaign_tag_full_test.go
@@ -224,6 +224,80 @@ func TestParseTag_AnchoringAdversarial(t *testing.T) {
 	}
 }
 
+func TestParseTagDetailed_RejectsSilentMerge(t *testing.T) {
+	cases := []struct {
+		name             string
+		subject          string
+		wantCampaign     string
+		wantQuest        string
+		wantFest         string
+		wantWorkitem     string
+		wantWarningField []string
+	}{
+		{
+			name:             "duplicate FE second is warned not overwritten",
+			subject:          "[OBEY-CAMPAIGN-abc-FE-CW0003-FE-SE0001] x",
+			wantCampaign:     "abc",
+			wantFest:         "CW0003",
+			wantWarningField: []string{"fest_ref"},
+		},
+		{
+			name:             "duplicate quest both fail shape both warned",
+			subject:          "[OBEY-CAMPAIGN-abc-qst_xyz-qst_abc] x",
+			wantCampaign:     "abc",
+			wantQuest:        "qst_xyz",
+			wantWarningField: []string{"quest_id"},
+		},
+		{
+			name:             "workitem shape failure zeroes ref",
+			subject:          "[OBEY-CAMPAIGN-abc-WI-WI-ZZZZ-extra-junk] x",
+			wantCampaign:     "abc",
+			wantWarningField: []string{"workitem_ref"},
+		},
+		{
+			name:             "unknown segment then valid WI still recovers",
+			subject:          "[OBEY-CAMPAIGN-abc-unknown-WI-WI-aaa111] x",
+			wantCampaign:     "abc",
+			wantWorkitem:     "WI-aaa111",
+			wantWarningField: []string{"unknown"},
+		},
+		{
+			name:             "valid FE then unknown extra then valid WI",
+			subject:          "[OBEY-CAMPAIGN-abc-FE-CW0003-extra-WI-WI-aaa111] x",
+			wantCampaign:     "abc",
+			wantFest:         "CW0003",
+			wantWorkitem:     "WI-aaa111",
+			wantWarningField: []string{"unknown"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, warnings := ParseTagDetailed(tc.subject)
+			if got.CampaignID != tc.wantCampaign {
+				t.Errorf("CampaignID = %q, want %q", got.CampaignID, tc.wantCampaign)
+			}
+			if got.QuestID != tc.wantQuest {
+				t.Errorf("QuestID = %q, want %q", got.QuestID, tc.wantQuest)
+			}
+			if got.FestRef != tc.wantFest {
+				t.Errorf("FestRef = %q, want %q", got.FestRef, tc.wantFest)
+			}
+			if got.WorkitemRef != tc.wantWorkitem {
+				t.Errorf("WorkitemRef = %q, want %q", got.WorkitemRef, tc.wantWorkitem)
+			}
+			if len(warnings) != len(tc.wantWarningField) {
+				t.Fatalf("warnings count = %d, want %d: %+v",
+					len(warnings), len(tc.wantWarningField), warnings)
+			}
+			for i, want := range tc.wantWarningField {
+				if warnings[i].Field != want {
+					t.Errorf("warning[%d].Field = %q, want %q", i, warnings[i].Field, want)
+				}
+			}
+		})
+	}
+}
+
 func TestTagBodyScanRegex_FindsEmbedded(t *testing.T) {
 	subject := "body has [OBEY-CAMPAIGN-aaa] and [OBEY-CAMPAIGN-bbb]"
 	matches := tagBodyScanRegex.FindAllString(subject, -1)

--- a/internal/git/campaign_tag_full_test.go
+++ b/internal/git/campaign_tag_full_test.go
@@ -192,6 +192,52 @@ func TestParseTag_RoundTripProperty(t *testing.T) {
 	}
 }
 
+func TestParseTag_AnchoringAdversarial(t *testing.T) {
+	cases := []struct {
+		name       string
+		subject    string
+		wantParsed bool
+		wantID     string
+		wantWIRef  string
+	}{
+		{name: "happy path leading tag", subject: "[OBEY-CAMPAIGN-abcd1234-WI-WI-deadbe] feat: X", wantParsed: true, wantID: "abcd1234", wantWIRef: "WI-deadbe"},
+		{name: "revert subject", subject: `Revert "[OBEY-CAMPAIGN-abcd1234] feat: X"`, wantParsed: false},
+		{name: "leading whitespace", subject: " [OBEY-CAMPAIGN-abcd1234] x", wantParsed: false},
+		{name: "embedded mid-subject", subject: "fix: tag was [OBEY-CAMPAIGN-abcd1234] in old log", wantParsed: false},
+		{name: "tag inside backticks", subject: "docs: example `[OBEY-CAMPAIGN-abcd1234]`", wantParsed: false},
+		{name: "two tags only the leading wins", subject: "[OBEY-CAMPAIGN-aaaaaaaa] body [OBEY-CAMPAIGN-bbbbbbbb]", wantParsed: true, wantID: "aaaaaaaa"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseTag(tc.subject)
+			if tc.wantParsed {
+				if got.CampaignID != tc.wantID {
+					t.Fatalf("CampaignID: want %q, got %q", tc.wantID, got.CampaignID)
+				}
+				if tc.wantWIRef != "" && got.WorkitemRef != tc.wantWIRef {
+					t.Fatalf("WorkitemRef: want %q, got %q", tc.wantWIRef, got.WorkitemRef)
+				}
+			} else if got != (TagComponents{}) {
+				t.Fatalf("expected zero-value TagComponents for non-leading tag, got %+v", got)
+			}
+		})
+	}
+}
+
+func TestTagBodyScanRegex_FindsEmbedded(t *testing.T) {
+	subject := "body has [OBEY-CAMPAIGN-aaa] and [OBEY-CAMPAIGN-bbb]"
+	matches := tagBodyScanRegex.FindAllString(subject, -1)
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 matches from body-scan regex, got %d: %v", len(matches), matches)
+	}
+	want := []string{"[OBEY-CAMPAIGN-aaa]", "[OBEY-CAMPAIGN-bbb]"}
+	for i, m := range matches {
+		if m != want[i] {
+			t.Errorf("match[%d] = %q, want %q", i, m, want[i])
+		}
+	}
+}
+
 func randHex(t *testing.T, n int) string {
 	t.Helper()
 	b := make([]byte, n)

--- a/internal/workitem/links/save.go
+++ b/internal/workitem/links/save.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"strconv"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -54,6 +56,42 @@ func Save(ctx context.Context, root string, links *Links) error {
 		return camperrors.Wrap(err, "write links.yaml")
 	}
 	return nil
+}
+
+// QuarantineBroken renames a malformed links.yaml to
+// `links.yaml.broken-<unix-nano>` and writes a fresh empty registry in its
+// place. The returned path is the quarantined file's new location (empty
+// string if the original did not exist). Doctor's `--fix` uses this to
+// unwedge a campaign whose registry cannot be loaded.
+func QuarantineBroken(ctx context.Context, root string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(linksDir(root), 0o755); err != nil {
+		return "", camperrors.Wrap(err, "create links dir")
+	}
+	path := LinksPath(root)
+	release, err := fsutil.AcquireFileLock(ctx, path+".lock")
+	if err != nil {
+		return "", err
+	}
+	defer release()
+
+	quarantined := ""
+	if _, err := os.Stat(path); err == nil {
+		quarantined = path + ".broken-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+		if err := os.Rename(path, quarantined); err != nil {
+			return "", camperrors.Wrap(err, "quarantine links.yaml")
+		}
+	}
+	data, err := marshalYAML(Empty())
+	if err != nil {
+		return quarantined, camperrors.Wrap(err, "marshal empty registry")
+	}
+	if err := fsutil.WriteFileAtomically(path, data, 0o644); err != nil {
+		return quarantined, camperrors.Wrap(err, "write empty registry")
+	}
+	return quarantined, nil
 }
 
 // SaveCurrent writes `current.yaml` under a file lock. Passing nil clears

--- a/internal/workitem/metadata.go
+++ b/internal/workitem/metadata.go
@@ -6,11 +6,17 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"gopkg.in/yaml.v3"
+)
+
+var (
+	refShape     = regexp.MustCompile(`^WI-[0-9a-f]{6}$`)
+	questIDShape = regexp.MustCompile(`^qst_[A-Za-z0-9_-]{1,40}$`)
 )
 
 const MetadataFilename = ".workitem"
@@ -103,6 +109,14 @@ func validateMetadata(m *Metadata) error {
 	}
 	if m.Type == "" {
 		return camperrors.NewValidation("type", "required field type is empty", nil)
+	}
+	if m.Ref != "" && !refShape.MatchString(m.Ref) {
+		return camperrors.NewValidation("ref",
+			"ref must match WI-<6 hex>, got "+m.Ref, nil)
+	}
+	if m.QuestID != "" && !questIDShape.MatchString(m.QuestID) {
+		return camperrors.NewValidation("quest_id",
+			"quest_id must match qst_<id>, got "+m.QuestID, nil)
 	}
 	return nil
 }

--- a/internal/workitem/metadata_test.go
+++ b/internal/workitem/metadata_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"testing/fstest"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 
 func mapFSWith(body string) fstest.MapFS {
@@ -184,6 +186,47 @@ quest_id: not_a_quest_id
 			}
 			if !strings.Contains(err.Error(), tc.wantSubstr) {
 				t.Errorf("error %q missing %q", err.Error(), tc.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestValidateMetadata_RefShape(t *testing.T) {
+	base := Metadata{Version: "v1alpha6", Kind: MetadataKind, ID: "x", Type: "design"}
+	cases := []struct {
+		name      string
+		mutate    func(*Metadata)
+		wantErr   bool
+		wantField string
+	}{
+		{"empty ref ok", func(m *Metadata) {}, false, ""},
+		{"valid ref", func(m *Metadata) { m.Ref = "WI-abcdef" }, false, ""},
+		{"uppercase hex", func(m *Metadata) { m.Ref = "WI-ABCDEF" }, true, "ref"},
+		{"wrong length", func(m *Metadata) { m.Ref = "WI-abc" }, true, "ref"},
+		{"missing WI prefix", func(m *Metadata) { m.Ref = "abcdef" }, true, "ref"},
+		{"embedded dash junk", func(m *Metadata) { m.Ref = "WI-abc-def" }, true, "ref"},
+		{"review repro junk", func(m *Metadata) { m.Ref = "NOT-A-VALID-REF-12345" }, true, "ref"},
+		{"valid quest_id", func(m *Metadata) { m.QuestID = "qst_20260525_abc" }, false, ""},
+		{"empty quest_id ok", func(m *Metadata) {}, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := base
+			tc.mutate(&m)
+			err := validateMetadata(&m)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %s, got nil", tc.name)
+				}
+				var verr *camperrors.ValidationError
+				if !errors.As(err, &verr) {
+					t.Fatalf("expected ValidationError, got %T: %v", err, err)
+				}
+				if verr.Field != tc.wantField {
+					t.Errorf("Field = %q, want %q", verr.Field, tc.wantField)
+				}
+			} else if err != nil {
+				t.Fatalf("expected no error for %s, got %v", tc.name, err)
 			}
 		})
 	}

--- a/internal/workitem/metadata_test.go
+++ b/internal/workitem/metadata_test.go
@@ -142,6 +142,39 @@ title: T
 `,
 			wantSubstr: "type is empty",
 		},
+		{
+			name: "invalid ref shape",
+			body: `version: v1alpha6
+kind: workitem
+id: x
+type: design
+title: T
+ref: NOT-A-VALID-REF-12345
+`,
+			wantSubstr: "ref must match WI-<6 hex>",
+		},
+		{
+			name: "ref with wrong length",
+			body: `version: v1alpha6
+kind: workitem
+id: x
+type: design
+title: T
+ref: WI-abc
+`,
+			wantSubstr: "ref must match WI-<6 hex>",
+		},
+		{
+			name: "invalid quest_id shape",
+			body: `version: v1alpha6
+kind: workitem
+id: x
+type: design
+title: T
+quest_id: not_a_quest_id
+`,
+			wantSubstr: "quest_id must match qst_",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/workitem/resolver/resolver.go
+++ b/internal/workitem/resolver/resolver.go
@@ -101,17 +101,19 @@ func Resolve(ctx context.Context, root string, opts Options) (*Resolution, error
 	}
 	for _, tier := range tiers {
 		wi, step, err := tier.fn()
-		if err != nil {
-			step.Result = "error"
-			if step.Detail == "" {
-				step.Detail = err.Error()
-			} else {
-				step.Detail = step.Detail + ": " + err.Error()
-			}
-			result.Trace = append(result.Trace, step)
-			continue
-		}
 		result.Trace = append(result.Trace, step)
+		if err != nil {
+			// Operational failures (cancellation, registry parse, unexpected
+			// I/O, malformed selector input) bubble up so callers don't get a
+			// silently-misattributed lower-priority workitem. The only
+			// recoverable case is the stale-link condition where a primary
+			// path link points to a workitem that no longer exists; tier
+			// helpers signal that by encoding the failure in step.Result
+			// without returning a non-nil err.
+			result.Source = tier.source
+			result.Reason = firstNonEmpty(step.Detail, err.Error())
+			return result, err
+		}
 		if wi != nil {
 			result.Workitem = wi
 			result.Source = tier.source
@@ -158,7 +160,11 @@ func resolveExplicit(ctx context.Context, root string, opts Options) (*workitem.
 	}
 	wi, err := selector.Resolve(ctx, root, opts.Explicit, selector.ResolveOptions{AllowFuzzy: opts.AllowFuzzy})
 	if err != nil {
-		return nil, TraceStep{Tier: SourceExplicit, Result: "error", Detail: err.Error()}, nil
+		// User asked for an explicit workitem; if we cannot resolve it,
+		// fail loudly rather than fall through to a lower-priority tier
+		// and silently tag against the wrong context.
+		return nil, TraceStep{Tier: SourceExplicit, Result: "error", Detail: err.Error()},
+			camperrors.Wrap(err, "resolve --workitem "+opts.Explicit)
 	}
 	return wi, TraceStep{Tier: SourceExplicit, Result: "match", Detail: wi.Key}, nil
 }
@@ -176,6 +182,14 @@ func resolveAncestor(ctx context.Context, root, cwd string) (*workitem.WorkItem,
 			if err == nil {
 				return wi, TraceStep{Tier: SourceAncestor, Result: "match", Detail: filepath.ToSlash(rel)}, nil
 			}
+			// We found a .workitem on disk but the selector cannot
+			// parse it. Fail loudly rather than skip; a malformed
+			// marker that gets silently bypassed is exactly the
+			// "wrong-context tag" case the reviewer flagged.
+			if !errors.Is(err, selector.ErrSelectorNotFound) {
+				return nil, TraceStep{Tier: SourceAncestor, Result: "error", Detail: err.Error()},
+					camperrors.Wrap(err, "resolve ancestor "+filepath.ToSlash(rel))
+			}
 		}
 		if dir == root || dir == filepath.Dir(dir) {
 			break
@@ -191,7 +205,8 @@ func resolveAncestor(ctx context.Context, root, cwd string) (*workitem.WorkItem,
 func resolveLink(ctx context.Context, root, cwd string) (*workitem.WorkItem, TraceStep, error) {
 	registry, err := links.Load(ctx, root)
 	if err != nil {
-		return nil, TraceStep{Tier: SourceLink, Result: "error", Detail: err.Error()}, nil
+		return nil, TraceStep{Tier: SourceLink, Result: "error", Detail: err.Error()},
+			camperrors.Wrap(err, "load links registry")
 	}
 	rel, err := filepath.Rel(root, cwd)
 	if err != nil || relOutsideRoot(rel) {
@@ -225,16 +240,20 @@ func resolveLink(ctx context.Context, root, cwd string) (*workitem.WorkItem, Tra
 	}
 	wi, err := selector.Resolve(ctx, root, best.WorkitemID, selector.ResolveOptions{})
 	if err != nil {
-		detail := "primary link " + best.ID + " points to missing workitem " + best.WorkitemID
-		if !errors.Is(err, selector.ErrSelectorNotFound) {
-			detail = "primary link " + best.ID + " could not resolve workitem " + best.WorkitemID + ": " + err.Error()
+		// Stale-link: the registry references a workitem that no longer
+		// exists on disk. Record the diagnostic and let the orchestrator
+		// fall through to the next tier. Any other selector failure is
+		// returned so the caller sees the operational problem.
+		if errors.Is(err, selector.ErrSelectorNotFound) {
+			return nil, TraceStep{
+				Tier:   SourceLink,
+				Result: "error",
+				Detail: "primary link " + best.ID + " points to missing workitem " + best.WorkitemID,
+			}, nil
 		}
-		step := TraceStep{
-			Tier:   SourceLink,
-			Result: "error",
-			Detail: detail,
-		}
-		return nil, step, camperrors.NewValidation("workitem_link", detail, err)
+		detail := "primary link " + best.ID + " could not resolve workitem " + best.WorkitemID + ": " + err.Error()
+		return nil, TraceStep{Tier: SourceLink, Result: "error", Detail: detail},
+			camperrors.NewValidation("workitem_link", detail, err)
 	}
 	return wi, TraceStep{
 		Tier:   SourceLink,
@@ -249,7 +268,8 @@ func resolveFestival(ctx context.Context, root, festivalID string) (*workitem.Wo
 	}
 	registry, err := links.Load(ctx, root)
 	if err != nil {
-		return nil, TraceStep{Tier: SourceFestival, Result: "error", Detail: err.Error()}, nil
+		return nil, TraceStep{Tier: SourceFestival, Result: "error", Detail: err.Error()},
+			camperrors.Wrap(err, "load links registry")
 	}
 	for i := range registry.Links {
 		link := &registry.Links[i]
@@ -267,6 +287,14 @@ func resolveFestival(ctx context.Context, root, festivalID string) (*workitem.Wo
 				Detail: "via link " + link.ID + " on festival " + link.Scope.Path,
 			}, nil
 		}
+		// Stale-link parallel of the path-link case: continue looking for
+		// other festival links if this one points to a missing workitem.
+		// Anything other than ErrSelectorNotFound is operational and bubbles up.
+		if !errors.Is(err, selector.ErrSelectorNotFound) {
+			detail := "festival link " + link.ID + " could not resolve workitem " + link.WorkitemID + ": " + err.Error()
+			return nil, TraceStep{Tier: SourceFestival, Result: "error", Detail: detail},
+				camperrors.NewValidation("festival_link", detail, err)
+		}
 	}
 	return nil, TraceStep{Tier: SourceFestival, Result: "miss", Detail: "no festival link matches " + festivalID}, nil
 }
@@ -274,14 +302,29 @@ func resolveFestival(ctx context.Context, root, festivalID string) (*workitem.Wo
 func resolveCurrent(ctx context.Context, root string) (*workitem.WorkItem, TraceStep, error) {
 	cur, err := links.LoadCurrent(ctx, root)
 	if err != nil {
-		return nil, TraceStep{Tier: SourceCurrent, Result: "error", Detail: err.Error()}, nil
+		return nil, TraceStep{Tier: SourceCurrent, Result: "error", Detail: err.Error()},
+			camperrors.Wrap(err, "load current.yaml")
 	}
 	if cur == nil {
 		return nil, TraceStep{Tier: SourceCurrent, Result: "skip", Detail: "no current.yaml"}, nil
 	}
 	wi, err := selector.Resolve(ctx, root, cur.WorkitemID, selector.ResolveOptions{})
 	if err != nil {
-		return nil, TraceStep{Tier: SourceCurrent, Result: "error", Detail: err.Error()}, nil
+		// Stale current selection: file points to a workitem that no
+		// longer exists. Record the diagnostic and let the orchestrator
+		// fall through; current is the lowest-priority tier so any
+		// match below it (none in practice today) would be acceptable.
+		// Any other failure is operational.
+		if errors.Is(err, selector.ErrSelectorNotFound) {
+			return nil, TraceStep{
+				Tier:   SourceCurrent,
+				Result: "error",
+				Detail: "current.yaml points to missing workitem " + cur.WorkitemID,
+			}, nil
+		}
+		detail := "current.yaml could not resolve workitem " + cur.WorkitemID + ": " + err.Error()
+		return nil, TraceStep{Tier: SourceCurrent, Result: "error", Detail: detail},
+			camperrors.NewValidation("current_workitem", detail, err)
 	}
 	return wi, TraceStep{Tier: SourceCurrent, Result: "match", Detail: "via current.yaml"}, nil
 }

--- a/internal/workitem/resolver/resolver.go
+++ b/internal/workitem/resolver/resolver.go
@@ -101,10 +101,17 @@ func Resolve(ctx context.Context, root string, opts Options) (*Resolution, error
 	}
 	for _, tier := range tiers {
 		wi, step, err := tier.fn()
-		result.Trace = append(result.Trace, step)
 		if err != nil {
-			return nil, err
+			step.Result = "error"
+			if step.Detail == "" {
+				step.Detail = err.Error()
+			} else {
+				step.Detail = step.Detail + ": " + err.Error()
+			}
+			result.Trace = append(result.Trace, step)
+			continue
 		}
+		result.Trace = append(result.Trace, step)
 		if wi != nil {
 			result.Workitem = wi
 			result.Source = tier.source

--- a/internal/workitem/resolver/resolver_test.go
+++ b/internal/workitem/resolver/resolver_test.go
@@ -1,0 +1,100 @@
+package resolver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeMinimalCampaign(t *testing.T, root string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, ".campaign"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `version: campaign/v1
+id: testcampaign
+name: test
+type: product
+`
+	if err := os.WriteFile(filepath.Join(root, ".campaign", "campaign.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolve_TierLoadErrorContinues(t *testing.T) {
+	root := t.TempDir()
+	writeMinimalCampaign(t, root)
+
+	linksDir := filepath.Join(root, ".campaign", "workitems")
+	if err := os.MkdirAll(linksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	malformed := "version: workitem-links/v1alpha1\nlinks: [unterminated\n"
+	if err := os.WriteFile(filepath.Join(linksDir, "links.yaml"), []byte(malformed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Resolve(context.Background(), root, Options{Cwd: root})
+	if err != nil {
+		t.Fatalf("Resolve should not propagate per-tier load errors, got: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Resolve returned nil result")
+	}
+	if got.Source != SourceNone {
+		t.Errorf("Source = %q, want %q", got.Source, SourceNone)
+	}
+
+	sawError := false
+	for _, step := range got.Trace {
+		if step.Tier == SourceLink && step.Result == "error" {
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Errorf("expected at least one trace step with Tier=link and Result=error, got: %+v", got.Trace)
+	}
+}
+
+func TestResolve_AllTiersErrorReturnsSourceNone(t *testing.T) {
+	root := t.TempDir()
+	writeMinimalCampaign(t, root)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Resolve(context.Background(), root, Options{
+		Cwd:        root,
+		FestivalID: "ghost-festival-id",
+	})
+	if err != nil {
+		t.Fatalf("Resolve should not propagate per-tier errors, got: %v", err)
+	}
+	if got.Source != SourceNone {
+		t.Errorf("Source = %q, want %q (nothing should match)", got.Source, SourceNone)
+	}
+	if got.Workitem != nil {
+		t.Errorf("Workitem should be nil when no tier matches, got: %+v", got.Workitem)
+	}
+}
+
+func TestResolve_ContextCancelledStopsImmediately(t *testing.T) {
+	root := t.TempDir()
+	writeMinimalCampaign(t, root)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := Resolve(ctx, root, Options{Cwd: root})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+}

--- a/internal/workitem/resolver/resolver_test.go
+++ b/internal/workitem/resolver/resolver_test.go
@@ -23,7 +23,10 @@ type: product
 	}
 }
 
-func TestResolve_TierLoadErrorContinues(t *testing.T) {
+func TestResolve_MalformedRegistryReturnsHardError(t *testing.T) {
+	// Reviewer (CW0003 seq-02 re-review): a malformed links.yaml must surface
+	// as an operational failure, not get downgraded to a trace entry that
+	// allows a lower-priority tier to pick a wrong workitem.
 	root := t.TempDir()
 	writeMinimalCampaign(t, root)
 
@@ -37,16 +40,15 @@ func TestResolve_TierLoadErrorContinues(t *testing.T) {
 	}
 
 	got, err := Resolve(context.Background(), root, Options{Cwd: root})
-	if err != nil {
-		t.Fatalf("Resolve should not propagate per-tier load errors, got: %v", err)
+	if err == nil {
+		t.Fatalf("expected hard error for malformed registry, got nil; result=%+v", got)
 	}
 	if got == nil {
-		t.Fatal("Resolve returned nil result")
+		t.Fatal("Resolve should still return a partial result with trace on error")
 	}
-	if got.Source != SourceNone {
-		t.Errorf("Source = %q, want %q", got.Source, SourceNone)
+	if got.Source != SourceLink {
+		t.Errorf("Source should mark the failing tier as link, got %q", got.Source)
 	}
-
 	sawError := false
 	for _, step := range got.Trace {
 		if step.Tier == SourceLink && step.Result == "error" {
@@ -54,7 +56,55 @@ func TestResolve_TierLoadErrorContinues(t *testing.T) {
 		}
 	}
 	if !sawError {
-		t.Errorf("expected at least one trace step with Tier=link and Result=error, got: %+v", got.Trace)
+		t.Errorf("expected trace step with Tier=link Result=error, got: %+v", got.Trace)
+	}
+}
+
+func TestResolve_StaleLinkFallsThrough(t *testing.T) {
+	// Stale-link is the one and only recoverable tier failure: a primary
+	// link references a workitem id that no longer exists on disk. The
+	// resolver should record the diagnostic and continue to the next tier.
+	root := t.TempDir()
+	writeMinimalCampaign(t, root)
+
+	linksDir := filepath.Join(root, ".campaign", "workitems")
+	if err := os.MkdirAll(linksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	projDir := filepath.Join(root, "projects", "demo")
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := `version: workitem-links/v1alpha1
+links:
+  - id: lnk_20260524_aaaaaa
+    workitem_id: design-ghost-2026-05-26
+    scope:
+      kind: project
+      path: projects/demo
+    role: primary
+    created_at: 2026-05-24T19:00:00Z
+    created_by: camp_workitem_link
+`
+	if err := os.WriteFile(filepath.Join(linksDir, "links.yaml"), []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Resolve(context.Background(), root, Options{Cwd: projDir})
+	if err != nil {
+		t.Fatalf("stale link should fall through, got hard error: %v", err)
+	}
+	if got.Source != SourceNone {
+		t.Errorf("Source = %q, want %q (no lower tier should match)", got.Source, SourceNone)
+	}
+	sawLinkError := false
+	for _, step := range got.Trace {
+		if step.Tier == SourceLink && step.Result == "error" {
+			sawLinkError = true
+		}
+	}
+	if !sawLinkError {
+		t.Errorf("expected stale-link trace step Tier=link Result=error, got: %+v", got.Trace)
 	}
 }
 

--- a/pkg/commitkit/commitkit.go
+++ b/pkg/commitkit/commitkit.go
@@ -70,6 +70,17 @@ func ParseTag(subject string) TagComponents {
 	return git.ParseTag(subject)
 }
 
+// TagParseWarning records a degraded parse from ParseTagDetailed.
+// Re-exported from internal/git.
+type TagParseWarning = git.TagParseWarning
+
+// ParseTagDetailed is the warnings-aware peer of ParseTag. Callers that
+// need to surface "tag was malformed" diagnostics (commit query output,
+// doctor, etc.) should call this instead of ParseTag.
+func ParseTagDetailed(subject string) (TagComponents, []TagParseWarning) {
+	return git.ParseTagDetailed(subject)
+}
+
 // DetectCampaign finds the campaign root by walking up from the current
 // working directory. Returns the campaign ID string from the campaign's
 // config, or an error if the working directory is not inside a campaign.

--- a/pkg/commitkit/commitkit_tags_test.go
+++ b/pkg/commitkit/commitkit_tags_test.go
@@ -45,3 +45,20 @@ func TestCommitkit_ParseTag_RoundTrip(t *testing.T) {
 		t.Fatalf("parse round-trip broke: %#v", got)
 	}
 }
+
+func TestCommitkit_ParseTagDetailed_ReExport(t *testing.T) {
+	subject := "[OBEY-CAMPAIGN-abc-WI-WI-ZZZZ-extra-junk] x"
+	got, warnings := commitkit.ParseTagDetailed(subject)
+	if got.CampaignID != "abc" {
+		t.Errorf("CampaignID = %q, want abc", got.CampaignID)
+	}
+	if got.WorkitemRef != "" {
+		t.Errorf("WorkitemRef should be zeroed on shape failure, got %q", got.WorkitemRef)
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected at least one warning from degraded parse")
+	}
+	if warnings[0].Field != "workitem_ref" {
+		t.Errorf("warning[0].Field = %q, want workitem_ref", warnings[0].Field)
+	}
+}

--- a/tests/integration/commit_tags_test.go
+++ b/tests/integration/commit_tags_test.go
@@ -134,6 +134,38 @@ func TestIntegration_CommitTags_ExplicitOverride(t *testing.T) {
 	assert.Contains(t, subject, "WI-"+ref, "explicit override should win: %s", subject)
 }
 
+func TestIntegration_CommitTags_BackfillsV1Alpha5WorkitemOnCommit(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/commit-tags-v1alpha5-backfill"
+	initCommitTagsCampaign(t, tc, dir)
+
+	wiDir := dir + "/workflow/design/legacy"
+	marker := `version: v1alpha5
+kind: workitem
+id: design-legacy-2026-05-25
+type: design
+title: legacy
+`
+	require.NoError(t, tc.WriteFile(wiDir+"/.workitem", marker))
+	require.NoError(t, tc.WriteFile(wiDir+"/notes.md", "x\n"))
+	_, _, err := tc.ExecCommand("git", "-C", dir, "add", "-A")
+	require.NoError(t, err)
+
+	out, err := tc.RunCampInDir(wiDir, "commit", "-m", "design: legacy update")
+	require.NoError(t, err, "camp commit: %s", out)
+	assert.Contains(t, out, "backfilled missing ref",
+		"stderr must warn user about the auto-backfill: %s", out)
+
+	subject := lastCommitSubject(t, tc, dir)
+	assert.Regexp(t, `WI-WI-[0-9a-f]{6}`, subject,
+		"backfilled ref must appear in commit subject: %s", subject)
+
+	body, err := tc.ReadFile(wiDir + "/.workitem")
+	require.NoError(t, err)
+	assert.Contains(t, body, "ref: WI-",
+		"v1alpha5 .workitem must be auto-backfilled on commit, got:\n%s", body)
+}
+
 func TestIntegration_CommitTags_RejectsInvalidRef(t *testing.T) {
 	tc := GetSharedContainer(t)
 	dir := "/test/commit-tags-bad-ref"

--- a/tests/integration/commit_tags_test.go
+++ b/tests/integration/commit_tags_test.go
@@ -134,6 +134,37 @@ func TestIntegration_CommitTags_ExplicitOverride(t *testing.T) {
 	assert.Contains(t, subject, "WI-"+ref, "explicit override should win: %s", subject)
 }
 
+func TestIntegration_CommitTags_RejectsInvalidRef(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/commit-tags-bad-ref"
+	initCommitTagsCampaign(t, tc, dir)
+
+	wiDir := dir + "/workflow/design/badref"
+	marker := `version: v1alpha6
+kind: workitem
+id: design-badref-2026-05-25
+type: design
+title: badref
+ref: NOT-A-VALID-REF-12345
+`
+	require.NoError(t, tc.WriteFile(wiDir+"/.workitem", marker))
+	require.NoError(t, tc.WriteFile(wiDir+"/notes.md", "x\n"))
+	_, _, err := tc.ExecCommand("git", "-C", dir, "add", "-A")
+	require.NoError(t, err)
+
+	out, _ := tc.RunCampInDir(wiDir, "commit", "-m", "design: bad ref")
+	subject := lastCommitSubject(t, tc, dir)
+
+	assert.NotContains(t, subject, "NOT-A-VALID-REF-12345",
+		"commit subject must not echo hand-edited junk ref (CW0003-format-02): subject=%s out=%s",
+		subject, out)
+	assert.NotContains(t, subject, "WI-WI-",
+		"composer must not produce doubled WI-WI- segment: subject=%s out=%s",
+		subject, out)
+	assert.NotContains(t, out, "WI-NOT-A-VALID-REF-12345",
+		"output must not echo hand-edited junk ref: %s", out)
+}
+
 func TestIntegration_AutoWriteEnv(t *testing.T) {
 	tc := GetSharedContainer(t)
 	dir := "/test/commit-tags-autowrite"

--- a/tests/integration/doctor_intents_festivals_test.go
+++ b/tests/integration/doctor_intents_festivals_test.go
@@ -95,8 +95,12 @@ func seedDoctorDirectoryWorkitemFixture(t *testing.T, tc *TestContainer, dir str
 
 func parseDoctorReport(t *testing.T, raw string) doctorReport {
 	t.Helper()
+	// camp doctor --json may be followed by a cobra "Error: ..." line when
+	// the command exits non-zero. Decode just the first JSON object so the
+	// trailing text does not break parsing.
+	dec := json.NewDecoder(strings.NewReader(raw))
 	var r doctorReport
-	err := json.Unmarshal([]byte(raw), &r)
+	err := dec.Decode(&r)
 	require.NoError(t, err, "doctor --json must produce valid JSON, got: %s", raw)
 	return r
 }
@@ -177,7 +181,10 @@ func TestIntegration_Doctor_QuarantinesMalformedLinksYaml(t *testing.T) {
 	malformed := "version: workitem-links/v1alpha1\nlinks: [unterminated\n"
 	require.NoError(t, tc.WriteFile(linksPath, malformed))
 
-	out, _ := tc.RunCampInDir(dir, "workitem", "doctor", "--json")
+	out, runErr := tc.RunCampInDir(dir, "workitem", "doctor", "--json")
+	assert.Error(t, runErr,
+		"camp workitem doctor --json must exit non-zero when an error-severity "+
+			"workitem.registry.parse-error finding is present (CW0003 seq-02 re-review): %s", out)
 	report := parseDoctorReport(t, out)
 	parseFindings := countByCode(report, "workitem.registry.parse-error")
 	assert.GreaterOrEqual(t, parseFindings, 1,

--- a/tests/integration/doctor_intents_festivals_test.go
+++ b/tests/integration/doctor_intents_festivals_test.go
@@ -6,6 +6,7 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -164,5 +165,86 @@ func TestIntegration_Doctor_FixBackfillsDirectoryWorkitems(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, body, "ref: WI-",
 			"expected backfilled ref in %s, got:\n%s", rel, body)
+	}
+}
+
+func TestIntegration_Doctor_QuarantinesMalformedLinksYaml(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/doctor-malformed-links"
+	initWorkflowCampaign(t, tc, dir)
+
+	linksPath := dir + "/.campaign/workitems/links.yaml"
+	malformed := "version: workitem-links/v1alpha1\nlinks: [unterminated\n"
+	require.NoError(t, tc.WriteFile(linksPath, malformed))
+
+	out, _ := tc.RunCampInDir(dir, "workitem", "doctor", "--json")
+	report := parseDoctorReport(t, out)
+	parseFindings := countByCode(report, "workitem.registry.parse-error")
+	assert.GreaterOrEqual(t, parseFindings, 1,
+		"expected workitem.registry.parse-error finding before --fix, got: %s", out)
+
+	after, err := tc.ReadFile(linksPath)
+	require.NoError(t, err)
+	assert.Equal(t, malformed, after,
+		"doctor without --fix must not modify the malformed registry")
+
+	fixOut, _ := tc.RunCampInDir(dir, "workitem", "doctor", "--fix")
+	assert.Contains(t, fixOut, "quarantined",
+		"--fix output must announce quarantine: %s", fixOut)
+
+	quarantined, _, qerr := tc.ExecCommand("sh", "-c",
+		"ls "+dir+"/.campaign/workitems/ | grep 'links.yaml.broken-' | head -1")
+	require.NoError(t, qerr)
+	assert.NotEmpty(t, strings.TrimSpace(quarantined),
+		"a links.yaml.broken-<ts> file must exist after --fix")
+
+	final, err := tc.RunCampInDir(dir, "workitem", "doctor", "--json")
+	require.NoError(t, err, "doctor after fix: %s", final)
+	finalReport := parseDoctorReport(t, final)
+	assert.Equal(t, 0, countByCode(finalReport, "workitem.registry.parse-error"),
+		"no parse-error finding should remain after --fix bootstrapped Empty(): %s", final)
+}
+
+func TestBackfillMissingRefs_QueueContinuesOnPoison(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/doctor-backfill-poison"
+	initWorkflowCampaign(t, tc, dir)
+
+	good := []string{
+		"workflow/design/alpha",
+		"workflow/design/bravo",
+		"workflow/design/delta",
+		"workflow/design/echo",
+	}
+	for _, rel := range good {
+		marker := fmt.Sprintf(directoryWorkitemMarker,
+			"design-"+rel[len("workflow/design/"):]+"-2026-05-25",
+			"design",
+			rel)
+		require.NoError(t, tc.WriteFile(dir+"/"+rel+"/.workitem", marker))
+	}
+
+	poisonRel := "workflow/design/charlie"
+	poison := `version: v1alpha5
+[this is not yaml at all
+- {{{
+`
+	require.NoError(t, tc.WriteFile(dir+"/"+poisonRel+"/.workitem", poison))
+
+	out, _ := tc.RunCampInDir(dir, "workitem", "doctor", "--fix")
+	t.Logf("doctor --fix output:\n%s", out)
+
+	after, err := tc.RunCampInDir(dir, "workitem", "doctor", "--json")
+	require.NoError(t, err, "doctor --json after fix: %s", after)
+	report := parseDoctorReport(t, after)
+	missing := countByCode(report, "workitem.ref.missing")
+	assert.LessOrEqual(t, missing, 1,
+		"expected at most 1 ref.missing remaining (the poison item), got %d:\n%s", missing, after)
+
+	for _, rel := range good {
+		body, err := tc.ReadFile(dir + "/" + rel + "/.workitem")
+		require.NoError(t, err)
+		assert.Contains(t, body, "ref: WI-",
+			"expected backfilled ref on non-poison item %s, got:\n%s", rel, body)
 	}
 }

--- a/tests/integration/doctor_intents_festivals_test.go
+++ b/tests/integration/doctor_intents_festivals_test.go
@@ -1,0 +1,168 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type doctorFinding struct {
+	Code     string `json:"code"`
+	Severity string `json:"severity"`
+	Target   string `json:"target"`
+	Message  string `json:"message"`
+}
+
+type doctorReport struct {
+	SchemaVersion string          `json:"schema_version"`
+	Findings      []doctorFinding `json:"findings"`
+}
+
+const intentFrontmatter = `---
+id: int_%02d
+status: %s
+title: idea %02d
+---
+
+body
+`
+
+const directoryWorkitemMarker = `version: v1alpha5
+kind: workitem
+id: %s
+type: %s
+title: %s
+`
+
+const festivalGoal = `# Festival Goal
+
+Placeholder.
+`
+
+func seedDoctorIntentFestivalFixture(t *testing.T, tc *TestContainer, dir string) {
+	t.Helper()
+	initWorkflowCampaign(t, tc, dir)
+
+	for status, count := range map[string]int{"inbox": 20, "active": 15, "ready": 10} {
+		for i := 1; i <= count; i++ {
+			body := fmt.Sprintf(intentFrontmatter, i, status, i)
+			require.NoError(t, tc.WriteFile(
+				fmt.Sprintf("%s/.campaign/intents/%s/%02d-idea.md", dir, status, i), body))
+		}
+	}
+
+	festivals := []string{
+		"festivals/planning/01-test-CW0001",
+		"festivals/planning/02-test-CW0002",
+		"festivals/active/03-test-CW0003",
+		"festivals/dungeon/completed/04-test-CW0004",
+	}
+	for _, p := range festivals {
+		require.NoError(t, tc.WriteFile(dir+"/"+p+"/FESTIVAL_GOAL.md", festivalGoal))
+	}
+}
+
+func seedDoctorDirectoryWorkitemFixture(t *testing.T, tc *TestContainer, dir string) []string {
+	t.Helper()
+	initWorkflowCampaign(t, tc, dir)
+
+	paths := []struct {
+		rel  string
+		kind string
+		id   string
+	}{
+		{"workflow/design/under-design", "design", "design-under-design-2026-05-25"},
+		{"workflow/explore/spike-foo", "explore", "explore-spike-foo-2026-05-25"},
+		{"workflow/research/topic-bar", "research", "research-topic-bar-2026-05-25"},
+	}
+
+	relMarkers := make([]string, 0, len(paths))
+	for _, p := range paths {
+		marker := fmt.Sprintf(directoryWorkitemMarker, p.id, p.kind, p.id)
+		full := fmt.Sprintf("%s/%s/.workitem", dir, p.rel)
+		require.NoError(t, tc.WriteFile(full, marker))
+		relMarkers = append(relMarkers, p.rel+"/.workitem")
+	}
+	return relMarkers
+}
+
+func parseDoctorReport(t *testing.T, raw string) doctorReport {
+	t.Helper()
+	var r doctorReport
+	err := json.Unmarshal([]byte(raw), &r)
+	require.NoError(t, err, "doctor --json must produce valid JSON, got: %s", raw)
+	return r
+}
+
+func countByCode(report doctorReport, code string) int {
+	n := 0
+	for _, f := range report.Findings {
+		if f.Code == code {
+			n++
+		}
+	}
+	return n
+}
+
+func TestIntegration_Doctor_NoFalsePositiveOnIntents(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/doctor-intents-no-fp"
+	seedDoctorIntentFestivalFixture(t, tc, dir)
+
+	out, err := tc.RunCampInDir(dir, "workitem", "doctor", "--json")
+	require.NoError(t, err, "doctor --json: %s", out)
+	report := parseDoctorReport(t, out)
+	missing := countByCode(report, "workitem.ref.missing")
+	assert.Equal(t, 0, missing,
+		"expected 0 workitem.ref.missing findings on intent+festival fixture, got %d:\n%s",
+		missing, out)
+}
+
+func TestIntegration_Doctor_FixIsNoOpOnIntents(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/doctor-intents-fix-noop"
+	seedDoctorIntentFestivalFixture(t, tc, dir)
+
+	out, err := tc.RunCampInDir(dir, "workitem", "doctor", "--fix", "--json")
+	require.NoError(t, err, "doctor --fix --json: %s", out)
+	report := parseDoctorReport(t, out)
+	missing := countByCode(report, "workitem.ref.missing")
+	assert.Equal(t, 0, missing,
+		"doctor --fix on intent+festival fixture must not produce ref.missing findings, got:\n%s", out)
+}
+
+func TestIntegration_Doctor_FixBackfillsDirectoryWorkitems(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/doctor-fix-backfill"
+	markers := seedDoctorDirectoryWorkitemFixture(t, tc, dir)
+
+	before, err := tc.RunCampInDir(dir, "workitem", "doctor", "--json")
+	require.NoError(t, err, "doctor --json: %s", before)
+	beforeReport := parseDoctorReport(t, before)
+	beforeMissing := countByCode(beforeReport, "workitem.ref.missing")
+	assert.Equal(t, 3, beforeMissing,
+		"expected 3 ref.missing findings before --fix, got %d:\n%s", beforeMissing, before)
+
+	fixOut, err := tc.RunCampInDir(dir, "workitem", "doctor", "--fix")
+	require.NoError(t, err, "doctor --fix: %s", fixOut)
+
+	after, err := tc.RunCampInDir(dir, "workitem", "doctor", "--json")
+	require.NoError(t, err, "doctor --json after fix: %s", after)
+	afterReport := parseDoctorReport(t, after)
+	afterMissing := countByCode(afterReport, "workitem.ref.missing")
+	assert.Equal(t, 0, afterMissing,
+		"expected 0 ref.missing findings after --fix, got %d:\n%s", afterMissing, after)
+
+	for _, rel := range markers {
+		body, err := tc.ReadFile(dir + "/" + rel)
+		require.NoError(t, err)
+		assert.Contains(t, body, "ref: WI-",
+			"expected backfilled ref in %s, got:\n%s", rel, body)
+	}
+}

--- a/tests/integration/workflow_test.go
+++ b/tests/integration/workflow_test.go
@@ -308,3 +308,73 @@ func TestIntegration_WorkflowCreateDryRun(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, dirExists, "scaffold must exist after real create")
 }
+
+func TestIntegration_WorkflowDoctor_DedupeHintMatchesApply(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/workflow-dedupe-hint"
+	initWorkflowCampaign(t, tc, dir)
+
+	_, err := tc.RunCampInDir(dir, "workflow", "create", "research", "--shortcut", "re")
+	require.NoError(t, err)
+
+	jumpsPath := dir + "/.campaign/settings/jumps.yaml"
+	orig, err := tc.ReadFile(jumpsPath)
+	require.NoError(t, err)
+
+	withDup := orig + "    RE:\n        path: workflow/research/\n        source: user\n"
+	require.NoError(t, tc.WriteFile(jumpsPath, withDup))
+
+	out, _ := tc.RunCampInDir(dir, "workflow", "doctor", "--json")
+	var report struct {
+		Findings []struct {
+			Code    string `json:"code"`
+			FixHint string `json:"fix_hint"`
+		} `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &report), "doctor --json: %s", out)
+
+	var hint string
+	for _, f := range report.Findings {
+		if f.Code == "workflow.shortcut.duplicate" {
+			hint = f.FixHint
+			break
+		}
+	}
+	require.NotEmpty(t, hint, "expected workflow.shortcut.duplicate finding in: %s", out)
+	assert.Contains(t, hint, "normalized (lowercase)",
+		"hint must describe normalized-lowercase policy, got: %s", hint)
+
+	syncOut, err := tc.RunCampInDir(dir, "workflow", "sync", "--apply")
+	require.NoError(t, err, "sync --apply: %s", syncOut)
+
+	jumpsAfter, err := tc.ReadFile(jumpsPath)
+	require.NoError(t, err)
+	assert.Contains(t, jumpsAfter, "re:",
+		"hint claims auto-fix keeps lowercase 're', but it was removed:\n%s", jumpsAfter)
+	assert.NotContains(t, jumpsAfter, "RE:",
+		"hint claims auto-fix removes uppercase 'RE', but it survived:\n%s", jumpsAfter)
+}
+
+func TestIntegration_WorkflowCreate_DryRunPerActionLines(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/workflow-dryrun-lines"
+	initWorkflowCampaign(t, tc, dir)
+
+	out, err := tc.RunCampInDir(dir, "workflow", "create", "research",
+		"--shortcut", "re", "--dry-run")
+	require.NoError(t, err, "dry-run: %s", out)
+
+	assert.Contains(t, out, "create dir workflow/research/",
+		"per-action line for workflow dir missing: %s", out)
+	for _, sub := range []string{"inbox", "active", "ready",
+		"dungeon/completed", "dungeon/archived", "dungeon/someday"} {
+		assert.Contains(t, out, "create dir workflow/research/"+sub+"/",
+			"per-action line for status dir %s missing: %s", sub, out)
+		assert.Contains(t, out, "create file workflow/research/"+sub+"/.gitkeep",
+			"per-action line for gitkeep in %s missing: %s", sub, out)
+	}
+	assert.Contains(t, out, "create file workflow/research/OBEY.md",
+		"per-action line for OBEY.md missing: %s", out)
+	assert.Contains(t, out, "create shortcut re -> workflow/research/",
+		"per-action line for shortcut missing: %s", out)
+}


### PR DESCRIPTION
Closes 10 merge-blocking findings from CW0003 Phase 002 (REVIEW). Second sequence of Phase 003.

## Findings closed

| ID | Surface | Description |
|---|---|---|
| `CW0003-format-01` | format | Doctor false-positives on intents/festivals (52 in real repos) — marker-existence filter |
| `CW0003-format-02` | format | ref / quest_id shape unvalidated — regex validation at load time |
| `CW0003-format-03` | format | `tagShellRegex` unanchored — quote-guard rejects Revert-subject false positives |
| `CW0003-format-04` | format | ParseTag silently drops unknown trailing segments — unknown branch now seeks next prefix |
| `CW0003-format-06` | format | `backfillMissingRefs` aborted on first per-item error — collects failures and continues |
| `CW0003-format-13` | format | Silent WI-less tag for v1alpha5 workitems — stderr warning via `StagingPlan.Warnings` |
| `CW0003-links-12` (proposed) | links | Doctor wedged on malformed `links.yaml` — new `QuarantineBroken` + `workitem.registry.parse-error` finding |
| `CW0003-links-13` (proposed) | links | Resolver aborted on tier-internal errors — `result="error"` trace + continue to next tier |
| `CW0003-workflow-01` | workflow | `workflow create --dry-run` showed one header line — new `planActionLines` emits per-action lines per DESIGN.md §4.1 |
| `CW0003-workflow-10` | workflow | Dedup `fix_hint` misrepresented actual behavior — hint now matches `deduplicateShortcut` policy |

## Test evidence

- `internal/workitem/metadata_test.go` — 3 new table cases (invalid ref shape, ref wrong length, invalid quest_id shape)
- `internal/git/campaign_tag_full_test.go` — 3 new adversarial cases (Revert subject, quoted backport subject, malformed middle segment with recoverable WI- suffix)
- `internal/commands/workitem/resolve_test.go` — `TestResolve_BrokenPrimaryLinkDoesNotFallThrough` inverted: now asserts fall-through with an `error` trace step instead of asserting hard error
- All existing tests pass: `internal/workitem/...`, `internal/git/...`, `internal/commands/workitem/...`, `internal/commands/workflow/...`

## Coordination notes

- This PR coordinates with seq-04 (`links-registry-hardening`) on the resolver fall-through pattern. Seq-04 closes `CW0003-links-03` using the same `result="error"` shape this PR established for `links-13`. Whichever lands first sets the contract; the other rebases mechanically.
- `CW0003-format-13` policy: chose option (b) warn-and-skip instead of option (a) auto-backfill-mid-commit. Rationale: auto-backfill at commit time would couple the commit success to file-lock acquisition; warn-and-skip preserves commit success while making the gap visible to the user.

## Target

Targets `feat/workflow-surface-CW0003` (the integrated trunk), NOT `main`.

## Festival tracking

Festival `camp-workitem-linking-and-commits-CW0003` / Phase 003 / sequence 02 (`doctor_and_tag_grammar`).