### PR TITLE
fix(intent/tui): route legacy promote confirm to picker, not direct festival

### DIFF
--- a/internal/intent/tui/explorer/model.go
+++ b/internal/intent/tui/explorer/model.go
@@ -92,7 +92,7 @@ type Model struct {
 
 	// Confirmation dialog state
 	confirmDialog tui.ConfirmationDialog
-	pendingAction string         // "delete", "promote", "promote-ready", or "gather"
+	pendingAction string         // "delete", "promote-ready", or "gather"
 	pendingIntent *intent.Intent // Intent for pending action
 
 	// Preview pane state

--- a/internal/intent/tui/explorer/promote_picker_test.go
+++ b/internal/intent/tui/explorer/promote_picker_test.go
@@ -1,0 +1,82 @@
+package explorer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Obedience-Corp/camp/internal/intent"
+	"github.com/Obedience-Corp/camp/internal/intent/tui"
+)
+
+func makeReadyModel() Model {
+	ctx := context.Background()
+	m := NewModel(ctx, nil, nil, "/tmp/intents", "/tmp/campaign", "test-id", "", nil)
+	m.ready = true
+	m.width = 120
+	m.height = 30
+
+	readyIntent := &intent.Intent{
+		ID:        "ready-1",
+		Title:     "Implement search",
+		Status:    intent.StatusReady,
+		Type:      intent.TypeFeature,
+		CreatedAt: time.Now(),
+	}
+	m.intents = []*intent.Intent{readyIntent}
+	m.filteredIntents = m.intents
+	m.groups = groupIntentsByStatus(m.intents, false)
+	m.cursorGroup = 1
+	m.cursorItem = 0
+	return m
+}
+
+func asExplorerModel(t *testing.T, tm tea.Model) Model {
+	t.Helper()
+	switch v := tm.(type) {
+	case Model:
+		return v
+	case *Model:
+		return *v
+	default:
+		t.Fatalf("unexpected model type %T", tm)
+		return Model{}
+	}
+}
+
+func TestPromoteAction_PressP_ReadyIntent_ShowsPicker(t *testing.T) {
+	m := makeReadyModel()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
+	m = asExplorerModel(t, updated)
+
+	if m.focus != focusPromoteTarget {
+		t.Fatalf("focus = %v, want focusPromoteTarget after pressing p on ready intent", m.focus)
+	}
+	if m.promoteTargetIntent == nil {
+		t.Fatal("promoteTargetIntent should be set when showing picker")
+	}
+}
+
+func TestPromoteAction_ConfirmWithLegacyPromoteAction_RoutesToPicker(t *testing.T) {
+	m := makeReadyModel()
+
+	readyIntent := m.intents[0]
+
+	m.focus = focusConfirm
+	m.pendingAction = "promote"
+	m.pendingIntent = readyIntent
+	m.confirmDialog = tui.NewConfirmationDialog("Promote to Festival", "Promote?")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = asExplorerModel(t, updated)
+
+	if m.focus != focusPromoteTarget {
+		t.Fatalf("focus = %v, want focusPromoteTarget; legacy 'promote' confirm should route to picker, not skip it", m.focus)
+	}
+	if m.promoteTargetIntent == nil {
+		t.Fatal("promoteTargetIntent should be set when routing legacy promote confirm to picker")
+	}
+}

--- a/internal/intent/tui/explorer/update_overlays.go
+++ b/internal/intent/tui/explorer/update_overlays.go
@@ -90,10 +90,13 @@ func (m Model) updateConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 			case "promote":
 				if m.pendingIntent != nil {
-					cmd := m.promoteToFestival(m.pendingIntent)
+					i := m.pendingIntent
 					m.pendingAction = ""
 					m.pendingIntent = nil
-					return m, cmd
+					m.focus = focusPromoteTarget
+					m.promoteTargetIdx = 0
+					m.promoteTargetIntent = i
+					return m, nil
 				}
 			case "promote-ready":
 				if m.pendingIntent != nil {


### PR DESCRIPTION
## Summary

- Fixes a dead code path in the intent explorer TUI where a stale `pendingAction = "promote"` in the confirm dialog could call `promoteToFestival` directly, bypassing the Festival/Design picker entirely
- The original code (before the March 2026 refactor) set `pendingAction = "promote"` and the confirm dialog fired festival promotion without asking the user to choose between Festival and Design; the refactor removed the setter but left the handler in place
- The fix routes the `"promote"` confirm case to `focusPromoteTarget` (the picker) instead of directly calling `promoteToFestival`

## What changed

**`internal/intent/tui/explorer/update_overlays.go`**: Replaced the dead `case "promote"` handler in `updateConfirm` that called `promoteToFestival` directly with logic that sets `focusPromoteTarget` and `promoteTargetIntent`, routing to the Festival/Design picker as intended.

**`internal/intent/tui/explorer/model.go`**: Removed `"promote"` from the `pendingAction` comment (stale since the refactor).

**`internal/intent/tui/explorer/promote_picker_test.go`**: Two regression tests:
- `TestPromoteAction_PressP_ReadyIntent_ShowsPicker`: pressing `p` on a ready intent reaches `focusPromoteTarget`
- `TestPromoteAction_ConfirmWithLegacyPromoteAction_RoutesToPicker`: the `pendingAction = "promote"` confirm path now routes to the picker (was: failing before fix)

## Test plan

- [x] `just gate-fast` green: 84 packages, 2684/2684 tests passed
- [x] `just gate-push` green before push
- [x] `TestPromoteAction_ConfirmWithLegacyPromoteAction_RoutesToPicker` failed before fix, passes after
- [x] `TestPromoteAction_PressP_ReadyIntent_ShowsPicker` passes (behavioral spec for the normal `p` key path)

## Scope notes

The normal `p` key path and action menu promote path were already correct after the March 2026 refactor. This PR only closes the dead code gap in `updateConfirm`. No changes to the CLI (`camp intent promote`) or `internal/intent/promote` package.
