### PR TITLE
feat(list): add total counts and --count flag to list commands

### DIFF
--- a/cmd/camp/list.go
+++ b/cmd/camp/list.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -47,12 +48,16 @@ Examples:
   camp list --json           Output as JSON
   camp list --format json    Output as JSON
   camp list --sort name      Sort by name
-  camp list --format simple  Names only for scripting`,
+  camp list --format simple  Names only for scripting
+  camp list --count          Print only the total number of campaigns`,
 	Aliases: []string{"ls"},
 	RunE:    runList,
 }
 
-var listJSON bool
+var (
+	listJSON  bool
+	listCount bool
+)
 
 func init() {
 	rootCmd.AddCommand(listCmd)
@@ -60,6 +65,7 @@ func init() {
 
 	listCmd.Flags().StringP("format", "f", "table", "Output format (table, simple, json)")
 	listCmd.Flags().BoolVar(&listJSON, "json", false, "Output as JSON (shorthand for --format json)")
+	listCmd.Flags().BoolVar(&listCount, "count", false, "Print only the total number of campaigns")
 	listCmd.Flags().StringP("sort", "s", "accessed", "Sort by (name, accessed, type)")
 	listCmd.Flags().Bool("verify-verbose", false, "Show detailed verification output")
 }
@@ -104,9 +110,19 @@ func runList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if listCount {
+		if formatStr == "json" {
+			encoder := json.NewEncoder(os.Stdout)
+			encoder.SetIndent("", "  ")
+			return encoder.Encode(map[string]int{"count": reg.Len()})
+		}
+		fmt.Println(ui.CountLabel(reg.Len(), "campaign", "campaigns"))
+		return nil
+	}
+
 	if reg.Len() == 0 {
 		if formatStr == "json" {
-			return outputCampaigns([]campaignEntry{}, formatStr)
+			return outputCampaigns(os.Stdout, []campaignEntry{}, formatStr)
 		}
 		fmt.Println(ui.Warning("No campaigns registered."))
 		fmt.Println()
@@ -118,7 +134,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	sortBy, _ := cmd.Flags().GetString("sort")
 
 	campaigns := sortCampaigns(reg.Campaigns, sortBy)
-	return outputCampaigns(campaigns, formatStr)
+	return outputCampaigns(os.Stdout, campaigns, formatStr)
 }
 
 // sortCampaigns converts the registry map to a sorted slice.
@@ -155,20 +171,22 @@ func sortCampaigns(campaigns map[string]config.RegisteredCampaign, by string) []
 	return entries
 }
 
-// outputCampaigns writes campaigns to stdout in the specified format.
-func outputCampaigns(campaigns []campaignEntry, format string) error {
+// outputCampaigns writes campaigns to out in the specified format.
+func outputCampaigns(out io.Writer, campaigns []campaignEntry, format string) error {
 	switch format {
 	case "json":
-		encoder := json.NewEncoder(os.Stdout)
+		encoder := json.NewEncoder(out)
 		encoder.SetIndent("", "  ")
 		return encoder.Encode(campaigns)
 	case "simple":
 		for _, c := range campaigns {
-			fmt.Println(c.Name)
+			if _, err := fmt.Fprintln(out, c.Name); err != nil {
+				return err
+			}
 		}
 		return nil
 	default: // table
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
 			ui.Label("ID"), ui.Label("NAME"), ui.Label("TYPE"), ui.Label("PATH"))
 		for _, c := range campaigns {
@@ -188,7 +206,14 @@ func outputCampaigns(campaigns []campaignEntry, format string) error {
 				typeStyle.Render(campaignType),
 				ui.Dim(c.Path))
 		}
-		return w.Flush()
+		if err := w.Flush(); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(out); err != nil {
+			return err
+		}
+		_, err := fmt.Fprintln(out, ui.Dim(ui.CountLabel(len(campaigns), "campaign", "campaigns")))
+		return err
 	}
 }
 

