### PR TITLE
chore(quest,worktrees): render list tables with lipgloss/table

### DIFF
--- a/cmd/camp/quest/helpers.go
+++ b/cmd/camp/quest/helpers.go
@@ -8,9 +8,10 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"text/tabwriter"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
 	"github.com/spf13/cobra"
 
 	"github.com/Obedience-Corp/camp/internal/config"
@@ -19,6 +20,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/git/commit"
 	"github.com/Obedience-Corp/camp/internal/pathutil"
 	"github.com/Obedience-Corp/camp/internal/quest"
+	"github.com/Obedience-Corp/camp/internal/ui"
 )
 
 type questCommandContext struct {
@@ -177,22 +179,41 @@ func outputQuestTable(qctx *questCommandContext, quests []*quest.Quest) error {
 		return nil
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "NAME\tSTATUS\tID\tUPDATED\tPATH")
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(ui.CategoryColor)
+
+	statusStyle := func(s quest.Status) string {
+		return ui.GetQuestStatusStyle(string(s)).Render(string(s))
+	}
+
+	headers := []string{"NAME", "STATUS", "ID", "UPDATED", "PATH"}
+	rows := make([][]string, 0, len(quests))
+
 	for _, q := range quests {
 		updated := q.UpdatedAt
 		if updated.IsZero() {
 			updated = q.CreatedAt
 		}
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+		rows = append(rows, []string{
 			q.Name,
-			q.Status,
+			statusStyle(q.Status),
 			q.ID,
 			updated.Format("2006-01-02 15:04"),
 			quest.RelativePath(qctx.campaignRoot, q.Path),
-		)
+		})
 	}
-	_ = w.Flush()
+
+	t := table.New().
+		Border(lipgloss.HiddenBorder()).
+		Headers(headers...).
+		Rows(rows...).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return headerStyle
+			}
+			return lipgloss.NewStyle()
+		})
+
+	fmt.Println(t)
 	fmt.Printf("\n%d quest(s)\n", len(quests))
 	return nil
 }

--- a/cmd/camp/quest/helpers_test.go
+++ b/cmd/camp/quest/helpers_test.go
@@ -115,3 +115,127 @@ func captureQuestStdout(fn func() error) (string, error) {
 	}
 	return string(out), runErr
 }
