### PR TITLE
feat(workitem): add 'camp workitem priority' CLI command

### DIFF
--- a/internal/commands/workitem/json_contract.go
+++ b/internal/commands/workitem/json_contract.go
@@ -5,6 +5,8 @@ const (
 	WorkitemCreateJSONVersion = "workitem-create/v1alpha1"
 	// WorkitemResolveJSONVersion is the schema version of camp workitem resolve --json.
 	WorkitemResolveJSONVersion = "workitem-resolve/v1alpha1"
+	// WorkitemPriorityJSONVersion is the schema version of camp workitem priority --json.
+	WorkitemPriorityJSONVersion = "workitem-priority/v1alpha1"
 	// WorkitemCommitJSONVersion is the schema version of camp workitem commit --json.
 	WorkitemCommitJSONVersion = "workitem-commit/v1alpha1"
 	// WorkitemCommitsJSONVersion is the schema version of camp workitem commits --json.

--- a/internal/commands/workitem/priority.go
+++ b/internal/commands/workitem/priority.go
@@ -1,0 +1,127 @@
+package workitem
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/jsoncontract"
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
+	"github.com/Obedience-Corp/camp/internal/workitem/selector"
+)
+
+func newPriorityCommand() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "priority <selector> <high|medium|low|clear>",
+		Short: "Set or clear the manual priority of a workitem",
+		Long: `Set or clear the manual priority of a workitem.
+
+The selector accepts the same forms as 'camp workitem current': a stable
+.workitem id, the workitem key (<type>:<path>), a relative path, or a directory
+slug. Priority is one of high, medium, low, or clear (clear removes any manual
+priority). Assignments persist in .campaign/settings/workitems.json, the same
+store the interactive dashboard writes.
+
+Examples:
+  camp workitem priority festival:festivals/active/demo high
+  camp workitem priority demo clear
+  camp workitem priority demo high --json`,
+		Args: jsoncontract.Args(WorkitemPriorityJSONVersion, func() bool { return jsonOut }, cobra.ExactArgs(2)),
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Sets workitem priority with --json output for automation",
+		},
+		RunE: jsoncontract.RunE(WorkitemPriorityJSONVersion, func() bool { return jsonOut }, func(cmd *cobra.Command, args []string) error {
+			return runPriority(cmd.Context(), cmd, args[0], args[1], jsonOut)
+		}),
+	}
+	cmd.SetFlagErrorFunc(jsoncontract.FlagErrorFunc(WorkitemPriorityJSONVersion, func() bool { return jsonOut }))
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a structured JSON result")
+	return cmd
+}
+
+// parsePriorityLevel maps a user-supplied level to a ManualPriority and reports
+// whether the request clears the assignment.
+func parsePriorityLevel(raw string) (level priority.ManualPriority, clear bool, err error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "high":
+		return priority.High, false, nil
+	case "medium", "med":
+		return priority.Medium, false, nil
+	case "low":
+		return priority.Low, false, nil
+	case "clear", "none":
+		return priority.None, true, nil
+	default:
+		return priority.None, false, camperrors.NewValidation("priority",
+			fmt.Sprintf("unknown priority %q (valid: high, medium, low, clear)", raw), nil)
+	}
+}
+
+func runPriority(ctx context.Context, cmd *cobra.Command, selectorArg, levelArg string, jsonOut bool) error {
+	level, clear, err := parsePriorityLevel(levelArg)
+	if err != nil {
+		return err
+	}
+
+	_, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	wi, err := selector.Resolve(ctx, root, selectorArg, selector.ResolveOptions{})
+	if err != nil {
+		return err
+	}
+
+	storePath := priority.StorePath(root)
+	store, err := priority.Load(storePath)
+	if err != nil {
+		return camperrors.Wrap(err, "loading priority store")
+	}
+
+	if clear {
+		priority.Clear(store, wi.Key)
+	} else {
+		priority.Set(store, wi.Key, level)
+	}
+	if err := priority.SaveOrDelete(storePath, store); err != nil {
+		return camperrors.Wrap(err, "saving priority store")
+	}
+
+	if jsonOut {
+		return emitPriorityJSON(cmd.OutOrStdout(), wi.Key, level, clear)
+	}
+	if clear {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "cleared priority: %s\n", wi.Key)
+		return err
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "priority set: %s = %s\n", wi.Key, level)
+	return err
+}
+
+func emitPriorityJSON(w io.Writer, key string, level priority.ManualPriority, cleared bool) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(struct {
+		SchemaVersion string    `json:"schema_version"`
+		GeneratedAt   time.Time `json:"generated_at"`
+		Key           string    `json:"key"`
+		Priority      string    `json:"priority"`
+		Cleared       bool      `json:"cleared"`
+	}{
+		SchemaVersion: WorkitemPriorityJSONVersion,
+		GeneratedAt:   time.Now().UTC(),
+		Key:           key,
+		Priority:      string(level),
+		Cleared:       cleared,
+	})
+}

