### PR TITLE
test: isolate integration config state

### DIFF
--- a/tests/integration/helpers_container.go
+++ b/tests/integration/helpers_container.go
@@ -19,10 +19,12 @@ import (
 // begins — required for consistency on macOS/Colima where Docker exec runs through
 // a virtualization layer (overlayfs in a Linux VM).
 func (tc *TestContainer) Reset() error {
-	// Remove all test artifacts and recreate clean directories
+	// Remove all test artifacts and recreate clean directories. Include both
+	// current and legacy config homes so registry/global settings never leak
+	// between tests that share a pooled container.
 	exitCode, _, err := tc.container.Exec(tc.ctx, []string{
 		"sh", "-c",
-		"rm -rf /test /campaigns /root/.config/camp /root/.camp 2>/dev/null; " +
+		"rm -rf /test /campaigns /root/.obey /root/.config/camp /root/.camp 2>/dev/null; " +
 			"mkdir -p /test /campaigns /root/.config/camp; sync",
 	})
 	if err != nil {

--- a/tests/integration/project_test.go
+++ b/tests/integration/project_test.go
@@ -212,10 +212,10 @@ func TestProject_NotInCampaign(t *testing.T) {
 	err := tc.CreateGitRepo("/test/orphan")
 	require.NoError(t, err)
 
-	// Try to add project when not in a campaign and no target campaign is specified.
+	// Try to add project when not in a campaign and no target campaign is registered.
 	output, err := tc.RunCampInDir("/test", "project", "add", "--local", "/test/orphan")
 	require.Error(t, err, "project add should fail outside campaign")
-	assert.Contains(t, strings.ToLower(output), "campaign name required in non-interactive mode", "error should require an explicit target campaign")
+	assert.Contains(t, strings.ToLower(output), "no campaigns registered", "error should explain there is no target campaign to select")
 }
 
 func TestProject_NotAGitRepo(t *testing.T) {

--- a/tests/integration/settings_test.go
+++ b/tests/integration/settings_test.go
@@ -13,10 +13,9 @@ import (
 
 func TestCampSettings_CampaignsDirEditAndClear(t *testing.T) {
 	tc := GetSharedContainer(t)
-	tc.Shell(t, "rm -rf /root/.obey/campaign")
 
 	backFromGlobalSettings := strings.Repeat("\x1b[B", 6) + "\r"
-	exitCampSettings := "\x1b[B\r"
+	exitCampSettings := strings.Repeat("\x1b[B", 2) + "\r"
 	openCampaignsDir := strings.Repeat("\x1b[B", 2) + "\r"
 
 	output, err := tc.RunCampInteractiveStepsInDir(


### PR DESCRIPTION
## Summary
- clear the current Obey config home during integration container resets so pooled containers cannot leak registry or settings state
- update the camp settings TUI navigation test for the local settings menu entry
- align the outside-campaign project assertion with the empty-registry path

## Validation
- `CAMP_TEST_POOL_SIZE=1 just test integration-run 'Test(CampSettings_CampaignsDirEditAndClear|Project_NotInCampaign)'`
- `just test integration`
- `just test unit`
- `just lint`
- `just build-camp`
