### PR TITLE
fix(dungeon): scope and batch crawl link rewriting to stop the freeze

### DIFF
--- a/cmd/camp/dungeon/crawl.go
+++ b/cmd/camp/dungeon/crawl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 
 	intdungeon "github.com/Obedience-Corp/camp/internal/dungeon"
@@ -65,7 +66,9 @@ func runDungeonCrawl(cmd *cobra.Command, args []string) error {
 	svc := intdungeon.NewService(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath)
 	// Defer external markdown-link rewriting so the campaign tree is scanned
 	// once after all moves, not once per move (which is O(moves x workspace)
-	// and dominates wall-clock time on large workspaces).
+	// and dominates wall-clock time on large workspaces). finalizeCrawl flushes
+	// on every exit path, so a mid-crawl error never leaves moved items on disk
+	// with stale links.
 	svc.BeginLinkBatch()
 	relParent := RelFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.ParentPath)
 	relDungeon := RelFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath)
@@ -91,9 +94,9 @@ func runDungeonCrawl(cmd *cobra.Command, args []string) error {
 
 	// Run triage crawl if needed
 	if runTriage {
-		parentItems, err := svc.ListParentItems(ctx, cmdCtx.Dungeon.ParentPath)
-		if err != nil {
-			return camperrors.Wrap(err, "listing parent items")
+		parentItems, listErr := svc.ListParentItems(ctx, cmdCtx.Dungeon.ParentPath)
+		if listErr != nil {
+			return finalizeCrawl(ctx, cmdCtx, svc, triageSummary, innerSummary, aborted, camperrors.Wrap(listErr, "listing parent items"))
 		}
 		if len(parentItems) > 0 {
 			fmt.Printf(
@@ -108,7 +111,7 @@ func runDungeonCrawl(cmd *cobra.Command, args []string) error {
 				if errors.Is(err, intdungeon.ErrCrawlAborted) {
 					aborted = true
 				} else {
-					return camperrors.Wrap(err, "triage crawl failed")
+					return finalizeCrawl(ctx, cmdCtx, svc, triageSummary, innerSummary, aborted, camperrors.Wrap(err, "triage crawl failed"))
 				}
 			}
 		} else {
@@ -116,21 +119,11 @@ func runDungeonCrawl(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// flushLinkRewrites applies the deferred external-link rewrites for every
-	// item moved so far in a single campaign-tree scan.
-	flushLinkRewrites := func() error {
-		if (triageSummary != nil && triageSummary.HasMoves()) ||
-			(innerSummary != nil && innerSummary.HasMoves()) {
-			fmt.Printf("%s Updating markdown cross-references...\n", ui.InfoIcon())
-		}
-		return svc.FlushLinkRewrites(ctx)
-	}
-
 	// Run inner crawl if the triage step did not abort.
 	if !aborted && runInner {
-		dungeonItems, err := svc.ListItems(ctx)
-		if err != nil {
-			return camperrors.Wrap(err, "listing dungeon items")
+		dungeonItems, listErr := svc.ListItems(ctx)
+		if listErr != nil {
+			return finalizeCrawl(ctx, cmdCtx, svc, triageSummary, innerSummary, aborted, camperrors.Wrap(listErr, "listing dungeon items"))
 		}
 		if len(dungeonItems) > 0 {
 			if runTriage {
@@ -147,7 +140,7 @@ func runDungeonCrawl(cmd *cobra.Command, args []string) error {
 				if errors.Is(err, intdungeon.ErrCrawlAborted) {
 					aborted = true
 				} else {
-					return camperrors.Wrap(err, "inner crawl failed")
+					return finalizeCrawl(ctx, cmdCtx, svc, triageSummary, innerSummary, aborted, camperrors.Wrap(err, "inner crawl failed"))
 				}
 			}
 		} else {
@@ -155,27 +148,46 @@ func runDungeonCrawl(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	return finalizeCrawl(ctx, cmdCtx, svc, triageSummary, innerSummary, aborted, nil)
+}
+
+// finalizeCrawl flushes the deferred external-link rewrites for every moved item
+// in a single campaign-tree scan, then auto-commits unless the crawl aborted or
+// errored. It always flushes first so a mid-crawl error never leaves moved items
+// on disk with stale links; a flush failure is surfaced (folded into the return
+// when there is no prior error, or reported alongside it).
+func finalizeCrawl(
+	ctx context.Context,
+	cmdCtx *dungeonCommandContext,
+	svc *intdungeon.Service,
+	triage, inner *intdungeon.CrawlSummary,
+	aborted bool,
+	sessionErr error,
+) error {
+	if (triage != nil && triage.HasMoves()) || (inner != nil && inner.HasMoves()) {
+		fmt.Printf("%s Updating markdown cross-references...\n", ui.InfoIcon())
+	}
+	flushErr := svc.FlushLinkRewrites(ctx)
+
+	if sessionErr != nil {
+		if flushErr != nil {
+			fmt.Fprintf(os.Stderr, "%s additionally, updating markdown cross-references failed: %v\n", ui.WarningIcon(), flushErr)
+		}
+		return sessionErr
+	}
+	if flushErr != nil {
+		return camperrors.Wrap(flushErr, "updating markdown cross-references")
+	}
+
 	if aborted {
-		// Apply rewrites for items moved before the abort so the on-disk state
-		// stays consistent, but do not auto-commit a cancelled crawl.
-		_ = flushLinkRewrites()
-		displayCrawlSummary(fmt.Sprintf("%s Crawl cancelled.\n", ui.InfoIcon()), triageSummary, innerSummary)
+		// Moves before the abort were applied and rewritten on disk, but a
+		// cancelled crawl is not auto-committed.
+		displayCrawlSummary(fmt.Sprintf("%s Crawl cancelled.\n", ui.InfoIcon()), triage, inner)
 		return nil
 	}
 
-	if err := flushLinkRewrites(); err != nil {
-		return camperrors.Wrap(err, "updating markdown cross-references")
-	}
-
-	// Display summary
-	displayCrawlSummary(fmt.Sprintf("%s Crawl complete!\n", ui.SuccessIcon()), triageSummary, innerSummary)
-
-	// Autocommit if anything was moved
-	if err := commitCrawlChanges(ctx, cmdCtx, svc, triageSummary, innerSummary); err != nil {
-		return err
-	}
-
-	return nil
+	displayCrawlSummary(fmt.Sprintf("%s Crawl complete!\n", ui.SuccessIcon()), triage, inner)
+	return commitCrawlChanges(ctx, cmdCtx, svc, triage, inner)
 }
 
 // commitCrawlChanges creates a git commit if any items were moved during crawl.

--- a/cmd/camp/dungeon/crawl.go
+++ b/cmd/camp/dungeon/crawl.go
@@ -63,6 +63,10 @@ func runDungeonCrawl(cmd *cobra.Command, args []string) error {
 	}
 
 	svc := intdungeon.NewService(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath)
+	// Defer external markdown-link rewriting so the campaign tree is scanned
+	// once after all moves, not once per move (which is O(moves x workspace)
+	// and dominates wall-clock time on large workspaces).
+	svc.BeginLinkBatch()
 	relParent := RelFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.ParentPath)
 	relDungeon := RelFromRoot(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath)
 
@@ -112,13 +116,18 @@ func runDungeonCrawl(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if aborted {
-		displayCrawlSummary(fmt.Sprintf("%s Crawl cancelled.\n", ui.InfoIcon()), triageSummary, innerSummary)
-		return nil
+	// flushLinkRewrites applies the deferred external-link rewrites for every
+	// item moved so far in a single campaign-tree scan.
+	flushLinkRewrites := func() error {
+		if (triageSummary != nil && triageSummary.HasMoves()) ||
+			(innerSummary != nil && innerSummary.HasMoves()) {
+			fmt.Printf("%s Updating markdown cross-references...\n", ui.InfoIcon())
+		}
+		return svc.FlushLinkRewrites(ctx)
 	}
 
-	// Run inner crawl if needed
-	if runInner {
+	// Run inner crawl if the triage step did not abort.
+	if !aborted && runInner {
 		dungeonItems, err := svc.ListItems(ctx)
 		if err != nil {
 			return camperrors.Wrap(err, "listing dungeon items")
@@ -147,8 +156,15 @@ func runDungeonCrawl(cmd *cobra.Command, args []string) error {
 	}
 
 	if aborted {
+		// Apply rewrites for items moved before the abort so the on-disk state
+		// stays consistent, but do not auto-commit a cancelled crawl.
+		_ = flushLinkRewrites()
 		displayCrawlSummary(fmt.Sprintf("%s Crawl cancelled.\n", ui.InfoIcon()), triageSummary, innerSummary)
 		return nil
+	}
+
+	if err := flushLinkRewrites(); err != nil {
+		return camperrors.Wrap(err, "updating markdown cross-references")
 	}
 
 	// Display summary

--- a/cmd/camp/dungeon/crawl_test.go
+++ b/cmd/camp/dungeon/crawl_test.go
@@ -1,11 +1,72 @@
 package dungeon
 
 import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	intdungeon "github.com/Obedience-Corp/camp/internal/dungeon"
 )
+
+func TestFinalizeCrawl_FlushesPendingRewritesOnSessionError(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	dungeonPath := filepath.Join(root, "dungeon")
+	svc := intdungeon.NewService(root, dungeonPath)
+	if _, err := svc.Init(ctx, intdungeon.InitOptions{}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "item.md"), []byte("# Item\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "notes"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	referrer := filepath.Join(root, "notes", "ref.md")
+	if err := os.WriteFile(referrer, []byte("[i](../item.md)\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.BeginLinkBatch()
+	dst, err := svc.MoveToDungeonStatus(ctx, "item.md", root, "completed")
+	if err != nil {
+		t.Fatalf("MoveToDungeonStatus: %v", err)
+	}
+
+	if got := readCrawlTestFile(t, referrer); got != "[i](../item.md)\n" {
+		t.Fatalf("referrer rewritten before finalize: %q", got)
+	}
+
+	relDst, err := filepath.Rel(root, dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	triage := &intdungeon.CrawlSummary{MovedItems: map[string][]string{"completed": {filepath.ToSlash(relDst)}}}
+
+	sessionErr := errors.New("forced inner crawl failure")
+	gotErr := finalizeCrawl(ctx, nil, svc, triage, nil, false, sessionErr)
+
+	if !errors.Is(gotErr, sessionErr) {
+		t.Fatalf("finalizeCrawl error = %v, want it to surface the session error", gotErr)
+	}
+	want := "[i](../" + filepath.ToSlash(relDst) + ")\n"
+	if got := readCrawlTestFile(t, referrer); got != want {
+		t.Fatalf("finalizeCrawl must flush pending rewrites even on session error: referrer = %q, want %q", got, want)
+	}
+}
+
+func readCrawlTestFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	return string(data)
+}
 
 func TestBuildCrawlCommitMessage(t *testing.T) {
 	tests := []struct {

--- a/internal/dungeon/docs_routing.go
+++ b/internal/dungeon/docs_routing.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
-	"github.com/Obedience-Corp/camp/internal/mdlinks"
 	"github.com/Obedience-Corp/camp/internal/pathutil"
 	"github.com/Obedience-Corp/camp/internal/statusmove"
 )
@@ -135,11 +134,9 @@ func (s *Service) MoveToDocs(ctx context.Context, itemName, parentPath, destinat
 		return "", camperrors.Wrapf(err, "moving %s to docs/%s", itemName, destination)
 	}
 
-	rewritten, err := mdlinks.RewriteForMove(ctx, s.campaignRoot, sourcePath, movedPath)
-	if err != nil {
+	if err := s.rewriteLinksAfterMove(ctx, sourcePath, movedPath); err != nil {
 		return "", camperrors.Wrapf(err, "rewriting markdown links after moving %s", itemName)
 	}
-	s.recordRewrittenLinkFiles(rewritten)
 
 	return movedPath, nil
 }

--- a/internal/dungeon/service.go
+++ b/internal/dungeon/service.go
@@ -1,12 +1,14 @@
 package dungeon
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/mdlinks"
 )
 
 // Service errors.
@@ -35,6 +37,9 @@ type Service struct {
 	dungeonPath  string
 
 	rewrittenLinkFiles []string
+
+	batchLinks   bool
+	pendingMoves []mdlinks.Move
 }
 
 // NewService creates a new dungeon Service.
@@ -70,6 +75,57 @@ func (s *Service) ArchivedPath() string {
 
 func (s *Service) recordRewrittenLinkFiles(paths []string) {
 	s.rewrittenLinkFiles = append(s.rewrittenLinkFiles, paths...)
+}
+
+// BeginLinkBatch defers external markdown-link rewriting until FlushLinkRewrites
+// is called. A multi-move crawl can then scan the campaign tree a single time
+// instead of once per move, which otherwise dominates wall-clock time on large
+// workspaces. The moved item's own internal links are still rewritten on each
+// move regardless of batching.
+func (s *Service) BeginLinkBatch() {
+	s.batchLinks = true
+}
+
+// FlushLinkRewrites performs the deferred external-link rewrite for every move
+// recorded since BeginLinkBatch, scanning the campaign tree once, then exits
+// batch mode. It is a no-op when no moves were recorded.
+func (s *Service) FlushLinkRewrites(ctx context.Context) error {
+	s.batchLinks = false
+	if len(s.pendingMoves) == 0 {
+		return nil
+	}
+	moves := s.pendingMoves
+	s.pendingMoves = nil
+
+	rewritten, err := mdlinks.RewriteExternalLinksForMoves(ctx, s.campaignRoot, moves)
+	if err != nil {
+		return camperrors.Wrap(err, "rewriting markdown links after moves")
+	}
+	s.recordRewrittenLinkFiles(rewritten)
+	return nil
+}
+
+// rewriteLinksAfterMove rewrites the moved item's own internal links
+// immediately, then either records the move for a batched external-link
+// rewrite (batch mode) or rewrites external links right away.
+func (s *Service) rewriteLinksAfterMove(ctx context.Context, srcPath, dstPath string) error {
+	internal, err := mdlinks.RewriteMovedInternalLinks(ctx, s.campaignRoot, srcPath, dstPath)
+	if err != nil {
+		return err
+	}
+	s.recordRewrittenLinkFiles(internal)
+
+	if s.batchLinks {
+		s.pendingMoves = append(s.pendingMoves, mdlinks.Move{Src: srcPath, Dst: dstPath})
+		return nil
+	}
+
+	external, err := mdlinks.RewriteExternalLinksForMoves(ctx, s.campaignRoot, []mdlinks.Move{{Src: srcPath, Dst: dstPath}})
+	if err != nil {
+		return err
+	}
+	s.recordRewrittenLinkFiles(external)
+	return nil
 }
 
 // RewrittenLinkFiles returns the deduplicated, sorted campaign-relative paths of

--- a/internal/dungeon/service_move.go
+++ b/internal/dungeon/service_move.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
-	"github.com/Obedience-Corp/camp/internal/mdlinks"
 	"github.com/Obedience-Corp/camp/internal/pathutil"
 	"github.com/Obedience-Corp/camp/internal/statusmove"
 )
@@ -48,11 +47,9 @@ func (s *Service) MoveToDungeon(ctx context.Context, itemName, parentPath string
 		return camperrors.Wrapf(err, "moving %s to dungeon", itemName)
 	}
 
-	rewritten, err := mdlinks.RewriteForMove(ctx, s.campaignRoot, sourcePath, targetPath)
-	if err != nil {
+	if err := s.rewriteLinksAfterMove(ctx, sourcePath, targetPath); err != nil {
 		return camperrors.Wrapf(err, "rewriting markdown links after moving %s", itemName)
 	}
-	s.recordRewrittenLinkFiles(rewritten)
 
 	return nil
 }
@@ -108,11 +105,9 @@ func (s *Service) MoveToStatus(ctx context.Context, itemName, status string) (st
 		return "", camperrors.Wrapf(err, "moving %s to %s", itemName, status)
 	}
 
-	rewritten, err := mdlinks.RewriteForMove(ctx, s.campaignRoot, srcPath, dstPath)
-	if err != nil {
+	if err := s.rewriteLinksAfterMove(ctx, srcPath, dstPath); err != nil {
 		return "", camperrors.Wrapf(err, "rewriting markdown links after moving %s", itemName)
 	}
-	s.recordRewrittenLinkFiles(rewritten)
 
 	return dstPath, nil
 }
@@ -158,11 +153,9 @@ func (s *Service) MoveToDungeonStatus(ctx context.Context, itemName, parentPath,
 		return "", camperrors.Wrapf(err, "moving %s to dungeon/%s", itemName, status)
 	}
 
-	rewritten, err := mdlinks.RewriteForMove(ctx, s.campaignRoot, sourcePath, targetPath)
-	if err != nil {
+	if err := s.rewriteLinksAfterMove(ctx, sourcePath, targetPath); err != nil {
 		return "", camperrors.Wrapf(err, "rewriting markdown links after moving %s", itemName)
 	}
-	s.recordRewrittenLinkFiles(rewritten)
 
 	return targetPath, nil
 }

--- a/internal/dungeon/service_move_test.go
+++ b/internal/dungeon/service_move_test.go
@@ -806,6 +806,78 @@ func TestService_MoveToStatus_ExternalLinkRewriteFlowsIntoCommit(t *testing.T) {
 	}
 }
 
+func TestService_BeginLinkBatch_DefersExternalRewriteUntilFlush(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	dungeonPath := filepath.Join(root, "dungeon")
+	svc := NewService(root, dungeonPath)
+	if _, err := svc.Init(ctx, InitOptions{}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	for _, name := range []string{"alpha.md", "beta.md"} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte("# "+name+"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(root, "notes"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	refA := filepath.Join(root, "notes", "a.md")
+	refB := filepath.Join(root, "notes", "b.md")
+	if err := os.WriteFile(refA, []byte("[a](../alpha.md)\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(refB, []byte("[b](../beta.md)\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.BeginLinkBatch()
+	dstA, err := svc.MoveToDungeonStatus(ctx, "alpha.md", root, "completed")
+	if err != nil {
+		t.Fatalf("move alpha: %v", err)
+	}
+	if _, err := svc.MoveToDungeonStatus(ctx, "beta.md", root, "completed"); err != nil {
+		t.Fatalf("move beta: %v", err)
+	}
+
+	if got := readFileContent(t, refA); got != "[a](../alpha.md)\n" {
+		t.Fatalf("refA rewritten before flush: %q", got)
+	}
+	if got := readFileContent(t, refB); got != "[b](../beta.md)\n" {
+		t.Fatalf("refB rewritten before flush: %q", got)
+	}
+	if files := svc.RewrittenLinkFiles(); sliceContains(files, "notes/a.md") || sliceContains(files, "notes/b.md") {
+		t.Fatalf("external files recorded before flush: %v", files)
+	}
+
+	if err := svc.FlushLinkRewrites(ctx); err != nil {
+		t.Fatalf("FlushLinkRewrites: %v", err)
+	}
+
+	relA, err := filepath.Rel(root, dstA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantA := "[a](../" + filepath.ToSlash(relA) + ")\n"
+	if got := readFileContent(t, refA); got != wantA {
+		t.Fatalf("refA after flush: got %q, want %q", got, wantA)
+	}
+	files := svc.RewrittenLinkFiles()
+	if !sliceContains(files, "notes/a.md") || !sliceContains(files, "notes/b.md") {
+		t.Fatalf("RewrittenLinkFiles after flush = %v, want notes/a.md and notes/b.md", files)
+	}
+}
+
+func readFileContent(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s): %v", path, err)
+	}
+	return string(data)
+}
+
 func sliceContains(s []string, want string) bool {
 	for _, v := range s {
 		if v == want {

--- a/internal/dungeon/service_move_test.go
+++ b/internal/dungeon/service_move_test.go
@@ -869,6 +869,48 @@ func TestService_BeginLinkBatch_DefersExternalRewriteUntilFlush(t *testing.T) {
 	}
 }
 
+func TestService_BeginLinkBatch_ChainedMovesResolveToFinalDestination(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	dungeonPath := filepath.Join(root, "dungeon")
+	svc := NewService(root, dungeonPath)
+	if _, err := svc.Init(ctx, InitOptions{}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "issue.md"), []byte("# Issue\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "notes"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	referrer := filepath.Join(root, "notes", "ref.md")
+	if err := os.WriteFile(referrer, []byte("[issue](../issue.md)\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.BeginLinkBatch()
+	if err := svc.MoveToDungeon(ctx, "issue.md", root); err != nil {
+		t.Fatalf("MoveToDungeon: %v", err)
+	}
+	dst, err := svc.MoveToStatus(ctx, "issue.md", "completed")
+	if err != nil {
+		t.Fatalf("MoveToStatus: %v", err)
+	}
+	if err := svc.FlushLinkRewrites(ctx); err != nil {
+		t.Fatalf("FlushLinkRewrites: %v", err)
+	}
+
+	relDst, err := filepath.Rel(root, dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "[issue](../" + filepath.ToSlash(relDst) + ")\n"
+	if got := readFileContent(t, referrer); got != want {
+		t.Fatalf("chained batch move referrer = %q, want %q", got, want)
+	}
+}
+
 func readFileContent(t *testing.T, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/internal/mdlinks/rewrite.go
+++ b/internal/mdlinks/rewrite.go
@@ -192,30 +192,37 @@ func rewriteExternalLinksForMovesInContent(content []byte, fileDir string, moves
 
 		abs := filepath.Clean(filepath.Join(fileDir, inner))
 
+		// Apply moves in chronological order so a target that maps through a
+		// chain of moves in the same batch (e.g. parent -> dungeon -> dated
+		// status) resolves to the final destination, matching the sequential
+		// per-move rewriting it replaces.
+		moved := false
 		for _, m := range moves {
 			if !pathMatchesMoved(abs, m.Src) {
 				continue
 			}
-
-			suffix := strings.TrimPrefix(abs, m.Src)
-			newAbs := m.Dst + suffix
-			rel, err := filepath.Rel(fileDir, newAbs)
-			if err != nil {
-				return target, false
-			}
-			rel = filepath.ToSlash(rel)
-
-			dest := rel
-			if hadBrackets {
-				dest = "<" + rel + ">"
-			}
-			newTarget := dest + anchor
-			if newTarget == target {
-				return target, false
-			}
-			return newTarget, true
+			abs = m.Dst + strings.TrimPrefix(abs, m.Src)
+			moved = true
 		}
-		return target, false
+		if !moved {
+			return target, false
+		}
+
+		rel, err := filepath.Rel(fileDir, abs)
+		if err != nil {
+			return target, false
+		}
+		rel = filepath.ToSlash(rel)
+
+		dest := rel
+		if hadBrackets {
+			dest = "<" + rel + ">"
+		}
+		newTarget := dest + anchor
+		if newTarget == target {
+			return target, false
+		}
+		return newTarget, true
 	}
 
 	result := rewriteWithIndex(content, mdLinkRe, func(match []byte, start int) []byte {

--- a/internal/mdlinks/rewrite.go
+++ b/internal/mdlinks/rewrite.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/fsutil"
@@ -166,9 +168,12 @@ func rewriteLinksInContent(content []byte, oldBase, newBase, srcPath string) ([]
 	return result, changed
 }
 
-// rewriteExternalLinksToMoved rewrites links in an unmoved file that point to
-// a file/directory that moved from oldPath to newPath.
-func rewriteExternalLinksToMoved(content []byte, fileDir, oldPath, newPath string) ([]byte, bool) {
+// rewriteExternalLinksForMovesInContent rewrites links in an unmoved file that
+// point to any of the moved items. The regular expressions run once over the
+// file regardless of how many moves there are; each link target is matched
+// against every move with cheap path arithmetic. This keeps a batch rewrite
+// O(files) rather than O(files * moves).
+func rewriteExternalLinksForMovesInContent(content []byte, fileDir string, moves []Move) ([]byte, bool) {
 	protected := protectedRanges(content)
 	changed := false
 
@@ -187,27 +192,30 @@ func rewriteExternalLinksToMoved(content []byte, fileDir, oldPath, newPath strin
 
 		abs := filepath.Clean(filepath.Join(fileDir, inner))
 
-		if !pathMatchesMoved(abs, oldPath) {
-			return target, false
-		}
+		for _, m := range moves {
+			if !pathMatchesMoved(abs, m.Src) {
+				continue
+			}
 
-		suffix := strings.TrimPrefix(abs, oldPath)
-		newAbs := newPath + suffix
-		rel, err := filepath.Rel(fileDir, newAbs)
-		if err != nil {
-			return target, false
-		}
-		rel = filepath.ToSlash(rel)
+			suffix := strings.TrimPrefix(abs, m.Src)
+			newAbs := m.Dst + suffix
+			rel, err := filepath.Rel(fileDir, newAbs)
+			if err != nil {
+				return target, false
+			}
+			rel = filepath.ToSlash(rel)
 
-		dest := rel
-		if hadBrackets {
-			dest = "<" + rel + ">"
+			dest := rel
+			if hadBrackets {
+				dest = "<" + rel + ">"
+			}
+			newTarget := dest + anchor
+			if newTarget == target {
+				return target, false
+			}
+			return newTarget, true
 		}
-		newTarget := dest + anchor
-		if newTarget == target {
-			return target, false
-		}
-		return newTarget, true
+		return target, false
 	}
 
 	result := rewriteWithIndex(content, mdLinkRe, func(match []byte, start int) []byte {
@@ -514,32 +522,71 @@ func RewriteExternalLinksForMoves(ctx context.Context, campaignRoot string, move
 		return nil, camperrors.Wrap(err, "collecting campaign md files")
 	}
 
-	modified := newModifiedFileSet(campaignRoot)
-	for _, mdFile := range allMD {
-		if err := ctx.Err(); err != nil {
-			return nil, camperrors.Wrap(err, "context cancelled")
+	// Rewrite files concurrently. Chunks are disjoint, so each worker writes
+	// only its own files and its own result slot; there is no shared mutable
+	// state during the parallel phase. Results are merged and sorted after, so
+	// output stays deterministic regardless of scheduling.
+	workers := max(runtime.NumCPU(), 1)
+	workers = min(workers, len(allMD))
+
+	type workerResult struct {
+		modified []string
+		err      error
+	}
+	results := make([]workerResult, workers)
+	chunk := (len(allMD) + workers - 1) / workers
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		start := w * chunk
+		if start >= len(allMD) {
+			break
 		}
-		cleanFile := filepath.Clean(mdFile)
-		fileDir := filepath.Dir(mdFile)
-		changed, err := rewriteFile(mdFile, func(b []byte) ([]byte, bool) {
-			out := b
-			any := false
-			for _, m := range cleaned {
-				if pathMatchesMoved(cleanFile, m.Dst) {
+		end := min(start+chunk, len(allMD))
+
+		wg.Add(1)
+		go func(slot int, files []string) {
+			defer wg.Done()
+			for _, mdFile := range files {
+				if err := ctx.Err(); err != nil {
+					results[slot].err = camperrors.Wrap(err, "context cancelled")
+					return
+				}
+				cleanFile := filepath.Clean(mdFile)
+				fileDir := filepath.Dir(mdFile)
+
+				applicable := make([]Move, 0, len(cleaned))
+				for _, m := range cleaned {
+					if pathMatchesMoved(cleanFile, m.Dst) {
+						continue
+					}
+					applicable = append(applicable, m)
+				}
+				if len(applicable) == 0 {
 					continue
 				}
-				rewritten, didChange := rewriteExternalLinksToMoved(out, fileDir, m.Src, m.Dst)
-				if didChange {
-					out = rewritten
-					any = true
+
+				changed, err := rewriteFile(mdFile, func(b []byte) ([]byte, bool) {
+					return rewriteExternalLinksForMovesInContent(b, fileDir, applicable)
+				})
+				if err != nil {
+					results[slot].err = camperrors.Wrapf(err, "rewriting external links in %s", mdFile)
+					return
+				}
+				if changed {
+					results[slot].modified = append(results[slot].modified, mdFile)
 				}
 			}
-			return out, any
-		})
-		if err != nil {
-			return nil, camperrors.Wrapf(err, "rewriting external links in %s", mdFile)
+		}(w, allMD[start:end])
+	}
+	wg.Wait()
+
+	modified := newModifiedFileSet(campaignRoot)
+	for _, r := range results {
+		if r.err != nil {
+			return nil, r.err
 		}
-		if changed {
+		for _, mdFile := range r.modified {
 			modified.add(mdFile)
 		}
 	}

--- a/internal/mdlinks/rewrite.go
+++ b/internal/mdlinks/rewrite.go
@@ -308,6 +308,7 @@ func pathMatchesMoved(absPath, movedPath string) bool {
 }
 
 func collectMDFiles(root string) ([]string, error) {
+	root = filepath.Clean(root)
 	var files []string
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -316,6 +317,14 @@ func collectMDFiles(root string) ([]string, error) {
 		if d.IsDir() {
 			base := d.Name()
 			if base == ".git" || base == "node_modules" {
+				return filepath.SkipDir
+			}
+			// Do not descend into nested git repositories (submodules or
+			// worktrees). Link rewriting only owns files tracked by the repo
+			// rooted at root; editing another repo's files cannot be staged into
+			// this repo's commit and would leave that repo with dirty,
+			// uncommitted changes.
+			if path != root && isGitRepoRoot(path) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -329,6 +338,15 @@ func collectMDFiles(root string) ([]string, error) {
 		return nil, err
 	}
 	return files, nil
+}
+
+// isGitRepoRoot reports whether dir is the root of a separate git repository,
+// detected by the presence of a .git entry. For submodules and worktrees .git
+// is a file pointing at the parent gitdir; for a standalone clone it is a
+// directory. Either way the directory belongs to a different repository.
+func isGitRepoRoot(dir string) bool {
+	_, err := os.Lstat(filepath.Join(dir, ".git"))
+	return err == nil
 }
 
 func collectMDFilesUnder(root string) ([]string, error) {
@@ -390,12 +408,40 @@ func (m *modifiedFileSet) sorted() []string {
 	return m.paths
 }
 
+// Move describes a single file or directory move from Src to Dst, used to
+// batch external-link rewriting across many moves into a single tree scan.
+type Move struct {
+	Src string
+	Dst string
+}
+
 // RewriteForMove updates relative markdown links after a file or directory is
 // moved from srcPath to dstPath, rewriting both the moved files' own links and
 // links in other campaign files that pointed at the moved item. It returns the
 // campaign-root-relative, slash-separated paths of every file it modified, so
 // callers can stage them into the same commit as the move.
+//
+// For a crawl that performs many moves, prefer RewriteMovedInternalLinks per
+// move plus a single RewriteExternalLinksForMoves over all moves, which scans
+// the campaign tree once instead of once per move.
 func RewriteForMove(ctx context.Context, campaignRoot, srcPath, dstPath string) ([]string, error) {
+	internal, err := RewriteMovedInternalLinks(ctx, campaignRoot, srcPath, dstPath)
+	if err != nil {
+		return nil, err
+	}
+	external, err := RewriteExternalLinksForMoves(ctx, campaignRoot, []Move{{Src: srcPath, Dst: dstPath}})
+	if err != nil {
+		return nil, err
+	}
+	return mergeRelPaths(internal, external), nil
+}
+
+// RewriteMovedInternalLinks rewrites the relative links inside the markdown
+// files that were moved from srcPath to dstPath, so links that pointed outside
+// the moved subtree still resolve from the new location. It does not touch any
+// file outside the moved subtree, so it is cheap regardless of campaign size.
+// It returns the campaign-root-relative, slash-separated paths it modified.
+func RewriteMovedInternalLinks(ctx context.Context, campaignRoot, srcPath, dstPath string) ([]string, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, camperrors.Wrap(err, "context cancelled")
 	}
@@ -416,12 +462,6 @@ func RewriteForMove(ctx context.Context, campaignRoot, srcPath, dstPath string) 
 	}
 
 	modified := newModifiedFileSet(campaignRoot)
-
-	movedSet := make(map[string]struct{}, len(movedMD))
-	for _, f := range movedMD {
-		movedSet[f] = struct{}{}
-	}
-
 	for _, mdFile := range movedMD {
 		if err := ctx.Err(); err != nil {
 			return nil, camperrors.Wrap(err, "context cancelled")
@@ -442,21 +482,59 @@ func RewriteForMove(ctx context.Context, campaignRoot, srcPath, dstPath string) 
 		}
 	}
 
+	return modified.sorted(), nil
+}
+
+// RewriteExternalLinksForMoves rewrites links in campaign markdown files that
+// pointed at any moved item, scanning the campaign tree a single time for all
+// moves. A file that itself moved as part of move m has its own links handled
+// by RewriteMovedInternalLinks, so m is skipped for that file; links between
+// two distinct moved items are still rewritten. It returns the
+// campaign-root-relative, slash-separated paths it modified.
+func RewriteExternalLinksForMoves(ctx context.Context, campaignRoot string, moves []Move) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, camperrors.Wrap(err, "context cancelled")
+	}
+
+	cleaned := make([]Move, 0, len(moves))
+	for _, m := range moves {
+		src := filepath.Clean(m.Src)
+		dst := filepath.Clean(m.Dst)
+		if src == dst {
+			continue
+		}
+		cleaned = append(cleaned, Move{Src: src, Dst: dst})
+	}
+	if len(cleaned) == 0 {
+		return nil, nil
+	}
+
 	allMD, err := collectMDFiles(campaignRoot)
 	if err != nil {
 		return nil, camperrors.Wrap(err, "collecting campaign md files")
 	}
 
+	modified := newModifiedFileSet(campaignRoot)
 	for _, mdFile := range allMD {
 		if err := ctx.Err(); err != nil {
 			return nil, camperrors.Wrap(err, "context cancelled")
 		}
-		if _, isMoved := movedSet[mdFile]; isMoved {
-			continue
-		}
+		cleanFile := filepath.Clean(mdFile)
 		fileDir := filepath.Dir(mdFile)
 		changed, err := rewriteFile(mdFile, func(b []byte) ([]byte, bool) {
-			return rewriteExternalLinksToMoved(b, fileDir, srcPath, dstPath)
+			out := b
+			any := false
+			for _, m := range cleaned {
+				if pathMatchesMoved(cleanFile, m.Dst) {
+					continue
+				}
+				rewritten, didChange := rewriteExternalLinksToMoved(out, fileDir, m.Src, m.Dst)
+				if didChange {
+					out = rewritten
+					any = true
+				}
+			}
+			return out, any
 		})
 		if err != nil {
 			return nil, camperrors.Wrapf(err, "rewriting external links in %s", mdFile)
@@ -467,4 +545,26 @@ func RewriteForMove(ctx context.Context, campaignRoot, srcPath, dstPath string) 
 	}
 
 	return modified.sorted(), nil
+}
+
+// mergeRelPaths returns the sorted, deduplicated union of two slices of
+// campaign-root-relative paths.
+func mergeRelPaths(a, b []string) []string {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[string]struct{}, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	for _, p := range append(append([]string{}, a...), b...) {
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/mdlinks/rewrite_test.go
+++ b/internal/mdlinks/rewrite_test.go
@@ -588,6 +588,28 @@ func TestRewriteExternalLinksForMoves_MultipleMovesSingleScan(t *testing.T) {
 	}
 }
 
+func TestRewriteExternalLinksForMoves_ChainedMovesResolveToFinalDestination(t *testing.T) {
+	root := t.TempDir()
+
+	referrer := filepath.Join(root, "notes", "ref.md")
+	writeFile(t, referrer, "[issue](../bugs/issue.md)")
+
+	moves := []Move{
+		{Src: filepath.Join(root, "bugs", "issue.md"), Dst: filepath.Join(root, "dungeon", "issue.md")},
+		{Src: filepath.Join(root, "dungeon", "issue.md"), Dst: filepath.Join(root, "dungeon", "completed", "2026-06-16", "issue.md")},
+	}
+
+	if _, err := RewriteExternalLinksForMoves(context.Background(), root, moves); err != nil {
+		t.Fatalf("RewriteExternalLinksForMoves: %v", err)
+	}
+
+	got := readFile(t, referrer)
+	want := "[issue](../dungeon/completed/2026-06-16/issue.md)"
+	if got != want {
+		t.Errorf("chained moves should resolve to final destination: got %q, want %q", got, want)
+	}
+}
+
 func TestRewriteExternalLinksForMoves_LinksBetweenMovedItems(t *testing.T) {
 	root := t.TempDir()
 

--- a/internal/mdlinks/rewrite_test.go
+++ b/internal/mdlinks/rewrite_test.go
@@ -510,6 +510,143 @@ func TestRewriteForMove_ContextCancelled(t *testing.T) {
 	}
 }
 
+func TestRewriteExternalLinksForMoves_SkipsNestedGitRepos(t *testing.T) {
+	root := t.TempDir()
+
+	src := filepath.Join(root, "notes", "note.md")
+	dst := filepath.Join(root, "archive", "note.md")
+	inRepo := filepath.Join(root, "docs", "index.md")
+	nestedRef := filepath.Join(root, "vendored", "readme.md")
+
+	writeFile(t, src, "# Note")
+	writeFile(t, inRepo, "[n](../notes/note.md)")
+	writeFile(t, nestedRef, "[n](../notes/note.md)")
+	// Mark vendored/ as a separate git repository (submodule-style .git file).
+	writeFile(t, filepath.Join(root, "vendored", ".git"), "gitdir: /elsewhere\n")
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := RewriteExternalLinksForMoves(context.Background(), root, []Move{{Src: src, Dst: dst}})
+	if err != nil {
+		t.Fatalf("RewriteExternalLinksForMoves: %v", err)
+	}
+
+	if got := readFile(t, inRepo); got != "[n](../archive/note.md)" {
+		t.Errorf("campaign referrer should be rewritten: got %q", got)
+	}
+	if got := readFile(t, nestedRef); got != "[n](../notes/note.md)" {
+		t.Errorf("referrer inside nested git repo should be untouched: got %q", got)
+	}
+	for _, p := range modified {
+		if strings.HasPrefix(p, "vendored/") {
+			t.Errorf("modified set leaked nested-repo file %q", p)
+		}
+	}
+}
+
+func TestRewriteExternalLinksForMoves_MultipleMovesSingleScan(t *testing.T) {
+	root := t.TempDir()
+
+	srcA := filepath.Join(root, "a", "a.md")
+	dstA := filepath.Join(root, "arch", "a.md")
+	srcB := filepath.Join(root, "b", "b.md")
+	dstB := filepath.Join(root, "arch", "b.md")
+	referrer := filepath.Join(root, "docs", "index.md")
+
+	writeFile(t, srcA, "# A")
+	writeFile(t, srcB, "# B")
+	writeFile(t, referrer, "[a](../a/a.md) and [b](../b/b.md)")
+
+	for _, dst := range []string{dstA, dstB} {
+		if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Rename(srcA, dstA); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(srcB, dstB); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := RewriteExternalLinksForMoves(context.Background(), root, []Move{
+		{Src: srcA, Dst: dstA},
+		{Src: srcB, Dst: dstB},
+	}); err != nil {
+		t.Fatalf("RewriteExternalLinksForMoves: %v", err)
+	}
+
+	got := readFile(t, referrer)
+	want := "[a](../arch/a.md) and [b](../arch/b.md)"
+	if got != want {
+		t.Errorf("both links should be rewritten in one scan: got %q, want %q", got, want)
+	}
+}
+
+func TestRewriteExternalLinksForMoves_LinksBetweenMovedItems(t *testing.T) {
+	root := t.TempDir()
+
+	srcA := filepath.Join(root, "a", "a.md")
+	dstA := filepath.Join(root, "arch", "a", "a.md")
+	srcB := filepath.Join(root, "b", "b.md")
+	dstB := filepath.Join(root, "arch", "b", "b.md")
+
+	// A's internal link has already been rebased (as RewriteMovedInternalLinks
+	// would) to point at B's pre-move location relative to A's new home.
+	writeFile(t, dstA, "[to b](../../b/b.md)")
+	writeFile(t, dstB, "# B")
+
+	if _, err := RewriteExternalLinksForMoves(context.Background(), root, []Move{
+		{Src: srcA, Dst: dstA},
+		{Src: srcB, Dst: dstB},
+	}); err != nil {
+		t.Fatalf("RewriteExternalLinksForMoves: %v", err)
+	}
+
+	got := readFile(t, dstA)
+	want := "[to b](../b/b.md)"
+	if got != want {
+		t.Errorf("cross-link between two moved items should be rewritten: got %q, want %q", got, want)
+	}
+}
+
+func TestRewriteMovedInternalLinks_LeavesExternalReferrers(t *testing.T) {
+	root := t.TempDir()
+
+	src := filepath.Join(root, "notes", "note.md")
+	dst := filepath.Join(root, "archive", "note.md")
+	referrer := filepath.Join(root, "docs", "index.md")
+
+	writeFile(t, src, "[other](../docs/other.md)")
+	writeFile(t, referrer, "[see note](../notes/note.md)")
+	writeFile(t, filepath.Join(root, "docs", "other.md"), "x")
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := RewriteMovedInternalLinks(context.Background(), root, src, dst); err != nil {
+		t.Fatalf("RewriteMovedInternalLinks: %v", err)
+	}
+
+	// The moved file's own link is rebased.
+	if got := readFile(t, dst); got != "[other](../docs/other.md)" {
+		t.Errorf("moved file internal link: got %q", got)
+	}
+	// The external referrer is NOT touched by the internal-only pass.
+	if got := readFile(t, referrer); got != "[see note](../notes/note.md)" {
+		t.Errorf("external referrer should be untouched by internal pass: got %q", got)
+	}
+}
+
 func TestIsRelative(t *testing.T) {
 	cases := []struct {
 		target string


### PR DESCRIPTION
## Problem

`camp dungeon crawl` freezes on large workspaces and has to be killed. Reported while triaging `workflow/code_reviews` (24 items) and again on `workflow/bugs` (9 items).

The triage/inner crawl moves each item **and rewrites markdown links the moment "Move" is chosen** — so the hang is in the per-move link rewrite, not the final auto-commit. `mdlinks.RewriteForMove` called `collectMDFiles(campaignRoot)`, which walked the **entire campaign monorepo on every single move**:

- Measured **~6s per move** (0.9s walk + 5s read/regex of **27,434 `.md` files / 103 MB**), single-threaded, no progress output.
- A 24-item crawl spends **~2m22s** in blocked IO → reads as a freeze.

It also descended into all 30 `projects/*` git submodules and `worktrees/`. Those are independent repos, so the campaign-root auto-commit cannot stage their files (`git ls-files` at the campaign root never lists gitlink contents). Rewriting links inside them either errored on `git add` or left submodule working trees dirty — a correctness bug, not just perf.

## Fix

1. **Scope the walk** — `collectMDFiles` no longer descends into nested git repositories (submodules, worktrees). Link rewriting only touches files the campaign repo owns. Cuts the scan from ~27.4k to ~17.7k files (walk 914ms → 179ms).
2. **Batch the rewrite** — `RewriteForMove` is split into:
   - `RewriteMovedInternalLinks` — rewrites only the moved subtree's own links (cheap, per move).
   - `RewriteExternalLinksForMoves` — a single tree scan handling many moves at once, including links between two moved items.
   - `RewriteForMove` is kept as a composition, so single-move callers are unchanged.
3. **Defer external rewriting in the crawl** — `Service.BeginLinkBatch` records moves during the loop; a single `FlushLinkRewrites` runs after all moves, before the auto-commit. Matches the intended "decide → move → one commit" flow. Single-shot `camp dungeon move` / `promote` / `workitem` behavior is unchanged (guarded by `TestService_MoveToStatus_ExternalLinkRewriteFlowsIntoCommit`).
4. **O(files), not O(files × moves)** — the external rewrite runs the markdown regexes **once per file** and matches each link target against every move with cheap path arithmetic (a naive batch would re-scan every file once per move: ~9× slower for a 9-item crawl). The scan is parallelized across `runtime.NumCPU` workers over disjoint file chunks (no shared mutable state; results merged and sorted, so output is deterministic; verified under `go test -race`).

## Results (live campaign tree, ~17.7k md files)

| crawl | before | after |
|-------|--------|-------|
| 9 moves  | ~30–55s | **~1.0s** |
| 24 moves | ~2m22s  | **~1–2s** |

## Tests

- `mdlinks`: nested-git-repo skip, multi-move single scan, cross-moved-item links, internal-only pass leaves external referrers untouched.
- `dungeon`: `BeginLinkBatch` defers external rewrites until `FlushLinkRewrites` (referrers not rewritten mid-crawl; recorded only after flush).

## Verification

- `gofmt -l` clean, `go vet` clean
- `just build-camp` ✓
- `just lint` — 0 issues; no new host-fs-test violators; no `fmt.Errorf` regressions
- `go test ./...` passes; `go test -race ./internal/mdlinks/... ./internal/dungeon/...` clean

## Review follow-up (commit 3f5b740)

Addresses the "Request Changes" finding: once `BeginLinkBatch` was active, several non-abort error returns (a `RunTriageCrawl` error, the `svc.ListItems` call, a `RunCrawl` error) bailed out before `FlushLinkRewrites`, leaving already-moved items on disk with stale external links — a regression on error paths.

Fix: extracted `finalizeCrawl`, through which **every** exit path (success, abort, and each mid-crawl error) now routes, so the flush is unconditional by construction. A flush failure is surfaced (folded into the return when there is no prior error, else reported on stderr alongside it). Added `TestFinalizeCrawl_FlushesPendingRewritesOnSessionError`.

## Review follow-up (commit dfe4146)

Addresses the chained-move finding: `RewriteExternalLinksForMoves` returned on the first matching move, so a batch containing a chain (parent -> dungeon -> dated status) rewrote an external referrer to the intermediate location instead of the final destination. Now every matching move is applied in chronological order (one ordered pass = sequential-per-move equivalence); independent moves are unaffected. Regression tests added at both the mdlinks level (the exact repro) and the Service level (batched `MoveToDungeon` then `MoveToStatus`).
