### PR TITLE
fix(shell): make zsh completion resilient to compinit ordering

### DIFF
--- a/internal/shell/templates/zsh.sh.tmpl
+++ b/internal/shell/templates/zsh.sh.tmpl
@@ -156,8 +156,6 @@ _cgo() {
     fi
   fi
 }
-compdef _cgo cgo
-
 # Run command from campaign root
 # Usage: cr <command> [args...]
 cr() {
@@ -185,8 +183,6 @@ _csw() {
 
   (( ${#campaigns} )) && compadd -a campaigns
 }
-compdef _csw csw
-
 # Quick intent capture
 # Usage: cint "my idea"
 cint() {
@@ -264,4 +260,31 @@ _camp() {
       ;;
   esac
 }
-compdef _camp camp
+# Register completions, resilient to compinit ordering.
+#
+# compdef only exists after `compinit` has run. Some users source camp before
+# compinit (or never run it), which previously printed three
+# "command not found: compdef" errors at every shell startup and skipped
+# completion entirely. Register immediately when compdef is available;
+# otherwise defer to the first prompt so completion still loads once the
+# user's own compinit runs, without erroring when it never does.
+_camp_register_completions() {
+  compdef _cgo cgo
+  compdef _csw csw
+  compdef _camp camp
+}
+
+if (( $+functions[compdef] )); then
+  _camp_register_completions
+  unfunction _camp_register_completions
+elif autoload -Uz add-zsh-hook 2>/dev/null && (( $+functions[add-zsh-hook] )); then
+  _camp_deferred_completions() {
+    if (( $+functions[compdef] )); then
+      _camp_register_completions
+      unfunction _camp_register_completions
+    fi
+    add-zsh-hook -d precmd _camp_deferred_completions
+    unfunction _camp_deferred_completions
+  }
+  add-zsh-hook precmd _camp_deferred_completions
+fi

--- a/internal/shell/templates/zsh.sh.tmpl
+++ b/internal/shell/templates/zsh.sh.tmpl
@@ -293,5 +293,12 @@ elif autoload -Uz add-zsh-hook 2>/dev/null && (( $+functions[add-zsh-hook] )); t
     add-zsh-hook -d precmd _camp_deferred_completions
     unfunction _camp_deferred_completions
   }
-  add-zsh-hook precmd _camp_deferred_completions
+  if ! add-zsh-hook precmd _camp_deferred_completions 2>/dev/null; then
+    # autoload only declared add-zsh-hook; its definition file is not on fpath
+    # (e.g. a stripped fpath), so the precmd registration just failed. Back out
+    # cleanly and stay silent: completion is skipped here, but sourcing the init
+    # must not emit a startup error.
+    unfunction _camp_deferred_completions 2>/dev/null
+    unfunction _camp_register_completions 2>/dev/null
+  fi
 fi

--- a/internal/shell/templates/zsh.sh.tmpl
+++ b/internal/shell/templates/zsh.sh.tmpl
@@ -275,11 +275,18 @@ _camp_register_completions() {
 }
 
 if (( $+functions[compdef] )); then
+  # Sourced again after compinit: drop any deferred hook a pre-compinit
+  # source left queued, so the first prompt stays silent.
+  if (( $+functions[_camp_deferred_completions] )); then
+    (( $+functions[add-zsh-hook] )) && add-zsh-hook -d precmd _camp_deferred_completions
+    precmd_functions=(${precmd_functions:#_camp_deferred_completions})
+    unfunction _camp_deferred_completions
+  fi
   _camp_register_completions
   unfunction _camp_register_completions
 elif autoload -Uz add-zsh-hook 2>/dev/null && (( $+functions[add-zsh-hook] )); then
   _camp_deferred_completions() {
-    if (( $+functions[compdef] )); then
+    if (( $+functions[compdef] )) && (( $+functions[_camp_register_completions] )); then
       _camp_register_completions
       unfunction _camp_register_completions
     fi

--- a/tests/integration/shell_init_helpers_test.go
+++ b/tests/integration/shell_init_helpers_test.go
@@ -195,6 +195,78 @@ func runFishScript(t *testing.T, tc *TestContainer, initScript, stubSetup, testC
 	return output, exitCode
 }
 
+// sourceStderrMarkerBegin and sourceStderrMarkerEnd delimit the captured stderr
+// of the init-sourcing step inside the combined shell output, so the Go side can
+// extract exactly what was written to stderr while sourcing the camp init.
+const (
+	sourceStderrMarkerBegin = "===CAMP_SRC_STDERR_BEGIN==="
+	sourceStderrMarkerEnd   = "===CAMP_SRC_STDERR_END==="
+)
+
+// runShellCleanStartup sources the camp init for a shell in a controlled
+// environment and reports whatever the init wrote to stderr while sourcing.
+//
+// This is the generalized guard against the whole class of "shell command breaks
+// at startup for some users" bugs: a clean shell startup must produce NOTHING on
+// stderr, regardless of the user's completion-system state or rc ordering. The
+// camp stub is installed before sourcing so the init's `command -v camp` guard
+// passes; `preamble` simulates the user's environment (e.g. running compinit, or
+// not). `verify` runs after sourcing and echoes markers to stdout.
+//
+// Returns (sourceStderr, combinedOutput, exitCode). A non-empty sourceStderr
+// means the init emitted errors/warnings at startup.
+func runShellCleanStartup(t *testing.T, tc *TestContainer, shellName, preamble, initScript, stub, verify string) (string, string, int) {
+	t.Helper()
+
+	initPath := "/test/clean-" + shellName + "-init"
+	srcStderrPath := "/test/clean-" + shellName + "-src.stderr"
+	scriptPath := "/test/clean-" + shellName + ".script"
+
+	if err := tc.WriteFile(initPath, initScript); err != nil {
+		t.Fatalf("write init script: %v", err)
+	}
+
+	fullScript := preamble + "\n" +
+		stub + "\n" +
+		"source " + initPath + " 2>" + srcStderrPath + "\n" +
+		"echo '" + sourceStderrMarkerBegin + "'\n" +
+		"cat " + srcStderrPath + "\n" +
+		"echo '" + sourceStderrMarkerEnd + "'\n" +
+		verify + "\n"
+	if err := tc.WriteFile(scriptPath, fullScript); err != nil {
+		t.Fatalf("write test script: %v", err)
+	}
+
+	var argv []string
+	switch shellName {
+	case "bash":
+		argv = []string{"bash", scriptPath}
+	case "zsh":
+		argv = []string{"zsh", "--no-rcs", scriptPath}
+	case "fish":
+		argv = []string{"fish", "--no-config", scriptPath}
+	default:
+		t.Fatalf("unsupported shell: %s", shellName)
+	}
+
+	output, exitCode, err := tc.ExecCommand(argv...)
+	if err != nil {
+		t.Fatalf("exec %s: %v", shellName, err)
+	}
+	return extractSourceStderr(output), output, exitCode
+}
+
+// extractSourceStderr pulls the text captured between the stderr markers.
+func extractSourceStderr(combined string) string {
+	start := strings.Index(combined, sourceStderrMarkerBegin)
+	end := strings.Index(combined, sourceStderrMarkerEnd)
+	if start == -1 || end == -1 || end < start {
+		return ""
+	}
+	inner := combined[start+len(sourceStderrMarkerBegin) : end]
+	return strings.TrimSpace(inner)
+}
+
 // ensureCampInPath creates a symlink so that `command -v camp` succeeds
 // in the container. The real camp binary is at /camp; we create /camp-bin/camp.
 func ensureCampInPath(t *testing.T, tc *TestContainer) {

--- a/tests/integration/shell_init_helpers_test.go
+++ b/tests/integration/shell_init_helpers_test.go
@@ -149,6 +149,31 @@ func runZshScript(t *testing.T, tc *TestContainer, initScript, stubSetup, testCo
 	return output, exitCode
 }
 
+// runZshScriptNoCompinit runs a zsh script that sources the camp init WITHOUT
+// first running compinit. This reproduces the real-world environment of users
+// who source camp before initializing the completion system (or never call
+// compinit at all). The camp init must not emit "command not found: compdef"
+// errors in this case.
+func runZshScriptNoCompinit(t *testing.T, tc *TestContainer, initScript, stubSetup, testCommands string) (string, int) {
+	t.Helper()
+
+	if err := tc.WriteFile("/test/camp-init-nocompinit.zsh", initScript); err != nil {
+		t.Fatalf("write init script: %v", err)
+	}
+
+	fullScript := "emulate -R zsh\n" +
+		stubSetup + "\nsource /test/camp-init-nocompinit.zsh\n" + testCommands
+	if err := tc.WriteFile("/test/test-nocompinit.zsh", fullScript); err != nil {
+		t.Fatalf("write test script: %v", err)
+	}
+
+	output, exitCode, err := tc.ExecCommand("zsh", "--no-rcs", "/test/test-nocompinit.zsh")
+	if err != nil {
+		t.Fatalf("exec zsh: %v", err)
+	}
+	return output, exitCode
+}
+
 // runFishScript assembles and runs a fish script inside the container.
 // Order: stubSetup -> source init -> testCommands.
 func runFishScript(t *testing.T, tc *TestContainer, initScript, stubSetup, testCommands string) (string, int) {

--- a/tests/integration/shell_init_helpers_test.go
+++ b/tests/integration/shell_init_helpers_test.go
@@ -149,6 +149,8 @@ func runZshScript(t *testing.T, tc *TestContainer, initScript, stubSetup, testCo
 	return output, exitCode
 }
 
+const zshNoCompinitInitPath = "/test/camp-init-nocompinit.zsh"
+
 // runZshScriptNoCompinit runs a zsh script that sources the camp init WITHOUT
 // first running compinit. This reproduces the real-world environment of users
 // who source camp before initializing the completion system (or never call
@@ -157,12 +159,12 @@ func runZshScript(t *testing.T, tc *TestContainer, initScript, stubSetup, testCo
 func runZshScriptNoCompinit(t *testing.T, tc *TestContainer, initScript, stubSetup, testCommands string) (string, int) {
 	t.Helper()
 
-	if err := tc.WriteFile("/test/camp-init-nocompinit.zsh", initScript); err != nil {
+	if err := tc.WriteFile(zshNoCompinitInitPath, initScript); err != nil {
 		t.Fatalf("write init script: %v", err)
 	}
 
 	fullScript := "emulate -R zsh\n" +
-		stubSetup + "\nsource /test/camp-init-nocompinit.zsh\n" + testCommands
+		stubSetup + "\nsource " + zshNoCompinitInitPath + "\n" + testCommands
 	if err := tc.WriteFile("/test/test-nocompinit.zsh", fullScript); err != nil {
 		t.Fatalf("write test script: %v", err)
 	}

--- a/tests/integration/shell_init_test.go
+++ b/tests/integration/shell_init_test.go
@@ -509,6 +509,79 @@ func TestShellInit_ZshCompdefRegistered(t *testing.T) {
 	}
 }
 
+func TestShellInit_ZshNoCompinitNoErrors(t *testing.T) {
+	tc := GetSharedContainer(t)
+	installShells(t, tc)
+
+	const targetDir = "/test/zsh-nocompinit-target"
+	if _, _, err := tc.ExecCommand("mkdir", "-p", targetDir); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	initScript := shellInitScript(t, tc, "zsh")
+	stub := stubCampScriptPosix(targetDir)
+
+	t.Run("sourcing_without_compinit_emits_no_errors", func(t *testing.T) {
+		stdout, exitCode := runZshScriptNoCompinit(t, tc, initScript, stub, `
+echo "SOURCED_OK"
+`)
+		if exitCode != 0 {
+			t.Fatalf("sourcing without compinit exited %d, output:\n%s", exitCode, stdout)
+		}
+		if strings.Contains(stdout, "command not found") {
+			t.Errorf("sourcing without compinit emitted 'command not found' (compdef-before-compinit bug), output:\n%s", stdout)
+		}
+		if strings.Contains(stdout, "compdef") {
+			t.Errorf("sourcing without compinit leaked a compdef error, output:\n%s", stdout)
+		}
+		if !strings.Contains(stdout, "SOURCED_OK") {
+			t.Errorf("expected SOURCED_OK marker, output:\n%s", stdout)
+		}
+	})
+
+	t.Run("navigation_still_works_without_compinit", func(t *testing.T) {
+		stdout, exitCode := runZshScriptNoCompinit(t, tc, initScript, stub, `
+cgo foo
+echo "PWD=$PWD"
+`)
+		if exitCode != 0 {
+			t.Fatalf("exit code %d, output: %s", exitCode, stdout)
+		}
+		if !strings.Contains(stdout, "PWD="+targetDir) {
+			t.Errorf("expected PWD=%s, got:\n%s", targetDir, stdout)
+		}
+	})
+}
+
+func TestShellInit_ZshDeferredCompletionRegistersAfterCompinit(t *testing.T) {
+	tc := GetSharedContainer(t)
+	installShells(t, tc)
+	ensureCampInPath(t, tc)
+
+	initScript := shellInitScript(t, tc, "zsh")
+
+	// Source camp BEFORE compinit, then run compinit, then fire the deferred
+	// precmd hook(s) manually. After that, completion must be registered.
+	stdout, exitCode := runZshScriptNoCompinit(t, tc, initScript, `export PATH="/camp-bin:$PATH"`, `
+autoload -Uz compinit && compinit -u 2>/dev/null
+for f in $precmd_functions; do
+  (( $+functions[$f] )) && $f
+done
+if [[ -n "${_comps[cgo]}" ]]; then
+  echo "CGO_COMPLETION_REGISTERED"
+fi
+`)
+	if exitCode != 0 {
+		t.Fatalf("exit code %d, output:\n%s", exitCode, stdout)
+	}
+	if !strings.Contains(stdout, "CGO_COMPLETION_REGISTERED") {
+		t.Errorf("cgo completion not registered after deferred compinit, output:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "command not found") {
+		t.Errorf("deferred completion path emitted 'command not found', output:\n%s", stdout)
+	}
+}
+
 // ---------- Fish behavior tests ----------
 
 func TestShellInit_FishCampWrapperGo(t *testing.T) {

--- a/tests/integration/shell_init_test.go
+++ b/tests/integration/shell_init_test.go
@@ -582,6 +582,76 @@ fi
 	}
 }
 
+// TestShellInit_ZshRepeatedSourcingAroundCompinit guards against stale deferred
+// hooks when the init is sourced more than once from different rc/plugin paths.
+// The "resource_after_compinit_then_first_prompt" case is the reported bug: the
+// first source (pre-compinit) queues the deferred hook, the second source
+// (post-compinit) registers immediately and removes the registrar, and the
+// stale hook then errored at the first prompt. The helper performs the initial
+// pre-compinit source; each case's commands run after it.
+func TestShellInit_ZshRepeatedSourcingAroundCompinit(t *testing.T) {
+	tc := GetSharedContainer(t)
+	installShells(t, tc)
+	ensureCampInPath(t, tc)
+
+	initScript := shellInitScript(t, tc, "zsh")
+
+	resource := "source " + zshNoCompinitInitPath
+	const compinit = "autoload -Uz compinit && compinit -u 2>/dev/null"
+	const firePrecmd = `for f in $precmd_functions; do
+  (( $+functions[$f] )) && $f
+done`
+	const checkRegistered = `if [[ -n "${_comps[cgo]}" ]]; then
+  echo "CGO_COMPLETION_REGISTERED"
+fi`
+
+	cases := []struct {
+		name           string
+		commands       []string
+		wantRegistered bool
+	}{
+		{
+			name:           "resource_after_compinit_then_first_prompt",
+			commands:       []string{compinit, resource, firePrecmd, checkRegistered},
+			wantRegistered: true,
+		},
+		{
+			name:           "double_source_before_compinit",
+			commands:       []string{resource, compinit, firePrecmd, checkRegistered},
+			wantRegistered: true,
+		},
+		{
+			name:           "resource_after_deferred_hook_already_fired",
+			commands:       []string{compinit, firePrecmd, resource, firePrecmd, checkRegistered},
+			wantRegistered: true,
+		},
+		{
+			name:           "double_source_compinit_never_runs",
+			commands:       []string{resource, firePrecmd, firePrecmd, `echo "STILL_SILENT"`},
+			wantRegistered: false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, exitCode := runZshScriptNoCompinit(t, tc, initScript,
+				`export PATH="/camp-bin:$PATH"`, strings.Join(tt.commands, "\n"))
+			if exitCode != 0 {
+				t.Fatalf("exit code %d, output:\n%s", exitCode, stdout)
+			}
+			if strings.Contains(stdout, "command not found") {
+				t.Errorf("repeated sourcing emitted 'command not found', output:\n%s", stdout)
+			}
+			if strings.Contains(stdout, "unfunction") {
+				t.Errorf("repeated sourcing emitted an unfunction error, output:\n%s", stdout)
+			}
+			if tt.wantRegistered && !strings.Contains(stdout, "CGO_COMPLETION_REGISTERED") {
+				t.Errorf("cgo completion not registered, output:\n%s", stdout)
+			}
+		})
+	}
+}
+
 // TestShellInit_CleanStartupAcrossEnvironments is the general guard against the
 // class of "shell command breaks at startup for some users" bugs. For each
 // supported shell, across the realistic environment variations that differ

--- a/tests/integration/shell_init_test.go
+++ b/tests/integration/shell_init_test.go
@@ -582,6 +582,96 @@ fi
 	}
 }
 
+// TestShellInit_CleanStartupAcrossEnvironments is the general guard against the
+// class of "shell command breaks at startup for some users" bugs. For each
+// supported shell, across the realistic environment variations that differ
+// between users (notably zsh's completion-system state), sourcing the generated
+// init must:
+//   - write NOTHING to stderr (no errors, no warnings)
+//   - exit 0
+//   - define the camp and cgo wrapper functions
+//
+// The zsh "bare_no_compinit" case is exactly the reported bug: the old script
+// wrote three "command not found: compdef" lines to stderr here.
+func TestShellInit_CleanStartupAcrossEnvironments(t *testing.T) {
+	tc := GetSharedContainer(t)
+	installShells(t, tc)
+
+	const targetDir = "/test/clean-startup-target"
+	if _, _, err := tc.ExecCommand("mkdir", "-p", targetDir); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	posixStub := stubCampScriptPosix(targetDir)
+	fishStub := stubCampScriptFish(targetDir)
+
+	const bashVerify = `[[ $(type -t camp) == function ]] && echo CAMP_FN
+[[ $(type -t cgo) == function ]] && echo CGO_FN`
+
+	const zshVerify = `(( $+functions[camp] )) && echo CAMP_FN
+(( $+functions[cgo] )) && echo CGO_FN`
+
+	const fishVerify = `functions -q camp; and echo CAMP_FN
+functions -q cgo; and echo CGO_FN`
+
+	cases := []struct {
+		name     string
+		shell    string
+		preamble string
+		stub     string
+		verify   string
+	}{
+		{
+			name:     "bash_bare",
+			shell:    "bash",
+			preamble: "",
+			stub:     posixStub,
+			verify:   bashVerify,
+		},
+		{
+			name:     "zsh_bare_no_compinit",
+			shell:    "zsh",
+			preamble: "emulate -R zsh",
+			stub:     posixStub,
+			verify:   zshVerify,
+		},
+		{
+			name:     "zsh_compinit_first",
+			shell:    "zsh",
+			preamble: "emulate -R zsh\nautoload -Uz compinit && compinit -u 2>/dev/null",
+			stub:     posixStub,
+			verify:   zshVerify,
+		},
+		{
+			name:     "fish_bare",
+			shell:    "fish",
+			preamble: "",
+			stub:     fishStub,
+			verify:   fishVerify,
+		},
+	}
+
+	for _, tc2 := range cases {
+		t.Run(tc2.name, func(t *testing.T) {
+			initScript := shellInitScript(t, tc, tc2.shell)
+			srcStderr, output, exitCode := runShellCleanStartup(t, tc, tc2.shell, tc2.preamble, initScript, tc2.stub, tc2.verify)
+
+			if srcStderr != "" {
+				t.Errorf("sourcing camp init wrote to stderr (clean startup must be silent):\n%s\n\nfull output:\n%s", srcStderr, output)
+			}
+			if exitCode != 0 {
+				t.Errorf("shell exited %d, output:\n%s", exitCode, output)
+			}
+			if !strings.Contains(output, "CAMP_FN") {
+				t.Errorf("camp wrapper function not defined, output:\n%s", output)
+			}
+			if !strings.Contains(output, "CGO_FN") {
+				t.Errorf("cgo wrapper function not defined, output:\n%s", output)
+			}
+		})
+	}
+}
+
 // ---------- Fish behavior tests ----------
 
 func TestShellInit_FishCampWrapperGo(t *testing.T) {

--- a/tests/integration/shell_init_test.go
+++ b/tests/integration/shell_init_test.go
@@ -713,6 +713,17 @@ functions -q cgo; and echo CGO_FN`
 			verify:   zshVerify,
 		},
 		{
+			// Stripped fpath with no compinit: compdef is absent so the deferred
+			// path runs, but add-zsh-hook is only an autoload stub whose file
+			// cannot be found. Registration must fail silently, not print
+			// "add-zsh-hook: function definition file not found" at startup.
+			name:     "zsh_stripped_fpath_no_compinit",
+			shell:    "zsh",
+			preamble: "emulate -R zsh\nfpath=()",
+			stub:     posixStub,
+			verify:   zshVerify,
+		},
+		{
 			name:     "fish_bare",
 			shell:    "fish",
 			preamble: "",


### PR DESCRIPTION
## Problem

User reported a shell bug affecting "some users." Root cause: the zsh init
script (`internal/shell/templates/zsh.sh.tmpl`) called `compdef` unconditionally
at source time. `compdef` only exists after `compinit` has run. Users who source
camp before `compinit`, or never run it (bare zsh, no framework), got three
`command not found: compdef` errors at every shell startup and no tab-completion.
Framework users (oh-my-zsh / prezto) run `compinit` early, so they never saw it,
hence "some users."

Reproduction on the old script (bare zsh, no compinit):

```
$ zsh -d -f -c 'eval "$(camp shell-init zsh)"; echo exit=$?'
(eval):171: command not found: compdef
(eval):200: command not found: compdef
(eval):279: command not found: compdef
exit=127
```

## Fix

Replace the three scattered `compdef` calls with a single registration block
resilient to `compinit` ordering:

- compdef available (compinit already ran) → register immediately. Unchanged
  behavior for oh-my-zsh / prezto users.
- compdef not yet available → defer registration to the first prompt via an
  `add-zsh-hook precmd` one-shot, so completion still loads once the user's own
  `compinit` runs.
- compinit never runs → guard silently skips. No errors, navigation still works.

## Cross-shell audit

We support bash, zsh, and fish, so all three were checked empirically:

- **bash**: not a bug, left unchanged. `return` inside `eval` only unwinds the
  eval (does not abort the host rc); completion registers on bash 3.2 and 5.x.
- **fish**: uses `complete`, which has no `compinit`-equivalent ordering
  dependency. Left unchanged.
- **zsh**: fixed as above.

## Tests

The existing harness always ran `compinit` before sourcing camp, which is
exactly why this bug was never caught. Added:

- `runZshScriptNoCompinit` helper (sources without compinit).
- `TestShellInit_ZshNoCompinitNoErrors`: asserts exit 0, no `command not found`,
  navigation still works. Fails on the old script (exit 127, three compdef
  errors).
- `TestShellInit_ZshDeferredCompletionRegistersAfterCompinit`: sources before
  compinit, runs compinit, fires precmd hooks, asserts completion registers.

Verification: `go test ./internal/shell/...`, the full zsh integration suite,
`just lint` (0 issues), and `just build` all pass. Manual repro of all three init
orderings against a freshly built binary confirmed clean.