### PR TITLE
feat(commit): add unique crawl ID to dungeon and intent crawl commit subjects

### DIFF
--- a/cmd/camp/dungeon/crawl.go
+++ b/cmd/camp/dungeon/crawl.go
@@ -172,12 +172,18 @@ func commitCrawlChanges(ctx context.Context, cmdCtx *dungeonCommandContext, tria
 		return nil
 	}
 
+	crawlID, err := commit.NewCrawlID()
+	if err != nil {
+		crawlID = ""
+	}
+
 	result := commit.Crawl(ctx, commit.CrawlOptions{
 		Options: commit.Options{
 			CampaignRoot: cmdCtx.CampaignRoot,
 			CampaignID:   cmdCtx.Config.ID,
 			PreStaged:    plan.PreStaged,
 		},
+		CrawlID:     crawlID,
 		Description: plan.Description,
 		Files:       plan.Files,
 	})

--- a/cmd/camp/intent/crawl.go
+++ b/cmd/camp/intent/crawl.go
@@ -170,16 +170,9 @@ func printIntentCrawlSummary(result *intentcrawl.Result, aborted bool) {
 }
 
 func commitIntentCrawl(ctx context.Context, campaignRoot, campaignID string, result *intentcrawl.Result) error {
-	// IntentService returns absolute paths; commit.Intent expects
-	// repo-relative scope. NormalizeFiles handles the conversion
-	// (and dedups) for both the file list and the pre-staged set.
 	files := commit.NormalizeFiles(campaignRoot, result.CommitPaths.Files...)
 	preStaged := commit.NormalizeFiles(campaignRoot, result.CommitPaths.PreStaged...)
 
-	// Stage source deletions for tracked files so the commit scope
-	// includes the removal of the original intent file alongside
-	// the new destination. Mirrors stageTrackedCrawlSourceDeletions
-	// in cmd/camp/dungeon/crawl.go.
 	if len(preStaged) > 0 {
 		tracked, err := git.FilterTracked(ctx, campaignRoot, preStaged)
 		if err != nil {
@@ -195,6 +188,11 @@ func commitIntentCrawl(ctx context.Context, campaignRoot, campaignID string, res
 		}
 	}
 
+	crawlID, err := commit.NewCrawlID()
+	if err != nil {
+		crawlID = ""
+	}
+
 	res := commit.Intent(ctx, commit.IntentOptions{
 		Options: commit.Options{
 			CampaignRoot:  campaignRoot,
@@ -204,7 +202,7 @@ func commitIntentCrawl(ctx context.Context, campaignRoot, campaignID string, res
 			SelectiveOnly: true,
 		},
 		Action:      commit.IntentCrawl,
-		IntentTitle: "intent crawl completed",
+		IntentTitle: commit.IntentCrawlSubject(crawlID),
 		Description: buildIntentCrawlCommitDescription(result),
 	})
 

--- a/internal/git/commit/commit_test.go
+++ b/internal/git/commit/commit_test.go
@@ -476,6 +476,91 @@ func TestCrawl(t *testing.T) {
 	}
 }
 
+func TestNewCrawlID_UniqueAndHex(t *testing.T) {
+	id1, err := NewCrawlID()
+	if err != nil {
+		t.Fatalf("NewCrawlID() error = %v", err)
+	}
+	id2, err := NewCrawlID()
+	if err != nil {
+		t.Fatalf("NewCrawlID() error = %v", err)
+	}
+	if len(id1) != crawlIDLen*2 {
+		t.Errorf("crawl ID length = %d, want %d", len(id1), crawlIDLen*2)
+	}
+	for _, c := range id1 {
+		if !strings.ContainsRune("0123456789abcdef", c) {
+			t.Errorf("crawl ID %q contains non-hex character %q", id1, c)
+		}
+	}
+	if id1 == id2 {
+		t.Errorf("two consecutive NewCrawlID() calls returned identical IDs: %q", id1)
+	}
+}
+
+func TestCrawl_WithCrawlIDInSubject(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := exec.Command("git", "-C", tmpDir, "init").Run(); err != nil {
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+	if err := exec.Command("git", "-C", tmpDir, "config", "user.email", "test@test.com").Run(); err != nil {
+		t.Fatalf("failed to configure git email: %v", err)
+	}
+	if err := exec.Command("git", "-C", tmpDir, "config", "user.name", "Test").Run(); err != nil {
+		t.Fatalf("failed to configure git name: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "a.txt"), []byte("x"), 0644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	crawlID, err := NewCrawlID()
+	if err != nil {
+		t.Fatalf("NewCrawlID() error = %v", err)
+	}
+
+	result := Crawl(context.Background(), CrawlOptions{
+		Options: Options{
+			CampaignRoot: tmpDir,
+			CampaignID:   "test1234",
+		},
+		CrawlID:     crawlID,
+		Description: "one item moved",
+	})
+	if !result.Committed {
+		t.Fatalf("expected commit to succeed, got message: %s", result.Message)
+	}
+
+	out, err := exec.Command("git", "-C", tmpDir, "log", "-1", "--format=%s").Output()
+	if err != nil {
+		t.Fatalf("failed to get git log: %v", err)
+	}
+	subject := strings.TrimSpace(string(out))
+	if !strings.Contains(subject, "Crawl:") {
+		t.Errorf("subject missing Crawl: prefix: %q", subject)
+	}
+	if !strings.Contains(subject, "[CW-"+crawlID+"]") {
+		t.Errorf("subject missing crawl ID [CW-%s]: %q", crawlID, subject)
+	}
+}
+
+func TestIntentCrawlSubject_WithAndWithoutID(t *testing.T) {
+	tests := []struct {
+		crawlID string
+		want    string
+	}{
+		{"", "intent crawl completed"},
+		{"abc123", "intent crawl completed [CW-abc123]"},
+	}
+	for _, tt := range tests {
+		got := IntentCrawlSubject(tt.crawlID)
+		if got != tt.want {
+			t.Errorf("IntentCrawlSubject(%q) = %q, want %q", tt.crawlID, got, tt.want)
+		}
+	}
+}
+
 func TestCrawl_SelectiveStaging(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/git/commit/crawl.go
+++ b/internal/git/commit/crawl.go
@@ -1,10 +1,26 @@
 package commit
 
-import "context"
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+)
+
+const crawlIDLen = 3
+
+func NewCrawlID() (string, error) {
+	b := make([]byte, crawlIDLen)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
 
 // CrawlOptions configures a dungeon crawl commit.
 type CrawlOptions struct {
 	Options
+	CrawlID     string   // Unique identifier for this crawl session (e.g. "a3f1b2")
 	Description string   // Body text describing moved items
 	Files       []string // Paths to stage (e.g., parent dir + dungeon dir)
 }
@@ -17,5 +33,20 @@ func Crawl(ctx context.Context, opts CrawlOptions) Result {
 	if len(opts.Files) > 0 || len(opts.PreStaged) > 0 {
 		opts.SelectiveOnly = true
 	}
-	return doCommit(ctx, opts.Options, "Crawl", "dungeon crawl completed", opts.Description)
+	subject := crawlSubject(opts.CrawlID)
+	return doCommit(ctx, opts.Options, "Crawl", subject, opts.Description)
+}
+
+func crawlSubject(crawlID string) string {
+	if crawlID == "" {
+		return "dungeon crawl completed"
+	}
+	return fmt.Sprintf("dungeon crawl completed [CW-%s]", crawlID)
+}
+
+func IntentCrawlSubject(crawlID string) string {
+	if crawlID == "" {
+		return "intent crawl completed"
+	}
+	return fmt.Sprintf("intent crawl completed [CW-%s]", crawlID)
 }


### PR DESCRIPTION
## Summary

- `NewCrawlID()` in `internal/git/commit/crawl.go` generates a 6-hex-char random session ID via `crypto/rand`
- `CrawlOptions.CrawlID` threads the ID into the dungeon crawl commit subject as `[CW-<id>]`
- `IntentCrawlSubject(crawlID)` does the same for intent crawl commits
- Both `cmd/camp/dungeon/crawl.go` and `cmd/camp/intent/crawl.go` call `NewCrawlID()` before the auto-commit

Resulting commit subjects:
```
[OBEY-CAMPAIGN-8deed8b4] Crawl: dungeon crawl completed [CW-a3f1b2]
[OBEY-CAMPAIGN-8deed8b4] Crawl: intent crawl completed [CW-c9d4e5]
```

ID generation failure falls back to a commit without the tag (no error surfaced to the user).

## Test plan

- `TestNewCrawlID_UniqueAndHex` — asserts hex encoding, correct length, and that two consecutive calls produce different IDs
- `TestCrawl_WithCrawlIDInSubject` — asserts the commit subject carries `[CW-<id>]` when a crawl ID is provided
- `TestIntentCrawlSubject_WithAndWithoutID` — unit tests for the subject helper in both cases
- Existing `TestCrawl` and integration tests continue to pass (they use `Contains` on `"Crawl: dungeon/intent crawl completed"`, which still matches the extended subject)