--- a/cmd/camp/list_count_test.go
+++ b/cmd/camp/list_count_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestListCountFlagRegistered(t *testing.T) {
+	if listCmd.Flags().Lookup("count") == nil {
+		t.Fatal("camp list missing --count flag")
+	}
+}
+
+func TestOutputCampaigns_TableShowsCount(t *testing.T) {
+	campaigns := []campaignEntry{
+		{ID: "abc12345", Name: "alpha", Type: "work", Path: "/tmp/alpha"},
+		{ID: "def67890", Name: "beta", Type: "work", Path: "/tmp/beta"},
+	}
+
+	var buf bytes.Buffer
+	if err := outputCampaigns(&buf, campaigns, "table"); err != nil {
+		t.Fatalf("outputCampaigns() error = %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "2 campaigns") {
+		t.Errorf("table output missing count footer; got:\n%s", buf.String())
+	}
+}
+
+func TestOutputCampaigns_SimpleHasNoCount(t *testing.T) {
+	campaigns := []campaignEntry{
+		{ID: "abc12345", Name: "alpha"},
+		{ID: "def67890", Name: "beta"},
+	}
+
+	var buf bytes.Buffer
+	if err := outputCampaigns(&buf, campaigns, "simple"); err != nil {
+		t.Fatalf("outputCampaigns() error = %v", err)
+	}
+
+	out := strings.TrimSpace(buf.String())
+	if strings.Contains(out, "campaigns") {
+		t.Errorf("simple output should not include count footer; got:\n%s", out)
+	}
+	if lines := strings.Split(out, "\n"); len(lines) != 2 {
+		t.Errorf("simple output should have 2 lines, got %d", len(lines))
+	}
+}
+
+func TestOutputCampaigns_JSONHasNoCount(t *testing.T) {
+	campaigns := []campaignEntry{{ID: "abc12345", Name: "alpha"}}
+
+	var buf bytes.Buffer
+	if err := outputCampaigns(&buf, campaigns, "json"); err != nil {
+		t.Fatalf("outputCampaigns() error = %v", err)
+	}
+
+	var parsed []campaignEntry
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("JSON output is no longer a bare array: %v", err)
+	}
+	if len(parsed) != 1 {
+		t.Errorf("JSON has %d campaigns, want 1", len(parsed))
+	}
+}

--- a/cmd/camp/project/list.go
+++ b/cmd/camp/project/list.go
@@ -25,18 +25,23 @@ Examples:
   camp project list               List projects in table format
   camp project list --json        Output as JSON
   camp project list --format json Output as JSON
-  camp project list --format simple  Names only for scripting`,
+  camp project list --format simple  Names only for scripting
+  camp project list --count       Print only the total number of projects`,
 	Aliases: []string{"ls"},
 	RunE:    runProjectList,
 }
 
-var projectListJSON bool
+var (
+	projectListJSON  bool
+	projectListCount bool
+)
 
 func init() {
 	Cmd.AddCommand(projectListCmd)
 
 	projectListCmd.Flags().StringP("format", "f", "table", "Output format (table, simple, json)")
 	projectListCmd.Flags().BoolVar(&projectListJSON, "json", false, "Output as JSON (shorthand for --format json)")
+	projectListCmd.Flags().BoolVar(&projectListCount, "count", false, "Print only the total number of projects")
 }
 
 func runProjectList(cmd *cobra.Command, args []string) error {
@@ -60,6 +65,10 @@ func runProjectList(cmd *cobra.Command, args []string) error {
 		formatStr = "json"
 	}
 	format := projectsvc.OutputFormat(formatStr)
+
+	if projectListCount {
+		return projectsvc.FormatCount(os.Stdout, len(projects), format)
+	}
 
 	// Output projects
 	return projectsvc.FormatProjects(os.Stdout, projects, format)

--- a/cmd/camp/project/list_test.go
+++ b/cmd/camp/project/list_test.go
@@ -1,0 +1,9 @@
+package project
+
+import "testing"
+
+func TestProjectListCountFlagRegistered(t *testing.T) {
+	if projectListCmd.Flags().Lookup("count") == nil {
+		t.Fatal("camp project list missing --count flag")
+	}
+}

--- a/internal/project/output.go
+++ b/internal/project/output.go
@@ -76,7 +76,25 @@ func formatTable(w io.Writer, projects []Project) error {
 		}
 		fmt.Fprintf(tw, "%s\t%s\t%s\n", ui.Value(p.Name), ui.Dim(p.Path), getProjectTypeStyled(projectType))
 	}
