### PR TITLE
fix(intent): make notes.go and rename.go writes atomic (C-2 follow-up)

### DIFF
--- a/internal/intent/atomic_write_test.go
+++ b/internal/intent/atomic_write_test.go
@@ -1,0 +1,91 @@
+package intent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAtomicWrites_RenameRoundTripsWithoutTempLitter(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := NewIntentService(tmp, intentsDir)
+
+	created, err := svc.CreateDirect(ctx, CreateOptions{
+		Title:     "atomic rename target",
+		Type:      TypeIdea,
+		Timestamp: time.Date(2026, 2, 1, 9, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateDirect: %v", err)
+	}
+
+	renamed, err := svc.Rename(ctx, created.ID, "atomic rename target updated")
+	if err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	if _, err := os.Stat(renamed.Path); err != nil {
+		t.Errorf("renamed file missing: %v", err)
+	}
+
+	got, err := svc.Get(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("Get after rename: %v", err)
+	}
+	if got.Title != "atomic rename target updated" {
+		t.Errorf("title = %q after rename", got.Title)
+	}
+	assertNoTempLitter(t, intentsDir)
+}
+
+func TestAtomicWrites_NoteMovesRoundTripWithoutTempLitter(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := NewIntentService(tmp, intentsDir)
+
+	note, err := svc.CreateNote(ctx, CreateOptions{
+		Title:     "a captured note",
+		Timestamp: time.Date(2026, 2, 1, 9, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	promoted, err := svc.MoveNoteToStatus(ctx, note.ID, StatusInbox, TypeIdea)
+	if err != nil {
+		t.Fatalf("MoveNoteToStatus: %v", err)
+	}
+	if promoted.Status != StatusInbox {
+		t.Errorf("status = %q after promote, want inbox", promoted.Status)
+	}
+
+	got, err := svc.Get(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("Get after promote: %v", err)
+	}
+	if got.Title != "a captured note" {
+		t.Errorf("title = %q after promote", got.Title)
+	}
+	assertNoTempLitter(t, intentsDir)
+}
+
+func assertNoTempLitter(t *testing.T, root string) {
+	t.Helper()
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.Contains(d.Name(), ".tmp-") {
+			t.Errorf("leftover temp file from atomic write: %s", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+}

--- a/internal/intent/notes.go
+++ b/internal/intent/notes.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
 	"github.com/Obedience-Corp/camp/internal/intent/audit"
 )
 
@@ -179,7 +180,7 @@ func (s *IntentService) ArchiveNote(ctx context.Context, id string) (*Intent, er
 	if err != nil {
 		return nil, camperrors.Wrap(err, "serializing note")
 	}
-	if err := os.WriteFile(newPath, data, 0644); err != nil {
+	if err := fsutil.WriteFileAtomically(newPath, data, 0644); err != nil {
 		return nil, camperrors.Wrap(err, "writing note file")
 	}
 
@@ -242,7 +243,7 @@ func (s *IntentService) MoveIntentToNote(ctx context.Context, id string) (*Inten
 	if err != nil {
 		return nil, camperrors.Wrap(err, "serializing note")
 	}
-	if err := os.WriteFile(newPath, data, 0644); err != nil {
+	if err := fsutil.WriteFileAtomically(newPath, data, 0644); err != nil {
 		return nil, camperrors.Wrap(err, "writing note file")
 	}
 	if err := os.Remove(oldPath); err != nil {
@@ -299,7 +300,7 @@ func (s *IntentService) MoveNoteToStatus(ctx context.Context, id string, newStat
 	if err != nil {
 		return nil, camperrors.Wrap(err, "serializing converted note")
 	}
-	if err := os.WriteFile(newPath, data, 0644); err != nil {
+	if err := fsutil.WriteFileAtomically(newPath, data, 0644); err != nil {
 		return nil, camperrors.Wrap(err, "writing intent file")
 	}
 

--- a/internal/intent/rename.go
+++ b/internal/intent/rename.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
 )
 
 // Rename updates an intent's title and regenerates its human-readable filename
@@ -57,7 +58,7 @@ func (s *IntentService) Rename(ctx context.Context, id, newTitle string) (*Inten
 
 	if newPath == oldPath {
 		// Slug unchanged: rewrite in place.
-		if err := os.WriteFile(oldPath, data, 0644); err != nil {
+		if err := fsutil.WriteFileAtomically(oldPath, data, 0644); err != nil {
 			return nil, camperrors.Wrap(err, "writing renamed intent")
 		}
 		it.Path = oldPath
@@ -65,7 +66,7 @@ func (s *IntentService) Rename(ctx context.Context, id, newTitle string) (*Inten
 		return it, nil
 	}
 
-	if err := os.WriteFile(newPath, data, 0644); err != nil {
+	if err := fsutil.WriteFileAtomically(newPath, data, 0644); err != nil {
 		return nil, camperrors.Wrap(err, "writing renamed intent")
 	}
 	if err := os.Remove(oldPath); err != nil {


### PR DESCRIPTION
## What

Routes the 5 remaining non-atomic `os.WriteFile` sites in the intent package through `fsutil.WriteFileAtomically` (temp-file + fsync + rename), closing finding **C-2** from the camp #324 (camp-hardening) review.

- `internal/intent/rename.go` — in-place rewrite (slug unchanged) + slug-change move
- `internal/intent/notes.go` — `ArchiveNote`, `MoveIntentToNote`, `MoveNoteToStatus`

These landed after the camp-hardening festival's atomic-write sweep (R11/N-21) was planned (the #319/#321 intent-notes feature), so they were outside its scope and never converted. This restores the festival's "zero `os.WriteFile` on intent-state paths" invariant for the full current intent surface.

## Test

New `internal/intent/atomic_write_test.go` exercises both the rename and note-move paths and asserts the file round-trips and no `.tmp-*` litter remains after the atomic write. `just gate-fast` green (2684 tests, lint clean including the fmt.Errorf and host-fs-test ratchets).

## Scope note

A broader grep shows additional production `os.WriteFile` sites elsewhere in the package (`migration.go`, `migration_filesystem.go`, `promote/promote.go`, `feedback/tracker.go`, `feedback/builder.go`). Those were **not** part of C-2 and are intentionally left out of this PR to avoid over-scoping; capture as a separate intent if the same atomicity guarantee is wanted there.

---

Part of the intent-backlog cleanup. Base branch is the `intent-cleanup` umbrella. Closes intent `make-intent-notesgo-and-renamego-20260615-203000`. `[WI-ee98f2]`
