### PR TITLE
feat(init): auto-link campaign skills into tool directories

### DIFF
--- a/cmd/camp/create.go
+++ b/cmd/camp/create.go
@@ -41,6 +41,7 @@ func init() {
 	createCmd.Flags().StringP("description", "d", "", "Campaign description")
 	createCmd.Flags().StringP("mission", "m", "", "Campaign mission statement")
 	createCmd.Flags().Bool("no-git", false, "Skip git repository initialization")
+	createCmd.Flags().Bool("no-skills", false, "Skip linking campaign skills into .claude/skills and .agents/skills")
 	createCmd.Flags().Bool("dry-run", false, "Show what would be done without creating anything")
 	createCmd.Flags().String("path", "", "Override the base campaigns directory (campaign created at <path>/<name>/)")
 }
@@ -87,6 +88,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		Description: cmdutil.GetFlagString(cmd, "description"),
 		Mission:     cmdutil.GetFlagString(cmd, "mission"),
 		NoGit:       cmdutil.GetFlagBool(cmd, "no-git"),
+		NoSkills:    cmdutil.GetFlagBool(cmd, "no-skills"),
 		DryRun:      dryRun,
 		// force, noRegister, repair, yes stay zero — create deliberately does not support them.
 	}

--- a/cmd/camp/init/command.go
+++ b/cmd/camp/init/command.go
@@ -271,13 +271,16 @@ func RunFlow(ctx context.Context, p Params, w Writers, isInteractive bool) error
 	// before the repair auto-commit so healed links are committed in the same pass.
 	var skillsLinked []string
 	var skillsWarnings []string
+	var skillsProjectedPaths []string
 	if !p.NoSkills && !p.DryRun {
-		skillsLinked, skillsWarnings = projectCampaignSkills(result.CampaignRoot)
+		skillsLinked, skillsWarnings, skillsProjectedPaths = projectCampaignSkills(result.CampaignRoot)
 	}
 
-	// Auto-commit after repair (scaffold creates + migrations + skills).
+	// Auto-commit after repair (scaffold creates + migrations + skills). The
+	// repair commit stages a selective file list, so newly projected skill links
+	// must be passed in explicitly or they would be left untracked.
 	if p.Repair && !p.DryRun {
-		commitRepairChanges(ctx, result, opts.RepairPlan, migrationCount, w)
+		commitRepairChanges(ctx, result, opts.RepairPlan, migrationCount, skillsProjectedPaths, w)
 	}
 
 	// Initialize Festival Methodology (unless dry-run).