+
+func TestOutputQuestTableRendersColumns(t *testing.T) {
+	root := t.TempDir()
+	qctx := &questCommandContext{
+		cfg:          &config.CampaignConfig{ID: "camp1234"},
+		campaignRoot: root,
+		service:      quest.NewService(root),
+	}
+	now := time.Now().UTC()
+	quests := []*quest.Quest{
+		{
+			ID:        "qst_abc",
+			Name:      "Alpha Quest",
+			Status:    quest.StatusOpen,
+			CreatedAt: now,
+			UpdatedAt: now,
+			Slug:      "alpha-quest",
+			Path:      filepath.Join(root, ".campaign", "quests", "alpha-quest"),
+		},
+		{
+			ID:        "qst_def",
+			Name:      "Beta Quest",
+			Status:    quest.StatusPaused,
+			CreatedAt: now,
+			UpdatedAt: now,
+			Slug:      "beta-quest",
+			Path:      filepath.Join(root, ".campaign", "quests", "beta-quest"),
+		},
+	}
+
+	out, err := captureQuestStdout(func() error {
+		return outputQuestTable(qctx, quests)
+	})
+	if err != nil {
+		t.Fatalf("outputQuestTable: %v", err)
+	}
+
+	for _, col := range []string{"NAME", "STATUS", "ID", "UPDATED", "PATH"} {
+		if !strings.Contains(out, col) {
+			t.Errorf("outputQuestTable output missing column header %q", col)
+		}
+	}
+	if !strings.Contains(out, "Alpha Quest") {
+		t.Error("outputQuestTable output missing quest name Alpha Quest")
+	}
+	if !strings.Contains(out, "qst_abc") {
+		t.Error("outputQuestTable output missing quest ID qst_abc")
+	}
+	if !strings.Contains(out, "2 quest(s)") {
+		t.Errorf("outputQuestTable output missing count line, got:\n%s", out)
+	}
+}
+
+func TestOutputQuestTable_Empty(t *testing.T) {
+	root := t.TempDir()
+	qctx := &questCommandContext{
+		cfg:          &config.CampaignConfig{ID: "camp1234"},
+		campaignRoot: root,
+		service:      quest.NewService(root),
+	}
+
+	out, err := captureQuestStdout(func() error {
+		return outputQuestTable(qctx, nil)
+	})
+	if err != nil {
+		t.Fatalf("outputQuestTable: %v", err)
+	}
+	if !strings.Contains(out, "No quests found") {
+		t.Errorf("expected empty message, got: %s", out)
+	}
+}
+
+func TestOutputQuestTable_JSONUnchanged(t *testing.T) {
+	root := t.TempDir()
+	questPath := filepath.Join(root, ".campaign", "quests", "example", "quest.yaml")
+	if err := os.MkdirAll(filepath.Dir(questPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(questPath, []byte("id: qst_example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	qctx := &questCommandContext{
+		cfg:          &config.CampaignConfig{ID: "camp1234"},
+		campaignRoot: root,
+		service:      quest.NewService(root),
+	}
+	now := time.Now().UTC()
+	q := &quest.Quest{
+		ID:        "qst_json_check",
+		Name:      "JSON Check",
+		Status:    quest.StatusOpen,
+		CreatedAt: now,
+		UpdatedAt: now,
+		Slug:      "json-check",
+		Path:      questPath,
+	}
+
+	out, err := captureQuestStdout(func() error {
+		return outputQuestListJSON(qctx, []*quest.Quest{q})
+	})
+	if err != nil {
+		t.Fatalf("outputQuestListJSON: %v", err)
+	}
+
+	var payload questListJSONPayload
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("JSON output still valid after lipgloss refactor: %v\nraw: %s", err, out)
+	}
+	if len(payload.Items) != 1 || payload.Items[0].ID != "qst_json_check" {
+		t.Fatalf("unexpected JSON payload: %+v", payload)
+	}
+}
+
+func TestAutoCommitQuestNilResultIsNoOp(t *testing.T) {
+	root := t.TempDir()
+	qctx := &questCommandContext{
+		cfg:          &config.CampaignConfig{ID: "camp1234"},
+		campaignRoot: root,
+		service:      quest.NewService(root),
+	}
+	if err := autoCommitQuest(context.Background(), qctx, commit.QuestComplete, nil, ""); err != nil {
+		t.Fatalf("expected nil result to be a no-op, got: %v", err)
+	}
+}

--- a/cmd/camp/worktrees/list.go
+++ b/cmd/camp/worktrees/list.go
@@ -4,17 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"os"
-	"text/tabwriter"
 	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+	"github.com/spf13/cobra"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/jsoncontract"
 	"github.com/Obedience-Corp/camp/internal/paths"
+	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/Obedience-Corp/camp/internal/worktree"
-	"github.com/spf13/cobra"
 )
 
 const WorktreesListJSONVersion = "worktrees-list/v1alpha1"
@@ -286,37 +289,46 @@ func outputListTable(result *WorktreeListResult) error {
 		return nil
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(ui.CategoryColor)
 
-	currentProject := ""
+	staleStyle := lipgloss.NewStyle().Foreground(ui.WarningColor)
+
+	headers := []string{"PROJECT", "NAME", "BRANCH", "LAST ACCESSED", "STATUS"}
+	rows := make([][]string, 0, len(result.Worktrees))
+
 	for _, wt := range result.Worktrees {
-		if wt.Project != currentProject {
-			if currentProject != "" {
-				fmt.Fprintln(w)
-			}
-			fmt.Fprintf(w, "%s/\n", wt.Project)
-			currentProject = wt.Project
-		}
-
 		status := ""
 		if wt.Stale {
-			status = " [stale]"
+			status = staleStyle.Render("stale")
+			if wt.StaleReason != "" {
+				status = staleStyle.Render("stale: " + wt.StaleReason)
+			}
 		}
-
-		fmt.Fprintf(w, "  ├── %s\t%s\t%s%s\n",
+		rows = append(rows, []string{
+			wt.Project,
 			wt.Name,
 			wt.Branch,
 			wt.LastAccessed,
 			status,
-		)
+		})
 	}
 
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "Total: %d worktrees", result.Total)
+	t := table.New().
+		Border(lipgloss.HiddenBorder()).
+		Headers(headers...).
+		Rows(rows...).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return headerStyle
+			}
+			return lipgloss.NewStyle()
+		})
+
+	fmt.Println(t)
+	summary := fmt.Sprintf("\n%d worktree(s)", result.Total)
 	if result.StaleCount > 0 {
-		fmt.Fprintf(w, " (%d stale)", result.StaleCount)
+		summary += fmt.Sprintf(" (%d stale)", result.StaleCount)
 	}
-	fmt.Fprintln(w)
-
-	return w.Flush()
+	fmt.Println(summary)
+	return nil
 }