--- a/internal/commands/workitem/priority_test.go
+++ b/internal/commands/workitem/priority_test.go
@@ -1,0 +1,188 @@
+package workitem
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
+)
+
+const (
+	testWorkitemKey = "design:workflow/design/example"
+	testWorkitemID  = "design-example-2026-05-24"
+)
+
+func runPriorityCmd(t *testing.T, selectorArg, level string, jsonOut bool) (string, error) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	err := runPriority(context.Background(), cmd, selectorArg, level, jsonOut)
+	return stdout.String(), err
+}
+
+func loadPriority(t *testing.T, root, key string) (priority.ManualPriority, bool) {
+	t.Helper()
+	store, err := priority.Load(priority.StorePath(root))
+	if err != nil {
+		t.Fatalf("load priority store: %v", err)
+	}
+	entry, ok := store.ManualPriorities[key]
+	return entry.Priority, ok
+}
+
+func TestPriority_SetLevels(t *testing.T) {
+	cases := []struct {
+		name     string
+		selector string
+		level    string
+		want     priority.ManualPriority
+	}{
+		{"high by id", testWorkitemID, "high", priority.High},
+		{"medium by key", testWorkitemKey, "medium", priority.Medium},
+		{"low by slug", "example", "low", priority.Low},
+		{"medium alias", testWorkitemID, "med", priority.Medium},
+		{"case insensitive", testWorkitemID, "HIGH", priority.High},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := linkTestCampaign(t)
+			restore := chdir(t, root)
+			defer restore()
+
+			if _, err := runPriorityCmd(t, tc.selector, tc.level, false); err != nil {
+				t.Fatalf("runPriority: %v", err)
+			}
+
+			got, ok := loadPriority(t, root, testWorkitemKey)
+			if !ok {
+				t.Fatalf("no priority entry stored for %s", testWorkitemKey)
+			}
+			if got != tc.want {
+				t.Fatalf("priority = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPriority_ClearRemovesEntryAndDeletesEmptyStore(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	if _, err := runPriorityCmd(t, testWorkitemID, "high", false); err != nil {
+		t.Fatalf("seed priority: %v", err)
+	}
+	if _, ok := loadPriority(t, root, testWorkitemKey); !ok {
+		t.Fatal("expected a stored priority before clearing")
+	}
+
+	if _, err := runPriorityCmd(t, testWorkitemID, "clear", false); err != nil {
+		t.Fatalf("clear priority: %v", err)
+	}
+
+	if _, ok := loadPriority(t, root, testWorkitemKey); ok {
+		t.Fatal("expected priority entry to be removed after clear")
+	}
+	if _, err := os.Stat(priority.StorePath(root)); !os.IsNotExist(err) {
+		t.Fatalf("expected empty store file to be deleted, stat err = %v", err)
+	}
+}
+
+func TestPriority_JSONShape(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	out, err := runPriorityCmd(t, testWorkitemID, "high", true)
+	if err != nil {
+		t.Fatalf("runPriority --json: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\nraw=%s", err, out)
+	}
+	if payload["schema_version"] != WorkitemPriorityJSONVersion {
+		t.Fatalf("schema_version = %v, want %s", payload["schema_version"], WorkitemPriorityJSONVersion)
+	}
+	if payload["key"] != testWorkitemKey {
+		t.Fatalf("key = %v, want %s", payload["key"], testWorkitemKey)
+	}
+	if payload["priority"] != "high" {
+		t.Fatalf("priority = %v, want high", payload["priority"])
+	}
+	if payload["cleared"] != false {
+		t.Fatalf("cleared = %v, want false", payload["cleared"])
+	}
+}
+
+func TestPriority_JSONClearedShape(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	out, err := runPriorityCmd(t, testWorkitemID, "clear", true)
+	if err != nil {
+		t.Fatalf("runPriority --json clear: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\nraw=%s", err, out)
+	}
+	if payload["cleared"] != true {
+		t.Fatalf("cleared = %v, want true", payload["cleared"])
+	}
+	if payload["priority"] != "" {
+		t.Fatalf("priority = %v, want empty", payload["priority"])
+	}
+}
+
+func TestPriority_InvalidLevelIsValidationError(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	_, err := runPriorityCmd(t, testWorkitemID, "urgent", false)
+	if err == nil {
+		t.Fatal("expected an error for an unknown priority level")
+	}
+	if _, statErr := os.Stat(priority.StorePath(root)); !os.IsNotExist(statErr) {
+		t.Fatalf("invalid level must not write the store, stat err = %v", statErr)
+	}
+}
+
+func TestPriority_UnknownSelectorIsError(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	_, err := runPriorityCmd(t, "does-not-exist", "high", false)
+	if err == nil {
+		t.Fatal("expected an error for an unresolvable selector")
+	}
+}
+
+func TestPriority_ContextCancellationDoesNotMutateStore(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := runPriority(ctx, cmd, testWorkitemID, "high", false); err == nil {
+		t.Fatal("expected a cancellation error")
+	}
+	if _, statErr := os.Stat(priority.StorePath(root)); !os.IsNotExist(statErr) {
+		t.Fatalf("cancelled run must not write the store, stat err = %v", statErr)
+	}
+}

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -135,6 +135,7 @@ Examples:
 	cmd.AddCommand(newLinksCommand())
 	cmd.AddCommand(newCurrentCommand())
 	cmd.AddCommand(newResolveCommand())
+	cmd.AddCommand(newPriorityCommand())
 	cmd.AddCommand(newDoctorCommand())
 	cmd.AddCommand(newCommitCommand())
 	cmd.AddCommand(newCommitsCommand())


### PR DESCRIPTION
## Summary

Adds `camp workitem priority <selector> <high|medium|low|clear>` so manual priority can be set non-interactively.

Until now, manual priority (high/medium/low) was assignable **only** from the interactive workitem TUI (press `P`). The TUI writes `.campaign/settings/workitems.json` through the `internal/workitem/priority` package. That meant any non-interactive caller — agents, scripts, and the festival-app workitems viewer — had no way to set priority without re-implementing the on-disk store format, which would be a parallel implementation of camp's own logic.

This command is a thin wrapper over the same `priority` package the TUI already uses, so the CLI and the dashboard stay byte-for-byte compatible on the store.

## Behavior

```
camp workitem priority <selector> <high|medium|low|clear> [--json]
```

- **selector** accepts the same forms as `camp workitem current`: a stable `.workitem` id, the workitem key (`<type>:<path>`), a relative path, or a directory slug (resolved via `selector.Resolve`).
- **level** is `high`, `medium`, `low`, or `clear` (`none` is accepted as an alias for `clear`; `med` for `medium`; case-insensitive).
- Writes through `priority.Set` / `priority.Clear` + `SaveOrDelete`, so clearing removes the entry and deletes the store file when it becomes empty — identical to the TUI's semantics.
- `--json` emits a structured result (schema `workitem-priority/v1alpha1`) for automation; the command carries the `agent_allowed` annotation.
- Validates the level **before** touching the store; unknown levels and unresolvable selectors error out without writing anything.

## Verification

End-to-end against a scratch campaign:

```
$ camp workitem priority design:workflow/design/example high --json
{
  "schema_version": "workitem-priority/v1alpha1",
  "key": "design:workflow/design/example",
  "priority": "high",
  "cleared": false
}
$ camp workitem --json | jq '.items[] | [.key, .manual_priority]'
["design:workflow/design/example", "high"]      # set priority surfaces in list output
$ camp workitem priority example clear
cleared priority: design:workflow/design/example
# .campaign/settings/workitems.json is deleted once empty
$ camp workitem priority example bogus
Error: validation error on priority: unknown priority "bogus" (valid: high, medium, low, clear)   # exit 1
```

Gates:
- `go build ./...`: clean
- `just lint`: 0 issues (`lint-no-host-fs-tests`: no new violators)
- `go test ./internal/workitem/... ./internal/commands/workitem/...`: all pass

Tests added (`priority_test.go`): set-by-id/key/slug, level aliases + case-insensitivity, clear + empty-store deletion, `--json` set and cleared shapes, invalid level (no write), unknown selector, and context cancellation (no store mutation on cancel).

## Follow-up

This unblocks wiring a priority picker into the festival-app workitems viewer (it will shell out to this command rather than writing the store directly). That UI change ships separately.
