### PR TITLE
Implement campaign-local settings: real store, theme override, settings get/set

### DIFF
--- a/cmd/camp/manifest_test.go
+++ b/cmd/camp/manifest_test.go
@@ -92,6 +92,8 @@ func TestManifestCommand_AllRestrictedCommandsPresent(t *testing.T) {
 		"register":      false,
 		"unregister":    false,
 		"settings":      false,
+		"settings get":  false,
+		"settings set":  false,
 		"shell-init":    false,
 		"move":          false,
 		"doctor":        false,
@@ -130,6 +132,7 @@ func TestManifestCommand_AllRestrictedCommandsPresent(t *testing.T) {
 		expectedCommands["workitem current"] = false
 		expectedCommands["workitem link"] = false
 		expectedCommands["workitem links"] = false
+		expectedCommands["workitem priority"] = false
 		expectedCommands["workitem resolve"] = false
 		expectedCommands["workitem unlink"] = false
 		expectedCommands["workitem commit"] = false
@@ -148,15 +151,15 @@ func TestManifestCommand_AllRestrictedCommandsPresent(t *testing.T) {
 		}
 	}
 
-	wantCount := 18
+	wantCount := 20
 	if flowCommandsRegistered() {
-		wantCount = 21
+		wantCount = 23
 	}
 	if questCommandsRegistered() {
 		wantCount += 13
 	}
 	if workitemCommandRegistered() {
-		wantCount += 9
+		wantCount += 10
 	}
 	if len(manifest.Commands) != wantCount {
 		t.Errorf("expected exactly %d restricted commands, got %d", wantCount, len(manifest.Commands))
@@ -183,6 +186,8 @@ func TestManifestCommand_AllCommandsHaveAnnotations(t *testing.T) {
 		"dungeon list":  true,
 		"dungeon move":  true,
 		"promote":       true,
+		"settings get":  true,
+		"settings set":  true,
 		"switch":        true,
 		"skills link":   true,
 		"skills status": true,
@@ -211,6 +216,7 @@ func TestManifestCommand_AllCommandsHaveAnnotations(t *testing.T) {
 		agentAllowed["workitem current"] = true
 		agentAllowed["workitem link"] = true
 		agentAllowed["workitem links"] = true
+		agentAllowed["workitem priority"] = true
 		agentAllowed["workitem resolve"] = true
 		agentAllowed["workitem unlink"] = true
 		agentAllowed["workitem commit"] = true
@@ -261,6 +267,8 @@ func TestManifestCommand_InteractiveFlags(t *testing.T) {
 		"clone":         true,
 		"register":      true,
 		"unregister":    true,
+		"settings get":  true,
+		"settings set":  true,
 		"shell-init":    true,
 		"doctor":        true,
 		"dungeon list":  true,
@@ -293,6 +301,7 @@ func TestManifestCommand_InteractiveFlags(t *testing.T) {
 		nonInteractiveCommands["workitem current"] = true
 		nonInteractiveCommands["workitem link"] = true
 		nonInteractiveCommands["workitem links"] = true
+		nonInteractiveCommands["workitem priority"] = true
 		nonInteractiveCommands["workitem resolve"] = true
 		nonInteractiveCommands["workitem unlink"] = true
 		nonInteractiveCommands["workitem commit"] = true

--- a/cmd/camp/settings.go
+++ b/cmd/camp/settings.go
@@ -19,18 +19,22 @@ var settingsCmd = &cobra.Command{
 	Short: "Manage camp configuration",
 	Long: `Interactive menu for managing camp configuration.
 
-Today, this command edits global user preferences in
-~/.obey/campaign/config.json.
+Global settings live in ~/.obey/campaign/config.json and apply to every
+campaign. Local settings live in .campaign/settings/local.json and apply
+only to the current campaign; a local theme override wins over the global
+theme while you are inside that campaign.
 
-Campaign-local settings still live in files under .campaign/, and the
-"Local Settings" menu is currently a scaffold rather than a full editor.
-See docs/campaign-settings-files.md in the camp repository for the current
-file layout.`,
-	Example: `  camp settings   # Edit global editor/theme preferences`,
+For non-interactive access, use 'camp settings get' and
+'camp settings set'. See docs/campaign-settings-files.md in the camp
+repository for the file layout.`,
+	Example: `  camp settings                              # Interactive settings menu
+  camp settings get                          # Print all settings
+  camp settings set global.theme dark        # Set the global theme
+  camp settings set local.theme_override light`,
 	GroupID: "system",
 	Annotations: map[string]string{
 		"agent_allowed": "false",
-		"agent_reason":  "Fully interactive TUI menu",
+		"agent_reason":  "Fully interactive TUI menu; use 'settings get/set' for automation",
 		"interactive":   "true",
 	},
 	RunE: runSettings,
@@ -38,23 +42,21 @@ file layout.`,
 
 func init() {
 	rootCmd.AddCommand(settingsCmd)
+	settingsCmd.AddCommand(newSettingsGetCmd())
+	settingsCmd.AddCommand(newSettingsSetCmd())
 }
 
 func runSettings(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
-	// Check if we're in a campaign
-	_, _, err := config.LoadCampaignConfigFromCwd(ctx)
+	_, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
 	inCampaign := err == nil
 
-	// Build options
 	options := []huh.Option[string]{
 		huh.NewOption("Global Settings", "global"),
+		huh.NewOption("Local Settings (this campaign)", "local"),
+		huh.NewOption("Exit", "exit"),
 	}
-	if inCampaign {
-		options = append(options, huh.NewOption("Local Settings (this campaign)", "local"))
-	}
-	options = append(options, huh.NewOption("Exit", "exit"))
 
 	for {
 		var choice string
@@ -81,7 +83,11 @@ func runSettings(cmd *cobra.Command, args []string) error {
 				return err
 			}
 		case "local":
-			if err := runLocalSettings(ctx); err != nil {
+			if !inCampaign {
+				fmt.Println(ui.Warning("Not inside a campaign. Local settings live in .campaign/settings/local.json; run camp settings from a campaign directory to edit them."))
+				continue
+			}
+			if err := runLocalSettings(ctx, campaignRoot); err != nil {
 				return err
 			}
 		}
@@ -96,7 +102,7 @@ func runGlobalSettings(ctx context.Context) error {
 
 	for {
 		options := []huh.Option[string]{
-			huh.NewOption(fmt.Sprintf("Theme          %s", displayStr(cfg.TUI.Theme, "adaptive")), "theme"),
+			huh.NewOption(fmt.Sprintf("Theme          %s", displayStr(cfg.TUI.Theme, config.ThemeNameAdaptive)), "theme"),
 			huh.NewOption(fmt.Sprintf("Editor         %s", displayStr(cfg.Editor, "$EDITOR")), "editor"),
 			huh.NewOption(fmt.Sprintf("Campaigns Dir  %s", displayStr(cfg.CampaignsDir, "~/campaigns")), "campaigns_dir"),
 			huh.NewOption(fmt.Sprintf("Verbose        %s", boolStr(cfg.Verbose)), "verbose"),
@@ -153,17 +159,18 @@ func runGlobalSettings(ctx context.Context) error {
 	}
 }
 
-// runLocalSettings shows a mock/scaffold menu for local campaign settings.
-// TODO: Implement actual local config loading/saving when local settings are needed.
-// This scaffold exists to establish the navigation structure for future implementation.
-func runLocalSettings(ctx context.Context) error {
+func runLocalSettings(ctx context.Context, campaignRoot string) error {
 	for {
-		// MOCK: These are placeholder settings showing the intended structure.
+		local, err := config.LoadLocalSettings(ctx, campaignRoot)
+		if err != nil {
+			return camperrors.Wrap(err, "loading local settings")
+		}
+
 		options := []huh.Option[string]{
-			huh.NewOption("[MOCK] Theme Override       NOT IMPLEMENTED", "theme"),
-			huh.NewOption("[MOCK] Project Defaults     NOT IMPLEMENTED", "projects"),
-			huh.NewOption("[MOCK] Intent Defaults      NOT IMPLEMENTED", "intents"),
-			huh.NewOption("─────────────────────────────────────────", "_separator"),
+			huh.NewOption(fmt.Sprintf("Theme Override  %s (effective: %s)",
+				displayStr(local.ThemeOverride, "inherit global"),
+				config.EffectiveTheme(ctx)), "theme_override"),
+			huh.NewOption("─────────────────", "_separator"),
 			huh.NewOption("Back", "back"),
 		}
 
@@ -171,7 +178,7 @@ func runLocalSettings(ctx context.Context) error {
 		form := huh.NewForm(huh.NewGroup(
 			huh.NewSelect[string]().
 				Title("Local Settings (Campaign-Specific)").
-				Description("Local settings are not yet implemented - this is a UI scaffold").
+				Description("Changes apply only to this campaign").
 				Options(options...).
 				Value(&choice),
 		))
@@ -187,13 +194,42 @@ func runLocalSettings(ctx context.Context) error {
 		case "back":
 			return nil
 		case "_separator":
-			// Ignore separator selection, continue the loop
 			continue
-		default:
-			fmt.Println("\nThis setting is not yet implemented.")
-			fmt.Println("Local campaign settings will be added in a future update.")
+		case "theme_override":
+			if err := editLocalThemeOverride(ctx, campaignRoot, local.ThemeOverride); err != nil {
+				return err
+			}
 		}
 	}
+}
+
+func editLocalThemeOverride(ctx context.Context, campaignRoot, current string) error {
+	value := current
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewSelect[string]().
+			Title("Theme Override").
+			Description("Campaign-local theme; overrides the global theme in this campaign").
+			Options(
+				huh.NewOption("Inherit global", ""),
+				huh.NewOption("Adaptive - Auto-detect", config.ThemeNameAdaptive),
+				huh.NewOption("Light - For light backgrounds", config.ThemeNameLight),
+				huh.NewOption("Dark - For dark backgrounds", config.ThemeNameDark),
+				huh.NewOption("High Contrast - Maximum visibility", config.ThemeNameHighContrast),
+			).
+			Value(&value),
+	))
+
+	if err := theme.RunForm(ctx, form); err != nil {
+		if theme.IsCancelled(err) {
+			return nil
+		}
+		return err
+	}
+
+	return config.WithLocalSettingsLock(ctx, campaignRoot, func(s *config.LocalSettings) error {
+		s.ThemeOverride = value
+		return nil
+	})
 }
 
 func editTheme(ctx context.Context, cfg *config.GlobalConfig) error {
@@ -202,10 +238,10 @@ func editTheme(ctx context.Context, cfg *config.GlobalConfig) error {
 			Title("Theme").
 			Description("Color theme for TUI elements").
 			Options(
-				huh.NewOption("Adaptive - Auto-detect", "adaptive"),
-				huh.NewOption("Light - For light backgrounds", "light"),
-				huh.NewOption("Dark - For dark backgrounds", "dark"),
-				huh.NewOption("High Contrast - Maximum visibility", "high-contrast"),
+				huh.NewOption("Adaptive - Auto-detect", config.ThemeNameAdaptive),
+				huh.NewOption("Light - For light backgrounds", config.ThemeNameLight),
+				huh.NewOption("Dark - For dark backgrounds", config.ThemeNameDark),
+				huh.NewOption("High Contrast - Maximum visibility", config.ThemeNameHighContrast),
 			).
 			Value(&cfg.TUI.Theme),
 	))

--- a/cmd/camp/settings_cli.go
+++ b/cmd/camp/settings_cli.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/jsoncontract"
+)
+
+// SettingsJSONVersion is the schema version of camp settings get --json.
+//
+// Changelog:
+//   - v1alpha1: initial payload (global theme/editor/campaigns_dir/verbose/
+//     no_color, local theme_override when inside a campaign, effective theme,
+//     in_campaign). Single-key form emits {schema_version, generated_at, key,
+//     value}.
+const SettingsJSONVersion = "settings/v1alpha1"
+
+const (
+	settingsKeyGlobalTheme        = "global.theme"
+	settingsKeyGlobalEditor       = "global.editor"
+	settingsKeyGlobalCampaignsDir = "global.campaigns_dir"
+	settingsKeyGlobalVerbose      = "global.verbose"
+	settingsKeyGlobalNoColor      = "global.no_color"
+	settingsKeyLocalThemeOverride = "local.theme_override"
+	settingsKeyEffectiveTheme     = "effective.theme"
+)
+
+const settingsThemeInherit = "inherit"
+
+func settingsKeys() []string {
+	return []string{
+		settingsKeyGlobalTheme,
+		settingsKeyGlobalEditor,
+		settingsKeyGlobalCampaignsDir,
+		settingsKeyGlobalVerbose,
+		settingsKeyGlobalNoColor,
+		settingsKeyLocalThemeOverride,
+	}
+}
+
+type settingsPayload struct {
+	SchemaVersion string                   `json:"schema_version"`
+	GeneratedAt   time.Time                `json:"generated_at"`
+	InCampaign    bool                     `json:"in_campaign"`
+	Global        settingsGlobalPayload    `json:"global"`
+	Local         *settingsLocalPayload    `json:"local,omitempty"`
+	Effective     settingsEffectivePayload `json:"effective"`
+}
+
+type settingsGlobalPayload struct {
+	Theme        string `json:"theme"`
+	Editor       string `json:"editor"`
+	CampaignsDir string `json:"campaigns_dir"`
+	Verbose      bool   `json:"verbose"`
+	NoColor      bool   `json:"no_color"`
+}
+
+type settingsLocalPayload struct {
+	ThemeOverride string `json:"theme_override"`
+}
+
+type settingsEffectivePayload struct {
+	Theme string `json:"theme"`
+}
+
+type settingsValuePayload struct {
+	SchemaVersion string    `json:"schema_version"`
+	GeneratedAt   time.Time `json:"generated_at"`
+	Key           string    `json:"key"`
+	Value         any       `json:"value"`
+}
+
+func newSettingsGetCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "get [key]",
+		Short: "Print camp settings",
+		Long: `Print camp settings non-interactively.
+
+With no key, prints all settings including the effective theme. With a key,
+prints just that value.
+
+Keys:
+  global.theme           Color theme in ~/.obey/campaign/config.json
+  global.editor          Preferred editor
+  global.campaigns_dir   Where camp create places new campaigns
+  global.verbose         Verbose output
+  global.no_color        Disable colored output
+  local.theme_override   Campaign-local theme override (requires a campaign)`,
+		Example: `  camp settings get
+  camp settings get global.theme
+  camp settings get --json`,
+		Args:         jsoncontract.Args(SettingsJSONVersion, func() bool { return jsonOut }, cobra.MaximumNArgs(1)),
+		SilenceUsage: true,
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Read-only settings output with --json support",
+		},
+		RunE: jsoncontract.RunE(SettingsJSONVersion, func() bool { return jsonOut }, func(cmd *cobra.Command, args []string) error {
+			return runSettingsGet(cmd.Context(), cmd, args, jsonOut)
+		}),
+	}
+	cmd.SetFlagErrorFunc(jsoncontract.FlagErrorFunc(SettingsJSONVersion, func() bool { return jsonOut }))
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a structured JSON result")
+	return cmd
+}
+
+func newSettingsSetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <key> <value>",
+		Short: "Set a camp setting",
+		Long: `Set a camp setting non-interactively.
+
+Accepts the same keys as 'camp settings get'. Theme values are one of
+adaptive, light, dark, or high-contrast. Boolean values accept true/false.
+Setting local.theme_override to 'inherit' clears the override; local.* keys
+require running inside a campaign.`,
+		Example: `  camp settings set global.theme dark
+  camp settings set global.verbose true
+  camp settings set local.theme_override light
+  camp settings set local.theme_override inherit`,
+		Args:         cobra.ExactArgs(2),
+		SilenceUsage: true,
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Non-interactive settings mutation with validated values",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSettingsSet(cmd.Context(), cmd, args[0], args[1])
+		},
+	}
+}
+
+func runSettingsGet(ctx context.Context, cmd *cobra.Command, args []string, jsonOut bool) error {
+	cfg, err := config.LoadGlobalConfig(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "loading global config")
+	}
+
+	root, rootErr := campaign.DetectCached(ctx)
+	inCampaign := rootErr == nil && root != ""
+
+	var local *config.LocalSettings
+	if inCampaign {
+		local, err = config.LoadLocalSettings(ctx, root)
+		if err != nil {
+			return err
+		}
+	}
+
+	effective := config.EffectiveThemeFrom(cfg, local)
+
+	if len(args) == 1 {
+		return printSettingsValue(cmd, args[0], cfg, local, inCampaign, jsonOut)
+	}
+	if jsonOut {
+		return emitSettingsJSON(cmd.OutOrStdout(), cfg, local, inCampaign, effective)
+	}
+	return printSettingsAll(cmd.OutOrStdout(), cfg, local, inCampaign, effective)
+}
+
+func settingsValueFor(key string, cfg *config.GlobalConfig, local *config.LocalSettings, inCampaign bool) (any, error) {
+	switch key {
+	case settingsKeyGlobalTheme:
+		return cfg.TUI.Theme, nil
+	case settingsKeyGlobalEditor:
+		return cfg.Editor, nil
+	case settingsKeyGlobalCampaignsDir:
+		return cfg.CampaignsDir, nil
+	case settingsKeyGlobalVerbose:
+		return cfg.Verbose, nil
+	case settingsKeyGlobalNoColor:
+		return cfg.NoColor, nil
+	case settingsKeyLocalThemeOverride:
+		if !inCampaign {
+			return nil, errSettingsLocalOutsideCampaign(key)
+		}
+		return local.ThemeOverride, nil
+	default:
+		return nil, errSettingsUnknownKey(key)
+	}
+}
+
+func printSettingsValue(cmd *cobra.Command, key string, cfg *config.GlobalConfig, local *config.LocalSettings, inCampaign, jsonOut bool) error {
+	value, err := settingsValueFor(key, cfg, local, inCampaign)
+	if err != nil {
+		return err
+	}
+	if jsonOut {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(settingsValuePayload{
+			SchemaVersion: SettingsJSONVersion,
+			GeneratedAt:   time.Now().UTC(),
+			Key:           key,
+			Value:         value,
+		})
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "%v\n", value)
+	return err
+}
+
+func printSettingsAll(w io.Writer, cfg *config.GlobalConfig, local *config.LocalSettings, inCampaign bool, effective string) error {
+	lines := []struct {
+		key   string
+		value any
+	}{
+		{settingsKeyGlobalTheme, cfg.TUI.Theme},
+		{settingsKeyGlobalEditor, cfg.Editor},
+		{settingsKeyGlobalCampaignsDir, cfg.CampaignsDir},
+		{settingsKeyGlobalVerbose, cfg.Verbose},
+		{settingsKeyGlobalNoColor, cfg.NoColor},
+	}
+	for _, line := range lines {
+		if _, err := fmt.Fprintf(w, "%s = %v\n", line.key, line.value); err != nil {
+			return err
+		}
+	}
+	if inCampaign {
+		if _, err := fmt.Fprintf(w, "%s = %s\n", settingsKeyLocalThemeOverride, local.ThemeOverride); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintf(w, "%s = %s\n", settingsKeyEffectiveTheme, effective)
+	return err
+}
+
+func emitSettingsJSON(w io.Writer, cfg *config.GlobalConfig, local *config.LocalSettings, inCampaign bool, effective string) error {
+	payload := settingsPayload{
+		SchemaVersion: SettingsJSONVersion,
+		GeneratedAt:   time.Now().UTC(),
+		InCampaign:    inCampaign,
+		Global: settingsGlobalPayload{
+			Theme:        cfg.TUI.Theme,
+			Editor:       cfg.Editor,
+			CampaignsDir: cfg.CampaignsDir,
+			Verbose:      cfg.Verbose,
+			NoColor:      cfg.NoColor,
+		},
+		Effective: settingsEffectivePayload{Theme: effective},
+	}
+	if inCampaign {
+		payload.Local = &settingsLocalPayload{ThemeOverride: local.ThemeOverride}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(payload)
+}
+
+func runSettingsSet(ctx context.Context, cmd *cobra.Command, key, value string) error {
+	switch key {
+	case settingsKeyGlobalTheme, settingsKeyGlobalEditor, settingsKeyGlobalCampaignsDir,
+		settingsKeyGlobalVerbose, settingsKeyGlobalNoColor:
+		return setGlobalSetting(ctx, cmd, key, value)
+	case settingsKeyLocalThemeOverride:
+		return setLocalThemeOverride(ctx, cmd, value)
+	default:
+		return errSettingsUnknownKey(key)
+	}
+}
+
+func setGlobalSetting(ctx context.Context, cmd *cobra.Command, key, value string) error {
+	cfg, err := config.LoadGlobalConfig(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "loading global config")
+	}
+
+	display, err := applyGlobalSetting(cfg, key, value)
+	if err != nil {
+		return err
+	}
+
+	if err := config.SaveGlobalConfig(ctx, cfg); err != nil {
+		return camperrors.Wrap(err, "saving global config")
+	}
+
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "set %s = %s\n", key, display)
+	return err
+}
+
+func applyGlobalSetting(cfg *config.GlobalConfig, key, value string) (string, error) {
+	switch key {
+	case settingsKeyGlobalTheme:
+		themeName := strings.ToLower(strings.TrimSpace(value))
+		if !config.IsValidThemeName(themeName) {
+			return "", camperrors.NewValidation(key,
+				fmt.Sprintf("unknown theme %q (valid: %s)", value, strings.Join(config.ValidThemeNames(), ", ")), nil)
+		}
+		cfg.TUI.Theme = themeName
+		return themeName, nil
+	case settingsKeyGlobalEditor:
+		cfg.Editor = strings.TrimSpace(value)
+		return cfg.Editor, nil
+	case settingsKeyGlobalCampaignsDir:
+		next := *cfg
+		next.CampaignsDir = strings.TrimSpace(value)
+		if err := config.ValidateGlobalConfig(&next); err != nil {
+			return "", camperrors.NewValidation(key, err.Error(), err)
+		}
+		cfg.CampaignsDir = next.CampaignsDir
+		return cfg.CampaignsDir, nil
+	case settingsKeyGlobalVerbose, settingsKeyGlobalNoColor:
+		parsed, err := strconv.ParseBool(strings.ToLower(strings.TrimSpace(value)))
+		if err != nil {
+			return "", camperrors.NewValidation(key,
+				fmt.Sprintf("invalid boolean %q (valid: true, false)", value), err)
+		}
+		if key == settingsKeyGlobalVerbose {
+			cfg.Verbose = parsed
+		} else {
+			cfg.NoColor = parsed
+		}
+		return strconv.FormatBool(parsed), nil
+	default:
+		return "", errSettingsUnknownKey(key)
+	}
+}
+
+func setLocalThemeOverride(ctx context.Context, cmd *cobra.Command, value string) error {
+	root, err := campaign.DetectCached(ctx)
+	if err != nil || root == "" {
+		return errSettingsLocalOutsideCampaign(settingsKeyLocalThemeOverride)
+	}
+
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	if normalized == settingsThemeInherit {
+		normalized = ""
+	}
+	if normalized != "" && !config.IsValidThemeName(normalized) {
+		return camperrors.NewValidation(settingsKeyLocalThemeOverride,
+			fmt.Sprintf("unknown theme %q (valid: %s, %s)", value,
+				strings.Join(config.ValidThemeNames(), ", "), settingsThemeInherit), nil)
+	}
+
+	if err := config.WithLocalSettingsLock(ctx, root, func(s *config.LocalSettings) error {
+		s.ThemeOverride = normalized
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if normalized == "" {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "cleared %s\n", settingsKeyLocalThemeOverride)
+		return err
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "set %s = %s\n", settingsKeyLocalThemeOverride, normalized)
+	return err
+}
+
+func errSettingsUnknownKey(key string) error {
+	return camperrors.NewValidation("key",
+		fmt.Sprintf("unknown settings key %q (valid: %s)", key, strings.Join(settingsKeys(), ", ")), nil)
+}
+
+func errSettingsLocalOutsideCampaign(key string) error {
+	return camperrors.NewValidation(key,
+		"local settings require a campaign; run this command inside a campaign directory", nil)
+}

--- a/cmd/camp/settings_cli_test.go
+++ b/cmd/camp/settings_cli_test.go
@@ -1,0 +1,390 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+func execSettingsCmd(t *testing.T, newCmd func() *cobra.Command, args ...string) (string, string, error) {
+	t.Helper()
+	cmd := newCmd()
+	cmd.SetContext(context.Background())
+	out := new(bytes.Buffer)
+	errOut := new(bytes.Buffer)
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), errOut.String(), err
+}
+
+func setupSettingsTest(t *testing.T, inCampaign bool) string {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if !inCampaign {
+		t.Setenv("CAMP_ROOT", "")
+		chdirForTest(t, t.TempDir())
+		return ""
+	}
+	root := makeTestCampaign(t, "settings-test-campaign")
+	t.Setenv("CAMP_ROOT", root)
+	chdirForTest(t, root)
+	return root
+}
+
+func TestSettingsSet_ErrorPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		inCampaign bool
+		args       []string
+	}{
+		{"unknown key", true, []string{"bogus.key", "x"}},
+		{"invalid global theme", true, []string{"global.theme", "neon"}},
+		{"invalid verbose bool", true, []string{"global.verbose", "maybe"}},
+		{"invalid no_color bool", true, []string{"global.no_color", "2x"}},
+		{"invalid local theme", true, []string{"local.theme_override", "neon"}},
+		{"local key outside campaign", false, []string{"local.theme_override", "dark"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupSettingsTest(t, tt.inCampaign)
+
+			_, _, err := execSettingsCmd(t, newSettingsSetCmd, tt.args...)
+			if err == nil {
+				t.Fatal("settings set expected error")
+			}
+			var validation *camperrors.ValidationError
+			if !errors.As(err, &validation) {
+				t.Fatalf("settings set error = %v, want ValidationError", err)
+			}
+		})
+	}
+}
+
+func TestSettingsSet_GlobalValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		value  string
+		verify func(t *testing.T, cfg *config.GlobalConfig)
+	}{
+		{"theme", "global.theme", "dark", func(t *testing.T, cfg *config.GlobalConfig) {
+			if cfg.TUI.Theme != config.ThemeNameDark {
+				t.Fatalf("TUI.Theme = %q, want %q", cfg.TUI.Theme, config.ThemeNameDark)
+			}
+		}},
+		{"theme normalizes case", "global.theme", "LIGHT", func(t *testing.T, cfg *config.GlobalConfig) {
+			if cfg.TUI.Theme != config.ThemeNameLight {
+				t.Fatalf("TUI.Theme = %q, want %q", cfg.TUI.Theme, config.ThemeNameLight)
+			}
+		}},
+		{"editor", "global.editor", "nvim", func(t *testing.T, cfg *config.GlobalConfig) {
+			if cfg.Editor != "nvim" {
+				t.Fatalf("Editor = %q, want nvim", cfg.Editor)
+			}
+		}},
+		{"campaigns_dir", "global.campaigns_dir", "~/work/campaigns", func(t *testing.T, cfg *config.GlobalConfig) {
+			if cfg.CampaignsDir != "~/work/campaigns" {
+				t.Fatalf("CampaignsDir = %q, want ~/work/campaigns", cfg.CampaignsDir)
+			}
+		}},
+		{"verbose", "global.verbose", "true", func(t *testing.T, cfg *config.GlobalConfig) {
+			if !cfg.Verbose {
+				t.Fatal("Verbose = false, want true")
+			}
+		}},
+		{"no_color", "global.no_color", "true", func(t *testing.T, cfg *config.GlobalConfig) {
+			if !cfg.NoColor {
+				t.Fatal("NoColor = false, want true")
+			}
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupSettingsTest(t, false)
+
+			out, _, err := execSettingsCmd(t, newSettingsSetCmd, tt.key, tt.value)
+			if err != nil {
+				t.Fatalf("settings set error = %v", err)
+			}
+			if !strings.Contains(out, "set "+tt.key) {
+				t.Fatalf("settings set output = %q, want confirmation for %s", out, tt.key)
+			}
+
+			cfg, err := config.LoadGlobalConfig(context.Background())
+			if err != nil {
+				t.Fatalf("LoadGlobalConfig() error = %v", err)
+			}
+			tt.verify(t, cfg)
+		})
+	}
+}
+
+func TestSettingsSet_LocalThemeOverrideWritesFile(t *testing.T) {
+	root := setupSettingsTest(t, true)
+
+	out, _, err := execSettingsCmd(t, newSettingsSetCmd, "local.theme_override", "light")
+	if err != nil {
+		t.Fatalf("settings set error = %v", err)
+	}
+	if !strings.Contains(out, "set local.theme_override = light") {
+		t.Fatalf("settings set output = %q", out)
+	}
+
+	local, err := config.LoadLocalSettings(context.Background(), root)
+	if err != nil {
+		t.Fatalf("LoadLocalSettings() error = %v", err)
+	}
+	if local.ThemeOverride != config.ThemeNameLight {
+		t.Fatalf("ThemeOverride = %q, want %q", local.ThemeOverride, config.ThemeNameLight)
+	}
+}
+
+func TestSettingsSet_LocalThemeOverrideInheritDeletesFile(t *testing.T) {
+	root := setupSettingsTest(t, true)
+
+	if _, _, err := execSettingsCmd(t, newSettingsSetCmd, "local.theme_override", "dark"); err != nil {
+		t.Fatalf("seed settings set error = %v", err)
+	}
+	if _, err := os.Stat(config.LocalSettingsPath(root)); err != nil {
+		t.Fatalf("expected local.json after set: %v", err)
+	}
+
+	out, _, err := execSettingsCmd(t, newSettingsSetCmd, "local.theme_override", "inherit")
+	if err != nil {
+		t.Fatalf("settings set inherit error = %v", err)
+	}
+	if !strings.Contains(out, "cleared local.theme_override") {
+		t.Fatalf("settings set output = %q", out)
+	}
+	if _, err := os.Stat(config.LocalSettingsPath(root)); !os.IsNotExist(err) {
+		t.Fatalf("expected local.json removed, stat err = %v", err)
+	}
+}
+
+func TestSettingsGet_ErrorPaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		inCampaign bool
+		args       []string
+	}{
+		{"unknown key", true, []string{"bogus.key"}},
+		{"local key outside campaign", false, []string{"local.theme_override"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupSettingsTest(t, tt.inCampaign)
+
+			_, _, err := execSettingsCmd(t, newSettingsGetCmd, tt.args...)
+			if err == nil {
+				t.Fatal("settings get expected error")
+			}
+			var validation *camperrors.ValidationError
+			if !errors.As(err, &validation) {
+				t.Fatalf("settings get error = %v, want ValidationError", err)
+			}
+		})
+	}
+}
+
+func TestSettingsGet_AllKeysText(t *testing.T) {
+	setupSettingsTest(t, true)
+
+	if _, _, err := execSettingsCmd(t, newSettingsSetCmd, "global.theme", "dark"); err != nil {
+		t.Fatalf("seed set theme: %v", err)
+	}
+	if _, _, err := execSettingsCmd(t, newSettingsSetCmd, "local.theme_override", "light"); err != nil {
+		t.Fatalf("seed set override: %v", err)
+	}
+
+	out, _, err := execSettingsCmd(t, newSettingsGetCmd)
+	if err != nil {
+		t.Fatalf("settings get error = %v", err)
+	}
+
+	wantLines := []string{
+		"global.theme = dark",
+		"global.editor = ",
+		"global.campaigns_dir = ",
+		"global.verbose = false",
+		"global.no_color = false",
+		"local.theme_override = light",
+		"effective.theme = light",
+	}
+	for _, line := range wantLines {
+		if !strings.Contains(out, line) {
+			t.Errorf("settings get output missing %q\noutput:\n%s", line, out)
+		}
+	}
+}
+
+func TestSettingsGet_AllKeysTextOutsideCampaign(t *testing.T) {
+	setupSettingsTest(t, false)
+
+	out, _, err := execSettingsCmd(t, newSettingsGetCmd)
+	if err != nil {
+		t.Fatalf("settings get error = %v", err)
+	}
+	if strings.Contains(out, "local.theme_override") {
+		t.Fatalf("settings get outside campaign should omit local keys, got:\n%s", out)
+	}
+	if !strings.Contains(out, "effective.theme = adaptive") {
+		t.Fatalf("settings get output missing effective theme, got:\n%s", out)
+	}
+}
+
+func TestSettingsGet_SingleKey(t *testing.T) {
+	setupSettingsTest(t, true)
+
+	if _, _, err := execSettingsCmd(t, newSettingsSetCmd, "global.theme", "high-contrast"); err != nil {
+		t.Fatalf("seed set theme: %v", err)
+	}
+
+	out, _, err := execSettingsCmd(t, newSettingsGetCmd, "global.theme")
+	if err != nil {
+		t.Fatalf("settings get error = %v", err)
+	}
+	if strings.TrimSpace(out) != config.ThemeNameHighContrast {
+		t.Fatalf("settings get global.theme = %q, want %q", strings.TrimSpace(out), config.ThemeNameHighContrast)
+	}
+}
+
+func TestSettingsGet_JSONShape(t *testing.T) {
+	setupSettingsTest(t, true)
+
+	if _, _, err := execSettingsCmd(t, newSettingsSetCmd, "global.theme", "dark"); err != nil {
+		t.Fatalf("seed set theme: %v", err)
+	}
+	if _, _, err := execSettingsCmd(t, newSettingsSetCmd, "local.theme_override", "light"); err != nil {
+		t.Fatalf("seed set override: %v", err)
+	}
+
+	out, _, err := execSettingsCmd(t, newSettingsGetCmd, "--json")
+	if err != nil {
+		t.Fatalf("settings get --json error = %v", err)
+	}
+
+	var payload settingsPayload
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("settings get --json invalid JSON: %v\nraw: %s", err, out)
+	}
+	if payload.SchemaVersion != SettingsJSONVersion {
+		t.Errorf("schema_version = %q, want %q", payload.SchemaVersion, SettingsJSONVersion)
+	}
+	if payload.GeneratedAt.IsZero() {
+		t.Error("generated_at is zero")
+	}
+	if !payload.InCampaign {
+		t.Error("in_campaign = false, want true")
+	}
+	if payload.Global.Theme != config.ThemeNameDark {
+		t.Errorf("global.theme = %q, want %q", payload.Global.Theme, config.ThemeNameDark)
+	}
+	if payload.Local == nil || payload.Local.ThemeOverride != config.ThemeNameLight {
+		t.Errorf("local = %+v, want theme_override %q", payload.Local, config.ThemeNameLight)
+	}
+	if payload.Effective.Theme != config.ThemeNameLight {
+		t.Errorf("effective.theme = %q, want %q", payload.Effective.Theme, config.ThemeNameLight)
+	}
+}
+
+func TestSettingsGet_JSONOutsideCampaignOmitsLocal(t *testing.T) {
+	setupSettingsTest(t, false)
+
+	out, _, err := execSettingsCmd(t, newSettingsGetCmd, "--json")
+	if err != nil {
+		t.Fatalf("settings get --json error = %v", err)
+	}
+
+	var payload settingsPayload
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("settings get --json invalid JSON: %v\nraw: %s", err, out)
+	}
+	if payload.InCampaign {
+		t.Error("in_campaign = true, want false")
+	}
+	if payload.Local != nil {
+		t.Errorf("local = %+v, want omitted", payload.Local)
+	}
+}
+
+func TestSettingsGet_JSONSingleKey(t *testing.T) {
+	setupSettingsTest(t, true)
+
+	if _, _, err := execSettingsCmd(t, newSettingsSetCmd, "global.verbose", "true"); err != nil {
+		t.Fatalf("seed set verbose: %v", err)
+	}
+
+	out, _, err := execSettingsCmd(t, newSettingsGetCmd, "global.verbose", "--json")
+	if err != nil {
+		t.Fatalf("settings get --json error = %v", err)
+	}
+
+	var payload settingsValuePayload
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("settings get --json invalid JSON: %v\nraw: %s", err, out)
+	}
+	if payload.SchemaVersion != SettingsJSONVersion {
+		t.Errorf("schema_version = %q, want %q", payload.SchemaVersion, SettingsJSONVersion)
+	}
+	if payload.Key != "global.verbose" {
+		t.Errorf("key = %q, want global.verbose", payload.Key)
+	}
+	if value, ok := payload.Value.(bool); !ok || !value {
+		t.Errorf("value = %v, want true", payload.Value)
+	}
+}
+
+func TestSettingsGet_JSONErrorEnvelope(t *testing.T) {
+	setupSettingsTest(t, true)
+
+	_, errOut, err := execSettingsCmd(t, newSettingsGetCmd, "bogus.key", "--json")
+	if err == nil {
+		t.Fatal("settings get expected error")
+	}
+
+	var envelope struct {
+		SchemaVersion string `json:"schema_version"`
+		Error         struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if jsonErr := json.Unmarshal([]byte(errOut), &envelope); jsonErr != nil {
+		t.Fatalf("stderr is not a JSON envelope: %v\nraw: %s", jsonErr, errOut)
+	}
+	if envelope.SchemaVersion != SettingsJSONVersion {
+		t.Errorf("schema_version = %q, want %q", envelope.SchemaVersion, SettingsJSONVersion)
+	}
+	if envelope.Error.Code != "validation_error" {
+		t.Errorf("error.code = %q, want validation_error", envelope.Error.Code)
+	}
+}
+
+func TestSettingsSubcommandsRegistered(t *testing.T) {
+	for _, path := range [][]string{{"settings", "get"}, {"settings", "set"}} {
+		cmd := findCmd(path...)
+		if cmd == nil {
+			t.Errorf("command %v not registered", path)
+			continue
+		}
+		if cmd.Annotations["agent_allowed"] != "true" {
+			t.Errorf("command %v agent_allowed = %q, want true", path, cmd.Annotations["agent_allowed"])
+		}
+		if cmd.Annotations["interactive"] != "" {
+			t.Errorf("command %v should not carry interactive annotation", path)
+		}
+	}
+}

--- a/docs/campaign-settings-files.md
+++ b/docs/campaign-settings-files.md
@@ -23,6 +23,7 @@ For the full `.campaign/` directory layout, including `quests/`, `skills/`,
 | `.campaign/settings/fresh.yaml` | Campaign | YAML | `camp init` / `camp init --repair` | Yes |
 | `.campaign/settings/pins.json` | Campaign | JSON | `camp pin` / `camp unpin` | Usually no |
 | `.campaign/settings/allowlist.json` | Campaign | JSON | `camp init`, `camp init --repair`, or tooling that saves allowlist config | Sometimes |
+| `.campaign/settings/local.json` | Campaign | JSON | `camp settings` (Local Settings) or `camp settings set local.*` | Usually no |
 | `.campaign/watchers.yaml` | Campaign | YAML | `camp init`, `camp init --repair`, `fest`, contract writers | No |
 
 ## What `camp init` And `camp init --repair` Create
@@ -42,9 +43,11 @@ Today, `camp init` and `camp init --repair` reliably scaffold:
 They do not currently scaffold:
 
 - `.campaign/settings/pins.json`
+- `.campaign/settings/local.json`
 
-Files like `.campaign/settings/pins.json` and `.campaign/leverage/` are created
-later when the corresponding feature is used.
+Files like `.campaign/settings/pins.json`, `.campaign/settings/local.json`,
+and `.campaign/leverage/` are created later when the corresponding feature is
+used.
 
 ## Typical `.campaign/` Layout
 
@@ -68,7 +71,8 @@ Not everything under `.campaign/` is the same kind of file:
 
 - `campaign.yaml`, `settings/fresh.yaml`, and `settings/jumps.yaml` are normal
   user-editable configuration
-- `watchers.yaml`, `pins.json`, and most quest/runtime state are tool-managed
+- `watchers.yaml`, `pins.json`, `settings/local.json`, and most quest/runtime
+  state are tool-managed
 - `skills/` is campaign content that camp scaffolds and skill-related commands
   consume
 - `leverage/` appears later when leverage commands write config or snapshots
@@ -284,6 +288,29 @@ Notes:
 - `inherit_defaults: false` means only commands listed in this file are
   explicitly allowed.
 
+### `.campaign/settings/local.json`
+
+Campaign-local settings managed by `camp settings`.
+
+Example:
+
+```json
+{
+  "theme_override": "dark"
+}
+```
+
+Notes:
+
+- `theme_override` forces a color theme for this campaign: one of `adaptive`,
+  `light`, `dark`, or `high-contrast`. When absent or empty, the campaign
+  inherits the global theme from `~/.obey/campaign/config.json`.
+- The file is created on first save by `camp settings` (Local Settings) or
+  `camp settings set local.theme_override <value>`. Clearing the last setting
+  deletes the file.
+- Prefer the `camp settings` commands over hand-editing; writes are atomic and
+  lock-protected.
+
 ### `.campaign/watchers.yaml`
 
 The campaign watcher contract. This is camp/fest-owned machine-readable state
@@ -304,14 +331,29 @@ Important:
 - Users generally should not hand-edit it unless they are debugging contract
   behavior.
 
-## `camp settings` Status
+## `camp settings` Scope
 
-`camp settings` is only a partial configuration editor today:
+`camp settings` edits both configuration scopes:
 
-- Global settings are implemented and saved to `~/.obey/campaign/config.json`
-- Local campaign settings in the TUI are still a scaffold and do not write the
-  files under `.campaign/settings/`
+- Global settings are saved to `~/.obey/campaign/config.json`
+- Local Settings edits `.campaign/settings/local.json` (currently the
+  campaign theme override)
 
-For now, campaign-local configuration is file-based. Edit the relevant file
-directly when you need to customize `jumps.yaml`, `fresh.yaml`, or
-`allowlist.json`.
+For non-interactive access (agents, scripts, the festival app), use:
+
+```bash
+camp settings get                       # All settings plus the effective theme
+camp settings get global.theme          # One value
+camp settings get --json                # Versioned JSON payload
+camp settings set global.theme dark
+camp settings set local.theme_override light
+camp settings set local.theme_override inherit   # Clear the override
+```
+
+Keys: `global.theme`, `global.editor`, `global.campaigns_dir`,
+`global.verbose`, `global.no_color`, `local.theme_override`. The `local.*`
+keys require running inside a campaign.
+
+Other campaign-local files (`jumps.yaml`, `fresh.yaml`, `allowlist.json`)
+remain file-based; edit the relevant file directly when you need to customize
+them.

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -646,6 +646,7 @@ camp create <name> [flags]
   -m, --mission string       Campaign mission statement
   -n, --name string          Campaign display name (defaults to <name> positional)
       --no-git               Skip git repository initialization
+      --no-skills            Skip linking campaign skills into .claude/skills and .agents/skills
       --path string          Override the base campaigns directory (campaign created at <path>/<name>/)
   -t, --type string          Campaign type (product, research, tools, personal) (default "product")
 ```
@@ -1382,6 +1383,7 @@ camp init [path] [flags]
   -n, --name string          Campaign name (defaults to directory name)
       --no-git               Skip git repository initialization
       --no-register          Don't add to global registry
+      --no-skills            Skip linking campaign skills into .claude/skills and .agents/skills
       --repair               Add missing files to existing campaign
   -t, --type string          Campaign type (product, research, tools, personal) (default "product")
       --yes                  Skip repair confirmation prompt (for scripting)
@@ -4112,13 +4114,14 @@ Manage camp configuration
 
 Interactive menu for managing camp configuration.
 
-Today, this command edits global user preferences in
-~/.obey/campaign/config.json.
+Global settings live in ~/.obey/campaign/config.json and apply to every
+campaign. Local settings live in .campaign/settings/local.json and apply
+only to the current campaign; a local theme override wins over the global
+theme while you are inside that campaign.
 
-Campaign-local settings still live in files under .campaign/, and the
-"Local Settings" menu is currently a scaffold rather than a full editor.
-See docs/campaign-settings-files.md in the camp repository for the current
-file layout.
+For non-interactive access, use 'camp settings get' and
+'camp settings set'. See docs/campaign-settings-files.md in the camp
+repository for the file layout.
 
 ```
 camp settings [flags]
@@ -4127,13 +4130,104 @@ camp settings [flags]
 ### Examples
 
 ```
-  camp settings   # Edit global editor/theme preferences
+  camp settings                              # Interactive settings menu
+  camp settings get                          # Print all settings
+  camp settings set global.theme dark        # Set the global theme
+  camp settings set local.theme_override light
 ```
 
 ### Options
 
 ```
   -h, --help   help for settings
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp settings get
+
+Print camp settings
+
+### Synopsis
+
+Print camp settings non-interactively.
+
+With no key, prints all settings including the effective theme. With a key,
+prints just that value.
+
+Keys:
+  global.theme           Color theme in ~/.obey/campaign/config.json
+  global.editor          Preferred editor
+  global.campaigns_dir   Where camp create places new campaigns
+  global.verbose         Verbose output
+  global.no_color        Disable colored output
+  local.theme_override   Campaign-local theme override (requires a campaign)
+
+```
+camp settings get [key] [flags]
+```
+
+### Examples
+
+```
+  camp settings get
+  camp settings get global.theme
+  camp settings get --json
+```
+
+### Options
+
+```
+  -h, --help   help for get
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp settings set
+
+Set a camp setting
+
+### Synopsis
+
+Set a camp setting non-interactively.
+
+Accepts the same keys as 'camp settings get'. Theme values are one of
+adaptive, light, dark, or high-contrast. Boolean values accept true/false.
+Setting local.theme_override to 'inherit' clears the override; local.* keys
+require running inside a campaign.
+
+```
+camp settings set <key> <value> [flags]
+```
+
+### Examples
+
+```
+  camp settings set global.theme dark
+  camp settings set global.verbose true
+  camp settings set local.theme_override light
+  camp settings set local.theme_override inherit
+```
+
+### Options
+
+```
+  -h, --help   help for set
 ```
 
 ### Options inherited from parent commands
@@ -4519,7 +4613,10 @@ skills directories.
 This command creates one symlink per skill bundle. It does not replace entire
 provider skills directories, so existing user skills remain intact.
 
+With neither --tool nor --path, skills are projected into every registered tool.
+
 Examples:
+  camp skills link                     Project skills into all registered tools
   camp skills link --tool claude       Project skills into .claude/skills/
   camp skills link --tool agents       Project skills into .agents/skills/
   camp skills link --path custom/dir   Project skills into custom/dir
@@ -5495,6 +5592,45 @@ camp workitem links [selector] [flags]
 
 ```
   -h, --help   help for links
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+---
+
+## camp workitem priority
+
+Set or clear the manual priority of a workitem
+
+### Synopsis
+
+Set or clear the manual priority of a workitem.
+
+The selector accepts the same forms as 'camp workitem current': a stable
+.workitem id, the workitem key (<type>:<path>), a relative path, or a directory
+slug. Priority is one of high, medium, low, or clear (clear removes any manual
+priority). Assignments persist in .campaign/settings/workitems.json, the same
+store the interactive dashboard writes.
+
+Examples:
+  camp workitem priority festival:festivals/active/demo high
+  camp workitem priority demo clear
+  camp workitem priority demo high --json
+
+```
+camp workitem priority <selector> <high|medium|low|clear> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for priority
       --json   emit a structured JSON result
 ```
 

--- a/docs/cli-reference/camp_create.md
+++ b/docs/cli-reference/camp_create.md
@@ -28,6 +28,7 @@ camp create <name> [flags]
   -m, --mission string       Campaign mission statement
   -n, --name string          Campaign display name (defaults to <name> positional)
       --no-git               Skip git repository initialization
+      --no-skills            Skip linking campaign skills into .claude/skills and .agents/skills
       --path string          Override the base campaigns directory (campaign created at <path>/<name>/)
   -t, --type string          Campaign type (product, research, tools, personal) (default "product")
 ```

--- a/docs/cli-reference/camp_init.md
+++ b/docs/cli-reference/camp_init.md
@@ -54,6 +54,7 @@ camp init [path] [flags]
   -n, --name string          Campaign name (defaults to directory name)
       --no-git               Skip git repository initialization
       --no-register          Don't add to global registry
+      --no-skills            Skip linking campaign skills into .claude/skills and .agents/skills
       --repair               Add missing files to existing campaign
   -t, --type string          Campaign type (product, research, tools, personal) (default "product")
       --yes                  Skip repair confirmation prompt (for scripting)

--- a/docs/cli-reference/camp_settings.md
+++ b/docs/cli-reference/camp_settings.md
@@ -6,13 +6,14 @@ Manage camp configuration
 
 Interactive menu for managing camp configuration.
 
-Today, this command edits global user preferences in
-~/.obey/campaign/config.json.
+Global settings live in ~/.obey/campaign/config.json and apply to every
+campaign. Local settings live in .campaign/settings/local.json and apply
+only to the current campaign; a local theme override wins over the global
+theme while you are inside that campaign.
 
-Campaign-local settings still live in files under .campaign/, and the
-"Local Settings" menu is currently a scaffold rather than a full editor.
-See docs/campaign-settings-files.md in the camp repository for the current
-file layout.
+For non-interactive access, use 'camp settings get' and
+'camp settings set'. See docs/campaign-settings-files.md in the camp
+repository for the file layout.
 
 ```
 camp settings [flags]
@@ -21,7 +22,10 @@ camp settings [flags]
 ### Examples
 
 ```
-  camp settings   # Edit global editor/theme preferences
+  camp settings                              # Interactive settings menu
+  camp settings get                          # Print all settings
+  camp settings set global.theme dark        # Set the global theme
+  camp settings set local.theme_override light
 ```
 
 ### Options
@@ -41,3 +45,5 @@ camp settings [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
+* [camp settings get](camp_settings_get.md)	 - Print camp settings
+* [camp settings set](camp_settings_set.md)	 - Set a camp setting

--- a/docs/cli-reference/camp_settings_get.md
+++ b/docs/cli-reference/camp_settings_get.md
@@ -1,0 +1,49 @@
+## camp settings get
+
+Print camp settings
+
+### Synopsis
+
+Print camp settings non-interactively.
+
+With no key, prints all settings including the effective theme. With a key,
+prints just that value.
+
+Keys:
+  global.theme           Color theme in ~/.obey/campaign/config.json
+  global.editor          Preferred editor
+  global.campaigns_dir   Where camp create places new campaigns
+  global.verbose         Verbose output
+  global.no_color        Disable colored output
+  local.theme_override   Campaign-local theme override (requires a campaign)
+
+```
+camp settings get [key] [flags]
+```
+
+### Examples
+
+```
+  camp settings get
+  camp settings get global.theme
+  camp settings get --json
+```
+
+### Options
+
+```
+  -h, --help   help for get
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp settings](camp_settings.md)	 - Manage camp configuration