@@ -374,16 +377,18 @@ func skillsNeedProjection(root string) bool {
 // projectCampaignSkills links campaign skill bundles into every registered tool
 // directory under root. It is best-effort: failures are returned as human-readable
 // warnings rather than aborting the init flow. It returns the tools that were
-// fully linked and any warnings to surface.
-func projectCampaignSkills(root string) (linked []string, warnings []string) {
+// fully linked, any warnings to surface, and the campaign-root-relative paths of
+// the skill links that were created or replaced (so the caller can stage exactly
+// those paths in a selective repair commit).
+func projectCampaignSkills(root string) (linked []string, warnings []string, projectedPaths []string) {
 	skillsDir := filepath.Join(root, campaign.CampaignDir, intskills.SkillsSubdir)
 	if _, err := os.Stat(skillsDir); err != nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	results, err := intskills.LinkDefaultTools(root, skillsDir, false, false, os.Stderr)
 	if err != nil {
-		return nil, []string{fmt.Sprintf("skills not linked: %v", err)}
+		return nil, []string{fmt.Sprintf("skills not linked: %v", err)}, nil
 	}
 
 	for _, res := range results {
@@ -395,7 +400,16 @@ func projectCampaignSkills(root string) (linked []string, warnings []string) {
 			warnings = append(warnings, fmt.Sprintf("%s: %d conflicting path(s) left untouched (%s); run 'camp skills status'",
 				res.Tool, res.Summary.Conflicts, strings.Join(res.Summary.ConflictNames, ", ")))
 		}
+		relPath, err := intskills.ResolveToolPath(res.Tool)
+		if err == nil {
+			for _, slug := range res.Summary.CreatedNames {
+				projectedPaths = append(projectedPaths, filepath.Join(relPath, slug))
+			}
+			for _, slug := range res.Summary.ReplacedNames {
+				projectedPaths = append(projectedPaths, filepath.Join(relPath, slug))
+			}
+		}
 		linked = append(linked, res.Tool)
 	}
-	return linked, warnings
+	return linked, warnings, projectedPaths
 }

--- a/cmd/camp/init/command.go
+++ b/cmd/camp/init/command.go
@@ -15,6 +15,7 @@ import (
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/nav/tui"
 	"github.com/Obedience-Corp/camp/internal/scaffold"
+	intskills "github.com/Obedience-Corp/camp/internal/skills"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -70,6 +71,7 @@ Use --no-git to skip git initialization.`,
 	cmd.Flags().BoolP("force", "f", false, "Initialize in non-empty directory without prompting")
 	cmd.Flags().Bool("no-register", false, "Don't add to global registry")
 	cmd.Flags().Bool("no-git", false, "Skip git repository initialization")
+	cmd.Flags().Bool("no-skills", false, "Skip linking campaign skills into .claude/skills and .agents/skills")
 	cmd.Flags().Bool("dry-run", false, "Show what would be done without creating anything")
 	cmd.Flags().Bool("repair", false, "Add missing files to existing campaign")
 	cmd.Flags().Bool("yes", false, "Skip repair confirmation prompt (for scripting)")
@@ -88,6 +90,7 @@ type Params struct {
 	Force         bool
 	NoRegister    bool
 	NoGit         bool
+	NoSkills      bool
 	DryRun        bool
 	Repair        bool
 	Yes           bool
@@ -135,6 +138,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		Force:         cmdutil.GetFlagBool(cmd, "force"),
 		NoRegister:    cmdutil.GetFlagBool(cmd, "no-register"),
 		NoGit:         cmdutil.GetFlagBool(cmd, "no-git"),
+		NoSkills:      cmdutil.GetFlagBool(cmd, "no-skills"),
 		DryRun:        cmdutil.GetFlagBool(cmd, "dry-run"),
 		Repair:        cmdutil.GetFlagBool(cmd, "repair"),
 		Yes:           cmdutil.GetFlagBool(cmd, "yes"),
@@ -200,6 +204,7 @@ func RunFlow(ctx context.Context, p Params, w Writers, isInteractive bool) error
 		SkipGitInit: p.NoGit,
 		DryRun:      p.DryRun,
 		Repair:      p.Repair,
+		SkipSkills:  p.NoSkills,
 	}
 
 	// Validate options
@@ -214,12 +219,20 @@ func RunFlow(ctx context.Context, p Params, w Writers, isInteractive bool) error
 			return camperrors.Wrap(err, "failed to compute repair plan")
 		}
 
-		if !plan.HasChanges() {
+		skillsPending := !p.NoSkills && skillsNeedProjection(dir)
+
+		if !plan.HasChanges() && !skillsPending {
 			writeLine(w.HumanOut, ui.Success("Campaign is up to date — nothing to repair."))
 			return nil
 		}
 
-		printRepairDiff(plan, w)
+		if plan.HasChanges() {
+			printRepairDiff(plan, w)
+		}
+		if skillsPending {
+			writeLine(w.HumanOut, ui.Subheader("Skills to (re)link:"))
+			writef(w.HumanOut, "  %s project skill bundles into %s\n", ui.SuccessIcon(), strings.Join(intskills.ToolNames(), ", "))
+		}
 
 		if !p.Yes {
 			if !isInteractive {
@@ -254,7 +267,15 @@ func RunFlow(ctx context.Context, p Params, w Writers, isInteractive bool) error
 		migrationCount = moved
 	}
 
-	// Auto-commit after repair (scaffold creates + migrations).
+	// Project campaign skills into tool directories (.claude/skills, .agents/skills)
+	// before the repair auto-commit so healed links are committed in the same pass.
+	var skillsLinked []string
+	var skillsWarnings []string
+	if !p.NoSkills && !p.DryRun {
+		skillsLinked, skillsWarnings = projectCampaignSkills(result.CampaignRoot)
+	}
+
+	// Auto-commit after repair (scaffold creates + migrations + skills).
 	if p.Repair && !p.DryRun {
 		commitRepairChanges(ctx, result, opts.RepairPlan, migrationCount, w)
 	}
@@ -311,7 +332,70 @@ func RunFlow(ctx context.Context, p Params, w Writers, isInteractive bool) error
 		if festInitialized {
 			writeLine(w.HumanOut, ui.KeyValueColored("Festivals:", "initialized", ui.SuccessColor))
 		}
+		if !p.NoSkills {
+			if len(skillsLinked) > 0 {
+				writeLine(w.HumanOut, ui.KeyValueColored("Skills:", "linked ("+strings.Join(skillsLinked, ", ")+")", ui.SuccessColor))
+			}
+			for _, warn := range skillsWarnings {
+				writef(w.HumanOut, "  %s %s\n", ui.WarningIcon(), ui.Warning(warn))
+			}
+		}
 	}
 
 	return nil
+}
+
+// skillsNeedProjection reports whether any registered tool is missing one or
+// more campaign skill projections (so repair has skills work to do). It is a
+// best-effort check: on any error it returns false rather than forcing repair.
+func skillsNeedProjection(root string) bool {
+	skillsDir := filepath.Join(root, campaign.CampaignDir, intskills.SkillsSubdir)
+	slugs, err := intskills.DiscoverSkillSlugs(skillsDir)
+	if err != nil || len(slugs) == 0 {
+		return false
+	}
+	for _, tool := range intskills.ToolNames() {
+		relPath, err := intskills.ResolveToolPath(tool)
+		if err != nil {
+			continue
+		}
+		dest := filepath.Join(root, relPath)
+		state, err := intskills.InspectSkillProjection(dest, skillsDir, slugs)
+		if err != nil {
+			continue
+		}
+		if state.Linked < state.TotalSkills {
+			return true
+		}
+	}
+	return false
+}
+
+// projectCampaignSkills links campaign skill bundles into every registered tool
+// directory under root. It is best-effort: failures are returned as human-readable
+// warnings rather than aborting the init flow. It returns the tools that were
+// fully linked and any warnings to surface.
+func projectCampaignSkills(root string) (linked []string, warnings []string) {
+	skillsDir := filepath.Join(root, campaign.CampaignDir, intskills.SkillsSubdir)
+	if _, err := os.Stat(skillsDir); err != nil {
+		return nil, nil
+	}
+
+	results, err := intskills.LinkDefaultTools(root, skillsDir, false, false, os.Stderr)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("skills not linked: %v", err)}
+	}
+
+	for _, res := range results {
+		if res.Err != nil {
+			warnings = append(warnings, fmt.Sprintf("%s skills not linked: %v", res.Tool, res.Err))
+			continue
+		}
+		if res.Summary.Conflicts > 0 {
+			warnings = append(warnings, fmt.Sprintf("%s: %d conflicting path(s) left untouched (%s); run 'camp skills status'",
+				res.Tool, res.Summary.Conflicts, strings.Join(res.Summary.ConflictNames, ", ")))
+		}
+		linked = append(linked, res.Tool)
+	}
+	return linked, warnings
 }

--- a/cmd/camp/init/init_test.go
+++ b/cmd/camp/init/init_test.go
@@ -22,13 +22,27 @@ func TestBuildRepairCommitFiles_IncludesIntentMigrations(t *testing.T) {
 		},
 	}
 
-	files := buildRepairCommitFiles(result, plan)
+	files := buildRepairCommitFiles(result, plan, nil)
 	got := strings.Join(files, "\n")
 	if !strings.Contains(got, "workflow/intents/inbox/legacy.md") {
 		t.Fatalf("commit files missing legacy source path: %v", files)
 	}
 	if !strings.Contains(got, ".campaign/intents/inbox/legacy.md") {
 		t.Fatalf("commit files missing canonical destination path: %v", files)
+	}
+}
+
+func TestBuildRepairCommitFiles_IncludesSkillProjections(t *testing.T) {
+	result := &scaffold.InitResult{CampaignRoot: "/campaign"}
+	skillPaths := []string{".claude/skills/code-review", ".agents/skills/code-review"}
+
+	files := buildRepairCommitFiles(result, nil, skillPaths)
+	got := strings.Join(files, "\n")
+	if !strings.Contains(got, ".claude/skills/code-review") {
+		t.Fatalf("commit files missing projected claude skill link: %v", files)
+	}
+	if !strings.Contains(got, ".agents/skills/code-review") {
+		t.Fatalf("commit files missing projected agents skill link: %v", files)
 	}
 }
 
@@ -41,13 +55,25 @@ func TestBuildRepairCommitMessage_IncludesIntentMigrations(t *testing.T) {
 				Items:  []string{"legacy.md"},
 			},
 		},
-	}, 0)
+	}, 0, nil)
 
 	if !strings.Contains(msg, "Migrated 1 legacy intent item(s):") {
 		t.Fatalf("commit message missing intent migration summary: %q", msg)
 	}
 	if !strings.Contains(msg, "/campaign/workflow/intents/inbox/legacy.md → /campaign/.campaign/intents/inbox") {
 		t.Fatalf("commit message missing intent migration detail: %q", msg)
+	}
+}
+
+func TestBuildRepairCommitMessage_IncludesSkillProjections(t *testing.T) {
+	msg := buildRepairCommitMessage(&scaffold.InitResult{}, nil, 0,
+		[]string{".claude/skills/code-review"})
+
+	if !strings.Contains(msg, "Skill links projected:") {
+		t.Fatalf("commit message missing skill projection summary: %q", msg)
+	}
+	if !strings.Contains(msg, ".claude/skills/code-review") {
+		t.Fatalf("commit message missing projected skill path: %q", msg)
 	}
 }
 

--- a/cmd/camp/init/repair.go
+++ b/cmd/camp/init/repair.go
@@ -13,8 +13,11 @@ import (
 )
 
 // commitRepairChanges creates a git commit after a successful repair.
-func commitRepairChanges(ctx context.Context, initResult *scaffold.InitResult, plan *scaffold.RepairPlan, migrationCount int, w Writers) {
-	hasChanges := len(initResult.DirsCreated) > 0 || len(initResult.FilesCreated) > 0 || migrationCount > 0
+// skillPaths are campaign-root-relative skill projection links that were created
+// or replaced during repair; they must be staged explicitly because the repair
+// commit uses a selective file list.
+func commitRepairChanges(ctx context.Context, initResult *scaffold.InitResult, plan *scaffold.RepairPlan, migrationCount int, skillPaths []string, w Writers) {
+	hasChanges := len(initResult.DirsCreated) > 0 || len(initResult.FilesCreated) > 0 || migrationCount > 0 || len(skillPaths) > 0
 	if plan != nil && len(plan.IntentMigrations) > 0 {
 		hasChanges = true
 	}
@@ -27,8 +30,8 @@ func commitRepairChanges(ctx context.Context, initResult *scaffold.InitResult, p
 		return
 	}
 
-	description := buildRepairCommitMessage(initResult, plan, migrationCount)
-	files := buildRepairCommitFiles(initResult, plan)
+	description := buildRepairCommitMessage(initResult, plan, migrationCount, skillPaths)
+	files := buildRepairCommitFiles(initResult, plan, skillPaths)
 
 	result := commit.Repair(ctx, commit.RepairOptions{
 		Options: commit.Options{
@@ -47,10 +50,11 @@ func commitRepairChanges(ctx context.Context, initResult *scaffold.InitResult, p
 	}
 }
 
-func buildRepairCommitFiles(initResult *scaffold.InitResult, plan *scaffold.RepairPlan) []string {
-	files := make([]string, 0, len(initResult.FilesCreated)+len(initResult.DirsCreated))
+func buildRepairCommitFiles(initResult *scaffold.InitResult, plan *scaffold.RepairPlan, skillPaths []string) []string {
+	files := make([]string, 0, len(initResult.FilesCreated)+len(initResult.DirsCreated)+len(skillPaths))
 	files = append(files, initResult.FilesCreated...)
 	files = append(files, initResult.DirsCreated...)
+	files = append(files, skillPaths...)
 
 	if plan != nil {
 		for _, m := range plan.Migrations {
@@ -75,8 +79,16 @@ func buildRepairCommitFiles(initResult *scaffold.InitResult, plan *scaffold.Repa
 }
 
 // buildRepairCommitMessage constructs a descriptive commit body for repair operations.
-func buildRepairCommitMessage(initResult *scaffold.InitResult, plan *scaffold.RepairPlan, migrationCount int) string {
+func buildRepairCommitMessage(initResult *scaffold.InitResult, plan *scaffold.RepairPlan, migrationCount int, skillPaths []string) string {
 	var b strings.Builder
+
+	if len(skillPaths) > 0 {
+		fmt.Fprintf(&b, "Skill links projected:\n")
+		for _, p := range skillPaths {
+			fmt.Fprintf(&b, "  - %s\n", p)
+		}
+		b.WriteString("\n")
+	}
 
 	if len(initResult.DirsCreated) > 0 {
 		fmt.Fprintf(&b, "Directories created:\n")

--- a/cmd/camp/skills/link.go
+++ b/cmd/camp/skills/link.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	intskills "github.com/Obedience-Corp/camp/internal/skills"
@@ -17,7 +18,10 @@ skills directories.
 This command creates one symlink per skill bundle. It does not replace entire
 provider skills directories, so existing user skills remain intact.
 
+With neither --tool nor --path, skills are projected into every registered tool.
+
 Examples:
+  camp skills link                     Project skills into all registered tools
   camp skills link --tool claude       Project skills into .claude/skills/
   camp skills link --tool agents       Project skills into .agents/skills/
   camp skills link --path custom/dir   Project skills into custom/dir
@@ -54,9 +58,6 @@ func runSkillsLink(cmd *cobra.Command, _ []string) error {
 	if tool != "" && destPath != "" {
 		return fmt.Errorf("--tool and --path are mutually exclusive; use one or the other")
 	}
-	if tool == "" && destPath == "" {
-		return fmt.Errorf("specify --tool <name> or --path <destination>\n\nAvailable tools: claude, agents")
-	}
 
 	skillsDir, err := intskills.FindSkillsDir(ctx)
 	if err != nil {
@@ -66,6 +67,11 @@ func runSkillsLink(cmd *cobra.Command, _ []string) error {
 	root, err := campaign.DetectCached(ctx)
 	if err != nil {
 		return err
+	}
+
+	// With neither --tool nor --path, project into every registered tool.
+	if tool == "" && destPath == "" {
+		return linkAllTools(out, errOut, root, skillsDir, force, dryRun)
 	}
 
 	dest, err := resolveSkillsDestination(root, tool, destPath)
@@ -118,6 +124,40 @@ func runSkillsLink(cmd *cobra.Command, _ []string) error {
 		if _, err := fmt.Fprintf(out, "already linked: all campaign skill bundles are projected into %s\n", dest); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// linkAllTools projects skill bundles into every registered tool directory.
+func linkAllTools(out, errOut io.Writer, root, skillsDir string, force, dryRun bool) error {
+	results, err := intskills.LinkDefaultTools(root, skillsDir, dryRun, force, errOut)
+	if err != nil {
+		return err
+	}
+
+	verb := "projected"
+	if dryRun {
+		verb = "would project"
+	}
+
+	var conflicts int
+	var conflictNames []string
+	for _, res := range results {
+		if res.Err != nil {
+			return fmt.Errorf("link %s: %w", res.Tool, res.Err)
+		}
+		s := res.Summary
+		if _, err := fmt.Fprintf(out, "%s %d skill bundle(s) into %s (created=%d replaced=%d unchanged=%d)\n",
+			verb, s.Created+s.Replaced+s.AlreadyLinked, res.Dest, s.Created, s.Replaced, s.AlreadyLinked); err != nil {
+			return err
+		}
+		conflicts += s.Conflicts
+		conflictNames = append(conflictNames, s.ConflictNames...)
+	}
+
+	if conflicts > 0 {
+		return fmt.Errorf("projection incomplete: %d conflicting skill path(s) exist and were not overwritten: %v", conflicts, conflictNames)
 	}
 
 	return nil

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -41,6 +41,8 @@ type InitOptions struct {
 	DryRun bool
 	// Repair adds missing files to an existing campaign.
 	Repair bool
+	// SkipSkills disables projecting campaign skills into tool directories.
+	SkipSkills bool
 	// RepairPlan is the pre-computed repair plan (set by the caller after preview).
 	// When set, Init uses the merged jumps config from the plan instead of defaults.
 	RepairPlan *RepairPlan

--- a/internal/skills/link.go
+++ b/internal/skills/link.go
@@ -1,0 +1,68 @@
+package skills
+
+import (
+	"io"
+	"path/filepath"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// LinkResult reports the projection outcome for a single tool.
+type LinkResult struct {
+	Tool    string
+	Dest    string
+	Summary ProjectionSummary
+	Err     error
+}
+
+// LinkDefaultTools projects every skill bundle in skillsDir into every tool in
+// the registry, rooted at campaignRoot. It never aborts on a single tool's
+// failure: per-tool errors are captured in the returned LinkResult slice. A
+// top-level error is returned only when the skills directory cannot be read.
+//
+// force only affects user-placed foreign symlinks; camp-managed links are healed
+// regardless and real files/directories are never overwritten (reported as
+// conflicts in the per-tool summary).
+func LinkDefaultTools(campaignRoot, skillsDir string, dryRun, force bool, errOut io.Writer) ([]LinkResult, error) {
+	slugs, err := DiscoverSkillSlugs(skillsDir)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "discover skill bundles")
+	}
+
+	tools := ToolNames()
+	results := make([]LinkResult, 0, len(tools))
+	for _, tool := range tools {
+		res := LinkResult{Tool: tool}
+
+		relPath, err := ResolveToolPath(tool)
+		if err != nil {
+			res.Err = err
+			results = append(results, res)
+			continue
+		}
+		dest := filepath.Join(campaignRoot, relPath)
+		res.Dest = dest
+
+		if err := ValidateDestination(dest, campaignRoot); err != nil {
+			res.Err = err
+			results = append(results, res)
+			continue
+		}
+		if len(slugs) == 0 {
+			results = append(results, res)
+			continue
+		}
+		if err := EnsureProjectionDirectory(dest, dryRun, errOut); err != nil {
+			res.Err = err
+			results = append(results, res)
+			continue
+		}
+
+		summary, err := ProjectSkillEntries(dest, skillsDir, slugs, dryRun, force)
+		res.Summary = summary
+		res.Err = err
+		results = append(results, res)
+	}
+
+	return results, nil
+}

--- a/internal/skills/link_test.go
+++ b/internal/skills/link_test.go
@@ -1,0 +1,187 @@
+package skills
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeBundle(t *testing.T, skillsDir, slug string) {
+	t.Helper()
+	dir := filepath.Join(skillsDir, slug)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: "+slug+"\n---\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+}
+
+func resultByTool(results []LinkResult, tool string) (LinkResult, bool) {
+	for _, r := range results {
+		if r.Tool == tool {
+			return r, true
+		}
+	}
+	return LinkResult{}, false
+}
+
+func TestLinkDefaultTools_FreshProjectsAllTools(t *testing.T) {
+	t.Parallel()
+	root := resolvePath(t, t.TempDir())
+	skillsDir := filepath.Join(root, ".campaign", "skills")
+	writeBundle(t, skillsDir, "code-review")
+	writeBundle(t, skillsDir, "deep-research")
+
+	results, err := LinkDefaultTools(root, skillsDir, false, false, io.Discard)
+	if err != nil {
+		t.Fatalf("LinkDefaultTools: %v", err)
+	}
+	if len(results) != len(ToolNames()) {
+		t.Fatalf("expected %d results, got %d", len(ToolNames()), len(results))
+	}
+
+	for _, tool := range ToolNames() {
+		res, ok := resultByTool(results, tool)
+		if !ok {
+			t.Fatalf("missing result for tool %q", tool)
+		}
+		if res.Err != nil {
+			t.Errorf("tool %q error: %v", tool, res.Err)
+		}
+		if res.Summary.Created != 2 {
+			t.Errorf("tool %q expected 2 created, got %d", tool, res.Summary.Created)
+		}
+		relPath, _ := ResolveToolPath(tool)
+		link := filepath.Join(root, relPath, "code-review")
+		if _, err := os.Lstat(link); err != nil {
+			t.Errorf("expected projected link %s: %v", link, err)
+		}
+	}
+}
+
+func TestLinkDefaultTools_Idempotent(t *testing.T) {
+	t.Parallel()
+	root := resolvePath(t, t.TempDir())
+	skillsDir := filepath.Join(root, ".campaign", "skills")
+	writeBundle(t, skillsDir, "code-review")
+
+	if _, err := LinkDefaultTools(root, skillsDir, false, false, io.Discard); err != nil {
+		t.Fatalf("first link: %v", err)
+	}
+	results, err := LinkDefaultTools(root, skillsDir, false, false, io.Discard)
+	if err != nil {
+		t.Fatalf("second link: %v", err)
+	}
+	for _, res := range results {
+		if res.Summary.Created != 0 {
+			t.Errorf("tool %q expected 0 created on rerun, got %d", res.Tool, res.Summary.Created)
+		}
+		if res.Summary.AlreadyLinked != 1 {
+			t.Errorf("tool %q expected 1 already-linked on rerun, got %d", res.Tool, res.Summary.AlreadyLinked)
+		}
+	}
+}
+
+func TestLinkDefaultTools_HealsBrokenManagedLink(t *testing.T) {
+	t.Parallel()
+	root := resolvePath(t, t.TempDir())
+	skillsDir := filepath.Join(root, ".campaign", "skills")
+	writeBundle(t, skillsDir, "code-review")
+
+	if _, err := LinkDefaultTools(root, skillsDir, false, false, io.Discard); err != nil {
+		t.Fatalf("initial link: %v", err)
+	}
+
+	relPath, _ := ResolveToolPath("claude")
+	link := filepath.Join(root, relPath, "code-review")
+	if err := os.Remove(link); err != nil {
+		t.Fatalf("remove link: %v", err)
+	}
+
+	results, err := LinkDefaultTools(root, skillsDir, false, false, io.Discard)
+	if err != nil {
+		t.Fatalf("repair link: %v", err)
+	}
+	res, _ := resultByTool(results, "claude")
+	if res.Summary.Created != 1 {
+		t.Errorf("expected 1 recreated link, got created=%d", res.Summary.Created)
+	}
+	if _, err := os.Lstat(link); err != nil {
+		t.Errorf("expected restored link %s: %v", link, err)
+	}
+}
+
+func TestLinkDefaultTools_RealFileIsConflictNotOverwritten(t *testing.T) {
+	t.Parallel()
+	root := resolvePath(t, t.TempDir())
+	skillsDir := filepath.Join(root, ".campaign", "skills")
+	writeBundle(t, skillsDir, "code-review")
+
+	relPath, _ := ResolveToolPath("claude")
+	destDir := filepath.Join(root, relPath)
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		t.Fatalf("mkdir dest: %v", err)
+	}
+	realFile := filepath.Join(destDir, "code-review")
+	if err := os.WriteFile(realFile, []byte("user data"), 0o644); err != nil {
+		t.Fatalf("write real file: %v", err)
+	}
+
+	results, err := LinkDefaultTools(root, skillsDir, false, true, io.Discard)
+	if err != nil {
+		t.Fatalf("LinkDefaultTools: %v", err)
+	}
+	res, _ := resultByTool(results, "claude")
+	if res.Summary.Conflicts != 1 {
+		t.Errorf("expected 1 conflict, got %d", res.Summary.Conflicts)
+	}
+	content, err := os.ReadFile(realFile)
+	if err != nil {
+		t.Fatalf("read real file: %v", err)
+	}
+	if string(content) != "user data" {
+		t.Errorf("real file overwritten: got %q", string(content))
+	}
+}
+
+func TestLinkDefaultTools_DryRunTouchesNothing(t *testing.T) {
+	t.Parallel()
+	root := resolvePath(t, t.TempDir())
+	skillsDir := filepath.Join(root, ".campaign", "skills")
+	writeBundle(t, skillsDir, "code-review")
+
+	results, err := LinkDefaultTools(root, skillsDir, true, false, io.Discard)
+	if err != nil {
+		t.Fatalf("LinkDefaultTools dry-run: %v", err)
+	}
+	for _, res := range results {
+		if res.Summary.Created != 1 {
+			t.Errorf("tool %q expected 1 would-create, got %d", res.Tool, res.Summary.Created)
+		}
+		relPath, _ := ResolveToolPath(res.Tool)
+		if _, err := os.Lstat(filepath.Join(root, relPath, "code-review")); !os.IsNotExist(err) {
+			t.Errorf("tool %q dry-run created a link", res.Tool)
+		}
+	}
+}
+
+func TestLinkDefaultTools_EmptySkillsDir(t *testing.T) {
+	t.Parallel()
+	root := resolvePath(t, t.TempDir())
+	skillsDir := filepath.Join(root, ".campaign", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	results, err := LinkDefaultTools(root, skillsDir, false, false, io.Discard)
+	if err != nil {
+		t.Fatalf("LinkDefaultTools: %v", err)
+	}
+	for _, res := range results {
+		if res.Summary.Created != 0 {
+			t.Errorf("tool %q expected nothing created for empty skills dir, got %d", res.Tool, res.Summary.Created)
+		}
+	}
+}

--- a/internal/skills/projection.go
+++ b/internal/skills/projection.go
@@ -17,6 +17,10 @@ type ProjectionSummary struct {
 	AlreadyLinked int
 	Conflicts     int
 	ConflictNames []string
+	// CreatedNames and ReplacedNames list the slugs that were newly linked or
+	// relinked, so callers can stage exactly those projection paths.
+	CreatedNames  []string
+	ReplacedNames []string
 }
 
 // ProjectionState describes the current projection state for a tool destination.
@@ -176,6 +180,7 @@ func ProjectSkillEntries(destDir, skillsDir string, slugs []string, dryRun, forc
 				return summary, camperrors.Wrapf(err, "link skill %q", slug)
 			}
 			summary.Created++
+			summary.CreatedNames = append(summary.CreatedNames, slug)
 
 		case StateNotALink:
 			addConflict(&summary, slug)
@@ -198,6 +203,7 @@ func ProjectSkillEntries(destDir, skillsDir string, slugs []string, dryRun, forc
 				return summary, camperrors.Wrapf(err, "relink skill %q", slug)
 			}
 			summary.Replaced++
+			summary.ReplacedNames = append(summary.ReplacedNames, slug)
 		}
 	}
 

--- a/tests/integration/init_skills_test.go
+++ b/tests/integration/init_skills_test.go
@@ -82,6 +82,46 @@ func TestInit_RepairHealsBrokenSkillLink(t *testing.T) {
 	assert.Equal(t, 0, exitCode)
 }
 
+// TestInit_RepairCommitsProjectedSkillLinks reproduces an older campaign with no
+// projected tool skills and verifies that 'camp init --repair --yes' both
+// recreates the links AND commits them (the selective repair commit must stage
+// the newly projected paths, not leave them untracked).
+func TestInit_RepairCommitsProjectedSkillLinks(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	path := "/campaigns/test-init-repair-commit"
+	_, err := tc.InitCampaign(path, "test-init-repair-commit", "product")
+	require.NoError(t, err)
+
+	// Simulate an older campaign: remove all projected tool skills and commit
+	// that removal so the working tree starts clean with no .claude/.agents links.
+	_, exitCode, err := tc.ExecCommand("sh", "-c",
+		"cd "+path+" && rm -rf .claude/skills .agents/skills && git add -A && git commit -q -m 'remove projected skills' && sync")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+
+	_, err = tc.RunCampInDir(path, "init", "--repair", "--yes")
+	require.NoError(t, err)
+
+	for _, rel := range []string{".claude/skills/camp-workitems", ".agents/skills/camp-workitems"} {
+		_, exitCode, err = tc.ExecCommand("test", "-L", path+"/"+rel)
+		require.NoError(t, err)
+		assert.Equal(t, 0, exitCode, "repair should restore %s", rel)
+
+		// The link must be tracked in git (committed), not left untracked.
+		out, exitCode, err := tc.ExecCommand("sh", "-c",
+			"cd "+path+" && git ls-files --error-unmatch "+rel+" 2>&1")
+		require.NoError(t, err)
+		assert.Equal(t, 0, exitCode, "repair should commit %s (git output: %s)", rel, strings.TrimSpace(out))
+	}
+
+	// Working tree should be clean: repair committed everything it created.
+	out, exitCode, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git status --porcelain")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	assert.Empty(t, strings.TrimSpace(out), "repair should leave a clean working tree")
+}
+
 // TestSkills_LinkNoFlagsProjectsAllTools verifies that bare 'camp skills link'
 // projects into every registered tool.
 func TestSkills_LinkNoFlagsProjectsAllTools(t *testing.T) {

--- a/tests/integration/init_skills_test.go
+++ b/tests/integration/init_skills_test.go
@@ -1,0 +1,101 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInit_AutoLinksSkills verifies that camp init projects scaffolded skill
+// bundles into both .claude/skills and .agents/skills with no extra command.
+func TestInit_AutoLinksSkills(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	path := "/campaigns/test-init-autolink"
+	output, err := tc.InitCampaign(path, "test-init-autolink", "product")
+	require.NoError(t, err)
+	assert.Contains(t, output, "Skills:", "init summary should report skills linking")
+
+	for _, rel := range []string{".claude/skills", ".agents/skills"} {
+		link := path + "/" + rel + "/camp-workitems"
+		_, exitCode, err := tc.ExecCommand("test", "-L", link)
+		require.NoError(t, err)
+		assert.Equal(t, 0, exitCode, "expected projected symlink at %s", rel)
+
+		target, exitCode, err := tc.ExecCommand("readlink", link)
+		require.NoError(t, err)
+		require.Equal(t, 0, exitCode)
+		assert.Contains(t, strings.TrimSpace(target), ".campaign/skills/camp-workitems")
+	}
+}
+
+// TestInit_NoSkillsFlag verifies --no-skills scaffolds .campaign/skills but
+// projects nothing into tool directories.
+func TestInit_NoSkillsFlag(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	path := "/campaigns/test-init-no-skills"
+	_, err := tc.RunCamp("init", path, "--name", "test-init-no-skills",
+		"-d", "Test campaign", "-m", "Test mission", "--type", "product", "--no-skills")
+	require.NoError(t, err)
+
+	exists, err := tc.CheckFileExists(path + "/.campaign/skills/camp-workitems/SKILL.md")
+	require.NoError(t, err)
+	assert.True(t, exists, ".campaign/skills should still be scaffolded")
+
+	_, exitCode, err := tc.ExecCommand("test", "-e", path+"/.claude/skills")
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, exitCode, ".claude/skills should not exist with --no-skills")
+}
+
+// TestInit_RepairHealsBrokenSkillLink verifies that init --repair re-projects a
+// deleted skill link and is idempotent on a second run.
+func TestInit_RepairHealsBrokenSkillLink(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	path := "/campaigns/test-init-repair-skills"
+	_, err := tc.InitCampaign(path, "test-init-repair-skills", "product")
+	require.NoError(t, err)
+
+	link := path + "/.claude/skills/camp-workitems"
+	_, exitCode, err := tc.ExecCommand("rm", link)
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+
+	_, err = tc.RunCampInDir(path, "init", "--repair", "--yes")
+	require.NoError(t, err)
+
+	_, exitCode, err = tc.ExecCommand("test", "-L", link)
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode, "repair should restore the deleted skill link")
+
+	// Second repair is a no-op for skills (idempotent).
+	_, err = tc.RunCampInDir(path, "init", "--repair", "--yes")
+	require.NoError(t, err)
+	_, exitCode, err = tc.ExecCommand("test", "-L", link)
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+}
+
+// TestSkills_LinkNoFlagsProjectsAllTools verifies that bare 'camp skills link'
+// projects into every registered tool.
+func TestSkills_LinkNoFlagsProjectsAllTools(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupSkillsCampaign(t, tc, "skills-link-all")
+
+	output, err := tc.RunCampInDir(path, "skills", "link")
+	require.NoError(t, err)
+	assert.Contains(t, output, ".claude/skills")
+	assert.Contains(t, output, ".agents/skills")
+
+	for _, rel := range []string{".claude/skills", ".agents/skills"} {
+		_, exitCode, err := tc.ExecCommand("test", "-L", path+"/"+rel+"/"+testSkillSlug)
+		require.NoError(t, err)
+		assert.Equal(t, 0, exitCode, "expected projected symlink at %s", rel)
+	}
+}

--- a/tests/integration/skills_test.go
+++ b/tests/integration/skills_test.go
@@ -21,8 +21,17 @@ func setupSkillsCampaign(t *testing.T, tc *TestContainer, name string) string {
 	_, err := tc.InitCampaign(path, name, "product")
 	require.NoError(t, err)
 
+	// init auto-links scaffolded skills into tool directories. These lifecycle
+	// tests exercise linking from a clean slate, so reset to the unlinked state.
+	// The trailing sync flushes the removal before the next exec (macOS/Colima
+	// overlayfs buffers otherwise leave the deleted links visible).
+	_, exitCode, err := tc.ExecCommand("sh", "-c",
+		"rm -rf "+path+"/.claude/skills "+path+"/.agents/skills; sync")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+
 	// Ensure .campaign/skills/<slug>/SKILL.md exists
-	_, exitCode, err := tc.ExecCommand("mkdir", "-p", path+"/.campaign/skills/"+testSkillSlug)
+	_, exitCode, err = tc.ExecCommand("mkdir", "-p", path+"/.campaign/skills/"+testSkillSlug)
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode)
 	err = tc.WriteFile(path+"/.campaign/skills/"+testSkillSlug+"/SKILL.md", `---


### PR DESCRIPTION
## Summary

`camp init` and `camp create` now automatically project scaffolded skill bundles from `.campaign/skills/` into every registered tool directory (`.claude/skills/`, `.agents/skills/`) by default. Previously, init only scaffolded the bundles into `.campaign/skills/` — projecting them into the tool dirs required the user to separately run `camp skills link --tool claude` **and** `camp skills link --tool agents`. New users didn't know that command existed, so a fresh campaign's agents started with zero campaign skills loaded. This closes that first-run gap.

Design package: `workflow/design/auto-link-skills-on-init/` in the campaign repo.

## What changed

- **`internal/skills.LinkDefaultTools`** — new helper that projects all registry tools in a single call, capturing per-tool results (`LinkResult`) without aborting on a single tool's failure. Reuses the existing per-bundle relative-symlink projection (`ProjectSkillEntries`, `ValidateDestination`).
- **`--no-skills` opt-out** — threaded through both `camp init` and `camp create` (`InitOptions.SkipSkills`, `Params.NoSkills`). Default is on (auto-link), matching the no-init-time-friction principle.
- **Flow integration** — projection runs in `RunFlow` after festivals init. Repair's `!plan.HasChanges()` early-return is now gated on pending skill projections (`skillsNeedProjection`), so `camp init --repair` heals broken/missing links. Projection runs **before** the repair auto-commit so links are committed in the same pass.
- **Bare `camp skills link`** (no `--tool`/`--path`) now projects all registered tools instead of erroring.
- **`force=false` everywhere** — managed links self-heal; real files are never overwritten (reported as conflicts). Confirmed against `ProjectSkillEntries`: `force` only ever clobbers user-placed *foreign* symlinks, which we never do silently.

## Decisions (from the design package)

| # | Decision |
|---|----------|
| Git tracking | Commit projected symlinks — matches the existing `CLAUDE.md -> AGENTS.md` precedent; relative links resolve after clone. |
| Repair force | `force=false`; managed links heal without it, real files stay safe. |
| Bare `skills link` | Projects all registered tools. |
| Tool default | Full `ToolNames()` registry (`claude`, `agents`). |

## Notable bug caught during implementation

The acceptance test for repair healing exposed a real ordering bug: `RunFlow` early-returned at `!plan.HasChanges()` *before* the projection step, so a campaign with only a broken skill link (no missing scaffold files) would never heal. Fixed by detecting pending skill projections before the early-return.

## Testing

- **Unit** (`internal/skills/link_test.go`): fresh projection, idempotency, broken-managed-link healing, real-file-conflict-not-overwritten, dry-run-touches-nothing, empty-skills-dir.
- **Integration** (`tests/integration/init_skills_test.go`): init auto-links both tools, `--no-skills` skips projection, `--repair` heals a deleted link and is idempotent, bare `skills link` projects all tools.
- Existing skills lifecycle tests updated: `setupSkillsCampaign` resets `.claude/skills`/`.agents/skills` post-init (with `sync` for Colima overlayfs) so they still start from an unlinked slate.
- `golangci-lint`: 0 issues. host-fs lint: clean. Full Init+Skills integration suite green across 4 non-cached runs.
