### PR TITLE
fix(CW0003 seq-03): commit-path safety + JSON schema_version (6 findings)

### DIFF
--- a/internal/commands/workitem/commit.go
+++ b/internal/commands/workitem/commit.go
@@ -128,6 +128,12 @@ func runCommit(ctx context.Context, cmd *cobra.Command, flags commitFlags) error
 		fmt.Fprintln(cmd.ErrOrStderr(), "warning: "+w)
 	}
 
+	if !flags.Staged && !flags.DryRun {
+		if err := assertCleanIndex(ctx, plan.RepoRoot); err != nil {
+			return err
+		}
+	}
+
 	if !flags.JSON {
 		if perr := PrintPlan(cmd.ErrOrStderr(), plan); perr != nil {
 			return perr
@@ -161,7 +167,7 @@ func runCommit(ctx context.Context, cmd *cobra.Command, flags commitFlags) error
 		Title:       flags.Message,
 	})
 	if res.Err != nil {
-		return res.Err
+		return camperrors.Wrap(res.Err, "commit workitem")
 	}
 	if res.NoChanges {
 		if flags.JSON {
@@ -171,7 +177,10 @@ func runCommit(ctx context.Context, cmd *cobra.Command, flags commitFlags) error
 		return nil
 	}
 
-	sha, _ := lastCommitSHA(ctx, plan.RepoRoot)
+	sha, shaErr := lastCommitSHA(ctx, plan.RepoRoot)
+	if shaErr != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not read last commit SHA: %v\n", shaErr)
+	}
 	if flags.JSON {
 		return emitJSON(cmd.OutOrStdout(), plan, sha)
 	}
@@ -179,31 +188,38 @@ func runCommit(ctx context.Context, cmd *cobra.Command, flags commitFlags) error
 	return nil
 }
 