--- a/docs/cli-reference/camp_settings_set.md
+++ b/docs/cli-reference/camp_settings_set.md
@@ -1,0 +1,43 @@
+## camp settings set
+
+Set a camp setting
+
+### Synopsis
+
+Set a camp setting non-interactively.
+
+Accepts the same keys as 'camp settings get'. Theme values are one of
+adaptive, light, dark, or high-contrast. Boolean values accept true/false.
+Setting local.theme_override to 'inherit' clears the override; local.* keys
+require running inside a campaign.
+
+```
+camp settings set <key> <value> [flags]
+```
+
+### Examples
+
+```
+  camp settings set global.theme dark
+  camp settings set global.verbose true
+  camp settings set local.theme_override light
+  camp settings set local.theme_override inherit
+```
+
+### Options
+
+```
+  -h, --help   help for set
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp settings](camp_settings.md)	 - Manage camp configuration

--- a/docs/cli-reference/camp_skills_link.md
+++ b/docs/cli-reference/camp_skills_link.md
@@ -10,7 +10,10 @@ skills directories.
 This command creates one symlink per skill bundle. It does not replace entire
 provider skills directories, so existing user skills remain intact.
 
+With neither --tool nor --path, skills are projected into every registered tool.
+
 Examples:
+  camp skills link                     Project skills into all registered tools
   camp skills link --tool claude       Project skills into .claude/skills/
   camp skills link --tool agents       Project skills into .agents/skills/
   camp skills link --path custom/dir   Project skills into custom/dir

--- a/docs/cli-reference/camp_workitem.md
+++ b/docs/cli-reference/camp_workitem.md
@@ -51,5 +51,6 @@ camp workitem [flags]
 * [camp workitem doctor](camp_workitem_doctor.md)	 - Report workitem link-registry health issues
 * [camp workitem link](camp_workitem_link.md)	 - Attach a workitem to a project, festival, worktree, or campaign path
 * [camp workitem links](camp_workitem_links.md)	 - List workitem links
+* [camp workitem priority](camp_workitem_priority.md)	 - Set or clear the manual priority of a workitem
 * [camp workitem resolve](camp_workitem_resolve.md)	 - Print the workitem the current context resolves to (read-only)
 * [camp workitem unlink](camp_workitem_unlink.md)	 - Remove one or more workitem links

--- a/docs/cli-reference/camp_workitem_priority.md
+++ b/docs/cli-reference/camp_workitem_priority.md
@@ -1,0 +1,41 @@
+## camp workitem priority
+
+Set or clear the manual priority of a workitem
+
+### Synopsis
+
+Set or clear the manual priority of a workitem.
+
+The selector accepts the same forms as 'camp workitem current': a stable
+.workitem id, the workitem key (<type>:<path>), a relative path, or a directory
+slug. Priority is one of high, medium, low, or clear (clear removes any manual
+priority). Assignments persist in .campaign/settings/workitems.json, the same
+store the interactive dashboard writes.
+
+Examples:
+  camp workitem priority festival:festivals/active/demo high
+  camp workitem priority demo clear
+  camp workitem priority demo high --json
+
+```
+camp workitem priority <selector> <high|medium|low|clear> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for priority
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   config file (default: ~/.obey/campaign/config.json)
+      --no-color        disable colored output
+      --verbose         enable verbose output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -183,6 +183,6 @@ func (c *CampaignConfig) ApplyDefaults() {
 func (c *GlobalConfig) ApplyDefaults() {
 	// Apply TUI defaults
 	if c.TUI.Theme == "" {
-		c.TUI.Theme = "adaptive"
+		c.TUI.Theme = ThemeNameAdaptive
 	}
 }

--- a/internal/config/localsettings.go
+++ b/internal/config/localsettings.go
@@ -1,0 +1,213 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+)
+
+const LocalSettingsFile = "local.json"
+
+const (
+	ThemeNameAdaptive     = "adaptive"
+	ThemeNameLight        = "light"
+	ThemeNameDark         = "dark"
+	ThemeNameHighContrast = "high-contrast"
+)
+
+func ValidThemeNames() []string {
+	return []string{ThemeNameAdaptive, ThemeNameLight, ThemeNameDark, ThemeNameHighContrast}
+}
+
+func IsValidThemeName(name string) bool {
+	switch name {
+	case ThemeNameAdaptive, ThemeNameLight, ThemeNameDark, ThemeNameHighContrast:
+		return true
+	}
+	return false
+}
+
+type LocalSettings struct {
+	ThemeOverride string `json:"theme_override,omitempty"`
+}
+
+func (s *LocalSettings) IsEmpty() bool {
+	return s == nil || *s == LocalSettings{}
+}
+
+func LocalSettingsPath(campaignRoot string) string {
+	return filepath.Join(campaignRoot, CampaignDir, SettingsDir, LocalSettingsFile)
+}
+
+func LoadLocalSettings(ctx context.Context, campaignRoot string) (*LocalSettings, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	path := LocalSettingsPath(campaignRoot)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return &LocalSettings{}, nil
+	}
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "failed to read local settings %s", path)
+	}
+
+	var s LocalSettings
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, camperrors.Wrapf(err, "failed to parse local settings %s", path)
+	}
+	return &s, nil
+}
+
+func ValidateLocalSettings(s *LocalSettings) error {
+	if s == nil {
+		return camperrors.NewValidation("local_settings", "cannot save nil local settings", nil)
+	}
+	if s.ThemeOverride != "" && !IsValidThemeName(s.ThemeOverride) {
+		return camperrors.NewValidation("theme_override",
+			fmt.Sprintf("unknown theme %q (valid: %s)", s.ThemeOverride, strings.Join(ValidThemeNames(), ", ")), nil)
+	}
+	return nil
+}
+
+func SaveLocalSettings(ctx context.Context, campaignRoot string, s *LocalSettings) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(SettingsDirPath(campaignRoot), 0o755); err != nil {
+		return camperrors.Wrap(err, "failed to create settings directory")
+	}
+
+	release, err := fsutil.AcquireFileLock(ctx, LocalSettingsPath(campaignRoot)+".lock")
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	return saveLocalSettingsLocked(ctx, campaignRoot, s)
+}
+
+func saveLocalSettingsLocked(ctx context.Context, campaignRoot string, s *LocalSettings) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := ValidateLocalSettings(s); err != nil {
+		return err
+	}
+
+	path := LocalSettingsPath(campaignRoot)
+	if s.IsEmpty() {
+		if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return camperrors.Wrapf(err, "failed to remove empty local settings %s", path)
+		}
+		invalidateLocalThemeCache()
+		return nil
+	}
+
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return camperrors.Wrap(err, "failed to marshal local settings")
+	}
+	data = append(data, '\n')
+
+	if err := fsutil.WriteFileAtomically(path, data, 0o644); err != nil {
+		return camperrors.Wrap(err, "failed to write local settings")
+	}
+	invalidateLocalThemeCache()
+	return nil
+}
+
+func WithLocalSettingsLock(ctx context.Context, campaignRoot string, fn func(*LocalSettings) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(SettingsDirPath(campaignRoot), 0o755); err != nil {
+		return camperrors.Wrap(err, "failed to create settings directory")
+	}
+
+	release, err := fsutil.AcquireFileLock(ctx, LocalSettingsPath(campaignRoot)+".lock")
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	s, err := LoadLocalSettings(ctx, campaignRoot)
+	if err != nil {
+		return err
+	}
+	if err := fn(s); err != nil {
+		return err
+	}
+	return saveLocalSettingsLocked(ctx, campaignRoot, s)
+}
+
+type localThemeCache struct {
+	mu    sync.Mutex
+	root  string
+	value string
+	valid bool
+}
+
+var localTheme localThemeCache
+
+func EffectiveTheme(ctx context.Context) string {
+	var cfg *GlobalConfig
+	if loaded, err := LoadGlobalConfig(ctx); err == nil {
+		cfg = loaded
+	}
+	return EffectiveThemeFrom(cfg, &LocalSettings{ThemeOverride: localThemeOverride(ctx)})
+}
+
+func EffectiveThemeFrom(cfg *GlobalConfig, local *LocalSettings) string {
+	theme := ThemeNameAdaptive
+	if cfg != nil && IsValidThemeName(cfg.TUI.Theme) {
+		theme = cfg.TUI.Theme
+	}
+	if local != nil && IsValidThemeName(local.ThemeOverride) {
+		theme = local.ThemeOverride
+	}
+	return theme
+}
+
+func localThemeOverride(ctx context.Context) string {
+	root, err := campaign.DetectCached(ctx)
+	if err != nil || root == "" {
+		return ""
+	}
+
+	localTheme.mu.Lock()
+	defer localTheme.mu.Unlock()
+	if localTheme.valid && localTheme.root == root {
+		return localTheme.value
+	}
+
+	value := ""
+	if s, loadErr := LoadLocalSettings(ctx, root); loadErr == nil {
+		value = s.ThemeOverride
+	}
+	localTheme.root = root
+	localTheme.value = value
+	localTheme.valid = true
+	return value
+}
+
+func invalidateLocalThemeCache() {
+	localTheme.mu.Lock()
+	defer localTheme.mu.Unlock()
+	localTheme.root = ""
+	localTheme.value = ""
+	localTheme.valid = false
+}

