### PR TITLE
feat(dungeon): rewrite relative markdown links on crawl move

### DIFF
--- a/internal/dungeon/docs_routing.go
+++ b/internal/dungeon/docs_routing.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/mdlinks"
 	"github.com/Obedience-Corp/camp/internal/pathutil"
 	"github.com/Obedience-Corp/camp/internal/statusmove"
 )
@@ -132,6 +133,10 @@ func (s *Service) MoveToDocs(ctx context.Context, itemName, parentPath, destinat
 			return "", camperrors.Wrapf(ErrAlreadyExists, "%s already exists in docs destination", itemName)
 		}
 		return "", camperrors.Wrapf(err, "moving %s to docs/%s", itemName, destination)
+	}
+
+	if err := mdlinks.RewriteForMove(ctx, s.campaignRoot, sourcePath, movedPath); err != nil {
+		return "", camperrors.Wrapf(err, "rewriting markdown links after moving %s", itemName)
 	}
 
 	return movedPath, nil

--- a/internal/dungeon/service_move.go
+++ b/internal/dungeon/service_move.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/mdlinks"
 	"github.com/Obedience-Corp/camp/internal/pathutil"
 	"github.com/Obedience-Corp/camp/internal/statusmove"
 )
@@ -45,6 +46,10 @@ func (s *Service) MoveToDungeon(ctx context.Context, itemName, parentPath string
 			return camperrors.Wrapf(ErrAlreadyExists, "%s already in dungeon", itemName)
 		}
 		return camperrors.Wrapf(err, "moving %s to dungeon", itemName)
+	}
+
+	if err := mdlinks.RewriteForMove(ctx, s.campaignRoot, sourcePath, targetPath); err != nil {
+		return camperrors.Wrapf(err, "rewriting markdown links after moving %s", itemName)
 	}
 
 	return nil
@@ -101,6 +106,10 @@ func (s *Service) MoveToStatus(ctx context.Context, itemName, status string) (st
 		return "", camperrors.Wrapf(err, "moving %s to %s", itemName, status)
 	}
 
+	if err := mdlinks.RewriteForMove(ctx, s.campaignRoot, srcPath, dstPath); err != nil {
+		return "", camperrors.Wrapf(err, "rewriting markdown links after moving %s", itemName)
+	}
+
 	return dstPath, nil
 }
 
@@ -143,6 +152,10 @@ func (s *Service) MoveToDungeonStatus(ctx context.Context, itemName, parentPath,
 			return "", camperrors.Wrapf(ErrAlreadyExists, "%s already in %s/", itemName, status)
 		}
 		return "", camperrors.Wrapf(err, "moving %s to dungeon/%s", itemName, status)
+	}
+
+	if err := mdlinks.RewriteForMove(ctx, s.campaignRoot, sourcePath, targetPath); err != nil {
+		return "", camperrors.Wrapf(err, "rewriting markdown links after moving %s", itemName)
 	}
 
 	return targetPath, nil

