### PR TITLE
feat(workitem): camp workitem promote + shared internal/promote seam + shelve fold-in

### DIFF
--- a/cmd/camp/intent/promote_test.go
+++ b/cmd/camp/intent/promote_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/Obedience-Corp/camp/internal/intent/promote"
+	"github.com/Obedience-Corp/camp/internal/promote"
 )
 
 func TestExtractFirstParagraph(t *testing.T) {

--- a/cmd/camp/manifest.go
+++ b/cmd/camp/manifest.go
@@ -54,6 +54,12 @@ func walkCommands(cmd *cobra.Command, prefix string, entries *[]CommandEntry) {
 			path = prefix + " " + child.Name()
 		}
 
+		// Hidden commands (e.g. the deprecated shelve alias) are not advertised
+		// in the agent manifest, mirroring their absence from --help.
+		if child.Hidden {
+			continue
+		}
+
 		// Only include commands that have the agent_allowed annotation
 		if val, ok := child.Annotations["agent_allowed"]; ok {
 			entry := CommandEntry{

--- a/cmd/camp/manifest_test.go
+++ b/cmd/camp/manifest_test.go
@@ -125,7 +125,6 @@ func TestManifestCommand_AllRestrictedCommandsPresent(t *testing.T) {
 		"dungeon list":  false,
 		"dungeon move":  false,
 		"intent crawl":  false,
-		"shelve":        false,
 		"skills link":   false,
 		"skills status": false,
 		"skills unlink": false,

--- a/cmd/camp/promote/promote.go
+++ b/cmd/camp/promote/promote.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	dungeoncmd "github.com/Obedience-Corp/camp/cmd/camp/dungeon"
+	wicmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/config"
-	intdungeon "github.com/Obedience-Corp/camp/internal/dungeon"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
 	"github.com/Obedience-Corp/camp/internal/ui"
@@ -19,27 +18,22 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:     "shelve <status>",
-	Short:   "Shelve the workitem at cwd to a dungeon status",
-	GroupID: "planning",
-	Long: `Shelve the directory-style workitem containing the current working
-directory to a named dungeon status. Status directories live under the
-workitem type's local dungeon (workflow/<type>/dungeon/<status>/); outside
-the dungeon a workitem is treated as active.
+	Use:    "shelve <status>",
+	Short:  "Deprecated: use camp workitem promote --target <status>",
+	Hidden: true,
+	Long: `Deprecated alias for camp workitem promote --target <status>.
 
-Run this from anywhere inside workflow/<type>/<slug>/. The workitem
-boundary is detected from cwd. The status argument is the destination
-directory name (e.g., completed, archived, someday) - no need to spell
-out "dungeon/".`,
-	Example: `  camp shelve completed   Shelve the workitem to its local dungeon/completed
-  camp shelve archived    Move to dungeon/archived
-  camp shelve someday     Move to dungeon/someday`,
-	Args: cobra.ExactArgs(1),
+Shelve the directory-style workitem containing the current working directory
+to a named dungeon status (completed, archived, someday). Run from anywhere
+inside workflow/<type>/<slug>/. Prefer camp workitem promote --target <status>
+or camp promote.`,
+	Example: `  camp shelve completed   # use: camp workitem promote --target completed`,
+	Args:    cobra.ExactArgs(1),
 	Annotations: map[string]string{
 		"agent_allowed": "true",
 		"agent_reason":  "Non-interactive shelving of the workitem at cwd to a dungeon status",
 	},
-	RunE: runPromote,
+	RunE: runShelveAlias,
 }
 
 func init() {
@@ -59,7 +53,7 @@ type promoteResult struct {
 	Warnings      []string `json:"warnings,omitempty"`
 }
 
-func runPromote(cmd *cobra.Command, args []string) error {
+func runShelveAlias(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	status := args[0]
 
@@ -67,7 +61,7 @@ func runPromote(cmd *cobra.Command, args []string) error {
 	jsonOut, _ := cmd.Flags().GetBool("json")
 
 	if status == "active" {
-		return fmt.Errorf("shelve cannot target %q: %q is not a dungeon status (outside the dungeon a workitem is already active); restoring workitems out of dungeon is not supported by shelve", status, status)
+		return camperrors.New(fmt.Sprintf("shelve cannot target %q: %q is not a dungeon status (outside the dungeon a workitem is already active); restoring workitems out of dungeon is not supported by shelve", status, status))
 	}
 
 	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
@@ -85,35 +79,17 @@ func runPromote(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	info, err := os.Stat(loc.SourcePath)
+	move, err := wicmd.MoveToDungeon(ctx, campaignRoot, loc, status)
 	if err != nil {
-		return camperrors.Wrapf(err, "stat workitem %s", loc.SourcePath)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("workitem %s is not a directory; shelve only handles directory-style workitems", dungeoncmd.RelFromRoot(campaignRoot, loc.SourcePath))
-	}
-
-	if loc.InDungeon && loc.Status == status {
-		return fmt.Errorf("workitem %q is already at status %q", loc.Slug, status)
-	}
-
-	svc := intdungeon.NewService(campaignRoot, loc.DungeonPath)
-	initResult, err := svc.Init(ctx, intdungeon.InitOptions{})
-	if err != nil {
-		return camperrors.Wrap(err, "initializing workitem dungeon")
-	}
-
-	targetPath, err := svc.MoveToDungeonStatus(ctx, loc.Slug, loc.ParentPath, status)
-	if err != nil {
-		return dungeoncmd.WrapDungeonMoveError(err, loc.Slug, status)
+		return err
 	}
 
 	result := promoteResult{
 		Slug:   loc.Slug,
 		Type:   loc.Type,
 		Status: status,
-		From:   filepath.ToSlash(dungeoncmd.RelFromRoot(campaignRoot, loc.SourcePath)),
-		To:     filepath.ToSlash(dungeoncmd.RelFromRoot(campaignRoot, targetPath)),
+		From:   move.FromRel,
+		To:     move.ToRel,
 	}
 
 	stdout := cmd.OutOrStdout()
@@ -133,14 +109,14 @@ func runPromote(cmd *cobra.Command, args []string) error {
 		if jsonOut {
 			result.Warnings = append(result.Warnings, msg)
 		} else {
-			fmt.Fprintf(stdout, "%s %s\n", ui.WarningIcon(), msg)
+			_, _ = fmt.Fprintf(stdout, "%s %s\n", ui.WarningIcon(), msg)
 		}
 	}
 
 	var commitErr error
 	if !noCommit {
-		destinationPaths := append([]string{}, initResult.CreatedFiles...)
-		destinationPaths = append(destinationPaths, targetPath)
+		destinationPaths := append([]string{}, move.CreatedFiles...)
+		destinationPaths = append(destinationPaths, move.TargetPath)
 		description := fmt.Sprintf("Shelve workitem %s → %s", loc.Slug, result.To)
 
 		outcome := dungeoncmd.StageAndCommitDungeonMove(ctx, &dungeoncmd.DungeonMoveCommit{
@@ -149,7 +125,7 @@ func runPromote(cmd *cobra.Command, args []string) error {
 			Description:      description,
 			SourcePaths:      []string{loc.SourcePath},
 			DestinationPaths: destinationPaths,
-			RewrittenFiles:   svc.RewrittenLinkFiles(),
+			RewrittenFiles:   move.Svc.RewrittenLinkFiles(),
 		})
 		dungeoncmd.PrintDungeonMoveOutcome(textOut, outcome)
 		result.Committed = outcome.Committed
@@ -161,7 +137,9 @@ func runPromote(cmd *cobra.Command, args []string) error {
 		if err := json.NewEncoder(stdout).Encode(result); err != nil {
 			return camperrors.Wrap(err, "encoding JSON output")
 		}
+		return commitErr
 	}
 
+	_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "camp shelve is deprecated; use camp workitem promote --target "+status+" (or camp promote).")
 	return commitErr
 }

--- a/cmd/camp/promote/promote.go
+++ b/cmd/camp/promote/promote.go
@@ -15,6 +15,7 @@ import (
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
 	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/internal/workitem/locate"
 )
 
 var Cmd = &cobra.Command{
@@ -79,7 +80,7 @@ func runPromote(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "getting current directory")
 	}
 
-	loc, err := detectWorkitemFromCwd(campaignRoot, cwd)
+	loc, err := locate.DetectFromCwd(campaignRoot, cwd)
 	if err != nil {
 		return err
 	}

--- a/cmd/camp/promote/promote_test.go
+++ b/cmd/camp/promote/promote_test.go
@@ -1,0 +1,15 @@
+package promote
+
+import "testing"
+
+func TestShelveCommandIsHiddenAlias(t *testing.T) {
+	if !Cmd.Hidden {
+		t.Fatal("shelve command should be Hidden (deprecated alias)")
+	}
+	if Cmd.Use != "shelve <status>" {
+		t.Fatalf("Use = %q, want %q", Cmd.Use, "shelve <status>")
+	}
+	if Cmd.RunE == nil {
+		t.Fatal("shelve command should keep a RunE delegate")
+	}
+}

--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -67,6 +67,7 @@ var manifestAgentAllowedReasons = map[string]string{
 	"workitem link":       "Non-interactive workitem link operation",
 	"workitem links":      "Read-only workitem link listing",
 	"workitem priority":   "Non-interactive priority update with explicit selector",
+	"workitem promote":    "Non-interactive promote fully specified by --target and flags",
 	"workitem resolve":    "Read-only workitem context resolution",
 	"workitem unlink":     "Non-interactive workitem unlink operation",
 	"worktrees info":      "Read-only worktree metadata",

--- a/internal/commands/workitem/promote.go
+++ b/internal/commands/workitem/promote.go
@@ -1,0 +1,476 @@
+package workitem
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	dungeoncmd "github.com/Obedience-Corp/camp/cmd/camp/dungeon"
+	"github.com/Obedience-Corp/camp/internal/config"
+	intdungeon "github.com/Obedience-Corp/camp/internal/dungeon"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/intent"
+	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
+	promotepkg "github.com/Obedience-Corp/camp/internal/promote"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	wkaudit "github.com/Obedience-Corp/camp/internal/workitem/audit"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/locate"
+)
+
+type runWorkitemPromoteOptions struct {
+	ID       string
+	Target   string
+	Dest     string
+	Goal     string
+	Keep     bool
+	Force    bool
+	DryRun   bool
+	NoCommit bool
+	JSON     bool
+}
+
+type workitemPromoteResult struct {
+	ID            string   `json:"id"`
+	Type          string   `json:"type"`
+	Target        string   `json:"target"`
+	From          string   `json:"from"`
+	To            string   `json:"to"`
+	PromotedTo    string   `json:"promoted_to"`
+	SourceShelved string   `json:"source_shelved,omitempty"`
+	Committed     bool     `json:"committed"`
+	CommitMessage string   `json:"commit_message,omitempty"`
+	Warnings      []string `json:"warnings,omitempty"`
+}
+
+type commitInputs struct {
+	description string
+	sourcePaths []string
+	destPaths   []string
+	rewritten   []string
+}
+
+func newPromoteCommand() *cobra.Command {
+	var (
+		target   string
+		dest     string
+		goal     string
+		keep     bool
+		force    bool
+		dryRun   bool
+		noCommit bool
+		jsonOut  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "promote [id] --target <target>",
+		Short: "Promote a workitem to a festival, doc, or dungeon status",
+		Long: `Promote the workitem identified by [id], by cwd, or by the current pointer.
+
+TARGETS:
+  festival    Create a festival from the workitem and shelve the source
+  doc         Copy the workitem doc into docs/ and shelve the source
+  completed   Move the workitem to its local dungeon/completed
+  archived    Move the workitem to its local dungeon/archived
+  someday     Move the workitem to its local dungeon/someday`,
+		Args: cobra.RangeArgs(0, 1),
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Fully specified by flags; only the bare camp promote selector is interactive",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := ""
+			if len(args) == 1 {
+				id = args[0]
+			}
+			return runWorkitemPromote(cmd, runWorkitemPromoteOptions{
+				ID: id, Target: target, Dest: dest, Goal: goal,
+				Keep: keep, Force: force, DryRun: dryRun, NoCommit: noCommit, JSON: jsonOut,
+			})
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&target, "target", "", "Promotion target: festival, doc, completed, archived, someday")
+	f.StringVar(&dest, "dest", "", "Destination path override for doc/festival targets")
+	f.StringVar(&goal, "goal", "", "Festival goal override (default: first paragraph of the workitem doc)")
+	f.BoolVar(&keep, "keep", false, "On festival/doc, do not move the source workitem to the dungeon")
+	f.BoolVar(&force, "force", false, "Skip readiness checks (e.g. empty doc)")
+	f.BoolVar(&dryRun, "dry-run", false, "Print the planned action, change nothing")
+	f.BoolVar(&noCommit, "no-commit", false, "Skip the auto-commit")
+	f.BoolVar(&jsonOut, "json", false, "Output result as a single JSON object")
+	return cmd
+}
+
+func runWorkitemPromote(cmd *cobra.Command, opts runWorkitemPromoteOptions) error {
+	ctx := cmd.Context()
+
+	switch opts.Target {
+	case "festival", "doc", "completed", "archived", "someday":
+	case "active":
+		return camperrors.New("cannot promote to active: a workitem outside the dungeon is already active; restoring workitems out of the dungeon is not a promote")
+	case "":
+		return camperrors.New("required flag --target not set")
+	default:
+		return camperrors.New("invalid target: " + opts.Target + " (use festival, doc, completed, archived, someday)")
+	}
+
+	cfg, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	loc, err := resolveWorkitem(ctx, root, opts.ID)
+	if err != nil {
+		return err
+	}
+
+	result := workitemPromoteResult{
+		ID:     loc.Slug,
+		Type:   loc.Type,
+		Target: opts.Target,
+		From:   filepath.ToSlash(dungeoncmd.RelFromRoot(root, loc.SourcePath)),
+	}
+
+	if opts.DryRun {
+		if opts.JSON {
+			return emitPromoteJSON(cmd, result)
+		}
+		_, err := fmt.Fprintf(cmd.OutOrStdout(),
+			"dry-run: would promote workitem %s (%s) to %s\n", loc.Slug, loc.Type, opts.Target)
+		return err
+	}
+
+	var ci *commitInputs
+	switch opts.Target {
+	case "festival":
+		ci, err = doFestivalPromote(ctx, cmd, opts, root, loc, &result)
+	case "doc":
+		ci, err = doDocPromote(ctx, opts, root, loc, &result)
+	case "completed", "archived", "someday":
+		ci, err = doDungeonPromote(ctx, root, loc, opts.Target, &result)
+	default:
+		return camperrors.New("unhandled target: " + opts.Target)
+	}
+	if err != nil {
+		return err
+	}
+	if ci == nil {
+		return nil
+	}
+
+	if err := wkaudit.AppendEvent(ctx, root, wkaudit.Event{
+		Event:      wkaudit.EventPromote,
+		ID:         result.ID,
+		Type:       result.Type,
+		From:       result.From,
+		To:         result.To,
+		Target:     result.Target,
+		PromotedTo: result.PromotedTo,
+	}); err != nil {
+		return camperrors.Wrap(err, "writing workitem audit event")
+	}
+	ci.destPaths = append(ci.destPaths, filepath.Join(root, ".campaign", "workitems", wkaudit.AuditFile))
+
+	if !opts.NoCommit {
+		outcome := dungeoncmd.StageAndCommitDungeonMove(ctx, &dungeoncmd.DungeonMoveCommit{
+			Config:           cfg,
+			CampaignRoot:     root,
+			Description:      ci.description,
+			SourcePaths:      ci.sourcePaths,
+			DestinationPaths: ci.destPaths,
+			RewrittenFiles:   ci.rewritten,
+		})
+		if !opts.JSON {
+			dungeoncmd.PrintDungeonMoveOutcome(cmd.OutOrStdout(), outcome)
+		}
+		result.Committed = outcome.Committed
+		result.CommitMessage = outcome.Message
+		if cerr := outcome.Err(); cerr != nil {
+			return cerr
+		}
+	}
+
+	if navErr := navindex.Delete(root); navErr != nil {
+		msg := fmt.Sprintf("failed to invalidate navigation cache: %v", navErr)
+		result.Warnings = append(result.Warnings, msg)
+		if !opts.JSON {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s %s\n", ui.WarningIcon(), msg)
+		}
+	}
+
+	if opts.JSON {
+		return emitPromoteJSON(cmd, result)
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s Promoted workitem %s to %s\n", ui.SuccessIcon(), result.ID, result.To)
+	return err
+}
+
+func emitPromoteJSON(cmd *cobra.Command, result workitemPromoteResult) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(result); err != nil {
+		return camperrors.Wrap(err, "encoding JSON output")
+	}
+	return nil
+}
+
+func doDungeonPromote(ctx context.Context, campaignRoot string, loc *locate.Location, status string, result *workitemPromoteResult) (*commitInputs, error) {
+	moveRes, err := promoteToDungeon(ctx, campaignRoot, loc, status)
+	if err != nil {
+		return nil, err
+	}
+	result.To = moveRes.toRel
+
+	dest := append([]string{moveRes.targetPath}, moveRes.createdFiles...)
+	return &commitInputs{
+		description: fmt.Sprintf("Promote workitem %s to %s", loc.Slug, status),
+		sourcePaths: []string{loc.SourcePath},
+		destPaths:   dest,
+		rewritten:   moveRes.svc.RewrittenLinkFiles(),
+	}, nil
+}
+
+func doFestivalPromote(ctx context.Context, cmd *cobra.Command, opts runWorkitemPromoteOptions, campaignRoot string, loc *locate.Location, result *workitemPromoteResult) (*commitInputs, error) {
+	docContent, err := primaryDocContent(loc.SourcePath)
+	if err != nil {
+		return nil, err
+	}
+	if !opts.Force && strings.TrimSpace(docContent) == "" {
+		return nil, camperrors.New("workitem doc is empty; use --force to promote anyway")
+	}
+
+	name := intent.SlugFromTitle(titleFromDoc(docContent, loc.Slug))
+	goal := opts.Goal
+	if goal == "" {
+		goal = promotepkg.ExtractFirstParagraph(docContent)
+	}
+
+	fr, err := promotepkg.FindAndCreateFestival(ctx, campaignRoot, name, goal)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "creating festival")
+	}
+	if fr.NotFound {
+		_, perr := fmt.Fprintf(cmd.ErrOrStderr(),
+			"Note: fest CLI not found. Workitem left active. Create the festival manually with:\n"+
+				"  fest create festival --type standard --name %q\n", name)
+		return nil, perr
+	}
+	if !fr.Created {
+		return nil, camperrors.New("festival creation failed: " + fr.CLIError)
+	}
+
+	ingestDir := filepath.Join(campaignRoot, "festivals", fr.Dest, fr.Dir, "001_INGEST", "input_specs", loc.Slug)
+	if err := promotepkg.CopyTree(loc.SourcePath, ingestDir); err != nil {
+		return nil, camperrors.Wrap(err, "copying workitem into festival ingest")
+	}
+	promotedTo := filepath.ToSlash(filepath.Join("festivals", fr.Dest, fr.Dir))
+
+	if err := recordPromotedTo(ctx, campaignRoot, loc, promotedTo); err != nil {
+		return nil, err
+	}
+
+	result.To = promotedTo
+	result.PromotedTo = promotedTo
+
+	ci := &commitInputs{
+		description: fmt.Sprintf("Promote workitem %s to festival %s", loc.Slug, promotedTo),
+		destPaths: []string{
+			filepath.Join(campaignRoot, "festivals", fr.Dest, fr.Dir),
+			filepath.Join(campaignRoot, "festivals", ".festival", ".state"),
+		},
+	}
+	return appendShelve(ctx, opts, campaignRoot, loc, ci, result)
+}
+
+func doDocPromote(ctx context.Context, opts runWorkitemPromoteOptions, campaignRoot string, loc *locate.Location, result *workitemPromoteResult) (*commitInputs, error) {
+	docContent, err := primaryDocContent(loc.SourcePath)
+	if err != nil {
+		return nil, err
+	}
+	if !opts.Force && strings.TrimSpace(docContent) == "" {
+		return nil, camperrors.New("workitem doc is empty; use --force to promote anyway")
+	}
+
+	relDest := opts.Dest
+	if relDest == "" {
+		relDest = loc.Slug
+	}
+	destDir := filepath.Join(campaignRoot, "docs", relDest)
+
+	if !opts.Force {
+		if entries, _ := os.ReadDir(destDir); len(entries) > 0 {
+			return nil, camperrors.New("docs/" + relDest + " already exists and is not empty; use --force to overwrite")
+		}
+	}
+	if err := promotepkg.CopyTree(loc.SourcePath, destDir); err != nil {
+		return nil, camperrors.Wrap(err, "copying workitem into docs")
+	}
+	promotedTo := filepath.ToSlash(filepath.Join("docs", relDest))
+
+	if err := recordPromotedTo(ctx, campaignRoot, loc, promotedTo); err != nil {
+		return nil, err
+	}
+
+	result.To = promotedTo
+	result.PromotedTo = promotedTo
+
+	ci := &commitInputs{
+		description: fmt.Sprintf("Promote workitem %s to %s", loc.Slug, promotedTo),
+		destPaths:   []string{destDir},
+	}
+	return appendShelve(ctx, opts, campaignRoot, loc, ci, result)
+}
+
+func recordPromotedTo(ctx context.Context, campaignRoot string, loc *locate.Location, promotedTo string) error {
+	if _, err := os.Stat(filepath.Join(loc.SourcePath, wkitem.MetadataFilename)); os.IsNotExist(err) {
+		return nil
+	}
+	relPath := filepath.ToSlash(dungeoncmd.RelFromRoot(campaignRoot, loc.SourcePath))
+	if err := promotepkg.RecordPromotion(promotedTo, func(rec promotepkg.PromotionRecord) error {
+		return wkitem.RecordPromotion(ctx, campaignRoot, relPath, rec.PromotedTo, rec.PromotedAt)
+	}); err != nil {
+		return camperrors.Wrap(err, "recording promotion on workitem")
+	}
+	return nil
+}
+
+func appendShelve(ctx context.Context, opts runWorkitemPromoteOptions, campaignRoot string, loc *locate.Location, ci *commitInputs, result *workitemPromoteResult) (*commitInputs, error) {
+	if opts.Keep {
+		ci.destPaths = append(ci.destPaths, loc.SourcePath)
+		return ci, nil
+	}
+
+	moveRes, err := promoteToDungeon(ctx, campaignRoot, loc, "completed")
+	if err != nil {
+		return nil, camperrors.Wrap(err, "shelving source workitem")
+	}
+	result.SourceShelved = moveRes.toRel
+	ci.sourcePaths = []string{loc.SourcePath}
+	ci.destPaths = append(ci.destPaths, moveRes.targetPath)
+	ci.destPaths = append(ci.destPaths, moveRes.createdFiles...)
+	ci.rewritten = moveRes.svc.RewrittenLinkFiles()
+	return ci, nil
+}
+
+type dungeonMoveResult struct {
+	svc          *intdungeon.Service
+	createdFiles []string
+	targetPath   string
+	fromRel      string
+	toRel        string
+}
+
+func promoteToDungeon(ctx context.Context, campaignRoot string, loc *locate.Location, status string) (dungeonMoveResult, error) {
+	info, err := os.Stat(loc.SourcePath)
+	if err != nil {
+		return dungeonMoveResult{}, camperrors.Wrapf(err, "stat workitem %s", loc.SourcePath)
+	}
+	if !info.IsDir() {
+		return dungeonMoveResult{}, camperrors.New(fmt.Sprintf("workitem %s is not a directory; promote dungeon targets only handle directory-style workitems", dungeoncmd.RelFromRoot(campaignRoot, loc.SourcePath)))
+	}
+
+	if loc.InDungeon && loc.Status == status {
+		return dungeonMoveResult{}, camperrors.New(fmt.Sprintf("workitem %q is already at status %q", loc.Slug, status))
+	}
+
+	svc := intdungeon.NewService(campaignRoot, loc.DungeonPath)
+	initResult, err := svc.Init(ctx, intdungeon.InitOptions{})
+	if err != nil {
+		return dungeonMoveResult{}, camperrors.Wrap(err, "initializing workitem dungeon")
+	}
+
+	targetPath, err := svc.MoveToDungeonStatus(ctx, loc.Slug, loc.ParentPath, status)
+	if err != nil {
+		return dungeonMoveResult{}, dungeoncmd.WrapDungeonMoveError(err, loc.Slug, status)
+	}
+
+	return dungeonMoveResult{
+		svc:          svc,
+		createdFiles: initResult.CreatedFiles,
+		targetPath:   targetPath,
+		fromRel:      filepath.ToSlash(dungeoncmd.RelFromRoot(campaignRoot, loc.SourcePath)),
+		toRel:        filepath.ToSlash(dungeoncmd.RelFromRoot(campaignRoot, targetPath)),
+	}, nil
+}
+
+func primaryDocContent(srcDir string) (string, error) {
+	if data, err := os.ReadFile(filepath.Join(srcDir, "README.md")); err == nil {
+		return string(data), nil
+	} else if !os.IsNotExist(err) {
+		return "", camperrors.Wrap(err, "reading workitem README")
+	}
+
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return "", camperrors.Wrap(err, "reading workitem directory")
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
+			data, readErr := os.ReadFile(filepath.Join(srcDir, e.Name()))
+			if readErr != nil {
+				return "", camperrors.Wrap(readErr, "reading workitem doc")
+			}
+			return string(data), nil
+		}
+	}
+	return "", nil
+}
+
+func titleFromDoc(content, fallbackSlug string) string {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "# ") {
+			return strings.TrimSpace(strings.TrimPrefix(trimmed, "# "))
+		}
+	}
+	return fallbackSlug
+}
+
+func resolveWorkitem(ctx context.Context, campaignRoot, id string) (*locate.Location, error) {
+	if id != "" {
+		return locateByID(ctx, campaignRoot, id)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, camperrors.Wrap(err, "getting current directory")
+	}
+	if loc, err := locate.DetectFromCwd(campaignRoot, cwd); err == nil {
+		return loc, nil
+	}
+
+	if loc, err := locateFromCurrent(ctx, campaignRoot); err == nil && loc != nil {
+		return loc, nil
+	}
+
+	return nil, camperrors.New("no workitem in context (pass an id, cd into a workitem, or set current)")
+}
+
+func locateByID(ctx context.Context, root, id string) (*locate.Location, error) {
+	wi, err := resolveSelector(ctx, root, id, false)
+	if err != nil {
+		return nil, err
+	}
+	if wi.RelativePath == "" {
+		return nil, camperrors.New("resolved workitem has no path on disk")
+	}
+	return locate.DetectFromCwd(root, filepath.Join(root, wi.RelativePath))
+}
+
+func locateFromCurrent(ctx context.Context, root string) (*locate.Location, error) {
+	cur, err := links.LoadCurrent(ctx, root)
+	if err != nil {
+		return nil, err
+	}
+	if cur == nil || cur.WorkitemID == "" {
+		return nil, camperrors.New("no current workitem set")
+	}
+	return locateByID(ctx, root, cur.WorkitemID)
+}

--- a/internal/commands/workitem/promote.go
+++ b/internal/commands/workitem/promote.go
@@ -222,18 +222,18 @@ func emitPromoteJSON(cmd *cobra.Command, result workitemPromoteResult) error {
 }
 
 func doDungeonPromote(ctx context.Context, campaignRoot string, loc *locate.Location, status string, result *workitemPromoteResult) (*commitInputs, error) {
-	moveRes, err := promoteToDungeon(ctx, campaignRoot, loc, status)
+	moveRes, err := MoveToDungeon(ctx, campaignRoot, loc, status)
 	if err != nil {
 		return nil, err
 	}
-	result.To = moveRes.toRel
+	result.To = moveRes.ToRel
 
-	dest := append([]string{moveRes.targetPath}, moveRes.createdFiles...)
+	dest := append([]string{moveRes.TargetPath}, moveRes.CreatedFiles...)
 	return &commitInputs{
 		description: fmt.Sprintf("Promote workitem %s to %s", loc.Slug, status),
 		sourcePaths: []string{loc.SourcePath},
 		destPaths:   dest,
-		rewritten:   moveRes.svc.RewrittenLinkFiles(),
+		rewritten:   moveRes.Svc.RewrittenLinkFiles(),
 	}, nil
 }
 
@@ -347,56 +347,61 @@ func appendShelve(ctx context.Context, opts runWorkitemPromoteOptions, campaignR
 		return ci, nil
 	}
 
-	moveRes, err := promoteToDungeon(ctx, campaignRoot, loc, "completed")
+	moveRes, err := MoveToDungeon(ctx, campaignRoot, loc, "completed")
 	if err != nil {
 		return nil, camperrors.Wrap(err, "shelving source workitem")
 	}
-	result.SourceShelved = moveRes.toRel
+	result.SourceShelved = moveRes.ToRel
 	ci.sourcePaths = []string{loc.SourcePath}
-	ci.destPaths = append(ci.destPaths, moveRes.targetPath)
-	ci.destPaths = append(ci.destPaths, moveRes.createdFiles...)
-	ci.rewritten = moveRes.svc.RewrittenLinkFiles()
+	ci.destPaths = append(ci.destPaths, moveRes.TargetPath)
+	ci.destPaths = append(ci.destPaths, moveRes.CreatedFiles...)
+	ci.rewritten = moveRes.Svc.RewrittenLinkFiles()
 	return ci, nil
 }
 
-type dungeonMoveResult struct {
-	svc          *intdungeon.Service
-	createdFiles []string
-	targetPath   string
-	fromRel      string
-	toRel        string
+// DungeonMove is the outcome of moving a workitem directory into a dungeon
+// status, carrying everything the auto-commit step needs.
+type DungeonMove struct {
+	Svc          *intdungeon.Service
+	CreatedFiles []string
+	TargetPath   string
+	FromRel      string
+	ToRel        string
 }
 
-func promoteToDungeon(ctx context.Context, campaignRoot string, loc *locate.Location, status string) (dungeonMoveResult, error) {
+// MoveToDungeon moves the workitem at loc into the given dungeon status using
+// the shared dungeon plumbing. It is the single implementation behind both
+// camp workitem promote and the deprecated camp shelve alias.
+func MoveToDungeon(ctx context.Context, campaignRoot string, loc *locate.Location, status string) (DungeonMove, error) {
 	info, err := os.Stat(loc.SourcePath)
 	if err != nil {
-		return dungeonMoveResult{}, camperrors.Wrapf(err, "stat workitem %s", loc.SourcePath)
+		return DungeonMove{}, camperrors.Wrapf(err, "stat workitem %s", loc.SourcePath)
 	}
 	if !info.IsDir() {
-		return dungeonMoveResult{}, camperrors.New(fmt.Sprintf("workitem %s is not a directory; promote dungeon targets only handle directory-style workitems", dungeoncmd.RelFromRoot(campaignRoot, loc.SourcePath)))
+		return DungeonMove{}, camperrors.New(fmt.Sprintf("workitem %s is not a directory; only directory-style workitems can be moved to the dungeon", dungeoncmd.RelFromRoot(campaignRoot, loc.SourcePath)))
 	}
 
 	if loc.InDungeon && loc.Status == status {
-		return dungeonMoveResult{}, camperrors.New(fmt.Sprintf("workitem %q is already at status %q", loc.Slug, status))
+		return DungeonMove{}, camperrors.New(fmt.Sprintf("workitem %q is already at status %q", loc.Slug, status))
 	}
 
 	svc := intdungeon.NewService(campaignRoot, loc.DungeonPath)
 	initResult, err := svc.Init(ctx, intdungeon.InitOptions{})
 	if err != nil {
-		return dungeonMoveResult{}, camperrors.Wrap(err, "initializing workitem dungeon")
+		return DungeonMove{}, camperrors.Wrap(err, "initializing workitem dungeon")
 	}
 
 	targetPath, err := svc.MoveToDungeonStatus(ctx, loc.Slug, loc.ParentPath, status)
 	if err != nil {
-		return dungeonMoveResult{}, dungeoncmd.WrapDungeonMoveError(err, loc.Slug, status)
+		return DungeonMove{}, dungeoncmd.WrapDungeonMoveError(err, loc.Slug, status)
 	}
 
-	return dungeonMoveResult{
-		svc:          svc,
-		createdFiles: initResult.CreatedFiles,
-		targetPath:   targetPath,
-		fromRel:      filepath.ToSlash(dungeoncmd.RelFromRoot(campaignRoot, loc.SourcePath)),
-		toRel:        filepath.ToSlash(dungeoncmd.RelFromRoot(campaignRoot, targetPath)),
+	return DungeonMove{
+		Svc:          svc,
+		CreatedFiles: initResult.CreatedFiles,
+		TargetPath:   targetPath,
+		FromRel:      filepath.ToSlash(dungeoncmd.RelFromRoot(campaignRoot, loc.SourcePath)),
+		ToRel:        filepath.ToSlash(dungeoncmd.RelFromRoot(campaignRoot, targetPath)),
 	}, nil
 }
 

--- a/internal/commands/workitem/promote.go
+++ b/internal/commands/workitem/promote.go
@@ -16,6 +16,7 @@ import (
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/intent"
 	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
+	"github.com/Obedience-Corp/camp/internal/pathutil"
 	promotepkg "github.com/Obedience-Corp/camp/internal/promote"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
@@ -98,7 +99,7 @@ TARGETS:
 
 	f := cmd.Flags()
 	f.StringVar(&target, "target", "", "Promotion target: festival, doc, completed, archived, someday")
-	f.StringVar(&dest, "dest", "", "Destination path override for doc/festival targets")
+	f.StringVar(&dest, "dest", "", "Destination path under docs/ for the doc target (must stay within docs/)")
 	f.StringVar(&goal, "goal", "", "Festival goal override (default: first paragraph of the workitem doc)")
 	f.BoolVar(&keep, "keep", false, "On festival/doc, do not move the source workitem to the dungeon")
 	f.BoolVar(&force, "force", false, "Skip readiness checks (e.g. empty doc)")
@@ -245,6 +246,9 @@ func doFestivalPromote(ctx context.Context, cmd *cobra.Command, opts runWorkitem
 	if !opts.Force && strings.TrimSpace(docContent) == "" {
 		return nil, camperrors.New("workitem doc is empty; use --force to promote anyway")
 	}
+	if opts.Dest != "" {
+		return nil, camperrors.New("--dest is only valid for --target doc; fest chooses the festival directory")
+	}
 
 	name := intent.SlugFromTitle(titleFromDoc(docContent, loc.Slug))
 	goal := opts.Goal
@@ -302,7 +306,14 @@ func doDocPromote(ctx context.Context, opts runWorkitemPromoteOptions, campaignR
 	if relDest == "" {
 		relDest = loc.Slug
 	}
-	destDir := filepath.Join(campaignRoot, "docs", relDest)
+	docsRoot := filepath.Join(campaignRoot, "docs")
+	if err := os.MkdirAll(docsRoot, 0o755); err != nil {
+		return nil, camperrors.Wrap(err, "creating docs directory")
+	}
+	destDir := filepath.Join(docsRoot, relDest)
+	if err := pathutil.ValidateBoundary(docsRoot, destDir); err != nil {
+		return nil, camperrors.Wrapf(err, "doc destination %q must stay within docs/", relDest)
+	}
 
 	if !opts.Force {
 		if entries, _ := os.ReadDir(destDir); len(entries) > 0 {

--- a/internal/commands/workitem/promote_test.go
+++ b/internal/commands/workitem/promote_test.go
@@ -402,3 +402,26 @@ func TestPromoteJSONSingleObject(t *testing.T) {
 		t.Fatal("Committed should be false with --no-commit")
 	}
 }
+
+func TestPromoteDocRejectsDestEscape(t *testing.T) {
+	root := promoteCampaign(t)
+	src := addWorkitem(t, root, "design", "feat", "Feat", "body")
+
+	_, _, err := execPromote(t, src, "--target", "doc", "--dest", "../escaped", "--keep", "--no-commit")
+	if err == nil || !strings.Contains(err.Error(), "docs/") {
+		t.Fatalf("err = %v, want a docs boundary error", err)
+	}
+	if _, serr := os.Stat(filepath.Join(root, "escaped")); serr == nil {
+		t.Fatal("escaped directory must not be created outside docs/")
+	}
+}
+
+func TestPromoteFestivalRejectsDest(t *testing.T) {
+	root := promoteCampaign(t)
+	src := addWorkitem(t, root, "design", "feat", "Feat", "body")
+
+	_, _, err := execPromote(t, src, "--target", "festival", "--dest", "whatever", "--no-commit")
+	if err == nil || !strings.Contains(err.Error(), "--dest is only valid for --target doc") {
+		t.Fatalf("err = %v, want festival --dest rejection", err)
+	}
+}

--- a/internal/commands/workitem/promote_test.go
+++ b/internal/commands/workitem/promote_test.go
@@ -1,0 +1,404 @@
+package workitem
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/fest"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+func promoteCampaign(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, ".campaign", "campaign.yaml"), "id: test-campaign\nname: Test\ntype: product\n")
+	return root
+}
+
+func addWorkitem(t *testing.T, root, wtype, slug, title, body string) string {
+	t.Helper()
+	dir := filepath.Join(root, "workflow", wtype, slug)
+	meta := "version: v1alpha6\nkind: workitem\nid: " + wtype + "-" + slug + "-fixed\ntype: " + wtype + "\ntitle: " + title + "\nref: WI-aaaaaa\n"
+	writeFile(t, filepath.Join(dir, ".workitem"), meta)
+	writeFile(t, filepath.Join(dir, "README.md"), "# "+title+"\n\n"+body+"\n")
+	return dir
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func execPromote(t *testing.T, cwd string, args ...string) (string, string, error) {
+	t.Helper()
+	restore := chdir(t, cwd)
+	defer restore()
+
+	cmd := newPromoteCommand()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+	cmd.SetContext(context.Background())
+	err := cmd.Execute()
+	return out.String(), errOut.String(), err
+}
+
+func setCurrentPtr(t *testing.T, root, id string) {
+	t.Helper()
+	if err := links.SaveCurrent(context.Background(), root, &links.Current{
+		Version:    links.CurrentSchemaVersion,
+		WorkitemID: id,
+	}); err != nil {
+		t.Fatalf("SaveCurrent: %v", err)
+	}
+}
+
+func stubFest(t *testing.T) string {
+	t.Helper()
+	bin := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> fest-args.txt\n" +
+		"mkdir -p festivals/planning/sample-feature-stub/001_INGEST/input_specs\n" +
+		"printf '%s' '{\"ok\":true,\"festival\":{\"directory\":\"sample-feature-stub\",\"dest\":\"planning\"}}'\n"
+	writeExecutable(t, filepath.Join(bin, "fest"), script)
+	return bin
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func dungeonWorkitemDir(t *testing.T, root, wtype, status, slug string) string {
+	t.Helper()
+	matches, _ := filepath.Glob(filepath.Join(root, "workflow", wtype, "dungeon", status, "*", slug))
+	if len(matches) > 0 {
+		return matches[0]
+	}
+	flat := filepath.Join(root, "workflow", wtype, "dungeon", status, slug)
+	if dirExists(flat) {
+		return flat
+	}
+	return ""
+}
+
+func TestPromoteResolution(t *testing.T) {
+	cases := []struct {
+		name    string
+		setup   func(t *testing.T, root string) string
+		id      string
+		wantErr string
+	}{
+		{"no id no cwd no current", func(t *testing.T, root string) string { return root }, "", "no workitem in context"},
+		{"id given", func(t *testing.T, root string) string { return root }, "design-sample-feature-fixed", ""},
+		{"cwd inside workitem", func(t *testing.T, root string) string {
+			return filepath.Join(root, "workflow", "design", "sample-feature")
+		}, "", ""},
+		{"current pointer set", func(t *testing.T, root string) string {
+			setCurrentPtr(t, root, "design-sample-feature-fixed")
+			return root
+		}, "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := promoteCampaign(t)
+			addWorkitem(t, root, "design", "sample-feature", "Sample Feature", "A sample workitem.")
+			cwd := tc.setup(t, root)
+
+			args := []string{"--target", "completed", "--no-commit"}
+			if tc.id != "" {
+				args = append([]string{tc.id}, args...)
+			}
+			_, _, err := execPromote(t, cwd, args...)
+
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestPromoteRejectsBadTargets(t *testing.T) {
+	cases := []struct {
+		target  string
+		wantErr string
+	}{
+		{"active", "cannot promote to active"},
+		{"bogus", "invalid target"},
+		{"", "required flag --target not set"},
+	}
+	for _, tc := range cases {
+		t.Run("target="+tc.target, func(t *testing.T) {
+			root := promoteCampaign(t)
+			addWorkitem(t, root, "design", "sample-feature", "Sample", "body")
+			args := []string{"--no-commit"}
+			if tc.target != "" {
+				args = append(args, "--target", tc.target)
+			}
+			_, _, err := execPromote(t, filepath.Join(root, "workflow", "design", "sample-feature"), args...)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestPromoteDungeonTargets(t *testing.T) {
+	for _, status := range []string{"completed", "archived", "someday"} {
+		t.Run(status, func(t *testing.T) {
+			root := promoteCampaign(t)
+			src := addWorkitem(t, root, "design", "feat", "Feat", "body")
+
+			_, _, err := execPromote(t, src, "--target", status, "--no-commit")
+			if err != nil {
+				t.Fatalf("promote %s: %v", status, err)
+			}
+
+			if dirExists(src) {
+				t.Fatalf("source %s should have moved", src)
+			}
+			if dungeonWorkitemDir(t, root, "design", status, "feat") == "" {
+				t.Fatalf("workitem not found under dungeon/%s", status)
+			}
+		})
+	}
+}
+
+func TestPromoteDoublePromoteErrors(t *testing.T) {
+	root := promoteCampaign(t)
+	src := addWorkitem(t, root, "design", "feat", "Feat", "body")
+
+	if _, _, err := execPromote(t, src, "--target", "completed", "--no-commit"); err != nil {
+		t.Fatalf("first promote: %v", err)
+	}
+
+	moved := dungeonWorkitemDir(t, root, "design", "completed", "feat")
+	if moved == "" {
+		t.Fatal("workitem not in dungeon after first promote")
+	}
+	_, _, err := execPromote(t, moved, "--target", "completed", "--no-commit")
+	if err == nil || !strings.Contains(err.Error(), "already at status") {
+		t.Fatalf("err = %v, want 'already at status'", err)
+	}
+}
+
+func TestPromoteDocTarget(t *testing.T) {
+	t.Run("empty doc rejected without force", func(t *testing.T) {
+		root := promoteCampaign(t)
+		dir := filepath.Join(root, "workflow", "design", "empty")
+		writeFile(t, filepath.Join(dir, ".workitem"), "version: v1alpha6\nkind: workitem\nid: design-empty-fixed\ntype: design\n")
+		writeFile(t, filepath.Join(dir, "README.md"), "")
+		_, _, err := execPromote(t, dir, "--target", "doc", "--no-commit")
+		if err == nil || !strings.Contains(err.Error(), "workitem doc is empty") {
+			t.Fatalf("err = %v, want 'workitem doc is empty'", err)
+		}
+	})
+
+	t.Run("clobber rejected without force", func(t *testing.T) {
+		root := promoteCampaign(t)
+		src := addWorkitem(t, root, "design", "feat", "Feat", "body")
+		writeFile(t, filepath.Join(root, "docs", "feat", "existing.md"), "keep")
+		_, _, err := execPromote(t, src, "--target", "doc", "--no-commit")
+		if err == nil || !strings.Contains(err.Error(), "already exists and is not empty") {
+			t.Fatalf("err = %v, want clobber error", err)
+		}
+	})
+
+	t.Run("copies to docs and shelves source", func(t *testing.T) {
+		root := promoteCampaign(t)
+		src := addWorkitem(t, root, "design", "feat", "Feat", "body")
+		if _, _, err := execPromote(t, src, "--target", "doc", "--no-commit"); err != nil {
+			t.Fatalf("doc promote: %v", err)
+		}
+		if !dirExists(filepath.Join(root, "docs", "feat")) {
+			t.Fatal("docs/feat should exist")
+		}
+		if _, err := os.Stat(filepath.Join(root, "docs", "feat", "README.md")); err != nil {
+			t.Fatalf("docs/feat/README.md missing: %v", err)
+		}
+		if dirExists(src) {
+			t.Fatal("source should have been shelved")
+		}
+	})
+
+	t.Run("dest override and keep", func(t *testing.T) {
+		root := promoteCampaign(t)
+		src := addWorkitem(t, root, "design", "feat", "Feat", "body")
+		if _, _, err := execPromote(t, src, "--target", "doc", "--dest", "guides/feat", "--keep", "--no-commit"); err != nil {
+			t.Fatalf("doc promote: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(root, "docs", "guides", "feat", "README.md")); err != nil {
+			t.Fatalf("docs/guides/feat/README.md missing: %v", err)
+		}
+		if !dirExists(src) {
+			t.Fatal("source should remain with --keep")
+		}
+		meta, err := wkitem.LoadMetadata(context.Background(), src)
+		if err != nil {
+			t.Fatalf("LoadMetadata: %v", err)
+		}
+		if meta.PromotedTo != "docs/guides/feat" {
+			t.Fatalf("PromotedTo = %q, want docs/guides/feat", meta.PromotedTo)
+		}
+	})
+}
+
+func TestPromoteFestivalTarget(t *testing.T) {
+	root := promoteCampaign(t)
+	src := addWorkitem(t, root, "design", "myfeature", "My Feature", "Build it.")
+
+	fest.ResetCache()
+	t.Setenv("PATH", stubFest(t))
+
+	if _, _, err := execPromote(t, src, "--target", "festival", "--goal", "custom goal here", "--no-commit"); err != nil {
+		t.Fatalf("festival promote: %v", err)
+	}
+
+	festDir := filepath.Join(root, "festivals", "planning", "sample-feature-stub")
+	if !dirExists(festDir) {
+		t.Fatal("festival dir should exist")
+	}
+	if _, err := os.Stat(filepath.Join(festDir, "001_INGEST", "input_specs", "myfeature", "README.md")); err != nil {
+		t.Fatalf("ingest copy missing: %v", err)
+	}
+	if dirExists(src) {
+		t.Fatal("source should have been shelved")
+	}
+
+	dungeoned := dungeonWorkitemDir(t, root, "design", "completed", "myfeature")
+	if dungeoned == "" {
+		t.Fatal("source not in dungeon/completed")
+	}
+	meta, err := wkitem.LoadMetadata(context.Background(), dungeoned)
+	if err != nil {
+		t.Fatalf("LoadMetadata: %v", err)
+	}
+	if meta.PromotedTo != "festivals/planning/sample-feature-stub" {
+		t.Fatalf("PromotedTo = %q", meta.PromotedTo)
+	}
+
+	args, err := os.ReadFile(filepath.Join(root, "fest-args.txt"))
+	if err != nil {
+		t.Fatalf("read fest-args.txt: %v", err)
+	}
+	if !strings.Contains(string(args), "custom goal here") {
+		t.Fatalf("fest not called with --goal override: %s", args)
+	}
+}
+
+func TestPromoteFestivalKeepLeavesSource(t *testing.T) {
+	root := promoteCampaign(t)
+	src := addWorkitem(t, root, "design", "myfeature", "My Feature", "Build it.")
+
+	fest.ResetCache()
+	t.Setenv("PATH", stubFest(t))
+
+	if _, _, err := execPromote(t, src, "--target", "festival", "--keep", "--no-commit"); err != nil {
+		t.Fatalf("festival promote --keep: %v", err)
+	}
+	if !dirExists(src) {
+		t.Fatal("source should remain with --keep")
+	}
+}
+
+func TestPromoteFestivalMissingFest(t *testing.T) {
+	root := promoteCampaign(t)
+	src := addWorkitem(t, root, "design", "myfeature", "My Feature", "Build it.")
+
+	fest.ResetCache()
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	_, errOut, err := execPromote(t, src, "--target", "festival", "--no-commit")
+	if err != nil {
+		t.Fatalf("fest-missing should be a graceful no-op, got: %v", err)
+	}
+	if !strings.Contains(errOut, "fest CLI not found") {
+		t.Fatalf("stderr = %q, want fest-not-found notice", errOut)
+	}
+	if !dirExists(src) {
+		t.Fatal("source must stay active when fest is missing")
+	}
+	if dirExists(filepath.Join(root, "festivals", "planning")) {
+		if entries, _ := os.ReadDir(filepath.Join(root, "festivals", "planning")); len(entries) > 0 {
+			t.Fatal("no festival should be created when fest is missing")
+		}
+	}
+}
+
+func TestPromoteDryRunChangesNothing(t *testing.T) {
+	root := promoteCampaign(t)
+	src := addWorkitem(t, root, "design", "feat", "Feat", "body")
+
+	out, _, err := execPromote(t, src, "--target", "completed", "--dry-run", "--no-commit")
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	if !strings.Contains(out, "dry-run") {
+		t.Fatalf("stdout = %q, want dry-run plan", out)
+	}
+	if !dirExists(src) {
+		t.Fatal("dry-run must not move the source")
+	}
+}
+
+func TestPromoteJSONSingleObject(t *testing.T) {
+	root := promoteCampaign(t)
+	src := addWorkitem(t, root, "design", "feat", "Feat", "body")
+
+	out, _, err := execPromote(t, src, "--target", "completed", "--no-commit", "--json")
+	if err != nil {
+		t.Fatalf("json promote: %v", err)
+	}
+
+	dec := json.NewDecoder(strings.NewReader(out))
+	var res struct {
+		ID        string `json:"id"`
+		Type      string `json:"type"`
+		Target    string `json:"target"`
+		From      string `json:"from"`
+		To        string `json:"to"`
+		Committed bool   `json:"committed"`
+	}
+	if err := dec.Decode(&res); err != nil {
+		t.Fatalf("decode: %v\n%s", err, out)
+	}
+	if dec.More() {
+		t.Fatal("expected exactly one JSON object")
+	}
+	if res.ID != "feat" || res.Type != "design" || res.Target != "completed" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if res.From != "workflow/design/feat" {
+		t.Fatalf("From = %q", res.From)
+	}
+	if res.Committed {
+		t.Fatal("Committed should be false with --no-commit")
+	}
+}

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -132,6 +132,7 @@ Examples:
 	cmd.AddCommand(newCurrentCommand())
 	cmd.AddCommand(newResolveCommand())
 	cmd.AddCommand(newPriorityCommand())
+	cmd.AddCommand(newPromoteCommand())
 	cmd.AddCommand(newDoctorCommand())
 	cmd.AddCommand(newCommitCommand())
 	cmd.AddCommand(newCommitsCommand())

--- a/internal/intent/promote/promote.go
+++ b/internal/intent/promote/promote.go
@@ -11,19 +11,15 @@ package promote
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
-	"github.com/Obedience-Corp/camp/internal/fest"
 	"github.com/Obedience-Corp/camp/internal/intent"
+	promotecore "github.com/Obedience-Corp/camp/internal/promote"
 )
 
 // Target identifies the promotion target.
@@ -59,12 +55,6 @@ type Result struct {
 	DesignDir       string        // Path to created design doc directory
 	DesignCreated   bool          // True if design doc was created
 	NewStatus       intent.Status // The status the intent was moved to
-}
-
-// festCreateOutput mirrors the JSON output from `fest create festival --json`.
-type festCreateOutput struct {
-	OK       bool              `json:"ok"`
-	Festival map[string]string `json:"festival"`
 }
 
 // Promote orchestrates intent promotion based on the target.
@@ -116,20 +106,34 @@ func promoteToFestival(ctx context.Context, svc *intent.IntentService, i *intent
 		return Result{}, camperrors.New("intent is not ready for promotion (status: " + i.Status.String() + ")")
 	}
 
-	// Move to active status (work is beginning, not done).
 	moved, err := svc.Move(ctx, i.ID, intent.StatusActive)
 	if err != nil {
 		return Result{}, camperrors.Wrap(err, "failed to move intent to active")
 	}
 
-	// Create festival (best-effort from here on).
-	result := createFestival(ctx, opts.CampaignRoot, moved)
-	result.NewStatus = intent.StatusActive
+	name := intent.SlugFromTitle(moved.Title)
+	goal := promotecore.ExtractFirstParagraph(moved.Content)
+	fr, _ := promotecore.FindAndCreateFestival(ctx, opts.CampaignRoot, name, goal)
 
-	// Set PromotedTo if a festival was created.
-	if result.FestivalCreated && result.FestivalDir != "" {
-		moved.PromotedTo = result.FestivalDir
-		if err := svc.Save(ctx, moved); err != nil {
+	result := Result{
+		FestivalName:    fr.Name,
+		FestivalDir:     fr.Dir,
+		FestivalDest:    fr.Dest,
+		FestivalCreated: fr.Created,
+		FestNotFound:    fr.NotFound,
+		FestCLIError:    fr.CLIError,
+		NewStatus:       intent.StatusActive,
+	}
+
+	if fr.Created {
+		result.IntentCopied = promotecore.CopyIntoFestivalIngest(opts.CampaignRoot, fr.Dest, fr.Dir, moved.Path)
+	}
+
+	if fr.Created && fr.Dir != "" {
+		moved.PromotedTo = fr.Dir
+		if err := promotecore.RecordPromotion(fr.Dir, func(promotecore.PromotionRecord) error {
+			return svc.Save(ctx, moved)
+		}); err != nil {
 			return result, camperrors.Wrap(err, "saving promoted_to for festival")
 		}
 	}
@@ -220,7 +224,7 @@ func createDesignDoc(ctx context.Context, campaignRoot string, i *intent.Intent)
 	}
 
 	// Build README content from intent.
-	firstParagraph := ExtractFirstParagraph(i.Content)
+	firstParagraph := promotecore.ExtractFirstParagraph(i.Content)
 	date := time.Now().Format("2006-01-02")
 
 	var content strings.Builder
@@ -303,140 +307,4 @@ func ValidTargetsForStatus(status intent.Status) []Target {
 	default:
 		return nil
 	}
-}
-
-// createFestival runs `fest create festival --json` and parses the output
-// to determine the actual directory name (which includes an ID suffix).
-func createFestival(ctx context.Context, campaignRoot string, i *intent.Intent) Result {
-	festPath, err := fest.FindFestCLI()
-	if err != nil {
-		return Result{FestNotFound: true}
-	}
-
-	festivalName := intent.SlugFromTitle(i.Title)
-	festivalGoal := ExtractFirstParagraph(i.Content)
-
-	args := []string{"create", "festival", "--type", "standard", "--name", festivalName, "--json"}
-	if festivalGoal != "" {
-		args = append(args, "--goal", festivalGoal)
-	}
-
-	cmd := exec.CommandContext(ctx, festPath, args...)
-	cmd.Dir = campaignRoot
-	output, err := cmd.Output()
-	if err != nil {
-		return Result{
-			FestivalName: festivalName,
-			FestCLIError: extractFestStderr(err),
-		}
-	}
-
-	// Parse JSON to get actual directory and dest.
-	var festOut festCreateOutput
-	if err := json.Unmarshal(output, &festOut); err != nil || !festOut.OK {
-		return Result{FestivalName: festivalName}
-	}
-
-	dir := festOut.Festival["directory"]
-	dest := festOut.Festival["dest"]
-	if dir == "" {
-		dir = festivalName
-	}
-	if dest == "" {
-		dest = "planning"
-	}
-
-	result := Result{
-		FestivalName:    festivalName,
-		FestivalDir:     dir,
-		FestivalDest:    dest,
-		FestivalCreated: true,
-	}
-
-	// Copy intent file into the festival's ingest directory.
-	result.IntentCopied = copyIntentToIngest(campaignRoot, dest, dir, i)
-
-	return result
-}
-
-func extractFestStderr(err error) string {
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
-		return strings.TrimSpace(string(exitErr.Stderr))
-	}
-	return ""
-}
-
-// copyIntentToIngest copies the intent markdown file into the festival's
-// 001_INGEST/input_specs/ directory. Returns true on success.
-func copyIntentToIngest(campaignRoot, dest, festivalDir string, i *intent.Intent) bool {
-	if i.Path == "" {
-		return false
-	}
-
-	ingestDir := filepath.Join(campaignRoot, "festivals", dest, festivalDir, "001_INGEST", "input_specs")
-
-	if _, err := os.Stat(ingestDir); os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr,
-			"Notice: intent file not copied to festival ingest directory because %s does not exist.\n"+
-				"Use fest to ingest this file once `fest ingest <file>` is available.\n"+
-				"File to ingest: %s\n",
-			ingestDir, i.Path)
-		return false
-	} else if err != nil {
-		return false
-	}
-
-	destPath := filepath.Join(ingestDir, filepath.Base(i.Path))
-	return copyFile(i.Path, destPath) == nil
-}
-
-// copyFile copies src to dst.
-func copyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return camperrors.Wrap(err, "opening source file")
-	}
-	defer in.Close()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return camperrors.Wrap(err, "creating destination file")
-	}
-	defer out.Close()
-
-	_, err = io.Copy(out, in)
-	if err != nil {
-		return camperrors.Wrap(err, "copying file contents")
-	}
-	return nil
-}
-
-// ExtractFirstParagraph returns the first non-header paragraph from markdown content.
-func ExtractFirstParagraph(content string) string {
-	content = strings.TrimSpace(content)
-	if content == "" {
-		return ""
-	}
-
-	paragraphs := strings.Split(content, "\n\n")
-	for _, p := range paragraphs {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-
-		// Skip paragraphs that are just markdown headers.
-		if strings.HasPrefix(p, "#") {
-			lines := strings.SplitN(p, "\n", 2)
-			if len(lines) > 1 {
-				return strings.TrimSpace(lines[1])
-			}
-			continue
-		}
-
-		return p
-	}
-
-	return ""
 }

--- a/internal/intent/promote/promote_test.go
+++ b/internal/intent/promote/promote_test.go
@@ -3,9 +3,7 @@ package promote
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -334,48 +332,6 @@ func TestPromoteToDesignRollbackPreservesPreExistingDesignDir(t *testing.T) {
 	}
 	if string(got) != "keep my notes" {
 		t.Fatalf("user file content = %q, want %q", string(got), "keep my notes")
-	}
-}
-
-func TestCopyIntentToIngest_SkipsAbsentIngestDir(t *testing.T) {
-	campaignRoot := t.TempDir()
-	festivalDir := filepath.Join(campaignRoot, "festivals", "planning", "my-festival-abc123")
-	if err := os.MkdirAll(festivalDir, 0755); err != nil {
-		t.Fatalf("MkdirAll(festivalDir) error = %v", err)
-	}
-
-	intentPath := filepath.Join(campaignRoot, "intent.md")
-	if err := os.WriteFile(intentPath, []byte("# Test"), 0644); err != nil {
-		t.Fatalf("WriteFile(intentPath) error = %v", err)
-	}
-
-	i := &intent.Intent{Path: intentPath}
-	if copyIntentToIngest(campaignRoot, "planning", "my-festival-abc123", i) {
-		t.Fatal("copyIntentToIngest returned true, want false")
-	}
-
-	if _, err := os.Stat(filepath.Join(festivalDir, "001_INGEST")); !os.IsNotExist(err) {
-		t.Fatalf("001_INGEST should not have been created, stat err = %v", err)
-	}
-	entries, err := os.ReadDir(festivalDir)
-	if err != nil {
-		t.Fatalf("ReadDir(festivalDir) error = %v", err)
-	}
-	if len(entries) != 0 {
-		t.Fatalf("festival dir should remain empty, got %d entries", len(entries))
-	}
-}
-
-func TestCreateFestival_SurfacesStderr(t *testing.T) {
-	cmd := exec.Command("sh", "-c", "echo 'fest: festival already exists' >&2; exit 1")
-	_, err := cmd.Output()
-	if err == nil {
-		t.Fatal("expected non-zero exit")
-	}
-
-	got := extractFestStderr(err)
-	if !strings.Contains(got, "fest: festival already exists") {
-		t.Fatalf("extractFestStderr() = %q, want stderr text", got)
 	}
 }
 

--- a/internal/promote/festival.go
+++ b/internal/promote/festival.go
@@ -1,0 +1,187 @@
+// Package promote holds the shared festival-creation seam used by the intent
+// and workitem promote flows.
+package promote
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fest"
+)
+
+type Promotable interface {
+	Title() string
+	GoalText() string
+	PrimaryDocPath() string
+}
+
+type FestivalResult struct {
+	Name      string
+	Dir       string
+	Dest      string
+	Created   bool
+	DocCopied bool
+	NotFound  bool
+	CLIError  string
+}
+
+type festCreateOutput struct {
+	OK       bool              `json:"ok"`
+	Festival map[string]string `json:"festival"`
+}
+
+func FindAndCreateFestival(ctx context.Context, campaignRoot, name, goal string) (FestivalResult, error) {
+	festPath, err := fest.FindFestCLI()
+	if err != nil {
+		return FestivalResult{NotFound: true}, nil
+	}
+
+	args := []string{"create", "festival", "--type", "standard", "--name", name, "--json"}
+	if goal != "" {
+		args = append(args, "--goal", goal)
+	}
+
+	cmd := exec.CommandContext(ctx, festPath, args...)
+	cmd.Dir = campaignRoot
+	output, err := cmd.Output()
+	if err != nil {
+		return FestivalResult{Name: name, CLIError: extractFestStderr(err)}, nil
+	}
+
+	var festOut festCreateOutput
+	if err := json.Unmarshal(output, &festOut); err != nil || !festOut.OK {
+		return FestivalResult{Name: name}, nil
+	}
+
+	dir := festOut.Festival["directory"]
+	dest := festOut.Festival["dest"]
+	if dir == "" {
+		dir = name
+	}
+	if dest == "" {
+		dest = "planning"
+	}
+
+	return FestivalResult{Name: name, Dir: dir, Dest: dest, Created: true}, nil
+}
+
+func extractFestStderr(err error) string {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+		return strings.TrimSpace(string(exitErr.Stderr))
+	}
+	return ""
+}
+
+func CopyIntoFestivalIngest(campaignRoot, dest, festivalDir, srcDoc string) bool {
+	if srcDoc == "" {
+		return false
+	}
+
+	ingestDir := filepath.Join(campaignRoot, "festivals", dest, festivalDir, "001_INGEST", "input_specs")
+	if _, err := os.Stat(ingestDir); os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr,
+			"Notice: source doc not copied to festival ingest directory because %s does not exist.\n"+
+				"File to ingest: %s\n",
+			ingestDir, srcDoc)
+		return false
+	} else if err != nil {
+		return false
+	}
+
+	destPath := filepath.Join(ingestDir, filepath.Base(srcDoc))
+	return copyFile(srcDoc, destPath) == nil
+}
+
+func CopyTree(srcDir, dstDir string) error {
+	return filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		base := filepath.Base(path)
+		if base == ".workitem" || strings.HasPrefix(base, ".workflow") {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dstDir, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return copyFile(path, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return camperrors.Wrap(err, "opening source file")
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return camperrors.Wrap(err, "creating destination file")
+	}
+	defer func() { _ = out.Close() }()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return camperrors.Wrap(err, "copying file contents")
+	}
+	return nil
+}
+
+type PromotionRecord struct {
+	PromotedTo string
+	PromotedAt time.Time
+}
+
+func RecordPromotion(target string, save func(PromotionRecord) error) error {
+	return save(PromotionRecord{PromotedTo: target, PromotedAt: time.Now().UTC()})
+}
+
+func ExtractFirstParagraph(content string) string {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return ""
+	}
+
+	paragraphs := strings.Split(content, "\n\n")
+	for _, p := range paragraphs {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+
+		if strings.HasPrefix(p, "#") {
+			lines := strings.SplitN(p, "\n", 2)
+			if len(lines) > 1 {
+				return strings.TrimSpace(lines[1])
+			}
+			continue
+		}
+
+		return p
+	}
+
+	return ""
+}

--- a/internal/promote/festival_test.go
+++ b/internal/promote/festival_test.go
@@ -1,0 +1,126 @@
+package promote
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCopyIntoFestivalIngest_SkipsAbsentIngestDir(t *testing.T) {
+	campaignRoot := t.TempDir()
+	festivalDir := filepath.Join(campaignRoot, "festivals", "planning", "my-festival-abc123")
+	if err := os.MkdirAll(festivalDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(festivalDir) error = %v", err)
+	}
+
+	srcDoc := filepath.Join(campaignRoot, "intent.md")
+	if err := os.WriteFile(srcDoc, []byte("# Test"), 0o644); err != nil {
+		t.Fatalf("WriteFile(srcDoc) error = %v", err)
+	}
+
+	if CopyIntoFestivalIngest(campaignRoot, "planning", "my-festival-abc123", srcDoc) {
+		t.Fatal("CopyIntoFestivalIngest returned true, want false")
+	}
+
+	if _, err := os.Stat(filepath.Join(festivalDir, "001_INGEST")); !os.IsNotExist(err) {
+		t.Fatalf("001_INGEST should not have been created, stat err = %v", err)
+	}
+	entries, err := os.ReadDir(festivalDir)
+	if err != nil {
+		t.Fatalf("ReadDir(festivalDir) error = %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("festival dir should remain empty, got %d entries", len(entries))
+	}
+}
+
+func TestExtractFestStderr(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "echo 'fest: festival already exists' >&2; exit 1")
+	_, err := cmd.Output()
+	if err == nil {
+		t.Fatal("expected non-zero exit")
+	}
+
+	got := extractFestStderr(err)
+	if !strings.Contains(got, "fest: festival already exists") {
+		t.Fatalf("extractFestStderr() = %q, want stderr text", got)
+	}
+}
+
+func TestCopyTree_CopiesContentAndSkipsBookkeeping(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+
+	writeFile(t, filepath.Join(src, "a.md"), "alpha")
+	writeFile(t, filepath.Join(src, "sub", "b.md"), "beta")
+	writeFile(t, filepath.Join(src, ".workitem"), "marker")
+	writeFile(t, filepath.Join(src, ".workflow.yaml"), "wf")
+	writeFile(t, filepath.Join(src, "nested", ".workitem", "c.md"), "skip-dir")
+
+	if err := CopyTree(src, dst); err != nil {
+		t.Fatalf("CopyTree() error = %v", err)
+	}
+
+	if got := readFile(t, filepath.Join(dst, "a.md")); got != "alpha" {
+		t.Fatalf("a.md = %q, want %q", got, "alpha")
+	}
+	if got := readFile(t, filepath.Join(dst, "sub", "b.md")); got != "beta" {
+		t.Fatalf("sub/b.md = %q, want %q", got, "beta")
+	}
+
+	skipped := []string{".workitem", ".workflow.yaml", filepath.Join("nested", ".workitem")}
+	for _, rel := range skipped {
+		if _, err := os.Stat(filepath.Join(dst, rel)); !os.IsNotExist(err) {
+			t.Fatalf("%s should have been skipped, stat err = %v", rel, err)
+		}
+	}
+}
+
+func TestRecordPromotion(t *testing.T) {
+	t.Run("propagates record to save", func(t *testing.T) {
+		var got PromotionRecord
+		if err := RecordPromotion("planning/my-festival-abc123", func(r PromotionRecord) error {
+			got = r
+			return nil
+		}); err != nil {
+			t.Fatalf("RecordPromotion() error = %v", err)
+		}
+		if got.PromotedTo != "planning/my-festival-abc123" {
+			t.Fatalf("PromotedTo = %q, want %q", got.PromotedTo, "planning/my-festival-abc123")
+		}
+		if got.PromotedAt.IsZero() {
+			t.Fatal("PromotedAt should be set")
+		}
+	})
+
+	t.Run("returns save error", func(t *testing.T) {
+		want := errors.New("save failed")
+		if err := RecordPromotion("festival", func(PromotionRecord) error {
+			return want
+		}); !errors.Is(err, want) {
+			t.Fatalf("RecordPromotion() error = %v, want %v", err, want)
+		}
+	})
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	return string(data)
+}

--- a/internal/workitem/audit/audit.go
+++ b/internal/workitem/audit/audit.go
@@ -1,0 +1,62 @@
+// Package audit appends promote (and future) events to a campaign-level
+// workitem audit log, parallel to the intent audit log.
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+const AuditFile = ".workitems.jsonl"
+
+type EventType string
+
+const EventPromote EventType = "promote"
+
+type Event struct {
+	Timestamp  time.Time `json:"ts"`
+	Event      EventType `json:"event"`
+	ID         string    `json:"id"`
+	Type       string    `json:"type,omitempty"`
+	From       string    `json:"from,omitempty"`
+	To         string    `json:"to,omitempty"`
+	Target     string    `json:"target,omitempty"`
+	PromotedTo string    `json:"promoted_to,omitempty"`
+}
+
+func AppendEvent(ctx context.Context, campaignRoot string, e Event) error {
+	if err := ctx.Err(); err != nil {
+		return camperrors.Wrap(err, "context cancelled before writing audit event")
+	}
+
+	if e.Timestamp.IsZero() {
+		e.Timestamp = time.Now().UTC()
+	}
+
+	dir := filepath.Join(campaignRoot, ".campaign", "workitems")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return camperrors.Wrap(err, "creating workitem audit directory")
+	}
+
+	data, err := json.Marshal(e)
+	if err != nil {
+		return camperrors.Wrap(err, "marshaling audit event")
+	}
+	data = append(data, '\n')
+
+	f, err := os.OpenFile(filepath.Join(dir, AuditFile), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return camperrors.Wrap(err, "opening workitem audit log")
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.Write(data); err != nil {
+		return camperrors.Wrap(err, "writing workitem audit event")
+	}
+	return nil
+}

--- a/internal/workitem/audit/audit_test.go
+++ b/internal/workitem/audit/audit_test.go
@@ -1,0 +1,44 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAppendEvent(t *testing.T) {
+	root := t.TempDir()
+
+	if err := AppendEvent(context.Background(), root, Event{
+		Event:      EventPromote,
+		ID:         "shiny",
+		Type:       "feature",
+		From:       "workflow/feature/shiny",
+		To:         "festivals/planning/shiny-x",
+		Target:     "festival",
+		PromotedTo: "festivals/planning/shiny-x",
+	}); err != nil {
+		t.Fatalf("AppendEvent() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, ".campaign", "workitems", AuditFile))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	var got Event
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got.Event != EventPromote {
+		t.Fatalf("Event = %q, want %q", got.Event, EventPromote)
+	}
+	if got.ID != "shiny" || got.Target != "festival" || got.PromotedTo != "festivals/planning/shiny-x" {
+		t.Fatalf("unexpected event: %+v", got)
+	}
+	if got.Timestamp.IsZero() {
+		t.Fatal("Timestamp should be set")
+	}
+}

--- a/internal/workitem/locate/locate.go
+++ b/internal/workitem/locate/locate.go
@@ -22,6 +22,12 @@ type Location struct {
 }
 
 func DetectFromCwd(campaignRoot, cwd string) (*Location, error) {
+	if resolved, rerr := filepath.EvalSymlinks(campaignRoot); rerr == nil {
+		campaignRoot = resolved
+	}
+	if resolved, rerr := filepath.EvalSymlinks(cwd); rerr == nil {
+		cwd = resolved
+	}
 	rel, err := filepath.Rel(campaignRoot, cwd)
 	if err != nil {
 		return nil, camperrors.Wrap(err, "resolving cwd relative to campaign root")

--- a/internal/workitem/locate/locate.go
+++ b/internal/workitem/locate/locate.go
@@ -1,4 +1,6 @@
-package promote
+// Package locate resolves a workitem's on-disk location from a working
+// directory under workflow/<type>/<slug>/, including dungeon layouts.
+package locate
 
 import (
 	"fmt"
@@ -6,9 +8,10 @@ import (
 	"strings"
 
 	"github.com/Obedience-Corp/camp/internal/dungeon/statuspath"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 
-type WorkitemLocation struct {
+type Location struct {
 	Type        string
 	Slug        string
 	ParentPath  string
@@ -18,29 +21,29 @@ type WorkitemLocation struct {
 	Status      string
 }
 
-func detectWorkitemFromCwd(campaignRoot, cwd string) (*WorkitemLocation, error) {
+func DetectFromCwd(campaignRoot, cwd string) (*Location, error) {
 	rel, err := filepath.Rel(campaignRoot, cwd)
 	if err != nil {
-		return nil, fmt.Errorf("resolving cwd relative to campaign root: %w", err)
+		return nil, camperrors.Wrap(err, "resolving cwd relative to campaign root")
 	}
 	rel = filepath.ToSlash(filepath.Clean(rel))
 	if rel == ".." || strings.HasPrefix(rel, "../") {
-		return nil, fmt.Errorf("cwd %q is not under campaign root %q", cwd, campaignRoot)
+		return nil, camperrors.New(fmt.Sprintf("cwd %q is not under campaign root %q", cwd, campaignRoot))
 	}
 	if rel == "." {
-		return nil, fmt.Errorf("not inside a workitem; cwd is at the campaign root")
+		return nil, camperrors.New("not inside a workitem; cwd is at the campaign root")
 	}
 
 	parts := strings.Split(rel, "/")
 	if parts[0] != "workflow" {
-		return nil, fmt.Errorf("not inside a workitem; cwd must be under workflow/<type>/<slug>/")
+		return nil, camperrors.New("not inside a workitem; cwd must be under workflow/<type>/<slug>/")
 	}
 	if len(parts) < 3 {
-		return nil, fmt.Errorf("not inside a workitem; cwd is at workflow root, expected workflow/<type>/<slug>/")
+		return nil, camperrors.New("not inside a workitem; cwd is at workflow root, expected workflow/<type>/<slug>/")
 	}
 	typeName := parts[1]
 	if typeName == "" || typeName == "dungeon" {
-		return nil, fmt.Errorf("not inside a workitem; %q is not a valid workflow type", typeName)
+		return nil, camperrors.New(fmt.Sprintf("not inside a workitem; %q is not a valid workflow type", typeName))
 	}
 
 	if parts[2] != "dungeon" {
@@ -48,7 +51,7 @@ func detectWorkitemFromCwd(campaignRoot, cwd string) (*WorkitemLocation, error) 
 		parentRel := filepath.Join("workflow", typeName)
 		sourceRel := filepath.Join("workflow", typeName, slug)
 		dungeonRel := filepath.Join("workflow", typeName, "dungeon")
-		return &WorkitemLocation{
+		return &Location{
 			Type:        typeName,
 			Slug:        slug,
 			ParentPath:  filepath.Join(campaignRoot, parentRel),
@@ -58,18 +61,18 @@ func detectWorkitemFromCwd(campaignRoot, cwd string) (*WorkitemLocation, error) 
 	}
 
 	if len(parts) < 5 {
-		return nil, fmt.Errorf("not inside a workitem; cwd is at workflow/%s/dungeon[/...] without a slug", typeName)
+		return nil, camperrors.New(fmt.Sprintf("not inside a workitem; cwd is at workflow/%s/dungeon[/...] without a slug", typeName))
 	}
 	status := parts[3]
 	if status == "" {
-		return nil, fmt.Errorf("not inside a workitem; cwd is at the dungeon root")
+		return nil, camperrors.New("not inside a workitem; cwd is at the dungeon root")
 	}
 
 	var slug string
 	var parentRel string
 	if statuspath.IsDateDir(parts[4]) {
 		if len(parts) < 6 || parts[5] == "" {
-			return nil, fmt.Errorf("not inside a workitem; cwd is at workflow/%s/dungeon/%s/%s without a slug", typeName, status, parts[4])
+			return nil, camperrors.New(fmt.Sprintf("not inside a workitem; cwd is at workflow/%s/dungeon/%s/%s without a slug", typeName, status, parts[4]))
 		}
 		slug = parts[5]
 		parentRel = filepath.Join("workflow", typeName, "dungeon", status, parts[4])
@@ -79,7 +82,7 @@ func detectWorkitemFromCwd(campaignRoot, cwd string) (*WorkitemLocation, error) 
 	}
 
 	dungeonRel := filepath.Join("workflow", typeName, "dungeon")
-	return &WorkitemLocation{
+	return &Location{
 		Type:        typeName,
 		Slug:        slug,
 		ParentPath:  filepath.Join(campaignRoot, parentRel),

--- a/internal/workitem/locate/locate_test.go
+++ b/internal/workitem/locate/locate_test.go
@@ -1,10 +1,31 @@
 package locate
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestDetectFromCwd_ResolvesSymlinkedRoot(t *testing.T) {
+	real := t.TempDir()
+	wiDir := filepath.Join(real, "workflow", "design", "slug")
+	if err := os.MkdirAll(wiDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	link := filepath.Join(t.TempDir(), "campaign-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	loc, err := DetectFromCwd(link, wiDir)
+	if err != nil {
+		t.Fatalf("DetectFromCwd with symlinked root: %v", err)
+	}
+	if loc.Type != "design" || loc.Slug != "slug" {
+		t.Fatalf("loc = %+v, want design/slug", loc)
+	}
+}
 
 func TestDetectFromCwd(t *testing.T) {
 	const root = "/campaign"

--- a/internal/workitem/locate/locate_test.go
+++ b/internal/workitem/locate/locate_test.go
@@ -1,4 +1,4 @@
-package promote
+package locate
 
 import (
 	"path/filepath"
@@ -6,20 +6,20 @@ import (
 	"testing"
 )
 
-func TestDetectWorkitemFromCwd(t *testing.T) {
+func TestDetectFromCwd(t *testing.T) {
 	const root = "/campaign"
 
 	tests := []struct {
-		name      string
-		cwd       string
-		wantErr   string
-		wantType  string
-		wantSlug  string
-		wantSrc   string
-		wantPar   string
-		wantDun   string
-		wantIn    bool
-		wantStat  string
+		name     string
+		cwd      string
+		wantErr  string
+		wantType string
+		wantSlug string
+		wantSrc  string
+		wantPar  string
+		wantDun  string
+		wantIn   bool
+		wantStat string
 	}{
 		{
 			name:     "active workitem root",
@@ -130,7 +130,7 @@ func TestDetectWorkitemFromCwd(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := detectWorkitemFromCwd(root, tc.cwd)
+			got, err := DetectFromCwd(root, tc.cwd)
 			if tc.wantErr != "" {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil (result=%+v)", tc.wantErr, got)

--- a/internal/workitem/metadata.go
+++ b/internal/workitem/metadata.go
@@ -49,6 +49,11 @@ type Metadata struct {
 	// or adopted. Empty when no quest resolved (no --quest flag and no
 	// CAMP_QUEST env var). Added in v1alpha6.
 	QuestID string `yaml:"quest_id,omitempty"`
+	// PromotedTo records the destination a workitem was promoted to
+	// (festivals/<dir> or docs/<dest>). Set by `camp workitem promote`.
+	PromotedTo string `yaml:"promoted_to,omitempty"`
+	// PromotedAt is the RFC3339 UTC timestamp of the promotion.
+	PromotedAt string `yaml:"promoted_at,omitempty"`
 }
 
 // LoadMetadata reads .workitem from dir on the host filesystem.

--- a/internal/workitem/promotion.go
+++ b/internal/workitem/promotion.go
@@ -1,0 +1,46 @@
+package workitem
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+)
+
+func RecordPromotion(ctx context.Context, root, relPath, promotedTo string, at time.Time) error {
+	abs := filepath.Join(root, filepath.FromSlash(relPath), MetadataFilename)
+
+	release, err := fsutil.AcquireFileLock(ctx, abs+".lock")
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	raw, err := os.ReadFile(abs)
+	if err != nil {
+		return camperrors.Wrapf(err, "read %s", abs)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return camperrors.Wrapf(err, "parse %s", abs)
+	}
+
+	if err := insertScalarAfter(&doc, "type", "promoted_to", promotedTo); err != nil {
+		return err
+	}
+	if err := insertScalarAfter(&doc, "promoted_to", "promoted_at", at.UTC().Format(time.RFC3339)); err != nil {
+		return err
+	}
+
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return camperrors.Wrap(err, "marshal updated workitem")
+	}
+	return fsutil.WriteFileAtomically(abs, out, 0o644)
+}

--- a/internal/workitem/promotion_test.go
+++ b/internal/workitem/promotion_test.go
@@ -1,0 +1,50 @@
+package workitem
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRecordPromotion(t *testing.T) {
+	root := t.TempDir()
+	rel := filepath.Join("workflow", "feature", "shiny")
+	dir := filepath.Join(root, rel)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	original := "version: v1alpha6\nkind: workitem\nid: feature-shiny-x\ntype: feature\ntitle: Shiny\nref: WI-abc123\n"
+	if err := os.WriteFile(filepath.Join(dir, MetadataFilename), []byte(original), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	at := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	if err := RecordPromotion(context.Background(), root, rel, "festivals/planning/shiny-x", at); err != nil {
+		t.Fatalf("RecordPromotion() error = %v", err)
+	}
+
+	got, err := LoadMetadata(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("LoadMetadata() error = %v", err)
+	}
+	if got.PromotedTo != "festivals/planning/shiny-x" {
+		t.Fatalf("PromotedTo = %q, want %q", got.PromotedTo, "festivals/planning/shiny-x")
+	}
+	if got.PromotedAt != "2026-06-18T12:00:00Z" {
+		t.Fatalf("PromotedAt = %q, want %q", got.PromotedAt, "2026-06-18T12:00:00Z")
+	}
+	if got.Ref != "WI-abc123" {
+		t.Fatalf("Ref = %q, want preserved", got.Ref)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, MetadataFilename))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !strings.Contains(string(raw), "promoted_to: festivals/planning/shiny-x") {
+		t.Fatalf("on-disk metadata missing promoted_to:\n%s", raw)
+	}
+}


### PR DESCRIPTION
Implements Issue 1 of the unified promotion flow (design: workflow/design/camp-workitem-promote-2026-06-16).

## Scope
- [x] Extract the festival-create seam into `internal/promote` (FindAndCreateFestival, CopyIntoFestivalIngest, CopyTree, promoted_to/promoted_at writer over a Promotable interface), lifted verbatim with no `internal/intent` dependency
- [x] Repoint `internal/intent/promote` at `internal/promote` with no behavior change; intent promote tests green
- [x] `camp workitem promote [id]` with id/cwd/current resolution and flags `--target/--dest/--goal/--keep/--force/--dry-run/--no-commit/--json`
- [x] Dungeon targets completed/archived/someday via `intdungeon.Service.MoveToDungeonStatus`; `active` rejected
- [x] festival target: create festival, copy whole workitem dir into `001_INGEST/input_specs/<slug>/`, record promoted_to, shelve source unless `--keep`, graceful fest-missing fallback (no partial corruption)
- [x] doc target: copy whole workitem dir to `docs/<dest>` (default slug), refuse non-empty dest without `--force`, record promoted_to, shelve source unless `--keep`
- [x] promoted_to/promoted_at in `.workitem` (minimal-diff atomic write), workitem audit promote event, single-object `--json` contract, auto-commit unless `--no-commit`
- [x] `camp shelve` folded into a Hidden deprecated alias delegating to the shared move; `--json`/`--no-commit` preserved byte-for-byte; one-line stderr deprecation note
- [x] Tests: resolution, all five targets, every flag, fest-missing fallback, double-promote error; shelve alias hidden-assertion + existing integration tests

## Notes
- The cwd workitem detector was relocated from `cmd/camp/promote` to a shared `internal/workitem/locate` package (proper internal->internal layering; its `fmt.Errorf` calls converted to `camperrors`).
- Hidden commands are now excluded from the agent `__manifest` (mirrors their absence from `--help`).
- No behavior change in the `internal/promote` extraction; shelve output is byte-for-byte unchanged for existing scripts.
- Issue 2 (camp promote router) depends on this branch.