-	return tw.Flush()
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintln(w, ui.Dim(ui.CountLabel(len(projects), "project", "projects")))
+	return err
+}
+
+// FormatCount writes only the project total to w, emitting {"count": n} for JSON.
+func FormatCount(w io.Writer, n int, format OutputFormat) error {
+	if format == FormatJSON {
+		encoder := json.NewEncoder(w)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(map[string]int{"count": n})
+	}
+	_, err := fmt.Fprintln(w, ui.CountLabel(n, "project", "projects"))
+	return err
 }
 
 // getProjectTypeStyled returns styled project type text.

--- a/internal/project/output_test.go
+++ b/internal/project/output_test.go
@@ -144,6 +144,91 @@ func TestFormatProjects_JSONEmpty(t *testing.T) {
 	}
 }
 
+func TestFormatProjects_TableShowsCount(t *testing.T) {
+	projects := []Project{
+		{Name: "api", Path: "projects/api", Type: "go"},
+		{Name: "frontend", Path: "projects/frontend", Type: "typescript"},
+	}
+
+	var buf bytes.Buffer
+	if err := FormatProjects(&buf, projects, FormatTable); err != nil {
+		t.Fatalf("FormatProjects() error = %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "2 projects") {
+		t.Errorf("table output missing count footer; got:\n%s", buf.String())
+	}
+}
+
+func TestFormatProjects_SimpleHasNoCount(t *testing.T) {
+	projects := []Project{
+		{Name: "api", Path: "projects/api", Type: "go"},
+		{Name: "frontend", Path: "projects/frontend", Type: "typescript"},
+	}
+
+	var buf bytes.Buffer
+	if err := FormatProjects(&buf, projects, FormatSimple); err != nil {
+		t.Fatalf("FormatProjects() error = %v", err)
+	}
+
+	if strings.Contains(buf.String(), "projects") {
+		t.Errorf("simple output should not include count footer; got:\n%s", buf.String())
+	}
+}
+
+func TestFormatProjects_JSONHasNoCount(t *testing.T) {
+	projects := []Project{{Name: "api", Path: "projects/api", Type: "go"}}
+
+	var buf bytes.Buffer
+	if err := FormatProjects(&buf, projects, FormatJSON); err != nil {
+		t.Fatalf("FormatProjects() error = %v", err)
+	}
+
+	var parsed []Project
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("JSON output is no longer a bare array: %v", err)
+	}
+	if len(parsed) != 1 {
+		t.Errorf("JSON has %d projects, want 1", len(parsed))
+	}
+}
+
+func TestFormatCount_Labeled(t *testing.T) {
+	cases := []struct {
+		n      int
+		format OutputFormat
+		want   string
+	}{
+		{3, FormatTable, "3 projects"},
+		{1, FormatSimple, "1 project"},
+		{0, FormatTable, "0 projects"},
+	}
+	for _, tc := range cases {
+		var buf bytes.Buffer
+		if err := FormatCount(&buf, tc.n, tc.format); err != nil {
+			t.Fatalf("FormatCount() error = %v", err)
+		}
+		if got := strings.TrimSpace(buf.String()); got != tc.want {
+			t.Errorf("FormatCount(%d, %q) = %q, want %q", tc.n, tc.format, got, tc.want)
+		}
+	}
+}
+
+func TestFormatCount_JSON(t *testing.T) {
+	var buf bytes.Buffer
+	if err := FormatCount(&buf, 5, FormatJSON); err != nil {
+		t.Fatalf("FormatCount() error = %v", err)
+	}
+
+	var parsed map[string]int
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if parsed["count"] != 5 {
+		t.Errorf("count = %d, want 5", parsed["count"])
+	}
+}
+
 func TestFormatProjects_DefaultIsTable(t *testing.T) {
 	projects := []Project{
 		{Name: "test", Path: "projects/test", Type: "go"},

--- a/internal/ui/count_test.go
+++ b/internal/ui/count_test.go
@@ -1,0 +1,20 @@
+package ui
+
+import "testing"
+
+func TestCountLabel(t *testing.T) {
+	cases := []struct {
+		n    int
+		want string
+	}{
+		{0, "0 campaigns"},
+		{1, "1 campaign"},
+		{2, "2 campaigns"},
+		{42, "42 campaigns"},
+	}
+	for _, tc := range cases {
+		if got := CountLabel(tc.n, "campaign", "campaigns"); got != tc.want {
+			t.Errorf("CountLabel(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}

--- a/internal/ui/text.go
+++ b/internal/ui/text.go
@@ -5,6 +5,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -137,6 +138,14 @@ func KeyValue(key, value string) string {
 // KeyValueColored formats a key-value pair with a colored value
 func KeyValueColored(key, value string, color lipgloss.Color) string {
 	return Label(key) + " " + Value(value, color)
+}
+
+// CountLabel formats a count with its noun, pluralizing when n != 1.
+func CountLabel(n int, singular, plural string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, singular)
+	}
+	return fmt.Sprintf("%d %s", n, plural)
 }
 
 // Indent adds indentation to text


### PR DESCRIPTION
## What

Adds totals to the two list commands so you can see *how many* at a glance, plus a scriptable count-only mode.

- **`camp list`** and **`camp project list`** now print a count footer on the default **table** output:
  - `19 campaigns`
  - `43 projects`
- New **`--count`** flag prints only the labeled total:
  - `camp list --count` → `19 campaigns`
  - `camp project list --count` → `43 projects`
  - With `--json`: `camp list --count --json` → `{"count": 19}`

## Behavior

| | table (default) | simple | json | `--count` | `--count --json` |
|---|---|---|---|---|---|
| `camp list` | table + `N campaigns` footer | unchanged | unchanged (array) | `N campaigns` | `{"count": N}` |
| `camp project list` | table + `N projects` footer | unchanged | unchanged (array) | `N projects` | `{"count": N}` |

- Footer is **table-only**. `simple` (scripting) and `json` output are byte-for-byte unchanged. The existing `--json` array shape is preserved, so downstream `--json` consumers (e.g. festival-app) are unaffected; the only new JSON is the opt-in `--count --json` object.
- Pluralization: `1 campaign` / `2 campaigns`, `1 project` / `7 projects`. `--count` on an empty workspace prints `0 …`.
- Empty-state messages ("No campaigns registered." / "No projects found.") are unchanged (no footer on empty).

## Implementation

- New shared helper `ui.CountLabel(n, singular, plural)` for pluralization.
- `internal/project/output.go`: footer in `formatTable`; new `FormatCount(w, n, format)`.
- `cmd/camp/list.go`: `outputCampaigns` refactored to take an `io.Writer` (testability); `--count` short-circuit in `runList`.
- `cmd/camp/project/list.go`: `--count` short-circuit in `runProjectList`.

## Tests

- `ui.CountLabel` pluralization (singular/plural/zero).
- Project: table footer present, absent from simple/json (json still unmarshals to a bare array); `FormatCount` labeled + `{"count":N}` JSON.
- Campaign: `outputCampaigns` footer present on table, absent from simple/json; `--count` flag registered on both commands.

## Verification

`just lint` clean (errcheck + fmt/host-fs/fmt.Errorf ratchets), `go test` green for the affected packages, and verified end-to-end against the live registry (19 campaigns) and this campaign's projects (43 projects) across table / `--count` / `--count --json` / `--json`.