--- a/internal/mdlinks/rewrite.go
+++ b/internal/mdlinks/rewrite.go
@@ -1,0 +1,244 @@
+package mdlinks
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+)
+
+var mdLinkRe = regexp.MustCompile(`(!?\[(?:[^\[\]]*|\[[^\[\]]*\])*\])\(([^)]+)\)`)
+
+func isRelative(target string) bool {
+	if target == "" {
+		return false
+	}
+	if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
+		return false
+	}
+	if strings.HasPrefix(target, "/") {
+		return false
+	}
+	if strings.HasPrefix(target, "#") {
+		return false
+	}
+	return true
+}
+
+func splitAnchor(target string) (path, anchor string) {
+	if idx := strings.LastIndex(target, "#"); idx != -1 {
+		return target[:idx], target[idx:]
+	}
+	return target, ""
+}
+
+func rewriteLinksInContent(content []byte, oldBase, newBase string) ([]byte, bool) {
+	changed := false
+	result := mdLinkRe.ReplaceAllFunc(content, func(match []byte) []byte {
+		sub := mdLinkRe.FindSubmatch(match)
+		if sub == nil {
+			return match
+		}
+		label := sub[1]
+		target := string(sub[2])
+
+		if !isRelative(target) {
+			return match
+		}
+
+		path, anchor := splitAnchor(target)
+		if path == "" {
+			return match
+		}
+
+		abs := filepath.Join(oldBase, path)
+		rel, err := filepath.Rel(newBase, abs)
+		if err != nil {
+			return match
+		}
+		rel = filepath.ToSlash(rel)
+
+		newTarget := rel + anchor
+		if newTarget == target {
+			return match
+		}
+
+		changed = true
+		return append(label, []byte("("+newTarget+")")...)
+	})
+	return result, changed
+}
+
+func rewriteExternalLinksToMoved(content []byte, fileDir, oldPath, newPath string) ([]byte, bool) {
+	changed := false
+	result := mdLinkRe.ReplaceAllFunc(content, func(match []byte) []byte {
+		sub := mdLinkRe.FindSubmatch(match)
+		if sub == nil {
+			return match
+		}
+		label := sub[1]
+		target := string(sub[2])
+
+		if !isRelative(target) {
+			return match
+		}
+
+		path, anchor := splitAnchor(target)
+		if path == "" {
+			return match
+		}
+
+		abs := filepath.Clean(filepath.Join(fileDir, path))
+
+		if !pathMatchesMoved(abs, oldPath) {
+			return match
+		}
+
+		suffix := strings.TrimPrefix(abs, oldPath)
+
+		newAbs := newPath + suffix
+		rel, err := filepath.Rel(fileDir, newAbs)
+		if err != nil {
+			return match
+		}
+		rel = filepath.ToSlash(rel)
+
+		newTarget := rel + anchor
+		if newTarget == target {
+			return match
+		}
+
+		changed = true
+		return append(label, []byte("("+newTarget+")")...)
+	})
+	return result, changed
+}
+
+func pathMatchesMoved(absPath, movedPath string) bool {
+	if absPath == movedPath {
+		return true
+	}
+	return strings.HasPrefix(absPath, movedPath+string(filepath.Separator))
+}
+
+func collectMDFiles(root string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			base := d.Name()
+			if base == ".git" || base == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(d.Name(), ".md") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+func collectMDFilesUnder(root string) ([]string, error) {
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		if strings.HasSuffix(root, ".md") {
+			return []string{root}, nil
+		}
+		return nil, nil
+	}
+	return collectMDFiles(root)
+}
+
+func rewriteFile(path string, rewriteFn func([]byte) ([]byte, bool)) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return camperrors.Wrap(err, "reading file")
+	}
+	updated, changed := rewriteFn(content)
+	if !changed {
+		return nil
+	}
+	if err := fsutil.WriteFileAtomically(path, updated, 0644); err != nil {
+		return camperrors.Wrap(err, "writing file")
+	}
+	return nil
+}
+
+func RewriteForMove(ctx context.Context, campaignRoot, srcPath, dstPath string) error {
+	if err := ctx.Err(); err != nil {
+		return camperrors.Wrap(err, "context cancelled")
+	}
+
+	srcPath = filepath.Clean(srcPath)
+	dstPath = filepath.Clean(dstPath)
+
+	if srcPath == dstPath {
+		return nil
+	}
+
+	movedMD, err := collectMDFilesUnder(dstPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return camperrors.Wrap(err, "collecting moved md files")
+	}
+
+	movedSet := make(map[string]struct{}, len(movedMD))
+	for _, f := range movedMD {
+		movedSet[f] = struct{}{}
+	}
+
+	for _, mdFile := range movedMD {
+		if err := ctx.Err(); err != nil {
+			return camperrors.Wrap(err, "context cancelled")
+		}
+		oldBase := filepath.Dir(filepath.Join(srcPath, strings.TrimPrefix(mdFile, dstPath)))
+		newBase := filepath.Dir(mdFile)
+		if oldBase == newBase {
+			continue
+		}
+		if err := rewriteFile(mdFile, func(b []byte) ([]byte, bool) {
+			return rewriteLinksInContent(b, oldBase, newBase)
+		}); err != nil {
+			return camperrors.Wrapf(err, "rewriting links in %s", mdFile)
+		}
+	}
+
+	allMD, err := collectMDFiles(campaignRoot)
+	if err != nil {
+		return camperrors.Wrap(err, "collecting campaign md files")
+	}
+
+	for _, mdFile := range allMD {
+		if err := ctx.Err(); err != nil {
+			return camperrors.Wrap(err, "context cancelled")
+		}
+		if _, isMoved := movedSet[mdFile]; isMoved {
+			continue
+		}
+		fileDir := filepath.Dir(mdFile)
+		if err := rewriteFile(mdFile, func(b []byte) ([]byte, bool) {
+			return rewriteExternalLinksToMoved(b, fileDir, srcPath, dstPath)
+		}); err != nil {
+			return camperrors.Wrapf(err, "rewriting external links in %s", mdFile)
+		}
+	}
+
+	return nil
+}