--- a/cmd/camp/worktrees/list_test.go
+++ b/cmd/camp/worktrees/list_test.go
@@ -1,0 +1,96 @@
+package worktrees
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureWorktreesStdout(fn func() error) (string, error) {
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+	os.Stdout = w
+	runErr := fn()
+	_ = w.Close()
+	os.Stdout = oldStdout
+	out, readErr := io.ReadAll(r)
+	_ = r.Close()
+	if readErr != nil {
+		return "", readErr
+	}
+	return string(out), runErr
+}
+
+func TestOutputListTable_RendersColumns(t *testing.T) {
+	result := &WorktreeListResult{
+		Worktrees: []WorktreeListItem{
+			{Project: "camp", Name: "ic-feature-x", Branch: "ic-feature-x", LastAccessed: "2 days ago", Stale: false},
+			{Project: "fest", Name: "ic-fix-y", Branch: "ic-fix-y", LastAccessed: "1 hour ago", Stale: true, StaleReason: "missing .git"},
+		},
+		Total:      2,
+		StaleCount: 1,
+	}
+
+	out, err := captureWorktreesStdout(func() error {
+		return outputListTable(result)
+	})
+	if err != nil {
+		t.Fatalf("outputListTable: %v", err)
+	}
+
+	for _, col := range []string{"PROJECT", "NAME", "BRANCH", "LAST ACCESSED", "STATUS"} {
+		if !strings.Contains(out, col) {
+			t.Errorf("outputListTable output missing column header %q", col)
+		}
+	}
+	if !strings.Contains(out, "ic-feature-x") {
+		t.Error("outputListTable missing worktree name ic-feature-x")
+	}
+	if !strings.Contains(out, "camp") {
+		t.Error("outputListTable missing project name camp")
+	}
+	if !strings.Contains(out, "2 worktree(s)") {
+		t.Errorf("outputListTable missing count line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "(1 stale)") {
+		t.Errorf("outputListTable missing stale count, got:\n%s", out)
+	}
+}
+
+func TestOutputListTable_Empty(t *testing.T) {
+	result := &WorktreeListResult{Worktrees: nil, Total: 0, StaleCount: 0}
+
+	out, err := captureWorktreesStdout(func() error {
+		return outputListTable(result)
+	})
+	if err != nil {
+		t.Fatalf("outputListTable: %v", err)
+	}
+	if !strings.Contains(out, "No worktrees found") {
+		t.Errorf("expected empty message, got: %s", out)
+	}
+}
+
+func TestOutputListTable_StaleReasonInStatus(t *testing.T) {
+	result := &WorktreeListResult{
+		Worktrees: []WorktreeListItem{
+			{Project: "camp", Name: "wt-broken", Branch: "unknown", LastAccessed: "5 days ago", Stale: true, StaleReason: "missing .git"},
+		},
+		Total:      1,
+		StaleCount: 1,
+	}
+
+	out, err := captureWorktreesStdout(func() error {
+		return outputListTable(result)
+	})
+	if err != nil {
+		t.Fatalf("outputListTable: %v", err)
+	}
+	if !strings.Contains(out, "missing .git") {
+		t.Errorf("outputListTable missing stale reason in output, got:\n%s", out)
+	}
+}

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -172,6 +172,22 @@ func GetWorkflowTypeColor(wfType string) lipgloss.TerminalColor {
 	}
 }
 
+// GetQuestStatusStyle returns the style for a quest status.
+func GetQuestStatusStyle(status string) lipgloss.Style {
+	switch status {
+	case "open":
+		return lipgloss.NewStyle().Foreground(StatusActiveColor)
+	case "paused":
+		return lipgloss.NewStyle().Foreground(WarningColor)
+	case "completed":
+		return lipgloss.NewStyle().Foreground(SuccessColor)
+	case "archived":
+		return lipgloss.NewStyle().Foreground(DimColor)
+	default:
+		return lipgloss.NewStyle().Foreground(DimColor)
+	}
+}
+
 // GetLifecycleStageStyle returns the style for a lifecycle stage.
 func GetLifecycleStageStyle(stage string) lipgloss.Style {
 	switch stage {


### PR DESCRIPTION
## Summary

- Replace `tabwriter` in `camp quest list` (`cmd/camp/quest/helpers.go`) and `camp worktrees list` (`cmd/camp/worktrees/list.go`) with the established `lipgloss/table` pattern already used by `intent list` and `dungeon list`
- Add `ui.GetQuestStatusStyle` to `internal/ui/styles.go` for coloured quest status cells (open=green, paused=yellow, completed=green, archived=dim)
- Worktrees list gains PROJECT column and shows stale reason inline in a STATUS column

## Test plan

- `TestOutputQuestTableRendersColumns` — headers and row values present
- `TestOutputQuestTable_Empty` — empty message branch
- `TestOutputQuestTable_JSONUnchanged` — JSON path untouched after refactor
- `TestAutoCommitQuestNilResultIsNoOp` — nil-result guard
- `TestOutputListTable_RendersColumns` — headers, names, count, stale count
- `TestOutputListTable_Empty` — empty message branch
- `TestOutputListTable_StaleReasonInStatus` — stale reason in STATUS column
- gate-fast: 2689/2689 tests passed, both lint ratchets clean

## Scope

JSON output paths (`outputQuestListJSON`, `outputListJSON`) are unchanged. `camp quest show` prose output is out of scope for this chore.

Intent: `add-lipglosstable-to-camp-quest-20260316-080957` [WI-ee98f2]
