### PR TITLE
feat(switch): add @tab completion for csw / camp switch

### DIFF
--- a/cmd/camp/switch.go
+++ b/cmd/camp/switch.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"strings"
+
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
 	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/Obedience-Corp/camp/internal/nav"
 	"github.com/Obedience-Corp/camp/internal/nav/fuzzy"
 	"github.com/Obedience-Corp/camp/internal/nav/tui"
 )
@@ -25,11 +29,16 @@ Use with the cgo shell function for instant navigation:
   cgo switch a1b2             # Switch by ID prefix
 
 The --print flag outputs just the path for shell integration:
-  cd "$(camp switch --print)"`,
-	Example: `  camp switch                    # Interactive picker
-  camp switch obey-campaign      # Switch by name
-  camp switch a1b2               # Switch by ID prefix
-  camp switch --print            # Picker, output path only`,
+  cd "$(camp switch --print)"
+
+Use campaign@tab to navigate to a specific location in the target campaign:
+  camp switch obey-campaign@p    # Switch and navigate to projects/
+  camp switch obey-campaign@f    # Switch and navigate to festivals/`,
+	Example: `  camp switch                        # Interactive picker
+  camp switch obey-campaign          # Switch by name
+  camp switch a1b2                   # Switch by ID prefix
+  camp switch --print                # Picker, output path only
+  camp switch obey-campaign@p        # Switch and navigate to projects/`,
 	Aliases: []string{"sw"},
 	Args:    cobra.MaximumNArgs(1),
 	Annotations: map[string]string{
@@ -47,6 +56,18 @@ The --print flag outputs just the path for shell integration:
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
+
+		if at := strings.IndexByte(toComplete, '@'); at >= 0 {
+			campaignQuery := toComplete[:at]
+			tabPrefix := toComplete[at+1:]
+			tabs := completeSwitchTabs(ctx, reg, campaignQuery, tabPrefix)
+			completions := make([]string, len(tabs))
+			for i, t := range tabs {
+				completions[i] = campaignQuery + "@" + t
+			}
+			return completions, cobra.ShellCompDirectiveNoFileComp
+		}
+
 		names := reg.List()
 		if toComplete == "" {
 			return names, cobra.ShellCompDirectiveNoFileComp
@@ -60,6 +81,39 @@ func init() {
 	rootCmd.AddCommand(switchCmd)
 	switchCmd.GroupID = "global"
 	switchCmd.Flags().Bool("print", false, "Print path only (for shell integration)")
+}
+
+func completeSwitchTabs(ctx context.Context, reg *config.Registry, campaignQuery, tabPrefix string) []string {
+	c, ok := reg.GetByName(campaignQuery)
+	if !ok {
+		names := reg.List()
+		matches := fuzzy.Filter(names, campaignQuery)
+		if len(matches) == 0 {
+			return nil
+		}
+		c, ok = reg.GetByName(matches[0].Target)
+		if !ok {
+			return nil
+		}
+	}
+
+	cfg, err := config.LoadCampaignConfig(ctx, c.Path)
+	if err != nil {
+		return nil
+	}
+
+	all := nav.TopLevelNavigationNames(cfg)
+	if tabPrefix == "" {
+		return all
+	}
+
+	var filtered []string
+	for _, name := range all {
+		if strings.HasPrefix(name, tabPrefix) {
+			filtered = append(filtered, name)
+		}
+	}
+	return filtered
 }
 
 func runSwitch(cmd *cobra.Command, args []string) error {

--- a/cmd/camp/switch_test.go
+++ b/cmd/camp/switch_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -262,5 +263,96 @@ func TestSwitchContextCancellation(t *testing.T) {
 	_, err := config.LoadRegistry(ctx)
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func newTestCampaignDir(t *testing.T, name string) (string, config.RegisteredCampaign) {
+	t.Helper()
+	root := t.TempDir()
+	cfg := &config.CampaignConfig{
+		ID:        name + "-id",
+		Name:      name,
+		Type:      config.CampaignTypeProduct,
+		CreatedAt: time.Now(),
+	}
+	if err := config.SaveCampaignConfig(context.Background(), root, cfg); err != nil {
+		t.Fatalf("save campaign config: %v", err)
+	}
+	c := config.RegisteredCampaign{
+		ID:   name + "-id",
+		Name: name,
+		Path: root,
+		Type: "product",
+	}
+	return root, c
+}
+
+func TestCompleteSwitchTabs(t *testing.T) {
+	_, campaign := newTestCampaignDir(t, "test-campaign")
+	reg := newTestRegistry(campaign)
+
+	tests := []struct {
+		name          string
+		campaignQuery string
+		tabPrefix     string
+		wantContains  []string
+		wantEmpty     bool
+	}{
+		{
+			name:          "exact campaign no prefix returns default tabs",
+			campaignQuery: "test-campaign",
+			tabPrefix:     "",
+			wantContains:  []string{"p", "f", "d", "w"},
+		},
+		{
+			name:          "tab prefix filters to matching tabs",
+			campaignQuery: "test-campaign",
+			tabPrefix:     "d",
+			wantContains:  []string{"d", "de", "du", "docs"},
+		},
+		{
+			name:          "fuzzy campaign name resolves and returns tabs",
+			campaignQuery: "test",
+			tabPrefix:     "",
+			wantContains:  []string{"p", "f"},
+		},
+		{
+			name:          "unknown campaign returns empty",
+			campaignQuery: "does-not-exist",
+			tabPrefix:     "",
+			wantEmpty:     true,
+		},
+		{
+			name:          "tab prefix with no matches returns empty",
+			campaignQuery: "test-campaign",
+			tabPrefix:     "zzz",
+			wantEmpty:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			got := completeSwitchTabs(ctx, reg, tt.campaignQuery, tt.tabPrefix)
+			if tt.wantEmpty {
+				if len(got) != 0 {
+					t.Errorf("expected empty result, got %v", got)
+				}
+				return
+			}
+			sort.Strings(got)
+			for _, want := range tt.wantContains {
+				found := false
+				for _, g := range got {
+					if g == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("completeSwitchTabs(%q, %q): missing %q in %v", tt.campaignQuery, tt.tabPrefix, want, got)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `@tab` tab-completion to `camp switch` (and `csw`): typing `campaign-name@<tab>` now offers the top-level navigation tabs available in the target campaign, sourced from that campaign's nav index (`jumps.yaml` shortcuts or defaults)
- Extracted `completeSwitchTabs` as a testable function that looks up the campaign path from the registry, loads its config, and returns `TopLevelNavigationNames` filtered by any typed prefix
- Typing a partial tab prefix after `@` (e.g. `obey-campaign@d`) filters to only matching tabs (`d`, `de`, `du`, `docs`)

## Test plan

- [ ] `TestCompleteSwitchTabs` covers: exact campaign name returns all default tabs, tab prefix filtering, fuzzy campaign name resolution, unknown campaign returns empty, no-match prefix returns empty
- [ ] `just gate-fast` passed (2683/2683 tests, lint clean, both build profiles)
- [ ] `gate-push` passed on pre-push hook