--- a/internal/mdlinks/rewrite_test.go
+++ b/internal/mdlinks/rewrite_test.go
@@ -1,0 +1,278 @@
+package mdlinks
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	return string(data)
+}
+
+func TestRewriteForMove_SingleFileMoved_InternalLinksUpdated(t *testing.T) {
+	root := t.TempDir()
+
+	other := filepath.Join(root, "docs", "other.md")
+	src := filepath.Join(root, "notes", "note.md")
+	dst := filepath.Join(root, "archive", "note.md")
+
+	writeFile(t, other, "hello")
+	writeFile(t, src, "[link](../docs/other.md)")
+
+	if err := os.MkdirAll(filepath.Join(root, "archive"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RewriteForMove(context.Background(), root, src, dst); err != nil {
+		t.Fatalf("RewriteForMove: %v", err)
+	}
+
+	got := readFile(t, dst)
+	if got != "[link](../docs/other.md)" {
+		t.Errorf("internal link: got %q", got)
+	}
+}
+
+func TestRewriteForMove_SingleFileMoved_InternalLinksRewritten(t *testing.T) {
+	root := t.TempDir()
+
+	other := filepath.Join(root, "docs", "other.md")
+	src := filepath.Join(root, "notes", "note.md")
+	dst := filepath.Join(root, "archive", "2026-01-01", "note.md")
+
+	writeFile(t, other, "hello")
+	writeFile(t, src, "[link](../docs/other.md)")
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RewriteForMove(context.Background(), root, src, dst); err != nil {
+		t.Fatalf("RewriteForMove: %v", err)
+	}
+
+	got := readFile(t, dst)
+	want := "[link](../../docs/other.md)"
+	if got != want {
+		t.Errorf("internal link after deep move: got %q, want %q", got, want)
+	}
+}
+
+func TestRewriteForMove_ExternalFileLinksToMoved_Updated(t *testing.T) {
+	root := t.TempDir()
+
+	src := filepath.Join(root, "notes", "note.md")
+	dst := filepath.Join(root, "archive", "2026-01-01", "note.md")
+	referrer := filepath.Join(root, "docs", "index.md")
+
+	writeFile(t, src, "# Note")
+	writeFile(t, referrer, "[see note](../notes/note.md)")
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RewriteForMove(context.Background(), root, src, dst); err != nil {
+		t.Fatalf("RewriteForMove: %v", err)
+	}
+
+	got := readFile(t, referrer)
+	want := "[see note](../archive/2026-01-01/note.md)"
+	if got != want {
+		t.Errorf("external referrer: got %q, want %q", got, want)
+	}
+}
+
+func TestRewriteForMove_ExternalURLsUntouched(t *testing.T) {
+	root := t.TempDir()
+
+	src := filepath.Join(root, "notes", "note.md")
+	dst := filepath.Join(root, "archive", "note.md")
+	referrer := filepath.Join(root, "docs", "index.md")
+
+	writeFile(t, src, "# Note")
+	writeFile(t, referrer, "[ext](https://example.com) [local](../notes/note.md)")
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RewriteForMove(context.Background(), root, src, dst); err != nil {
+		t.Fatalf("RewriteForMove: %v", err)
+	}
+
+	got := readFile(t, referrer)
+	want := "[ext](https://example.com) [local](../archive/note.md)"
+	if got != want {
+		t.Errorf("mixed links: got %q, want %q", got, want)
+	}
+}
+
+func TestRewriteForMove_AbsolutePathsUntouched(t *testing.T) {
+	root := t.TempDir()
+
+	src := filepath.Join(root, "notes", "note.md")
+	dst := filepath.Join(root, "archive", "note.md")
+	referrer := filepath.Join(root, "docs", "index.md")
+
+	writeFile(t, src, "# Note")
+	writeFile(t, referrer, "[abs](/absolute/path.md)")
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RewriteForMove(context.Background(), root, src, dst); err != nil {
+		t.Fatalf("RewriteForMove: %v", err)
+	}
+
+	got := readFile(t, referrer)
+	want := "[abs](/absolute/path.md)"
+	if got != want {
+		t.Errorf("absolute link: got %q, want %q", got, want)
+	}
+}
+
+func TestRewriteForMove_AnchorsOnlyUntouched(t *testing.T) {
+	root := t.TempDir()
+
+	src := filepath.Join(root, "notes", "note.md")
+	dst := filepath.Join(root, "archive", "note.md")
+	referrer := filepath.Join(root, "docs", "index.md")
+
+	writeFile(t, src, "# Note")
+	writeFile(t, referrer, "[anchor](#section)")
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RewriteForMove(context.Background(), root, src, dst); err != nil {
+		t.Fatalf("RewriteForMove: %v", err)
+	}
+
+	got := readFile(t, referrer)
+	want := "[anchor](#section)"
+	if got != want {
+		t.Errorf("anchor-only link: got %q, want %q", got, want)
+	}
+}
+
+func TestRewriteForMove_DirectoryMoved_AllMDFilesRewritten(t *testing.T) {
+	root := t.TempDir()
+
+	srcDir := filepath.Join(root, "project")
+	dstDir := filepath.Join(root, "archive", "project")
+
+	writeFile(t, filepath.Join(srcDir, "README.md"), "[link](../shared/guide.md)")
+	writeFile(t, filepath.Join(srcDir, "sub", "page.md"), "[link](../../shared/guide.md)")
+	writeFile(t, filepath.Join(root, "shared", "guide.md"), "guide")
+	referrer := filepath.Join(root, "docs", "index.md")
+	writeFile(t, referrer, "[proj readme](../project/README.md)")
+
+	if err := os.MkdirAll(filepath.Dir(dstDir), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(srcDir, dstDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RewriteForMove(context.Background(), root, srcDir, dstDir); err != nil {
+		t.Fatalf("RewriteForMove: %v", err)
+	}
+
+	readme := readFile(t, filepath.Join(dstDir, "README.md"))
+	wantReadme := "[link](../../shared/guide.md)"
+	if readme != wantReadme {
+		t.Errorf("moved README: got %q, want %q", readme, wantReadme)
+	}
+
+	page := readFile(t, filepath.Join(dstDir, "sub", "page.md"))
+	wantPage := "[link](../../../shared/guide.md)"
+	if page != wantPage {
+		t.Errorf("moved sub/page.md: got %q, want %q", page, wantPage)
+	}
+
+	gotReferrer := readFile(t, referrer)
+	wantReferrer := "[proj readme](../archive/project/README.md)"
+	if gotReferrer != wantReferrer {
+		t.Errorf("external referrer: got %q, want %q", gotReferrer, wantReferrer)
+	}
+}
+
+func TestRewriteForMove_ContextCancelled(t *testing.T) {
+	root := t.TempDir()
+
+	src := filepath.Join(root, "notes", "note.md")
+	dst := filepath.Join(root, "archive", "note.md")
+	writeFile(t, src, "# Note")
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := RewriteForMove(ctx, root, src, dst)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestIsRelative(t *testing.T) {
+	cases := []struct {
+		target string
+		want   bool
+	}{
+		{"relative/path.md", true},
+		{"../other.md", true},
+		{"https://example.com", false},
+		{"http://example.com", false},
+		{"/absolute/path.md", false},
+		{"#section", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isRelative(c.target); got != c.want {
+			t.Errorf("isRelative(%q) = %v, want %v", c.target, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/mdlinks` package with `RewriteForMove(ctx, campaignRoot, srcPath, dstPath)` that rewrites intra-campaign relative markdown links after a dungeon move
- Hooks the rewrite into `Service.MoveToStatus`, `Service.MoveToDungeonStatus`, and `Service.MoveToDocs` so every dungeon crawl move (inner, triage, and docs-routing) keeps relative links valid
- Rewrites two classes of links: relative links inside the moved file(s) whose base changed, and relative links in other campaign markdown files that pointed to the old location

## Scope

In scope: relative markdown links (`[text](rel/path)`, `![alt](rel/img)`) inside `.md` files. Skips http/https URLs, absolute paths (`/…`), and anchor-only links (`#section`). Handles both single-file and directory moves.

Out of scope: the intent crawl (`camp intent crawl`) does its own move via `IntentService.Move`; intent files have a dedicated status-frontmatter mechanism and their paths are well-known — a separate intent was deferred for that surface if needed.

## Test plan

- `TestRewriteForMove_ExternalFileLinksToMoved_Updated`: link in another file pointing to the moved file is rewritten
- `TestRewriteForMove_SingleFileMoved_InternalLinksRewritten`: relative link inside the moved file is rewritten when depth changes
- `TestRewriteForMove_DirectoryMoved_AllMDFilesRewritten`: directory move rewrites both internal and external links for all files in the tree
- `TestRewriteForMove_ExternalURLsUntouched`, `TestRewriteForMove_AbsolutePathsUntouched`, `TestRewriteForMove_AnchorsOnlyUntouched`: exclusion cases verified
- `TestRewriteForMove_ContextCancelled`: context propagation verified
- `just gate-fast`: green (2691 tests, stable + dev builds, both lint ratchets)

Intent: dungeon-crawl-needs-to-update-20260331-103500 [WI-ee98f2]