--- a/internal/config/localsettings_test.go
+++ b/internal/config/localsettings_test.go
@@ -1,0 +1,461 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+func makeLocalSettingsCampaign(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".campaign"), 0o755); err != nil {
+		t.Fatalf("mkdir .campaign: %v", err)
+	}
+	return root
+}
+
+func chdirLocalSettingsTest(t *testing.T, dir string) {
+	t.Helper()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	campaign.ClearCache()
+	invalidateLocalThemeCache()
+	t.Cleanup(func() {
+		if err := os.Chdir(origDir); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+		campaign.ClearCache()
+		invalidateLocalThemeCache()
+	})
+}
+
+func TestLoadLocalSettings_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := LoadLocalSettings(ctx, t.TempDir())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("LoadLocalSettings() error = %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestLoadLocalSettings_CorruptFile(t *testing.T) {
+	root := makeLocalSettingsCampaign(t)
+	path := LocalSettingsPath(root)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadLocalSettings(context.Background(), root)
+	if err == nil {
+		t.Fatal("LoadLocalSettings() expected error for corrupt JSON")
+	}
+}
+
+func TestLoadLocalSettings_MissingFileReturnsZeroValue(t *testing.T) {
+	root := makeLocalSettingsCampaign(t)
+
+	s, err := LoadLocalSettings(context.Background(), root)
+	if err != nil {
+		t.Fatalf("LoadLocalSettings() error = %v", err)
+	}
+	if !s.IsEmpty() {
+		t.Fatalf("LoadLocalSettings() = %+v, want zero value", s)
+	}
+}
+
+func TestSaveLocalSettings_ErrorPaths(t *testing.T) {
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name           string
+		ctx            context.Context
+		settings       *LocalSettings
+		wantCancel     bool
+		wantValidation bool
+	}{
+		{"cancelled context", cancelled, &LocalSettings{}, true, false},
+		{"nil settings", context.Background(), nil, false, true},
+		{"invalid theme", context.Background(), &LocalSettings{ThemeOverride: "neon"}, false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := makeLocalSettingsCampaign(t)
+			err := SaveLocalSettings(tt.ctx, root, tt.settings)
+			if err == nil {
+				t.Fatal("SaveLocalSettings() expected error")
+			}
+			if tt.wantCancel && !errors.Is(err, context.Canceled) {
+				t.Fatalf("SaveLocalSettings() error = %v, want %v", err, context.Canceled)
+			}
+			if tt.wantValidation {
+				var validation *camperrors.ValidationError
+				if !errors.As(err, &validation) {
+					t.Fatalf("SaveLocalSettings() error = %v, want ValidationError", err)
+				}
+			}
+		})
+	}
+}
+
+func TestSaveLocalSettings_RoundTrip(t *testing.T) {
+	root := makeLocalSettingsCampaign(t)
+	ctx := context.Background()
+
+	if err := SaveLocalSettings(ctx, root, &LocalSettings{ThemeOverride: ThemeNameDark}); err != nil {
+		t.Fatalf("SaveLocalSettings() error = %v", err)
+	}
+
+	loaded, err := LoadLocalSettings(ctx, root)
+	if err != nil {
+		t.Fatalf("LoadLocalSettings() error = %v", err)
+	}
+	if loaded.ThemeOverride != ThemeNameDark {
+		t.Fatalf("ThemeOverride = %q, want %q", loaded.ThemeOverride, ThemeNameDark)
+	}
+}
+
+func TestSaveLocalSettings_EmptyRemovesFile(t *testing.T) {
+	root := makeLocalSettingsCampaign(t)
+	ctx := context.Background()
+
+	if err := SaveLocalSettings(ctx, root, &LocalSettings{ThemeOverride: ThemeNameLight}); err != nil {
+		t.Fatalf("seed SaveLocalSettings() error = %v", err)
+	}
+	if _, err := os.Stat(LocalSettingsPath(root)); err != nil {
+		t.Fatalf("expected local.json to exist after save: %v", err)
+	}
+
+	if err := SaveLocalSettings(ctx, root, &LocalSettings{}); err != nil {
+		t.Fatalf("SaveLocalSettings(empty) error = %v", err)
+	}
+	if _, err := os.Stat(LocalSettingsPath(root)); !os.IsNotExist(err) {
+		t.Fatalf("expected local.json removed, stat err = %v", err)
+	}
+}
+
+func TestSaveLocalSettings_EmptyWithNoFileSucceeds(t *testing.T) {
+	root := makeLocalSettingsCampaign(t)
+
+	if err := SaveLocalSettings(context.Background(), root, &LocalSettings{}); err != nil {
+		t.Fatalf("SaveLocalSettings(empty, no file) error = %v", err)
+	}
+}
+
+func TestWithLocalSettingsLock_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := WithLocalSettingsLock(ctx, t.TempDir(), func(s *LocalSettings) error { return nil })
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WithLocalSettingsLock() error = %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestWithLocalSettingsLock_FnErrorSkipsSave(t *testing.T) {
+	root := makeLocalSettingsCampaign(t)
+	ctx := context.Background()
+	wantErr := errors.New("boom")
+
+	err := WithLocalSettingsLock(ctx, root, func(s *LocalSettings) error {
+		s.ThemeOverride = ThemeNameDark
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("WithLocalSettingsLock() error = %v, want %v", err, wantErr)
+	}
+	if _, statErr := os.Stat(LocalSettingsPath(root)); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no local.json after fn error, stat err = %v", statErr)
+	}
+}
+
+func TestWithLocalSettingsLock_SavesMutation(t *testing.T) {
+	root := makeLocalSettingsCampaign(t)
+	ctx := context.Background()
+
+	err := WithLocalSettingsLock(ctx, root, func(s *LocalSettings) error {
+		s.ThemeOverride = ThemeNameHighContrast
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WithLocalSettingsLock() error = %v", err)
+	}
+
+	loaded, err := LoadLocalSettings(ctx, root)
+	if err != nil {
+		t.Fatalf("LoadLocalSettings() error = %v", err)
+	}
+	if loaded.ThemeOverride != ThemeNameHighContrast {
+		t.Fatalf("ThemeOverride = %q, want %q", loaded.ThemeOverride, ThemeNameHighContrast)
+	}
+}
+
+func TestWithLocalSettingsLock_ClearingDeletesFile(t *testing.T) {
+	root := makeLocalSettingsCampaign(t)
+	ctx := context.Background()
+
+	if err := SaveLocalSettings(ctx, root, &LocalSettings{ThemeOverride: ThemeNameDark}); err != nil {
+		t.Fatalf("seed SaveLocalSettings() error = %v", err)
+	}
+
+	err := WithLocalSettingsLock(ctx, root, func(s *LocalSettings) error {
+		s.ThemeOverride = ""
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WithLocalSettingsLock() error = %v", err)
+	}
+	if _, statErr := os.Stat(LocalSettingsPath(root)); !os.IsNotExist(statErr) {
+		t.Fatalf("expected local.json removed, stat err = %v", statErr)
+	}
+}
+
+func TestWithLocalSettingsLock_ConcurrentWritersDoNotCorrupt(t *testing.T) {
+	root := makeLocalSettingsCampaign(t)
+	ctx := context.Background()
+	themes := ValidThemeNames()
+
+	const workers = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs <- WithLocalSettingsLock(ctx, root, func(s *LocalSettings) error {
+				s.ThemeOverride = themes[i%len(themes)]
+				return nil
+			})
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent WithLocalSettingsLock: %v", err)
+		}
+	}
+
+	loaded, err := LoadLocalSettings(ctx, root)
+	if err != nil {
+		t.Fatalf("LoadLocalSettings() after concurrent writers: %v", err)
+	}
+	if !IsValidThemeName(loaded.ThemeOverride) {
+		t.Fatalf("ThemeOverride = %q, want a valid theme", loaded.ThemeOverride)
+	}
+}
+
+func TestIsValidThemeName(t *testing.T) {
+	tests := []struct {
+		name  string
+		theme string
+		want  bool
+	}{
+		{"empty", "", false},
+		{"unknown", "neon", false},
+		{"case sensitive", "Dark", false},
+		{"adaptive", ThemeNameAdaptive, true},
+		{"light", ThemeNameLight, true},
+		{"dark", ThemeNameDark, true},
+		{"high contrast", ThemeNameHighContrast, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidThemeName(tt.theme); got != tt.want {
+				t.Fatalf("IsValidThemeName(%q) = %v, want %v", tt.theme, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveThemeFrom(t *testing.T) {
+	tests := []struct {
+		name  string
+		cfg   *GlobalConfig
+		local *LocalSettings
+		want  string
+	}{
+		{"nil inputs", nil, nil, ThemeNameAdaptive},
+		{"invalid global falls back", &GlobalConfig{TUI: TUIConfig{Theme: "neon"}}, nil, ThemeNameAdaptive},
+		{"invalid override ignored", &GlobalConfig{TUI: TUIConfig{Theme: ThemeNameDark}}, &LocalSettings{ThemeOverride: "neon"}, ThemeNameDark},
+		{"global only", &GlobalConfig{TUI: TUIConfig{Theme: ThemeNameLight}}, nil, ThemeNameLight},
+		{"empty override inherits", &GlobalConfig{TUI: TUIConfig{Theme: ThemeNameDark}}, &LocalSettings{}, ThemeNameDark},
+		{"override wins", &GlobalConfig{TUI: TUIConfig{Theme: ThemeNameDark}}, &LocalSettings{ThemeOverride: ThemeNameLight}, ThemeNameLight},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EffectiveThemeFrom(tt.cfg, tt.local); got != tt.want {
+				t.Fatalf("EffectiveThemeFrom() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveTheme_OutsideCampaignUsesGlobal(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("CAMP_ROOT", "")
+	chdirLocalSettingsTest(t, t.TempDir())
+
+	ctx := context.Background()
+	if err := SaveGlobalConfig(ctx, &GlobalConfig{TUI: TUIConfig{Theme: ThemeNameDark}}); err != nil {
+		t.Fatalf("SaveGlobalConfig() error = %v", err)
+	}
+
+	if got := EffectiveTheme(ctx); got != ThemeNameDark {
+		t.Fatalf("EffectiveTheme() = %q, want %q", got, ThemeNameDark)
+	}
+}
+
+func TestEffectiveTheme_InsideCampaignWithoutOverrideUsesGlobal(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	root := makeLocalSettingsCampaign(t)
+	t.Setenv("CAMP_ROOT", root)
+	chdirLocalSettingsTest(t, root)
+
+	ctx := context.Background()
+	if err := SaveGlobalConfig(ctx, &GlobalConfig{TUI: TUIConfig{Theme: ThemeNameLight}}); err != nil {
+		t.Fatalf("SaveGlobalConfig() error = %v", err)
+	}
+
+	if got := EffectiveTheme(ctx); got != ThemeNameLight {
+		t.Fatalf("EffectiveTheme() = %q, want %q", got, ThemeNameLight)
+	}
+}
+
+func TestEffectiveTheme_LocalOverrideWins(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	root := makeLocalSettingsCampaign(t)
+	t.Setenv("CAMP_ROOT", root)
+	chdirLocalSettingsTest(t, root)
+
+	ctx := context.Background()
+	if err := SaveGlobalConfig(ctx, &GlobalConfig{TUI: TUIConfig{Theme: ThemeNameDark}}); err != nil {
+		t.Fatalf("SaveGlobalConfig() error = %v", err)
+	}
+	if err := SaveLocalSettings(ctx, root, &LocalSettings{ThemeOverride: ThemeNameHighContrast}); err != nil {
+		t.Fatalf("SaveLocalSettings() error = %v", err)
+	}
+
+	if got := EffectiveTheme(ctx); got != ThemeNameHighContrast {
+		t.Fatalf("EffectiveTheme() = %q, want %q", got, ThemeNameHighContrast)
+	}
+}
+
+func TestEffectiveTheme_SaveInvalidatesCachedOverride(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	root := makeLocalSettingsCampaign(t)
+	t.Setenv("CAMP_ROOT", root)
+	chdirLocalSettingsTest(t, root)
+
+	ctx := context.Background()
+	if err := SaveGlobalConfig(ctx, &GlobalConfig{TUI: TUIConfig{Theme: ThemeNameDark}}); err != nil {
+		t.Fatalf("SaveGlobalConfig() error = %v", err)
+	}
+
+	if err := SaveLocalSettings(ctx, root, &LocalSettings{ThemeOverride: ThemeNameLight}); err != nil {
+		t.Fatalf("SaveLocalSettings() error = %v", err)
+	}
+	if got := EffectiveTheme(ctx); got != ThemeNameLight {
+		t.Fatalf("EffectiveTheme() = %q, want %q", got, ThemeNameLight)
+	}
+
+	if err := WithLocalSettingsLock(ctx, root, func(s *LocalSettings) error {
+		s.ThemeOverride = ""
+		return nil
+	}); err != nil {
+		t.Fatalf("WithLocalSettingsLock() error = %v", err)
+	}
+	if got := EffectiveTheme(ctx); got != ThemeNameDark {
+		t.Fatalf("EffectiveTheme() after clear = %q, want %q", got, ThemeNameDark)
+	}
+}
+
+func TestLocalSettingsPath(t *testing.T) {
+	got := LocalSettingsPath("/campaign/root")
+	want := filepath.Join("/campaign/root", CampaignDir, SettingsDir, LocalSettingsFile)
+	if got != want {
+		t.Fatalf("LocalSettingsPath() = %q, want %q", got, want)
+	}
+}
+
+func TestLocalSettings_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings *LocalSettings
+		want     bool
+	}{
+		{"nil", nil, true},
+		{"zero value", &LocalSettings{}, true},
+		{"with override", &LocalSettings{ThemeOverride: ThemeNameDark}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.settings.IsEmpty(); got != tt.want {
+				t.Fatalf("IsEmpty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateLocalSettings(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings *LocalSettings
+		wantErr  bool
+	}{
+		{"nil", nil, true},
+		{"invalid theme", &LocalSettings{ThemeOverride: "neon"}, true},
+		{"empty", &LocalSettings{}, false},
+		{"valid theme", &LocalSettings{ThemeOverride: ThemeNameLight}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateLocalSettings(tt.settings)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateLocalSettings() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				var validation *camperrors.ValidationError
+				if !errors.As(err, &validation) {
+					t.Fatalf("ValidateLocalSettings() error = %v, want ValidationError", err)
+				}
+			}
+		})
+	}
+}
+
+func TestSaveLocalSettings_FilePersistsValidJSON(t *testing.T) {
+	root := makeLocalSettingsCampaign(t)
+	ctx := context.Background()
+
+	if err := SaveLocalSettings(ctx, root, &LocalSettings{ThemeOverride: ThemeNameDark}); err != nil {
+		t.Fatalf("SaveLocalSettings() error = %v", err)
+	}
+
+	data, err := os.ReadFile(LocalSettingsPath(root))
+	if err != nil {
+		t.Fatalf("read local.json: %v", err)
+	}
+	want := fmt.Sprintf("{\n  \"theme_override\": %q\n}\n", ThemeNameDark)
+	if string(data) != want {
+		t.Fatalf("local.json = %q, want %q", data, want)
+	}
+}

--- a/internal/intent/tui/explorer/model.go
+++ b/internal/intent/tui/explorer/model.go
@@ -158,12 +158,7 @@ type Model struct {
 func NewModel(ctx context.Context, svc *intent.IntentService, conceptSvc concept.Service, intentsDir, campaignRoot, campaignID, author string, shortcuts map[string]string) Model {
 	// Initialize glamour style once at startup (handles adaptive detection).
 	// This avoids the slow OSC terminal query on every markdown render.
-	globalCfg, _ := config.LoadGlobalConfig(ctx)
-	themeName := "adaptive" // default
-	if globalCfg != nil {
-		themeName = globalCfg.TUI.Theme
-	}
-	tui.InitGlamourStyle(themeName)
+	tui.InitGlamourStyle(config.EffectiveTheme(ctx))
 
 	ti := textinput.New()
 	ti.Placeholder = "Search intents..."

--- a/internal/ui/theme/forms.go
+++ b/internal/ui/theme/forms.go
@@ -26,22 +26,13 @@ func redirectToTTY(form *huh.Form) (*huh.Form, func()) {
 }
 
 // RunForm runs a huh form with the configured theme applied.
-// It loads the theme from global config and applies it before running.
+// It resolves the effective theme (global config plus any campaign-local
+// override) and applies it before running.
 func RunForm(ctx context.Context, form *huh.Form) error {
 	form, cleanup := redirectToTTY(form)
 	defer cleanup()
 
-	cfg, err := config.LoadGlobalConfig(ctx)
-	if err != nil {
-		return form.WithTheme(GetTheme(ThemeAdaptive)).Run()
-	}
-
-	themeName := ThemeName(cfg.TUI.Theme)
-	if themeName == "" {
-		themeName = ThemeAdaptive
-	}
-
-	return form.WithTheme(GetTheme(themeName)).Run()
+	return form.WithTheme(GetTheme(ThemeName(config.EffectiveTheme(ctx)))).Run()
 }
 
 // RunFormAccessible runs a huh form with accessible mode enabled.
@@ -50,17 +41,7 @@ func RunFormAccessible(ctx context.Context, form *huh.Form) error {
 	form, cleanup := redirectToTTY(form)
 	defer cleanup()
 
-	cfg, err := config.LoadGlobalConfig(ctx)
-	if err != nil {
-		return form.WithTheme(GetTheme(ThemeAdaptive)).WithAccessible(true).Run()
-	}
-
-	themeName := ThemeName(cfg.TUI.Theme)
-	if themeName == "" {
-		themeName = ThemeAdaptive
-	}
-
-	return form.WithTheme(GetTheme(themeName)).WithAccessible(true).Run()
+	return form.WithTheme(GetTheme(ThemeName(config.EffectiveTheme(ctx)))).WithAccessible(true).Run()
 }
 
 // IsCancelled returns true if the error indicates user cancellation.

--- a/internal/ui/theme/theme.go
+++ b/internal/ui/theme/theme.go
@@ -4,6 +4,8 @@ package theme
 import (
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Obedience-Corp/camp/internal/config"
 )
 
 // ThemeName represents a color theme name.
@@ -11,13 +13,13 @@ type ThemeName string
 
 const (
 	// ThemeAdaptive uses huh's default theme which auto-adapts to terminal.
-	ThemeAdaptive ThemeName = "adaptive"
+	ThemeAdaptive ThemeName = ThemeName(config.ThemeNameAdaptive)
 	// ThemeLight is optimized for light terminal backgrounds.
-	ThemeLight ThemeName = "light"
+	ThemeLight ThemeName = ThemeName(config.ThemeNameLight)
 	// ThemeDark is optimized for dark terminal backgrounds.
-	ThemeDark ThemeName = "dark"
+	ThemeDark ThemeName = ThemeName(config.ThemeNameDark)
 	// ThemeHighContrast provides maximum visibility.
-	ThemeHighContrast ThemeName = "high-contrast"
+	ThemeHighContrast ThemeName = ThemeName(config.ThemeNameHighContrast)
 )
 
 // ValidThemes lists all valid theme names.


### PR DESCRIPTION
Implements workitem WI-cb1937 (camp-settings-local-implementation). The Local Settings half of `camp settings` was a UI scaffold rendering [MOCK] NOT IMPLEMENTED options; this makes it real.

## What changed

**Local settings store** (`internal/config/localsettings.go`)
- `LocalSettings` persisted at `.campaign/settings/local.json`; first real field is `theme_override`
- Load returns zero value when the file is missing; corrupt files error loudly
- Save validates, writes via `fsutil.WriteFileAtomically` under `fsutil.AcquireFileLock`, and deletes the file when settings are empty (priority-store SaveOrDelete semantics)
- `WithLocalSettingsLock` holds the lock across load-mutate-save, mirroring the links registry pattern, so concurrent camp invocations cannot lose writes

**Effective theme resolution**
- `config.EffectiveTheme`: local override wins inside a campaign, global otherwise; cached per campaign root and invalidated on save
- Wired into the two GlobalConfig theme consumers (theme forms, intent explorer glamour styles)
- Theme names are now constants in `internal/config`; the magic string in defaults.go is gone

**Real editor replaces the mock** (`cmd/camp/settings.go`)
- Theme Override entry shows the current override and effective value; Inherit global clears it
- The fake Project Defaults and Intent Defaults entries are removed, not stubbed: no semantics or consumers exist yet, and inventing them would be feature sprawl
- Outside a campaign the Local Settings entry explains itself instead of breaking

**Non-interactive surface** (`cmd/camp/settings_cli.go`)
- `camp settings get [key]` and `camp settings set <key> <value>` over six enumerated dotted keys (global.theme, global.editor, global.campaigns_dir, global.verbose, global.no_color, local.theme_override)
- `get --json` emits a versioned `settings/v1alpha1` payload following the existing jsoncontract discipline, including the stderr error envelope
- `set` validates with typed errors and refuses local.* outside a campaign; `set local.theme_override inherit` clears the override
- This also gives the festival-app a settings read surface instead of parsing campaign files directly

**Manifest test fix (pre-existing red gate)**
- `cmd/camp/manifest_test.go` on main is missing the `workitem priority` entries from PR #318, so the unit gate fails in both profiles before this branch. Since this PR must touch that test anyway for `settings get/set`, it adds the missing entries and corrects the counts. Overlaps camp-hardening festival CH0001 sequence 01 task 01, which should verify-and-skip.

**Docs**: `docs/campaign-settings-files.md` gains the local.json row and a real scope section.

## Tests
- `internal/config/localsettings_test.go` (461 lines): error paths first, context cancellation, missing/corrupt file, lock round-trip, delete-on-empty, concurrent writers, precedence tables, cache invalidation
- `cmd/camp/settings_cli_test.go` (390 lines): validation errors, local.* outside campaign refused, all keys, JSON shapes and error envelope, registration and annotation assertions

## Gates (all run locally, both profiles)
- `just build` stable and dev: BUILD SUCCESSFUL
- `just test unit`: 2559/2559 passing (includes the manifest test that is red on main)
- `just lint`: 0 issues; no new host-fs-test violators
- `go vet ./...` plain and -tags dev: clean
- Live smoke test in a temp campaign: get/set round-trip, override precedence, file delete on inherit, JSON payload

## Deliberately out of scope
- Speculative local settings (project/intent defaults) until real consumers exist
- `--json` on set; quarantine-style recovery for corrupt local.json (follow-up if wanted)