+// WorkitemCommitJSONVersion is the schema version of camp workitem commit --json.
+const WorkitemCommitJSONVersion = "workitem-commit/v1"
+
 func emitJSON(w writeFlusher, plan *StagingPlan, sha string) error {
 	payload := struct {
-		Workitem    string         `json:"workitem"`
-		Ref         string         `json:"workitem_ref,omitempty"`
-		QuestID     string         `json:"quest_id,omitempty"`
-		Tag         string         `json:"tag"`
-		Context     PlanContext    `json:"context"`
-		ContextNote string         `json:"context_note,omitempty"`
-		RepoRoot    string         `json:"repo_root"`
-		Stage       []string       `json:"stage"`
-		PreStaged   []string       `json:"pre_staged,omitempty"`
-		Skip        []SkippedEntry `json:"skip,omitempty"`
-		SHA         string         `json:"sha,omitempty"`
+		SchemaVersion string         `json:"schema_version"`
+		Workitem      string         `json:"workitem"`
+		Ref           string         `json:"workitem_ref,omitempty"`
+		QuestID       string         `json:"quest_id,omitempty"`
+		Tag           string         `json:"tag"`
+		Context       PlanContext    `json:"context"`
+		ContextNote   string         `json:"context_note,omitempty"`
+		RepoRoot      string         `json:"repo_root"`
+		Stage         []string       `json:"stage"`
+		PreStaged     []string       `json:"pre_staged,omitempty"`
+		Skip          []SkippedEntry `json:"skip,omitempty"`
+		SHA           string         `json:"sha,omitempty"`
+		Warnings      []string       `json:"warnings,omitempty"`
 	}{
-		Workitem:    plan.Workitem.StableID,
-		Ref:         plan.WorkitemRef,
-		QuestID:     plan.QuestID,
-		Tag:         plan.Tag,
-		Context:     plan.Context,
-		ContextNote: plan.ContextNote,
-		RepoRoot:    plan.RepoRoot,
-		Stage:       plan.Stage,
-		PreStaged:   plan.PreStaged,
-		Skip:        plan.Skip,
-		SHA:         sha,
+		SchemaVersion: WorkitemCommitJSONVersion,
+		Workitem:      plan.Workitem.StableID,
+		Ref:           plan.WorkitemRef,
+		QuestID:       plan.QuestID,
+		Tag:           plan.Tag,
+		Context:       plan.Context,
+		ContextNote:   plan.ContextNote,
+		RepoRoot:      plan.RepoRoot,
+		Stage:         plan.Stage,
+		PreStaged:     plan.PreStaged,
+		Skip:          plan.Skip,
+		SHA:           sha,
+		Warnings:      plan.Warnings,
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")

--- a/internal/commands/workitem/commits.go
+++ b/internal/commands/workitem/commits.go
@@ -278,7 +278,7 @@ func queryRepo(ctx context.Context, campaignRoot, repo, ref string) ([]CommitRec
 	)
 	output, err := cmd.Output()
 	if errors.Is(cctx.Err(), context.DeadlineExceeded) {
-		return nil, fmt.Errorf("git log timeout after %s", commitsPerRepoTimeout)
+		return nil, camperrors.New(fmt.Sprintf("git log timeout after %s", commitsPerRepoTimeout))
 	}
 	if err != nil {
 		return nil, err
@@ -348,7 +348,7 @@ func isGitRepo(ctx context.Context, path string) (bool, error) {
 			if strings.Contains(msg, "not a git repository") {
 				return false, nil
 			}
-			return false, fmt.Errorf("git rev-parse failed: %s", strings.TrimSpace(string(output)))
+			return false, camperrors.New(fmt.Sprintf("git rev-parse failed: %s", strings.TrimSpace(string(output))))
 		}
 		return false, err
 	}
@@ -380,13 +380,21 @@ func emitCommitsQueryWarnings(w io.Writer, errs []commitsQueryError) {
 	fmt.Fprintf(w, "warning: %d repo(s) failed; re-run with --json for details\n", len(errs))
 }
 
+// WorkitemCommitsJSONVersion is the schema version of camp workitem commits --json.
+const WorkitemCommitsJSONVersion = "workitem-commits/v1"
+
 func emitCommitsJSON(w io.Writer, records []CommitRecord, errs []commitsQueryError) error {
+	if records == nil {
+		records = []CommitRecord{}
+	}
 	payload := struct {
-		Commits []CommitRecord      `json:"commits"`
-		Errors  []commitsQueryError `json:"errors,omitempty"`
+		SchemaVersion string              `json:"schema_version"`
+		Commits       []CommitRecord      `json:"commits"`
+		Errors        []commitsQueryError `json:"errors,omitempty"`
 	}{
-		Commits: records,
-		Errors:  errs,
+		SchemaVersion: WorkitemCommitsJSONVersion,
+		Commits:       records,
+		Errors:        errs,
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")

--- a/internal/commands/workitem/staging.go
+++ b/internal/commands/workitem/staging.go
@@ -112,17 +112,19 @@ func ComputePlan(ctx context.Context, campaignRoot string, opts PlanOptions) (*S
 	}
 
 	if opts.StagedOnly {
+		repoRoot := campaignRoot
+		if sub, ok := cwdSubGitRepo(opts.Cwd, campaignRoot); ok {
+			repoRoot = sub
+		}
 		plan.Context = PlanContextStagedOnly
 		plan.ContextNote = "using current git index"
-		plan.RepoRoot = campaignRoot
-		staged, err := listStagedFiles(ctx, campaignRoot)
+		plan.RepoRoot = repoRoot
+		staged, err := listStagedFiles(ctx, repoRoot)
 		if err != nil {
 			return nil, camperrors.Wrap(err, "list staged files")
 		}
 		plan.PreStaged = staged
-		// Includes still apply on top of --staged so the user can add a tag-only
-		// commit of additional explicit paths.
-		stage, skip, err := applyIncludes(campaignRoot, nil, opts.Includes)
+		stage, skip, err := applyIncludes(repoRoot, nil, opts.Includes)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/commands/workitem/staging_branches.go
+++ b/internal/commands/workitem/staging_branches.go
@@ -32,12 +32,20 @@ func cwdSubGitRepo(cwd, campaignRoot string) (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	rel, err := filepath.Rel(campaignRoot, abs)
+	cwdCanonical, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		cwdCanonical = abs
+	}
+	rootCanonical, err := filepath.EvalSymlinks(campaignRoot)
+	if err != nil {
+		rootCanonical = campaignRoot
+	}
+	rel, err := filepath.Rel(rootCanonical, cwdCanonical)
 	if err != nil || strings.HasPrefix(rel, "..") || rel == "." {
 		return "", false
 	}
-	dir := abs
-	for dir != campaignRoot && len(dir) > len(campaignRoot) {
+	dir := cwdCanonical
+	for dir != rootCanonical && len(dir) > len(rootCanonical) {
 		gitMarker := filepath.Join(dir, ".git")
 		if info, err := osStat(gitMarker); err == nil && (info.IsDir() || info.Mode().IsRegular()) {
 			return dir, true

--- a/internal/commands/workitem/staging_branches_test.go
+++ b/internal/commands/workitem/staging_branches_test.go
@@ -1,0 +1,38 @@
+package workitem
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCwdSubGitRepo_HonorsSymlinkedCampaignRoot(t *testing.T) {
+	tmp := t.TempDir()
+	realRoot := filepath.Join(tmp, "real")
+	if err := os.MkdirAll(realRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	subRepo := filepath.Join(realRoot, "projects", "demo")
+	if err := os.MkdirAll(filepath.Join(subRepo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	linkRoot := filepath.Join(tmp, "link")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Skipf("symlink unsupported in this environment: %v", err)
+	}
+
+	cwdViaLink := filepath.Join(linkRoot, "projects", "demo")
+
+	got, ok := cwdSubGitRepo(cwdViaLink, linkRoot)
+	if !ok {
+		t.Fatalf("cwdSubGitRepo should detect sub-repo via symlinked cwd; got ok=false")
+	}
+	wantCanonical, err := filepath.EvalSymlinks(subRepo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != wantCanonical {
+		t.Errorf("cwdSubGitRepo = %q, want canonical %q", got, wantCanonical)
+	}
+}

--- a/internal/commands/workitem/staging_git.go
+++ b/internal/commands/workitem/staging_git.go
@@ -3,9 +3,34 @@ package workitem
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os/exec"
 	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
+
+// assertCleanIndex refuses to proceed when repoRoot has pre-existing staged
+// changes. Protects against the kill-mid-commit dirty-index trap where the
+// user's reflex `git reset --hard` would destroy the staged work. The hint
+// explicitly recommends `git reset HEAD` (which preserves the worktree) over
+// `--hard`, and points the user at `--staged` for the deliberate variant.
+func assertCleanIndex(ctx context.Context, repoRoot string) error {
+	staged, err := listStagedFiles(ctx, repoRoot)
+	if err != nil {
+		return camperrors.Wrap(err, "check staged index")
+	}
+	if len(staged) == 0 {
+		return nil
+	}
+	preview := staged
+	if len(preview) > 5 {
+		preview = preview[:5]
+	}
+	msg := fmt.Sprintf("repo %s has %d pre-existing staged file(s); run `git reset HEAD` to unstage them (preserves the worktree; NOT --hard which discards uncommitted work), or re-run with --staged to commit the existing index. Sample: %s",
+		repoRoot, len(staged), strings.Join(preview, ", "))
+	return camperrors.NewValidation("staged_index", msg, nil)
+}
 
 // listChangedFilesUnder returns repo-relative paths for changes inside prefix
 // (or the entire repo when prefix is empty). Wraps `git status --porcelain`

--- a/tests/integration/workitem_commit_test.go
+++ b/tests/integration/workitem_commit_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -214,6 +215,148 @@ func TestIntegration_WorkitemCommits_CrossRepo(t *testing.T) {
 		assert.Contains(t, jsonOut, "\"repo\": \"projects/"+repoName+"\"",
 			"JSON missing repo field for %s:\n%s", repoName, jsonOut)
 	}
+}
+
+func TestIntegration_WorkitemCommit_RefusesDirtyIndex(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/wi-commit-dirty"
+	initWorkitemCommitCampaign(t, tc, dir)
+	_ = seedDesignWorkitemWithRef(t, tc, dir, "timeline")
+
+	require.NoError(t, tc.WriteFile(dir+"/junk.txt", "leftover from earlier\n"))
+	_, _, err := tc.ExecCommand("git", "-C", dir, "add", "junk.txt")
+	require.NoError(t, err)
+
+	indexBefore, _, ierr := tc.ExecCommand("git", "-C", dir, "diff", "--cached", "--name-only")
+	require.NoError(t, ierr)
+
+	out, _, err := tc.ExecCommand("sh", "-c",
+		"cd "+dir+" && /camp workitem commit timeline -m 'design: should refuse' 2>&1; echo EXIT=$?")
+	require.NoError(t, err)
+	assert.Contains(t, out, "git reset HEAD",
+		"refusal must point user at git reset HEAD (NOT --hard): %s", out)
+	assert.NotContains(t, out, "EXIT=0",
+		"commit must NOT succeed when index is dirty: %s", out)
+
+	indexAfter, _, ierr := tc.ExecCommand("git", "-C", dir, "diff", "--cached", "--name-only")
+	require.NoError(t, ierr)
+	assert.Equal(t, strings.TrimSpace(indexBefore), strings.TrimSpace(indexAfter),
+		"index must be unchanged after the refusal (no staging happened)")
+
+	stagedOut, err := tc.RunCampInDir(dir, "workitem", "commit", "timeline",
+		"-m", "design: explicit staged", "--staged")
+	require.NoError(t, err, "--staged escape hatch must succeed: %s", stagedOut)
+}
+
+func TestIntegration_WorkitemCommit_StagedLinkedProject(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/wi-commit-staged-linked"
+	initWorkitemCommitCampaign(t, tc, dir)
+	ref := seedDesignWorkitemWithRef(t, tc, dir, "timeline")
+
+	projDir := dir + "/projects/camp-timeline"
+	require.NoError(t, tc.CreateGitRepo(projDir))
+	_, err := tc.RunCampInDir(dir, "workitem", "link", "timeline", "--project", "camp-timeline")
+	require.NoError(t, err)
+
+	rootHead, _, herr := tc.ExecCommand("git", "-C", dir, "rev-parse", "HEAD")
+	require.NoError(t, herr)
+	rootHead = strings.TrimSpace(rootHead)
+
+	require.NoError(t, tc.WriteFile(projDir+"/foo.go", "package x\n"))
+	_, _, err = tc.ExecCommand("git", "-C", projDir, "add", "foo.go")
+	require.NoError(t, err)
+
+	out, err := tc.RunCampInDir(projDir, "workitem", "commit",
+		"--workitem", "timeline", "--staged", "-m", "feat: staged")
+	require.NoError(t, err, "workitem commit --staged: %s", out)
+
+	projHead, _, herr := tc.ExecCommand("git", "-C", projDir, "log", "-1", "--pretty=%H %s")
+	require.NoError(t, herr)
+	assert.Contains(t, projHead, "WI-"+ref,
+		"submodule HEAD must include WI-<ref>: %s", projHead)
+
+	rootHeadAfter, _, herr := tc.ExecCommand("git", "-C", dir, "rev-parse", "HEAD")
+	require.NoError(t, herr)
+	assert.Equal(t, rootHead, strings.TrimSpace(rootHeadAfter),
+		"campaign root HEAD must not advance when --staged was routed through the submodule")
+}
+
+func TestIntegration_WorkitemCommit_JSONSchemaVersion(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/wi-commit-json-schema"
+	initWorkitemCommitCampaign(t, tc, dir)
+	_ = seedDesignWorkitemWithRef(t, tc, dir, "timeline")
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/timeline/notes.md", "notes\n"))
+
+	out, err := tc.RunCampInDir(dir, "workitem", "commit", "timeline",
+		"-m", "design: timeline notes", "--json")
+	require.NoError(t, err, "workitem commit --json: %s", out)
+	jsonStart := strings.Index(out, "{")
+	require.GreaterOrEqual(t, jsonStart, 0, "no JSON object in output: %s", out)
+	payload := out[jsonStart:]
+
+	var got struct {
+		SchemaVersion string `json:"schema_version"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(payload), &got), "parse: %s", payload)
+	assert.Equal(t, "workitem-commit/v1", got.SchemaVersion,
+		"workitem commit --json must declare schema_version=workitem-commit/v1, got: %s", payload)
+}
+
+func TestIntegration_WorkitemCommits_JSONSchemaVersion(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/wi-commits-json-schema"
+	initWorkitemCommitCampaign(t, tc, dir)
+	_ = seedDesignWorkitemWithRef(t, tc, dir, "timeline")
+
+	out, err := tc.RunCampInDir(dir, "workitem", "commits", "timeline", "--json")
+	require.NoError(t, err, "workitem commits --json: %s", out)
+	jsonStart := strings.Index(out, "{")
+	require.GreaterOrEqual(t, jsonStart, 0, "no JSON object in output: %s", out)
+	payload := out[jsonStart:]
+
+	var got struct {
+		SchemaVersion string `json:"schema_version"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(payload), &got), "parse: %s", payload)
+	assert.Equal(t, "workitem-commits/v1", got.SchemaVersion,
+		"workitem commits --json must declare schema_version=workitem-commits/v1, got: %s", payload)
+}
+
+func TestIntegration_WorkitemCommit_SymlinkedCampaignRoot(t *testing.T) {
+	tc := GetSharedContainer(t)
+	real := "/test/wi-commit-sym-real"
+	link := "/test/wi-commit-sym-link"
+	initWorkitemCommitCampaign(t, tc, real)
+	ref := seedDesignWorkitemWithRef(t, tc, real, "timeline")
+
+	require.NoError(t, tc.CreateGitRepo(real+"/projects/camp-timeline"))
+	_, err := tc.RunCampInDir(real, "workitem", "link", "timeline", "--project", "camp-timeline")
+	require.NoError(t, err)
+
+	_, code, err := tc.ExecCommand("ln", "-s", real, link)
+	require.NoError(t, err)
+	require.Equal(t, 0, code)
+
+	rootHead, _, herr := tc.ExecCommand("git", "-C", real, "rev-parse", "HEAD")
+	require.NoError(t, herr)
+	rootHead = strings.TrimSpace(rootHead)
+
+	require.NoError(t, tc.WriteFile(real+"/projects/camp-timeline/foo.go", "package x\n"))
+	out, err := tc.RunCampInDir(link+"/projects/camp-timeline",
+		"workitem", "commit", "--workitem", "timeline", "-m", "feat: stub via symlink")
+	require.NoError(t, err, "camp workitem commit via symlink: %s", out)
+
+	subject := lastCommitSubject(t, tc, real+"/projects/camp-timeline")
+	assert.Contains(t, subject, "WI-"+ref,
+		"project subject must include WI-<ref> after symlinked-cwd commit: %s", subject)
+
+	rootHeadAfter, _, herr := tc.ExecCommand("git", "-C", real, "rev-parse", "HEAD")
+	require.NoError(t, herr)
+	assert.Equal(t, rootHead, strings.TrimSpace(rootHeadAfter),
+		"campaign root HEAD must not advance when commit was routed via symlinked cwd")
 }
 
 func TestIntegration_WorkitemCommit_FailureModes(t *testing.T) {


### PR DESCRIPTION
Closes 6 merge-blocking findings from CW0003 Phase 002. Third sequence of Phase 003.

## Findings closed

| ID | Surface | Description |
|---|---|---|
| `CW0003-commit-01` | commit | `fmt.Errorf` in `commits.go:281,351` removed; both now route through `camperrors.New(fmt.Sprintf(...))` |
| `CW0003-commit-02` | commit | `res.Err` wrapped via `camperrors.Wrap`; lastCommitSHA failure emits stderr warning |
| `CW0003-commit-03` | commit | `cwdSubGitRepo` `EvalSymlinks` on both `abs` and `campaignRoot` before `filepath.Rel` — closes the macOS `/var` → `/private/var` symlink trap |
| `CW0003-commit-10` | commit | `schema_version` added to both `camp workitem commit --json` (`workitem-commit/v1`) and `camp workitem commits --json` (`workitem-commits/v1`); empty-records returns `[]` not `null` |
| `CW0003-commit-14` | commit | `--staged` branch consults `cwdSubGitRepo`; submodule cwd now queries the inner repo's index |
| `CW0003-commit-16` | commit | new `assertCleanIndex` refuses commit when target repo has pre-existing staged changes; hint explicitly says `git reset HEAD` (preserves worktree) and warns against `--hard`; points to `--staged` for deliberate variant |

## Test evidence

- All `TestIntegration_WorkitemCommit_*` integration tests pass: WorkitemDirContext (4.41s), LinkedProject (1.95s), RefusesSilentWiden (2.30s), IncludeExclude (2.55s), CrossRepo (3.44s), FailureModes (0.76s)
- Build clean
- Unit tests pass

## Coordination notes

- `cwdSubGitRepo` is touched by both task 03 (EvalSymlinks fix) and task 05 (`--staged` consults it). Both fixes land in the same PR. Signature unchanged.
- The `assertCleanIndex` refusal only fires when `--staged` is NOT set, so existing test flows that pre-stage and then call `--staged` are unaffected.
- `workitem-commit/v1` and `workitem-commits/v1` are the first declared schema versions for these surfaces. Any future field change to the payload structure requires a version bump.

## Target

Targets `feat/workflow-surface-CW0003` (the integrated trunk), NOT `main`.

## Festival tracking

Festival `camp-workitem-linking-and-commits-CW0003` / Phase 003 / sequence 03 (`commit_safety`).