### PR TITLE
feat(intent): notes category, tags, rename, and workflows as sub-concepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,11 +331,15 @@ cgo p                    # Runs: cd "$(camp go p --print)"
 cgo p api                # Runs: cd "$(camp go p api --print)"
 cgo -c p ls              # Runs: camp go p -c ls (no cd)
 
-# 2. Tab completion for cgo
+# 2. Quick capture helpers
+cint "new feature idea"  # Runs: camp intent add "new feature idea"
+cnote "meeting note"     # Runs: camp intent note "meeting note"
+
+# 3. Tab completion for cgo
 cgo <TAB>                # Completes categories: p f w a d i wt du cr pi de
 cgo p <TAB>              # Completes project names
 
-# 3. Tab completion for camp commands
+# 4. Tab completion for camp commands
 camp <TAB>               # Completes: init go project list register...
 camp project <TAB>       # Completes: add commit link list new prune remote remove run unlink worktree
 ```

--- a/cmd/camp/concepts.go
+++ b/cmd/camp/concepts.go
@@ -61,20 +61,34 @@ func printConcepts(campaignName string, concepts []concept.Concept) {
 	}
 
 	for _, c := range concepts {
-		desc := ""
-		if c.Description != "" {
-			desc = ui.Dim(" # " + c.Description)
-		}
-		fmt.Printf("  %s %s %s%s\n",
-			ui.Accent(fmt.Sprintf("%-8s", c.Name)),
-			ui.ArrowIcon(),
-			ui.Value(c.Path),
-			desc)
+		printConcept(c, 0)
+	}
 
-		// Metadata line
+	// Always show how to customize concepts.
+	fmt.Println()
+	fmt.Printf("Customize concepts in %s. Nest workflows under the\n", ui.Accent(".campaign/campaign.yaml"))
+	fmt.Printf("%s concept's %s list.\n", ui.Accent("workflow"), ui.Accent("children:"))
+}
+
+// printConcept renders a concept and recurses into its children, indenting each
+// level so the parent -> sub-concept tree is visible.
+func printConcept(c concept.Concept, depth int) {
+	indent := strings.Repeat("  ", depth+1)
+
+	desc := ""
+	if c.Description != "" {
+		desc = ui.Dim(" # " + c.Description)
+	}
+	fmt.Printf("%s%s %s %s%s\n",
+		indent,
+		ui.Accent(fmt.Sprintf("%-12s", c.Name)),
+		ui.ArrowIcon(),
+		ui.Value(c.Path),
+		desc)
+
+	// Top-level concepts show a metadata line; children stay compact.
+	if depth == 0 {
 		var meta []string
-
-		// Depth info
 		if c.MaxDepth == nil {
 			meta = append(meta, "depth: unlimited")
 		} else if *c.MaxDepth == 0 {
@@ -82,19 +96,18 @@ func printConcepts(campaignName string, concepts []concept.Concept) {
 		} else {
 			meta = append(meta, fmt.Sprintf("depth: %d", *c.MaxDepth))
 		}
-
-		// Ignore patterns
 		if len(c.Ignore) > 0 {
 			meta = append(meta, fmt.Sprintf("ignore: [%s]", strings.Join(c.Ignore, ", ")))
 		}
-
-		// Items indicator
 		if c.HasItems {
 			meta = append(meta, ui.Success("has items"))
 		} else {
 			meta = append(meta, "no items")
 		}
+		fmt.Printf("%s%s\n", indent+strings.Repeat(" ", 13), ui.Dim(strings.Join(meta, "  ")))
+	}
 
-		fmt.Printf("  %s %s\n", strings.Repeat(" ", 8), ui.Dim(strings.Join(meta, "  ")))
+	for _, child := range c.Children {
+		printConcept(child, depth+1)
 	}
 }

--- a/cmd/camp/intent/add.go
+++ b/cmd/camp/intent/add.go
@@ -213,7 +213,7 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 			Concept: saved.Concept,
 			Body:    saved.Body,
 			Author:  saved.Author,
-			Tags:    saved.Tags,
+			Tags:    mergeTags(tagsFlag, saved.Tags),
 		}
 		if createNote {
 			if err := runNoteCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, savedOpts); err != nil {
@@ -243,7 +243,7 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 		Concept: result.Concept,
 		Body:    result.Body,
 		Author:  result.Author,
-		Tags:    result.Tags,
+		Tags:    mergeTags(tagsFlag, result.Tags),
 	}
 
 	if createNote {

--- a/cmd/camp/intent/add.go
+++ b/cmd/camp/intent/add.go
@@ -85,6 +85,7 @@ func init() {
 	flags.String("body-file", "", "Read intent body from file (- for stdin, 10 MiB cap)")
 	flags.String("concept", "", "Set the concept field (e.g., projects/camp)")
 	flags.String("author", "", "Override the default author attribution")
+	flags.StringArray("tag", nil, "Add a tag (repeatable)")
 }
 
 func runIntentAdd(cmd *cobra.Command, args []string) error {
@@ -99,6 +100,7 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 	targetCampaign, args = normalizeIntentAddCampaignArgs(args, targetCampaign)
 	conceptFlag, _ := cmd.Flags().GetString("concept")
 	authorFlag, _ := cmd.Flags().GetString("author")
+	tagsFlag, _ := cmd.Flags().GetStringArray("tag")
 
 	// Resolve body from --body / --body-file (mutual exclusivity checked inside)
 	body, bodySet, err := resolveBody(cmd)
@@ -143,6 +145,7 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 			Author:  author,
 			Body:    body,
 			Concept: conceptFlag,
+			Tags:    tagsFlag,
 		}
 
 		// Deep capture overrides ultra-fast; body flags pre-fill the template
@@ -176,11 +179,12 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 
 	// Run BubbleTea TUI
 	model, err := runIntentAddTUI(ctx, conceptSvc, tui.AddOptions{
-		DefaultType:  intentType,
-		FullMode:     fullMode,
-		Author:       author,
-		CampaignRoot: campaignRoot,
-		Shortcuts:    shortcuts,
+		DefaultType:   intentType,
+		FullMode:      fullMode,
+		Author:        author,
+		CampaignRoot:  campaignRoot,
+		Shortcuts:     shortcuts,
+		AvailableTags: cfg.IntentTags(),
 	})
 	if err != nil {
 		return err
@@ -194,6 +198,7 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 			Concept: saved.Concept,
 			Body:    saved.Body,
 			Author:  saved.Author,
+			Tags:    saved.Tags,
 		}
 		if err := runFastCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, savedOpts); err != nil {
 			return err
@@ -217,6 +222,7 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 		Concept: result.Concept,
 		Body:    result.Body,
 		Author:  result.Author,
+		Tags:    result.Tags,
 	}
 
 	// Deep capture if requested

--- a/cmd/camp/intent/add.go
+++ b/cmd/camp/intent/add.go
@@ -48,6 +48,7 @@ PROGRAMMATIC (agent) FLAGS:
   --body              Set intent body from a literal string
   --body-file         Read intent body from a file (- for stdin)
   --concept           Set the concept field (e.g., "projects/camp")
+  --note              Create a note instead of a lifecycle intent
   --author            Override the default author attribution
 
   --body and --body-file are mutually exclusive.
@@ -60,6 +61,8 @@ Examples:
   camp intent add                        Fast TUI (3-step form)
   camp intent add --campaign             Pick a target campaign interactively
   camp intent add --full                 Full TUI (includes body)
+  camp intent add --note                 Note TUI (title + body, no type/concept)
+  camp intent add --note "Meeting note" --body "Follow up next week"
   camp intent add -e "Complex feature"   Deep capture with editor
   camp intent add -t feature "New API"   Set type explicitly
   camp intent add "Fix login" --body "The login page returns 500"
@@ -84,6 +87,7 @@ func init() {
 	flags.String("body", "", "Set intent body as a literal string")
 	flags.String("body-file", "", "Read intent body from file (- for stdin, 10 MiB cap)")
 	flags.String("concept", "", "Set the concept field (e.g., projects/camp)")
+	flags.Bool("note", false, "Create a note instead of a lifecycle intent")
 	flags.String("author", "", "Override the default author attribution")
 	flags.StringArray("tag", nil, "Add a tag (repeatable)")
 }
@@ -97,10 +101,18 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 	fullMode, _ := cmd.Flags().GetBool("full")
 	targetCampaign, _ := cmd.Flags().GetString("campaign")
 	noCommit, _ := cmd.Flags().GetBool("no-commit")
+	createNote, _ := cmd.Flags().GetBool("note")
 	targetCampaign, args = normalizeIntentAddCampaignArgs(args, targetCampaign)
 	conceptFlag, _ := cmd.Flags().GetString("concept")
 	authorFlag, _ := cmd.Flags().GetString("author")
 	tagsFlag, _ := cmd.Flags().GetStringArray("tag")
+
+	if createNote && cmd.Flags().Changed("concept") {
+		return camperrors.Wrap(camperrors.ErrInvalidInput, "--note cannot be combined with --concept")
+	}
+	if createNote && cmd.Flags().Changed("type") {
+		return camperrors.Wrap(camperrors.ErrInvalidInput, "--note cannot be combined with --type")
+	}
 
 	// Resolve body from --body / --body-file (mutual exclusivity checked inside)
 	body, bodySet, err := resolveBody(cmd)
@@ -148,6 +160,13 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 			Tags:    tagsFlag,
 		}
 
+		if createNote {
+			if useEditor {
+				return runDeepNoteCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, opts)
+			}
+			return runNoteCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, opts)
+		}
+
 		// Deep capture overrides ultra-fast; body flags pre-fill the template
 		if useEditor {
 			return runDeepCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, opts)
@@ -170,17 +189,13 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build navigation shortcuts map (key -> path) for @ completion
-	shortcuts := make(map[string]string)
-	for key, sc := range cfg.Shortcuts() {
-		if sc.HasPath() {
-			shortcuts[key] = sc.Path
-		}
-	}
+	shortcuts := navigationShortcuts(cfg)
 
 	// Run BubbleTea TUI
 	model, err := runIntentAddTUI(ctx, conceptSvc, tui.AddOptions{
 		DefaultType:   intentType,
 		FullMode:      fullMode,
+		NoteMode:      createNote,
 		Author:        author,
 		CampaignRoot:  campaignRoot,
 		Shortcuts:     shortcuts,
@@ -199,6 +214,12 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 			Body:    saved.Body,
 			Author:  saved.Author,
 			Tags:    saved.Tags,
+		}
+		if createNote {
+			if err := runNoteCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, savedOpts); err != nil {
+				return err
+			}
+			continue
 		}
 		if err := runFastCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, savedOpts); err != nil {
 			return err
@@ -225,12 +246,26 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 		Tags:    result.Tags,
 	}
 
+	if createNote {
+		return runNoteCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, opts)
+	}
+
 	// Deep capture if requested
 	if useEditor {
 		return runDeepCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, opts)
 	}
 
 	return runFastCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, opts)
+}
+
+func navigationShortcuts(cfg *config.CampaignConfig) map[string]string {
+	shortcuts := make(map[string]string)
+	for key, sc := range cfg.Shortcuts() {
+		if sc.HasPath() {
+			shortcuts[key] = sc.Path
+		}
+	}
+	return shortcuts
 }
 
 func validateIntentAddArgs(cmd *cobra.Command, args []string) error {
@@ -372,6 +407,26 @@ func runDeepCapture(ctx context.Context, svc *intent.IntentService, intentsDir s
 	}
 
 	return finalizeCreatedIntent(ctx, result, intentsDir, cfg, campaignRoot, noCommit)
+}
+
+// runDeepNoteCapture opens the note template in $EDITOR and saves it to notes/.
+func runDeepNoteCapture(ctx context.Context, svc *intent.IntentService, intentsDir string, cfg *config.CampaignConfig, campaignRoot string, noCommit bool, opts intent.CreateOptions) error {
+	editorFn := func(ctx context.Context, path string) error {
+		return editor.Edit(ctx, path)
+	}
+	opts.Category = intent.CategoryNote
+	opts.Type = ""
+	opts.Concept = ""
+
+	result, err := svc.CreateWithEditor(ctx, opts, editorFn)
+	if err != nil {
+		if errors.Is(err, camperrors.ErrCancelled) {
+			return intent.ErrCancelled
+		}
+		return camperrors.Wrap(err, "failed to create note")
+	}
+
+	return finalizeCreatedNote(ctx, result, intentsDir, cfg, campaignRoot, noCommit)
 }
 
 func finalizeCreatedIntent(ctx context.Context, result *intent.Intent, intentsDir string, cfg *config.CampaignConfig, campaignRoot string, noCommit bool) error {

--- a/cmd/camp/intent/add_flags_test.go
+++ b/cmd/camp/intent/add_flags_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/config"
 	intentcore "github.com/Obedience-Corp/camp/internal/intent"
 	"github.com/Obedience-Corp/camp/internal/paths"
+	"github.com/spf13/cobra"
 )
 
 // setupAddFlagsTest creates a campaign root and returns the service, path resolver,
@@ -81,16 +82,54 @@ func TestIntentAdd_NoteFlagRegistered(t *testing.T) {
 	}
 }
 
-func TestIntentAdd_NoteRouteCreatesNoteWithBody(t *testing.T) {
-	svc, intentsDir, cfg, root := setupAddFlagsTest(t)
+func newIntentAddTestCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "add [title]",
+		RunE: runIntentAdd,
+	}
+	flags := cmd.Flags()
+	flags.StringP("type", "t", string(intentcore.TypeIdea), "")
+	flags.BoolP("edit", "e", false, "")
+	flags.BoolP("full", "f", false, "")
+	flags.StringP("campaign", "c", "", "")
+	flags.Lookup("campaign").NoOptDefVal = noOptCampaign
+	flags.Bool("no-commit", false, "")
+	flags.String("body", "", "")
+	flags.String("body-file", "", "")
+	flags.String("concept", "", "")
+	flags.Bool("note", false, "")
+	flags.String("author", "", "")
+	flags.StringArray("tag", nil, "")
+	return cmd
+}
 
-	err := runNoteCapture(context.Background(), svc, intentsDir, cfg, root, true, intentcore.CreateOptions{
-		Title:  "Test note with body",
-		Author: "agent",
-		Body:   "This note has details",
-	})
+func TestIntentAdd_NoteFlagRoutesThroughAddCommand(t *testing.T) {
+	_, intentsDir, _, root := setupAddFlagsTest(t)
+
+	originalWD, err := os.Getwd()
 	if err != nil {
-		t.Fatalf("runNoteCapture: %v", err)
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("Chdir(%s): %v", root, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWD)
+	})
+
+	cmd := newIntentAddTestCmd()
+	cmd.SetContext(context.Background())
+	if err := cmd.Flags().Set("note", "true"); err != nil {
+		t.Fatalf("Set(note): %v", err)
+	}
+	if err := cmd.Flags().Set("body", "This note has details"); err != nil {
+		t.Fatalf("Set(body): %v", err)
+	}
+	if err := cmd.Flags().Set("no-commit", "true"); err != nil {
+		t.Fatalf("Set(no-commit): %v", err)
+	}
+	if err := runIntentAdd(cmd, []string{"Test note with body"}); err != nil {
+		t.Fatalf("runIntentAdd(--note): %v", err)
 	}
 
 	notesDir := filepath.Join(intentsDir, "notes")

--- a/cmd/camp/intent/add_flags_test.go
+++ b/cmd/camp/intent/add_flags_test.go
@@ -75,6 +75,56 @@ func TestIntentAdd_WithBody(t *testing.T) {
 	}
 }
 
+func TestIntentAdd_NoteFlagRegistered(t *testing.T) {
+	if intentAddCmd.Flags().Lookup("note") == nil {
+		t.Fatal("intent add should expose --note so c shortcuts can route note capture through add")
+	}
+}
+
+func TestIntentAdd_NoteRouteCreatesNoteWithBody(t *testing.T) {
+	svc, intentsDir, cfg, root := setupAddFlagsTest(t)
+
+	err := runNoteCapture(context.Background(), svc, intentsDir, cfg, root, true, intentcore.CreateOptions{
+		Title:  "Test note with body",
+		Author: "agent",
+		Body:   "This note has details",
+	})
+	if err != nil {
+		t.Fatalf("runNoteCapture: %v", err)
+	}
+
+	notesDir := filepath.Join(intentsDir, "notes")
+	entries, err := os.ReadDir(notesDir)
+	if err != nil {
+		t.Fatalf("ReadDir(notes): %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("notes entries = %d, want 1", len(entries))
+	}
+
+	inboxEntries, err := os.ReadDir(filepath.Join(intentsDir, "inbox"))
+	if err != nil {
+		t.Fatalf("ReadDir(inbox): %v", err)
+	}
+	if len(inboxEntries) != 0 {
+		t.Fatalf("inbox entries = %d, want 0 for note route", len(inboxEntries))
+	}
+
+	content, err := os.ReadFile(filepath.Join(notesDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile(note): %v", err)
+	}
+	raw := string(content)
+	for _, want := range []string{"status: notes", "This note has details"} {
+		if !strings.Contains(raw, want) {
+			t.Fatalf("note content missing %q:\n%s", want, raw)
+		}
+	}
+	if strings.Contains(raw, "type:") || strings.Contains(raw, "concept:") {
+		t.Fatalf("note should not include lifecycle type/concept:\n%s", raw)
+	}
+}
+
 func TestIntentAdd_WithConcept(t *testing.T) {
 	svc, intentsDir, cfg, root := setupAddFlagsTest(t)
 

--- a/cmd/camp/intent/convert.go
+++ b/cmd/camp/intent/convert.go
@@ -1,0 +1,99 @@
+package intent
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git/commit"
+	"github.com/Obedience-Corp/camp/internal/intent"
+	"github.com/Obedience-Corp/camp/internal/intent/audit"
+	"github.com/Obedience-Corp/camp/internal/paths"
+)
+
+var intentConvertCmd = &cobra.Command{
+	Use:   "convert <id>",
+	Short: "Convert a note into an intent",
+	Long: `Promote a note into the intent lifecycle.
+
+A note lives outside the inbox → ready → active lifecycle. Converting it moves
+the note into inbox/ and attaches an intent type, after which it behaves like
+any other intent. This is the only bridge from a note into the lifecycle.
+
+Examples:
+  camp intent convert check-daemon-socket --type idea
+  camp intent convert check-daemon-socket -t feature`,
+	Args: cobra.ExactArgs(1),
+	RunE: runIntentConvert,
+}
+
+func init() {
+	Cmd.AddCommand(intentConvertCmd)
+
+	intentConvertCmd.Flags().StringP("type", "t", "idea", "Intent type to attach (idea, feature, bug, research, chore)")
+	intentConvertCmd.Flags().Bool("no-commit", false, "Don't create a git commit")
+}
+
+func runIntentConvert(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	id := args[0]
+	typeFlag, _ := cmd.Flags().GetString("type")
+	noCommit, _ := cmd.Flags().GetBool("no-commit")
+
+	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	resolver := paths.NewResolverFromConfig(campaignRoot, cfg)
+	svc := intent.NewIntentService(campaignRoot, resolver.Intents())
+	if err := svc.EnsureDirectories(ctx); err != nil {
+		return camperrors.Wrap(err, "ensuring intent directories")
+	}
+
+	note, err := svc.GetNote(ctx, id)
+	if err != nil {
+		return camperrors.Wrapf(err, "note not found: %s", id)
+	}
+	sourcePath := note.Path
+
+	result, err := svc.Convert(ctx, id, intent.Type(typeFlag))
+	if err != nil {
+		return camperrors.Wrap(err, "failed to convert note")
+	}
+
+	fmt.Printf("✓ Note converted to %s intent: %s\n", typeFlag, result.Path)
+
+	if err := appendIntentAuditEvent(ctx, resolver.Intents(), audit.Event{
+		Type:   audit.EventMove,
+		ID:     result.ID,
+		Title:  result.Title,
+		From:   string(intent.StatusNote),
+		To:     string(intent.StatusInbox),
+		Reason: "converted note to " + typeFlag,
+	}); err != nil {
+		return err
+	}
+
+	if !noCommit {
+		files := commit.NormalizeFiles(campaignRoot, sourcePath, result.Path, audit.FilePath(resolver.Intents()))
+		commitResult := commit.Intent(ctx, commit.IntentOptions{
+			Options: commit.Options{
+				CampaignRoot:  campaignRoot,
+				CampaignID:    cfg.ID,
+				Files:         files,
+				SelectiveOnly: true,
+			},
+			Action:      commit.IntentMove,
+			IntentTitle: result.Title,
+			Description: "Converted note to " + typeFlag + " intent",
+		})
+		if commitResult.Message != "" {
+			fmt.Printf("  %s\n", commitResult.Message)
+		}
+	}
+
+	return nil
+}

--- a/cmd/camp/intent/edit.go
+++ b/cmd/camp/intent/edit.go
@@ -88,6 +88,7 @@ func init() {
 	flags.String("priority", "", "Change priority (low, medium, high)")
 	flags.String("horizon", "", "Change horizon (now, next, later, someday)")
 	flags.String("author", "", "Override the author attribution")
+	flags.StringArray("tag", nil, "Replace the intent's tags (repeatable)")
 	flags.Bool("no-commit", false, "Don't create a git commit")
 }
 
@@ -315,6 +316,11 @@ func buildUpdateOptions(cmd *cobra.Command) (intent.UpdateOptions, error) {
 		opts.Author = &v
 	}
 
+	if cmd.Flags().Changed("tag") {
+		v, _ := cmd.Flags().GetStringArray("tag")
+		opts.Tags = &v
+	}
+
 	return opts, nil
 }
 
@@ -323,7 +329,7 @@ func buildUpdateOptions(cmd *cobra.Command) (intent.UpdateOptions, error) {
 func hasProgrammaticEditFlags(cmd *cobra.Command) bool {
 	programmaticFlags := []string{
 		"title", "body", "body-file", "append-body", "append-body-file",
-		"set-type", "set-status", "set-concept", "priority", "horizon", "author",
+		"set-type", "set-status", "set-concept", "priority", "horizon", "author", "tag",
 	}
 	for _, name := range programmaticFlags {
 		if cmd.Flags().Changed(name) {

--- a/cmd/camp/intent/explore.go
+++ b/cmd/camp/intent/explore.go
@@ -117,7 +117,8 @@ func runIntentExplore(cmd *cobra.Command, args []string) error {
 	defer restoreLogger()
 
 	// Create and run the TUI
-	model := explorer.NewModel(ctx, svc, conceptSvc, intentsDir, campaignRoot, cfg.ID, author, shortcuts)
+	model := explorer.NewModel(ctx, svc, conceptSvc, intentsDir, campaignRoot, cfg.ID, author, shortcuts).
+		WithAvailableTags(cfg.IntentTags())
 	p := tea.NewProgram(model, tea.WithAltScreen())
 
 	if _, err := p.Run(); err != nil {

--- a/cmd/camp/intent/note.go
+++ b/cmd/camp/intent/note.go
@@ -1,0 +1,182 @@
+package intent
+
+import (
+	"context"
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/concept"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git"
+	"github.com/Obedience-Corp/camp/internal/git/commit"
+	"github.com/Obedience-Corp/camp/internal/intent"
+	"github.com/Obedience-Corp/camp/internal/intent/audit"
+	"github.com/Obedience-Corp/camp/internal/intent/tui"
+	navtui "github.com/Obedience-Corp/camp/internal/nav/tui"
+	"github.com/Obedience-Corp/camp/internal/paths"
+)
+
+var intentNoteCmd = &cobra.Command{
+	Use:   "note [text]",
+	Short: "Capture a quick note",
+	Long: `Capture a freeform note. Notes are a separate category from intents: they
+are stored in .campaign/intents/notes/ and do not flow through the
+inbox → ready → active lifecycle. A note carries no type or concept; tags
+organize them.
+
+Fast capture skips the type wheel and concept picker entirely.
+
+Examples:
+  camp intent note "check the daemon socket path"   Capture a note immediately
+  camp intent note "follow up" --body "details..."  Note with a longer body
+  echo "body" | camp intent note "idea" --body-file -
+  camp intent note                                  Quick-add note (TUI)`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runIntentNote,
+}
+
+func init() {
+	Cmd.AddCommand(intentNoteCmd)
+
+	flags := intentNoteCmd.Flags()
+	flags.Bool("no-commit", false, "Don't create a git commit")
+	flags.String("body", "", "Set note body as a literal string")
+	flags.String("body-file", "", "Read note body from file (- for stdin, 10 MiB cap)")
+	flags.String("author", "", "Override the default author attribution")
+}
+
+func runIntentNote(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	noCommit, _ := cmd.Flags().GetBool("no-commit")
+	authorFlag, _ := cmd.Flags().GetString("author")
+
+	body, _, err := resolveBody(cmd)
+	if err != nil {
+		return err
+	}
+
+	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return err
+	}
+
+	resolver := paths.NewResolverFromConfig(campaignRoot, cfg)
+	svc := intent.NewIntentService(campaignRoot, resolver.Intents())
+	if err := svc.EnsureDirectories(ctx); err != nil {
+		return camperrors.Wrap(err, "ensuring intent directories")
+	}
+
+	// Fast path: note text provided as an argument
+	if len(args) > 0 {
+		author := "agent"
+		if cmd.Flags().Changed("author") {
+			author = authorFlag
+		}
+		opts := intent.CreateOptions{Title: args[0], Author: author, Body: body}
+		return runNoteCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, opts)
+	}
+
+	// No argument: non-TTY requires note text (can't launch TUI)
+	if !navtui.IsTerminal() {
+		return camperrors.Wrap(camperrors.ErrInvalidInput, "note text required in non-interactive mode\n       Usage: camp intent note <text> [flags]")
+	}
+
+	author := git.GetUserName(ctx)
+	if cmd.Flags().Changed("author") {
+		author = authorFlag
+	}
+
+	conceptSvc := concept.NewService(campaignRoot, cfg.Concepts())
+	model, err := runIntentNoteTUI(ctx, conceptSvc, tui.AddOptions{
+		NoteMode:     true,
+		Author:       author,
+		CampaignRoot: campaignRoot,
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, saved := range model.SavedResults() {
+		if err := runNoteCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, intent.CreateOptions{
+			Title:  saved.Title,
+			Author: saved.Author,
+		}); err != nil {
+			return err
+		}
+	}
+
+	result := model.Result()
+	if result == nil {
+		if len(model.SavedResults()) > 0 {
+			return nil
+		}
+		return intent.ErrCancelled
+	}
+
+	return runNoteCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, intent.CreateOptions{
+		Title:  result.Title,
+		Author: result.Author,
+	})
+}
+
+func runIntentNoteTUI(ctx context.Context, conceptSvc concept.Service, opts tui.AddOptions) (*tui.IntentAddModel, error) {
+	model := tui.NewIntentAddModel(ctx, conceptSvc, opts)
+
+	p := tea.NewProgram(model, tea.WithAltScreen())
+	finalModel, err := p.Run()
+	if err != nil {
+		return nil, camperrors.Wrap(err, "TUI error")
+	}
+
+	m, ok := finalModel.(tui.IntentAddModel)
+	if !ok {
+		return nil, camperrors.Wrapf(camperrors.ErrInvalidInput, "unexpected model type: %T", finalModel)
+	}
+
+	return &m, nil
+}
+
+func runNoteCapture(ctx context.Context, svc *intent.IntentService, intentsDir string, cfg *config.CampaignConfig, campaignRoot string, noCommit bool, opts intent.CreateOptions) error {
+	result, err := svc.CreateNote(ctx, opts)
+	if err != nil {
+		return camperrors.Wrap(err, "failed to create note")
+	}
+
+	return finalizeCreatedNote(ctx, result, intentsDir, cfg, campaignRoot, noCommit)
+}
+
+func finalizeCreatedNote(ctx context.Context, result *intent.Intent, intentsDir string, cfg *config.CampaignConfig, campaignRoot string, noCommit bool) error {
+	if err := appendIntentAuditEvent(ctx, intentsDir, audit.Event{
+		Type:  audit.EventCreate,
+		ID:    result.ID,
+		Title: result.Title,
+		To:    string(result.Status),
+	}); err != nil {
+		return err
+	}
+
+	fmt.Printf("✓ Note created: %s\n", result.Path)
+
+	if !noCommit {
+		files := commit.NormalizeFiles(campaignRoot, result.Path, audit.FilePath(intentsDir))
+		commitResult := commit.Intent(ctx, commit.IntentOptions{
+			Options: commit.Options{
+				CampaignRoot:  campaignRoot,
+				CampaignID:    cfg.ID,
+				Files:         files,
+				SelectiveOnly: true,
+			},
+			Action:      commit.IntentCreate,
+			IntentTitle: result.Title,
+		})
+		if commitResult.Message != "" {
+			fmt.Printf("  %s\n", commitResult.Message)
+		}
+	}
+
+	return nil
+}

--- a/cmd/camp/intent/note.go
+++ b/cmd/camp/intent/note.go
@@ -27,13 +27,14 @@ are stored in .campaign/intents/notes/ and do not flow through the
 inbox → ready → active lifecycle. A note carries no type or concept; tags
 organize them.
 
-Fast capture skips the type wheel and concept picker entirely.
+Fast capture skips the TUI. Interactive capture uses the same title/body/tag
+flow as intent add, but skips the type wheel and concept picker.
 
 Examples:
   camp intent note "check the daemon socket path"   Capture a note immediately
   camp intent note "follow up" --body "details..."  Note with a longer body
   echo "body" | camp intent note "idea" --body-file -
-  camp intent note                                  Quick-add note (TUI)`,
+  camp intent note                                  Note TUI (title + body)`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runIntentNote,
 }
@@ -97,6 +98,7 @@ func runIntentNote(cmd *cobra.Command, args []string) error {
 		NoteMode:      true,
 		Author:        author,
 		CampaignRoot:  campaignRoot,
+		Shortcuts:     navigationShortcuts(cfg),
 		AvailableTags: cfg.IntentTags(),
 	})
 	if err != nil {
@@ -107,6 +109,7 @@ func runIntentNote(cmd *cobra.Command, args []string) error {
 		if err := runNoteCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, intent.CreateOptions{
 			Title:  saved.Title,
 			Author: saved.Author,
+			Body:   saved.Body,
 			Tags:   mergeTags(tags, saved.Tags),
 		}); err != nil {
 			return err
@@ -124,6 +127,7 @@ func runIntentNote(cmd *cobra.Command, args []string) error {
 	return runNoteCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, intent.CreateOptions{
 		Title:  result.Title,
 		Author: result.Author,
+		Body:   result.Body,
 		Tags:   mergeTags(tags, result.Tags),
 	})
 }

--- a/cmd/camp/intent/note.go
+++ b/cmd/camp/intent/note.go
@@ -46,6 +46,7 @@ func init() {
 	flags.String("body", "", "Set note body as a literal string")
 	flags.String("body-file", "", "Read note body from file (- for stdin, 10 MiB cap)")
 	flags.String("author", "", "Override the default author attribution")
+	flags.StringArrayP("tag", "t", nil, "Add a tag (repeatable)")
 }
 
 func runIntentNote(cmd *cobra.Command, args []string) error {
@@ -53,6 +54,7 @@ func runIntentNote(cmd *cobra.Command, args []string) error {
 
 	noCommit, _ := cmd.Flags().GetBool("no-commit")
 	authorFlag, _ := cmd.Flags().GetString("author")
+	tags, _ := cmd.Flags().GetStringArray("tag")
 
 	body, _, err := resolveBody(cmd)
 	if err != nil {
@@ -76,7 +78,7 @@ func runIntentNote(cmd *cobra.Command, args []string) error {
 		if cmd.Flags().Changed("author") {
 			author = authorFlag
 		}
-		opts := intent.CreateOptions{Title: args[0], Author: author, Body: body}
+		opts := intent.CreateOptions{Title: args[0], Author: author, Body: body, Tags: tags}
 		return runNoteCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, opts)
 	}
 
@@ -92,9 +94,10 @@ func runIntentNote(cmd *cobra.Command, args []string) error {
 
 	conceptSvc := concept.NewService(campaignRoot, cfg.Concepts())
 	model, err := runIntentNoteTUI(ctx, conceptSvc, tui.AddOptions{
-		NoteMode:     true,
-		Author:       author,
-		CampaignRoot: campaignRoot,
+		NoteMode:      true,
+		Author:        author,
+		CampaignRoot:  campaignRoot,
+		AvailableTags: cfg.IntentTags(),
 	})
 	if err != nil {
 		return err
@@ -104,6 +107,7 @@ func runIntentNote(cmd *cobra.Command, args []string) error {
 		if err := runNoteCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, intent.CreateOptions{
 			Title:  saved.Title,
 			Author: saved.Author,
+			Tags:   mergeTags(tags, saved.Tags),
 		}); err != nil {
 			return err
 		}
@@ -120,6 +124,7 @@ func runIntentNote(cmd *cobra.Command, args []string) error {
 	return runNoteCapture(ctx, svc, resolver.Intents(), cfg, campaignRoot, noCommit, intent.CreateOptions{
 		Title:  result.Title,
 		Author: result.Author,
+		Tags:   mergeTags(tags, result.Tags),
 	})
 }
 
@@ -138,6 +143,23 @@ func runIntentNoteTUI(ctx context.Context, conceptSvc concept.Service, opts tui.
 	}
 
 	return &m, nil
+}
+
+// mergeTags unions flag tags and overlay tags, preserving order and dropping
+// duplicates and empties.
+func mergeTags(a, b []string) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, list := range [][]string{a, b} {
+		for _, t := range list {
+			if t == "" || seen[t] {
+				continue
+			}
+			seen[t] = true
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 func runNoteCapture(ctx context.Context, svc *intent.IntentService, intentsDir string, cfg *config.CampaignConfig, campaignRoot string, noCommit bool, opts intent.CreateOptions) error {

--- a/cmd/camp/intent/rename.go
+++ b/cmd/camp/intent/rename.go
@@ -21,8 +21,10 @@ var intentRenameCmd = &cobra.Command{
 filename. The intent's stable id is preserved, so references and lookups survive
 the rename.
 
+Resolution is by exact id (run 'camp intent list' to copy one).
+
 Examples:
-  camp intent rename add-dark "Add a dark mode toggle"`,
+  camp intent rename add-dark-mode-20260119-153412 "Add a dark mode toggle"`,
 	Args: cobra.ExactArgs(2),
 	RunE: runIntentRename,
 }
@@ -50,6 +52,11 @@ func runIntentRename(cmd *cobra.Command, args []string) error {
 	}
 
 	before, err := svc.Get(ctx, id)
+	if err != nil {
+		// Notes resolve through a separate store; fall back so a note can be
+		// renamed by id too.
+		before, err = svc.GetNote(ctx, id)
+	}
 	if err != nil {
 		return camperrors.Wrapf(err, "intent not found: %s", id)
 	}

--- a/cmd/camp/intent/rename.go
+++ b/cmd/camp/intent/rename.go
@@ -1,0 +1,97 @@
+package intent
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git/commit"
+	"github.com/Obedience-Corp/camp/internal/intent"
+	"github.com/Obedience-Corp/camp/internal/intent/audit"
+	"github.com/Obedience-Corp/camp/internal/paths"
+)
+
+var intentRenameCmd = &cobra.Command{
+	Use:   "rename <id> <new title>",
+	Short: "Rename an intent",
+	Long: `Rename an intent: update its title and regenerate its human-readable
+filename. The intent's stable id is preserved, so references and lookups survive
+the rename.
+
+Examples:
+  camp intent rename add-dark "Add a dark mode toggle"`,
+	Args: cobra.ExactArgs(2),
+	RunE: runIntentRename,
+}
+
+func init() {
+	Cmd.AddCommand(intentRenameCmd)
+	intentRenameCmd.Flags().Bool("no-commit", false, "Don't create a git commit")
+}
+
+func runIntentRename(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	id := args[0]
+	newTitle := args[1]
+	noCommit, _ := cmd.Flags().GetBool("no-commit")
+
+	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	resolver := paths.NewResolverFromConfig(campaignRoot, cfg)
+	svc := intent.NewIntentService(campaignRoot, resolver.Intents())
+	if err := svc.EnsureDirectories(ctx); err != nil {
+		return camperrors.Wrap(err, "ensuring intent directories")
+	}
+
+	before, err := svc.Get(ctx, id)
+	if err != nil {
+		return camperrors.Wrapf(err, "intent not found: %s", id)
+	}
+	oldTitle := before.Title
+	oldPath := before.Path
+
+	renamed, err := svc.Rename(ctx, id, newTitle)
+	if err != nil {
+		return camperrors.Wrap(err, "failed to rename intent")
+	}
+
+	fmt.Printf("✓ Intent renamed: %s\n", renamed.Path)
+
+	if err := appendIntentAuditEvent(ctx, resolver.Intents(), audit.Event{
+		Type:  audit.EventRename,
+		ID:    renamed.ID,
+		Title: renamed.Title,
+		Changes: []audit.FieldChange{
+			{Field: "title", Old: oldTitle, New: renamed.Title},
+			{Field: "filename", Old: filepath.Base(oldPath), New: filepath.Base(renamed.Path)},
+		},
+	}); err != nil {
+		return err
+	}
+
+	if !noCommit {
+		files := commit.NormalizeFiles(campaignRoot, oldPath, renamed.Path, audit.FilePath(resolver.Intents()))
+		commitResult := commit.Intent(ctx, commit.IntentOptions{
+			Options: commit.Options{
+				CampaignRoot:  campaignRoot,
+				CampaignID:    cfg.ID,
+				Files:         files,
+				SelectiveOnly: true,
+			},
+			Action:      commit.IntentRename,
+			IntentTitle: renamed.Title,
+			Description: "Renamed from " + oldTitle,
+		})
+		if commitResult.Message != "" {
+			fmt.Printf("  %s\n", commitResult.Message)
+		}
+	}
+
+	return nil
+}

--- a/cmd/camp/intent/tags_test.go
+++ b/cmd/camp/intent/tags_test.go
@@ -1,0 +1,28 @@
+package intent
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestMergeTags(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []string
+		b    []string
+		want []string
+	}{
+		{"flag and overlay union", []string{"urgent"}, []string{"backend"}, []string{"urgent", "backend"}},
+		{"dedup across both", []string{"x", "y"}, []string{"y", "z"}, []string{"x", "y", "z"}},
+		{"drops empties", []string{"", "a"}, []string{"", "b"}, []string{"a", "b"}},
+		{"flag only", []string{"flagged"}, nil, []string{"flagged"}},
+		{"overlay only", nil, []string{"picked"}, []string{"picked"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mergeTags(tt.a, tt.b); !slices.Equal(got, tt.want) {
+				t.Errorf("mergeTags(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/migrations/workflow-subconcepts-2026-06.md
+++ b/docs/migrations/workflow-subconcepts-2026-06.md
@@ -1,0 +1,83 @@
+# Workflow Sub-Concepts Upgrade Guide (June 2026)
+
+This note covers the concept-menu and `campaign.yaml` changes delivered in
+`camp` during June 2026, where workflows become sub-concepts of a single
+`workflow` parent.
+
+## What Changed
+
+### 1. The concept picker is now a small tree
+
+The intent concept picker previously listed every workflow collection as its own
+top-level entry (`festivals`, `design`, `explore`, `code_reviews`, `pipelines`,
+plus `worktrees`, `intents`, and any custom workflow). It now shows three
+top-level concepts:
+
+```
+projects
+workflow
+  festivals
+  design
+  explore
+  code_reviews
+  pipelines
+docs
+```
+
+Selecting `workflow` opens its sub-concepts. Each sub-concept stores the same
+path-based `Intent.Concept` value as before (`festivals/`, `workflow/design/`,
+and so on), so existing intents need no migration. `worktrees` and `dungeon` are
+no longer picker concepts (worktrees is a projects detail, and dungeon is
+resolved dynamically).
+
+### 2. `camp workflow create` nests new workflows
+
+`camp workflow create <type>` now registers the new collection as a child of the
+`workflow` concept instead of a flat top-level entry. The new workflow appears in
+the picker submenu automatically, and `camp workflow list`, `show`, `doctor`, and
+`sync` continue to work against the nested tree.
+
+### 3. The config gained a recursive `children` field
+
+`ConceptEntry` now has an optional `children` list. A concept without `children`
+behaves exactly as before, so configs that never nest are unaffected.
+
+## Upgrading an Existing Campaign
+
+Run the repair command from the campaign root:
+
+```
+camp init --repair
+```
+
+The migration is non-destructive and idempotent:
+
+- Built-in workflow-family concepts (`festivals`, `design`, `explore`,
+  `code_reviews`, `pipelines`) and any `workflow/`-prefixed concept move under a
+  single `workflow` parent.
+- The default `worktrees` entry is dropped from the picker (navigation shortcuts
+  are unaffected).
+- `projects`, `docs`, and any custom or unknown top-level concept are preserved.
+- Custom workflows already nested under `workflow` are left in place.
+- Running `--repair` again makes no further changes.
+
+## Customizing Concepts
+
+Concepts live in `.campaign/campaign.yaml` under the `concepts:` block. To add or
+reorder workflow collections, edit the `workflow` concept's `children:` list:
+
+```yaml
+concepts:
+  - name: workflow
+    path: workflow/
+    description: Workflows
+    children:
+      - name: festivals
+        path: festivals/
+      - name: design
+        path: workflow/design/
+      # add custom workflows here, or use `camp workflow create`
+```
+
+`camp concepts` prints the current tree and a customization hint. See the
+campaign config reference for the full schema.

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -110,6 +110,16 @@ cint "my idea for a new feature"
 
 Equivalent to `camp intent add "..."`. Quickly capture thoughts and ideas.
 
+### `cnote` - Quick Note Capture
+
+```bash
+cnote "quick research note"
+cnote "follow up" --body "details to remember"
+```
+
+Equivalent to `camp intent note "..."`. Quickly capture notes without routing
+them through the intent lifecycle.
+
 ### `cie` - Explore Intents
 
 ```bash

--- a/internal/commands/workflow/create.go
+++ b/internal/commands/workflow/create.go
@@ -75,6 +75,7 @@ type shortcutPlan struct {
 type conceptPlan struct {
 	Name     string `json:"name"`
 	Path     string `json:"path"`
+	Parent   string `json:"parent,omitempty"` // parent concept the new collection nests under
 	Existing string `json:"existing,omitempty"`
 	Replaced bool   `json:"replaced"`
 	NoChange bool   `json:"no_change"`

--- a/internal/commands/workflow/create_apply.go
+++ b/internal/commands/workflow/create_apply.go
@@ -127,10 +127,33 @@ func upsertShortcut(ctx context.Context, campaignRoot string, cfg *config.Campai
 // workflowParentName is the concept that groups all workflow collections.
 const workflowParentName = "workflow"
 
+// flatWorkflowConceptIndex finds a legacy top-level workflow concept of the
+// given name, or -1. These predate the nested shape and survive until init
+// --repair, so create folds one in rather than registering a duplicate child.
+func flatWorkflowConceptIndex(concepts []config.ConceptEntry, name string) int {
+	for i := range concepts {
+		if strings.EqualFold(concepts[i].Name, workflowParentName) {
+			continue
+		}
+		if strings.EqualFold(concepts[i].Name, name) && strings.HasPrefix(concepts[i].Path, "workflow/") {
+			return i
+		}
+	}
+	return -1
+}
+
 func upsertConcept(ctx context.Context, campaignRoot string, cfg *config.CampaignConfig, name, relPath, title string, replace bool) error {
 	concepts := cfg.ConceptList
 	if len(concepts) == 0 {
 		concepts = cfg.Concepts()
+	}
+
+	// Drop a legacy flat top-level workflow concept with this name so it does not
+	// linger beside the nested child registered below.
+	migrated := false
+	if idx := flatWorkflowConceptIndex(concepts, name); idx != -1 {
+		concepts = append(concepts[:idx], concepts[idx+1:]...)
+		migrated = true
 	}
 
 	// Find the workflow parent, creating it if absent.
@@ -157,7 +180,11 @@ func upsertConcept(ctx context.Context, campaignRoot string, cfg *config.Campaig
 			continue
 		}
 		if children[j].Path == relPath {
+			concepts[parentIdx].Children = children
 			cfg.ConceptList = concepts
+			if migrated {
+				return config.SaveCampaignConfig(ctx, campaignRoot, cfg)
+			}
 			return nil
 		}
 		if !replace {

--- a/internal/commands/workflow/create_apply.go
+++ b/internal/commands/workflow/create_apply.go
@@ -124,37 +124,53 @@ func upsertShortcut(ctx context.Context, campaignRoot string, cfg *config.Campai
 	return nil
 }
 
+// workflowParentName is the concept that groups all workflow collections.
+const workflowParentName = "workflow"
+
 func upsertConcept(ctx context.Context, campaignRoot string, cfg *config.CampaignConfig, name, relPath, title string, replace bool) error {
 	concepts := cfg.ConceptList
 	if len(concepts) == 0 {
 		concepts = cfg.Concepts()
 	}
 
-	for i, concept := range concepts {
-		if strings.EqualFold(concept.Name, name) {
-			if concept.Path == relPath {
-				cfg.ConceptList = concepts
-				return nil
-			}
-			if !replace {
-				return camperrors.NewValidation("type",
-					"concept "+name+" already points to "+concept.Path+"; use --replace to update it", nil)
-			}
-			concepts[i] = config.ConceptEntry{
-				Name:        name,
-				Path:        relPath,
-				Description: title + " workflow",
-			}
-			cfg.ConceptList = concepts
-			return config.SaveCampaignConfig(ctx, campaignRoot, cfg)
+	// Find the workflow parent, creating it if absent.
+	parentIdx := -1
+	for i := range concepts {
+		if strings.EqualFold(concepts[i].Name, workflowParentName) {
+			parentIdx = i
+			break
 		}
 	}
+	if parentIdx == -1 {
+		concepts = append(concepts, config.ConceptEntry{
+			Name:        workflowParentName,
+			Path:        "workflow/",
+			Description: "Workflows",
+		})
+		parentIdx = len(concepts) - 1
+	}
 
-	concepts = append(concepts, config.ConceptEntry{
-		Name:        name,
-		Path:        relPath,
-		Description: title + " workflow",
-	})
+	child := config.ConceptEntry{Name: name, Path: relPath, Description: title + " workflow"}
+	children := concepts[parentIdx].Children
+	for j := range children {
+		if !strings.EqualFold(children[j].Name, name) {
+			continue
+		}
+		if children[j].Path == relPath {
+			cfg.ConceptList = concepts
+			return nil
+		}
+		if !replace {
+			return camperrors.NewValidation("type",
+				"concept "+name+" already points to "+children[j].Path+"; use --replace to update it", nil)
+		}
+		children[j] = child
+		concepts[parentIdx].Children = children
+		cfg.ConceptList = concepts
+		return config.SaveCampaignConfig(ctx, campaignRoot, cfg)
+	}
+
+	concepts[parentIdx].Children = append(children, child)
 	cfg.ConceptList = concepts
 	return config.SaveCampaignConfig(ctx, campaignRoot, cfg)
 }

--- a/internal/commands/workflow/create_plan.go
+++ b/internal/commands/workflow/create_plan.go
@@ -152,6 +152,18 @@ func planConcept(cfg *config.CampaignConfig, plan *createPlan, opts createOption
 			return nil
 		}
 	}
+
+	// A legacy flat top-level workflow concept counts as an existing entry: apply
+	// folds it under the parent rather than adding a duplicate child.
+	if idx := flatWorkflowConceptIndex(concepts, opts.Type); idx != -1 {
+		existing := concepts[idx]
+		if existing.Path != plan.WorkflowRel && !opts.Replace {
+			return camperrors.NewValidation("type",
+				"concept "+opts.Type+" already points to "+existing.Path+"; use --replace to update it", nil)
+		}
+		plan.Concept.Replaced = true
+		plan.Concept.Existing = existing.Path
+	}
 	return nil
 }
 

--- a/internal/commands/workflow/create_plan.go
+++ b/internal/commands/workflow/create_plan.go
@@ -123,27 +123,34 @@ func planShortcut(cfg *config.CampaignConfig, plan *createPlan, opts createOptio
 func planConcept(cfg *config.CampaignConfig, plan *createPlan, opts createOptions) error {
 	plan.Concept.Name = opts.Type
 	plan.Concept.Path = plan.WorkflowRel
+	plan.Concept.Parent = workflowParentName
 
 	concepts := cfg.ConceptList
 	if len(concepts) == 0 {
 		concepts = cfg.Concepts()
 	}
 
-	for _, concept := range concepts {
-		if !strings.EqualFold(concept.Name, opts.Type) {
+	// New collections nest under the workflow parent; look for an existing child.
+	for _, parent := range concepts {
+		if !strings.EqualFold(parent.Name, workflowParentName) {
 			continue
 		}
-		if concept.Path == plan.WorkflowRel {
-			plan.Concept.NoChange = true
+		for _, child := range parent.Children {
+			if !strings.EqualFold(child.Name, opts.Type) {
+				continue
+			}
+			if child.Path == plan.WorkflowRel {
+				plan.Concept.NoChange = true
+				return nil
+			}
+			if !opts.Replace {
+				return camperrors.NewValidation("type",
+					"concept "+opts.Type+" already points to "+child.Path+"; use --replace to update it", nil)
+			}
+			plan.Concept.Replaced = true
+			plan.Concept.Existing = child.Path
 			return nil
 		}
-		if !opts.Replace {
-			return camperrors.NewValidation("type",
-				"concept "+opts.Type+" already points to "+concept.Path+"; use --replace to update it", nil)
-		}
-		plan.Concept.Replaced = true
-		plan.Concept.Existing = concept.Path
-		return nil
 	}
 	return nil
 }

--- a/internal/commands/workflow/create_test.go
+++ b/internal/commands/workflow/create_test.go
@@ -213,6 +213,86 @@ func TestUpsertConceptReplace(t *testing.T) {
 	}
 }
 
+func TestUpsertConceptFoldsLegacyFlatConcept(t *testing.T) {
+	root := t.TempDir()
+	cfg := &config.CampaignConfig{
+		ConceptList: []config.ConceptEntry{
+			{Name: "workflow", Path: "workflow/", Description: "Workflows"},
+			{Name: "research", Path: "workflow/research/", Description: "Research workflow"},
+		},
+	}
+
+	err := upsertConcept(context.Background(), root, cfg, "research", "workflow/research/", "Research", false)
+	if err != nil {
+		t.Fatalf("upsertConcept: %v", err)
+	}
+
+	if len(cfg.ConceptList) != 1 {
+		t.Fatalf("len(ConceptList) = %d, want 1 (legacy flat concept folded under workflow): %#v", len(cfg.ConceptList), cfg.ConceptList)
+	}
+	workflow := cfg.ConceptList[0]
+	if workflow.Name != "workflow" {
+		t.Fatalf("top-level concept = %q, want workflow", workflow.Name)
+	}
+	count := 0
+	for _, ch := range workflow.Children {
+		if strings.EqualFold(ch.Name, "research") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("research child count = %d, want 1: %#v", count, workflow.Children)
+	}
+}
+
+func TestRunCreateFoldsLegacyFlatConcept(t *testing.T) {
+	root := newWorkflowTestCampaign(t)
+	cfg := &config.CampaignConfig{
+		ID:   "test-campaign",
+		Name: "Workflow Test",
+		Type: config.CampaignTypeProduct,
+		ConceptList: []config.ConceptEntry{
+			{Name: "projects", Path: "projects/", Description: "Projects"},
+			{Name: "research", Path: "workflow/research/", Description: "Research workflow"},
+		},
+	}
+	if err := config.SaveCampaignConfig(context.Background(), root, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := &cobra.Command{}
+	if err := runCreate(context.Background(), cmd, createOptions{Type: "research", Shortcut: "re", Title: "Research"}); err != nil {
+		t.Fatalf("runCreate: %v", err)
+	}
+
+	reloaded, err := config.LoadCampaignConfig(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	topLevel, child := 0, 0
+	for _, c := range reloaded.ConceptList {
+		if strings.EqualFold(c.Name, "research") {
+			topLevel++
+		}
+		if strings.EqualFold(c.Name, "workflow") {
+			for _, ch := range c.Children {
+				if strings.EqualFold(ch.Name, "research") {
+					child++
+				}
+			}
+		}
+	}
+	if topLevel != 0 {
+		t.Errorf("legacy flat research concept still top-level: %#v", reloaded.ConceptList)
+	}
+	if child != 1 {
+		t.Errorf("research child count = %d, want 1: %#v", child, reloaded.ConceptList)
+	}
+}
+
 func TestRunCreateRegistersExistingUserWorkflow(t *testing.T) {
 	root := newWorkflowTestCampaign(t)
 	workflowDir := filepath.Join(root, "workflow", "research")

--- a/internal/commands/workflow/create_test.go
+++ b/internal/commands/workflow/create_test.go
@@ -161,7 +161,9 @@ func TestUpsertConceptCollisionWithoutReplace(t *testing.T) {
 	root := t.TempDir()
 	cfg := &config.CampaignConfig{
 		ConceptList: []config.ConceptEntry{
-			{Name: "Research", Path: "workflow/old-research/"},
+			{Name: "workflow", Path: "workflow/", Description: "Workflows", Children: []config.ConceptEntry{
+				{Name: "Research", Path: "workflow/old-research/"},
+			}},
 		},
 	}
 
@@ -178,7 +180,9 @@ func TestUpsertConceptReplace(t *testing.T) {
 	root := t.TempDir()
 	cfg := &config.CampaignConfig{
 		ConceptList: []config.ConceptEntry{
-			{Name: "Research", Path: "workflow/old-research/"},
+			{Name: "workflow", Path: "workflow/", Description: "Workflows", Children: []config.ConceptEntry{
+				{Name: "Research", Path: "workflow/old-research/"},
+			}},
 		},
 	}
 
@@ -187,13 +191,17 @@ func TestUpsertConceptReplace(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(cfg.ConceptList) != 1 {
-		t.Fatalf("len(ConceptList) = %d, want 1", len(cfg.ConceptList))
+		t.Fatalf("len(ConceptList) = %d, want 1 (workflow parent)", len(cfg.ConceptList))
 	}
-	if cfg.ConceptList[0].Name != "research" {
-		t.Fatalf("concept name = %q, want research", cfg.ConceptList[0].Name)
+	workflow := cfg.ConceptList[0]
+	if workflow.Name != "workflow" {
+		t.Fatalf("top-level concept = %q, want workflow", workflow.Name)
 	}
-	if cfg.ConceptList[0].Path != "workflow/research/" {
-		t.Fatalf("concept path = %q, want workflow/research/", cfg.ConceptList[0].Path)
+	if len(workflow.Children) != 1 || workflow.Children[0].Name != "research" {
+		t.Fatalf("workflow children = %#v, want [research]", workflow.Children)
+	}
+	if workflow.Children[0].Path != "workflow/research/" {
+		t.Fatalf("research child path = %q, want workflow/research/", workflow.Children[0].Path)
 	}
 
 	campaignYAML, err := os.ReadFile(config.CampaignConfigPath(root))
@@ -275,13 +283,17 @@ func TestRunCreateRegistersExistingUserWorkflow(t *testing.T) {
 	}
 	foundConcept := false
 	for _, concept := range cfg.ConceptList {
-		if concept.Name == "research" && concept.Path == "workflow/research/" {
-			foundConcept = true
-			break
+		if !strings.EqualFold(concept.Name, "workflow") {
+			continue
+		}
+		for _, child := range concept.Children {
+			if child.Name == "research" && child.Path == "workflow/research/" {
+				foundConcept = true
+			}
 		}
 	}
 	if !foundConcept {
-		t.Fatalf("research concept missing from campaign config: %#v", cfg.ConceptList)
+		t.Fatalf("research child concept missing from campaign config: %#v", cfg.ConceptList)
 	}
 }
 
@@ -325,14 +337,20 @@ func TestRunCreateIdempotentForSameWorkflow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// research nests as a child of the workflow parent, exactly once.
 	count := 0
 	for _, concept := range cfg.ConceptList {
-		if strings.EqualFold(concept.Name, "research") && concept.Path == "workflow/research/" {
-			count++
+		if !strings.EqualFold(concept.Name, "workflow") {
+			continue
+		}
+		for _, child := range concept.Children {
+			if strings.EqualFold(child.Name, "research") && child.Path == "workflow/research/" {
+				count++
+			}
 		}
 	}
 	if count != 1 {
-		t.Fatalf("research concept count = %d, want 1: %#v", count, cfg.ConceptList)
+		t.Fatalf("research child concept count = %d, want 1: %#v", count, cfg.ConceptList)
 	}
 }
 
@@ -343,7 +361,9 @@ func TestRunCreateReplacePersistsShortcutAndConcept(t *testing.T) {
 		Name: "Workflow Test",
 		Type: config.CampaignTypeProduct,
 		ConceptList: []config.ConceptEntry{
-			{Name: "Research", Path: "workflow/old-research/"},
+			{Name: "workflow", Path: "workflow/", Description: "Workflows", Children: []config.ConceptEntry{
+				{Name: "Research", Path: "workflow/old-research/"},
+			}},
 		},
 	}
 	if err := config.SaveCampaignConfig(context.Background(), root, cfg); err != nil {
@@ -388,13 +408,17 @@ func TestRunCreateReplacePersistsShortcutAndConcept(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(reloadedCfg.ConceptList) != 1 {
-		t.Fatalf("len(ConceptList) = %d, want 1: %#v", len(reloadedCfg.ConceptList), reloadedCfg.ConceptList)
+		t.Fatalf("len(ConceptList) = %d, want 1 (workflow parent): %#v", len(reloadedCfg.ConceptList), reloadedCfg.ConceptList)
 	}
-	if reloadedCfg.ConceptList[0].Name != "research" {
-		t.Fatalf("concept name = %q, want research", reloadedCfg.ConceptList[0].Name)
+	workflow := reloadedCfg.ConceptList[0]
+	if workflow.Name != "workflow" {
+		t.Fatalf("top-level concept = %q, want workflow", workflow.Name)
 	}
-	if reloadedCfg.ConceptList[0].Path != "workflow/research/" {
-		t.Fatalf("concept path = %q, want workflow/research/", reloadedCfg.ConceptList[0].Path)
+	if len(workflow.Children) != 1 || workflow.Children[0].Name != "research" {
+		t.Fatalf("workflow children = %#v, want [research]", workflow.Children)
+	}
+	if workflow.Children[0].Path != "workflow/research/" {
+		t.Fatalf("research child path = %q, want workflow/research/", workflow.Children[0].Path)
 	}
 }
 

--- a/internal/commands/workflow/doctor.go
+++ b/internal/commands/workflow/doctor.go
@@ -115,7 +115,7 @@ func collectFindings(ctx context.Context, campaignRoot string, cfg *config.Campa
 	var findings []finding
 
 	shortcuts := cfg.Shortcuts()
-	concepts := cfg.Concepts()
+	concepts := flattenConcepts(cfg.Concepts())
 
 	// workflow.shortcut.missing-target: shortcut points to nonexistent
 	// workflow/<type>/ directory.

--- a/internal/commands/workflow/internal.go
+++ b/internal/commands/workflow/internal.go
@@ -49,28 +49,46 @@ type workflowEntry struct {
 // enumerateWorkflowEntries returns the union of concept-listed workflows and
 // on-disk workflow/<type>/ directories. Builtin types are filtered out.
 // Entries are sorted by type name.
+// flattenConcepts returns every concept including nested children, depth-first.
+func flattenConcepts(concepts []config.ConceptEntry) []config.ConceptEntry {
+	var out []config.ConceptEntry
+	for _, c := range concepts {
+		out = append(out, c)
+		if len(c.Children) > 0 {
+			out = append(out, flattenConcepts(c.Children)...)
+		}
+	}
+	return out
+}
+
+// collectWorkflowConcepts records non-builtin workflow/ concepts, descending
+// into nested children so collections under the workflow parent are found.
+func collectWorkflowConcepts(concepts []config.ConceptEntry, entries map[string]*workflowEntry) {
+	for _, concept := range concepts {
+		if strings.HasPrefix(concept.Path, "workflow/") {
+			if typeName := workflowTypeFromPath(concept.Path); typeName != "" && !builtinWorkflowTypes[typeName] {
+				entry := entries[typeName]
+				if entry == nil {
+					entry = &workflowEntry{Type: typeName, Path: concept.Path}
+					entries[typeName] = entry
+				}
+				entry.HasConcept = true
+				if entry.Title == "" {
+					entry.Title = stripWorkflowSuffix(concept.Description)
+				}
+			}
+		}
+		if len(concept.Children) > 0 {
+			collectWorkflowConcepts(concept.Children, entries)
+		}
+	}
+}
+
 func enumerateWorkflowEntries(campaignRoot string, cfg *config.CampaignConfig) ([]workflowEntry, error) {
 	entries := make(map[string]*workflowEntry)
 
-	for _, concept := range cfg.Concepts() {
-		relPath := concept.Path
-		if !strings.HasPrefix(relPath, "workflow/") {
-			continue
-		}
-		typeName := workflowTypeFromPath(relPath)
-		if typeName == "" || builtinWorkflowTypes[typeName] {
-			continue
-		}
-		entry := entries[typeName]
-		if entry == nil {
-			entry = &workflowEntry{Type: typeName, Path: relPath}
-			entries[typeName] = entry
-		}
-		entry.HasConcept = true
-		if entry.Title == "" {
-			entry.Title = stripWorkflowSuffix(concept.Description)
-		}
-	}
+	// Workflow concepts may be nested under the workflow parent, so descend.
+	collectWorkflowConcepts(cfg.Concepts(), entries)
 
 	workflowRoot := filepath.Join(campaignRoot, "workflow")
 	dirEntries, err := os.ReadDir(workflowRoot)

--- a/internal/commands/workflow/sync.go
+++ b/internal/commands/workflow/sync.go
@@ -185,21 +185,35 @@ func (s *syncState) removeShortcut(key string) bool {
 
 func (s *syncState) removeConcept(name string) bool {
 	concepts := s.currentConcepts()
-	next := make([]config.ConceptEntry, 0, len(concepts))
-	removed := false
-	for _, c := range concepts {
-		if strings.EqualFold(c.Name, name) {
-			removed = true
-			continue
-		}
-		next = append(next, c)
-	}
+	next, removed := removeConceptByName(concepts, name)
 	if !removed {
 		return false
 	}
 	s.cfg.ConceptList = next
 	s.conceptsDirty = true
 	return true
+}
+
+// removeConceptByName removes a concept by name from the tree, descending into
+// children (workflow collections nest under the workflow parent).
+func removeConceptByName(concepts []config.ConceptEntry, name string) ([]config.ConceptEntry, bool) {
+	removed := false
+	next := make([]config.ConceptEntry, 0, len(concepts))
+	for _, c := range concepts {
+		if strings.EqualFold(c.Name, name) {
+			removed = true
+			continue
+		}
+		if len(c.Children) > 0 {
+			children, childRemoved := removeConceptByName(c.Children, name)
+			if childRemoved {
+				c.Children = children
+				removed = true
+			}
+		}
+		next = append(next, c)
+	}
+	return next, removed
 }
 
 func (s *syncState) addConcept(target string) bool {
@@ -209,16 +223,30 @@ func (s *syncState) addConcept(target string) bool {
 		return false
 	}
 	concepts := s.currentConcepts()
-	for _, c := range concepts {
+	for _, c := range flattenConcepts(concepts) {
 		if strings.EqualFold(c.Name, typeName) {
 			return false
 		}
 	}
-	s.cfg.ConceptList = append(concepts, config.ConceptEntry{
+
+	// Nest the new collection under the workflow parent, creating it if absent.
+	parentIdx := -1
+	for i := range concepts {
+		if strings.EqualFold(concepts[i].Name, workflowParentName) {
+			parentIdx = i
+			break
+		}
+	}
+	if parentIdx == -1 {
+		concepts = append(concepts, config.ConceptEntry{Name: workflowParentName, Path: "workflow/", Description: "Workflows"})
+		parentIdx = len(concepts) - 1
+	}
+	concepts[parentIdx].Children = append(concepts[parentIdx].Children, config.ConceptEntry{
 		Name:        typeName,
 		Path:        rel,
 		Description: typeName + " workflow",
 	})
+	s.cfg.ConceptList = concepts
 	s.conceptsDirty = true
 	return true
 }

--- a/internal/concept/children.go
+++ b/internal/concept/children.go
@@ -1,0 +1,72 @@
+package concept
+
+import "github.com/Obedience-Corp/camp/internal/config"
+
+// pickerHiddenChildren are workflow registry entries that should never appear in
+// the concept picker submenu even though they live in the config registry. The
+// intents workflow is config-managed but linking an intent to the intents
+// directory is noise (design Q3).
+var pickerHiddenChildren = map[string]bool{
+	"intent":  true,
+	"intents": true,
+}
+
+// isPickerHidden reports whether a child concept is filtered from the picker.
+func isPickerHidden(name string) bool {
+	return pickerHiddenChildren[name]
+}
+
+// childConcepts maps configured ConceptEntry children to Concepts.
+func childConcepts(entries []config.ConceptEntry) []Concept {
+	if len(entries) == 0 {
+		return nil
+	}
+	children := make([]Concept, 0, len(entries))
+	for _, e := range entries {
+		children = append(children, Concept{
+			Name:        e.Name,
+			Path:        e.Path,
+			Description: e.Description,
+			MaxDepth:    e.Depth,
+			Ignore:      e.Ignore,
+		})
+	}
+	return children
+}
+
+// parentChildItems builds the picker items for a parent concept: configured
+// children first (authoritative order/labels, each pointing at its own path),
+// then any on-disk subdirectory under the parent path not already covered by a
+// child name. The intents workflow is filtered out. countFn returns the
+// child-count for a campaign-relative directory path.
+func parentChildItems(parent *Concept, diskItems []Item, countFn func(relPath string) int) []Item {
+	var items []Item
+	covered := make(map[string]bool)
+
+	for _, ch := range parent.Children {
+		if isPickerHidden(ch.Name) {
+			continue
+		}
+		items = append(items, Item{
+			Name:     ch.Name,
+			Path:     ch.Path,
+			IsDir:    true,
+			Children: countFn(ch.Path),
+		})
+		covered[ch.Name] = true
+	}
+
+	ignoreSet := makeIgnoreSet(parent.Ignore)
+	for _, di := range diskItems {
+		if !di.IsDir || covered[di.Name] || isPickerHidden(di.Name) {
+			continue
+		}
+		if ignoreSet[di.Name] || ignoreSet[di.Name+"/"] {
+			continue
+		}
+		items = append(items, di)
+		covered[di.Name] = true
+	}
+
+	return items
+}

--- a/internal/concept/children.go
+++ b/internal/concept/children.go
@@ -1,6 +1,10 @@
 package concept
 
-import "github.com/Obedience-Corp/camp/internal/config"
+import (
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+)
 
 // pickerHiddenChildren are workflow registry entries that should never appear in
 // the concept picker submenu even though they live in the config registry. The
@@ -29,9 +33,28 @@ func childConcepts(entries []config.ConceptEntry) []Concept {
 			Description: e.Description,
 			MaxDepth:    e.Depth,
 			Ignore:      e.Ignore,
+			Children:    childConcepts(e.Children),
 		})
 	}
 	return children
+}
+
+// childForSubpath matches the first segment of a drill subpath against the
+// parent's configured children. A match means traversal continues under the
+// child's own path and depth/ignore rules instead of the parent's path.
+// Picker-hidden children never appear in the submenu, so they never remap.
+func childForSubpath(parent *Concept, subpath string) (*Concept, string, bool) {
+	first, rest, _ := strings.Cut(subpath, "/")
+	for i := range parent.Children {
+		ch := &parent.Children[i]
+		if isPickerHidden(ch.Name) {
+			continue
+		}
+		if ch.Name == first {
+			return ch, rest, true
+		}
+	}
+	return nil, "", false
 }
 
 // parentChildItems builds the picker items for a parent concept: configured
@@ -48,10 +71,11 @@ func parentChildItems(parent *Concept, diskItems []Item, countFn func(relPath st
 			continue
 		}
 		items = append(items, Item{
-			Name:     ch.Name,
-			Path:     ch.Path,
-			IsDir:    true,
-			Children: countFn(ch.Path),
+			Name:          ch.Name,
+			Path:          ch.Path,
+			IsDir:         true,
+			Children:      countFn(ch.Path),
+			DrillDisabled: ch.MaxDepth != nil && *ch.MaxDepth == 0,
 		})
 		covered[ch.Name] = true
 	}

--- a/internal/concept/children_test.go
+++ b/internal/concept/children_test.go
@@ -112,6 +112,136 @@ func TestListItems_ParentChildren_FiltersIntent(t *testing.T) {
 	}
 }
 
+func TestListItems_ParentChildren_DrillUsesChildPath(t *testing.T) {
+	concepts := workflowParentConcepts(
+		config.ConceptEntry{Name: "festivals", Path: "festivals"},
+	)
+	fsys := fstest.MapFS{
+		"festivals/active/my-fest/FESTIVAL_GOAL.md": &fstest.MapFile{Data: []byte("")},
+		"festivals/planning/other-fest/file":        &fstest.MapFile{Data: []byte("")},
+		"workflow/festivals/decoy/file":             &fstest.MapFile{Data: []byte("")},
+	}
+	svc := NewFSService("", concepts, fsys)
+
+	items, err := svc.ListItems(context.Background(), "workflow", "festivals")
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	got := itemNames(items)
+	if len(got) != 2 || got[0] != "active" || got[1] != "planning" {
+		t.Fatalf("drill items = %v, want [active planning] from festivals/, not workflow/festivals", got)
+	}
+	if p, _ := itemPath(items, "active"); p != "festivals/active" {
+		t.Errorf("active path = %q, want festivals/active", p)
+	}
+
+	items, err = svc.ListItems(context.Background(), "workflow", "festivals/active")
+	if err != nil {
+		t.Fatalf("ListItems nested: %v", err)
+	}
+	if got := itemNames(items); len(got) != 1 || got[0] != "my-fest" {
+		t.Fatalf("nested drill items = %v, want [my-fest]", got)
+	}
+	if p, _ := itemPath(items, "my-fest"); p != "festivals/active/my-fest" {
+		t.Errorf("my-fest path = %q, want festivals/active/my-fest", p)
+	}
+}
+
+func TestListItems_ParentChildren_DrillHonorsChildDepth(t *testing.T) {
+	depth1 := 1
+	concepts := workflowParentConcepts(
+		config.ConceptEntry{Name: "design", Path: "workflow/design", Depth: &depth1},
+	)
+	fsys := fstest.MapFS{
+		"workflow/design/doc/nested/file": &fstest.MapFile{Data: []byte("")},
+	}
+	svc := NewFSService("", concepts, fsys)
+
+	items, err := svc.ListItems(context.Background(), "workflow", "design")
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if len(items) != 1 || items[0].Name != "doc" {
+		t.Fatalf("design items = %v, want [doc]", itemNames(items))
+	}
+	if !items[0].DrillDisabled {
+		t.Error("child depth 1 should mark items at max depth DrillDisabled")
+	}
+
+	items, err = svc.ListItems(context.Background(), "workflow", "design/doc")
+	if err != nil {
+		t.Fatalf("ListItems beyond depth: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("drilling past child depth = %v, want empty", itemNames(items))
+	}
+}
+
+func TestListItems_ParentChildren_DrillHonorsChildIgnore(t *testing.T) {
+	concepts := workflowParentConcepts(
+		config.ConceptEntry{Name: "festivals", Path: "festivals", Ignore: []string{"dungeon/"}},
+	)
+	fsys := fstest.MapFS{
+		"festivals/active/my-fest/file": &fstest.MapFile{Data: []byte("")},
+		"festivals/dungeon/done/file":   &fstest.MapFile{Data: []byte("")},
+	}
+	svc := NewFSService("", concepts, fsys)
+
+	items, err := svc.ListItems(context.Background(), "workflow", "festivals")
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if got := itemNames(items); len(got) != 1 || got[0] != "active" {
+		t.Fatalf("drill items = %v, want [active] with dungeon ignored", got)
+	}
+}
+
+func TestListItems_ParentChildren_DiskOnlyDirUsesParentPath(t *testing.T) {
+	concepts := workflowParentConcepts(
+		config.ConceptEntry{Name: "festivals", Path: "festivals"},
+	)
+	fsys := fstest.MapFS{
+		"festivals/active/file":          &fstest.MapFile{Data: []byte("")},
+		"workflow/research/topic/file":   &fstest.MapFile{Data: []byte("")},
+		"workflow/research/another/file": &fstest.MapFile{Data: []byte("")},
+	}
+	svc := NewFSService("", concepts, fsys)
+
+	items, err := svc.ListItems(context.Background(), "workflow", "research")
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	got := itemNames(items)
+	if len(got) != 2 || got[0] != "another" || got[1] != "topic" {
+		t.Fatalf("disk-only drill items = %v, want [another topic] under workflow/research", got)
+	}
+	if p, _ := itemPath(items, "topic"); p != "workflow/research/topic" {
+		t.Errorf("topic path = %q, want workflow/research/topic", p)
+	}
+}
+
+func TestListItems_ParentChildren_DepthZeroChildNotDrillable(t *testing.T) {
+	depth0 := 0
+	concepts := workflowParentConcepts(
+		config.ConceptEntry{Name: "docs", Path: "docs", Depth: &depth0},
+	)
+	fsys := fstest.MapFS{
+		"docs/api/file": &fstest.MapFile{Data: []byte("")},
+	}
+	svc := NewFSService("", concepts, fsys)
+
+	items, err := svc.ListItems(context.Background(), "workflow", "")
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if len(items) != 1 || items[0].Name != "docs" {
+		t.Fatalf("submenu = %v, want [docs]", itemNames(items))
+	}
+	if !items[0].DrillDisabled {
+		t.Error("depth-0 child should be DrillDisabled in the parent submenu")
+	}
+}
+
 func TestList_PopulatesChildren(t *testing.T) {
 	concepts := workflowParentConcepts(
 		config.ConceptEntry{Name: "festivals", Path: "festivals"},

--- a/internal/concept/children_test.go
+++ b/internal/concept/children_test.go
@@ -1,0 +1,141 @@
+package concept
+
+import (
+	"context"
+	"testing"
+	"testing/fstest"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+)
+
+func itemNames(items []Item) []string {
+	names := make([]string, len(items))
+	for i, it := range items {
+		names[i] = it.Name
+	}
+	return names
+}
+
+func itemPath(items []Item, name string) (string, bool) {
+	for _, it := range items {
+		if it.Name == name {
+			return it.Path, true
+		}
+	}
+	return "", false
+}
+
+func workflowParentConcepts(children ...config.ConceptEntry) []config.ConceptEntry {
+	return []config.ConceptEntry{
+		{Name: "projects", Path: "projects"},
+		{Name: "workflow", Path: "workflow", Children: children},
+		{Name: "docs", Path: "docs"},
+	}
+}
+
+func TestListItems_ParentChildren_ConfigOnly(t *testing.T) {
+	concepts := workflowParentConcepts(
+		config.ConceptEntry{Name: "festivals", Path: "festivals"},
+		config.ConceptEntry{Name: "design", Path: "workflow/design"},
+	)
+	fsys := fstest.MapFS{
+		"workflow/design/doc/file": &fstest.MapFile{Data: []byte("")},
+	}
+	svc := NewFSService("", concepts, fsys)
+
+	items, err := svc.ListItems(context.Background(), "workflow", "")
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	got := itemNames(items)
+	if len(got) != 2 || got[0] != "festivals" || got[1] != "design" {
+		t.Fatalf("children = %v, want [festivals design] in config order", got)
+	}
+
+	// Each child resolves to its own configured path.
+	if p, _ := itemPath(items, "festivals"); p != "festivals" {
+		t.Errorf("festivals path = %q, want festivals", p)
+	}
+	if p, _ := itemPath(items, "design"); p != "workflow/design" {
+		t.Errorf("design path = %q, want workflow/design", p)
+	}
+}
+
+func TestListItems_ParentChildren_MergesDiskOnly(t *testing.T) {
+	concepts := workflowParentConcepts(
+		config.ConceptEntry{Name: "design", Path: "workflow/design"},
+	)
+	fsys := fstest.MapFS{
+		"workflow/design/file":    &fstest.MapFile{Data: []byte("")},
+		"workflow/research/file":  &fstest.MapFile{Data: []byte("")}, // disk-only custom workflow
+		"workflow/.hidden/file":   &fstest.MapFile{Data: []byte("")},
+		"workflow/notes-file.txt": &fstest.MapFile{Data: []byte("")}, // not a dir, must not appear
+	}
+	svc := NewFSService("", concepts, fsys)
+
+	items, err := svc.ListItems(context.Background(), "workflow", "")
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	got := itemNames(items)
+	// design (config) first, then research (disk-only). No hidden/file entries.
+	if len(got) != 2 {
+		t.Fatalf("items = %v, want exactly [design research]", got)
+	}
+	if got[0] != "design" {
+		t.Errorf("config child should come first, got %v", got)
+	}
+	if _, ok := itemPath(items, "research"); !ok {
+		t.Errorf("disk-only workflow/research not surfaced: %v", got)
+	}
+}
+
+func TestListItems_ParentChildren_FiltersIntent(t *testing.T) {
+	concepts := workflowParentConcepts(
+		config.ConceptEntry{Name: "intent", Path: "workflow/intent"},
+		config.ConceptEntry{Name: "design", Path: "workflow/design"},
+	)
+	fsys := fstest.MapFS{
+		"workflow/design/file": &fstest.MapFile{Data: []byte("")},
+		"workflow/intent/file": &fstest.MapFile{Data: []byte("")},
+	}
+	svc := NewFSService("", concepts, fsys)
+
+	items, err := svc.ListItems(context.Background(), "workflow", "")
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	for _, name := range itemNames(items) {
+		if name == "intent" || name == "intents" {
+			t.Fatalf("intent workflow should be filtered from the picker, got %v", itemNames(items))
+		}
+	}
+}
+
+func TestList_PopulatesChildren(t *testing.T) {
+	concepts := workflowParentConcepts(
+		config.ConceptEntry{Name: "festivals", Path: "festivals"},
+		config.ConceptEntry{Name: "design", Path: "workflow/design"},
+	)
+	svc := NewFSService("", concepts, fstest.MapFS{})
+
+	list, err := svc.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var workflow *Concept
+	for i := range list {
+		if list[i].Name == "workflow" {
+			workflow = &list[i]
+		}
+	}
+	if workflow == nil {
+		t.Fatal("workflow concept missing from List")
+	}
+	if !workflow.HasItems {
+		t.Error("workflow with children should report HasItems")
+	}
+	if len(workflow.Children) != 2 || workflow.Children[0].Name != "festivals" {
+		t.Errorf("workflow.Children = %+v, want [festivals design]", workflow.Children)
+	}
+}

--- a/internal/concept/concept.go
+++ b/internal/concept/concept.go
@@ -25,6 +25,11 @@ type Concept struct {
 
 	// Ignore lists subdirectory paths to exclude from listing.
 	Ignore []string
+
+	// Children are configured sub-concepts (e.g. workflow collections under a
+	// workflow parent). The picker shows these as the parent's submenu, merged
+	// with any ad-hoc subdirectories discovered on disk.
+	Children []Concept
 }
 
 // Item represents a selectable item within a concept.

--- a/internal/concept/service.go
+++ b/internal/concept/service.go
@@ -73,16 +73,28 @@ func (s *DefaultService) ListItems(ctx context.Context, conceptName, subpath str
 		return nil, err
 	}
 
-	// A parent concept's submenu is its configured children merged with ad-hoc
-	// subdirectories under its own path.
-	if subpath == "" && len(concept.Children) > 0 {
-		var disk []Item
-		if concept.Path != "" {
-			disk, _ = s.listDirItems(filepath.Join(s.campaignRoot, concept.Path), concept.Path)
+	return s.conceptItems(concept, subpath)
+}
+
+// conceptItems lists the submenu for a concept at the given subpath. A drill
+// subpath whose first segment names a configured child concept continues
+// under the child's own path and depth/ignore rules, not the parent's path.
+func (s *DefaultService) conceptItems(concept *Concept, subpath string) ([]Item, error) {
+	if len(concept.Children) > 0 {
+		// A parent concept's submenu is its configured children merged with
+		// ad-hoc subdirectories under its own path.
+		if subpath == "" {
+			var disk []Item
+			if concept.Path != "" {
+				disk, _ = s.listDirItems(filepath.Join(s.campaignRoot, concept.Path), concept.Path)
+			}
+			return parentChildItems(concept, disk, func(rel string) int {
+				return s.countChildren(filepath.Join(s.campaignRoot, rel))
+			}), nil
 		}
-		return parentChildItems(concept, disk, func(rel string) int {
-			return s.countChildren(filepath.Join(s.campaignRoot, rel))
-		}), nil
+		if child, rest, ok := childForSubpath(concept, subpath); ok {
+			return s.conceptItems(child, rest)
+		}
 	}
 
 	if concept.Path == "" {
@@ -436,16 +448,28 @@ func (s *FSService) ListItems(ctx context.Context, conceptName, subpath string) 
 		return nil, err
 	}
 
-	// A parent concept's submenu is its configured children merged with ad-hoc
-	// subdirectories under its own path.
-	if subpath == "" && len(concept.Children) > 0 {
-		var disk []Item
-		if concept.Path != "" {
-			disk, _ = s.listDirItemsFS(concept.Path)
+	return s.conceptItems(concept, subpath)
+}
+
+// conceptItems lists the submenu for a concept at the given subpath. A drill
+// subpath whose first segment names a configured child concept continues
+// under the child's own path and depth/ignore rules, not the parent's path.
+func (s *FSService) conceptItems(concept *Concept, subpath string) ([]Item, error) {
+	if len(concept.Children) > 0 {
+		// A parent concept's submenu is its configured children merged with
+		// ad-hoc subdirectories under its own path.
+		if subpath == "" {
+			var disk []Item
+			if concept.Path != "" {
+				disk, _ = s.listDirItemsFS(concept.Path)
+			}
+			return parentChildItems(concept, disk, func(rel string) int {
+				return s.countChildrenFS(rel)
+			}), nil
 		}
-		return parentChildItems(concept, disk, func(rel string) int {
-			return s.countChildrenFS(rel)
-		}), nil
+		if child, rest, ok := childForSubpath(concept, subpath); ok {
+			return s.conceptItems(child, rest)
+		}
 	}
 
 	if concept.Path == "" {

--- a/internal/concept/service.go
+++ b/internal/concept/service.go
@@ -41,11 +41,11 @@ func (s *DefaultService) List(ctx context.Context) ([]Concept, error) {
 
 	var result []Concept
 	for _, c := range s.concepts {
-		if c.Path == "" {
+		if c.Path == "" && len(c.Children) == 0 {
 			continue
 		}
 
-		hasItems := s.hasItemsWithIgnore(c.Path, c.Ignore, c.Depth)
+		hasItems := len(c.Children) > 0 || s.hasItemsWithIgnore(c.Path, c.Ignore, c.Depth)
 
 		result = append(result, Concept{
 			Name:        c.Name,
@@ -54,6 +54,7 @@ func (s *DefaultService) List(ctx context.Context) ([]Concept, error) {
 			HasItems:    hasItems,
 			MaxDepth:    c.Depth,
 			Ignore:      c.Ignore,
+			Children:    childConcepts(c.Children),
 		})
 	}
 
@@ -70,6 +71,18 @@ func (s *DefaultService) ListItems(ctx context.Context, conceptName, subpath str
 	concept, err := s.Get(ctx, conceptName)
 	if err != nil {
 		return nil, err
+	}
+
+	// A parent concept's submenu is its configured children merged with ad-hoc
+	// subdirectories under its own path.
+	if subpath == "" && len(concept.Children) > 0 {
+		var disk []Item
+		if concept.Path != "" {
+			disk, _ = s.listDirItems(filepath.Join(s.campaignRoot, concept.Path), concept.Path)
+		}
+		return parentChildItems(concept, disk, func(rel string) int {
+			return s.countChildren(filepath.Join(s.campaignRoot, rel))
+		}), nil
 	}
 
 	if concept.Path == "" {
@@ -154,9 +167,10 @@ func (s *DefaultService) Get(ctx context.Context, name string) (*Concept, error)
 				Name:        c.Name,
 				Path:        c.Path,
 				Description: c.Description,
-				HasItems:    s.hasItemsWithIgnore(c.Path, c.Ignore, c.Depth),
+				HasItems:    len(c.Children) > 0 || s.hasItemsWithIgnore(c.Path, c.Ignore, c.Depth),
 				MaxDepth:    c.Depth,
 				Ignore:      c.Ignore,
+				Children:    childConcepts(c.Children),
 			}, nil
 		}
 	}
@@ -391,11 +405,11 @@ func (s *FSService) List(ctx context.Context) ([]Concept, error) {
 
 	var result []Concept
 	for _, c := range s.concepts {
-		if c.Path == "" {
+		if c.Path == "" && len(c.Children) == 0 {
 			continue
 		}
 
-		hasItems := s.hasItemsWithIgnore(c.Path, c.Ignore, c.Depth)
+		hasItems := len(c.Children) > 0 || s.hasItemsWithIgnore(c.Path, c.Ignore, c.Depth)
 
 		result = append(result, Concept{
 			Name:        c.Name,
@@ -404,6 +418,7 @@ func (s *FSService) List(ctx context.Context) ([]Concept, error) {
 			HasItems:    hasItems,
 			MaxDepth:    c.Depth,
 			Ignore:      c.Ignore,
+			Children:    childConcepts(c.Children),
 		})
 	}
 
@@ -419,6 +434,18 @@ func (s *FSService) ListItems(ctx context.Context, conceptName, subpath string) 
 	concept, err := s.Get(ctx, conceptName)
 	if err != nil {
 		return nil, err
+	}
+
+	// A parent concept's submenu is its configured children merged with ad-hoc
+	// subdirectories under its own path.
+	if subpath == "" && len(concept.Children) > 0 {
+		var disk []Item
+		if concept.Path != "" {
+			disk, _ = s.listDirItemsFS(concept.Path)
+		}
+		return parentChildItems(concept, disk, func(rel string) int {
+			return s.countChildrenFS(rel)
+		}), nil
 	}
 
 	if concept.Path == "" {
@@ -495,9 +522,10 @@ func (s *FSService) Get(ctx context.Context, name string) (*Concept, error) {
 				Name:        c.Name,
 				Path:        c.Path,
 				Description: c.Description,
-				HasItems:    s.hasItemsWithIgnore(c.Path, c.Ignore, c.Depth),
+				HasItems:    len(c.Children) > 0 || s.hasItemsWithIgnore(c.Path, c.Ignore, c.Depth),
 				MaxDepth:    c.Depth,
 				Ignore:      c.Ignore,
+				Children:    childConcepts(c.Children),
 			}, nil
 		}
 	}

--- a/internal/config/concept_children_test.go
+++ b/internal/config/concept_children_test.go
@@ -15,7 +15,7 @@ func nestedConceptFixture() []ConceptEntry {
 			Path:        "workflow/",
 			Description: "Workflows",
 			Children: []ConceptEntry{
-				{Name: "festivals", Path: "festivals/", Description: "Planning cycles"},
+				{Name: "festivals", Path: "festivals/", Description: "Multi-step festival plans"},
 				{Name: "design", Path: "workflow/design/", Description: "Design documents", Depth: &depth1},
 				{Name: "explore", Path: "workflow/explore/", Description: "Exploratory notes", Depth: &depth1},
 			},

--- a/internal/config/concept_children_test.go
+++ b/internal/config/concept_children_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func nestedConceptFixture() []ConceptEntry {
+	depth1 := 1
+	return []ConceptEntry{
+		{Name: "projects", Path: "projects/", Description: "Active development projects", Depth: &depth1, Ignore: []string{"worktrees/"}},
+		{
+			Name:        "workflow",
+			Path:        "workflow/",
+			Description: "Workflows",
+			Children: []ConceptEntry{
+				{Name: "festivals", Path: "festivals/", Description: "Planning cycles"},
+				{Name: "design", Path: "workflow/design/", Description: "Design documents", Depth: &depth1},
+				{Name: "explore", Path: "workflow/explore/", Description: "Exploratory notes", Depth: &depth1},
+			},
+		},
+		{Name: "docs", Path: "docs/", Description: "Documentation"},
+	}
+}
+
+func TestConceptChildren_RoundTrips(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+
+	cfg := &CampaignConfig{
+		ID:          "id-1",
+		Name:        "round-trip",
+		Type:        CampaignTypeProduct,
+		ConceptList: nestedConceptFixture(),
+	}
+
+	if err := SaveCampaignConfig(ctx, root, cfg); err != nil {
+		t.Fatalf("SaveCampaignConfig: %v", err)
+	}
+
+	loaded, err := LoadCampaignConfig(ctx, root)
+	if err != nil {
+		t.Fatalf("LoadCampaignConfig: %v", err)
+	}
+
+	if !reflect.DeepEqual(loaded.ConceptList, cfg.ConceptList) {
+		t.Errorf("concept tree did not round-trip:\n got  %#v\n want %#v", loaded.ConceptList, cfg.ConceptList)
+	}
+
+	// The workflow parent must keep its children, in order.
+	var workflow *ConceptEntry
+	for i := range loaded.ConceptList {
+		if loaded.ConceptList[i].Name == "workflow" {
+			workflow = &loaded.ConceptList[i]
+		}
+	}
+	if workflow == nil {
+		t.Fatal("workflow concept missing after round-trip")
+	}
+	if len(workflow.Children) != 3 || workflow.Children[0].Name != "festivals" {
+		t.Errorf("workflow children not preserved in order: %+v", workflow.Children)
+	}
+}
+
+func TestConceptChildren_AbsentBehavesAsFlat(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+
+	flat := []ConceptEntry{
+		{Name: "projects", Path: "projects/"},
+		{Name: "festivals", Path: "festivals/"},
+		{Name: "docs", Path: "docs/"},
+	}
+	cfg := &CampaignConfig{ID: "id-2", Name: "flat", Type: CampaignTypeProduct, ConceptList: flat}
+
+	if err := SaveCampaignConfig(ctx, root, cfg); err != nil {
+		t.Fatalf("SaveCampaignConfig: %v", err)
+	}
+	loaded, err := LoadCampaignConfig(ctx, root)
+	if err != nil {
+		t.Fatalf("LoadCampaignConfig: %v", err)
+	}
+
+	if !reflect.DeepEqual(loaded.ConceptList, flat) {
+		t.Errorf("flat config changed: got %#v want %#v", loaded.ConceptList, flat)
+	}
+	for _, c := range loaded.ConceptList {
+		if c.Children != nil {
+			t.Errorf("flat concept %q gained children: %+v", c.Name, c.Children)
+		}
+	}
+}

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -6,6 +6,11 @@ import "time"
 // ResolvedCampaignsDir() when GlobalConfig.CampaignsDir is empty.
 const defaultCampaignsDirTilde = "~/campaigns/"
 
+// DefaultIntentTags returns the starter tag list for a fresh campaign.
+func DefaultIntentTags() []string {
+	return []string{"personal", "reference", "question", "follow-up"}
+}
+
 // DefaultConcepts returns the default concept configuration for campaigns.
 // Each concept has a name, path, description, and optional depth/ignore settings.
 func DefaultConcepts() []ConceptEntry {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -37,7 +37,7 @@ func DefaultConcepts() []ConceptEntry {
 			Path:        "workflow/",
 			Description: "Workflows",
 			Children: []ConceptEntry{
-				{Name: "festivals", Path: "festivals/", Description: "Planning cycles"},
+				{Name: "festivals", Path: "festivals/", Description: "Multi-step festival plans"},
 				{Name: "design", Path: "workflow/design/", Description: "Design documents", Depth: &depth1},
 				{Name: "explore", Path: "workflow/explore/", Description: "Exploratory notes and discovery work", Depth: &depth1},
 				{Name: "code_reviews", Path: "workflow/code_reviews/", Description: "Code reviews", Depth: &depth1},

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -12,14 +12,18 @@ func DefaultIntentTags() []string {
 }
 
 // DefaultConcepts returns the default concept configuration for campaigns.
-// Each concept has a name, path, description, and optional depth/ignore settings.
+// The picker is a small tree: projects, a single workflow parent whose children
+// are the workflow collections (festivals, design, explore, code_reviews,
+// pipelines), and docs. workflow keeps its own Path so custom workflow dirs are
+// still surfaced from disk.
+//
+// worktrees, intents, and dungeon are intentionally not picker concepts:
+// worktrees is a projects detail, intents would be circular, and dungeon is
+// resolved dynamically by nearest-path lookup.
 func DefaultConcepts() []ConceptEntry {
 	depth0 := 0
 	depth1 := 1
 
-	// Dungeon is intentionally not modeled as a default concept entry.
-	// Dungeon context is resolved dynamically by nearest-path lookup, and a
-	// static concept path implies root-only behavior that conflicts with that model.
 	return []ConceptEntry{
 		{
 			Name:        "projects",
@@ -29,41 +33,16 @@ func DefaultConcepts() []ConceptEntry {
 			Ignore:      []string{"worktrees/"},
 		},
 		{
-			Name:        "worktrees",
-			Path:        "projects/worktrees/",
-			Description: "Git worktrees",
-			Depth:       &depth1,
-		},
-		{
-			Name:        "festivals",
-			Path:        "festivals/",
-			Description: "Planning cycles",
-			// Depth nil = unlimited
-		},
-		{
-			Name:        "intents",
-			Path:        ".campaign/intents/",
-			Description: "Ideas and tasks",
-			Depth:       &depth0,
-		},
-		{
 			Name:        "workflow",
 			Path:        "workflow/",
-			Description: "Work management",
-			Depth:       &depth1,
-			Ignore:      []string{"intents/", "design/", "explore/"},
-		},
-		{
-			Name:        "design",
-			Path:        "workflow/design/",
-			Description: "Design documents",
-			Depth:       &depth1,
-		},
-		{
-			Name:        "explore",
-			Path:        "workflow/explore/",
-			Description: "Exploratory notes and discovery work",
-			Depth:       &depth1,
+			Description: "Workflows",
+			Children: []ConceptEntry{
+				{Name: "festivals", Path: "festivals/", Description: "Planning cycles"},
+				{Name: "design", Path: "workflow/design/", Description: "Design documents", Depth: &depth1},
+				{Name: "explore", Path: "workflow/explore/", Description: "Exploratory notes and discovery work", Depth: &depth1},
+				{Name: "code_reviews", Path: "workflow/code_reviews/", Description: "Code reviews", Depth: &depth1},
+				{Name: "pipelines", Path: "workflow/pipelines/", Description: "Pipelines", Depth: &depth1},
+			},
 		},
 		{
 			Name:        "docs",

--- a/internal/config/defaults_concepts_test.go
+++ b/internal/config/defaults_concepts_test.go
@@ -2,7 +2,16 @@ package config
 
 import "testing"
 
-func TestDefaultConcepts_ExploreIncludedDungeonExcluded(t *testing.T) {
+func childByName(children []ConceptEntry, name string) (ConceptEntry, bool) {
+	for _, c := range children {
+		if c.Name == name {
+			return c, true
+		}
+	}
+	return ConceptEntry{}, false
+}
+
+func TestDefaultConcepts_NestedWorkflowShape(t *testing.T) {
 	concepts := DefaultConcepts()
 
 	byName := make(map[string]ConceptEntry, len(concepts))
@@ -10,62 +19,54 @@ func TestDefaultConcepts_ExploreIncludedDungeonExcluded(t *testing.T) {
 		byName[c.Name] = c
 	}
 
-	explore, ok := byName["explore"]
+	// Top level is exactly projects, workflow, docs.
+	for _, want := range []string{"projects", "workflow", "docs"} {
+		if _, ok := byName[want]; !ok {
+			t.Fatalf("default concepts should include top-level %q", want)
+		}
+	}
+	// worktrees, intents, dungeon, and the workflow collections are NOT top-level.
+	for _, gone := range []string{"worktrees", "intents", "dungeon", "explore", "design", "festivals"} {
+		if _, ok := byName[gone]; ok {
+			t.Fatalf("%q should not be a top-level concept anymore", gone)
+		}
+	}
+
+	workflow := byName["workflow"]
+	explore, ok := childByName(workflow.Children, "explore")
 	if !ok {
-		t.Fatal("default concepts should include workflow/explore concept")
+		t.Fatal("explore should be a child of workflow")
 	}
 	if explore.Path != "workflow/explore/" {
 		t.Fatalf("explore path = %q, want %q", explore.Path, "workflow/explore/")
 	}
-
-	if _, ok := byName["dungeon"]; ok {
-		t.Fatal("default concepts should not include dungeon concept")
-	}
-
-	intents, ok := byName["intents"]
-	if !ok {
-		t.Fatal("default concepts should include intents concept")
-	}
-	if intents.Path != ".campaign/intents/" {
-		t.Fatalf("intents path = %q, want %q", intents.Path, ".campaign/intents/")
-	}
-
-	workflow, ok := byName["workflow"]
-	if !ok {
-		t.Fatal("default concepts should include workflow concept")
-	}
-	if !containsString(workflow.Ignore, "explore/") {
-		t.Fatalf("workflow ignore list should include explore/, got %v", workflow.Ignore)
+	if _, ok := childByName(workflow.Children, "festivals"); !ok {
+		t.Fatal("festivals should be a child of workflow")
 	}
 }
 
-func TestCampaignConfigConcepts_FallbackExcludesDungeonIncludesExplore(t *testing.T) {
+func TestCampaignConfigConcepts_FallbackNestedShape(t *testing.T) {
 	cfg := &CampaignConfig{} // no explicit ConceptList, uses fallback
 	concepts := cfg.Concepts()
 
-	hasExplore := false
-	hasDungeon := false
-	for _, c := range concepts {
-		switch c.Name {
-		case "intents":
-			if c.Path != ".campaign/intents/" {
-				t.Fatalf("fallback intents path = %q, want %q", c.Path, ".campaign/intents/")
-			}
-		case "explore":
-			hasExplore = true
-			if c.Path != "workflow/explore/" {
-				t.Fatalf("fallback explore path = %q, want %q", c.Path, "workflow/explore/")
-			}
-		case "dungeon":
-			hasDungeon = true
+	var workflow *ConceptEntry
+	for i := range concepts {
+		switch concepts[i].Name {
+		case "dungeon", "intents", "worktrees":
+			t.Fatalf("fallback should not include top-level %q", concepts[i].Name)
+		case "workflow":
+			workflow = &concepts[i]
 		}
 	}
-
-	if !hasExplore {
-		t.Fatal("fallback concepts should include explore")
+	if workflow == nil {
+		t.Fatal("fallback concepts should include workflow")
 	}
-	if hasDungeon {
-		t.Fatal("fallback concepts should not include dungeon")
+	explore, ok := childByName(workflow.Children, "explore")
+	if !ok {
+		t.Fatal("fallback workflow should include an explore child")
+	}
+	if explore.Path != "workflow/explore/" {
+		t.Fatalf("fallback explore path = %q, want %q", explore.Path, "workflow/explore/")
 	}
 }
 
@@ -104,13 +105,4 @@ func TestDefaultNavigationShortcuts_DungeonIsNavigationOnly(t *testing.T) {
 	if du.Concept != "" {
 		t.Fatalf("du concept = %q, want empty for navigation-only shortcut", du.Concept)
 	}
-}
-
-func containsString(values []string, want string) bool {
-	for _, v := range values {
-		if v == want {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/config/intents_test.go
+++ b/internal/config/intents_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestIntentTags_ReturnsConfiguredWhenSet(t *testing.T) {
+	cfg := &CampaignConfig{Intents: IntentsConfig{Tags: []string{"alpha", "beta"}}}
+	got := cfg.IntentTags()
+	want := []string{"alpha", "beta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("IntentTags() = %v, want %v", got, want)
+	}
+}
+
+func TestIntentTags_ReturnsDefaultsWhenUnset(t *testing.T) {
+	cfg := &CampaignConfig{}
+	got := cfg.IntentTags()
+	if !reflect.DeepEqual(got, DefaultIntentTags()) {
+		t.Errorf("IntentTags() = %v, want defaults %v", got, DefaultIntentTags())
+	}
+	if len(got) == 0 {
+		t.Error("default intent tags should be non-empty")
+	}
+}
+
+func TestIntentsConfig_RoundTrips(t *testing.T) {
+	cfg := &CampaignConfig{
+		ID:      "id",
+		Name:    "c",
+		Type:    CampaignTypeProduct,
+		Intents: IntentsConfig{Tags: []string{"personal", "follow-up"}},
+	}
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var got CampaignConfig
+	if err := yaml.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(got.Intents.Tags, cfg.Intents.Tags) {
+		t.Errorf("round-trip tags = %v, want %v", got.Intents.Tags, cfg.Intents.Tags)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -65,17 +65,23 @@ type CommitMessageHookConfig struct {
 }
 
 // ConceptEntry defines a concept for the picker with ordering and depth control.
+// Concepts may nest via Children, so a parent concept (e.g. "workflow") can group
+// sub-concepts. A parent that only groups may omit Path.
 type ConceptEntry struct {
 	// Name is the concept name (e.g., "projects", "festivals").
 	Name string `yaml:"name"`
-	// Path is the relative path from campaign root.
-	Path string `yaml:"path"`
+	// Path is the relative path from campaign root. Optional for pure-parent
+	// nodes that only group children.
+	Path string `yaml:"path,omitempty"`
 	// Description provides human-readable help text.
 	Description string `yaml:"description,omitempty"`
 	// Depth controls drilling depth: nil=unlimited, 0=no drilling, 1+=levels.
 	Depth *int `yaml:"depth,omitempty"`
 	// Ignore lists subdirectories to exclude from listing.
 	Ignore []string `yaml:"ignore,omitempty"`
+	// Children are nested sub-concepts. Absent means a flat concept (today's
+	// behavior); present makes this a parent in the picker tree.
+	Children []ConceptEntry `yaml:"children,omitempty"`
 }
 
 // Paths returns the campaign paths configuration.
@@ -115,38 +121,40 @@ func (c *CampaignConfig) Concepts() []ConceptEntry {
 	return c.deriveConceptsFromPaths()
 }
 
-// deriveConceptsFromPaths creates ConceptEntry list from CampaignPaths.
-// This provides backwards compatibility when concepts aren't explicitly defined.
+// deriveConceptsFromPaths creates a ConceptEntry list from CampaignPaths when
+// no explicit ConceptList is set. It mirrors the nested DefaultConcepts shape:
+// projects, a workflow parent with its collections as children, and docs.
 func (c *CampaignConfig) deriveConceptsFromPaths() []ConceptEntry {
 	paths := c.Paths()
-	defs := []struct {
+
+	childDefs := []struct {
 		name        string
 		path        string
 		description string
 	}{
-		{"projects", paths.Projects, "Projects directory"},
-		{"worktrees", paths.Worktrees, "Git worktrees"},
-		{"festivals", paths.Festivals, "Festivals directory"},
-		{"intents", paths.Intents, "Intents directory"},
-		{"workflow", paths.Workflow, "Workflow directory"},
-		{"code_reviews", paths.CodeReviews, "Code reviews"},
-		{"pipelines", paths.Pipelines, "Pipelines"},
+		{"festivals", paths.Festivals, "Planning cycles"},
 		{"design", paths.Design, "Design documents"},
 		{"explore", "workflow/explore/", "Exploratory notes and discovery work"},
-		{"ai_docs", paths.AIDocs, "AI documentation"},
-		{"docs", paths.Docs, "Documentation"},
+		{"code_reviews", paths.CodeReviews, "Code reviews"},
+		{"pipelines", paths.Pipelines, "Pipelines"},
 	}
-
-	var concepts []ConceptEntry
-	for _, def := range defs {
+	var children []ConceptEntry
+	for _, def := range childDefs {
 		if def.path == "" {
 			continue
 		}
-		concepts = append(concepts, ConceptEntry{
-			Name:        def.name,
-			Path:        def.path,
-			Description: def.description,
-		})
+		children = append(children, ConceptEntry{Name: def.name, Path: def.path, Description: def.description})
+	}
+
+	var concepts []ConceptEntry
+	if paths.Projects != "" {
+		concepts = append(concepts, ConceptEntry{Name: "projects", Path: paths.Projects, Description: "Active development projects"})
+	}
+	if paths.Workflow != "" || len(children) > 0 {
+		concepts = append(concepts, ConceptEntry{Name: "workflow", Path: paths.Workflow, Description: "Workflows", Children: children})
+	}
+	if paths.Docs != "" {
+		concepts = append(concepts, ConceptEntry{Name: "docs", Path: paths.Docs, Description: "Documentation"})
 	}
 	return concepts
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -38,10 +38,18 @@ type CampaignConfig struct {
 	ConceptList []ConceptEntry `yaml:"concepts,omitempty"`
 	// Hooks contains optional campaign-local command hooks.
 	Hooks HooksConfig `yaml:"hooks,omitempty"`
+	// Intents holds intent-specific campaign settings (e.g. the tag list).
+	Intents IntentsConfig `yaml:"intents,omitempty"`
 
 	// Jumps holds the loaded jumps configuration (from .campaign/settings/jumps.yaml).
 	// This field is not serialized to campaign.yaml - it's loaded separately.
 	Jumps *JumpsConfig `yaml:"-"`
+}
+
+// IntentsConfig holds intent-specific campaign settings.
+type IntentsConfig struct {
+	// Tags is the suggested tag list offered during intent/note capture.
+	Tags []string `yaml:"tags,omitempty"`
 }
 
 // HooksConfig contains optional campaign-local command hooks.
@@ -86,6 +94,14 @@ func (c *CampaignConfig) Shortcuts() map[string]ShortcutConfig {
 		return c.Jumps.Shortcuts
 	}
 	return DefaultNavigationShortcuts()
+}
+
+// IntentTags returns the configured intent tags, or the default set when unset.
+func (c *CampaignConfig) IntentTags() []string {
+	if len(c.Intents.Tags) > 0 {
+		return c.Intents.Tags
+	}
+	return DefaultIntentTags()
 }
 
 // Concepts returns the concept list for the picker.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -132,7 +132,7 @@ func (c *CampaignConfig) deriveConceptsFromPaths() []ConceptEntry {
 		path        string
 		description string
 	}{
-		{"festivals", paths.Festivals, "Planning cycles"},
+		{"festivals", paths.Festivals, "Multi-step festival plans"},
 		{"design", paths.Design, "Design documents"},
 		{"explore", "workflow/explore/", "Exploratory notes and discovery work"},
 		{"code_reviews", paths.CodeReviews, "Code reviews"},

--- a/internal/git/commit/intent.go
+++ b/internal/git/commit/intent.go
@@ -14,6 +14,7 @@ const (
 	IntentGather  IntentAction = "Gather"
 	IntentPromote IntentAction = "Promote"
 	IntentCrawl   IntentAction = "Crawl"
+	IntentRename  IntentAction = "Rename"
 )
 
 // IntentOptions configures an intent commit.

--- a/internal/intent/audit/audit.go
+++ b/internal/intent/audit/audit.go
@@ -34,6 +34,7 @@ const (
 	EventArchive EventType = "archive"
 	EventDelete  EventType = "delete"
 	EventGather  EventType = "gather"
+	EventRename  EventType = "rename"
 )
 
 // FieldChange records a single field's old and new value within an edit event.

--- a/internal/intent/idindex.go
+++ b/internal/intent/idindex.go
@@ -1,0 +1,77 @@
+package intent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// resolveByID returns the file path of the intent whose id: frontmatter equals
+// id. Identity lives in the frontmatter, not the filename, so a renamed file
+// (whose slug drifted from its id) still resolves.
+//
+// Resolution order, never a full per-lookup directory walk:
+//  1. Fast path: stat the expected <id>.md across the intent status dirs. For
+//     the common case (filename == id, no rename) this is O(statuses), the same
+//     cost as before.
+//  2. Index fallback: a lazily-built id->path map from a single directory pass,
+//     cached on the service and invalidated on mutation.
+func (s *IntentService) resolveByID(id string) (string, error) {
+	for _, status := range AllStatuses() {
+		p := s.getIntentPath(status, id)
+		if it, err := s.loadIntent(p); err == nil && it.ID == id {
+			return p, nil
+		}
+	}
+
+	s.idIndexMu.Lock()
+	defer s.idIndexMu.Unlock()
+	if s.idIndex == nil {
+		if err := s.buildIDIndexLocked(); err != nil {
+			return "", err
+		}
+	}
+	if p, ok := s.idIndex[id]; ok {
+		return p, nil
+	}
+	return "", camperrors.Wrap(ErrNotFound, id)
+}
+
+// buildIDIndexLocked scans the intent status directories once and maps each
+// intent's id: to its path. The caller must hold idIndexMu.
+func (s *IntentService) buildIDIndexLocked() error {
+	index := make(map[string]string)
+	for _, status := range AllStatuses() {
+		dir := filepath.Join(s.intentsDir, string(status))
+		files, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return camperrors.Wrapf(err, "reading directory %s", dir)
+		}
+		for _, f := range files {
+			if f.IsDir() || !strings.HasSuffix(f.Name(), ".md") {
+				continue
+			}
+			p := filepath.Join(dir, f.Name())
+			it, err := s.loadIntent(p)
+			if err != nil || it.ID == "" {
+				continue
+			}
+			index[it.ID] = p
+		}
+	}
+	s.idIndex = index
+	return nil
+}
+
+// invalidateIDIndex drops the cached id->path index so it rebuilds on the next
+// fast-path miss. Called after any mutation that adds, moves, or removes a file.
+func (s *IntentService) invalidateIDIndex() {
+	s.idIndexMu.Lock()
+	s.idIndex = nil
+	s.idIndexMu.Unlock()
+}

--- a/internal/intent/idindex_test.go
+++ b/internal/intent/idindex_test.go
@@ -1,0 +1,92 @@
+package intent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeRenamedIntent writes an intent file whose on-disk filename slug differs
+// from its id: frontmatter, simulating the post-rename state.
+func writeRenamedIntent(t *testing.T, intentsDir, status, filenameSlug, id, title string) string {
+	t.Helper()
+	dir := filepath.Join(intentsDir, status)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	content := "---\n" +
+		"id: " + id + "\n" +
+		"title: " + title + "\n" +
+		"status: " + status + "\n" +
+		"created_at: 2026-01-01T00:00:00Z\n" +
+		"type: idea\n" +
+		"---\n\n# " + title + "\n"
+	path := filepath.Join(dir, filenameSlug+".md")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}
+
+func TestResolveByID_FilenameSlugDiffersFromID(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := NewIntentService(tmp, intentsDir)
+
+	id := "original-title-20260101-000000"
+	wantPath := writeRenamedIntent(t, intentsDir, "inbox", "a-renamed-slug-20260101-000000", id, "A renamed slug")
+
+	// Get resolves by id: even though the filename slug differs.
+	got, err := svc.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", id, err)
+	}
+	if got.ID != id {
+		t.Errorf("resolved ID = %q, want %q", got.ID, id)
+	}
+	if got.Path != wantPath {
+		t.Errorf("resolved path = %q, want %q", got.Path, wantPath)
+	}
+}
+
+func TestMove_ResolvesRenamedFileByID(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := NewIntentService(tmp, intentsDir)
+
+	id := "do-the-thing-20260101-000000"
+	writeRenamedIntent(t, intentsDir, "inbox", "renamed-thing-20260101-000000", id, "Renamed thing")
+
+	moved, err := svc.Move(ctx, id, StatusReady)
+	if err != nil {
+		t.Fatalf("Move(%q): %v", id, err)
+	}
+	if moved.Status != StatusReady {
+		t.Errorf("Status = %q, want ready", moved.Status)
+	}
+	// The intent is now resolvable in its new status.
+	if _, err := svc.Get(ctx, id); err != nil {
+		t.Errorf("Get after move: %v", err)
+	}
+}
+
+func TestParser_TrustsFrontmatterID(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := NewIntentService(tmp, intentsDir)
+
+	id := "trusted-id-20260101-000000"
+	writeRenamedIntent(t, intentsDir, "inbox", "totally-different-filename", id, "Trust the frontmatter")
+
+	got, err := svc.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != id {
+		t.Errorf("ID = %q, want %q (must come from frontmatter, not filename)", got.ID, id)
+	}
+}

--- a/internal/intent/merge.go
+++ b/internal/intent/merge.go
@@ -60,46 +60,12 @@ func MergeIntents(sources []*Intent, opts MergeOptions) (*Intent, error) {
 	return merged, nil
 }
 
-// generateMergedID creates an ID for the gathered intent.
+// generateMergedID creates an ID for the gathered intent. The slug uses the
+// shared SlugFromTitle so merged IDs slug identically to created ones.
 func generateMergedID(title string, t time.Time) string {
-	slug := generateSlugFromTitle(title)
+	slug := SlugFromTitle(title)
 	timestamp := t.Format("20060102-150405")
 	return fmt.Sprintf("%s-%s", timestamp, slug)
-}
-
-// generateSlugFromTitle creates a URL-friendly slug from a title.
-func generateSlugFromTitle(title string) string {
-	// Lowercase
-	slug := strings.ToLower(title)
-
-	// Replace spaces with hyphens
-	slug = strings.ReplaceAll(slug, " ", "-")
-
-	// Remove non-alphanumeric chars (except hyphens)
-	var b strings.Builder
-	for _, r := range slug {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
-			b.WriteRune(r)
-		}
-	}
-	slug = b.String()
-
-	// Collapse multiple hyphens
-	for strings.Contains(slug, "--") {
-		slug = strings.ReplaceAll(slug, "--", "-")
-	}
-
-	// Trim leading/trailing hyphens
-	slug = strings.Trim(slug, "-")
-
-	// Limit length
-	if len(slug) > 50 {
-		slug = slug[:50]
-		// Don't end with hyphen
-		slug = strings.TrimRight(slug, "-")
-	}
-
-	return slug
 }
 
 // buildGatheredSources creates GatheredSource entries from source intents.

--- a/internal/intent/merge.go
+++ b/internal/intent/merge.go
@@ -37,7 +37,7 @@ func MergeIntents(sources []*Intent, opts MergeOptions) (*Intent, error) {
 	now := time.Now()
 
 	merged := &Intent{
-		ID:           generateMergedID(opts.Title, now),
+		ID:           GenerateID(opts.Title, now),
 		Title:        opts.Title,
 		Status:       StatusInbox,
 		CreatedAt:    now,
@@ -58,14 +58,6 @@ func MergeIntents(sources []*Intent, opts MergeOptions) (*Intent, error) {
 	merged.Content = buildMergedContent(sources, now)
 
 	return merged, nil
-}
-
-// generateMergedID creates an ID for the gathered intent. The slug uses the
-// shared SlugFromTitle so merged IDs slug identically to created ones.
-func generateMergedID(title string, t time.Time) string {
-	slug := SlugFromTitle(title)
-	timestamp := t.Format("20060102-150405")
-	return fmt.Sprintf("%s-%s", timestamp, slug)
 }
 
 // buildGatheredSources creates GatheredSource entries from source intents.

--- a/internal/intent/merge_test.go
+++ b/internal/intent/merge_test.go
@@ -338,31 +338,9 @@ func TestMergeIntents_ContentFormat(t *testing.T) {
 	}
 }
 
-func TestGenerateSlugFromTitle(t *testing.T) {
-	tests := []struct {
-		title string
-		want  string
-	}{
-		{"Simple Title", "simple-title"},
-		{"Title With  Multiple   Spaces", "title-with-multiple-spaces"},
-		{"Title-With-Hyphens", "title-with-hyphens"},
-		{"Title_With_Underscores", "titlewithunderscores"},
-		{"Title With 123 Numbers", "title-with-123-numbers"},
-		{"Special!@#$%Characters", "specialcharacters"},
-		{"A Very Long Title That Should Be Truncated Because It Exceeds The Maximum Length", "a-very-long-title-that-should-be-truncated-because"},
-		{"", ""},
-		{"---", ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.title, func(t *testing.T) {
-			got := generateSlugFromTitle(tt.title)
-			if got != tt.want {
-				t.Errorf("generateSlugFromTitle(%q) = %q, want %q", tt.title, got, tt.want)
-			}
-		})
-	}
-}
+// Slug generation is covered comprehensively by TestSlugFromTitle in
+// slug_test.go. generateMergedID now shares that single SlugFromTitle helper,
+// so the previous duplicate slug test here has been removed.
 
 func TestExtractBodyContent(t *testing.T) {
 	tests := []struct {

--- a/internal/intent/merge_test.go
+++ b/internal/intent/merge_test.go
@@ -51,9 +51,15 @@ func TestMergeIntents_Basic(t *testing.T) {
 		t.Errorf("Status = %q, want %q", merged.Status, StatusInbox)
 	}
 
-	// Check ID format (should include timestamp and slug)
-	if !strings.Contains(merged.ID, "unified-auth-feature") {
-		t.Errorf("ID = %q, should contain slug", merged.ID)
+	// The merged ID must follow the canonical slug-YYYYMMDD-HHMMSS contract.
+	if !strings.HasPrefix(merged.ID, "unified-auth-feature-") {
+		t.Errorf("ID = %q, want slug-first canonical format", merged.ID)
+	}
+	if !intentIDPattern.MatchString(merged.ID) {
+		t.Errorf("ID = %q does not match canonical id pattern", merged.ID)
+	}
+	if errs := merged.Validate(); len(errs) > 0 {
+		t.Errorf("merged intent fails validation: %v", errs)
 	}
 
 	// Check type resolution (both are feature)
@@ -338,9 +344,9 @@ func TestMergeIntents_ContentFormat(t *testing.T) {
 	}
 }
 
-// Slug generation is covered comprehensively by TestSlugFromTitle in
-// slug_test.go. generateMergedID now shares that single SlugFromTitle helper,
-// so the previous duplicate slug test here has been removed.
+// Slug and ID generation are covered by TestSlugFromTitle in slug_test.go.
+// MergeIntents shares GenerateID, so the previous duplicate slug test here has
+// been removed; the canonical ID-shape assertion lives in TestMergeIntents_Basic.
 
 func TestExtractBodyContent(t *testing.T) {
 	tests := []struct {

--- a/internal/intent/notes.go
+++ b/internal/intent/notes.go
@@ -2,6 +2,7 @@ package intent
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -122,14 +123,81 @@ func (s *IntentService) ArchiveNote(ctx context.Context, id string) (*Intent, er
 	return note, nil
 }
 
-// Convert promotes a note into the intent lifecycle: it moves
-// notes/<id>.md into inbox/<id>.md, attaches the given type, and refreshes
-// updated_at. This is the only bridge from a note into inbox/ready/active.
-func (s *IntentService) Convert(ctx context.Context, id string, newType Type) (*Intent, error) {
+// MoveIntentToNote moves a lifecycle intent into the active notes/ store. The
+// file keeps its title, body, author, tags, and timestamps, but drops lifecycle
+// metadata that notes do not carry.
+func (s *IntentService) MoveIntentToNote(ctx context.Context, id string) (*Intent, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, camperrors.Wrap(err, "context cancelled")
 	}
 
+	if _, err := s.GetNote(ctx, id); err == nil {
+		return nil, camperrors.Wrap(ErrFileExists, id)
+	} else if !errors.Is(err, ErrNotFound) {
+		return nil, err
+	}
+
+	it, err := s.Find(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if it.Status.IsNote() {
+		return it, nil
+	}
+
+	oldPath := it.Path
+	it.Status = StatusNote
+	it.Type = ""
+	it.Concept = ""
+	it.Priority = ""
+	it.Horizon = ""
+	it.BlockedBy = nil
+	it.DependsOn = nil
+	it.PromotionCriteria = ""
+	it.PromotedTo = ""
+	it.GatheredFrom = nil
+	it.GatheredAt = time.Time{}
+	it.GatheredInto = ""
+	it.UpdatedAt = time.Now()
+
+	newPath := s.moveTargetPath(it.ID, StatusNote, oldPath)
+	if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
+		return nil, camperrors.Wrap(err, "creating directory")
+	}
+
+	data, err := SerializeIntent(it)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "serializing note")
+	}
+	if err := os.WriteFile(newPath, data, 0644); err != nil {
+		return nil, camperrors.Wrap(err, "writing note file")
+	}
+	if err := os.Remove(oldPath); err != nil {
+		_ = os.Remove(newPath)
+		return nil, camperrors.Wrap(err, "removing old intent file")
+	}
+
+	s.removeAllCopies(id, newPath)
+	it.Path = newPath
+	s.invalidateIDIndex()
+	return it, nil
+}
+
+// Convert promotes a note into inbox, attaches the given type, and refreshes
+// updated_at. Use MoveNoteToStatus when the caller already has a target status.
+func (s *IntentService) Convert(ctx context.Context, id string, newType Type) (*Intent, error) {
+	return s.MoveNoteToStatus(ctx, id, StatusInbox, newType)
+}
+
+// MoveNoteToStatus promotes a note into the selected non-note lifecycle status.
+func (s *IntentService) MoveNoteToStatus(ctx context.Context, id string, newStatus Status, newType Type) (*Intent, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, camperrors.Wrap(err, "context cancelled")
+	}
+
+	if newStatus.IsNote() || !isLifecycleStatus(newStatus) {
+		return nil, camperrors.Wrapf(ErrInvalidStatus, "%q", newStatus)
+	}
 	if newType != "" && !isValidType(newType) {
 		return nil, camperrors.Wrapf(ErrInvalidType, "%q", newType)
 	}
@@ -138,21 +206,20 @@ func (s *IntentService) Convert(ctx context.Context, id string, newType Type) (*
 	if err != nil {
 		return nil, err
 	}
+	if _, err := s.resolveByID(note.ID); err == nil {
+		return nil, camperrors.Wrap(ErrFileExists, note.ID)
+	} else if !errors.Is(err, ErrNotFound) {
+		return nil, err
+	}
 
 	oldPath := note.Path
-	note.Status = StatusInbox
+	note.Status = newStatus
 	note.Type = newType
 	note.UpdatedAt = time.Now()
 
-	newPath := s.getIntentPath(StatusInbox, note.ID)
+	newPath := s.moveTargetPath(note.ID, newStatus, oldPath)
 	if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
 		return nil, camperrors.Wrap(err, "creating directory")
-	}
-
-	// Notes and intents are separate stores that share the same id generator, so
-	// an intent could already occupy inbox/<id>.md. Never overwrite it.
-	if _, err := os.Stat(newPath); err == nil {
-		return nil, camperrors.Wrap(ErrFileExists, newPath)
 	}
 
 	data, err := SerializeIntent(note)
@@ -171,6 +238,15 @@ func (s *IntentService) Convert(ctx context.Context, id string, newType Type) (*
 	note.Path = newPath
 	s.invalidateIDIndex()
 	return note, nil
+}
+
+func isLifecycleStatus(status Status) bool {
+	for _, s := range AllStatuses() {
+		if status == s {
+			return true
+		}
+	}
+	return false
 }
 
 // noteSortKey returns the timestamp used to order notes (updated, else created).

--- a/internal/intent/notes.go
+++ b/internal/intent/notes.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -22,20 +23,51 @@ func (s *IntentService) CreateNote(ctx context.Context, opts CreateOptions) (*In
 	return s.CreateDirect(ctx, opts)
 }
 
-// GetNote retrieves a note by its exact ID from the note store.
+// GetNote retrieves a note by its frontmatter id from the note store.
+// Resolution is id-authoritative, not filename-based, so a renamed note whose
+// slug has drifted from its id still resolves.
 func (s *IntentService) GetNote(ctx context.Context, id string) (*Intent, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, camperrors.Wrap(err, "context cancelled")
 	}
 
+	path, err := s.resolveNoteByID(id)
+	if err != nil {
+		return nil, err
+	}
+	return s.loadIntent(path)
+}
+
+// resolveNoteByID returns the path of the note whose id: frontmatter equals id.
+// Notes are few and live only under NoteStatuses(), so a filename fast path
+// followed by a small directory scan (covering renamed notes) is enough — no
+// cached index is needed here, unlike the lifecycle id index.
+func (s *IntentService) resolveNoteByID(id string) (string, error) {
+	// Fast path: filename == id (an unrenamed note).
 	for _, status := range NoteStatuses() {
-		path := s.getIntentPath(status, id)
-		if note, err := s.loadIntent(path); err == nil {
-			return note, nil
+		p := s.getIntentPath(status, id)
+		if note, err := s.loadIntent(p); err == nil && note.ID == id {
+			return p, nil
 		}
 	}
-
-	return nil, camperrors.Wrap(ErrNotFound, id)
+	// Slow path: a renamed note whose filename no longer matches its id.
+	for _, status := range NoteStatuses() {
+		dir := filepath.Join(s.intentsDir, string(status))
+		files, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, f := range files {
+			if f.IsDir() || !strings.HasSuffix(f.Name(), ".md") {
+				continue
+			}
+			p := filepath.Join(dir, f.Name())
+			if note, err := s.loadIntent(p); err == nil && note.ID == id {
+				return p, nil
+			}
+		}
+	}
+	return "", camperrors.Wrap(ErrNotFound, id)
 }
 
 // ListNotes returns notes from the note store, newest first. By default only
@@ -137,7 +169,10 @@ func (s *IntentService) MoveIntentToNote(ctx context.Context, id string) (*Inten
 		return nil, err
 	}
 
-	it, err := s.Find(ctx, id)
+	// Resolve by exact id, never a fuzzy substring match: this relocates a file
+	// and strips its lifecycle metadata, so acting on a truncated or mistyped id
+	// would silently convert the wrong intent.
+	it, err := s.Get(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -241,12 +276,7 @@ func (s *IntentService) MoveNoteToStatus(ctx context.Context, id string, newStat
 }
 
 func isLifecycleStatus(status Status) bool {
-	for _, s := range AllStatuses() {
-		if status == s {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(AllStatuses(), status)
 }
 
 // noteSortKey returns the timestamp used to order notes (updated, else created).

--- a/internal/intent/notes.go
+++ b/internal/intent/notes.go
@@ -149,6 +149,12 @@ func (s *IntentService) Convert(ctx context.Context, id string, newType Type) (*
 		return nil, camperrors.Wrap(err, "creating directory")
 	}
 
+	// Notes and intents are separate stores that share the same id generator, so
+	// an intent could already occupy inbox/<id>.md. Never overwrite it.
+	if _, err := os.Stat(newPath); err == nil {
+		return nil, camperrors.Wrap(ErrFileExists, newPath)
+	}
+
 	data, err := SerializeIntent(note)
 	if err != nil {
 		return nil, camperrors.Wrap(err, "serializing converted note")

--- a/internal/intent/notes.go
+++ b/internal/intent/notes.go
@@ -118,6 +118,7 @@ func (s *IntentService) ArchiveNote(ctx context.Context, id string) (*Intent, er
 	}
 
 	note.Path = newPath
+	s.invalidateIDIndex()
 	return note, nil
 }
 
@@ -162,6 +163,7 @@ func (s *IntentService) Convert(ctx context.Context, id string, newType Type) (*
 	}
 
 	note.Path = newPath
+	s.invalidateIDIndex()
 	return note, nil
 }
 

--- a/internal/intent/notes.go
+++ b/internal/intent/notes.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/intent/audit"
 )
 
 // CreateNote creates a note in the flat notes/ store, bypassing the
@@ -111,6 +112,43 @@ func (s *IntentService) ListNotes(ctx context.Context, includeArchived bool) ([]
 	})
 
 	return notes, nil
+}
+
+// UpdateNoteTags is the note-store equivalent of UpdateDirect's tag path: notes
+// resolve outside the lifecycle id index UpdateDirect uses, so they need their
+// own entry point that still normalizes/validates tags, refreshes updated_at,
+// and returns a FieldChange (empty when unchanged) for the caller's audit/commit.
+func (s *IntentService) UpdateNoteTags(ctx context.Context, id string, tags []string) (*Intent, []audit.FieldChange, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, camperrors.Wrap(err, "context cancelled")
+	}
+
+	normTags, err := validateAndNormalizeTags(tags)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	note, err := s.GetNote(ctx, id)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if slices.Equal(note.Tags, normTags) {
+		return note, nil, nil
+	}
+
+	change := audit.FieldChange{
+		Field: "tags",
+		Old:   strings.Join(note.Tags, ","),
+		New:   strings.Join(normTags, ","),
+	}
+	note.Tags = normTags
+	note.UpdatedAt = time.Now()
+
+	if err := s.Save(ctx, note); err != nil {
+		return nil, nil, err
+	}
+	return note, []audit.FieldChange{change}, nil
 }
 
 // ArchiveNote moves a note from notes/ into notes/archived/.

--- a/internal/intent/notes.go
+++ b/internal/intent/notes.go
@@ -1,0 +1,174 @@
+package intent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// CreateNote creates a note in the flat notes/ store, bypassing the
+// inbox/ready/active intent lifecycle. Notes carry no type and are not shown by
+// normal intent listings; tags organize them.
+func (s *IntentService) CreateNote(ctx context.Context, opts CreateOptions) (*Intent, error) {
+	opts.Category = CategoryNote
+	opts.Type = ""
+	opts.Concept = ""
+	return s.CreateDirect(ctx, opts)
+}
+
+// GetNote retrieves a note by its exact ID from the note store.
+func (s *IntentService) GetNote(ctx context.Context, id string) (*Intent, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, camperrors.Wrap(err, "context cancelled")
+	}
+
+	for _, status := range NoteStatuses() {
+		path := s.getIntentPath(status, id)
+		if note, err := s.loadIntent(path); err == nil {
+			return note, nil
+		}
+	}
+
+	return nil, camperrors.Wrap(ErrNotFound, id)
+}
+
+// ListNotes returns notes from the note store, newest first. By default only
+// the active notes/ directory is listed; pass includeArchived to also include
+// notes/archived/.
+func (s *IntentService) ListNotes(ctx context.Context, includeArchived bool) ([]*Intent, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, camperrors.Wrap(err, "context cancelled")
+	}
+
+	statuses := []Status{StatusNote}
+	if includeArchived {
+		statuses = NoteStatuses()
+	}
+
+	var notes []*Intent
+	for _, status := range statuses {
+		dir := filepath.Join(s.intentsDir, string(status))
+		files, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, camperrors.Wrapf(err, "reading directory %s", dir)
+		}
+
+		for _, file := range files {
+			if file.IsDir() || !strings.HasSuffix(file.Name(), ".md") {
+				continue
+			}
+			note, err := s.loadIntent(filepath.Join(dir, file.Name()))
+			if err != nil {
+				continue
+			}
+			notes = append(notes, note)
+		}
+	}
+
+	sort.Slice(notes, func(i, j int) bool {
+		return noteSortKey(notes[i]).After(noteSortKey(notes[j]))
+	})
+
+	return notes, nil
+}
+
+// ArchiveNote moves a note from notes/ into notes/archived/.
+func (s *IntentService) ArchiveNote(ctx context.Context, id string) (*Intent, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, camperrors.Wrap(err, "context cancelled")
+	}
+
+	note, err := s.GetNote(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if note.Status == StatusNoteArchived {
+		return note, nil
+	}
+
+	oldPath := note.Path
+	note.Status = StatusNoteArchived
+	note.UpdatedAt = time.Now()
+
+	newPath := s.getIntentPath(StatusNoteArchived, note.ID)
+	if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
+		return nil, camperrors.Wrap(err, "creating directory")
+	}
+
+	data, err := SerializeIntent(note)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "serializing note")
+	}
+	if err := os.WriteFile(newPath, data, 0644); err != nil {
+		return nil, camperrors.Wrap(err, "writing note file")
+	}
+
+	if err := os.Remove(oldPath); err != nil {
+		_ = os.Remove(newPath)
+		return nil, camperrors.Wrap(err, "removing old note file")
+	}
+
+	note.Path = newPath
+	return note, nil
+}
+
+// Convert promotes a note into the intent lifecycle: it moves
+// notes/<id>.md into inbox/<id>.md, attaches the given type, and refreshes
+// updated_at. This is the only bridge from a note into inbox/ready/active.
+func (s *IntentService) Convert(ctx context.Context, id string, newType Type) (*Intent, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, camperrors.Wrap(err, "context cancelled")
+	}
+
+	if newType != "" && !isValidType(newType) {
+		return nil, camperrors.Wrapf(ErrInvalidType, "%q", newType)
+	}
+
+	note, err := s.GetNote(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	oldPath := note.Path
+	note.Status = StatusInbox
+	note.Type = newType
+	note.UpdatedAt = time.Now()
+
+	newPath := s.getIntentPath(StatusInbox, note.ID)
+	if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
+		return nil, camperrors.Wrap(err, "creating directory")
+	}
+
+	data, err := SerializeIntent(note)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "serializing converted note")
+	}
+	if err := os.WriteFile(newPath, data, 0644); err != nil {
+		return nil, camperrors.Wrap(err, "writing intent file")
+	}
+
+	if err := os.Remove(oldPath); err != nil {
+		_ = os.Remove(newPath)
+		return nil, camperrors.Wrap(err, "removing old note file")
+	}
+
+	note.Path = newPath
+	return note, nil
+}
+
+// noteSortKey returns the timestamp used to order notes (updated, else created).
+func noteSortKey(n *Intent) time.Time {
+	if !n.UpdatedAt.IsZero() {
+		return n.UpdatedAt
+	}
+	return n.CreatedAt
+}

--- a/internal/intent/notes_test.go
+++ b/internal/intent/notes_test.go
@@ -1,0 +1,258 @@
+package intent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newNotesTestService(t *testing.T) (*IntentService, context.Context) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	return NewIntentService(tmpDir, filepath.Join(tmpDir, "intents")), context.Background()
+}
+
+func TestCreateNote_RoutesToNotesDir(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	note, err := svc.CreateNote(ctx, CreateOptions{
+		Title:     "remember to check the daemon socket path",
+		Type:      TypeFeature, // should be ignored for notes
+		Concept:   "projects/camp",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	if note.Status != StatusNote {
+		t.Errorf("Status = %q, want %q", note.Status, StatusNote)
+	}
+	if note.Type != "" {
+		t.Errorf("Type = %q, want empty for a note", note.Type)
+	}
+	wantDir := filepath.Join(svc.intentsDir, "notes")
+	if filepath.Dir(note.Path) != wantDir {
+		t.Errorf("note dir = %q, want %q", filepath.Dir(note.Path), wantDir)
+	}
+	if _, err := os.Stat(note.Path); err != nil {
+		t.Errorf("note file not written: %v", err)
+	}
+	if errs := note.Validate(); len(errs) > 0 {
+		t.Errorf("note failed validation: %v", errs)
+	}
+}
+
+func TestCreateDirect_IntentRoutesToInbox(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	intent, err := svc.CreateDirect(ctx, CreateOptions{
+		Title:     "add a search command",
+		Type:      TypeFeature,
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+	if intent.Status != StatusInbox {
+		t.Errorf("Status = %q, want %q", intent.Status, StatusInbox)
+	}
+	if filepath.Dir(intent.Path) != filepath.Join(svc.intentsDir, "inbox") {
+		t.Errorf("intent dir = %q, want inbox", filepath.Dir(intent.Path))
+	}
+}
+
+func TestList_ExcludesNotes(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	if _, err := svc.CreateDirect(ctx, CreateOptions{
+		Title:     "real intent that should be listed",
+		Type:      TypeFeature,
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+	note, err := svc.CreateNote(ctx, CreateOptions{
+		Title:     "a stray note that must not appear in intent lists",
+		Timestamp: time.Date(2026, 6, 9, 10, 1, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	intents, err := svc.List(ctx, nil)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(intents) != 1 {
+		t.Fatalf("List returned %d intents, want 1 (notes must be excluded)", len(intents))
+	}
+	for _, i := range intents {
+		if i.ID == note.ID {
+			t.Errorf("note %q leaked into intent List", note.ID)
+		}
+	}
+}
+
+func TestGetAndFind_DoNotResolveNotes(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	note, err := svc.CreateNote(ctx, CreateOptions{
+		Title:     "note invisible to intent lookups",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	if _, err := svc.Get(ctx, note.ID); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get(note) err = %v, want ErrNotFound", err)
+	}
+	if _, err := svc.Find(ctx, note.ID); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Find(note) err = %v, want ErrNotFound", err)
+	}
+
+	got, err := svc.GetNote(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("GetNote: %v", err)
+	}
+	if got.ID != note.ID {
+		t.Errorf("GetNote ID = %q, want %q", got.ID, note.ID)
+	}
+}
+
+func TestArchiveNote_MovesToArchived(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	note, err := svc.CreateNote(ctx, CreateOptions{
+		Title:     "note to be archived",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	oldPath := note.Path
+
+	archived, err := svc.ArchiveNote(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("ArchiveNote: %v", err)
+	}
+	if archived.Status != StatusNoteArchived {
+		t.Errorf("Status = %q, want %q", archived.Status, StatusNoteArchived)
+	}
+	wantDir := filepath.Join(svc.intentsDir, "notes", "archived")
+	if filepath.Dir(archived.Path) != wantDir {
+		t.Errorf("archived dir = %q, want %q", filepath.Dir(archived.Path), wantDir)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf("old note file still present at %q", oldPath)
+	}
+
+	active, err := svc.ListNotes(ctx, false)
+	if err != nil {
+		t.Fatalf("ListNotes(active): %v", err)
+	}
+	if len(active) != 0 {
+		t.Errorf("active notes = %d, want 0 after archive", len(active))
+	}
+	all, err := svc.ListNotes(ctx, true)
+	if err != nil {
+		t.Fatalf("ListNotes(all): %v", err)
+	}
+	if len(all) != 1 {
+		t.Errorf("all notes = %d, want 1 including archived", len(all))
+	}
+}
+
+func TestConvert_NoteBecomesIntent(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	note, err := svc.CreateNote(ctx, CreateOptions{
+		Title:     "this note turned out to be actionable",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	oldPath := note.Path
+
+	got, err := svc.Convert(ctx, note.ID, TypeFeature)
+	if err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if got.Status != StatusInbox {
+		t.Errorf("Status = %q, want %q", got.Status, StatusInbox)
+	}
+	if got.Type != TypeFeature {
+		t.Errorf("Type = %q, want %q", got.Type, TypeFeature)
+	}
+	if filepath.Dir(got.Path) != filepath.Join(svc.intentsDir, "inbox") {
+		t.Errorf("converted dir = %q, want inbox", filepath.Dir(got.Path))
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf("note still present in notes/ at %q", oldPath)
+	}
+
+	// It now resolves as an intent and appears in intent listings.
+	if _, err := svc.Get(ctx, note.ID); err != nil {
+		t.Errorf("converted intent not resolvable via Get: %v", err)
+	}
+	intents, err := svc.List(ctx, nil)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(intents) != 1 {
+		t.Errorf("List returned %d intents, want 1 after convert", len(intents))
+	}
+	// And it is gone from the notes store.
+	notes, err := svc.ListNotes(ctx, true)
+	if err != nil {
+		t.Fatalf("ListNotes: %v", err)
+	}
+	if len(notes) != 0 {
+		t.Errorf("notes = %d, want 0 after convert", len(notes))
+	}
+}
+
+func TestConvert_RejectsInvalidType(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	note, err := svc.CreateNote(ctx, CreateOptions{
+		Title:     "note with a bad convert type",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	if _, err := svc.Convert(ctx, note.ID, Type("bogus")); err == nil {
+		t.Error("Convert with invalid type should error")
+	}
+	// The note must remain a note after a rejected convert.
+	if _, err := svc.GetNote(ctx, note.ID); err != nil {
+		t.Errorf("note should still exist after rejected convert: %v", err)
+	}
+}
+
+func TestNoteFrontmatter_HasNotesStatus(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	note, err := svc.CreateNote(ctx, CreateOptions{
+		Title:     "frontmatter status should be notes",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	raw, err := os.ReadFile(note.Path)
+	if err != nil {
+		t.Fatalf("read note: %v", err)
+	}
+	if !strings.Contains(string(raw), "status: notes") {
+		t.Errorf("note frontmatter missing 'status: notes':\n%s", raw)
+	}
+}

--- a/internal/intent/notes_test.go
+++ b/internal/intent/notes_test.go
@@ -218,6 +218,43 @@ func TestConvert_NoteBecomesIntent(t *testing.T) {
 	}
 }
 
+func TestConvert_DoesNotOverwriteExistingIntent(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+	ts := time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC)
+
+	// A note and an intent created from the same title at the same timestamp
+	// share an id (slug + timestamp).
+	note, err := svc.CreateNote(ctx, CreateOptions{Title: "duplicate identity", Timestamp: ts})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	existing, err := svc.CreateDirect(ctx, CreateOptions{Title: "duplicate identity", Type: TypeFeature, Timestamp: ts})
+	if err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+	if note.ID != existing.ID {
+		t.Fatalf("test precondition: ids should collide, got %q vs %q", note.ID, existing.ID)
+	}
+
+	// Converting the note must NOT overwrite the existing inbox intent.
+	if _, err := svc.Convert(ctx, note.ID, TypeIdea); !errors.Is(err, ErrFileExists) {
+		t.Fatalf("Convert on id collision err = %v, want ErrFileExists", err)
+	}
+
+	// The existing intent file is intact (still TypeFeature, not clobbered).
+	raw, err := os.ReadFile(existing.Path)
+	if err != nil {
+		t.Fatalf("read existing intent: %v", err)
+	}
+	if !strings.Contains(string(raw), "type: feature") {
+		t.Errorf("existing intent was overwritten by convert:\n%s", raw)
+	}
+	// The note still exists in the note store.
+	if _, err := svc.GetNote(ctx, note.ID); err != nil {
+		t.Errorf("note should still exist after rejected convert: %v", err)
+	}
+}
+
 func TestConvert_RejectsInvalidType(t *testing.T) {
 	svc, ctx := newNotesTestService(t)
 

--- a/internal/intent/notes_test.go
+++ b/internal/intent/notes_test.go
@@ -16,6 +16,62 @@ func newNotesTestService(t *testing.T) (*IntentService, context.Context) {
 	return NewIntentService(tmpDir, filepath.Join(tmpDir, "intents")), context.Background()
 }
 
+func TestUpdateNoteTags_NormalizesStampsAndReturnsChange(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	note, err := svc.CreateNote(ctx, CreateOptions{
+		Title:     "taggable note",
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	if !note.UpdatedAt.IsZero() {
+		t.Fatalf("precondition: fresh note should have zero UpdatedAt, got %v", note.UpdatedAt)
+	}
+
+	updated, changes, err := svc.UpdateNoteTags(ctx, note.ID, []string{" keep ", "keep", "drop-me"})
+	if err != nil {
+		t.Fatalf("UpdateNoteTags: %v", err)
+	}
+	if len(changes) != 1 || changes[0].Field != "tags" {
+		t.Fatalf("changes = %#v, want a single tags change", changes)
+	}
+	if len(updated.Tags) != 2 || updated.Tags[0] != "keep" || updated.Tags[1] != "drop-me" {
+		t.Fatalf("tags = %v, want trimmed+deduped [keep drop-me]", updated.Tags)
+	}
+	if updated.UpdatedAt.IsZero() {
+		t.Error("UpdateNoteTags did not refresh UpdatedAt")
+	}
+
+	reloaded, err := svc.GetNote(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("GetNote: %v", err)
+	}
+	if len(reloaded.Tags) != 2 {
+		t.Fatalf("persisted tags = %v, want 2", reloaded.Tags)
+	}
+	if reloaded.UpdatedAt.IsZero() {
+		t.Error("persisted note has zero UpdatedAt")
+	}
+}
+
+func TestUpdateNoteTags_RejectsInvalidTag(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	note, err := svc.CreateNote(ctx, CreateOptions{
+		Title:     "another note",
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	if _, _, err := svc.UpdateNoteTags(ctx, note.ID, []string{"bad,tag"}); err == nil {
+		t.Fatal("UpdateNoteTags should reject a tag containing a comma")
+	}
+}
+
 func TestCreateNote_RoutesToNotesDir(t *testing.T) {
 	svc, ctx := newNotesTestService(t)
 

--- a/internal/intent/notes_test.go
+++ b/internal/intent/notes_test.go
@@ -381,3 +381,69 @@ func TestNoteFrontmatter_HasNotesStatus(t *testing.T) {
 		t.Errorf("note frontmatter missing 'status: notes':\n%s", raw)
 	}
 }
+
+func TestMoveIntentToNote_RejectsPartialID(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	created, err := svc.CreateDirect(ctx, CreateOptions{
+		Title:     "fix the widget renderer",
+		Type:      TypeBug,
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+
+	if _, err := svc.MoveIntentToNote(ctx, "widget"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("MoveIntentToNote(partial id) err = %v, want ErrNotFound", err)
+	}
+
+	got, err := svc.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get after rejected move: %v", err)
+	}
+	if got.Status != StatusInbox {
+		t.Errorf("status = %q, want inbox; the intent must not move on a fuzzy guess", got.Status)
+	}
+}
+
+func TestRename_WorksForNotes(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	note, err := svc.CreateNote(ctx, CreateOptions{
+		Title:     "socket path note",
+		Timestamp: time.Date(2026, 1, 19, 15, 34, 12, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	renamed, err := svc.Rename(ctx, note.ID, "daemon socket path reminder")
+	if err != nil {
+		t.Fatalf("Rename note: %v", err)
+	}
+	if renamed.ID != note.ID {
+		t.Errorf("id changed on rename: %q -> %q", note.ID, renamed.ID)
+	}
+	if renamed.Status != StatusNote {
+		t.Errorf("status = %q, want %q; rename must keep it a note", renamed.Status, StatusNote)
+	}
+	base := filepath.Base(renamed.Path)
+	if !strings.HasPrefix(base, "daemon-socket-path-reminder-") {
+		t.Errorf("filename = %q, want slug of new title", base)
+	}
+	if filepath.Dir(renamed.Path) != filepath.Join(svc.intentsDir, "notes") {
+		t.Errorf("renamed note dir = %q, want notes/", filepath.Dir(renamed.Path))
+	}
+
+	got, err := svc.GetNote(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("GetNote after rename: %v", err)
+	}
+	if got.Title != "daemon socket path reminder" {
+		t.Errorf("resolved title = %q", got.Title)
+	}
+	if _, err := svc.Get(ctx, note.ID); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get(renamed note) err = %v, want ErrNotFound; notes stay out of intent resolution", err)
+	}
+}

--- a/internal/intent/notes_test.go
+++ b/internal/intent/notes_test.go
@@ -218,6 +218,94 @@ func TestConvert_NoteBecomesIntent(t *testing.T) {
 	}
 }
 
+func TestMoveIntentToNote_ClearsLifecycleMetadata(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	created, err := svc.CreateDirect(ctx, CreateOptions{
+		Title:     "turn this intent into a note",
+		Type:      TypeFeature,
+		Concept:   "projects/camp",
+		Body:      "important details stay in the body",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+	oldPath := created.Path
+
+	note, err := svc.MoveIntentToNote(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("MoveIntentToNote: %v", err)
+	}
+	if note.Status != StatusNote {
+		t.Errorf("Status = %q, want %q", note.Status, StatusNote)
+	}
+	if note.Type != "" {
+		t.Errorf("Type = %q, want empty for note", note.Type)
+	}
+	if note.Concept != "" {
+		t.Errorf("Concept = %q, want empty for note", note.Concept)
+	}
+	if !strings.Contains(note.Content, "important details stay in the body") {
+		t.Errorf("Content = %q, want preserved body details", note.Content)
+	}
+	if filepath.Dir(note.Path) != filepath.Join(svc.intentsDir, "notes") {
+		t.Errorf("note dir = %q, want notes/", filepath.Dir(note.Path))
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf("old intent still present at %q", oldPath)
+	}
+	if _, err := svc.Get(ctx, created.ID); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get(converted note) err = %v, want ErrNotFound", err)
+	}
+	if _, err := svc.GetNote(ctx, created.ID); err != nil {
+		t.Errorf("GetNote(converted note): %v", err)
+	}
+	raw, err := os.ReadFile(note.Path)
+	if err != nil {
+		t.Fatalf("ReadFile(note): %v", err)
+	}
+	if strings.Contains(string(raw), "type:") || strings.Contains(string(raw), "concept:") {
+		t.Fatalf("note frontmatter retained lifecycle metadata:\n%s", raw)
+	}
+}
+
+func TestMoveNoteToStatus_UsesSelectedStatus(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	note, err := svc.CreateNote(ctx, CreateOptions{
+		Title:     "ready note",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	oldPath := note.Path
+
+	got, err := svc.MoveNoteToStatus(ctx, note.ID, StatusReady, TypeResearch)
+	if err != nil {
+		t.Fatalf("MoveNoteToStatus: %v", err)
+	}
+	if got.Status != StatusReady {
+		t.Errorf("Status = %q, want %q", got.Status, StatusReady)
+	}
+	if got.Type != TypeResearch {
+		t.Errorf("Type = %q, want %q", got.Type, TypeResearch)
+	}
+	if filepath.Dir(got.Path) != filepath.Join(svc.intentsDir, "ready") {
+		t.Errorf("converted dir = %q, want ready/", filepath.Dir(got.Path))
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf("note still present in notes/ at %q", oldPath)
+	}
+	if _, err := svc.Get(ctx, note.ID); err != nil {
+		t.Errorf("converted note not resolvable as intent: %v", err)
+	}
+	if _, err := svc.GetNote(ctx, note.ID); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetNote(converted intent) err = %v, want ErrNotFound", err)
+	}
+}
+
 func TestConvert_DoesNotOverwriteExistingIntent(t *testing.T) {
 	svc, ctx := newNotesTestService(t)
 	ts := time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC)

--- a/internal/intent/promote/promote.go
+++ b/internal/intent/promote/promote.go
@@ -185,7 +185,7 @@ func createDesignDoc(ctx context.Context, campaignRoot string, i *intent.Intent)
 		return "", false, camperrors.Wrap(err, "context cancelled before creating design doc")
 	}
 
-	slug := intent.GenerateSlug(i.Title)
+	slug := intent.SlugFromTitle(i.Title)
 	if slug == "" {
 		return "", false, camperrors.New("could not generate slug from intent title")
 	}
@@ -296,7 +296,7 @@ func createFestival(ctx context.Context, campaignRoot string, i *intent.Intent) 
 		return Result{FestNotFound: true}
 	}
 
-	festivalName := intent.GenerateSlug(i.Title)
+	festivalName := intent.SlugFromTitle(i.Title)
 	festivalGoal := ExtractFirstParagraph(i.Content)
 
 	args := []string{"create", "festival", "--type", "standard", "--name", festivalName, "--json"}

--- a/internal/intent/query.go
+++ b/internal/intent/query.go
@@ -27,18 +27,15 @@ func (s *IntentService) Find(ctx context.Context, id string) (*Intent, error) {
 		return nil, camperrors.Wrap(err, "context cancelled")
 	}
 
-	statuses := AllStatuses()
-
-	// First try exact match
-	for _, status := range statuses {
-		path := s.getIntentPath(status, id)
+	// First try exact match by id: frontmatter (fast path + index fallback)
+	if path, err := s.resolveByID(id); err == nil {
 		if intent, err := s.loadIntent(path); err == nil {
 			return intent, nil
 		}
 	}
 
 	// Try fuzzy match (ID contains the search term)
-	for _, status := range statuses {
+	for _, status := range AllStatuses() {
 		dir := filepath.Join(s.intentsDir, string(status))
 		files, err := os.ReadDir(dir)
 		if err != nil {
@@ -62,20 +59,21 @@ func (s *IntentService) Find(ctx context.Context, id string) (*Intent, error) {
 	return nil, camperrors.Wrap(ErrNotFound, id)
 }
 
-// Get retrieves an intent by its exact ID.
+// Get retrieves an intent by its exact ID (resolved via id: frontmatter).
 func (s *IntentService) Get(ctx context.Context, id string) (*Intent, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, camperrors.Wrap(err, "context cancelled")
 	}
 
-	for _, status := range AllStatuses() {
-		path := s.getIntentPath(status, id)
-		if intent, err := s.loadIntent(path); err == nil {
-			return intent, nil
-		}
+	path, err := s.resolveByID(id)
+	if err != nil {
+		return nil, err
 	}
-
-	return nil, camperrors.Wrap(ErrNotFound, id)
+	intent, err := s.loadIntent(path)
+	if err != nil {
+		return nil, camperrors.Wrap(ErrNotFound, id)
+	}
+	return intent, nil
 }
 
 // List returns all intents matching the given options.

--- a/internal/intent/rename.go
+++ b/internal/intent/rename.go
@@ -27,7 +27,14 @@ func (s *IntentService) Rename(ctx context.Context, id, newTitle string) (*Inten
 
 	oldPath, err := s.resolveByID(id)
 	if err != nil {
-		return nil, err
+		// Notes live outside the lifecycle status dirs resolveByID scans; fall
+		// back to the note store so renaming a note works too. The rename logic
+		// below is directory-agnostic, so the note stays in notes/.
+		notePath, nerr := s.resolveNoteByID(id)
+		if nerr != nil {
+			return nil, err
+		}
+		oldPath = notePath
 	}
 	it, err := s.loadIntent(oldPath)
 	if err != nil {

--- a/internal/intent/rename.go
+++ b/internal/intent/rename.go
@@ -1,0 +1,114 @@
+package intent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// Rename updates an intent's title and regenerates its human-readable filename
+// (<new-slug>-<stable-suffix>.md) while preserving its stable id. The file is
+// moved on disk and title:/updated_at: are rewritten. Identity (id:) never
+// changes, so existing references and id-based lookups survive the rename.
+func (s *IntentService) Rename(ctx context.Context, id, newTitle string) (*Intent, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, camperrors.Wrap(err, "context cancelled")
+	}
+
+	newTitle = strings.TrimSpace(newTitle)
+	if newTitle == "" {
+		return nil, camperrors.Wrap(camperrors.ErrInvalidInput, "rename: new title is empty")
+	}
+
+	oldPath, err := s.resolveByID(id)
+	if err != nil {
+		return nil, err
+	}
+	it, err := s.loadIntent(oldPath)
+	if err != nil {
+		return nil, camperrors.Wrap(ErrNotFound, id)
+	}
+
+	newPath := s.uniqueRenamePath(filepath.Dir(oldPath), renameBase(it.ID, newTitle), oldPath)
+
+	it.Title = newTitle
+	it.UpdatedAt = time.Now()
+
+	data, err := SerializeIntent(it)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "serializing renamed intent")
+	}
+
+	if newPath == oldPath {
+		// Slug unchanged: rewrite in place.
+		if err := os.WriteFile(oldPath, data, 0644); err != nil {
+			return nil, camperrors.Wrap(err, "writing renamed intent")
+		}
+		it.Path = oldPath
+		s.invalidateIDIndex()
+		return it, nil
+	}
+
+	if err := os.WriteFile(newPath, data, 0644); err != nil {
+		return nil, camperrors.Wrap(err, "writing renamed intent")
+	}
+	if err := os.Remove(oldPath); err != nil {
+		_ = os.Remove(newPath)
+		return nil, camperrors.Wrap(err, "removing old intent file")
+	}
+
+	it.Path = newPath
+	s.invalidateIDIndex()
+	return it, nil
+}
+
+// renameBase builds <new-slug>-<stable-suffix> from the new title and the
+// intent's stable id suffix.
+func renameBase(id, newTitle string) string {
+	suffix := stableSuffix(id)
+	slug := SlugFromTitle(newTitle)
+	switch {
+	case slug == "":
+		return suffix
+	case suffix == "":
+		return slug
+	default:
+		return slug + "-" + suffix
+	}
+}
+
+// stableSuffix returns the timestamp portion (YYYYMMDD-HHMMSS) of an intent id,
+// which is stable across renames. Ids are <slug>-YYYYMMDD-HHMMSS.
+func stableSuffix(id string) string {
+	parts := strings.Split(id, "-")
+	if len(parts) >= 2 {
+		return parts[len(parts)-2] + "-" + parts[len(parts)-1]
+	}
+	return id
+}
+
+// uniqueRenamePath returns base.md in dir, appending -2, -3, ... when a
+// different file already occupies the path.
+func (s *IntentService) uniqueRenamePath(dir, base, oldPath string) string {
+	candidate := filepath.Join(dir, base+".md")
+	if candidate == oldPath {
+		return candidate
+	}
+	if _, err := os.Stat(candidate); os.IsNotExist(err) {
+		return candidate
+	}
+	for i := 2; ; i++ {
+		c := filepath.Join(dir, fmt.Sprintf("%s-%d.md", base, i))
+		if c == oldPath {
+			return c
+		}
+		if _, err := os.Stat(c); os.IsNotExist(err) {
+			return c
+		}
+	}
+}

--- a/internal/intent/rename.go
+++ b/internal/intent/rename.go
@@ -46,6 +46,10 @@ func (s *IntentService) Rename(ctx context.Context, id, newTitle string) (*Inten
 	it.Title = newTitle
 	it.UpdatedAt = time.Now()
 
+	if errs := it.Validate(); len(errs) > 0 {
+		return nil, intentValidationError(errs)
+	}
+
 	data, err := SerializeIntent(it)
 	if err != nil {
 		return nil, camperrors.Wrap(err, "serializing renamed intent")

--- a/internal/intent/rename_test.go
+++ b/internal/intent/rename_test.go
@@ -166,6 +166,38 @@ func TestRename_EmptyTitleRejected(t *testing.T) {
 	}
 }
 
+func TestRename_InvalidTitleRejectedWithoutMutating(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := NewIntentService(tmp, intentsDir)
+
+	created, err := svc.CreateDirect(ctx, CreateOptions{
+		Title:     "keep me valid",
+		Timestamp: time.Date(2026, 1, 19, 15, 34, 12, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+	originalBase := filepath.Base(created.Path)
+
+	// "xy" is non-empty but fails Intent.Validate (ErrTitleTooShort).
+	if _, err := svc.Rename(ctx, created.ID, "xy"); err == nil {
+		t.Fatal("Rename to a too-short title should error")
+	}
+
+	got, err := svc.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get after rejected rename: %v", err)
+	}
+	if got.Title != "keep me valid" {
+		t.Errorf("title mutated by rejected rename: %q", got.Title)
+	}
+	if filepath.Base(got.Path) != originalBase {
+		t.Errorf("file moved by rejected rename: %q -> %q", originalBase, filepath.Base(got.Path))
+	}
+}
+
 // sharedBasenameAcrossStatuses returns two distinct intents that, after both are
 // renamed to the same title, share a basename across status dirs: a in inbox and
 // b in ready. Rename uniqueness is per-directory, so this collision is legitimate

--- a/internal/intent/rename_test.go
+++ b/internal/intent/rename_test.go
@@ -165,3 +165,131 @@ func TestRename_EmptyTitleRejected(t *testing.T) {
 		t.Error("Rename with empty title should error")
 	}
 }
+
+// sharedBasenameAcrossStatuses returns two distinct intents that, after both are
+// renamed to the same title, share a basename across status dirs: a in inbox and
+// b in ready. Rename uniqueness is per-directory, so this collision is legitimate
+// (same timestamp suffix, same new slug, different ids) and a move of a into
+// ready must not overwrite b.
+func sharedBasenameAcrossStatuses(t *testing.T, ctx context.Context) (svc *IntentService, a, b *Intent, intentsDir string) {
+	t.Helper()
+	tmp := t.TempDir()
+	intentsDir = filepath.Join(tmp, "intents")
+	svc = NewIntentService(tmp, intentsDir)
+	ts := time.Date(2026, 1, 19, 15, 34, 12, 0, time.UTC)
+
+	ca, err := svc.CreateDirect(ctx, CreateOptions{Title: "alpha original", Type: TypeIdea, Timestamp: ts})
+	if err != nil {
+		t.Fatalf("create a: %v", err)
+	}
+	cb, err := svc.CreateDirect(ctx, CreateOptions{Title: "beta original", Type: TypeIdea, Timestamp: ts})
+	if err != nil {
+		t.Fatalf("create b: %v", err)
+	}
+	if ca.ID == cb.ID {
+		t.Fatalf("precondition: ids must differ, got %q", ca.ID)
+	}
+
+	if _, err := svc.Move(ctx, cb.ID, StatusReady); err != nil {
+		t.Fatalf("park b in ready: %v", err)
+	}
+	a, err = svc.Rename(ctx, ca.ID, "shared title")
+	if err != nil {
+		t.Fatalf("rename a: %v", err)
+	}
+	b, err = svc.Rename(ctx, cb.ID, "shared title")
+	if err != nil {
+		t.Fatalf("rename b: %v", err)
+	}
+	if filepath.Base(a.Path) != filepath.Base(b.Path) {
+		t.Fatalf("precondition: basenames should collide, got %q vs %q", filepath.Base(a.Path), filepath.Base(b.Path))
+	}
+	if filepath.Dir(a.Path) != filepath.Join(intentsDir, "inbox") {
+		t.Fatalf("precondition: a should be in inbox, got %q", a.Path)
+	}
+	return svc, a, b, intentsDir
+}
+
+func assertNoCrossStatusClobber(t *testing.T, ctx context.Context, svc *IntentService, a, b *Intent, intentsDir, movedPath, bBase string) {
+	t.Helper()
+
+	if filepath.Dir(movedPath) != filepath.Join(intentsDir, "ready") {
+		t.Errorf("moved a not in ready: %q", movedPath)
+	}
+	if filepath.Base(movedPath) == bBase {
+		t.Fatalf("a collided onto b's basename %q", bBase)
+	}
+
+	gotB, err := svc.Get(ctx, b.ID)
+	if err != nil {
+		t.Fatalf("b lost after moving a: %v", err)
+	}
+	if filepath.Base(gotB.Path) != bBase {
+		t.Errorf("b basename changed: got %q want %q", filepath.Base(gotB.Path), bBase)
+	}
+	if gotB.Title != "shared title" {
+		t.Errorf("b title corrupted: %q", gotB.Title)
+	}
+
+	gotA, err := svc.Get(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("a not resolvable after move: %v", err)
+	}
+	if gotA.Title != "shared title" {
+		t.Errorf("a title = %q, want %q", gotA.Title, "shared title")
+	}
+
+	ready := StatusReady
+	inReady, err := svc.List(ctx, &ListOptions{Status: &ready})
+	if err != nil {
+		t.Fatalf("List(ready): %v", err)
+	}
+	if len(inReady) != 2 {
+		t.Errorf("ready holds %d intents, want 2 (a and b distinct)", len(inReady))
+	}
+}
+
+func TestMove_DoesNotOverwriteCrossStatusBasename(t *testing.T) {
+	ctx := context.Background()
+	svc, a, b, intentsDir := sharedBasenameAcrossStatuses(t, ctx)
+	bBase := filepath.Base(b.Path)
+
+	moved, err := svc.Move(ctx, a.ID, StatusReady)
+	if err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	assertNoCrossStatusClobber(t, ctx, svc, a, b, intentsDir, moved.Path, bBase)
+}
+
+func TestUpdateDirect_DoesNotOverwriteCrossStatusBasename(t *testing.T) {
+	ctx := context.Background()
+	svc, a, b, intentsDir := sharedBasenameAcrossStatuses(t, ctx)
+	bBase := filepath.Base(b.Path)
+
+	ready := StatusReady
+	moved, _, err := svc.UpdateDirect(ctx, a.ID, UpdateOptions{Status: &ready})
+	if err != nil {
+		t.Fatalf("UpdateDirect: %v", err)
+	}
+	assertNoCrossStatusClobber(t, ctx, svc, a, b, intentsDir, moved.Path, bBase)
+}
+
+func TestEdit_DoesNotOverwriteCrossStatusBasename(t *testing.T) {
+	ctx := context.Background()
+	svc, a, b, intentsDir := sharedBasenameAcrossStatuses(t, ctx)
+	bBase := filepath.Base(b.Path)
+
+	editor := func(_ context.Context, path string) error {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		out := strings.Replace(string(raw), "status: inbox", "status: ready", 1)
+		return os.WriteFile(path, []byte(out), 0644)
+	}
+	moved, err := svc.Edit(ctx, a.ID, editor)
+	if err != nil {
+		t.Fatalf("Edit: %v", err)
+	}
+	assertNoCrossStatusClobber(t, ctx, svc, a, b, intentsDir, moved.Path, bBase)
+}

--- a/internal/intent/rename_test.go
+++ b/internal/intent/rename_test.go
@@ -1,0 +1,109 @@
+package intent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRename_UpdatesTitleAndFilenameKeepsID(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := NewIntentService(tmp, intentsDir)
+
+	created, err := svc.CreateDirect(ctx, CreateOptions{
+		Title:     "original title here",
+		Type:      TypeIdea,
+		Timestamp: time.Date(2026, 1, 19, 15, 34, 12, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+	originalID := created.ID
+
+	renamed, err := svc.Rename(ctx, originalID, "a much better title")
+	if err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+
+	if renamed.ID != originalID {
+		t.Errorf("id changed on rename: %q -> %q", originalID, renamed.ID)
+	}
+	if renamed.Title != "a much better title" {
+		t.Errorf("Title = %q, want %q", renamed.Title, "a much better title")
+	}
+	base := filepath.Base(renamed.Path)
+	if !strings.HasPrefix(base, "a-much-better-title-") {
+		t.Errorf("filename = %q, want slug of new title", base)
+	}
+	if !strings.HasSuffix(base, "20260119-153412.md") {
+		t.Errorf("filename = %q, want stable timestamp suffix preserved", base)
+	}
+	if _, err := os.Stat(created.Path); !os.IsNotExist(err) {
+		t.Errorf("old file still present at %q", created.Path)
+	}
+
+	// Lookup by the stable id still resolves after rename.
+	got, err := svc.Get(ctx, originalID)
+	if err != nil {
+		t.Fatalf("Get after rename: %v", err)
+	}
+	if got.Title != "a much better title" {
+		t.Errorf("resolved title = %q", got.Title)
+	}
+}
+
+func TestRename_CollisionProducesDistinctFilename(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := NewIntentService(tmp, intentsDir)
+
+	// Two intents sharing the same timestamp suffix would collide if renamed to
+	// the same slug. Write one occupying the target filename directly.
+	suffix := "20260119-153412"
+	id := "first-title-" + suffix
+	writeRenamedIntent(t, intentsDir, "inbox", id, id, "first title")
+	// Occupy the slug the rename will target.
+	occupied := filepath.Join(intentsDir, "inbox", "shared-slug-"+suffix+".md")
+	if err := os.WriteFile(occupied, []byte("---\nid: other-"+suffix+"\ntitle: other\nstatus: inbox\ncreated_at: 2026-01-01T00:00:00Z\n---\n"), 0644); err != nil {
+		t.Fatalf("write occupied: %v", err)
+	}
+
+	renamed, err := svc.Rename(ctx, id, "shared slug")
+	if err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	base := filepath.Base(renamed.Path)
+	if base == "shared-slug-"+suffix+".md" {
+		t.Errorf("rename collided onto occupied file: %q", base)
+	}
+	if !strings.HasPrefix(base, "shared-slug-"+suffix) {
+		t.Errorf("filename = %q, want disambiguated shared-slug base", base)
+	}
+	if _, err := os.Stat(occupied); err != nil {
+		t.Errorf("occupied file should be untouched: %v", err)
+	}
+}
+
+func TestRename_EmptyTitleRejected(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := NewIntentService(tmp, intentsDir)
+
+	created, err := svc.CreateDirect(ctx, CreateOptions{
+		Title:     "keep me",
+		Timestamp: time.Date(2026, 1, 19, 15, 34, 12, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+	if _, err := svc.Rename(ctx, created.ID, "   "); err == nil {
+		t.Error("Rename with empty title should error")
+	}
+}

--- a/internal/intent/rename_test.go
+++ b/internal/intent/rename_test.go
@@ -57,6 +57,64 @@ func TestRename_UpdatesTitleAndFilenameKeepsID(t *testing.T) {
 	}
 }
 
+func TestRename_SurvivesStatusMove(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := NewIntentService(tmp, intentsDir)
+
+	created, err := svc.CreateDirect(ctx, CreateOptions{
+		Title:     "fix the thing",
+		Type:      TypeBug,
+		Timestamp: time.Date(2026, 1, 19, 15, 34, 12, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+
+	renamed, err := svc.Rename(ctx, created.ID, "a much clearer title")
+	if err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	renamedBase := filepath.Base(renamed.Path)
+	if !strings.HasPrefix(renamedBase, "a-much-clearer-title-") {
+		t.Fatalf("rename did not produce expected slug: %q", renamedBase)
+	}
+
+	// A normal triage move must NOT revert the renamed slug to <id>.md.
+	moved, err := svc.Move(ctx, created.ID, StatusReady)
+	if err != nil {
+		t.Fatalf("Move: %v", err)
+	}
+	if got := filepath.Base(moved.Path); got != renamedBase {
+		t.Errorf("move reverted renamed basename: got %q, want %q", got, renamedBase)
+	}
+	if filepath.Dir(moved.Path) != filepath.Join(intentsDir, "ready") {
+		t.Errorf("moved dir = %q, want ready", filepath.Dir(moved.Path))
+	}
+	// Still resolvable by id after the move, with the renamed title.
+	got, err := svc.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get after move: %v", err)
+	}
+	if got.Title != "a much clearer title" {
+		t.Errorf("title = %q after move", got.Title)
+	}
+
+	// The same holds for an audited status change via UpdateDirect.
+	active := StatusActive
+	if _, _, err := svc.UpdateDirect(ctx, created.ID, UpdateOptions{Status: &active}); err != nil {
+		t.Fatalf("UpdateDirect status change: %v", err)
+	}
+	afterUpdate, err := svc.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get after UpdateDirect: %v", err)
+	}
+	if filepath.Base(afterUpdate.Path) != renamedBase {
+		t.Errorf("UpdateDirect reverted renamed basename: got %q, want %q", filepath.Base(afterUpdate.Path), renamedBase)
+	}
+}
+
 func TestRename_CollisionProducesDistinctFilename(t *testing.T) {
 	ctx := context.Background()
 	tmp := t.TempDir()

--- a/internal/intent/service.go
+++ b/internal/intent/service.go
@@ -44,6 +44,7 @@ type CreateOptions struct {
 	Category  Category // Intent (default) or note; decides storage root
 	Author    string
 	Body      string    // Description/body content for the intent
+	Tags      []string  // Optional frontmatter tags
 	Timestamp time.Time // Optional; defaults to time.Now()
 }
 
@@ -58,8 +59,9 @@ func createStatus(category Category) Status {
 
 // renderForCreate renders the right template for the category and stamps the
 // frontmatter status to match the storage root.
-func renderForCreate(data TemplateData, category Category) (string, error) {
+func renderForCreate(data TemplateData, category Category, tags []string) (string, error) {
 	data.Status = string(createStatus(category))
+	data.Tags = tags
 	if category == CategoryNote {
 		return RenderNote(data)
 	}
@@ -82,7 +84,7 @@ func (s *IntentService) CreateDirect(ctx context.Context, opts CreateOptions) (*
 	data := NewTemplateDataFromInput(opts.Title, string(opts.Type), opts.Concept, opts.Author, opts.Body, ts)
 
 	// Render template (note vs intent) and stamp the matching status
-	content, err := renderForCreate(data, opts.Category)
+	content, err := renderForCreate(data, opts.Category, opts.Tags)
 	if err != nil {
 		return nil, camperrors.Wrap(err, "rendering template")
 	}
@@ -132,7 +134,7 @@ func (s *IntentService) CreateWithEditor(ctx context.Context, opts CreateOptions
 	data := NewTemplateDataFromInput(opts.Title, string(opts.Type), opts.Concept, opts.Author, opts.Body, ts)
 
 	// Render template (note vs intent) and stamp the matching status
-	content, err := renderForCreate(data, opts.Category)
+	content, err := renderForCreate(data, opts.Category, opts.Tags)
 	if err != nil {
 		return nil, camperrors.Wrap(err, "rendering template")
 	}

--- a/internal/intent/service.go
+++ b/internal/intent/service.go
@@ -2,6 +2,7 @@ package intent
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -251,7 +252,7 @@ func (s *IntentService) Edit(ctx context.Context, id string, editorFn EditorFunc
 	// Handle status change (move to new directory), preserving the basename so
 	// a renamed slug survives.
 	if updated.Status != originalStatus {
-		newPath := s.moveTargetPath(updated.Status, originalPath)
+		newPath := s.moveTargetPath(updated.ID, updated.Status, originalPath)
 		if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
 			return nil, camperrors.Wrap(err, "creating directory")
 		}
@@ -335,8 +336,9 @@ func (s *IntentService) Move(ctx context.Context, id string, newStatus Status) (
 	intent.UpdatedAt = time.Now()
 
 	// Determine new path, preserving the current (possibly renamed) basename so
-	// a renamed slug survives the move.
-	newPath := s.moveTargetPath(newStatus, oldPath)
+	// a renamed slug survives the move without clobbering a different intent that
+	// shares the basename in the target status.
+	newPath := s.moveTargetPath(intent.ID, newStatus, oldPath)
 
 	// Ensure directory exists
 	if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
@@ -421,12 +423,49 @@ func (s *IntentService) getIntentPath(status Status, id string) string {
 	return filepath.Join(s.intentsDir, string(status), id+".md")
 }
 
-// moveTargetPath returns the destination when moving an existing file to
-// newStatus, preserving its current basename so a renamed slug survives status
-// changes. Identity is the id: frontmatter, not the filename, so carrying the
-// basename across directories is safe.
-func (s *IntentService) moveTargetPath(newStatus Status, oldPath string) string {
-	return filepath.Join(s.intentsDir, string(newStatus), filepath.Base(oldPath))
+// moveTargetPath returns the destination when moving the intent identified by id
+// from oldPath into newStatus. It preserves the current (possibly renamed)
+// basename so a renamed slug survives status changes.
+//
+// Rename only enforces filename uniqueness within a single status directory, so
+// two distinct intents (different id:, same timestamp suffix, same renamed title)
+// can legitimately share a basename across statuses. Carrying that basename into
+// the target status must never clobber a different intent already parked there:
+// when the basename is held by another id we disambiguate with a -2, -3, ...
+// suffix (the same scheme rename uses) rather than overwriting. A path already
+// holding this same id is reused — it is our own orphan copy.
+func (s *IntentService) moveTargetPath(id string, newStatus Status, oldPath string) string {
+	dir := filepath.Join(s.intentsDir, string(newStatus))
+	base := strings.TrimSuffix(filepath.Base(oldPath), ".md")
+	return s.collisionSafeMovePath(dir, base, id)
+}
+
+// collisionSafeMovePath returns dir/base.md, or dir/base-2.md, dir/base-3.md, ...
+// choosing the first candidate that is free or already belongs to id. A candidate
+// occupied by a different frontmatter id is skipped so a move never overwrites an
+// unrelated intent.
+func (s *IntentService) collisionSafeMovePath(dir, base, id string) string {
+	candidate := filepath.Join(dir, base+".md")
+	if s.pathAvailableForID(candidate, id) {
+		return candidate
+	}
+	for i := 2; ; i++ {
+		c := filepath.Join(dir, fmt.Sprintf("%s-%d.md", base, i))
+		if s.pathAvailableForID(c, id) {
+			return c
+		}
+	}
+}
+
+// pathAvailableForID reports whether the intent with the given id may safely
+// occupy path: true when nothing is there or the existing file is the same intent
+// (same id:), false when a different intent holds it or it cannot be read.
+func (s *IntentService) pathAvailableForID(path, id string) bool {
+	it, err := s.loadIntent(path)
+	if err != nil {
+		return os.IsNotExist(err)
+	}
+	return it.ID == id
 }
 
 // removeAllCopies removes all files for the given intent ID across all

--- a/internal/intent/service.go
+++ b/internal/intent/service.go
@@ -248,9 +248,10 @@ func (s *IntentService) Edit(ctx context.Context, id string, editorFn EditorFunc
 		return nil, intentValidationError(errs)
 	}
 
-	// Handle status change (move to new directory)
+	// Handle status change (move to new directory), preserving the basename so
+	// a renamed slug survives.
 	if updated.Status != originalStatus {
-		newPath := s.getIntentPath(updated.Status, updated.ID)
+		newPath := s.moveTargetPath(updated.Status, originalPath)
 		if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
 			return nil, camperrors.Wrap(err, "creating directory")
 		}
@@ -333,8 +334,9 @@ func (s *IntentService) Move(ctx context.Context, id string, newStatus Status) (
 	intent.Status = newStatus
 	intent.UpdatedAt = time.Now()
 
-	// Determine new path
-	newPath := s.getIntentPath(newStatus, intent.ID)
+	// Determine new path, preserving the current (possibly renamed) basename so
+	// a renamed slug survives the move.
+	newPath := s.moveTargetPath(newStatus, oldPath)
 
 	// Ensure directory exists
 	if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
@@ -414,8 +416,17 @@ func (s *IntentService) Count(ctx context.Context) ([]StatusCount, int, error) {
 // Helper methods
 
 // getIntentPath returns the file path for an intent given its status and ID.
+// Used when creating files (filename derived from id at birth).
 func (s *IntentService) getIntentPath(status Status, id string) string {
 	return filepath.Join(s.intentsDir, string(status), id+".md")
+}
+
+// moveTargetPath returns the destination when moving an existing file to
+// newStatus, preserving its current basename so a renamed slug survives status
+// changes. Identity is the id: frontmatter, not the filename, so carrying the
+// basename across directories is safe.
+func (s *IntentService) moveTargetPath(newStatus Status, oldPath string) string {
+	return filepath.Join(s.intentsDir, string(newStatus), filepath.Base(oldPath))
 }
 
 // removeAllCopies removes all files for the given intent ID across all

--- a/internal/intent/service.go
+++ b/internal/intent/service.go
@@ -83,6 +83,12 @@ func (s *IntentService) CreateDirect(ctx context.Context, opts CreateOptions) (*
 		return nil, camperrors.Wrap(err, "context cancelled")
 	}
 
+	normTags, err := validateAndNormalizeTags(opts.Tags)
+	if err != nil {
+		return nil, err
+	}
+	opts.Tags = normTags
+
 	ts := opts.Timestamp
 	if ts.IsZero() {
 		ts = time.Now()
@@ -133,6 +139,12 @@ func (s *IntentService) CreateWithEditor(ctx context.Context, opts CreateOptions
 	if err := ctx.Err(); err != nil {
 		return nil, camperrors.Wrap(err, "context cancelled")
 	}
+
+	normTags, err := validateAndNormalizeTags(opts.Tags)
+	if err != nil {
+		return nil, err
+	}
+	opts.Tags = normTags
 
 	ts := opts.Timestamp
 	if ts.IsZero() {

--- a/internal/intent/service.go
+++ b/internal/intent/service.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -25,6 +26,12 @@ var (
 type IntentService struct {
 	campaignRoot string
 	intentsDir   string
+
+	// idIndex maps an intent's id: frontmatter to its file path. It is built
+	// lazily on the first fast-path miss (a renamed file whose slug drifted from
+	// its id) and invalidated on mutation. nil means "not built".
+	idIndex   map[string]string
+	idIndexMu sync.Mutex
 }
 
 // NewIntentService creates a new IntentService.
@@ -114,6 +121,7 @@ func (s *IntentService) CreateDirect(ctx context.Context, opts CreateOptions) (*
 	}
 
 	intent.Path = finalPath
+	s.invalidateIDIndex()
 	return intent, nil
 }
 
@@ -197,6 +205,7 @@ func (s *IntentService) CreateWithEditor(ctx context.Context, opts CreateOptions
 	}
 
 	intent.Path = finalPath
+	s.invalidateIDIndex()
 	return intent, nil
 }
 
@@ -259,6 +268,7 @@ func (s *IntentService) Edit(ctx context.Context, id string, editorFn EditorFunc
 		return nil, err
 	}
 
+	s.invalidateIDIndex()
 	return updated, nil
 }
 
@@ -299,6 +309,7 @@ func (s *IntentService) Delete(ctx context.Context, id string) error {
 		return camperrors.Wrap(err, "removing intent file")
 	}
 
+	s.invalidateIDIndex()
 	return nil
 }
 
@@ -350,6 +361,7 @@ func (s *IntentService) Move(ctx context.Context, id string, newStatus Status) (
 	s.removeAllCopies(id, newPath)
 
 	intent.Path = newPath
+	s.invalidateIDIndex()
 	return intent, nil
 }
 

--- a/internal/intent/service.go
+++ b/internal/intent/service.go
@@ -40,10 +40,30 @@ func NewIntentService(campaignRoot, intentsDir string) *IntentService {
 type CreateOptions struct {
 	Title     string
 	Type      Type
-	Concept   string // Full concept path (e.g., "projects/camp")
+	Concept   string   // Full concept path (e.g., "projects/camp")
+	Category  Category // Intent (default) or note; decides storage root
 	Author    string
 	Body      string    // Description/body content for the intent
 	Timestamp time.Time // Optional; defaults to time.Now()
+}
+
+// createStatus returns the directory a freshly created item lands in for the
+// given category: notes route to notes/, intents to inbox/.
+func createStatus(category Category) Status {
+	if category == CategoryNote {
+		return StatusNote
+	}
+	return StatusInbox
+}
+
+// renderForCreate renders the right template for the category and stamps the
+// frontmatter status to match the storage root.
+func renderForCreate(data TemplateData, category Category) (string, error) {
+	data.Status = string(createStatus(category))
+	if category == CategoryNote {
+		return RenderNote(data)
+	}
+	return RenderTemplate(data)
 }
 
 // CreateDirect creates a new intent directly without opening an editor.
@@ -61,8 +81,8 @@ func (s *IntentService) CreateDirect(ctx context.Context, opts CreateOptions) (*
 	// Generate ID and template data
 	data := NewTemplateDataFromInput(opts.Title, string(opts.Type), opts.Concept, opts.Author, opts.Body, ts)
 
-	// Render template
-	content, err := RenderTemplate(data)
+	// Render template (note vs intent) and stamp the matching status
+	content, err := renderForCreate(data, opts.Category)
 	if err != nil {
 		return nil, camperrors.Wrap(err, "rendering template")
 	}
@@ -73,8 +93,8 @@ func (s *IntentService) CreateDirect(ctx context.Context, opts CreateOptions) (*
 		return nil, camperrors.Wrap(err, "parsing rendered template")
 	}
 
-	// Determine final path (inbox by default)
-	finalPath := s.getIntentPath(StatusInbox, data.ID)
+	// Determine final path: notes route to notes/, intents to inbox/
+	finalPath := s.getIntentPath(createStatus(opts.Category), data.ID)
 
 	// Ensure directory exists
 	if err := os.MkdirAll(filepath.Dir(finalPath), 0755); err != nil {
@@ -111,8 +131,8 @@ func (s *IntentService) CreateWithEditor(ctx context.Context, opts CreateOptions
 	// Generate template data
 	data := NewTemplateDataFromInput(opts.Title, string(opts.Type), opts.Concept, opts.Author, opts.Body, ts)
 
-	// Render template
-	content, err := RenderTemplate(data)
+	// Render template (note vs intent) and stamp the matching status
+	content, err := renderForCreate(data, opts.Category)
 	if err != nil {
 		return nil, camperrors.Wrap(err, "rendering template")
 	}

--- a/internal/intent/slug.go
+++ b/internal/intent/slug.go
@@ -15,7 +15,9 @@ var (
 	multipleHyphens = regexp.MustCompile(`-+`)
 )
 
-// GenerateSlug creates a URL-safe slug from a title.
+// SlugFromTitle creates a URL-safe slug from a title. It is the single slug
+// generator shared by create, merge, and rename so they all produce identical
+// slugs.
 //
 // Algorithm:
 //  1. Convert to lowercase
@@ -25,7 +27,7 @@ var (
 //  5. Trim leading/trailing hyphens
 //  6. Limit to 5 words maximum
 //  7. Limit to 50 characters maximum
-func GenerateSlug(title string) string {
+func SlugFromTitle(title string) string {
 	// 1. Lowercase
 	slug := strings.ToLower(title)
 
@@ -68,7 +70,7 @@ func GenerateSlug(title string) string {
 // Example: add-dark-mode-toggle-20260119-153412
 func GenerateID(title string, timestamp time.Time) string {
 	suffix := timestamp.Format("20060102-150405")
-	slug := GenerateSlug(title)
+	slug := SlugFromTitle(title)
 	if slug == "" {
 		return suffix
 	}

--- a/internal/intent/slug_test.go
+++ b/internal/intent/slug_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func TestGenerateSlug(t *testing.T) {
+func TestSlugFromTitle(t *testing.T) {
 	tests := []struct {
 		name  string
 		input string
@@ -80,9 +80,9 @@ func TestGenerateSlug(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GenerateSlug(tt.input)
+			got := SlugFromTitle(tt.input)
 			if got != tt.want {
-				t.Errorf("GenerateSlug(%q) = %q, want %q", tt.input, got, tt.want)
+				t.Errorf("SlugFromTitle(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}
@@ -150,44 +150,44 @@ func TestGenerateID_DifferentTimestamps(t *testing.T) {
 	}
 }
 
-func TestGenerateSlug_LengthLimit(t *testing.T) {
+func TestSlugFromTitle_LengthLimit(t *testing.T) {
 	// Verify 50 char limit
 	longTitle := "this is a very long title that should be truncated to fifty characters"
-	slug := GenerateSlug(longTitle)
+	slug := SlugFromTitle(longTitle)
 
 	if len(slug) > 50 {
-		t.Errorf("GenerateSlug produced slug longer than 50 chars: %d", len(slug))
+		t.Errorf("SlugFromTitle produced slug longer than 50 chars: %d", len(slug))
 	}
 
 	// Shouldn't end with hyphen
 	if len(slug) > 0 && slug[len(slug)-1] == '-' {
-		t.Errorf("GenerateSlug produced slug ending with hyphen: %q", slug)
+		t.Errorf("SlugFromTitle produced slug ending with hyphen: %q", slug)
 	}
 }
 
-func TestGenerateSlug_WordLimit(t *testing.T) {
+func TestSlugFromTitle_WordLimit(t *testing.T) {
 	// Verify 5 word limit
 	manyWords := "one two three four five six seven eight nine ten"
-	slug := GenerateSlug(manyWords)
+	slug := SlugFromTitle(manyWords)
 
 	words := strings.Split(slug, "-")
 	if len(words) > 5 {
-		t.Errorf("GenerateSlug produced more than 5 words: %d, slug=%q", len(words), slug)
+		t.Errorf("SlugFromTitle produced more than 5 words: %d, slug=%q", len(words), slug)
 	}
 }
 
-func TestGenerateSlug_Idempotent(t *testing.T) {
+func TestSlugFromTitle_Idempotent(t *testing.T) {
 	// Running slug generation twice should produce same result
 	input := "Add dark mode toggle"
-	first := GenerateSlug(input)
-	second := GenerateSlug(first)
+	first := SlugFromTitle(input)
+	second := SlugFromTitle(first)
 
 	if first != second {
-		t.Errorf("GenerateSlug is not idempotent: first=%q, second=%q", first, second)
+		t.Errorf("SlugFromTitle is not idempotent: first=%q, second=%q", first, second)
 	}
 }
 
-func TestGenerateSlug_NoConsecutiveHyphens(t *testing.T) {
+func TestSlugFromTitle_NoConsecutiveHyphens(t *testing.T) {
 	inputs := []string{
 		"Fix   bug",
 		"Fix - - bug",
@@ -197,14 +197,14 @@ func TestGenerateSlug_NoConsecutiveHyphens(t *testing.T) {
 	}
 
 	for _, input := range inputs {
-		slug := GenerateSlug(input)
+		slug := SlugFromTitle(input)
 		if strings.Contains(slug, "--") {
-			t.Errorf("GenerateSlug(%q) produced consecutive hyphens: %q", input, slug)
+			t.Errorf("SlugFromTitle(%q) produced consecutive hyphens: %q", input, slug)
 		}
 	}
 }
 
-func TestGenerateSlug_StartsAndEndsWithAlphanumeric(t *testing.T) {
+func TestSlugFromTitle_StartsAndEndsWithAlphanumeric(t *testing.T) {
 	inputs := []string{
 		"---Fix bug---",
 		"   Fix bug   ",
@@ -214,15 +214,15 @@ func TestGenerateSlug_StartsAndEndsWithAlphanumeric(t *testing.T) {
 	}
 
 	for _, input := range inputs {
-		slug := GenerateSlug(input)
+		slug := SlugFromTitle(input)
 		if slug == "" {
 			continue // Empty slugs are allowed
 		}
 		if slug[0] == '-' {
-			t.Errorf("GenerateSlug(%q) starts with hyphen: %q", input, slug)
+			t.Errorf("SlugFromTitle(%q) starts with hyphen: %q", input, slug)
 		}
 		if slug[len(slug)-1] == '-' {
-			t.Errorf("GenerateSlug(%q) ends with hyphen: %q", input, slug)
+			t.Errorf("SlugFromTitle(%q) ends with hyphen: %q", input, slug)
 		}
 	}
 }

--- a/internal/intent/tags.go
+++ b/internal/intent/tags.go
@@ -1,0 +1,54 @@
+package intent
+
+import (
+	"strings"
+	"unicode"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// validateAndNormalizeTags trims each tag, drops empties, de-duplicates while
+// preserving order, and rejects any tag whose characters would corrupt the
+// flow-style YAML the templates render (tags: [a, b, ...]). Without this guard a
+// tag containing a comma silently splits into two tags and a tag containing a
+// colon makes the frontmatter unparseable. Tags may use letters, numbers,
+// spaces, and the separators - _ / . + ; anything else is rejected here, at the
+// single entry point every create/update path funnels through.
+func validateAndNormalizeTags(tags []string) ([]string, error) {
+	if len(tags) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]bool, len(tags))
+	out := make([]string, 0, len(tags))
+	for _, raw := range tags {
+		t := strings.TrimSpace(raw)
+		if t == "" {
+			continue
+		}
+		for _, r := range t {
+			if !validTagRune(r) {
+				return nil, camperrors.Wrapf(camperrors.ErrInvalidInput,
+					"tag %q contains unsupported character %q (allowed: letters, numbers, spaces, and - _ / . +)", t, string(r))
+			}
+		}
+		if seen[t] {
+			continue
+		}
+		seen[t] = true
+		out = append(out, t)
+	}
+	return out, nil
+}
+
+// validTagRune reports whether r is allowed in a tag. The set is deliberately
+// narrow so a rendered tag is always a valid YAML flow scalar.
+func validTagRune(r rune) bool {
+	if unicode.IsLetter(r) || unicode.IsNumber(r) || r == ' ' {
+		return true
+	}
+	switch r {
+	case '-', '_', '/', '.', '+':
+		return true
+	}
+	return false
+}

--- a/internal/intent/tags_test.go
+++ b/internal/intent/tags_test.go
@@ -1,0 +1,87 @@
+package intent
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+func TestValidateAndNormalizeTags(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      []string
+		want    []string
+		wantErr bool
+	}{
+		{"nil", nil, nil, false},
+		{"trim and drop empties", []string{" personal ", "", "  "}, []string{"personal"}, false},
+		{"dedup preserves order", []string{"a", "b", "a"}, []string{"a", "b"}, false},
+		{"allowed separators", []string{"follow-up", "v1.2", "a/b", "c_d", "c++"}, []string{"follow-up", "v1.2", "a/b", "c_d", "c++"}, false},
+		{"spaces allowed", []string{"in progress"}, []string{"in progress"}, false},
+		{"comma rejected", []string{"a,b"}, nil, true},
+		{"colon rejected", []string{"key:value"}, nil, true},
+		{"bracket rejected", []string{"a]b"}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateAndNormalizeTags(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got nil (out=%v)", got)
+				}
+				if !errors.Is(err, camperrors.ErrInvalidInput) {
+					t.Errorf("err = %v, want ErrInvalidInput", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateDirect_RejectsHostileTags(t *testing.T) {
+	tmp := t.TempDir()
+	svc := NewIntentService(tmp, filepath.Join(tmp, "intents"))
+	ctx := context.Background()
+
+	for _, bad := range []string{"a,b", "key: value"} {
+		_, err := svc.CreateDirect(ctx, CreateOptions{
+			Title:     "tagged intent",
+			Type:      TypeIdea,
+			Tags:      []string{bad},
+			Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		})
+		if !errors.Is(err, camperrors.ErrInvalidInput) {
+			t.Errorf("CreateDirect with tag %q err = %v, want ErrInvalidInput", bad, err)
+		}
+	}
+}
+
+func TestCreateDirect_NormalizesTags(t *testing.T) {
+	tmp := t.TempDir()
+	svc := NewIntentService(tmp, filepath.Join(tmp, "intents"))
+	ctx := context.Background()
+
+	created, err := svc.CreateDirect(ctx, CreateOptions{
+		Title:     "deduped tags",
+		Type:      TypeIdea,
+		Tags:      []string{" personal ", "personal", "reference"},
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+	if !slices.Equal(created.Tags, []string{"personal", "reference"}) {
+		t.Errorf("tags = %v, want [personal reference]", created.Tags)
+	}
+}

--- a/internal/intent/template.go
+++ b/internal/intent/template.go
@@ -12,8 +12,14 @@ import (
 //go:embed templates/intent.md.tmpl
 var intentTemplateContent string
 
+//go:embed templates/note.md.tmpl
+var noteTemplateContent string
+
 // intentTemplate is the parsed template, initialized on first use.
 var intentTemplate *template.Template
+
+// noteTemplate is the parsed note template, initialized on first use.
+var noteTemplate *template.Template
 
 // TemplateData contains the values to substitute into the intent template.
 type TemplateData struct {
@@ -21,6 +27,7 @@ type TemplateData struct {
 	Title     string
 	Type      string
 	Concept   string // Full concept path (e.g., "projects/camp")
+	Status    string // Lifecycle/category directory (defaults to inbox)
 	Author    string
 	CreatedAt string // Formatted as YYYY-MM-DD
 	Body      string // Description/body content
@@ -45,6 +52,25 @@ func RenderTemplate(data TemplateData) (string, error) {
 	return buf.String(), nil
 }
 
+// RenderNote generates a note file from the lightweight note template. Notes
+// carry no type, concept, or promotion metadata; tags organize them.
+func RenderNote(data TemplateData) (string, error) {
+	if noteTemplate == nil {
+		tmpl, err := template.New("note").Parse(noteTemplateContent)
+		if err != nil {
+			return "", camperrors.Wrap(err, "parsing note template")
+		}
+		noteTemplate = tmpl
+	}
+
+	var buf bytes.Buffer
+	if err := noteTemplate.Execute(&buf, data); err != nil {
+		return "", camperrors.Wrap(err, "executing note template")
+	}
+
+	return buf.String(), nil
+}
+
 // FormatCreatedAt formats a time.Time as YYYY-MM-DD for template use.
 func FormatCreatedAt(t time.Time) string {
 	return t.Format("2006-01-02")
@@ -53,11 +79,16 @@ func FormatCreatedAt(t time.Time) string {
 // NewTemplateData creates a TemplateData struct from an Intent struct.
 // This is useful for re-rendering an existing intent.
 func NewTemplateData(intent *Intent) TemplateData {
+	status := intent.Status
+	if status == "" {
+		status = StatusInbox
+	}
 	return TemplateData{
 		ID:        intent.ID,
 		Title:     intent.Title,
 		Type:      string(intent.Type),
 		Concept:   intent.Concept,
+		Status:    string(status),
 		Author:    intent.Author,
 		CreatedAt: FormatCreatedAt(intent.CreatedAt),
 		Body:      intent.Content,
@@ -72,6 +103,7 @@ func NewTemplateDataFromInput(title, typ, concept, author, body string, timestam
 		Title:     title,
 		Type:      typ,
 		Concept:   concept,
+		Status:    string(StatusInbox),
 		Author:    author,
 		CreatedAt: FormatCreatedAt(timestamp),
 		Body:      body,

--- a/internal/intent/template.go
+++ b/internal/intent/template.go
@@ -29,8 +29,9 @@ type TemplateData struct {
 	Concept   string // Full concept path (e.g., "projects/camp")
 	Status    string // Lifecycle/category directory (defaults to inbox)
 	Author    string
-	CreatedAt string // Formatted as YYYY-MM-DD
-	Body      string // Description/body content
+	CreatedAt string   // Formatted as YYYY-MM-DD
+	Body      string   // Description/body content
+	Tags      []string // Optional frontmatter tags
 }
 
 // RenderTemplate generates an intent file from a template with the given data.

--- a/internal/intent/template.go
+++ b/internal/intent/template.go
@@ -29,7 +29,7 @@ type TemplateData struct {
 	Concept   string // Full concept path (e.g., "projects/camp")
 	Status    string // Lifecycle/category directory (defaults to inbox)
 	Author    string
-	CreatedAt string   // Formatted as YYYY-MM-DD
+	CreatedAt string   // Formatted as RFC3339 so same-day age math is accurate.
 	Body      string   // Description/body content
 	Tags      []string // Optional frontmatter tags
 }
@@ -72,9 +72,11 @@ func RenderNote(data TemplateData) (string, error) {
 	return buf.String(), nil
 }
 
-// FormatCreatedAt formats a time.Time as YYYY-MM-DD for template use.
+// FormatCreatedAt formats a time.Time for frontmatter. Keep the time component:
+// date-only values parse as midnight and make newly-created intents look hours
+// old in the explorer later the same day.
 func FormatCreatedAt(t time.Time) string {
-	return t.Format("2006-01-02")
+	return t.Format(time.RFC3339)
 }
 
 // NewTemplateData creates a TemplateData struct from an Intent struct.

--- a/internal/intent/template_test.go
+++ b/internal/intent/template_test.go
@@ -277,22 +277,22 @@ func TestFormatCreatedAt(t *testing.T) {
 		{
 			name: "simple date",
 			time: time.Date(2026, 1, 19, 0, 0, 0, 0, time.UTC),
-			want: "2026-01-19",
+			want: "2026-01-19T00:00:00Z",
 		},
 		{
 			name: "date with time",
 			time: time.Date(2026, 6, 15, 12, 30, 45, 0, time.UTC),
-			want: "2026-06-15",
+			want: "2026-06-15T12:30:45Z",
 		},
 		{
 			name: "end of year",
 			time: time.Date(2026, 12, 31, 23, 59, 59, 0, time.UTC),
-			want: "2026-12-31",
+			want: "2026-12-31T23:59:59Z",
 		},
 		{
 			name: "start of year",
 			time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
-			want: "2026-01-01",
+			want: "2026-01-01T00:00:00Z",
 		},
 	}
 
@@ -333,8 +333,8 @@ func TestNewTemplateData(t *testing.T) {
 	if data.Author != intent.Author {
 		t.Errorf("Author = %q, want %q", data.Author, intent.Author)
 	}
-	if data.CreatedAt != "2026-01-19" {
-		t.Errorf("CreatedAt = %q, want %q", data.CreatedAt, "2026-01-19")
+	if data.CreatedAt != "2026-01-19T15:34:12Z" {
+		t.Errorf("CreatedAt = %q, want %q", data.CreatedAt, "2026-01-19T15:34:12Z")
 	}
 }
 
@@ -362,8 +362,8 @@ func TestNewTemplateDataFromInput(t *testing.T) {
 	if data.Author != "lance" {
 		t.Errorf("Author = %q, want %q", data.Author, "lance")
 	}
-	if data.CreatedAt != "2026-01-19" {
-		t.Errorf("CreatedAt = %q, want %q", data.CreatedAt, "2026-01-19")
+	if data.CreatedAt != "2026-01-19T15:34:12Z" {
+		t.Errorf("CreatedAt = %q, want %q", data.CreatedAt, "2026-01-19T15:34:12Z")
 	}
 	if data.Body != "Test body content" {
 		t.Errorf("Body = %q, want %q", data.Body, "Test body content")
@@ -415,5 +415,22 @@ func TestRenderTemplate_RoundTrip(t *testing.T) {
 	// Body content should include template sections
 	if !strings.Contains(intent.Content, "## Description") {
 		t.Error("Content should contain Description section")
+	}
+}
+
+func TestRenderTemplate_RoundTripPreservesCreatedAtTime(t *testing.T) {
+	ts := time.Date(2026, 6, 10, 23, 42, 31, 0, time.UTC)
+	data := NewTemplateDataFromInput("Fresh intent", "idea", "", "agent", "", ts)
+
+	output, err := RenderTemplate(data)
+	if err != nil {
+		t.Fatalf("RenderTemplate: %v", err)
+	}
+	parsed, err := ParseIntent([]byte(output))
+	if err != nil {
+		t.Fatalf("ParseIntent: %v", err)
+	}
+	if !parsed.CreatedAt.Equal(ts) {
+		t.Fatalf("CreatedAt = %s, want %s", parsed.CreatedAt.Format(time.RFC3339), ts.Format(time.RFC3339))
 	}
 }

--- a/internal/intent/template_test.go
+++ b/internal/intent/template_test.go
@@ -20,6 +20,7 @@ func TestRenderTemplate(t *testing.T) {
 				Title:     "Test Intent",
 				Type:      "feature",
 				Concept:   "camp",
+				Status:    "inbox",
 				Author:    "lance",
 				CreatedAt: "2026-01-19",
 			},

--- a/internal/intent/templates/intent.md.tmpl
+++ b/internal/intent/templates/intent.md.tmpl
@@ -3,7 +3,7 @@ id: {{ .ID }}
 title: {{ .Title }}
 type: {{ .Type }}
 concept: {{ .Concept }}
-status: inbox
+status: {{ .Status }}
 created_at: {{ .CreatedAt }}
 author: {{ .Author }}
 

--- a/internal/intent/templates/intent.md.tmpl
+++ b/internal/intent/templates/intent.md.tmpl
@@ -6,6 +6,7 @@ concept: {{ .Concept }}
 status: {{ .Status }}
 created_at: {{ .CreatedAt }}
 author: {{ .Author }}
+tags: [{{ range $i, $t := .Tags }}{{ if $i }}, {{ end }}{{ $t }}{{ end }}]
 
 priority: medium
 horizon: later

--- a/internal/intent/templates/note.md.tmpl
+++ b/internal/intent/templates/note.md.tmpl
@@ -4,7 +4,7 @@ title: {{ .Title }}
 status: {{ .Status }}
 created_at: {{ .CreatedAt }}
 author: {{ .Author }}
-tags: []
+tags: [{{ range $i, $t := .Tags }}{{ if $i }}, {{ end }}{{ $t }}{{ end }}]
 ---
 
 # {{ .Title }}

--- a/internal/intent/templates/note.md.tmpl
+++ b/internal/intent/templates/note.md.tmpl
@@ -1,0 +1,12 @@
+---
+id: {{ .ID }}
+title: {{ .Title }}
+status: {{ .Status }}
+created_at: {{ .CreatedAt }}
+author: {{ .Author }}
+tags: []
+---
+
+# {{ .Title }}
+
+{{ .Body }}

--- a/internal/intent/tui/action_menu.go
+++ b/internal/intent/tui/action_menu.go
@@ -12,7 +12,7 @@ import (
 // ActionMenuItem represents an item in the action menu.
 type ActionMenuItem struct {
 	Label   string
-	Action  string // "view", "edit", "move", "promote", "archive", "gather", "delete", "open", "reveal"
+	Action  string // "view", "edit", "convert", "move", "promote", "archive", "gather", "delete", "open", "reveal"
 	Enabled bool
 }
 
@@ -34,6 +34,14 @@ type ActionMenuCancelledMsg struct{}
 
 // NewActionMenu creates a new action menu for the given intent.
 func NewActionMenu(i *intent.Intent) ActionMenu {
+	if i.Status.IsNote() {
+		return newActionMenu([]ActionMenuItem{
+			{Label: "View full screen", Action: "view", Enabled: true},
+			{Label: "Edit in editor", Action: "edit", Enabled: true},
+			{Label: "Convert to intent", Action: "convert", Enabled: i.Status == intent.StatusNote},
+		})
+	}
+
 	items := []ActionMenuItem{
 		{Label: "View full screen", Action: "view", Enabled: true},
 		{Label: "Edit in editor", Action: "edit", Enabled: true},
@@ -44,6 +52,10 @@ func NewActionMenu(i *intent.Intent) ActionMenu {
 		{Label: "Delete", Action: "delete", Enabled: true},
 	}
 
+	return newActionMenu(items)
+}
+
+func newActionMenu(items []ActionMenuItem) ActionMenu {
 	// Find first enabled item
 	selectedIdx := 0
 	for idx, item := range items {

--- a/internal/intent/tui/action_menu.go
+++ b/internal/intent/tui/action_menu.go
@@ -38,6 +38,7 @@ func NewActionMenu(i *intent.Intent) ActionMenu {
 		return newActionMenu([]ActionMenuItem{
 			{Label: "View full screen", Action: "view", Enabled: true},
 			{Label: "Edit in editor", Action: "edit", Enabled: true},
+			{Label: "Move to status", Action: "move", Enabled: i.Status == intent.StatusNote},
 			{Label: "Convert to intent", Action: "convert", Enabled: i.Status == intent.StatusNote},
 		})
 	}

--- a/internal/intent/tui/add_model.go
+++ b/internal/intent/tui/add_model.go
@@ -74,7 +74,7 @@ type IntentAddModel struct {
 	campaignRoot string
 	shortcuts    map[string]string // key → campaign-relative path
 
-	// Tag overlay (opened with ctrl+t in any step)
+	// Tag overlay (opened with ctrl+t in the body editor)
 	availableTags []string
 	tags          []string
 	tagOverlay    TagOverlay
@@ -183,14 +183,9 @@ func (m IntentAddModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		// Tag overlay (ctrl+t) is modal and reachable from any input step.
+		// Tag overlay (ctrl+t) is modal once opened from the body editor.
 		if m.tagging {
 			return m.updateTagOverlay(msg)
-		}
-		if msg.String() == "ctrl+t" {
-			m.tagOverlay = NewTagOverlay(m.availableTags, m.tags)
-			m.tagging = true
-			return m, nil
 		}
 		switch m.step {
 		case addStepTitle:
@@ -470,6 +465,13 @@ func (m IntentAddModel) updateBody(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Handle ctrl+e for external editor (always available)
 	if msg.String() == "ctrl+e" {
 		return m, m.openExternalEditor()
+	}
+
+	// Handle ctrl+t for tags from the editor step.
+	if msg.String() == "ctrl+t" {
+		m.tagOverlay = NewTagOverlay(m.availableTags, m.tags)
+		m.tagging = true
+		return m, nil
 	}
 
 	// Handle ctrl+n for save-and-new (always available)
@@ -899,14 +901,10 @@ func (m IntentAddModel) viewTitleStep() string {
 		b.WriteString("\n")
 	}
 
-	if len(m.tags) > 0 {
-		b.WriteString(HelpStyle.Render("Tags: ") + IntentTypeStyle.Render(strings.Join(m.tags, ", ")) + "\n")
-	}
-
 	b.WriteString("\n")
-	help := "Enter: continue • Ctrl+T: tags • Ctrl+N: save & new • Esc: cancel"
+	help := "Enter: continue • Ctrl+N: save & new • Esc: cancel"
 	if m.noteMode {
-		help = "Enter: add body • Ctrl+T: tags • Ctrl+N: save title-only & new • Esc: cancel"
+		help = "Enter: add body • Ctrl+N: save title-only & new • Esc: cancel"
 	}
 	b.WriteString(HelpStyle.Render(help))
 
@@ -979,6 +977,10 @@ func (m IntentAddModel) viewBodyStep() string {
 		b.WriteString("\n")
 	}
 
+	if len(m.tags) > 0 {
+		b.WriteString(HelpStyle.Render("Tags: ") + IntentTypeStyle.Render(strings.Join(m.tags, ", ")) + "\n")
+	}
+
 	// Show vim command buffer if in command mode
 	if m.vimEditor.IsCommandMode() {
 		b.WriteString(":" + m.vimEditor.CommandBuffer())
@@ -989,13 +991,13 @@ func (m IntentAddModel) viewBodyStep() string {
 	// Context-sensitive help
 	switch m.vimEditor.Mode() {
 	case vim.ModeInsert:
-		b.WriteString(HelpStyle.Render("Esc: normal mode • Ctrl+S: save • Ctrl+N: save & new • Ctrl+E: editor"))
+		b.WriteString(HelpStyle.Render("Esc: normal mode • Ctrl+S: save • Ctrl+N: save & new • Ctrl+T: tags • Ctrl+E: editor"))
 	case vim.ModeVisual, vim.ModeVisualLine:
 		b.WriteString(HelpStyle.Render("d: delete • y: yank • c: change • Esc: normal"))
 	case vim.ModeCommand:
 		b.WriteString(HelpStyle.Render(":wq save • :q! cancel • Esc: back"))
 	default:
-		b.WriteString(HelpStyle.Render("i: insert • v: visual • Enter/:wq: save • Ctrl+N: new • Ctrl+E: editor"))
+		b.WriteString(HelpStyle.Render("i: insert • v: visual • Enter/:wq: save • Ctrl+N: new • Ctrl+T: tags • Ctrl+E: editor"))
 	}
 
 	return b.String()

--- a/internal/intent/tui/add_model.go
+++ b/internal/intent/tui/add_model.go
@@ -27,12 +27,13 @@ const (
 
 // AddOptions configures the IntentAddModel behavior.
 type AddOptions struct {
-	DefaultType  string            // Default intent type (e.g., "idea")
-	FullMode     bool              // Include body textarea step
-	NoteMode     bool              // Note quick-add: collect text only, skip type/concept/body
-	Author       string            // Auto-populated author (e.g., from git config)
-	CampaignRoot string            // Campaign root for @ completion
-	Shortcuts    map[string]string // Navigation shortcuts (key → campaign-relative path, e.g., "de" → "workflow/design/")
+	DefaultType   string            // Default intent type (e.g., "idea")
+	FullMode      bool              // Include body textarea step
+	NoteMode      bool              // Note quick-add: collect text only, skip type/concept/body
+	Author        string            // Auto-populated author (e.g., from git config)
+	CampaignRoot  string            // Campaign root for @ completion
+	Shortcuts     map[string]string // Navigation shortcuts (key → campaign-relative path, e.g., "de" → "workflow/design/")
+	AvailableTags []string          // Configured tags offered by the tag overlay (ctrl+t)
 }
 
 // AddResult contains the collected intent data.
@@ -42,6 +43,7 @@ type AddResult struct {
 	Concept string
 	Body    string
 	Author  string
+	Tags    []string
 }
 
 // IntentAddModel is a BubbleTea model for creating new intents.
@@ -71,6 +73,12 @@ type IntentAddModel struct {
 	author       string
 	campaignRoot string
 	shortcuts    map[string]string // key → campaign-relative path
+
+	// Tag overlay (opened with ctrl+t in any step)
+	availableTags []string
+	tags          []string
+	tagOverlay    TagOverlay
+	tagging       bool
 
 	// Completion state
 	completion completionState
@@ -124,18 +132,19 @@ func NewIntentAddModel(ctx context.Context, conceptSvc concept.Service, opts Add
 	}
 
 	return IntentAddModel{
-		ctx:          ctx,
-		conceptSvc:   conceptSvc,
-		step:         addStepTitle,
-		titleInput:   ti,
-		typeIdx:      typeIdx,
-		vimEditor:    vimEd,
-		fullMode:     opts.FullMode,
-		noteMode:     opts.NoteMode,
-		defaultType:  opts.DefaultType,
-		author:       opts.Author,
-		campaignRoot: opts.CampaignRoot,
-		shortcuts:    opts.Shortcuts,
+		ctx:           ctx,
+		conceptSvc:    conceptSvc,
+		step:          addStepTitle,
+		titleInput:    ti,
+		typeIdx:       typeIdx,
+		vimEditor:     vimEd,
+		fullMode:      opts.FullMode,
+		noteMode:      opts.NoteMode,
+		defaultType:   opts.DefaultType,
+		author:        opts.Author,
+		campaignRoot:  opts.CampaignRoot,
+		shortcuts:     opts.Shortcuts,
+		availableTags: opts.AvailableTags,
 	}
 }
 
@@ -174,6 +183,15 @@ func (m IntentAddModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		// Tag overlay (ctrl+t) is modal and reachable from any input step.
+		if m.tagging {
+			return m.updateTagOverlay(msg)
+		}
+		if msg.String() == "ctrl+t" {
+			m.tagOverlay = NewTagOverlay(m.availableTags, m.tags)
+			m.tagging = true
+			return m, nil
+		}
 		switch m.step {
 		case addStepTitle:
 			return m.updateTitle(msg)
@@ -677,9 +695,24 @@ func (m IntentAddModel) finishBodyStep() (tea.Model, tea.Cmd) {
 		Concept: conceptPath,
 		Body:    strings.TrimSpace(m.vimEditor.Content()),
 		Author:  m.author,
+		Tags:    m.tags,
 	}
 	m.step = addStepDone
 	return m, tea.Quit
+}
+
+// updateTagOverlay routes keys to the tag overlay; on confirm it stores the
+// selected tags on the in-progress item.
+func (m IntentAddModel) updateTagOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	var done bool
+	m.tagOverlay, done = m.tagOverlay.Update(msg)
+	if done {
+		if !m.tagOverlay.Cancelled() {
+			m.tags = m.tagOverlay.Result()
+		}
+		m.tagging = false
+	}
+	return m, nil
 }
 
 // finishNoteStep completes a note quick-add: the title text is the note, with
@@ -688,6 +721,7 @@ func (m IntentAddModel) finishNoteStep() (tea.Model, tea.Cmd) {
 	m.result = &AddResult{
 		Title:  strings.TrimSpace(m.titleInput.Value()),
 		Author: m.author,
+		Tags:   m.tags,
 	}
 	m.step = addStepDone
 	return m, tea.Quit
@@ -701,7 +735,7 @@ func (m IntentAddModel) collectCurrentResult() *AddResult {
 	}
 
 	if m.noteMode {
-		return &AddResult{Title: title, Author: m.author}
+		return &AddResult{Title: title, Author: m.author, Tags: m.tags}
 	}
 
 	conceptPath := ""
@@ -720,6 +754,7 @@ func (m IntentAddModel) collectCurrentResult() *AddResult {
 		Concept: conceptPath,
 		Body:    body,
 		Author:  m.author,
+		Tags:    m.tags,
 	}
 }
 
@@ -755,6 +790,9 @@ func (m IntentAddModel) saveAndReset() (tea.Model, tea.Cmd) {
 	// Reset vim editor
 	m.vimEditor.SetContent("")
 
+	// Reset tags for the next item
+	m.tags = nil
+
 	return m, textinput.Blink
 }
 
@@ -767,6 +805,10 @@ func (m IntentAddModel) SavedResults() []*AddResult {
 func (m IntentAddModel) View() string {
 	if m.step == addStepDone {
 		return ""
+	}
+
+	if m.tagging {
+		return m.tagOverlay.View()
 	}
 
 	var b strings.Builder
@@ -844,10 +886,14 @@ func (m IntentAddModel) viewTitleStep() string {
 		b.WriteString("\n")
 	}
 
+	if len(m.tags) > 0 {
+		b.WriteString(HelpStyle.Render("Tags: ") + IntentTypeStyle.Render(strings.Join(m.tags, ", ")) + "\n")
+	}
+
 	b.WriteString("\n")
-	help := "Enter: continue • Ctrl+N: save & new • Esc: cancel"
+	help := "Enter: continue • Ctrl+T: tags • Ctrl+N: save & new • Esc: cancel"
 	if m.noteMode {
-		help = "Enter: save note • Ctrl+N: save & new • Esc: cancel"
+		help = "Enter: save note • Ctrl+T: tags • Ctrl+N: save & new • Esc: cancel"
 	}
 	b.WriteString(HelpStyle.Render(help))
 

--- a/internal/intent/tui/add_model.go
+++ b/internal/intent/tui/add_model.go
@@ -29,7 +29,7 @@ const (
 type AddOptions struct {
 	DefaultType   string            // Default intent type (e.g., "idea")
 	FullMode      bool              // Include body textarea step
-	NoteMode      bool              // Note quick-add: collect text only, skip type/concept/body
+	NoteMode      bool              // Note capture: collect title/body/tags, skip type/concept
 	Author        string            // Auto-populated author (e.g., from git config)
 	CampaignRoot  string            // Campaign root for @ completion
 	Shortcuts     map[string]string // Navigation shortcuts (key → campaign-relative path, e.g., "de" → "workflow/design/")
@@ -63,7 +63,7 @@ type IntentAddModel struct {
 	// Concept selection
 	conceptPicker ConceptPickerModel
 
-	// Body vim editor (only used in full mode)
+	// Body vim editor (used in full mode and note mode)
 	vimEditor *vim.Editor
 
 	// Configuration
@@ -254,7 +254,7 @@ func (m IntentAddModel) updateTitle(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if m.noteMode {
-			return m.finishNoteStep()
+			return m.finishNoteTitleStep()
 		}
 		m.step = addStepType
 		m.titleInput.Blur()
@@ -683,6 +683,17 @@ func (m IntentAddModel) openExternalEditor() tea.Cmd {
 
 // finishBodyStep completes the body step and finishes creation.
 func (m IntentAddModel) finishBodyStep() (tea.Model, tea.Cmd) {
+	if m.noteMode {
+		m.result = &AddResult{
+			Title:  strings.TrimSpace(m.titleInput.Value()),
+			Body:   strings.TrimSpace(m.vimEditor.Content()),
+			Author: m.author,
+			Tags:   m.tags,
+		}
+		m.step = addStepDone
+		return m, tea.Quit
+	}
+
 	// Get concept path (may be empty if skipped)
 	conceptPath := ""
 	if m.conceptPicker.SelectedConcept() != nil {
@@ -715,16 +726,14 @@ func (m IntentAddModel) updateTagOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// finishNoteStep completes a note quick-add: the title text is the note, with
-// no type, concept, or body.
-func (m IntentAddModel) finishNoteStep() (tea.Model, tea.Cmd) {
-	m.result = &AddResult{
-		Title:  strings.TrimSpace(m.titleInput.Value()),
-		Author: m.author,
-		Tags:   m.tags,
-	}
-	m.step = addStepDone
-	return m, tea.Quit
+// finishNoteTitleStep completes the note title step and moves to the body
+// editor. Notes skip type and concept, but still support long-form body capture.
+func (m IntentAddModel) finishNoteTitleStep() (tea.Model, tea.Cmd) {
+	m.step = addStepBody
+	w, h := m.calculateBodySize()
+	m.vimEditor.SetSize(w, h)
+	m.vimEditor.State().EnterInsert()
+	return m, nil
 }
 
 // collectCurrentResult builds an AddResult from the model's current state.
@@ -735,7 +744,11 @@ func (m IntentAddModel) collectCurrentResult() *AddResult {
 	}
 
 	if m.noteMode {
-		return &AddResult{Title: title, Author: m.author, Tags: m.tags}
+		body := ""
+		if m.step >= addStepBody {
+			body = strings.TrimSpace(m.vimEditor.Content())
+		}
+		return &AddResult{Title: title, Body: body, Author: m.author, Tags: m.tags}
 	}
 
 	conceptPath := ""
@@ -852,12 +865,12 @@ func (m IntentAddModel) viewProgress() string {
 	}
 
 	// Type
-	if m.step > addStepType {
+	if !m.noteMode && m.step > addStepType {
 		parts = append(parts, HelpStyle.Render("Type: ")+IntentTypeStyle.Render(intentTypes[m.typeIdx]))
 	}
 
 	// Concept (if selected)
-	if m.step > addStepConcept && m.conceptPicker.SelectedPath() != "" {
+	if !m.noteMode && m.step > addStepConcept && m.conceptPicker.SelectedPath() != "" {
 		parts = append(parts, HelpStyle.Render("Concept: ")+IntentConceptStyle.Render(m.conceptPicker.SelectedPath()))
 	}
 
@@ -893,7 +906,7 @@ func (m IntentAddModel) viewTitleStep() string {
 	b.WriteString("\n")
 	help := "Enter: continue • Ctrl+T: tags • Ctrl+N: save & new • Esc: cancel"
 	if m.noteMode {
-		help = "Enter: save note • Ctrl+T: tags • Ctrl+N: save & new • Esc: cancel"
+		help = "Enter: add body • Ctrl+T: tags • Ctrl+N: save title-only & new • Esc: cancel"
 	}
 	b.WriteString(HelpStyle.Render(help))
 
@@ -949,7 +962,11 @@ func (m IntentAddModel) viewBodyStep() string {
 
 	// Show mode indicator
 	modeStr := m.vimEditor.Mode().String()
-	b.WriteString(HelpStyle.Render("Description (optional) — "+modeStr) + "\n")
+	label := "Description"
+	if m.noteMode {
+		label = "Note body"
+	}
+	b.WriteString(HelpStyle.Render(label+" (optional) — "+modeStr) + "\n")
 
 	// Render vim editor
 	cfg := vim.DefaultViewConfig()

--- a/internal/intent/tui/add_model.go
+++ b/internal/intent/tui/add_model.go
@@ -29,6 +29,7 @@ const (
 type AddOptions struct {
 	DefaultType  string            // Default intent type (e.g., "idea")
 	FullMode     bool              // Include body textarea step
+	NoteMode     bool              // Note quick-add: collect text only, skip type/concept/body
 	Author       string            // Auto-populated author (e.g., from git config)
 	CampaignRoot string            // Campaign root for @ completion
 	Shortcuts    map[string]string // Navigation shortcuts (key → campaign-relative path, e.g., "de" → "workflow/design/")
@@ -65,6 +66,7 @@ type IntentAddModel struct {
 
 	// Configuration
 	fullMode     bool
+	noteMode     bool
 	defaultType  string
 	author       string
 	campaignRoot string
@@ -98,6 +100,9 @@ func NewIntentAddModel(ctx context.Context, conceptSvc concept.Service, opts Add
 	// Title input
 	ti := textinput.New()
 	ti.Placeholder = "What's the intent?"
+	if opts.NoteMode {
+		ti.Placeholder = "What's the note?"
+	}
 	ti.CharLimit = 100
 	ti.Width = 50
 	ti.Focus()
@@ -126,6 +131,7 @@ func NewIntentAddModel(ctx context.Context, conceptSvc concept.Service, opts Add
 		typeIdx:      typeIdx,
 		vimEditor:    vimEd,
 		fullMode:     opts.FullMode,
+		noteMode:     opts.NoteMode,
 		defaultType:  opts.DefaultType,
 		author:       opts.Author,
 		campaignRoot: opts.CampaignRoot,
@@ -228,6 +234,9 @@ func (m IntentAddModel) updateTitle(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		title := strings.TrimSpace(m.titleInput.Value())
 		if title == "" {
 			return m, nil
+		}
+		if m.noteMode {
+			return m.finishNoteStep()
 		}
 		m.step = addStepType
 		m.titleInput.Blur()
@@ -673,11 +682,26 @@ func (m IntentAddModel) finishBodyStep() (tea.Model, tea.Cmd) {
 	return m, tea.Quit
 }
 
+// finishNoteStep completes a note quick-add: the title text is the note, with
+// no type, concept, or body.
+func (m IntentAddModel) finishNoteStep() (tea.Model, tea.Cmd) {
+	m.result = &AddResult{
+		Title:  strings.TrimSpace(m.titleInput.Value()),
+		Author: m.author,
+	}
+	m.step = addStepDone
+	return m, tea.Quit
+}
+
 // collectCurrentResult builds an AddResult from the model's current state.
 func (m IntentAddModel) collectCurrentResult() *AddResult {
 	title := strings.TrimSpace(m.titleInput.Value())
 	if title == "" {
 		return nil
+	}
+
+	if m.noteMode {
+		return &AddResult{Title: title, Author: m.author}
 	}
 
 	conceptPath := ""
@@ -747,7 +771,11 @@ func (m IntentAddModel) View() string {
 
 	var b strings.Builder
 
-	b.WriteString(TitleStyle.Render("Create Intent"))
+	header := "Create Intent"
+	if m.noteMode {
+		header = "Create Note"
+	}
+	b.WriteString(TitleStyle.Render(header))
 	if m.savedCount > 0 {
 		b.WriteString(SuccessStyle.Render(fmt.Sprintf("  [%d saved]", m.savedCount)))
 	}
@@ -802,7 +830,11 @@ func (m IntentAddModel) viewProgress() string {
 func (m IntentAddModel) viewTitleStep() string {
 	var b strings.Builder
 
-	b.WriteString("Title:\n")
+	label := "Title:\n"
+	if m.noteMode {
+		label = "Note:\n"
+	}
+	b.WriteString(label)
 	b.WriteString(m.titleInput.View())
 	b.WriteString("\n")
 
@@ -813,7 +845,11 @@ func (m IntentAddModel) viewTitleStep() string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(HelpStyle.Render("Enter: continue • Ctrl+N: save & new • Esc: cancel"))
+	help := "Enter: continue • Ctrl+N: save & new • Esc: cancel"
+	if m.noteMode {
+		help = "Enter: save note • Ctrl+N: save & new • Esc: cancel"
+	}
+	b.WriteString(HelpStyle.Render(help))
 
 	return b.String()
 }

--- a/internal/intent/tui/add_model.go
+++ b/internal/intent/tui/add_model.go
@@ -366,6 +366,9 @@ func (m IntentAddModel) updateType(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+n":
 		return m.saveAndReset()
 
+	case "ctrl+t":
+		return m.openTagOverlay()
+
 	case "j", "down":
 		if m.typeIdx < len(intentTypes)-1 {
 			m.typeIdx++
@@ -398,6 +401,9 @@ func (m IntentAddModel) updateConcept(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	case "ctrl+n":
 		return m.saveAndReset()
+
+	case "ctrl+t":
+		return m.openTagOverlay()
 
 	case "tab":
 		// Skip concept selection
@@ -469,9 +475,7 @@ func (m IntentAddModel) updateBody(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	// Handle ctrl+t for tags from the editor step.
 	if msg.String() == "ctrl+t" {
-		m.tagOverlay = NewTagOverlay(m.availableTags, m.tags)
-		m.tagging = true
-		return m, nil
+		return m.openTagOverlay()
 	}
 
 	// Handle ctrl+n for save-and-new (always available)
@@ -714,6 +718,15 @@ func (m IntentAddModel) finishBodyStep() (tea.Model, tea.Cmd) {
 	return m, tea.Quit
 }
 
+// openTagOverlay opens the modal tag overlay seeded with the configured tags and
+// the item's current tags. It is reachable from the type, concept, and body
+// steps so the fast capture flow can always attach a tag without a flag.
+func (m IntentAddModel) openTagOverlay() (tea.Model, tea.Cmd) {
+	m.tagOverlay = NewTagOverlay(m.availableTags, m.tags)
+	m.tagging = true
+	return m, nil
+}
+
 // updateTagOverlay routes keys to the tag overlay; on confirm it stores the
 // selected tags on the in-progress item.
 func (m IntentAddModel) updateTagOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -938,7 +951,7 @@ func (m IntentAddModel) viewTypeStep() string {
 	}
 
 	b.WriteString("\n")
-	b.WriteString(HelpStyle.Render("j/k: navigate • Enter: select • Ctrl+N: save & new • Esc: cancel"))
+	b.WriteString(HelpStyle.Render("j/k: navigate • Enter: select • Ctrl+N: save & new • Ctrl+T: tags • Esc: cancel"))
 
 	return b.String()
 }
@@ -949,7 +962,7 @@ func (m IntentAddModel) viewConceptStep() string {
 
 	b.WriteString(m.conceptPicker.View())
 	b.WriteString("\n")
-	b.WriteString(HelpStyle.Render("Tab: skip • Enter: select • Ctrl+N: save & new • Esc: cancel"))
+	b.WriteString(HelpStyle.Render("Tab: skip • Enter: select • Ctrl+N: save & new • Ctrl+T: tags • Esc: cancel"))
 
 	return b.String()
 }

--- a/internal/intent/tui/add_model_test.go
+++ b/internal/intent/tui/add_model_test.go
@@ -89,6 +89,38 @@ func TestIntentAddModel_TitleStep(t *testing.T) {
 	}
 }
 
+func TestIntentAddModel_NoteModeFinishesAtTitle(t *testing.T) {
+	ctx := context.Background()
+	svc := mockConceptService{}
+
+	m := NewIntentAddModel(ctx, svc, AddOptions{NoteMode: true})
+
+	for _, char := range "a quick note" {
+		model, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{char}})
+		m = model.(IntentAddModel)
+	}
+
+	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = model.(IntentAddModel)
+
+	if m.step != addStepDone {
+		t.Fatalf("note mode should finish at title, step = %v", m.step)
+	}
+	result := m.Result()
+	if result == nil {
+		t.Fatal("note mode produced no result")
+	}
+	if result.Title != "a quick note" {
+		t.Errorf("Title = %q, want %q", result.Title, "a quick note")
+	}
+	if result.Type != "" {
+		t.Errorf("Type = %q, want empty for a note", result.Type)
+	}
+	if result.Concept != "" {
+		t.Errorf("Concept = %q, want empty for a note", result.Concept)
+	}
+}
+
 func TestIntentAddModel_EmptyTitleNoAdvance(t *testing.T) {
 	ctx := context.Background()
 	svc := mockConceptService{}

--- a/internal/intent/tui/add_model_test.go
+++ b/internal/intent/tui/add_model_test.go
@@ -89,7 +89,7 @@ func TestIntentAddModel_TitleStep(t *testing.T) {
 	}
 }
 
-func TestIntentAddModel_NoteModeFinishesAtTitle(t *testing.T) {
+func TestIntentAddModel_NoteModeCollectsBody(t *testing.T) {
 	ctx := context.Background()
 	svc := mockConceptService{}
 
@@ -103,9 +103,18 @@ func TestIntentAddModel_NoteModeFinishesAtTitle(t *testing.T) {
 	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = model.(IntentAddModel)
 
-	if m.step != addStepDone {
-		t.Fatalf("note mode should finish at title, step = %v", m.step)
+	if m.step != addStepBody {
+		t.Fatalf("note mode should move from title to body, step = %v", m.step)
 	}
+
+	for _, char := range "body details" {
+		model, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{char}})
+		m = model.(IntentAddModel)
+	}
+
+	model, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+	m = model.(IntentAddModel)
+
 	result := m.Result()
 	if result == nil {
 		t.Fatal("note mode produced no result")
@@ -118,6 +127,9 @@ func TestIntentAddModel_NoteModeFinishesAtTitle(t *testing.T) {
 	}
 	if result.Concept != "" {
 		t.Errorf("Concept = %q, want empty for a note", result.Concept)
+	}
+	if result.Body != "body details" {
+		t.Errorf("Body = %q, want %q", result.Body, "body details")
 	}
 }
 

--- a/internal/intent/tui/add_model_test.go
+++ b/internal/intent/tui/add_model_test.go
@@ -133,6 +133,45 @@ func TestIntentAddModel_NoteModeCollectsBody(t *testing.T) {
 	}
 }
 
+func TestIntentAddModel_TitleStepDoesNotOpenTags(t *testing.T) {
+	ctx := context.Background()
+	svc := mockConceptService{}
+
+	m := NewIntentAddModel(ctx, svc, AddOptions{AvailableTags: []string{"urgent"}})
+	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlT})
+	m = model.(IntentAddModel)
+
+	if m.tagging {
+		t.Fatal("title step should not open tag overlay")
+	}
+}
+
+func TestIntentAddModel_BodyStepOpensTags(t *testing.T) {
+	ctx := context.Background()
+	svc := mockConceptService{}
+
+	m := NewIntentAddModel(ctx, svc, AddOptions{
+		NoteMode:      true,
+		AvailableTags: []string{"urgent"},
+	})
+
+	for _, char := range "taggable note" {
+		model, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{char}})
+		m = model.(IntentAddModel)
+	}
+	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = model.(IntentAddModel)
+	if m.step != addStepBody {
+		t.Fatalf("step = %v, want addStepBody", m.step)
+	}
+
+	model, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlT})
+	m = model.(IntentAddModel)
+	if !m.tagging {
+		t.Fatal("body step should open tag overlay")
+	}
+}
+
 func TestIntentAddModel_EmptyTitleNoAdvance(t *testing.T) {
 	ctx := context.Background()
 	svc := mockConceptService{}

--- a/internal/intent/tui/add_model_test.go
+++ b/internal/intent/tui/add_model_test.go
@@ -146,6 +146,54 @@ func TestIntentAddModel_TitleStepDoesNotOpenTags(t *testing.T) {
 	}
 }
 
+func TestIntentAddModel_TypeStepOpensTags(t *testing.T) {
+	ctx := context.Background()
+	svc := mockConceptService{}
+
+	m := NewIntentAddModel(ctx, svc, AddOptions{AvailableTags: []string{"urgent"}})
+
+	for _, char := range "an intent" {
+		model, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{char}})
+		m = model.(IntentAddModel)
+	}
+	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = model.(IntentAddModel)
+	if m.step != addStepType {
+		t.Fatalf("step = %v, want addStepType", m.step)
+	}
+
+	model, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlT})
+	m = model.(IntentAddModel)
+	if !m.tagging {
+		t.Fatal("type step should open tag overlay so the fast flow can tag")
+	}
+}
+
+func TestIntentAddModel_ConceptStepOpensTags(t *testing.T) {
+	ctx := context.Background()
+	svc := mockConceptService{}
+
+	m := NewIntentAddModel(ctx, svc, AddOptions{AvailableTags: []string{"urgent"}})
+
+	for _, char := range "an intent" {
+		model, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{char}})
+		m = model.(IntentAddModel)
+	}
+	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter}) // title -> type
+	m = model.(IntentAddModel)
+	model, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter}) // type -> concept
+	m = model.(IntentAddModel)
+	if m.step != addStepConcept {
+		t.Fatalf("step = %v, want addStepConcept", m.step)
+	}
+
+	model, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlT})
+	m = model.(IntentAddModel)
+	if !m.tagging {
+		t.Fatal("concept step should open tag overlay so the fast flow can tag")
+	}
+}
+
 func TestIntentAddModel_BodyStepOpensTags(t *testing.T) {
 	ctx := context.Background()
 	svc := mockConceptService{}

--- a/internal/intent/tui/concept_picker_test.go
+++ b/internal/intent/tui/concept_picker_test.go
@@ -649,3 +649,63 @@ func findSubstring(s, substr string) bool {
 	}
 	return false
 }
+
+func TestConceptPicker_WorkflowParentCascade(t *testing.T) {
+	svc := mockConceptService{
+		concepts: []concept.Concept{
+			{Name: "projects", Path: "projects/", Description: "Projects", HasItems: true},
+			{Name: "workflow", Path: "workflow/", Description: "Workflows", HasItems: true, Children: []concept.Concept{
+				{Name: "festivals", Path: "festivals/"},
+				{Name: "design", Path: "workflow/design/"},
+			}},
+		},
+		items: map[string][]concept.Item{
+			"workflow:": {
+				{Name: "festivals", Path: "festivals/", IsDir: true, Children: 2},
+				{Name: "design", Path: "workflow/design/", IsDir: true, Children: 1},
+			},
+		},
+	}
+
+	picker := NewConceptPickerModel(context.Background(), svc)
+
+	// Select the workflow concept (typeWheel: none, projects, workflow).
+	picker, _ = picker.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	picker, _ = picker.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	picker, _ = picker.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if picker.step != stepSelectingItem {
+		t.Fatalf("selecting workflow should open the sub-concept submenu, step = %v", picker.step)
+	}
+	if len(picker.items) != 2 || picker.items[0].Name != "festivals" {
+		t.Fatalf("submenu items = %+v, want festivals then design", picker.items)
+	}
+
+	// Selecting festivals stores its own path (festivals/), not workflow/festivals/.
+	picker, _ = picker.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if picker.step != stepDone {
+		t.Fatalf("selecting a sub-concept should finish, step = %v", picker.step)
+	}
+	if picker.SelectedPath() != "festivals/" {
+		t.Errorf("SelectedPath = %q, want %q", picker.SelectedPath(), "festivals/")
+	}
+}
+
+func TestConceptPicker_ChildlessConceptUnchanged(t *testing.T) {
+	svc := mockConceptService{
+		concepts: []concept.Concept{
+			{Name: "docs", Path: "docs/", Description: "Documentation", HasItems: false},
+		},
+	}
+	picker := NewConceptPickerModel(context.Background(), svc)
+	// Select docs (no items): should complete immediately with its path.
+	picker, _ = picker.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	picker, _ = picker.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if picker.step != stepDone {
+		t.Fatalf("childless concept should finish at type selection, step = %v", picker.step)
+	}
+	if picker.SelectedPath() != "docs/" {
+		t.Errorf("SelectedPath = %q, want docs/", picker.SelectedPath())
+	}
+}

--- a/internal/intent/tui/concept_picker_test.go
+++ b/internal/intent/tui/concept_picker_test.go
@@ -3,8 +3,10 @@ package tui
 import (
 	"context"
 	"testing"
+	"testing/fstest"
 
 	"github.com/Obedience-Corp/camp/internal/concept"
+	"github.com/Obedience-Corp/camp/internal/config"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -688,6 +690,74 @@ func TestConceptPicker_WorkflowParentCascade(t *testing.T) {
 	}
 	if picker.SelectedPath() != "festivals/" {
 		t.Errorf("SelectedPath = %q, want %q", picker.SelectedPath(), "festivals/")
+	}
+}
+
+func TestConceptPicker_DrillIntoConfiguredChild(t *testing.T) {
+	concepts := []config.ConceptEntry{
+		{Name: "workflow", Path: "workflow", Children: []config.ConceptEntry{
+			{Name: "festivals", Path: "festivals"},
+			{Name: "design", Path: "workflow/design"},
+		}},
+	}
+	fsys := fstest.MapFS{
+		"festivals/active/my-fest/FESTIVAL_GOAL.md": &fstest.MapFile{Data: []byte("")},
+		"workflow/festivals/decoy/file":             &fstest.MapFile{Data: []byte("")},
+		"workflow/design/doc/file":                  &fstest.MapFile{Data: []byte("")},
+	}
+	svc := concept.NewFSService("", concepts, fsys)
+
+	picker := NewConceptPickerModel(context.Background(), svc)
+
+	// Select the workflow concept (typeWheel: none, workflow).
+	picker, _ = picker.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	picker, _ = picker.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if picker.step != stepSelectingItem {
+		t.Fatalf("selecting workflow should open the submenu, step = %v", picker.step)
+	}
+	if len(picker.items) != 2 || picker.items[0].Name != "festivals" {
+		t.Fatalf("submenu items = %+v, want festivals then design", picker.items)
+	}
+
+	// Right-drill into the configured festivals child.
+	picker, _ = picker.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("l")})
+
+	if picker.step != stepSelectingItem {
+		t.Fatalf("drilling into festivals should stay in item selection, step = %v", picker.step)
+	}
+	if len(picker.items) != 1 || picker.items[0].Name != "active" {
+		t.Fatalf("festivals drill items = %+v, want [active] from festivals/, not workflow/festivals", picker.items)
+	}
+	if picker.items[0].Path != "festivals/active" {
+		t.Errorf("active path = %q, want festivals/active", picker.items[0].Path)
+	}
+	if bc := picker.buildBreadcrumb(); bc != "workflow > festivals" {
+		t.Errorf("breadcrumb = %q, want %q", bc, "workflow > festivals")
+	}
+
+	// Drill again into active, then select the festival.
+	picker, _ = picker.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("l")})
+	if len(picker.items) != 1 || picker.items[0].Name != "my-fest" {
+		t.Fatalf("active drill items = %+v, want [my-fest]", picker.items)
+	}
+	picker, _ = picker.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if picker.step != stepDone {
+		t.Fatalf("selecting a festival should finish, step = %v", picker.step)
+	}
+	if picker.SelectedPath() != "festivals/active/my-fest" {
+		t.Errorf("SelectedPath = %q, want festivals/active/my-fest", picker.SelectedPath())
+	}
+
+	// Backspace returns to the festivals listing, then the submenu.
+	// (Re-run navigation on a fresh picker since this one is done.)
+	picker = NewConceptPickerModel(context.Background(), svc)
+	picker, _ = picker.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	picker, _ = picker.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	picker, _ = picker.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("l")})
+	picker, _ = picker.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if len(picker.items) != 2 || picker.items[0].Name != "festivals" {
+		t.Fatalf("backspace should restore the workflow submenu, items = %+v", picker.items)
 	}
 }
 

--- a/internal/intent/tui/explorer/actions.go
+++ b/internal/intent/tui/explorer/actions.go
@@ -15,12 +15,15 @@ import (
 	"github.com/Obedience-Corp/camp/internal/intent/tui"
 )
 
-// moveStatusOptions are the available statuses for moving intents.
-// Dungeon statuses are visually indented to show hierarchy.
-var moveStatusOptions = []struct {
+type moveStatusOption struct {
 	name   string
 	status intent.Status
-}{
+}
+
+// intentMoveStatusOptions are the available statuses for moving lifecycle
+// intents. Dungeon statuses are visually indented to show hierarchy.
+var intentMoveStatusOptions = []moveStatusOption{
+	{"Notes", intent.StatusNote},
 	{"Inbox", intent.StatusInbox},
 	{"Ready", intent.StatusReady},
 	{"Active", intent.StatusActive},
@@ -30,8 +33,29 @@ var moveStatusOptions = []struct {
 	{"  Someday", intent.StatusSomeday},
 }
 
+var noteMoveStatusOptions = []moveStatusOption{
+	{"Inbox", intent.StatusInbox},
+	{"Ready", intent.StatusReady},
+	{"Active", intent.StatusActive},
+}
+
+func (m *Model) currentMoveStatusOptions() []moveStatusOption {
+	if m.intentToMove != nil && m.intentToMove.Status.IsNote() {
+		return noteMoveStatusOptions
+	}
+	return intentMoveStatusOptions
+}
+
 // updateMove handles key input during move action.
 func (m *Model) updateMove(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	options := m.currentMoveStatusOptions()
+	if m.moveStatusIdx >= len(options) {
+		m.moveStatusIdx = len(options) - 1
+	}
+	if m.moveStatusIdx < 0 {
+		m.moveStatusIdx = 0
+	}
+
 	switch msg.String() {
 	case "esc":
 		// Cancel move
@@ -39,7 +63,7 @@ func (m *Model) updateMove(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.intentToMove = nil
 		return m, nil
 	case "j", "down":
-		if m.moveStatusIdx < len(moveStatusOptions)-1 {
+		if m.moveStatusIdx < len(options)-1 {
 			m.moveStatusIdx++
 		}
 	case "k", "up":
@@ -48,14 +72,23 @@ func (m *Model) updateMove(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "enter":
 		// Execute move
-		if m.intentToMove != nil {
-			newStatus := moveStatusOptions[m.moveStatusIdx].status
+		if m.intentToMove != nil && len(options) > 0 {
+			newStatus := options[m.moveStatusIdx].status
 			if m.intentToMove.Status == newStatus {
 				// Already at this status
 				m.statusMessage = "Already at " + newStatus.String()
 				m.focus = focusList
 				m.intentToMove = nil
 				return m, nil
+			}
+			if m.intentToMove.Status.IsNote() {
+				m.startConvertToStatus(m.intentToMove, newStatus)
+				m.intentToMove = nil
+				return m, nil
+			}
+			if newStatus == intent.StatusNote {
+				m.focus = focusList
+				return m, m.moveIntentToNote(m.intentToMove)
 			}
 			// Require reason for dungeon moves
 			if newStatus.InDungeon() {
@@ -106,6 +139,31 @@ func (m *Model) moveIntent(i *intent.Intent, newStatus intent.Status) tea.Cmd {
 			err:       err,
 			intentID:  i.ID,
 			newStatus: newStatus,
+		}
+	}
+}
+
+func (m *Model) moveIntentToNote(i *intent.Intent) tea.Cmd {
+	return func() tea.Msg {
+		sourcePath := i.Path
+		prevStatus := i.Status
+		movedNote, err := m.service.MoveIntentToNote(m.ctx, i.ID)
+		if err == nil {
+			err = m.appendAuditEvent(audit.Event{
+				Type:  audit.EventMove,
+				ID:    i.ID,
+				Title: i.Title,
+				From:  string(prevStatus),
+				To:    string(intent.StatusNote),
+			})
+		}
+		if err == nil {
+			m.autoCommitIntent(commit.IntentMove, i.Title, "Moved to notes", sourcePath, movedNote.Path)
+		}
+		return moveFinishedMsg{
+			err:       err,
+			intentID:  i.ID,
+			newStatus: intent.StatusNote,
 		}
 	}
 }
@@ -226,7 +284,8 @@ func (m *Model) viewMove() string {
 
 	b.WriteString("Select new status:\n")
 	dungeonLabelShown := false
-	for i, opt := range moveStatusOptions {
+	options := m.currentMoveStatusOptions()
+	for i, opt := range options {
 		// Show dungeon label before first dungeon status
 		if !dungeonLabelShown && opt.status.InDungeon() {
 			dungeonLabelShown = true

--- a/internal/intent/tui/explorer/add_tui.go
+++ b/internal/intent/tui/explorer/add_tui.go
@@ -16,11 +16,12 @@ type addTUIFinishedMsg struct{}
 // notes view it launches the note quick-add (text only, no type/concept).
 func (m *Model) startAddTUI() {
 	addModel := tui.NewIntentAddModel(m.ctx, m.conceptSvc, tui.AddOptions{
-		FullMode:     !m.notesMode,
-		NoteMode:     m.notesMode,
-		Author:       m.author,
-		CampaignRoot: m.campaignRoot,
-		Shortcuts:    m.shortcuts,
+		FullMode:      !m.notesMode,
+		NoteMode:      m.notesMode,
+		Author:        m.author,
+		CampaignRoot:  m.campaignRoot,
+		Shortcuts:     m.shortcuts,
+		AvailableTags: m.availableTags,
 	})
 	m.addModel = &addModel
 	m.focus = focusAddTUI
@@ -76,6 +77,7 @@ func (m *Model) createIntentFromAddResult(result *tui.AddResult) {
 		Concept: result.Concept,
 		Body:    result.Body,
 		Author:  result.Author,
+		Tags:    result.Tags,
 	}
 
 	noun := "Intent"

--- a/internal/intent/tui/explorer/add_tui.go
+++ b/internal/intent/tui/explorer/add_tui.go
@@ -12,19 +12,32 @@ import (
 // This replaces tea.QuitMsg so the explorer stays alive.
 type addTUIFinishedMsg struct{}
 
-// startAddTUI launches the full IntentAddModel within the explorer. In the
-// notes view it launches note capture (title/body/tags, no type/concept).
+// startAddTUI launches the full IntentAddModel within the explorer. From the
+// notes group/view it launches note capture (title/body/tags, no type/concept).
 func (m *Model) startAddTUI() {
+	noteMode := m.shouldCreateNoteFromCurrentPosition()
 	addModel := tui.NewIntentAddModel(m.ctx, m.conceptSvc, tui.AddOptions{
-		FullMode:      !m.notesMode,
-		NoteMode:      m.notesMode,
+		FullMode:      !noteMode,
+		NoteMode:      noteMode,
 		Author:        m.author,
 		CampaignRoot:  m.campaignRoot,
 		Shortcuts:     m.shortcuts,
 		AvailableTags: m.availableTags,
 	})
 	m.addModel = &addModel
+	m.addNoteMode = noteMode
 	m.focus = focusAddTUI
+}
+
+func (m *Model) shouldCreateNoteFromCurrentPosition() bool {
+	if m.notesMode {
+		return true
+	}
+	if m.cursorGroup < 0 || m.cursorGroup >= len(m.groups) {
+		return false
+	}
+	group := m.groups[m.cursorGroup]
+	return group.Status.IsNote()
 }
 
 // updateAddTUI forwards messages to the embedded add model and checks completion.
@@ -63,12 +76,13 @@ func (m *Model) finishAddTUI() (tea.Model, tea.Cmd) {
 	}
 
 	m.addModel = nil
+	m.addNoteMode = false
 	m.focus = focusList
 
 	return m, m.loadIntents()
 }
 
-// createIntentFromAddResult creates an intent (or a note, in notes mode) and
+// createIntentFromAddResult creates an intent (or a note, in add note mode) and
 // auto-commits it.
 func (m *Model) createIntentFromAddResult(result *tui.AddResult) {
 	opts := intent.CreateOptions{
@@ -82,7 +96,7 @@ func (m *Model) createIntentFromAddResult(result *tui.AddResult) {
 
 	noun := "Intent"
 	create := m.service.CreateDirect
-	if m.notesMode {
+	if m.addNoteMode {
 		noun = "Note"
 		create = m.service.CreateNote
 	}

--- a/internal/intent/tui/explorer/add_tui.go
+++ b/internal/intent/tui/explorer/add_tui.go
@@ -13,7 +13,7 @@ import (
 type addTUIFinishedMsg struct{}
 
 // startAddTUI launches the full IntentAddModel within the explorer. In the
-// notes view it launches the note quick-add (text only, no type/concept).
+// notes view it launches note capture (title/body/tags, no type/concept).
 func (m *Model) startAddTUI() {
 	addModel := tui.NewIntentAddModel(m.ctx, m.conceptSvc, tui.AddOptions{
 		FullMode:      !m.notesMode,

--- a/internal/intent/tui/explorer/add_tui.go
+++ b/internal/intent/tui/explorer/add_tui.go
@@ -12,10 +12,12 @@ import (
 // This replaces tea.QuitMsg so the explorer stays alive.
 type addTUIFinishedMsg struct{}
 
-// startAddTUI launches the full IntentAddModel within the explorer.
+// startAddTUI launches the full IntentAddModel within the explorer. In the
+// notes view it launches the note quick-add (text only, no type/concept).
 func (m *Model) startAddTUI() {
 	addModel := tui.NewIntentAddModel(m.ctx, m.conceptSvc, tui.AddOptions{
-		FullMode:     true,
+		FullMode:     !m.notesMode,
+		NoteMode:     m.notesMode,
 		Author:       m.author,
 		CampaignRoot: m.campaignRoot,
 		Shortcuts:    m.shortcuts,
@@ -65,7 +67,8 @@ func (m *Model) finishAddTUI() (tea.Model, tea.Cmd) {
 	return m, m.loadIntents()
 }
 
-// createIntentFromAddResult creates an intent and auto-commits it.
+// createIntentFromAddResult creates an intent (or a note, in notes mode) and
+// auto-commits it.
 func (m *Model) createIntentFromAddResult(result *tui.AddResult) {
 	opts := intent.CreateOptions{
 		Title:   result.Title,
@@ -75,17 +78,23 @@ func (m *Model) createIntentFromAddResult(result *tui.AddResult) {
 		Author:  result.Author,
 	}
 
-	createdIntent, err := m.service.CreateDirect(m.ctx, opts)
+	noun := "Intent"
+	create := m.service.CreateDirect
+	if m.notesMode {
+		noun = "Note"
+		create = m.service.CreateNote
+	}
+	created, err := create(m.ctx, opts)
 	if err != nil {
-		m.statusMessage = "Error creating intent: " + err.Error()
+		m.statusMessage = "Error creating " + noun + ": " + err.Error()
 		return
 	}
 
 	if err := m.appendAuditEvent(audit.Event{
 		Type:  audit.EventCreate,
-		ID:    createdIntent.ID,
-		Title: createdIntent.Title,
-		To:    string(createdIntent.Status),
+		ID:    created.ID,
+		Title: created.Title,
+		To:    string(created.Status),
 	}); err != nil {
 		m.statusMessage = "Error writing audit event: " + err.Error()
 		return
@@ -93,10 +102,10 @@ func (m *Model) createIntentFromAddResult(result *tui.AddResult) {
 
 	// Auto-commit
 	if m.campaignRoot != "" && m.campaignID != "" {
-		m.autoCommitIntent(commit.IntentCreate, result.Title, "", createdIntent.Path)
+		m.autoCommitIntent(commit.IntentCreate, result.Title, "", created.Path)
 	}
 
-	m.statusMessage = "Intent created: " + result.Title
+	m.statusMessage = noun + " created: " + result.Title
 }
 
 // filterQuitCmd wraps a tea.Cmd to intercept tea.QuitMsg and convert it

--- a/internal/intent/tui/explorer/filtering.go
+++ b/internal/intent/tui/explorer/filtering.go
@@ -14,8 +14,20 @@ var statusFilterItems = []string{"All", "Inbox", "Ready", "Active", "Done", "Kil
 
 // applyFilters filters intents using search query and type filter.
 func (m *Model) applyFilters() {
-	query := m.searchInput.Value()
 	m.statusMessage = ""
+
+	// Notes mode: the intent-oriented filters (type/status/concept) and the
+	// intent search index do not apply. Show the loaded notes as-is.
+	if m.notesMode {
+		m.filteredIntents = m.intents
+		m.groups = groupNotes(m.filteredIntents)
+		m.cursorGroup = 0
+		m.cursorItem = -1
+		m.scrollOffset = 0
+		return
+	}
+
+	query := m.searchInput.Value()
 
 	// Start with all intents
 	var filtered []*intent.Intent

--- a/internal/intent/tui/explorer/filtering.go
+++ b/internal/intent/tui/explorer/filtering.go
@@ -4,13 +4,23 @@ import (
 	"strings"
 
 	"github.com/Obedience-Corp/camp/internal/intent"
+	"github.com/sahilm/fuzzy"
 )
 
 // typeFilterItems are the available type filter options.
 var typeFilterItems = []string{"All", "Idea", "Feature", "Bug", "Research", "Chore"}
 
 // statusFilterItems are the available status filter options.
-var statusFilterItems = []string{"All", "Inbox", "Ready", "Active", "Done", "Killed"}
+var statusFilterItems = []string{"All", "Notes", "Inbox", "Ready", "Active", "Done", "Killed"}
+
+type explorerItemSource []*intent.Intent
+
+func (s explorerItemSource) String(i int) string {
+	item := s[i]
+	return strings.Join([]string{item.Title, item.ID, item.Content}, " ")
+}
+
+func (s explorerItemSource) Len() int { return len(s) }
 
 // applyFilters filters intents using search query and type filter.
 func (m *Model) applyFilters() {
@@ -20,7 +30,7 @@ func (m *Model) applyFilters() {
 	// intent search index do not apply. Show the loaded notes as-is.
 	if m.notesMode {
 		m.filteredIntents = m.intents
-		m.groups = groupNotes(m.filteredIntents)
+		m.rebuildStatusGroups()
 		m.cursorGroup = 0
 		m.cursorItem = -1
 		m.scrollOffset = 0
@@ -32,17 +42,15 @@ func (m *Model) applyFilters() {
 	// Start with all intents
 	var filtered []*intent.Intent
 
-	// Apply search if there's a query
+	// Apply search if there's a query. Search the loaded explorer items directly
+	// so notes remain searchable in the combined default view.
 	if query == "" {
 		filtered = m.intents
 	} else {
-		// Use fuzzy search via the service
-		results, err := m.service.Search(m.ctx, query)
-		if err != nil {
-			m.statusMessage = "Search error: " + err.Error()
-			filtered = m.intents
-		} else {
-			filtered = results
+		matches := fuzzy.FindFrom(query, explorerItemSource(m.intents))
+		filtered = make([]*intent.Intent, len(matches))
+		for i, match := range matches {
+			filtered[i] = m.intents[match.Index]
 		}
 	}
 
@@ -93,8 +101,8 @@ func (m *Model) applyFilters() {
 
 	m.filteredIntents = filtered
 
-	// Rebuild groups from filtered intents
-	m.groups = groupIntentsByStatus(m.filteredIntents, m.dungeonExpanded)
+	// Rebuild groups from filtered explorer items
+	m.groups = groupExplorerItemsByStatus(m.filteredIntents, m.dungeonExpanded)
 
 	// Reset cursor position and scroll
 	m.cursorGroup = 0
@@ -130,6 +138,8 @@ func (m *Model) clearAllFilters() {
 
 func statusSelectionToStatus(selection string) (intent.Status, bool) {
 	switch strings.ToLower(strings.TrimSpace(selection)) {
+	case "notes":
+		return intent.StatusNote, true
 	case "inbox":
 		return intent.StatusInbox, true
 	case "ready":

--- a/internal/intent/tui/explorer/filtering_test.go
+++ b/internal/intent/tui/explorer/filtering_test.go
@@ -16,6 +16,7 @@ func TestStatusSelectionToStatus(t *testing.T) {
 		wantOK    bool
 	}{
 		{name: "inbox", selection: "Inbox", want: intent.StatusInbox, wantOK: true},
+		{name: "notes", selection: "Notes", want: intent.StatusNote, wantOK: true},
 		{name: "ready", selection: "Ready", want: intent.StatusReady, wantOK: true},
 		{name: "active", selection: "Active", want: intent.StatusActive, wantOK: true},
 		{name: "done label", selection: "Done", want: intent.StatusDone, wantOK: true},
@@ -51,23 +52,57 @@ func TestApplyFilters_StatusDoneAndKilledUseDungeonStatuses(t *testing.T) {
 	m.dungeonExpanded = true
 	m.groups = groupIntentsByStatus(m.intents, m.dungeonExpanded)
 
-	// Select "Done" and verify only dungeon/done intents remain.
 	statusChip := m.filterBar.ChipByLabel("Status")
 	if statusChip == nil {
 		t.Fatal("missing Status filter chip")
 	}
-	statusChip.SetSelected(4) // "Done"
+	statusChip.SetSelected(statusFilterIndex(t, "Done"))
 	m.applyFilters()
 
 	if len(m.filteredIntents) != 1 || m.filteredIntents[0].Status != intent.StatusDone {
 		t.Fatalf("Done filter returned %+v, want one dungeon/done intent", m.filteredIntents)
 	}
 
-	// Select "Killed" and verify only dungeon/killed intents remain.
-	statusChip.SetSelected(5) // "Killed"
+	statusChip.SetSelected(statusFilterIndex(t, "Killed"))
 	m.applyFilters()
 
 	if len(m.filteredIntents) != 1 || m.filteredIntents[0].Status != intent.StatusKilled {
 		t.Fatalf("Killed filter returned %+v, want one dungeon/killed intent", m.filteredIntents)
 	}
+}
+
+func TestApplyFilters_StatusNotes(t *testing.T) {
+	ctx := context.Background()
+	m := NewModel(ctx, nil, nil, "/tmp/intents", "/tmp/campaign", "test-id", "", nil)
+	m.ready = true
+
+	now := time.Now()
+	m.intents = []*intent.Intent{
+		{ID: "note-1", Title: "Note", Status: intent.StatusNote, CreatedAt: now},
+		{ID: "inbox-1", Title: "Inbox", Status: intent.StatusInbox, Type: intent.TypeFeature, CreatedAt: now},
+	}
+	m.filteredIntents = m.intents
+	m.groups = groupIntentsByStatus(m.intents, m.dungeonExpanded)
+
+	statusChip := m.filterBar.ChipByLabel("Status")
+	if statusChip == nil {
+		t.Fatal("missing Status filter chip")
+	}
+	statusChip.SetSelected(statusFilterIndex(t, "Notes"))
+	m.applyFilters()
+
+	if len(m.filteredIntents) != 1 || m.filteredIntents[0].Status != intent.StatusNote {
+		t.Fatalf("Notes filter returned %+v, want one note", m.filteredIntents)
+	}
+}
+
+func statusFilterIndex(t *testing.T, label string) int {
+	t.Helper()
+	for i, item := range statusFilterItems {
+		if item == label {
+			return i
+		}
+	}
+	t.Fatalf("status filter item %q not found in %v", label, statusFilterItems)
+	return -1
 }

--- a/internal/intent/tui/explorer/gather.go
+++ b/internal/intent/tui/explorer/gather.go
@@ -16,6 +16,10 @@ func (m *Model) toggleSelection(i *intent.Intent) {
 	if i == nil {
 		return
 	}
+	if i.Status.IsNote() {
+		m.statusMessage = "Convert note to an intent before gathering it"
+		return
+	}
 
 	if m.selectedIntents[i.ID] {
 		delete(m.selectedIntents, i.ID)
@@ -150,6 +154,10 @@ func (m *Model) handleGatherGroup() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	group := m.groups[m.cursorGroup]
+	if group.Status.IsNote() {
+		m.statusMessage = "Convert notes to intents before gathering them"
+		return m, nil
+	}
 	if len(group.Intents) < 2 {
 		m.statusMessage = "Group needs 2+ intents to gather"
 		return m, nil
@@ -165,6 +173,10 @@ func (m *Model) handleGatherGroup() (tea.Model, tea.Cmd) {
 
 // enterGatherModeFromAction enters multi-select mode with current intent pre-selected.
 func (m *Model) enterGatherModeFromAction(selected *intent.Intent) {
+	if selected.Status.IsNote() {
+		m.statusMessage = "Convert note to an intent before gathering it"
+		return
+	}
 	m.multiSelectMode = true
 	m.selectedIntents[selected.ID] = true
 	m.statusMessage = "Select more intents with Space, then ga to gather"

--- a/internal/intent/tui/explorer/model.go
+++ b/internal/intent/tui/explorer/model.go
@@ -161,8 +161,9 @@ type Model struct {
 	notesMode bool
 
 	// Convert action state (note → intent)
-	noteToConvert  *intent.Intent
-	convertTypeIdx int
+	noteToConvert       *intent.Intent
+	convertTypeIdx      int
+	convertTargetStatus intent.Status
 
 	// Tag overlay (opened with T on a selected item)
 	availableTags []string

--- a/internal/intent/tui/explorer/model.go
+++ b/internal/intent/tui/explorer/model.go
@@ -160,6 +160,18 @@ type Model struct {
 	// Convert action state (note → intent)
 	noteToConvert  *intent.Intent
 	convertTypeIdx int
+
+	// Tag overlay (opened with T on a selected item)
+	availableTags []string
+	tagOverlay    tui.TagOverlay
+	tagging       bool
+	tagTarget     *intent.Intent
+}
+
+// WithAvailableTags sets the configured tag list offered by the tag overlay.
+func (m Model) WithAvailableTags(tags []string) Model {
+	m.availableTags = tags
+	return m
 }
 
 // NewModel creates a new Explorer model.
@@ -263,6 +275,11 @@ func (m Model) View() string {
 	// Show convert type picker if active
 	if m.focus == focusConvertType {
 		return m.viewConvert()
+	}
+
+	// Show tag overlay if active
+	if m.tagging {
+		return m.viewTagEdit()
 	}
 
 	// Show confirmation dialog if active

--- a/internal/intent/tui/explorer/model.go
+++ b/internal/intent/tui/explorer/model.go
@@ -31,6 +31,7 @@ const (
 	focusPromoteTarget // Promote target picker
 	focusDungeonReason // Text input for dungeon move reason
 	focusConvertType   // Type picker for converting a note into an intent
+	focusRename        // Text input for renaming an intent
 )
 
 // IntentGroup represents a collapsible group of intents by status.
@@ -166,6 +167,14 @@ type Model struct {
 	tagOverlay    tui.TagOverlay
 	tagging       bool
 	tagTarget     *intent.Intent
+
+	// Rename overlay (opened with R on a selected item)
+	renameInput  textinput.Model
+	renameTarget *intent.Intent
+
+	// pendingReselectID, when set, selects the matching item after the next
+	// list reload (used to keep the renamed intent selected).
+	pendingReselectID string
 }
 
 // WithAvailableTags sets the configured tag list offered by the tag overlay.
@@ -280,6 +289,11 @@ func (m Model) View() string {
 	// Show tag overlay if active
 	if m.tagging {
 		return m.viewTagEdit()
+	}
+
+	// Show rename input if active
+	if m.focus == focusRename {
+		return m.viewRename()
 	}
 
 	// Show confirmation dialog if active

--- a/internal/intent/tui/explorer/model.go
+++ b/internal/intent/tui/explorer/model.go
@@ -151,11 +151,13 @@ type Model struct {
 	campaignID   string
 
 	// Full add TUI integration
-	addModel  *tui.IntentAddModel
-	author    string
-	shortcuts map[string]string
+	addModel    *tui.IntentAddModel
+	addNoteMode bool
+	author      string
+	shortcuts   map[string]string
 
-	// Notes view: when true the explorer lists notes instead of intents
+	// Notes view: when true the explorer lists only notes. The default explorer
+	// also includes active notes as the first group.
 	notesMode bool
 
 	// Convert action state (note → intent)
@@ -228,8 +230,9 @@ func (m Model) Init() tea.Cmd {
 	return m.loadIntents()
 }
 
-// loadIntents returns a command that loads intents from the service. In notes
-// mode it loads the note store instead, so the default view stays intents-only.
+// loadIntents returns a command that loads explorer items from the service. The
+// default view includes active notes before lifecycle intents; notes mode lists
+// the whole note store including archived notes.
 func (m Model) loadIntents() tea.Cmd {
 	notesMode := m.notesMode
 	return func() tea.Msg {
@@ -238,7 +241,17 @@ func (m Model) loadIntents() tea.Cmd {
 			return intentsLoadedMsg{intents: notes, err: err}
 		}
 		intents, err := m.service.List(m.ctx, nil)
-		return intentsLoadedMsg{intents: intents, err: err}
+		if err != nil {
+			return intentsLoadedMsg{err: err}
+		}
+		notes, err := m.service.ListNotes(m.ctx, false)
+		if err != nil {
+			return intentsLoadedMsg{err: err}
+		}
+		items := make([]*intent.Intent, 0, len(notes)+len(intents))
+		items = append(items, notes...)
+		items = append(items, intents...)
+		return intentsLoadedMsg{intents: items}
 	}
 }
 
@@ -331,8 +344,8 @@ func (m Model) SelectedIntent() *intent.Intent {
 	return nil
 }
 
-// groupIntentsByStatus organizes intents into groups by their status.
-// Groups are ordered: Inbox, Active, Ready, then a collapsible Dungeon parent
+// groupIntentsByStatus organizes lifecycle intents into groups by status.
+// Groups are ordered: Inbox, Ready, Active, then a collapsible Dungeon parent
 // that contains Done, Killed, Archived, Someday as children.
 // When dungeonExpanded is false, only the Dungeon parent group is shown.
 // When true, the 4 child groups are appended after the parent.
@@ -392,4 +405,43 @@ func groupIntentsByStatus(intents []*intent.Intent, dungeonExpanded bool) []Inte
 	}
 
 	return groups
+}
+
+func groupExplorerItemsByStatus(items []*intent.Intent, dungeonExpanded bool) []IntentGroup {
+	notes := IntentGroup{Name: "Notes", Status: intent.StatusNote, Expanded: true}
+	intents := make([]*intent.Intent, 0, len(items))
+	for _, item := range items {
+		if item.Status == intent.StatusNote {
+			notes.Intents = append(notes.Intents, item)
+			continue
+		}
+		if item.Status.IsNote() {
+			continue
+		}
+		intents = append(intents, item)
+	}
+
+	groups := groupIntentsByStatus(intents, dungeonExpanded)
+	return append([]IntentGroup{notes}, groups...)
+}
+
+func (m *Model) rebuildStatusGroups() {
+	if m.notesMode {
+		m.groups = groupNotes(m.filteredIntents)
+		return
+	}
+	if m.hasNotesGroup() {
+		m.groups = groupExplorerItemsByStatus(m.filteredIntents, m.dungeonExpanded)
+		return
+	}
+	m.groups = groupIntentsByStatus(m.filteredIntents, m.dungeonExpanded)
+}
+
+func (m *Model) hasNotesGroup() bool {
+	for _, group := range m.groups {
+		if group.Status.IsNote() {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/intent/tui/explorer/model.go
+++ b/internal/intent/tui/explorer/model.go
@@ -30,6 +30,7 @@ const (
 	focusAddTUI        // Full add TUI is active
 	focusPromoteTarget // Promote target picker
 	focusDungeonReason // Text input for dungeon move reason
+	focusConvertType   // Type picker for converting a note into an intent
 )
 
 // IntentGroup represents a collapsible group of intents by status.
@@ -152,6 +153,13 @@ type Model struct {
 	addModel  *tui.IntentAddModel
 	author    string
 	shortcuts map[string]string
+
+	// Notes view: when true the explorer lists notes instead of intents
+	notesMode bool
+
+	// Convert action state (note → intent)
+	noteToConvert  *intent.Intent
+	convertTypeIdx int
 }
 
 // NewModel creates a new Explorer model.
@@ -199,9 +207,15 @@ func (m Model) Init() tea.Cmd {
 	return m.loadIntents()
 }
 
-// loadIntents returns a command that loads intents from the service.
+// loadIntents returns a command that loads intents from the service. In notes
+// mode it loads the note store instead, so the default view stays intents-only.
 func (m Model) loadIntents() tea.Cmd {
+	notesMode := m.notesMode
 	return func() tea.Msg {
+		if notesMode {
+			notes, err := m.service.ListNotes(m.ctx, true)
+			return intentsLoadedMsg{intents: notes, err: err}
+		}
 		intents, err := m.service.List(m.ctx, nil)
 		return intentsLoadedMsg{intents: intents, err: err}
 	}
@@ -244,6 +258,11 @@ func (m Model) View() string {
 	// Show move status picker if active
 	if m.focus == focusMove {
 		return m.viewMove()
+	}
+
+	// Show convert type picker if active
+	if m.focus == focusConvertType {
+		return m.viewConvert()
 	}
 
 	// Show confirmation dialog if active

--- a/internal/intent/tui/explorer/navigation.go
+++ b/internal/intent/tui/explorer/navigation.go
@@ -27,7 +27,7 @@ func (m *Model) placeCursorAtFirstItem() bool {
 		// Auto-expand the Dungeon parent if it holds the only matches.
 		if m.groups[gi].IsDungeonParent && m.groups[gi].DungeonCount > 0 && !m.dungeonExpanded {
 			m.dungeonExpanded = true
-			m.groups = groupIntentsByStatus(m.filteredIntents, m.dungeonExpanded)
+			m.rebuildStatusGroups()
 			// Restart with the rebuilt slice — dungeon children are now present.
 			return m.placeCursorAtFirstItem()
 		}
@@ -251,7 +251,7 @@ func (m *Model) handleSelect() {
 		if group.IsDungeonParent {
 			// Toggle dungeon expansion and rebuild groups
 			m.dungeonExpanded = !m.dungeonExpanded
-			m.groups = groupIntentsByStatus(m.filteredIntents, m.dungeonExpanded)
+			m.rebuildStatusGroups()
 			m.ensureCursorVisible()
 			return
 		}

--- a/internal/intent/tui/explorer/notes_view.go
+++ b/internal/intent/tui/explorer/notes_view.go
@@ -59,8 +59,16 @@ func (m *Model) startConvert() {
 	if selected == nil {
 		return
 	}
+	m.startConvertToStatus(selected, intent.StatusInbox)
+}
+
+func (m *Model) startConvertToStatus(selected *intent.Intent, targetStatus intent.Status) {
+	if selected == nil {
+		return
+	}
 	m.noteToConvert = selected
 	m.convertTypeIdx = 0
+	m.convertTargetStatus = targetStatus
 	m.focus = focusConvertType
 }
 
@@ -70,6 +78,7 @@ func (m *Model) updateConvert(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "esc":
 		m.focus = focusList
 		m.noteToConvert = nil
+		m.convertTargetStatus = ""
 		return m, nil
 	case "j", "down":
 		if m.convertTypeIdx < len(convertTypeOptions)-1 {
@@ -83,26 +92,31 @@ func (m *Model) updateConvert(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.noteToConvert != nil {
 			note := m.noteToConvert
 			newType := convertTypeOptions[m.convertTypeIdx].typ
+			targetStatus := m.convertTargetStatus
+			if targetStatus == "" {
+				targetStatus = intent.StatusInbox
+			}
 			m.focus = focusList
 			m.noteToConvert = nil
-			return m, m.convertNote(note, newType)
+			m.convertTargetStatus = ""
+			return m, m.convertNote(note, newType, targetStatus)
 		}
 	}
 	return m, nil
 }
 
 // convertNote runs the conversion and emits a moveFinishedMsg so the list reloads.
-func (m *Model) convertNote(note *intent.Intent, newType intent.Type) tea.Cmd {
+func (m *Model) convertNote(note *intent.Intent, newType intent.Type, targetStatus intent.Status) tea.Cmd {
 	return func() tea.Msg {
 		sourcePath := note.Path
-		converted, err := m.service.Convert(m.ctx, note.ID, newType)
+		converted, err := m.service.MoveNoteToStatus(m.ctx, note.ID, targetStatus, newType)
 		if err == nil {
 			err = m.appendAuditEvent(audit.Event{
 				Type:   audit.EventMove,
 				ID:     note.ID,
 				Title:  note.Title,
 				From:   string(intent.StatusNote),
-				To:     string(intent.StatusInbox),
+				To:     string(targetStatus),
 				Reason: "converted note to " + string(newType),
 			})
 		}
@@ -112,7 +126,7 @@ func (m *Model) convertNote(note *intent.Intent, newType intent.Type) tea.Cmd {
 		return moveFinishedMsg{
 			err:       err,
 			intentID:  note.ID,
-			newStatus: intent.StatusInbox,
+			newStatus: targetStatus,
 		}
 	}
 }
@@ -121,11 +135,19 @@ func (m *Model) convertNote(note *intent.Intent, newType intent.Type) tea.Cmd {
 func (m *Model) viewConvert() string {
 	var b strings.Builder
 
-	b.WriteString(tui.TitleStyle.Render("Convert Note to Intent"))
+	title := "Convert Note to Intent"
+	if m.convertTargetStatus != "" && m.convertTargetStatus != intent.StatusInbox {
+		title = "Move Note to " + m.convertTargetStatus.String()
+	}
+	b.WriteString(tui.TitleStyle.Render(title))
 	b.WriteString("\n\n")
 
 	if m.noteToConvert != nil {
 		b.WriteString("Note: " + m.noteToConvert.Title + "\n\n")
+	}
+
+	if m.convertTargetStatus != "" {
+		b.WriteString("Moving to: " + m.convertTargetStatus.String() + "\n\n")
 	}
 
 	b.WriteString("Select intent type:\n")

--- a/internal/intent/tui/explorer/notes_view.go
+++ b/internal/intent/tui/explorer/notes_view.go
@@ -1,0 +1,143 @@
+package explorer
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Obedience-Corp/camp/internal/git/commit"
+	"github.com/Obedience-Corp/camp/internal/intent"
+	"github.com/Obedience-Corp/camp/internal/intent/audit"
+	"github.com/Obedience-Corp/camp/internal/intent/tui"
+)
+
+// convertTypeOptions are the intent types a note can be converted into.
+var convertTypeOptions = []struct {
+	name string
+	typ  intent.Type
+}{
+	{"Idea", intent.TypeIdea},
+	{"Feature", intent.TypeFeature},
+	{"Bug", intent.TypeBug},
+	{"Research", intent.TypeResearch},
+	{"Chore", intent.TypeChore},
+}
+
+// groupNotes organizes notes into Notes and Archived groups for the notes view.
+func groupNotes(notes []*intent.Intent) []IntentGroup {
+	groups := []IntentGroup{
+		{Name: "Notes", Status: intent.StatusNote, Expanded: true},
+		{Name: "Archived", Status: intent.StatusNoteArchived, Expanded: true},
+	}
+	for _, n := range notes {
+		idx := 0
+		if n.Status == intent.StatusNoteArchived {
+			idx = 1
+		}
+		groups[idx].Intents = append(groups[idx].Intents, n)
+	}
+	return groups
+}
+
+// toggleNotesMode switches between the intent triage view and the notes view,
+// resets the cursor, and reloads the list.
+func (m *Model) toggleNotesMode() tea.Cmd {
+	m.notesMode = !m.notesMode
+	m.cursorGroup = 0
+	m.cursorItem = -1
+	if m.notesMode {
+		m.statusMessage = "Notes view"
+	} else {
+		m.statusMessage = "Intents view"
+	}
+	return m.loadIntents()
+}
+
+// startConvert opens the type picker to convert the selected note into an intent.
+func (m *Model) startConvert() {
+	selected := m.SelectedIntent()
+	if selected == nil {
+		return
+	}
+	m.noteToConvert = selected
+	m.convertTypeIdx = 0
+	m.focus = focusConvertType
+}
+
+// updateConvert handles key input while picking a type for note conversion.
+func (m *Model) updateConvert(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.focus = focusList
+		m.noteToConvert = nil
+		return m, nil
+	case "j", "down":
+		if m.convertTypeIdx < len(convertTypeOptions)-1 {
+			m.convertTypeIdx++
+		}
+	case "k", "up":
+		if m.convertTypeIdx > 0 {
+			m.convertTypeIdx--
+		}
+	case "enter":
+		if m.noteToConvert != nil {
+			note := m.noteToConvert
+			newType := convertTypeOptions[m.convertTypeIdx].typ
+			m.focus = focusList
+			m.noteToConvert = nil
+			return m, m.convertNote(note, newType)
+		}
+	}
+	return m, nil
+}
+
+// convertNote runs the conversion and emits a moveFinishedMsg so the list reloads.
+func (m *Model) convertNote(note *intent.Intent, newType intent.Type) tea.Cmd {
+	return func() tea.Msg {
+		sourcePath := note.Path
+		converted, err := m.service.Convert(m.ctx, note.ID, newType)
+		if err == nil {
+			err = m.appendAuditEvent(audit.Event{
+				Type:   audit.EventMove,
+				ID:     note.ID,
+				Title:  note.Title,
+				From:   string(intent.StatusNote),
+				To:     string(intent.StatusInbox),
+				Reason: "converted note to " + string(newType),
+			})
+		}
+		if err == nil {
+			m.autoCommitIntent(commit.IntentMove, note.Title, "Converted note to "+string(newType)+" intent", sourcePath, converted.Path)
+		}
+		return moveFinishedMsg{
+			err:       err,
+			intentID:  note.ID,
+			newStatus: intent.StatusInbox,
+		}
+	}
+}
+
+// viewConvert renders the convert type picker.
+func (m *Model) viewConvert() string {
+	var b strings.Builder
+
+	b.WriteString(tui.TitleStyle.Render("Convert Note to Intent"))
+	b.WriteString("\n\n")
+
+	if m.noteToConvert != nil {
+		b.WriteString("Note: " + m.noteToConvert.Title + "\n\n")
+	}
+
+	b.WriteString("Select intent type:\n")
+	for i, opt := range convertTypeOptions {
+		cursor := "  "
+		if i == m.convertTypeIdx {
+			cursor = "> "
+		}
+		b.WriteString(cursor + opt.name + "\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(tui.HelpStyle.Render("j/k: navigate . Enter: convert . Esc: cancel"))
+
+	return b.String()
+}

--- a/internal/intent/tui/explorer/notes_view_test.go
+++ b/internal/intent/tui/explorer/notes_view_test.go
@@ -29,6 +29,24 @@ func TestGroupNotes_SplitsActiveAndArchived(t *testing.T) {
 	}
 }
 
+func TestGroupExplorerItemsByStatus_PutsNotesFirst(t *testing.T) {
+	items := []*intent.Intent{
+		{ID: "i", Title: "inbox", Status: intent.StatusInbox},
+		{ID: "n", Title: "note", Status: intent.StatusNote},
+	}
+
+	groups := groupExplorerItemsByStatus(items, false)
+	if len(groups) == 0 {
+		t.Fatal("groupExplorerItemsByStatus returned no groups")
+	}
+	if groups[0].Name != "Notes" || groups[0].Status != intent.StatusNote {
+		t.Fatalf("first group = %+v, want Notes group", groups[0])
+	}
+	if len(groups[0].Intents) != 1 || groups[0].Intents[0].ID != "n" {
+		t.Fatalf("Notes group intents = %+v, want note n", groups[0].Intents)
+	}
+}
+
 func TestToggleNotesMode_FlipsAndResetsCursor(t *testing.T) {
 	ctx := context.Background()
 	m := NewModel(ctx, nil, nil, "/tmp/intents", "/tmp/campaign", "test-id", "", nil)
@@ -65,8 +83,7 @@ func TestConvert_TUIFlow_NoteBecomesIntent(t *testing.T) {
 
 	m := NewModel(ctx, svc, nil, intentsDir, "", "", "", nil)
 	m.ready = true
-	m.notesMode = true
-	m.groups = groupNotes([]*intent.Intent{note})
+	m.groups = groupExplorerItemsByStatus([]*intent.Intent{note}, false)
 	m.cursorGroup = 0
 	m.cursorItem = 0
 
@@ -104,5 +121,41 @@ func TestConvert_TUIFlow_NoteBecomesIntent(t *testing.T) {
 	}
 	if got.Type != intent.TypeFeature {
 		t.Errorf("Type = %q, want feature", got.Type)
+	}
+}
+
+func TestUpdateNormal_COnSelectedNoteStartsConvert(t *testing.T) {
+	ctx := context.Background()
+	note := &intent.Intent{ID: "n", Title: "note", Status: intent.StatusNote}
+	m := NewModel(ctx, nil, nil, "/tmp/intents", "", "", "", nil)
+	m.ready = true
+	m.groups = groupExplorerItemsByStatus([]*intent.Intent{note}, false)
+	m.cursorGroup = 0
+	m.cursorItem = 0
+
+	updated, _ := m.updateNormal(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	got := updated.(Model)
+	if got.focus != focusConvertType {
+		t.Fatalf("focus = %v, want focusConvertType", got.focus)
+	}
+	if got.noteToConvert == nil || got.noteToConvert.ID != "n" {
+		t.Fatalf("noteToConvert = %+v, want note n", got.noteToConvert)
+	}
+}
+
+func TestStartAddTUI_FromNotesGroupUsesNoteMode(t *testing.T) {
+	ctx := context.Background()
+	m := NewModel(ctx, nil, nil, "/tmp/intents", "", "", "", nil)
+	m.ready = true
+	m.groups = groupExplorerItemsByStatus(nil, false)
+	m.cursorGroup = 0
+	m.cursorItem = -1
+
+	m.startAddTUI()
+	if !m.addNoteMode {
+		t.Fatal("startAddTUI from Notes group should enable note mode")
+	}
+	if m.addModel == nil {
+		t.Fatal("startAddTUI did not create an add model")
 	}
 }

--- a/internal/intent/tui/explorer/notes_view_test.go
+++ b/internal/intent/tui/explorer/notes_view_test.go
@@ -1,0 +1,108 @@
+package explorer
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Obedience-Corp/camp/internal/intent"
+)
+
+func TestGroupNotes_SplitsActiveAndArchived(t *testing.T) {
+	notes := []*intent.Intent{
+		{ID: "a", Title: "active note", Status: intent.StatusNote},
+		{ID: "b", Title: "archived note", Status: intent.StatusNoteArchived},
+	}
+	groups := groupNotes(notes)
+	if len(groups) != 2 {
+		t.Fatalf("groupNotes returned %d groups, want 2", len(groups))
+	}
+	if groups[0].Name != "Notes" || len(groups[0].Intents) != 1 {
+		t.Errorf("Notes group = %+v, want 1 active note", groups[0])
+	}
+	if groups[1].Name != "Archived" || len(groups[1].Intents) != 1 {
+		t.Errorf("Archived group = %+v, want 1 archived note", groups[1])
+	}
+}
+
+func TestToggleNotesMode_FlipsAndResetsCursor(t *testing.T) {
+	ctx := context.Background()
+	m := NewModel(ctx, nil, nil, "/tmp/intents", "/tmp/campaign", "test-id", "", nil)
+	m.cursorGroup = 3
+	m.cursorItem = 2
+
+	m.toggleNotesMode()
+	if !m.notesMode {
+		t.Error("toggleNotesMode did not enable notes mode")
+	}
+	if m.cursorGroup != 0 || m.cursorItem != -1 {
+		t.Errorf("cursor not reset: group=%d item=%d", m.cursorGroup, m.cursorItem)
+	}
+
+	m.toggleNotesMode()
+	if m.notesMode {
+		t.Error("second toggle did not disable notes mode")
+	}
+}
+
+func TestConvert_TUIFlow_NoteBecomesIntent(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := intent.NewIntentService(tmp, intentsDir)
+
+	note, err := svc.CreateNote(ctx, intent.CreateOptions{
+		Title:     "actionable note",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	m := NewModel(ctx, svc, nil, intentsDir, "", "", "", nil)
+	m.ready = true
+	m.notesMode = true
+	m.groups = groupNotes([]*intent.Intent{note})
+	m.cursorGroup = 0
+	m.cursorItem = 0
+
+	// Open the convert picker, pick Feature (index 1), and confirm.
+	m.startConvert()
+	if m.focus != focusConvertType {
+		t.Fatalf("focus = %v, want focusConvertType", m.focus)
+	}
+	updated, _ := m.updateConvert(tea.KeyMsg{Type: tea.KeyDown})
+	mp := updated.(*Model)
+	convertModel, cmd := mp.updateConvert(tea.KeyMsg{Type: tea.KeyEnter})
+	_ = convertModel
+	if cmd == nil {
+		t.Fatal("convert produced no command")
+	}
+
+	// Execute the async convert command.
+	msg := cmd()
+	if fin, ok := msg.(moveFinishedMsg); !ok {
+		t.Fatalf("expected moveFinishedMsg, got %T", msg)
+	} else if fin.err != nil {
+		t.Fatalf("convert failed: %v", fin.err)
+	}
+
+	// The note is gone from the note store and now an intent in inbox.
+	if _, err := svc.GetNote(ctx, note.ID); !errors.Is(err, intent.ErrNotFound) {
+		t.Errorf("note still in note store, err = %v", err)
+	}
+	got, err := svc.Get(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("converted intent not found: %v", err)
+	}
+	if got.Status != intent.StatusInbox {
+		t.Errorf("Status = %q, want inbox", got.Status)
+	}
+	if got.Type != intent.TypeFeature {
+		t.Errorf("Type = %q, want feature", got.Type)
+	}
+}

--- a/internal/intent/tui/explorer/notes_view_test.go
+++ b/internal/intent/tui/explorer/notes_view_test.go
@@ -124,6 +124,112 @@ func TestConvert_TUIFlow_NoteBecomesIntent(t *testing.T) {
 	}
 }
 
+func TestMove_TUIFlow_IntentBecomesNote(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := intent.NewIntentService(tmp, intentsDir)
+
+	created, err := svc.CreateDirect(ctx, intent.CreateOptions{
+		Title:     "not actionable anymore",
+		Type:      intent.TypeFeature,
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+
+	m := NewModel(ctx, svc, nil, intentsDir, "", "", "", nil)
+	m.ready = true
+	m.intentToMove = created
+	m.focus = focusMove
+	m.moveStatusIdx = moveStatusIndex(t, m.currentMoveStatusOptions(), intent.StatusNote)
+
+	updated, cmd := m.updateMove(tea.KeyMsg{Type: tea.KeyEnter})
+	_ = updated
+	if cmd == nil {
+		t.Fatal("move to notes produced no command")
+	}
+	msg := cmd()
+	if fin, ok := msg.(moveFinishedMsg); !ok {
+		t.Fatalf("expected moveFinishedMsg, got %T", msg)
+	} else if fin.err != nil {
+		t.Fatalf("move to notes failed: %v", fin.err)
+	}
+
+	if _, err := svc.Get(ctx, created.ID); !errors.Is(err, intent.ErrNotFound) {
+		t.Errorf("intent still resolves after move to note, err = %v", err)
+	}
+	note, err := svc.GetNote(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("GetNote after move: %v", err)
+	}
+	if note.Status != intent.StatusNote {
+		t.Errorf("Status = %q, want notes", note.Status)
+	}
+	if note.Type != "" {
+		t.Errorf("Type = %q, want empty for note", note.Type)
+	}
+}
+
+func TestMove_TUIFlow_NoteBecomesReadyIntent(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := intent.NewIntentService(tmp, intentsDir)
+
+	note, err := svc.CreateNote(ctx, intent.CreateOptions{
+		Title:     "ready from notes",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	m := NewModel(ctx, svc, nil, intentsDir, "", "", "", nil)
+	m.ready = true
+	m.intentToMove = note
+	m.focus = focusMove
+	m.moveStatusIdx = moveStatusIndex(t, m.currentMoveStatusOptions(), intent.StatusReady)
+
+	updated, cmd := m.updateMove(tea.KeyMsg{Type: tea.KeyEnter})
+	got := updated.(*Model)
+	if cmd != nil {
+		t.Fatal("note move should open type picker before producing command")
+	}
+	if got.focus != focusConvertType {
+		t.Fatalf("focus = %v, want focusConvertType", got.focus)
+	}
+	if got.convertTargetStatus != intent.StatusReady {
+		t.Fatalf("convertTargetStatus = %q, want ready", got.convertTargetStatus)
+	}
+
+	updated, _ = got.updateConvert(tea.KeyMsg{Type: tea.KeyDown}) // Feature
+	got = updated.(*Model)
+	updated, cmd = got.updateConvert(tea.KeyMsg{Type: tea.KeyEnter})
+	_ = updated
+	if cmd == nil {
+		t.Fatal("confirming note move produced no command")
+	}
+	msg := cmd()
+	if fin, ok := msg.(moveFinishedMsg); !ok {
+		t.Fatalf("expected moveFinishedMsg, got %T", msg)
+	} else if fin.err != nil {
+		t.Fatalf("move from note failed: %v", fin.err)
+	}
+
+	converted, err := svc.Get(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("Get converted intent: %v", err)
+	}
+	if converted.Status != intent.StatusReady {
+		t.Errorf("Status = %q, want ready", converted.Status)
+	}
+	if converted.Type != intent.TypeFeature {
+		t.Errorf("Type = %q, want feature", converted.Type)
+	}
+}
+
 func TestUpdateNormal_COnSelectedNoteStartsConvert(t *testing.T) {
 	ctx := context.Background()
 	note := &intent.Intent{ID: "n", Title: "note", Status: intent.StatusNote}
@@ -143,6 +249,25 @@ func TestUpdateNormal_COnSelectedNoteStartsConvert(t *testing.T) {
 	}
 }
 
+func TestUpdateNormal_MOnSelectedNoteStartsMove(t *testing.T) {
+	ctx := context.Background()
+	note := &intent.Intent{ID: "n", Title: "note", Status: intent.StatusNote}
+	m := NewModel(ctx, nil, nil, "/tmp/intents", "", "", "", nil)
+	m.ready = true
+	m.groups = groupExplorerItemsByStatus([]*intent.Intent{note}, false)
+	m.cursorGroup = 0
+	m.cursorItem = 0
+
+	updated, _ := m.updateNormal(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'m'}})
+	got := updated.(Model)
+	if got.focus != focusMove {
+		t.Fatalf("focus = %v, want focusMove", got.focus)
+	}
+	if got.intentToMove == nil || got.intentToMove.ID != "n" {
+		t.Fatalf("intentToMove = %+v, want note n", got.intentToMove)
+	}
+}
+
 func TestStartAddTUI_FromNotesGroupUsesNoteMode(t *testing.T) {
 	ctx := context.Background()
 	m := NewModel(ctx, nil, nil, "/tmp/intents", "", "", "", nil)
@@ -158,4 +283,15 @@ func TestStartAddTUI_FromNotesGroupUsesNoteMode(t *testing.T) {
 	if m.addModel == nil {
 		t.Fatal("startAddTUI did not create an add model")
 	}
+}
+
+func moveStatusIndex(t *testing.T, options []moveStatusOption, status intent.Status) int {
+	t.Helper()
+	for i, opt := range options {
+		if opt.status == status {
+			return i
+		}
+	}
+	t.Fatalf("status %q not found in move options %+v", status, options)
+	return -1
 }

--- a/internal/intent/tui/explorer/rename.go
+++ b/internal/intent/tui/explorer/rename.go
@@ -1,0 +1,109 @@
+package explorer
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Obedience-Corp/camp/internal/git/commit"
+	"github.com/Obedience-Corp/camp/internal/intent"
+	"github.com/Obedience-Corp/camp/internal/intent/audit"
+	"github.com/Obedience-Corp/camp/internal/intent/tui"
+)
+
+// renameFinishedMsg signals that a rename finished. renamedID carries the
+// stable id so the list can reselect the renamed item.
+type renameFinishedMsg struct {
+	err       error
+	renamedID string
+}
+
+// startRename opens the rename overlay prefilled with the selected item's title.
+func (m *Model) startRename() {
+	selected := m.SelectedIntent()
+	if selected == nil {
+		return
+	}
+	m.renameTarget = selected
+	ti := textinput.New()
+	ti.CharLimit = 100
+	ti.Width = 60
+	ti.SetValue(selected.Title)
+	ti.CursorEnd()
+	ti.Focus()
+	m.renameInput = ti
+	m.focus = focusRename
+}
+
+// updateRename handles keys while the rename input is active.
+func (m *Model) updateRename(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "ctrl+c":
+		m.focus = focusList
+		m.renameTarget = nil
+		return m, nil
+	case "enter":
+		newTitle := strings.TrimSpace(m.renameInput.Value())
+		target := m.renameTarget
+		m.focus = focusList
+		m.renameTarget = nil
+		if target == nil || newTitle == "" || newTitle == target.Title {
+			return m, nil
+		}
+		return m, m.renameIntent(target, newTitle)
+	}
+	var cmd tea.Cmd
+	m.renameInput, cmd = m.renameInput.Update(msg)
+	return m, cmd
+}
+
+// renameIntent runs the rename and emits a renameFinishedMsg.
+func (m *Model) renameIntent(target *intent.Intent, newTitle string) tea.Cmd {
+	return func() tea.Msg {
+		oldTitle := target.Title
+		oldPath := target.Path
+		renamed, err := m.service.Rename(m.ctx, target.ID, newTitle)
+		if err != nil {
+			return renameFinishedMsg{err: err}
+		}
+		_ = m.appendAuditEvent(audit.Event{
+			Type:  audit.EventRename,
+			ID:    renamed.ID,
+			Title: renamed.Title,
+			Changes: []audit.FieldChange{
+				{Field: "title", Old: oldTitle, New: renamed.Title},
+			},
+		})
+		m.autoCommitIntent(commit.IntentRename, renamed.Title, "Renamed from "+oldTitle, oldPath, renamed.Path)
+		return renameFinishedMsg{renamedID: renamed.ID}
+	}
+}
+
+// viewRename renders the rename input overlay.
+func (m *Model) viewRename() string {
+	var b strings.Builder
+	b.WriteString(tui.TitleStyle.Render("Rename Intent"))
+	b.WriteString("\n\n")
+	if m.renameTarget != nil {
+		b.WriteString(tui.HelpStyle.Render("Current: ") + m.renameTarget.Title + "\n\n")
+	}
+	b.WriteString("New title:\n")
+	b.WriteString(m.renameInput.View())
+	b.WriteString("\n\n")
+	b.WriteString(tui.HelpStyle.Render("Enter: rename . Esc: cancel"))
+	return b.String()
+}
+
+// reselectByID moves the cursor to the item with the given id after a reload.
+func (m *Model) reselectByID(id string) {
+	for gi := range m.groups {
+		for ii, it := range m.groups[gi].Intents {
+			if it.ID == id {
+				m.cursorGroup = gi
+				m.cursorItem = ii
+				return
+			}
+		}
+	}
+}

--- a/internal/intent/tui/explorer/rename_test.go
+++ b/internal/intent/tui/explorer/rename_test.go
@@ -1,0 +1,77 @@
+package explorer
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Obedience-Corp/camp/internal/intent"
+)
+
+func TestRenameAction_RenamesViaServiceAndReselects(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := intent.NewIntentService(tmp, intentsDir)
+
+	created, err := svc.CreateDirect(ctx, intent.CreateOptions{
+		Title:     "old title",
+		Type:      intent.TypeIdea,
+		Timestamp: time.Date(2026, 1, 19, 15, 34, 12, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+
+	m := NewModel(ctx, svc, nil, intentsDir, "", "", "", nil)
+	m.ready = true
+	m.groups = groupIntentsByStatus([]*intent.Intent{created}, false)
+	// Select the created intent (Inbox group, first item).
+	m.cursorGroup = 0
+	m.cursorItem = 0
+
+	m.startRename()
+	if m.focus != focusRename {
+		t.Fatalf("focus = %v, want focusRename", m.focus)
+	}
+	if m.renameInput.Value() != "old title" {
+		t.Fatalf("rename input not prefilled: %q", m.renameInput.Value())
+	}
+
+	// Replace the title and confirm.
+	m.renameInput.SetValue("brand new title")
+	updated, cmd := m.updateRename(tea.KeyMsg{Type: tea.KeyEnter})
+	mp := updated.(*Model)
+	if cmd == nil {
+		t.Fatal("rename produced no command")
+	}
+	msg := cmd()
+	fin, ok := msg.(renameFinishedMsg)
+	if !ok || fin.err != nil {
+		t.Fatalf("rename failed: %#v", msg)
+	}
+
+	// The service-level rename took effect.
+	got, err := svc.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get after rename: %v", err)
+	}
+	if got.Title != "brand new title" {
+		t.Errorf("title = %q, want renamed", got.Title)
+	}
+	if !strings.HasPrefix(filepath.Base(got.Path), "brand-new-title-") {
+		t.Errorf("filename not regenerated: %q", filepath.Base(got.Path))
+	}
+
+	// Simulate the reload + reselect path.
+	mp.pendingReselectID = fin.renamedID
+	reloaded, _ := mp.Update(intentsLoadedMsg{intents: []*intent.Intent{got}})
+	rm := reloaded.(Model)
+	if sel := rm.SelectedIntent(); sel == nil || sel.ID != created.ID {
+		t.Errorf("renamed intent not reselected after reload")
+	}
+}

--- a/internal/intent/tui/explorer/render.go
+++ b/internal/intent/tui/explorer/render.go
@@ -42,7 +42,11 @@ func (m *Model) renderIntentRow(i *intent.Intent, isSelected bool, maxTitleWidth
 
 	// Build row parts
 	titlePart := tui.IntentTitleStyle.Render(title)
-	typePart := tui.IntentTypeStyle.Render(fmt.Sprintf("[%s]", i.Type))
+	typeLabel := string(i.Type)
+	if i.Status.IsNote() {
+		typeLabel = "note"
+	}
+	typePart := tui.IntentTypeStyle.Render(fmt.Sprintf("[%s]", typeLabel))
 	datePart := tui.IntentDateStyle.Render(date)
 
 	var row string

--- a/internal/intent/tui/explorer/tags.go
+++ b/internal/intent/tui/explorer/tags.go
@@ -1,0 +1,83 @@
+package explorer
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Obedience-Corp/camp/internal/git/commit"
+	"github.com/Obedience-Corp/camp/internal/intent"
+	"github.com/Obedience-Corp/camp/internal/intent/audit"
+	"github.com/Obedience-Corp/camp/internal/intent/tui"
+)
+
+// tagsUpdatedMsg signals that a tag edit finished.
+type tagsUpdatedMsg struct {
+	err error
+}
+
+// startTagEdit opens the tag overlay for the selected intent or note.
+func (m *Model) startTagEdit() {
+	selected := m.SelectedIntent()
+	if selected == nil {
+		return
+	}
+	m.tagTarget = selected
+	m.tagOverlay = tui.NewTagOverlay(m.availableTags, selected.Tags)
+	m.tagging = true
+}
+
+// updateTagEdit routes keys to the overlay and persists on confirm.
+func (m *Model) updateTagEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	var done bool
+	m.tagOverlay, done = m.tagOverlay.Update(msg)
+	if !done {
+		return m, nil
+	}
+
+	m.tagging = false
+	if m.tagOverlay.Cancelled() || m.tagTarget == nil {
+		m.tagTarget = nil
+		return m, nil
+	}
+
+	target := m.tagTarget
+	tags := m.tagOverlay.Result()
+	m.tagTarget = nil
+	return m, m.persistTags(target, tags)
+}
+
+// persistTags writes the new tag set. Notes are saved directly (they live
+// outside the intent lookup); intents go through UpdateDirect for auditing.
+func (m *Model) persistTags(target *intent.Intent, tags []string) tea.Cmd {
+	return func() tea.Msg {
+		if target.Status.IsNote() {
+			note, err := m.service.GetNote(m.ctx, target.ID)
+			if err != nil {
+				return tagsUpdatedMsg{err: err}
+			}
+			note.Tags = tags
+			if err := m.service.Save(m.ctx, note); err != nil {
+				return tagsUpdatedMsg{err: err}
+			}
+			return tagsUpdatedMsg{}
+		}
+
+		updated, changes, err := m.service.UpdateDirect(m.ctx, target.ID, intent.UpdateOptions{Tags: &tags})
+		if err != nil {
+			return tagsUpdatedMsg{err: err}
+		}
+		if len(changes) > 0 {
+			_ = m.appendAuditEvent(audit.Event{Type: audit.EventEdit, ID: updated.ID, Title: updated.Title, Changes: changes})
+			m.autoCommitIntent(commit.IntentEdit, updated.Title, "Updated tags", updated.Path)
+		}
+		return tagsUpdatedMsg{}
+	}
+}
+
+// viewTagEdit renders the tag overlay with the target's title as a header.
+func (m *Model) viewTagEdit() string {
+	header := ""
+	if m.tagTarget != nil {
+		header = tui.HelpStyle.Render("Editing tags: ") + m.tagTarget.Title + "\n\n"
+	}
+	return header + m.tagOverlay.View()
+}

--- a/internal/intent/tui/explorer/tags.go
+++ b/internal/intent/tui/explorer/tags.go
@@ -45,23 +45,21 @@ func (m *Model) updateTagEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, m.persistTags(target, tags)
 }
 
-// persistTags writes the new tag set. Notes are saved directly (they live
-// outside the intent lookup); intents go through UpdateDirect for auditing.
+// persistTags writes the new tag set. Notes resolve through the note store and
+// intents through the lifecycle id index, but both normalize/validate tags,
+// refresh updated_at, and emit the same audit/commit side effects.
 func (m *Model) persistTags(target *intent.Intent, tags []string) tea.Cmd {
 	return func() tea.Msg {
+		var (
+			updated *intent.Intent
+			changes []audit.FieldChange
+			err     error
+		)
 		if target.Status.IsNote() {
-			note, err := m.service.GetNote(m.ctx, target.ID)
-			if err != nil {
-				return tagsUpdatedMsg{err: err}
-			}
-			note.Tags = tags
-			if err := m.service.Save(m.ctx, note); err != nil {
-				return tagsUpdatedMsg{err: err}
-			}
-			return tagsUpdatedMsg{}
+			updated, changes, err = m.service.UpdateNoteTags(m.ctx, target.ID, tags)
+		} else {
+			updated, changes, err = m.service.UpdateDirect(m.ctx, target.ID, intent.UpdateOptions{Tags: &tags})
 		}
-
-		updated, changes, err := m.service.UpdateDirect(m.ctx, target.ID, intent.UpdateOptions{Tags: &tags})
 		if err != nil {
 			return tagsUpdatedMsg{err: err}
 		}

--- a/internal/intent/tui/explorer/tags_test.go
+++ b/internal/intent/tui/explorer/tags_test.go
@@ -1,0 +1,69 @@
+package explorer
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Obedience-Corp/camp/internal/intent"
+)
+
+func TestPersistTags_Intent(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := intent.NewIntentService(tmp, intentsDir)
+
+	created, err := svc.CreateDirect(ctx, intent.CreateOptions{
+		Title:     "taggable intent",
+		Type:      intent.TypeIdea,
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+
+	m := NewModel(ctx, svc, nil, intentsDir, "", "", "", nil)
+	cmd := m.persistTags(created, []string{"personal", "follow-up"})
+	if msg, ok := cmd().(tagsUpdatedMsg); !ok || msg.err != nil {
+		t.Fatalf("persistTags failed: %#v", cmd())
+	}
+
+	reloaded, err := svc.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(reloaded.Tags) != 2 {
+		t.Fatalf("tags = %v, want 2", reloaded.Tags)
+	}
+}
+
+func TestPersistTags_Note(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := intent.NewIntentService(tmp, intentsDir)
+
+	note, err := svc.CreateNote(ctx, intent.CreateOptions{
+		Title:     "taggable note",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	m := NewModel(ctx, svc, nil, intentsDir, "", "", "", nil)
+	cmd := m.persistTags(note, []string{"reference"})
+	if msg, ok := cmd().(tagsUpdatedMsg); !ok || msg.err != nil {
+		t.Fatalf("persistTags failed: %#v", cmd())
+	}
+
+	reloaded, err := svc.GetNote(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("GetNote: %v", err)
+	}
+	if len(reloaded.Tags) != 1 || reloaded.Tags[0] != "reference" {
+		t.Fatalf("note tags = %v, want [reference]", reloaded.Tags)
+	}
+}

--- a/internal/intent/tui/explorer/update.go
+++ b/internal/intent/tui/explorer/update.go
@@ -44,6 +44,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateDungeonReason(msg)
 		}
 
+		if m.focus == focusConvertType {
+			return m.updateConvert(msg)
+		}
+
 		if m.focus == focusMove {
 			return m.updateMove(msg)
 		}
@@ -95,7 +99,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.intents = msg.intents
 		m.filteredIntents = msg.intents
-		m.groups = groupIntentsByStatus(msg.intents, m.dungeonExpanded)
+		if m.notesMode {
+			m.groups = groupNotes(msg.intents)
+		} else {
+			m.groups = groupIntentsByStatus(msg.intents, m.dungeonExpanded)
+		}
 
 	case editorFinishedMsg:
 		if msg.err != nil {

--- a/internal/intent/tui/explorer/update.go
+++ b/internal/intent/tui/explorer/update.go
@@ -52,6 +52,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateTagEdit(msg)
 		}
 
+		if m.focus == focusRename {
+			return m.updateRename(msg)
+		}
+
 		if m.focus == focusMove {
 			return m.updateMove(msg)
 		}
@@ -107,6 +111,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.groups = groupNotes(msg.intents)
 		} else {
 			m.groups = groupIntentsByStatus(msg.intents, m.dungeonExpanded)
+		}
+		if m.pendingReselectID != "" {
+			m.reselectByID(m.pendingReselectID)
+			m.pendingReselectID = ""
 		}
 
 	case editorFinishedMsg:
@@ -268,6 +276,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.statusMessage = "Tags updated"
 		}
+		return m, m.loadIntents()
+
+	case renameFinishedMsg:
+		if msg.err != nil {
+			m.statusMessage = "Rename failed: " + msg.err.Error()
+			return m, nil
+		}
+		m.statusMessage = "Renamed"
+		m.pendingReselectID = msg.renamedID
 		return m, m.loadIntents()
 
 	case addTUIFinishedMsg:

--- a/internal/intent/tui/explorer/update.go
+++ b/internal/intent/tui/explorer/update.go
@@ -48,6 +48,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateConvert(msg)
 		}
 
+		if m.tagging {
+			return m.updateTagEdit(msg)
+		}
+
 		if m.focus == focusMove {
 			return m.updateMove(msg)
 		}
@@ -256,6 +260,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Exit multi-select mode and clear selections
 		m.exitMultiSelectMode()
+		return m, m.loadIntents()
+
+	case tagsUpdatedMsg:
+		if msg.err != nil {
+			m.statusMessage = "Tag update failed: " + msg.err.Error()
+		} else {
+			m.statusMessage = "Tags updated"
+		}
 		return m, m.loadIntents()
 
 	case addTUIFinishedMsg:

--- a/internal/intent/tui/explorer/update.go
+++ b/internal/intent/tui/explorer/update.go
@@ -110,7 +110,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.notesMode {
 			m.groups = groupNotes(msg.intents)
 		} else {
-			m.groups = groupIntentsByStatus(msg.intents, m.dungeonExpanded)
+			m.groups = groupExplorerItemsByStatus(msg.intents, m.dungeonExpanded)
 		}
 		if m.pendingReselectID != "" {
 			m.reselectByID(m.pendingReselectID)
@@ -318,15 +318,35 @@ func (m Model) handleActionMenuSelection(msg tui.ActionMenuSelectedMsg) (tea.Mod
 		)
 	case "edit":
 		return m, openInEditor(m.ctx, selected.Path)
+	case "convert":
+		if selected.Status.IsNote() {
+			m.startConvert()
+		}
 	case "move":
+		if selected.Status.IsNote() {
+			m.statusMessage = "Convert note to an intent before moving it"
+			return m, nil
+		}
 		m.focus = focusMove
 		m.intentToMove = selected
 		m.moveStatusIdx = 0
 	case "promote":
+		if selected.Status.IsNote() {
+			m.statusMessage = "Convert note to an intent before promoting it"
+			return m, nil
+		}
 		return m.handlePromoteAction()
 	case "archive":
+		if selected.Status.IsNote() {
+			m.statusMessage = "Note archiving is not available in the explorer yet"
+			return m, nil
+		}
 		return m.handleArchiveAction()
 	case "delete":
+		if selected.Status.IsNote() {
+			m.statusMessage = "Note deletion is not available in the explorer yet"
+			return m, nil
+		}
 		m.focus = focusConfirm
 		m.pendingAction = "delete"
 		m.pendingIntent = selected

--- a/internal/intent/tui/explorer/update.go
+++ b/internal/intent/tui/explorer/update.go
@@ -323,10 +323,6 @@ func (m Model) handleActionMenuSelection(msg tui.ActionMenuSelectedMsg) (tea.Mod
 			m.startConvert()
 		}
 	case "move":
-		if selected.Status.IsNote() {
-			m.statusMessage = "Convert note to an intent before moving it"
-			return m, nil
-		}
 		m.focus = focusMove
 		m.intentToMove = selected
 		m.moveStatusIdx = 0

--- a/internal/intent/tui/explorer/update_keys.go
+++ b/internal/intent/tui/explorer/update_keys.go
@@ -99,6 +99,10 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Open the tag overlay on the selected intent or note
 		m.startTagEdit()
 		return m, nil
+	case "R":
+		// Open the rename overlay on the selected intent or note
+		m.startRename()
+		return m, nil
 	case "C":
 		// Clear concept filter
 		m.conceptFilterPath = ""

--- a/internal/intent/tui/explorer/update_keys.go
+++ b/internal/intent/tui/explorer/update_keys.go
@@ -82,9 +82,9 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.focusFilterChip(1)
 		return m, nil
 	case "c":
-		if m.notesMode {
-			// In the notes view, c converts the selected note into an intent
-			// (notes carry no concept, so concept-filtering does not apply).
+		if selected := m.SelectedIntent(); selected != nil && selected.Status.IsNote() {
+			// On notes, c converts the selected note into an intent. Notes carry
+			// no concept, so concept-filtering only applies to lifecycle intents.
 			m.startConvert()
 			return m, nil
 		}
@@ -109,7 +109,8 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.applyFilters()
 		return m, nil
 	case "n":
-		// Launch full add TUI for new intent creation
+		// Launch full add TUI for new intent/note creation. The Notes group
+		// starts note capture; lifecycle groups start intent capture.
 		m.startAddTUI()
 		return m, m.addModel.Init()
 	case "e":
@@ -130,6 +131,10 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "m":
 		// Start move action to change intent status
 		if selected := m.SelectedIntent(); selected != nil {
+			if selected.Status.IsNote() {
+				m.statusMessage = "Convert note to an intent before moving it"
+				return m, nil
+			}
 			m.focus = focusMove
 			m.intentToMove = selected
 			m.moveStatusIdx = 0
@@ -137,12 +142,24 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "p":
 		// Promote to festival (ready intents only)
+		if selected := m.SelectedIntent(); selected != nil && selected.Status.IsNote() {
+			m.statusMessage = "Convert note to an intent before promoting it"
+			return m, nil
+		}
 		return m.handlePromoteAction()
 	case "a":
 		// Archive (move to dungeon/archived) - requires reason
+		if selected := m.SelectedIntent(); selected != nil && selected.Status.IsNote() {
+			m.statusMessage = "Note archiving is not available in the explorer yet"
+			return m, nil
+		}
 		return m.handleArchiveAction()
 	case "d":
 		// Delete intent (permanently) - requires confirmation
+		if selected := m.SelectedIntent(); selected != nil && selected.Status.IsNote() {
+			m.statusMessage = "Note deletion is not available in the explorer yet"
+			return m, nil
+		}
 		return m.handleDeleteAction()
 	case "f":
 		// Open full-screen viewer for selected intent

--- a/internal/intent/tui/explorer/update_keys.go
+++ b/internal/intent/tui/explorer/update_keys.go
@@ -95,6 +95,10 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "N":
 		// Toggle between the intent triage view and the notes view
 		return m, m.toggleNotesMode()
+	case "T":
+		// Open the tag overlay on the selected intent or note
+		m.startTagEdit()
+		return m, nil
 	case "C":
 		// Clear concept filter
 		m.conceptFilterPath = ""

--- a/internal/intent/tui/explorer/update_keys.go
+++ b/internal/intent/tui/explorer/update_keys.go
@@ -82,10 +82,19 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.focusFilterChip(1)
 		return m, nil
 	case "c":
+		if m.notesMode {
+			// In the notes view, c converts the selected note into an intent
+			// (notes carry no concept, so concept-filtering does not apply).
+			m.startConvert()
+			return m, nil
+		}
 		// Enter concept filter mode
 		m.focus = focusConceptFilter
 		m.conceptFilterPicker = tui.NewConceptPickerModel(m.ctx, m.conceptSvc)
 		return m, nil
+	case "N":
+		// Toggle between the intent triage view and the notes view
+		return m, m.toggleNotesMode()
 	case "C":
 		// Clear concept filter
 		m.conceptFilterPath = ""

--- a/internal/intent/tui/explorer/update_keys.go
+++ b/internal/intent/tui/explorer/update_keys.go
@@ -131,10 +131,6 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "m":
 		// Start move action to change intent status
 		if selected := m.SelectedIntent(); selected != nil {
-			if selected.Status.IsNote() {
-				m.statusMessage = "Convert note to an intent before moving it"
-				return m, nil
-			}
 			m.focus = focusMove
 			m.intentToMove = selected
 			m.moveStatusIdx = 0

--- a/internal/intent/tui/tag_overlay.go
+++ b/internal/intent/tui/tag_overlay.go
@@ -1,0 +1,185 @@
+package tui
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TagOverlay is a reusable tag picker: a toggle list over the configured tags
+// plus a text input for a freeform custom tag. It is embedded by the capture
+// flow and the explorer; both route key messages to Update while it is active.
+type TagOverlay struct {
+	order     []string        // display order (configured tags, then custom additions)
+	selected  map[string]bool // which tags are toggled on
+	cursor    int
+	input     textinput.Model
+	inputting bool
+	done      bool
+	cancelled bool
+}
+
+// NewTagOverlay builds an overlay offering available tags, with current already
+// selected. Custom tags present in current but not in available are appended.
+func NewTagOverlay(available, current []string) TagOverlay {
+	selected := make(map[string]bool, len(current))
+	for _, t := range current {
+		selected[t] = true
+	}
+
+	order := make([]string, 0, len(available)+len(current))
+	seen := make(map[string]bool)
+	for _, t := range available {
+		if t == "" || seen[t] {
+			continue
+		}
+		seen[t] = true
+		order = append(order, t)
+	}
+	for _, t := range current {
+		if t == "" || seen[t] {
+			continue
+		}
+		seen[t] = true
+		order = append(order, t)
+	}
+
+	ti := textinput.New()
+	ti.Placeholder = "custom tag"
+	ti.CharLimit = 40
+	ti.Width = 30
+
+	return TagOverlay{order: order, selected: selected, input: ti}
+}
+
+// Update routes a key message. It returns the updated overlay and true once the
+// overlay has finished (confirmed or cancelled).
+func (o TagOverlay) Update(msg tea.KeyMsg) (TagOverlay, bool) {
+	if o.inputting {
+		switch msg.String() {
+		case "enter":
+			o.addCustomTag()
+			return o, false
+		case "esc":
+			o.inputting = false
+			o.input.Blur()
+			o.input.SetValue("")
+			return o, false
+		default:
+			var cmd tea.Cmd
+			o.input, cmd = o.input.Update(msg)
+			_ = cmd
+			return o, false
+		}
+	}
+
+	switch msg.String() {
+	case "esc", "ctrl+c":
+		o.cancelled = true
+		o.done = true
+		return o, true
+	case "enter":
+		o.done = true
+		return o, true
+	case "j", "down":
+		if o.cursor < len(o.order)-1 {
+			o.cursor++
+		}
+	case "k", "up":
+		if o.cursor > 0 {
+			o.cursor--
+		}
+	case " ":
+		if o.cursor >= 0 && o.cursor < len(o.order) {
+			tag := o.order[o.cursor]
+			o.selected[tag] = !o.selected[tag]
+		}
+	case "i", "a", "/":
+		o.inputting = true
+		o.input.Focus()
+	}
+	return o, false
+}
+
+// addCustomTag adds the typed tag (selected) and exits input mode.
+func (o *TagOverlay) addCustomTag() {
+	tag := strings.TrimSpace(o.input.Value())
+	o.input.SetValue("")
+	o.input.Blur()
+	o.inputting = false
+	if tag == "" {
+		return
+	}
+	if !o.selected[tag] {
+		// Append to order only if not already present.
+		known := false
+		for _, t := range o.order {
+			if t == tag {
+				known = true
+				break
+			}
+		}
+		if !known {
+			o.order = append(o.order, tag)
+		}
+	}
+	o.selected[tag] = true
+}
+
+// Result returns the selected tags in a stable, sorted order.
+func (o TagOverlay) Result() []string {
+	tags := make([]string, 0, len(o.selected))
+	for t, on := range o.selected {
+		if on {
+			tags = append(tags, t)
+		}
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+// Cancelled reports whether the overlay was dismissed without confirming.
+func (o TagOverlay) Cancelled() bool { return o.cancelled }
+
+// Done reports whether the overlay has finished.
+func (o TagOverlay) Done() bool { return o.done }
+
+// View renders the overlay.
+func (o TagOverlay) View() string {
+	var b strings.Builder
+	b.WriteString(TitleStyle.Render("Tags"))
+	b.WriteString("\n\n")
+
+	if len(o.order) == 0 {
+		b.WriteString(HelpStyle.Render("No configured tags. Press i to add a custom tag.\n\n"))
+	}
+
+	for i, tag := range o.order {
+		cursor := "  "
+		if i == o.cursor {
+			cursor = "> "
+		}
+		box := "[ ]"
+		if o.selected[tag] {
+			box = "[x]"
+		}
+		line := cursor + box + " " + tag
+		if i == o.cursor {
+			line = lipgloss.NewStyle().Foreground(pal.Accent).Render(line)
+		}
+		b.WriteString(line + "\n")
+	}
+
+	b.WriteString("\n")
+	if o.inputting {
+		b.WriteString("Custom tag: " + o.input.View() + "\n")
+		b.WriteString(HelpStyle.Render("Enter: add . Esc: cancel input"))
+	} else {
+		b.WriteString(HelpStyle.Render("space: toggle . i: custom tag . Enter: confirm . Esc: cancel"))
+	}
+
+	return b.String()
+}

--- a/internal/intent/tui/tag_overlay_test.go
+++ b/internal/intent/tui/tag_overlay_test.go
@@ -1,0 +1,93 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func key(s string) tea.KeyMsg {
+	switch s {
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	case "space":
+		return tea.KeyMsg{Type: tea.KeySpace}
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+}
+
+func TestTagOverlay_ToggleAndConfirm(t *testing.T) {
+	o := NewTagOverlay([]string{"personal", "reference", "question"}, nil)
+
+	// Toggle the first tag on.
+	o, done := o.Update(key("space"))
+	if done {
+		t.Fatal("space should not finish the overlay")
+	}
+	// Move to the third tag and toggle it on.
+	o, _ = o.Update(key("down"))
+	o, _ = o.Update(key("down"))
+	o, _ = o.Update(key("space"))
+
+	o, done = o.Update(key("enter"))
+	if !done {
+		t.Fatal("enter should finish the overlay")
+	}
+	if o.Cancelled() {
+		t.Fatal("enter should not cancel")
+	}
+
+	got := o.Result()
+	if len(got) != 2 || got[0] != "personal" || got[1] != "question" {
+		t.Fatalf("Result = %v, want [personal question]", got)
+	}
+}
+
+func TestTagOverlay_CustomTag(t *testing.T) {
+	o := NewTagOverlay([]string{"personal"}, nil)
+
+	// Enter input mode and type a custom tag.
+	o, _ = o.Update(key("i"))
+	for _, r := range "urgent" {
+		o, _ = o.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	o, _ = o.Update(key("enter")) // add custom tag
+	o, done := o.Update(key("enter"))
+	if !done {
+		t.Fatal("second enter should confirm")
+	}
+
+	got := o.Result()
+	found := false
+	for _, tag := range got {
+		if tag == "urgent" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("custom tag not in result: %v", got)
+	}
+}
+
+func TestTagOverlay_PreselectsCurrent(t *testing.T) {
+	o := NewTagOverlay([]string{"personal", "reference"}, []string{"reference"})
+	o, _ = o.Update(key("enter"))
+	got := o.Result()
+	if len(got) != 1 || got[0] != "reference" {
+		t.Fatalf("Result = %v, want [reference]", got)
+	}
+}
+
+func TestTagOverlay_Cancel(t *testing.T) {
+	o := NewTagOverlay([]string{"personal"}, nil)
+	o, _ = o.Update(key("space"))
+	o, done := o.Update(key("esc"))
+	if !done || !o.Cancelled() {
+		t.Fatalf("esc should finish and cancel: done=%v cancelled=%v", done, o.Cancelled())
+	}
+}

--- a/internal/intent/types.go
+++ b/internal/intent/types.go
@@ -47,7 +47,35 @@ const (
 
 	// StatusSomeday indicates the intent is deferred — maybe later, low priority.
 	StatusSomeday Status = "dungeon/someday"
+
+	// Note statuses (under notes/ directory)
+
+	// StatusNote is the flat note store. Notes are a separate category that sits
+	// outside the inbox/ready/active intent lifecycle.
+	StatusNote Status = "notes"
+
+	// StatusNoteArchived is the archived-note bucket: notes kept but hidden.
+	StatusNoteArchived Status = "notes/archived"
 )
+
+// Category distinguishes the two kinds of captured item: action-oriented
+// intents that flow through the inbox/ready/active lifecycle, and freeform
+// notes that live in a flat notes/ store outside that lifecycle. The directory
+// a file lives in is the source of truth for its category.
+type Category string
+
+const (
+	// CategoryIntent is the default category: an actionable intent.
+	CategoryIntent Category = "intent"
+
+	// CategoryNote is a freeform note, stored under notes/.
+	CategoryNote Category = "note"
+)
+
+// String returns the string representation of Category.
+func (c Category) String() string {
+	return string(c)
+}
 
 // String returns the string representation of Status.
 func (s Status) String() string {
@@ -76,6 +104,27 @@ func ActiveStatuses() []Status {
 // DungeonStatuses returns only the dungeon statuses.
 func DungeonStatuses() []Status {
 	return []Status{StatusDone, StatusKilled, StatusArchived, StatusSomeday}
+}
+
+// NoteStatuses returns the note-category directories (flat active + archived).
+// These are intentionally excluded from AllStatuses so intent queries never
+// scan notes.
+func NoteStatuses() []Status {
+	return []Status{StatusNote, StatusNoteArchived}
+}
+
+// IsNote returns true if the status belongs to the note category.
+func (s Status) IsNote() bool {
+	return s == StatusNote || strings.HasPrefix(string(s), string(StatusNote)+"/")
+}
+
+// Category returns the category implied by the status. The note directories map
+// to CategoryNote; everything else is an intent.
+func (s Status) Category() Category {
+	if s.IsNote() {
+		return CategoryNote
+	}
+	return CategoryIntent
 }
 
 // Type categorizes the nature of work described by an intent.

--- a/internal/intent/update.go
+++ b/internal/intent/update.go
@@ -51,6 +51,14 @@ func (s *IntentService) UpdateDirect(ctx context.Context, id string, opts Update
 		return nil, nil, camperrors.Wrap(camperrors.ErrInvalidInput, "no update fields specified")
 	}
 
+	if opts.Tags != nil {
+		normTags, terr := validateAndNormalizeTags(*opts.Tags)
+		if terr != nil {
+			return nil, nil, terr
+		}
+		opts.Tags = &normTags
+	}
+
 	intent, err := s.Find(ctx, id)
 	if err != nil {
 		return nil, nil, err

--- a/internal/intent/update.go
+++ b/internal/intent/update.go
@@ -130,9 +130,10 @@ func (s *IntentService) UpdateDirect(ctx context.Context, id string, opts Update
 
 	intent.UpdatedAt = time.Now()
 
-	// Handle status change (move to new directory)
+	// Handle status change (move to new directory), preserving the basename so
+	// a renamed slug survives.
 	if intent.Status != originalStatus {
-		newPath := s.getIntentPath(intent.Status, intent.ID)
+		newPath := s.moveTargetPath(intent.Status, originalPath)
 		if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
 			return nil, nil, camperrors.Wrap(err, "creating directory for status change")
 		}

--- a/internal/intent/update.go
+++ b/internal/intent/update.go
@@ -133,7 +133,7 @@ func (s *IntentService) UpdateDirect(ctx context.Context, id string, opts Update
 	// Handle status change (move to new directory), preserving the basename so
 	// a renamed slug survives.
 	if intent.Status != originalStatus {
-		newPath := s.moveTargetPath(intent.Status, originalPath)
+		newPath := s.moveTargetPath(intent.ID, intent.Status, originalPath)
 		if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
 			return nil, nil, camperrors.Wrap(err, "creating directory for status change")
 		}

--- a/internal/intent/update.go
+++ b/internal/intent/update.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -25,13 +27,16 @@ type UpdateOptions struct {
 
 	Priority *Priority
 	Horizon  *Horizon
+
+	Tags *[]string // Replaces the intent's tags
 }
 
 // hasChanges returns true if any field in the options is set.
 func (o *UpdateOptions) hasChanges() bool {
 	return o.Title != nil || o.Body != nil || o.Append != nil ||
 		o.Type != nil || o.Status != nil || o.Concept != nil ||
-		o.Author != nil || o.Priority != nil || o.Horizon != nil
+		o.Author != nil || o.Priority != nil || o.Horizon != nil ||
+		o.Tags != nil
 }
 
 // UpdateDirect applies programmatic field updates to an existing intent
@@ -106,6 +111,11 @@ func (s *IntentService) UpdateDirect(ctx context.Context, id string, opts Update
 	if opts.Horizon != nil && *opts.Horizon != intent.Horizon {
 		changes = append(changes, audit.FieldChange{Field: "horizon", Old: string(intent.Horizon), New: string(*opts.Horizon)})
 		intent.Horizon = *opts.Horizon
+	}
+
+	if opts.Tags != nil && !slices.Equal(intent.Tags, *opts.Tags) {
+		changes = append(changes, audit.FieldChange{Field: "tags", Old: strings.Join(intent.Tags, ","), New: strings.Join(*opts.Tags, ",")})
+		intent.Tags = *opts.Tags
 	}
 
 	if len(changes) == 0 {

--- a/internal/intent/update.go
+++ b/internal/intent/update.go
@@ -150,6 +150,7 @@ func (s *IntentService) UpdateDirect(ctx context.Context, id string, opts Update
 		s.removeAllCopies(intent.ID, intent.Path)
 	}
 
+	s.invalidateIDIndex()
 	return intent, changes, nil
 }
 

--- a/internal/intent/update_test.go
+++ b/internal/intent/update_test.go
@@ -228,6 +228,70 @@ func TestUpdateDirect_NoChanges(t *testing.T) {
 	}
 }
 
+func TestUpdateDirect_Tags(t *testing.T) {
+	svc, id, _ := setupTestService(t)
+	ctx := context.Background()
+
+	tags := []string{"personal", "follow-up"}
+	updated, changes, err := svc.UpdateDirect(ctx, id, UpdateOptions{
+		Tags: &tags,
+	})
+	if err != nil {
+		t.Fatalf("UpdateDirect: %v", err)
+	}
+	if !strings.EqualFold(strings.Join(updated.Tags, ","), "personal,follow-up") {
+		t.Fatalf("Tags = %v, want [personal follow-up]", updated.Tags)
+	}
+
+	found := false
+	for _, c := range changes {
+		if c.Field == "tags" {
+			found = true
+			if c.New != "personal,follow-up" {
+				t.Fatalf("tags change new = %q, want %q", c.New, "personal,follow-up")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected a tags field change")
+	}
+
+	// Re-read from disk to confirm tags persisted to frontmatter.
+	reloaded, err := svc.Get(ctx, id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(reloaded.Tags) != 2 {
+		t.Fatalf("persisted tags = %v, want 2", reloaded.Tags)
+	}
+}
+
+func TestUpdateDirect_NilTagsLeavesUnchanged(t *testing.T) {
+	svc, id, _ := setupTestService(t)
+	ctx := context.Background()
+
+	// Seed tags first.
+	seed := []string{"reference"}
+	if _, _, err := svc.UpdateDirect(ctx, id, UpdateOptions{Tags: &seed}); err != nil {
+		t.Fatalf("seed UpdateDirect: %v", err)
+	}
+
+	// An update with nil Tags must not touch the existing tags.
+	newTitle := "Retitled"
+	updated, changes, err := svc.UpdateDirect(ctx, id, UpdateOptions{Title: &newTitle})
+	if err != nil {
+		t.Fatalf("UpdateDirect: %v", err)
+	}
+	if len(updated.Tags) != 1 || updated.Tags[0] != "reference" {
+		t.Fatalf("tags changed unexpectedly: %v", updated.Tags)
+	}
+	for _, c := range changes {
+		if c.Field == "tags" {
+			t.Fatal("nil Tags should not record a tags change")
+		}
+	}
+}
+
 func TestUpdateDirect_NoFieldsSpecified(t *testing.T) {
 	svc, id, _ := setupTestService(t)
 	ctx := context.Background()

--- a/internal/intent/validate.go
+++ b/internal/intent/validate.go
@@ -3,6 +3,7 @@ package intent
 import (
 	"errors"
 	"regexp"
+	"slices"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
@@ -76,13 +77,10 @@ func (i *Intent) Validate() []error {
 }
 
 // isValidStatus returns true if the status is a known valid value.
+// Note statuses are valid too: notes are a separate category stored outside
+// the intent lifecycle but managed by the same tooling.
 func isValidStatus(s Status) bool {
-	for _, valid := range AllStatuses() {
-		if s == valid {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(AllStatuses(), s) || slices.Contains(NoteStatuses(), s)
 }
 
 // isValidType returns true if the type is a known valid value.

--- a/internal/scaffold/campaign_yaml.go
+++ b/internal/scaffold/campaign_yaml.go
@@ -73,6 +73,7 @@ func CreateCampaignConfig(ctx context.Context, campaignRoot string, opts InitOpt
 		CreatedAt:   time.Now().UTC(),
 		Description: fmt.Sprintf("Campaign: %s", opts.Name),
 		ConceptList: config.DefaultConcepts(),
+		Intents:     config.IntentsConfig{Tags: config.DefaultIntentTags()},
 	}
 
 	// Apply defaults

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -239,6 +239,7 @@ func Init(ctx context.Context, dir string, opts InitOptions) (*InitResult, error
 		Description: description,
 		Mission:     opts.Mission,
 		ConceptList: config.DefaultConcepts(),
+		Intents:     config.IntentsConfig{Tags: config.DefaultIntentTags()},
 	}
 
 	// In repair mode, preserve existing config values and merge concepts
@@ -247,6 +248,11 @@ func Init(ctx context.Context, dir string, opts InitOptions) (*InitResult, error
 		cfg.Description = existingCfg.Description
 		cfg.Projects = existingCfg.Projects
 		cfg.Hooks = existingCfg.Hooks
+		// Preserve existing intent tags; otherwise the defaults seeded above
+		// fill in the block for campaigns predating it.
+		if len(existingCfg.Intents.Tags) > 0 {
+			cfg.Intents = existingCfg.Intents
+		}
 		// Preserve existing mission unless a new one was provided
 		if opts.Mission != "" {
 			cfg.Mission = opts.Mission

--- a/internal/scaffold/repair.go
+++ b/internal/scaffold/repair.go
@@ -2,7 +2,6 @@ package scaffold
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -278,9 +277,12 @@ func computeScaffoldChanges(ctx context.Context, absDir string, opts InitOptions
 	return nil
 }
 
-// computeConceptChanges compares existing campaign concepts with defaults.
-// Default concepts with stale paths are updated. Missing defaults are added.
-// User-defined concepts (names not in defaults) are preserved.
+const conceptWorkflowParent = "workflow"
+
+// computeConceptChanges migrates existing campaign concepts toward the nested
+// shape: flat workflow-family concepts move under a single workflow parent,
+// missing default top-level concepts and workflow children are added, and
+// custom/unknown concepts are preserved. It is idempotent.
 func computeConceptChanges(ctx context.Context, absDir string, plan *RepairPlan) error {
 	existing, err := config.LoadCampaignConfig(ctx, absDir)
 	if err != nil || existing == nil {
@@ -291,58 +293,157 @@ func computeConceptChanges(ctx context.Context, absDir string, plan *RepairPlan)
 		return nil // No concepts; init will use defaults.
 	}
 
-	defaults := config.DefaultConcepts()
-	defaultsByName := make(map[string]config.ConceptEntry, len(defaults))
-	for _, d := range defaults {
-		defaultsByName[d.Name] = d
+	before := existing.ConceptList
+	hadParent := conceptIndexByName(before, conceptWorkflowParent) != -1
+
+	merged := migrateConceptsToNested(before)
+	if !hadParent {
+		plan.Changes = append(plan.Changes, RepairChange{
+			Type:        RepairAdd,
+			Category:    "concept",
+			Key:         conceptWorkflowParent,
+			Description: "Workflows",
+		})
+	} else if !conceptListsEqual(before, merged) {
+		plan.Changes = append(plan.Changes, RepairChange{
+			Type:        RepairModify,
+			Category:    "concept",
+			Key:         conceptWorkflowParent,
+			Description: "nest workflow collections under the workflow parent",
+		})
 	}
 
-	existingByName := make(map[string]config.ConceptEntry, len(existing.ConceptList))
-	for _, e := range existing.ConceptList {
-		existingByName[e.Name] = e
-	}
-
-	var merged []config.ConceptEntry
-
-	// Update existing concepts that match defaults by name.
-	for _, e := range existing.ConceptList {
-		if def, ok := defaultsByName[e.Name]; ok {
-			if e.Path != def.Path {
-				plan.Changes = append(plan.Changes, RepairChange{
-					Type:        RepairModify,
-					Category:    "concept",
-					Key:         e.Name,
-					Description: fmt.Sprintf("update path: %s → %s", e.Path, def.Path),
-				})
-			}
-			merged = append(merged, def)
-		} else {
-			// User-defined concept — preserve it.
-			plan.Changes = append(plan.Changes, RepairChange{
-				Type:        RepairPreserve,
-				Category:    "concept",
-				Key:         e.Name,
-				Description: e.Description,
-			})
-			merged = append(merged, e)
-		}
-	}
-
-	// Add missing default concepts.
-	for _, def := range defaults {
-		if _, exists := existingByName[def.Name]; !exists {
-			plan.Changes = append(plan.Changes, RepairChange{
-				Type:        RepairAdd,
-				Category:    "concept",
-				Key:         def.Name,
-				Description: def.Description,
-			})
-			merged = append(merged, def)
-		}
-	}
+	merged = ensureDefaultConcepts(merged, &plan.Changes)
 
 	plan.MergedConcepts = merged
 	return nil
+}
+
+// workflowFamilyNames returns the concept names that are workflow collections,
+// derived from the default workflow parent's children (plus the festival alias)
+// so there is no second hardcoded list.
+func workflowFamilyNames() map[string]bool {
+	names := map[string]bool{"festival": true}
+	for _, c := range config.DefaultConcepts() {
+		if strings.EqualFold(c.Name, conceptWorkflowParent) {
+			for _, ch := range c.Children {
+				names[strings.ToLower(ch.Name)] = true
+			}
+		}
+	}
+	return names
+}
+
+func isWorkflowFamily(c config.ConceptEntry, family map[string]bool) bool {
+	return family[strings.ToLower(c.Name)] || strings.HasPrefix(c.Path, "workflow/")
+}
+
+func conceptIndexByName(concepts []config.ConceptEntry, name string) int {
+	for i := range concepts {
+		if strings.EqualFold(concepts[i].Name, name) {
+			return i
+		}
+	}
+	return -1
+}
+
+// migrateConceptsToNested moves flat workflow-family concepts under a single
+// workflow parent, drops the default worktrees entry, and is idempotent.
+func migrateConceptsToNested(concepts []config.ConceptEntry) []config.ConceptEntry {
+	family := workflowFamilyNames()
+
+	var toNest []config.ConceptEntry
+	hasParent := false
+	for _, c := range concepts {
+		if strings.EqualFold(c.Name, conceptWorkflowParent) {
+			hasParent = true
+			continue
+		}
+		if isWorkflowFamily(c, family) {
+			toNest = append(toNest, c)
+		}
+	}
+	if len(toNest) == 0 && hasParent {
+		return concepts
+	}
+
+	nest := func(parent config.ConceptEntry) config.ConceptEntry {
+		seen := make(map[string]bool)
+		for _, ch := range parent.Children {
+			seen[strings.ToLower(ch.Name)] = true
+		}
+		for _, c := range toNest {
+			if seen[strings.ToLower(c.Name)] {
+				continue
+			}
+			parent.Children = append(parent.Children, c)
+			seen[strings.ToLower(c.Name)] = true
+		}
+		return parent
+	}
+
+	var result []config.ConceptEntry
+	parentEmitted := false
+	for _, c := range concepts {
+		switch {
+		case strings.EqualFold(c.Name, conceptWorkflowParent):
+			result = append(result, nest(c))
+			parentEmitted = true
+		case strings.EqualFold(c.Name, "worktrees") && c.Path == "projects/worktrees/":
+			// Drop the default worktrees entry (a projects detail, not a picker concept).
+		case isWorkflowFamily(c, family):
+			// Moved under the workflow parent.
+		default:
+			result = append(result, c)
+		}
+	}
+	if !parentEmitted {
+		result = append(result, nest(config.ConceptEntry{Name: conceptWorkflowParent, Path: "workflow/", Description: "Workflows"}))
+	}
+	return result
+}
+
+// ensureDefaultConcepts adds any missing default top-level concept and any
+// missing default workflow child, preserving existing and custom entries.
+func ensureDefaultConcepts(concepts []config.ConceptEntry, changes *[]RepairChange) []config.ConceptEntry {
+	for _, def := range config.DefaultConcepts() {
+		idx := conceptIndexByName(concepts, def.Name)
+		if idx == -1 {
+			concepts = append(concepts, def)
+			*changes = append(*changes, RepairChange{Type: RepairAdd, Category: "concept", Key: def.Name, Description: def.Description})
+			continue
+		}
+		if !strings.EqualFold(def.Name, conceptWorkflowParent) {
+			continue
+		}
+		parent := concepts[idx]
+		seen := make(map[string]bool)
+		for _, ch := range parent.Children {
+			seen[strings.ToLower(ch.Name)] = true
+		}
+		for _, defChild := range def.Children {
+			if seen[strings.ToLower(defChild.Name)] {
+				continue
+			}
+			parent.Children = append(parent.Children, defChild)
+			seen[strings.ToLower(defChild.Name)] = true
+			*changes = append(*changes, RepairChange{Type: RepairAdd, Category: "concept", Key: "workflow/" + defChild.Name, Description: defChild.Description})
+		}
+		concepts[idx] = parent
+	}
+	return concepts
+}
+
+func conceptListsEqual(a, b []config.ConceptEntry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name || a[i].Path != b[i].Path || len(a[i].Children) != len(b[i].Children) {
+			return false
+		}
+	}
+	return true
 }
 
 // computeJumpsChanges compares existing jumps.yaml shortcuts with defaults,

--- a/internal/scaffold/repair_test.go
+++ b/internal/scaffold/repair_test.go
@@ -722,7 +722,7 @@ func TestComputeConceptChanges_UpdatesStalePaths(t *testing.T) {
 		CreatedAt: time.Now(),
 		ConceptList: []config.ConceptEntry{
 			{Name: "projects", Path: "projects/", Description: "Active development projects", Depth: &depth1, Ignore: []string{"worktrees/"}},
-			{Name: "intents", Path: "workflow/intents/", Description: "Ideas and tasks", Depth: &depth0},
+			{Name: "intents", Path: ".campaign/intents/", Description: "Ideas and tasks", Depth: &depth0},
 			{Name: "custom", Path: "my/custom/", Description: "User concept"},
 		},
 	}
@@ -758,7 +758,7 @@ func TestComputeConceptChanges_UpdatesStalePaths(t *testing.T) {
 	// later sequence.
 	if intents, ok := byName["intents"]; !ok {
 		t.Error("preexisting 'intents' concept should be preserved")
-	} else if intents.Path != "workflow/intents/" {
+	} else if intents.Path != ".campaign/intents/" {
 		t.Errorf("preserved intents path = %q, want it untouched", intents.Path)
 	}
 
@@ -796,5 +796,90 @@ func setupCampaignDir(t *testing.T, dir string) {
 	settingsDir := filepath.Join(campaignDir, config.SettingsDir)
 	if err := os.MkdirAll(settingsDir, 0755); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func findConceptByName(concepts []config.ConceptEntry, name string) (config.ConceptEntry, bool) {
+	for _, c := range concepts {
+		if c.Name == name {
+			return c, true
+		}
+	}
+	return config.ConceptEntry{}, false
+}
+
+func TestMigrateConceptsToNested_FlatToNested(t *testing.T) {
+	depth1 := 1
+	flat := []config.ConceptEntry{
+		{Name: "projects", Path: "projects/", Depth: &depth1, Ignore: []string{"worktrees/"}},
+		{Name: "worktrees", Path: "projects/worktrees/"},
+		{Name: "festivals", Path: "festivals/"},
+		{Name: "intents", Path: ".campaign/intents/"},
+		{Name: "workflow", Path: "workflow/", Ignore: []string{"design/", "explore/"}},
+		{Name: "design", Path: "workflow/design/", Depth: &depth1},
+		{Name: "explore", Path: "workflow/explore/", Depth: &depth1},
+		{Name: "docs", Path: "docs/"},
+		{Name: "research", Path: "workflow/research/"}, // custom flat workflow
+	}
+
+	got := migrateConceptsToNested(flat)
+
+	// Top level: projects, workflow, intents, docs (worktrees dropped; family moved).
+	if _, ok := findConceptByName(got, "worktrees"); ok {
+		t.Error("default worktrees should be dropped")
+	}
+	for _, name := range []string{"festivals", "design", "explore", "research"} {
+		if _, ok := findConceptByName(got, name); ok {
+			t.Errorf("%q should no longer be top-level", name)
+		}
+	}
+	if _, ok := findConceptByName(got, "intents"); !ok {
+		t.Error("non-workflow custom concept (intents) should be preserved top-level")
+	}
+
+	workflow, ok := findConceptByName(got, "workflow")
+	if !ok {
+		t.Fatal("workflow parent missing")
+	}
+	for _, name := range []string{"festivals", "design", "explore", "research"} {
+		if _, ok := findConceptByName(workflow.Children, name); !ok {
+			t.Errorf("%q should be nested under workflow", name)
+		}
+	}
+}
+
+func TestMigrateConceptsToNested_Idempotent(t *testing.T) {
+	flat := []config.ConceptEntry{
+		{Name: "projects", Path: "projects/"},
+		{Name: "festivals", Path: "festivals/"},
+		{Name: "workflow", Path: "workflow/"},
+		{Name: "design", Path: "workflow/design/"},
+		{Name: "docs", Path: "docs/"},
+	}
+	once := migrateConceptsToNested(flat)
+	twice := migrateConceptsToNested(once)
+	if !conceptListsEqual(once, twice) {
+		t.Errorf("migration not idempotent:\n once  %#v\n twice %#v", once, twice)
+	}
+}
+
+func TestMigrateConceptsToNested_PreservesCustom(t *testing.T) {
+	already := []config.ConceptEntry{
+		{Name: "projects", Path: "projects/"},
+		{Name: "my-area", Path: "my-area/"}, // custom top-level
+		{Name: "workflow", Path: "workflow/", Children: []config.ConceptEntry{
+			{Name: "festivals", Path: "festivals/"},
+			{Name: "research", Path: "workflow/research/"}, // custom child
+		}},
+		{Name: "docs", Path: "docs/"},
+	}
+	got := migrateConceptsToNested(already)
+
+	if _, ok := findConceptByName(got, "my-area"); !ok {
+		t.Error("custom top-level concept should survive")
+	}
+	workflow, _ := findConceptByName(got, "workflow")
+	if _, ok := findConceptByName(workflow.Children, "research"); !ok {
+		t.Error("custom workflow child should survive")
 	}
 }

--- a/internal/scaffold/repair_test.go
+++ b/internal/scaffold/repair_test.go
@@ -741,52 +741,51 @@ func TestComputeConceptChanges_UpdatesStalePaths(t *testing.T) {
 		t.Fatal("expected merged concepts, got none")
 	}
 
-	// Verify intents path was updated.
-	var intentsPath string
+	byName := make(map[string]config.ConceptEntry, len(plan.MergedConcepts))
 	for _, c := range plan.MergedConcepts {
-		if c.Name == "intents" {
-			intentsPath = c.Path
-			break
-		}
-	}
-	if intentsPath != ".campaign/intents/" {
-		t.Errorf("intents path = %q, want %q", intentsPath, ".campaign/intents/")
+		byName[c.Name] = c
 	}
 
-	// Verify user-defined "custom" concept is preserved.
-	var foundCustom bool
-	for _, c := range plan.MergedConcepts {
-		if c.Name == "custom" {
-			foundCustom = true
-			if c.Path != "my/custom/" {
-				t.Errorf("custom path = %q, want %q", c.Path, "my/custom/")
-			}
-		}
-	}
-	if !foundCustom {
+	// User-defined "custom" concept is preserved.
+	if custom, ok := byName["custom"]; !ok {
 		t.Error("user-defined 'custom' concept was not preserved")
+	} else if custom.Path != "my/custom/" {
+		t.Errorf("custom path = %q, want %q", custom.Path, "my/custom/")
 	}
 
-	// Verify missing default "explore" was added.
-	var foundExplore bool
-	for _, c := range plan.MergedConcepts {
-		if c.Name == "explore" {
-			foundExplore = true
+	// A concept no longer in defaults (intents) is preserved as a user concept,
+	// untouched. Proper flat -> nested migration of such entries is handled in a
+	// later sequence.
+	if intents, ok := byName["intents"]; !ok {
+		t.Error("preexisting 'intents' concept should be preserved")
+	} else if intents.Path != "workflow/intents/" {
+		t.Errorf("preserved intents path = %q, want it untouched", intents.Path)
+	}
+
+	// The new nested workflow default is added, with its collections as children.
+	workflow, ok := byName["workflow"]
+	if !ok {
+		t.Fatal("nested 'workflow' default concept was not added")
+	}
+	var hasExploreChild bool
+	for _, child := range workflow.Children {
+		if child.Name == "explore" {
+			hasExploreChild = true
 		}
 	}
-	if !foundExplore {
-		t.Error("missing default 'explore' concept was not added")
+	if !hasExploreChild {
+		t.Error("workflow default should include an 'explore' child")
 	}
 
-	// Verify plan changes contain the intents modify entry.
-	var foundModify bool
+	// The workflow addition is recorded as a RepairAdd change.
+	var foundWorkflowAdd bool
 	for _, ch := range plan.Changes {
-		if ch.Category == "concept" && ch.Key == "intents" && ch.Type == RepairModify {
-			foundModify = true
+		if ch.Category == "concept" && ch.Key == "workflow" && ch.Type == RepairAdd {
+			foundWorkflowAdd = true
 		}
 	}
-	if !foundModify {
-		t.Error("expected RepairModify change for intents concept path update")
+	if !foundWorkflowAdd {
+		t.Error("expected RepairAdd change for the workflow concept")
 	}
 }
 

--- a/internal/shell/bash_test.go
+++ b/internal/shell/bash_test.go
@@ -25,6 +25,8 @@ func TestGenerateBash(t *testing.T) {
 		{"cgo function", "cgo()"},
 		{"cint function", "cint()"},
 		{"cint calls intent add", "camp intent add"},
+		{"cnote function", "cnote()"},
+		{"cnote calls intent note", "camp intent note"},
 		{"cd command", "cd \"$dest\""},
 		{"camp go call", "camp go"},
 		{"command camp binary call", "command camp"},

--- a/internal/shell/fish_test.go
+++ b/internal/shell/fish_test.go
@@ -24,6 +24,8 @@ func TestGenerateFish(t *testing.T) {
 		{"cgo function", "function cgo"},
 		{"cint function", "function cint"},
 		{"cint calls intent add", "camp intent add"},
+		{"cnote function", "function cnote"},
+		{"cnote calls intent note", "camp intent note"},
 		{"cd command", "cd $dest"},
 		{"camp go call", "camp go"},
 		{"workitem subcommand", "case workitem wi workitems"},

--- a/internal/shell/templates/bash.sh.tmpl
+++ b/internal/shell/templates/bash.sh.tmpl
@@ -148,6 +148,12 @@ cint() {
   camp intent add "$@"
 }
 
+# Quick note capture
+# Usage: cnote "a quick thought"
+cnote() {
+  camp intent note "$@"
+}
+
 # Explore intents interactively
 # Usage: cie
 cie() {

--- a/internal/shell/templates/fish.sh.tmpl
+++ b/internal/shell/templates/fish.sh.tmpl
@@ -145,6 +145,12 @@ function cint --description "Quick intent capture"
     camp intent add $argv
 end
 
+# Quick note capture
+# Usage: cnote "a quick thought"
+function cnote --description "Quick note capture"
+    camp intent note $argv
+end
+
 # Explore intents interactively
 # Usage: cie
 function cie --description "Explore intents interactively"

--- a/internal/shell/templates/zsh.sh.tmpl
+++ b/internal/shell/templates/zsh.sh.tmpl
@@ -193,6 +193,12 @@ cint() {
   camp intent add "$@"
 }
 
+# Quick note capture
+# Usage: cnote "a quick thought"
+cnote() {
+  camp intent note "$@"
+}
+
 # Explore intents interactively
 # Usage: cie
 cie() {

--- a/internal/shell/zsh_test.go
+++ b/internal/shell/zsh_test.go
@@ -23,6 +23,8 @@ func TestGenerateZsh(t *testing.T) {
 		{"cgo function", "cgo()"},
 		{"cint function", "cint()"},
 		{"cint implementation", "camp intent add"},
+		{"cnote function", "cnote()"},
+		{"cnote implementation", "camp intent note"},
 		{"cd command", "cd \"$dest\""},
 		{"camp go call", "camp go"},
 		{"command camp binary call", "command camp"},


### PR DESCRIPTION
Implements the **intent capture UX** feature across three threads. All work is on `projects/camp`; the festival and design package live at the campaign root and are out of scope for this PR.

## Thread 1 — Notes category + tags
- A note is a separate **category** (not a `Type`), stored in `.campaign/intents/notes/` outside the inbox/ready/active lifecycle (flat + `archived`). Notes are excluded from intent `list`/`gather`/index.
- Fast capture: `camp intent note "..."` and a `cnote` shell shortcut; a TUI note quick-add (text only, no type/concept).
- Explorer **notes view** (`N`) and **note→intent convert** via `camp intent convert` and a TUI action (`c`).
- Frontmatter **tags** via a reusable shortcut overlay (`ctrl+t` in capture, `T` in the explorer), `--tag` flags on `note`/`add`/`edit`, and a configurable `intents.tags` list seeded at init. A bare note needs zero tag interaction.

## Thread 2 — Rename intent
- `id:` frontmatter is made **authoritative**: perf-safe resolution (fast path `<id>.md` + lazy `id→path` index, no per-lookup directory scans), so a renamed filename slug never breaks lookups or cross-references.
- Single shared `SlugFromTitle` (merge's duplicate removed).
- `IntentService.Rename` regenerates `<new-slug>-<stable-suffix>.md`, preserves the id, handles filename collisions, and adds `audit.EventRename` / `commit.IntentRename`.
- Exposed via `camp intent rename <id> "<title>"` and the explorer (`R`, prefilled overlay, list refresh + reselect). One service method backs both.

## Thread 3 — Workflows as sub-concepts
- Recursive `ConceptEntry.Children`; `DefaultConcepts()` emits the nested `projects / workflow{festivals,design,explore,code_reviews,pipelines} / docs` shape; `camp init` seeds it.
- Concept service resolves a parent's children (config children merged with on-disk subdirs under the parent path); the `intent` workflow is filtered from the picker.
- The existing two-step picker renders the parent → sub-concept cascade (no new step needed).
- `camp workflow create` registers the collection as a **child** of `workflow`; `doctor`/`sync`/`list` descend into the nested tree.
- `camp init --repair` migrates a flat `concepts:` block into the nested shape, idempotently and non-destructively (custom/unknown concepts preserved).
- `camp concepts` renders the tree with a customization hint; upgrade guide added under `docs/migrations/`.

## Testing
- New unit/TUI tests for every thread (notes routing/exclusion/convert, id resolution, rename + collision, tag overlay + persistence, nested config round-trip, child resolution, picker cascade, workflow-create nesting, and migration: flat→nested, idempotency, custom survival).
- `just lint` is clean; the host-fs-tests guard reports no new violators.
- The only full-suite failures are the **pre-existing** `cmd/camp` manifest tests for `workitem priority` (#318) — they fail identically on the base of this branch and are unrelated to this work.
