### PR TITLE
fix(CW0003 seq-04): links registry hardening (4 findings)

### DIFF
--- a/internal/commands/workitem/link.go
+++ b/internal/commands/workitem/link.go
@@ -112,8 +112,12 @@ func runLink(ctx context.Context, cmd *cobra.Command, opts linkOptions) error {
 		return err
 	}
 
+	id, err := generateLinkID(registry)
+	if err != nil {
+		return err
+	}
 	link := links.Link{
-		ID:          generateLinkID(),
+		ID:          id,
 		WorkitemID:  workitemIDForLink(wi, opts),
 		WorkitemKey: workitemKeyForLink(wi),
 		Scope:       *scope,
@@ -290,19 +294,29 @@ func emitLinkJSON(w io.Writer, link links.Link) error {
 	})
 }
 
-func generateLinkID() string {
-	// Local-only ID generator: yyyymmdd + 6 hex bytes of randomness.
-	// crypto/rand keeps the per-day collision domain wide.
-	var b [3]byte
-	if _, err := readRand(b[:]); err != nil {
-		// In the unlikely case of rand failure, fall back to a time-derived
-		// suffix so we still produce a valid ID rather than abort the link.
-		return fmt.Sprintf("lnk_%s_%06x",
-			time.Now().UTC().Format("20060102"),
-			time.Now().UnixNano()&0xffffff)
+// generateLinkID returns a fresh lnk_YYYYMMDD_<6 hex> ID that does not
+// collide with any existing entry in registry. Retries up to 32 times against
+// crypto/rand per SCHEMA.md §4; returns an error rather than falling back to
+// a wall-clock suffix because a non-unique ID corrupts the registry's primary
+// key invariant.
+func generateLinkID(registry *links.Links) (string, error) {
+	existing := make(map[string]struct{}, len(registry.Links))
+	for _, l := range registry.Links {
+		existing[l.ID] = struct{}{}
 	}
-	return fmt.Sprintf("lnk_%s_%02x%02x%02x",
-		time.Now().UTC().Format("20060102"), b[0], b[1], b[2])
+	const maxAttempts = 32
+	for i := 0; i < maxAttempts; i++ {
+		var b [3]byte
+		if _, err := readRand(b[:]); err != nil {
+			return "", camperrors.Wrap(err, "generate link id: read random bytes")
+		}
+		candidate := fmt.Sprintf("lnk_%s_%02x%02x%02x",
+			time.Now().UTC().Format("20060102"), b[0], b[1], b[2])
+		if _, clash := existing[candidate]; !clash {
+			return candidate, nil
+		}
+	}
+	return "", camperrors.New(fmt.Sprintf("generate link id: %d-attempt collision retry exhausted", maxAttempts))
 }
 
 func isValidRole(r links.Role) bool {

--- a/internal/commands/workitem/link_rand_test.go
+++ b/internal/commands/workitem/link_rand_test.go
@@ -1,0 +1,74 @@
+package workitem
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+// TestGenerateLinkID_RetriesOnCollision proves the retry loop runs when the
+// first crypto/rand draw would have collided with an existing registry entry.
+// Pre-fix (no retry) this test fails: generateLinkID returns the same ID
+// twice.
+func TestGenerateLinkID_RetriesOnCollision(t *testing.T) {
+	today := time.Now().UTC().Format("20060102")
+	colliding := "lnk_" + today + "_010101"
+
+	registry := &links.Links{Links: []links.Link{{
+		ID:         colliding,
+		WorkitemID: "test",
+		Scope:      links.LinkScope{Kind: links.ScopeProject, Path: "projects/x"},
+		Role:       links.RolePrimary,
+		CreatedAt:  time.Now().UTC(),
+		CreatedBy:  "test",
+	}}}
+
+	call := 0
+	prev := readRand
+	defer func() { readRand = prev }()
+	readRand = func(b []byte) (int, error) {
+		call++
+		if call == 1 {
+			b[0], b[1], b[2] = 0x01, 0x01, 0x01
+			return 3, nil
+		}
+		b[0], b[1], b[2] = 0xab, 0xcd, 0xef
+		return 3, nil
+	}
+
+	id, err := generateLinkID(registry)
+	if err != nil {
+		t.Fatalf("generateLinkID: %v", err)
+	}
+	if id == colliding {
+		t.Fatalf("expected retry to produce non-colliding ID, got duplicate %q", id)
+	}
+	if !strings.HasSuffix(id, "_abcdef") {
+		t.Errorf("expected retry to use second rand draw (abcdef), got %q", id)
+	}
+	if call != 2 {
+		t.Errorf("expected exactly 2 rand draws (collide, succeed), got %d", call)
+	}
+}
+
+func TestGenerateLinkID_ReturnsWrappedErrorOnRandFailure(t *testing.T) {
+	prev := readRand
+	defer func() { readRand = prev }()
+	readRand = func(b []byte) (int, error) { return 0, errRandStub }
+
+	_, err := generateLinkID(&links.Links{})
+	if err == nil {
+		t.Fatal("expected error when readRand fails")
+	}
+	if !strings.Contains(err.Error(), "generate link id") {
+		t.Errorf("error should be wrapped with 'generate link id' context, got: %v", err)
+	}
+}
+
+var errRandStub = errStub("rand source unavailable")
+
+type errStub string
+
+func (e errStub) Error() string { return string(e) }

--- a/internal/commands/workitem/resolve_test.go
+++ b/internal/commands/workitem/resolve_test.go
@@ -98,7 +98,7 @@ func TestResolve_LinkTier(t *testing.T) {
 	}
 }
 
-func TestResolve_BrokenPrimaryLinkDoesNotFallThrough(t *testing.T) {
+func TestResolve_BrokenPrimaryLinkFallsThroughToLowerTier(t *testing.T) {
 	root := linkTestCampaign(t)
 	restore := chdir(t, root)
 	defer restore()
@@ -120,12 +120,22 @@ func TestResolve_BrokenPrimaryLinkDoesNotFallThrough(t *testing.T) {
 	}
 
 	cwd := filepath.Join(root, "projects", "demo")
-	_, err := resolver.Resolve(context.Background(), root, resolver.Options{Cwd: cwd})
-	if err == nil {
-		t.Fatal("expected broken primary link to fail instead of falling through")
+	res, err := resolver.Resolve(context.Background(), root, resolver.Options{Cwd: cwd})
+	if err != nil {
+		t.Fatalf("resolver should not error on broken primary link, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "primary link") {
-		t.Fatalf("err = %v, want primary link context", err)
+	if res == nil {
+		t.Fatal("expected non-nil result")
+	}
+	sawError := false
+	for _, step := range res.Trace {
+		if step.Result == "error" {
+			sawError = true
+			break
+		}
+	}
+	if !sawError {
+		t.Fatalf("expected an error trace step from the broken link tier, got %#v", res.Trace)
 	}
 }
 

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -325,6 +325,10 @@ workitems/current.yaml
 				return nil, camperrors.Wrap(err, "failed to create .gitignore")
 			}
 			result.FilesCreated = append(result.FilesCreated, ".campaign/.gitignore")
+		} else if opts.Repair {
+			if err := appendGitignoreEntryIfMissing(absDir, "workitems/current.yaml"); err != nil {
+				return nil, camperrors.Wrap(err, "failed to append workitems/current.yaml to .gitignore")
+			}
 		}
 	}
 

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -317,6 +317,9 @@ cache/
 
 # Tool-managed state (workitem priorities, regenerated automatically)
 settings/workitems.json
+
+# Per-machine current-workitem selection (do not share across machines)
+workitems/current.yaml
 `
 			if err := os.WriteFile(gitignorePath, []byte(gitignoreContent), 0644); err != nil {
 				return nil, camperrors.Wrap(err, "failed to create .gitignore")

--- a/internal/scaffold/repair.go
+++ b/internal/scaffold/repair.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/Obedience-Corp/camp/internal/config"
@@ -423,6 +424,16 @@ func computeMiscFileChanges(absDir string, plan *RepairPlan) {
 			Key:         ".campaign/.gitignore",
 			Description: "missing gitignore",
 		})
+	} else if err == nil {
+		raw, readErr := os.ReadFile(gitignorePath)
+		if readErr == nil && !strings.Contains(string(raw), "workitems/current.yaml") {
+			plan.Changes = append(plan.Changes, RepairChange{
+				Type:        RepairModify,
+				Category:    "file",
+				Key:         ".campaign/.gitignore",
+				Description: "missing workitems/current.yaml entry",
+			})
+		}
 	}
 
 	claudePath := filepath.Join(absDir, "CLAUDE.md")
@@ -434,6 +445,26 @@ func computeMiscFileChanges(absDir string, plan *RepairPlan) {
 			Description: "missing symlink",
 		})
 	}
+}
+
+// appendGitignoreEntryIfMissing appends a single line to the campaign
+// .gitignore when the entry is not already present. The operation is
+// append-only and never rewrites the file wholesale.
+func appendGitignoreEntryIfMissing(absDir, entry string) error {
+	gitignorePath := filepath.Join(absDir, config.CampaignDir, ".gitignore")
+	raw, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		return err
+	}
+	if strings.Contains(string(raw), entry) {
+		return nil
+	}
+	suffix := "\n"
+	if len(raw) > 0 && raw[len(raw)-1] != '\n' {
+		suffix = "\n\n"
+	}
+	addition := suffix + "# Per-machine current-workitem selection (do not share across machines)\n" + entry + "\n"
+	return os.WriteFile(gitignorePath, append(raw, []byte(addition)...), 0o644)
 }
 
 // isUserDefined returns true if a shortcut was added by the user (not auto-generated).

--- a/internal/workitem/links/links_test.go
+++ b/internal/workitem/links/links_test.go
@@ -97,6 +97,17 @@ func TestSaveLoadRoundTrip_ExampleLinksFixture(t *testing.T) {
 	in := loadFixture(t, "example_links.yaml")
 	seedScopeTargets(t, root, in)
 
+	fixtureNow, err := time.Parse(time.RFC3339, "2026-05-24T22:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if errs := Validate(context.Background(), in, ValidateOptions{
+		CampaignRoot: root,
+		Now:          fixtureNow,
+	}); len(errs) > 0 {
+		t.Fatalf("example_links.yaml fixture fails its own schema: %+v", errs)
+	}
+
 	if err := Save(context.Background(), root, in); err != nil {
 		t.Fatalf("Save: %v", err)
 	}

--- a/internal/workitem/links/testdata/example_links.yaml
+++ b/internal/workitem/links/testdata/example_links.yaml
@@ -10,7 +10,7 @@ links:
     created_at: 2026-05-24T19:00:00Z
     created_by: camp_workitem_link
 
-  - id: lnk_20260524_ef34gh
+  - id: lnk_20260524_ef34ab
     workitem_id: design-camp-timeline-2026-05-19
     workitem_key: design:workflow/design/camp-timeline
     scope:

--- a/internal/workitem/resolver/resolver.go
+++ b/internal/workitem/resolver/resolver.go
@@ -101,10 +101,17 @@ func Resolve(ctx context.Context, root string, opts Options) (*Resolution, error
 	}
 	for _, tier := range tiers {
 		wi, step, err := tier.fn()
-		result.Trace = append(result.Trace, step)
 		if err != nil {
-			return nil, err
+			step.Result = "error"
+			if step.Detail == "" {
+				step.Detail = err.Error()
+			} else {
+				step.Detail = step.Detail + ": " + err.Error()
+			}
+			result.Trace = append(result.Trace, step)
+			continue
 		}
+		result.Trace = append(result.Trace, step)
 		if wi != nil {
 			result.Workitem = wi
 			result.Source = tier.source

--- a/tests/integration/repair_test.go
+++ b/tests/integration/repair_test.go
@@ -156,3 +156,49 @@ func TestInitRepair_PreservesUserShortcuts(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, output, path+"/my-stuff")
 }
+
+func TestIntegration_Init_GitignoreCurrentYaml(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRepairCampaign(t, tc, "init-gitignore-current")
+
+	gi, err := tc.ReadFile(path + "/.campaign/.gitignore")
+	require.NoError(t, err)
+	assert.Contains(t, gi, "workitems/current.yaml",
+		"camp init must seed .campaign/.gitignore with workitems/current.yaml: %s", gi)
+}
+
+func TestIntegration_InitRepair_AppendsCurrentYamlIfMissing(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRepairCampaign(t, tc, "repair-gitignore-current")
+
+	gi, err := tc.ReadFile(path + "/.campaign/.gitignore")
+	require.NoError(t, err)
+	stripped := strings.ReplaceAll(gi, "workitems/current.yaml\n", "")
+	require.NotEqual(t, gi, stripped, "fixture must have the line so we can remove it")
+	require.NoError(t, tc.WriteFile(path+"/.campaign/.gitignore", stripped))
+
+	runRepair(t, tc, path)
+
+	after, err := tc.ReadFile(path + "/.campaign/.gitignore")
+	require.NoError(t, err)
+	assert.Contains(t, after, "workitems/current.yaml",
+		"repair must append workitems/current.yaml when missing")
+}
+
+func TestIntegration_WorkitemCurrent_ProducesIgnoredFile(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRepairCampaign(t, tc, "current-ignored")
+	require.NoError(t, tc.CreateGitRepo(path))
+
+	out, err := tc.RunCampInDir(path, "workitem", "create", "ignored-test", "--type", "design", "--title", "x")
+	require.NoError(t, err, "create: %s", out)
+
+	_, err = tc.RunCampInDir(path, "workitem", "current", "ignored-test")
+	require.NoError(t, err)
+
+	checkOut, _, err := tc.ExecCommand("git", "-C", path, "check-ignore", "-v",
+		".campaign/workitems/current.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, checkOut, "workitems/current.yaml",
+		"current.yaml must match a .gitignore rule, got:\n%s", checkOut)
+}


### PR DESCRIPTION
Closes 4 merge-blocking findings from CW0003 Phase 002. Fourth sequence of Phase 003.

## Findings closed

| ID | Surface | Description |
|---|---|---|
| `CW0003-links-01` | links | `generateLinkID` now retries up to 32 times against `crypto/rand` per SCHEMA.md §4; collisions against the loaded registry rejected; rand failure returns an error instead of falling back to the wall-clock suffix |
| `CW0003-links-02` | links | `.campaign/.gitignore` template excludes `workitems/current.yaml` so per-machine selection stops leaking into commits |
| `CW0003-links-03` | links | Resolver fall-through: tier-internal errors record `result="error"` trace and continue, mirroring the `CW0003-links-13` fix shape |
| `CW0003-links-04` | links | `testdata/example_links.yaml` ID corrected from non-hex `ef34gh` to valid hex `ef34ab`; round-trip test now calls `Validate(fixture)` on load to prevent recurrence |

## Test evidence

- `TestSaveLoadRoundTrip_ExampleLinksFixture` now asserts the fixture passes its own schema via `Validate(...)` before round-tripping
- `TestResolve_BrokenPrimaryLinkFallsThroughToLowerTier` (renamed + inverted from the old hard-error assertion) verifies the new trace-step behavior
- All existing tests pass: `internal/workitem/...`, `internal/commands/workitem/...`, `internal/scaffold/...`
- Build clean

## Coordination notes

- This PR's resolver fall-through (CW0003-links-03) is functionally identical to seq-02's CW0003-links-13 fix (both refactor the same loop in `internal/workitem/resolver/resolver.go`). Whichever lands in trunk first sets the contract; the other rebases as a no-op (or trivial conflict on the same lines).
- `generateLinkID` signature change is internal to the `internal/commands/workitem` package; no public API affected.

## Target

Targets `feat/workflow-surface-CW0003` (the integrated trunk).

## Festival tracking

Festival `camp-workitem-linking-and-commits-CW0003` / Phase 003 / sequence 04 (`links_registry_hardening`).