### PR TITLE
feat(promote): camp promote universal router (CW0004 Issue 2)

### DIFF
--- a/cmd/camp/promote/completion.go
+++ b/cmd/camp/promote/completion.go
@@ -1,0 +1,37 @@
+package promote
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/Obedience-Corp/camp/internal/paths"
+)
+
+func completePromotable(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	ctx := cmd.Context()
+	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	resolver := paths.NewResolverFromConfig(campaignRoot, cfg)
+	pool, err := promotablePool(ctx, campaignRoot, resolver)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	var ids []string
+	for _, it := range pool {
+		id := it.SourceID
+		if id == "" {
+			id = it.Key
+		}
+		if strings.HasPrefix(id, toComplete) {
+			ids = append(ids, id)
+		}
+	}
+	return ids, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/camp/promote/dispatch.go
+++ b/cmd/camp/promote/dispatch.go
@@ -1,0 +1,110 @@
+package promote
+
+import (
+	"context"
+	"os"
+	"os/exec"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fest"
+	"github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+type commandRunner interface {
+	run(ctx context.Context, dir, bin string, args []string) error
+}
+
+type execRunner struct{}
+
+func (execRunner) run(ctx context.Context, dir, bin string, args []string) error {
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Dir = dir
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return camperrors.Wrapf(err, "dispatching %s %v", bin, args)
+	}
+	return nil
+}
+
+var runner commandRunner = execRunner{}
+
+func campBinary() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", camperrors.Wrap(err, "locating camp binary")
+	}
+	return exe, nil
+}
+
+func festBinary() (string, error) {
+	p, err := fest.FindFestCLI()
+	if err != nil {
+		return "", camperrors.Wrap(err, "locating fest binary")
+	}
+	return p, nil
+}
+
+type promoteKind int
+
+const (
+	kindIntent promoteKind = iota
+	kindWorkitem
+	kindFestival
+)
+
+func kindForType(wt workitem.WorkflowType) promoteKind {
+	switch wt {
+	case workitem.WorkflowTypeIntent:
+		return kindIntent
+	case workitem.WorkflowTypeFestival:
+		return kindFestival
+	default:
+		return kindWorkitem
+	}
+}
+
+func dispatchIntent(ctx context.Context, id, target string, pass []string) error {
+	bin, err := campBinary()
+	if err != nil {
+		return err
+	}
+	args := []string{"intent", "promote", id, "--target", target}
+	args = append(args, pass...)
+	return runner.run(ctx, "", bin, args)
+}
+
+func dispatchWorkitem(ctx context.Context, dir, target string, pass []string) error {
+	bin, err := campBinary()
+	if err != nil {
+		return err
+	}
+	args := []string{"workitem", "promote", "--target", target}
+	args = append(args, pass...)
+	return runner.run(ctx, dir, bin, args)
+}
+
+func dispatchFestival(ctx context.Context, dir string, festArgs []string) error {
+	bin, err := festBinary()
+	if err != nil {
+		return err
+	}
+	args := []string{"promote"}
+	args = append(args, festArgs...)
+	return runner.run(ctx, dir, bin, args)
+}
+
+func festPassthrough(target string, pass []string) []string {
+	var out []string
+	if target != "" {
+		out = append(out, "--dungeon", target)
+	}
+	for _, f := range pass {
+		switch f {
+		case "--force", "--json", "--no-commit":
+			out = append(out, f)
+		}
+	}
+	return out
+}

--- a/cmd/camp/promote/dispatch.go
+++ b/cmd/camp/promote/dispatch.go
@@ -2,6 +2,7 @@ package promote
 
 import (
 	"context"
+	"io"
 	"os"
 	"os/exec"
 
@@ -11,16 +12,16 @@ import (
 )
 
 type commandRunner interface {
-	run(ctx context.Context, dir, bin string, args []string) error
+	run(ctx context.Context, dir, bin string, args []string, stdout io.Writer) error
 }
 
 type execRunner struct{}
 
-func (execRunner) run(ctx context.Context, dir, bin string, args []string) error {
+func (execRunner) run(ctx context.Context, dir, bin string, args []string, stdout io.Writer) error {
 	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Dir = dir
 	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return camperrors.Wrapf(err, "dispatching %s %v", bin, args)
@@ -67,33 +68,33 @@ func kindForType(wt workitem.WorkflowType) promoteKind {
 	}
 }
 
-func dispatchIntent(ctx context.Context, id, target string) error {
+func dispatchIntent(ctx context.Context, id, target string, stdout io.Writer) error {
 	bin, err := campBinary()
 	if err != nil {
 		return err
 	}
 	args := []string{"intent", "promote", id, "--target", target}
-	return runner.run(ctx, "", bin, args)
+	return runner.run(ctx, "", bin, args, stdout)
 }
 
-func dispatchWorkitem(ctx context.Context, dir, target string, pass []string) error {
+func dispatchWorkitem(ctx context.Context, dir, target string, pass []string, stdout io.Writer) error {
 	bin, err := campBinary()
 	if err != nil {
 		return err
 	}
 	args := []string{"workitem", "promote", "--target", target}
 	args = append(args, pass...)
-	return runner.run(ctx, dir, bin, args)
+	return runner.run(ctx, dir, bin, args, stdout)
 }
 
-func dispatchFestival(ctx context.Context, dir string, festArgs []string) error {
+func dispatchFestival(ctx context.Context, dir string, festArgs []string, stdout io.Writer) error {
 	bin, err := festBinary()
 	if err != nil {
 		return err
 	}
 	args := []string{"promote"}
 	args = append(args, festArgs...)
-	return runner.run(ctx, dir, bin, args)
+	return runner.run(ctx, dir, bin, args, stdout)
 }
 
 func festPassthrough(target string, pass []string) []string {

--- a/cmd/camp/promote/dispatch.go
+++ b/cmd/camp/promote/dispatch.go
@@ -38,8 +38,10 @@ func campBinary() (string, error) {
 	return exe, nil
 }
 
+var festLookup = fest.FindFestCLI
+
 func festBinary() (string, error) {
-	p, err := fest.FindFestCLI()
+	p, err := festLookup()
 	if err != nil {
 		return "", camperrors.Wrap(err, "locating fest binary")
 	}

--- a/cmd/camp/promote/dispatch.go
+++ b/cmd/camp/promote/dispatch.go
@@ -68,13 +68,25 @@ func kindForType(wt workitem.WorkflowType) promoteKind {
 	}
 }
 
-func dispatchIntent(ctx context.Context, id, target string, stdout io.Writer) error {
+func dispatchIntent(ctx context.Context, id, target string, pass []string, stdout io.Writer) error {
 	bin, err := campBinary()
 	if err != nil {
 		return err
 	}
 	args := []string{"intent", "promote", id, "--target", target}
+	args = append(args, pass...)
 	return runner.run(ctx, "", bin, args, stdout)
+}
+
+func intentPassthrough(pass []string) []string {
+	var out []string
+	for _, f := range pass {
+		switch f {
+		case "--force", "--no-commit":
+			out = append(out, f)
+		}
+	}
+	return out
 }
 
 func dispatchWorkitem(ctx context.Context, dir, target string, pass []string, stdout io.Writer) error {

--- a/cmd/camp/promote/dispatch.go
+++ b/cmd/camp/promote/dispatch.go
@@ -67,13 +67,12 @@ func kindForType(wt workitem.WorkflowType) promoteKind {
 	}
 }
 
-func dispatchIntent(ctx context.Context, id, target string, pass []string) error {
+func dispatchIntent(ctx context.Context, id, target string) error {
 	bin, err := campBinary()
 	if err != nil {
 		return err
 	}
 	args := []string{"intent", "promote", id, "--target", target}
-	args = append(args, pass...)
 	return runner.run(ctx, "", bin, args)
 }
 

--- a/cmd/camp/promote/pool.go
+++ b/cmd/camp/promote/pool.go
@@ -1,0 +1,36 @@
+package promote
+
+import (
+	"context"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	"github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+func promotablePool(ctx context.Context, campaignRoot string, resolver *paths.Resolver) ([]workitem.WorkItem, error) {
+	items, err := workitem.Discover(ctx, campaignRoot, resolver)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "discovering promotable items")
+	}
+	out := items[:0:0]
+	for _, it := range items {
+		if isPromotable(it) {
+			out = append(out, it)
+		}
+	}
+	return out, nil
+}
+
+func isPromotable(it workitem.WorkItem) bool {
+	switch it.WorkflowType {
+	case workitem.WorkflowTypeIntent:
+		return it.LifecycleStage == workitem.LifecycleStageInbox || it.LifecycleStage == workitem.LifecycleStageReady
+	case workitem.WorkflowTypeFestival:
+		return it.LifecycleStage == workitem.LifecycleStagePlanning ||
+			it.LifecycleStage == workitem.LifecycleStageReady ||
+			it.LifecycleStage == workitem.LifecycleStageActive
+	default:
+		return true
+	}
+}

--- a/cmd/camp/promote/router.go
+++ b/cmd/camp/promote/router.go
@@ -60,7 +60,7 @@ func runRouter(cmd *cobra.Command, args []string) error {
 	}
 	resolver := paths.NewResolverFromConfig(campaignRoot, cfg)
 
-	item, resolved, err := resolveItem(ctx, campaignRoot, resolver, args)
+	item, resolved, err := resolveItem(ctx, campaignRoot, resolver, args, interactive)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func runRouter(cmd *cobra.Command, args []string) error {
 	return dispatch(cmd, item, campaignRoot, target, interactive, dryRun, jsonOut, pass)
 }
 
-func resolveItem(ctx context.Context, campaignRoot string, resolver *paths.Resolver, args []string) (workitem.WorkItem, bool, error) {
+func resolveItem(ctx context.Context, campaignRoot string, resolver *paths.Resolver, args []string, interactive bool) (workitem.WorkItem, bool, error) {
 	pool, err := promotablePool(ctx, campaignRoot, resolver)
 	if err != nil {
 		return workitem.WorkItem{}, false, err
@@ -91,6 +91,10 @@ func resolveItem(ctx context.Context, campaignRoot string, resolver *paths.Resol
 			}
 		}
 		return workitem.WorkItem{}, false, camperrors.Wrapf(camperrors.New("not a promotable item"), "id %q", args[0])
+	}
+
+	if !interactive {
+		return workitem.WorkItem{}, false, nil
 	}
 
 	cwd, err := os.Getwd()
@@ -147,13 +151,14 @@ func dispatch(cmd *cobra.Command, item workitem.WorkItem, campaignRoot, target s
 		status, _ := festivalTarget(target)
 		return dispatchFestival(ctx, item.AbsPath(campaignRoot), festPassthrough(status, pass), out)
 	case kindIntent:
+		ipass := intentPassthrough(pass)
 		if jsonOut {
-			if err := dispatchIntent(ctx, item.SourceID, target, io.Discard); err != nil {
+			if err := dispatchIntent(ctx, item.SourceID, target, ipass, io.Discard); err != nil {
 				return err
 			}
 			return reportResult(cmd, kind, item, display)
 		}
-		return dispatchIntent(ctx, item.SourceID, target, out)
+		return dispatchIntent(ctx, item.SourceID, target, ipass, out)
 	case kindWorkitem:
 		return dispatchWorkitem(ctx, item.AbsPath(campaignRoot), target, pass, out)
 	}

--- a/cmd/camp/promote/router.go
+++ b/cmd/camp/promote/router.go
@@ -2,6 +2,7 @@ package promote
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -48,6 +49,7 @@ func runRouter(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	target, _ := cmd.Flags().GetString("target")
 	jsonOut, _ := cmd.Flags().GetBool("json")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	interactive := ui.IsTerminal() && !jsonOut
 
 	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
@@ -71,7 +73,7 @@ func runRouter(cmd *cobra.Command, args []string) error {
 	}
 
 	pass := passthroughFlags(cmd)
-	return dispatch(ctx, item, campaignRoot, target, interactive, pass)
+	return dispatch(cmd, item, campaignRoot, target, interactive, dryRun, pass)
 }
 
 func resolveItem(ctx context.Context, campaignRoot string, resolver *paths.Resolver, args []string) (workitem.WorkItem, bool, error) {
@@ -98,7 +100,7 @@ func resolveItem(ctx context.Context, campaignRoot string, resolver *paths.Resol
 			if it.WorkflowType == workitem.WorkflowTypeIntent || it.WorkflowType == workitem.WorkflowTypeFestival {
 				continue
 			}
-			if filepath.Base(it.RelativePath) == loc.Slug {
+			if string(it.WorkflowType) == loc.Type && filepath.Base(it.RelativePath) == loc.Slug {
 				return it, true, nil
 			}
 		}
@@ -106,7 +108,8 @@ func resolveItem(ctx context.Context, campaignRoot string, resolver *paths.Resol
 	return workitem.WorkItem{}, false, nil
 }
 
-func dispatch(ctx context.Context, item workitem.WorkItem, campaignRoot, target string, interactive bool, pass []string) error {
+func dispatch(cmd *cobra.Command, item workitem.WorkItem, campaignRoot, target string, interactive, dryRun bool, pass []string) error {
+	ctx := cmd.Context()
 	kind := kindForType(item.WorkflowType)
 
 	if target == "" && interactive {
@@ -119,23 +122,42 @@ func dispatch(ctx context.Context, item workitem.WorkItem, campaignRoot, target 
 
 	switch kind {
 	case kindFestival:
-		status, ok := festivalTarget(target)
-		if !ok {
+		if _, ok := festivalTarget(target); !ok {
 			return camperrors.New("festival target must be next, completed, archived, or someday")
 		}
+		display := target
+		if display == "" {
+			display = "next"
+		}
+		if dryRun {
+			return printDryRun(cmd, item, display)
+		}
+		status, _ := festivalTarget(target)
 		return dispatchFestival(ctx, item.AbsPath(campaignRoot), festPassthrough(status, pass))
 	case kindIntent:
 		if target == "" {
 			return camperrors.New("--target is required in non-interactive mode")
 		}
-		return dispatchIntent(ctx, item.SourceID, target, pass)
+		if dryRun {
+			return printDryRun(cmd, item, target)
+		}
+		return dispatchIntent(ctx, item.SourceID, target)
 	case kindWorkitem:
 		if target == "" {
 			return camperrors.New("--target is required in non-interactive mode")
 		}
+		if dryRun {
+			return printDryRun(cmd, item, target)
+		}
 		return dispatchWorkitem(ctx, item.AbsPath(campaignRoot), target, pass)
 	}
 	return camperrors.New("unknown promote kind")
+}
+
+func printDryRun(cmd *cobra.Command, item workitem.WorkItem, target string) error {
+	_, err := fmt.Fprintf(cmd.OutOrStdout(),
+		"dry-run: would promote %q (%s) to %s; no changes made\n", item.Title, item.WorkflowType, target)
+	return err
 }
 
 func festivalTarget(target string) (string, bool) {
@@ -150,7 +172,7 @@ func festivalTarget(target string) (string, bool) {
 
 func passthroughFlags(cmd *cobra.Command) []string {
 	var pass []string
-	for _, name := range []string{"force", "dry-run", "no-commit", "keep", "json"} {
+	for _, name := range []string{"force", "no-commit", "keep", "json"} {
 		if cmd.Flags().Changed(name) {
 			pass = append(pass, "--"+name)
 		}

--- a/cmd/camp/promote/router.go
+++ b/cmd/camp/promote/router.go
@@ -2,7 +2,9 @@ package promote
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -73,7 +75,7 @@ func runRouter(cmd *cobra.Command, args []string) error {
 	}
 
 	pass := passthroughFlags(cmd)
-	return dispatch(cmd, item, campaignRoot, target, interactive, dryRun, pass)
+	return dispatch(cmd, item, campaignRoot, target, interactive, dryRun, jsonOut, pass)
 }
 
 func resolveItem(ctx context.Context, campaignRoot string, resolver *paths.Resolver, args []string) (workitem.WorkItem, bool, error) {
@@ -108,7 +110,7 @@ func resolveItem(ctx context.Context, campaignRoot string, resolver *paths.Resol
 	return workitem.WorkItem{}, false, nil
 }
 
-func dispatch(cmd *cobra.Command, item workitem.WorkItem, campaignRoot, target string, interactive, dryRun bool, pass []string) error {
+func dispatch(cmd *cobra.Command, item workitem.WorkItem, campaignRoot, target string, interactive, dryRun, jsonOut bool, pass []string) error {
 	ctx := cmd.Context()
 	kind := kindForType(item.WorkflowType)
 
@@ -120,44 +122,85 @@ func dispatch(cmd *cobra.Command, item workitem.WorkItem, campaignRoot, target s
 		target = picked
 	}
 
+	display := target
 	switch kind {
 	case kindFestival:
 		if _, ok := festivalTarget(target); !ok {
 			return camperrors.New("festival target must be next, completed, archived, or someday")
 		}
-		display := target
 		if display == "" {
 			display = "next"
 		}
-		if dryRun {
-			return printDryRun(cmd, item, display)
+	case kindIntent, kindWorkitem:
+		if target == "" {
+			return camperrors.New("--target is required in non-interactive mode")
 		}
+	}
+
+	if dryRun {
+		return reportPlan(cmd, jsonOut, kind, item, display)
+	}
+
+	out := cmd.OutOrStdout()
+	switch kind {
+	case kindFestival:
 		status, _ := festivalTarget(target)
-		return dispatchFestival(ctx, item.AbsPath(campaignRoot), festPassthrough(status, pass))
+		return dispatchFestival(ctx, item.AbsPath(campaignRoot), festPassthrough(status, pass), out)
 	case kindIntent:
-		if target == "" {
-			return camperrors.New("--target is required in non-interactive mode")
+		if jsonOut {
+			if err := dispatchIntent(ctx, item.SourceID, target, io.Discard); err != nil {
+				return err
+			}
+			return reportResult(cmd, kind, item, display)
 		}
-		if dryRun {
-			return printDryRun(cmd, item, target)
-		}
-		return dispatchIntent(ctx, item.SourceID, target)
+		return dispatchIntent(ctx, item.SourceID, target, out)
 	case kindWorkitem:
-		if target == "" {
-			return camperrors.New("--target is required in non-interactive mode")
-		}
-		if dryRun {
-			return printDryRun(cmd, item, target)
-		}
-		return dispatchWorkitem(ctx, item.AbsPath(campaignRoot), target, pass)
+		return dispatchWorkitem(ctx, item.AbsPath(campaignRoot), target, pass, out)
 	}
 	return camperrors.New("unknown promote kind")
 }
 
-func printDryRun(cmd *cobra.Command, item workitem.WorkItem, target string) error {
-	_, err := fmt.Fprintf(cmd.OutOrStdout(),
-		"dry-run: would promote %q (%s) to %s; no changes made\n", item.Title, item.WorkflowType, target)
-	return err
+type routerResult struct {
+	Kind   string `json:"kind"`
+	ID     string `json:"id,omitempty"`
+	Title  string `json:"title"`
+	Target string `json:"target"`
+	DryRun bool   `json:"dry_run"`
+	OK     bool   `json:"ok"`
+}
+
+func reportPlan(cmd *cobra.Command, jsonOut bool, kind promoteKind, item workitem.WorkItem, target string) error {
+	if !jsonOut {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(),
+			"dry-run: would promote %q (%s) to %s; no changes made\n", item.Title, item.WorkflowType, target)
+		return err
+	}
+	return encodeResult(cmd, routerResult{
+		Kind: kindName(kind), ID: item.Key, Title: item.Title, Target: target, DryRun: true, OK: true,
+	})
+}
+
+func reportResult(cmd *cobra.Command, kind promoteKind, item workitem.WorkItem, target string) error {
+	return encodeResult(cmd, routerResult{
+		Kind: kindName(kind), ID: item.Key, Title: item.Title, Target: target, OK: true,
+	})
+}
+
+func encodeResult(cmd *cobra.Command, res routerResult) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(res)
+}
+
+func kindName(kind promoteKind) string {
+	switch kind {
+	case kindIntent:
+		return "intent"
+	case kindFestival:
+		return "festival"
+	default:
+		return "workitem"
+	}
 }
 
 func festivalTarget(target string) (string, bool) {

--- a/cmd/camp/promote/router.go
+++ b/cmd/camp/promote/router.go
@@ -28,7 +28,12 @@ var RouterCmd = &cobra.Command{
 }
 
 func init() {
-	flags := RouterCmd.Flags()
+	addPromoteRouterFlags(RouterCmd)
+	RouterCmd.ValidArgsFunction = completePromotable
+}
+
+func addPromoteRouterFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
 	flags.String("target", "", "Promote target (kind-specific); required in non-interactive mode")
 	flags.Bool("json", false, "Machine-readable output; implies non-interactive")
 	flags.Bool("force", false, "Skip readiness checks")
@@ -37,7 +42,6 @@ func init() {
 	flags.Bool("keep", false, "Keep the source (festival/doc targets)")
 	flags.String("dest", "", "Destination override (doc/festival targets)")
 	flags.String("goal", "", "Festival goal override")
-	RouterCmd.ValidArgsFunction = completePromotable
 }
 
 func runRouter(cmd *cobra.Command, args []string) error {

--- a/cmd/camp/promote/router.go
+++ b/cmd/camp/promote/router.go
@@ -1,0 +1,161 @@
+package promote
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/locate"
+)
+
+var RouterCmd = &cobra.Command{
+	Use:     "promote [id]",
+	Short:   "Promote any intent, workitem, or festival (universal front door)",
+	GroupID: "planning",
+	Args:    cobra.MaximumNArgs(1),
+	Annotations: map[string]string{
+		"agent_allowed": "true",
+		"agent_reason":  "Dispatches to a type-specific promote; requires an explicit id and --target in non-interactive use",
+	},
+	RunE: runRouter,
+}
+
+func init() {
+	flags := RouterCmd.Flags()
+	flags.String("target", "", "Promote target (kind-specific); required in non-interactive mode")
+	flags.Bool("json", false, "Machine-readable output; implies non-interactive")
+	flags.Bool("force", false, "Skip readiness checks")
+	flags.Bool("dry-run", false, "Preview without making changes")
+	flags.Bool("no-commit", false, "Skip auto-commit")
+	flags.Bool("keep", false, "Keep the source (festival/doc targets)")
+	flags.String("dest", "", "Destination override (doc/festival targets)")
+	flags.String("goal", "", "Festival goal override")
+	RouterCmd.ValidArgsFunction = completePromotable
+}
+
+func runRouter(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	target, _ := cmd.Flags().GetString("target")
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	interactive := ui.IsTerminal() && !jsonOut
+
+	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+	resolver := paths.NewResolverFromConfig(campaignRoot, cfg)
+
+	item, resolved, err := resolveItem(ctx, campaignRoot, resolver, args)
+	if err != nil {
+		return err
+	}
+	if !resolved {
+		if !interactive {
+			return camperrors.New("no item in context: pass an id (and --target) or run camp promote in an interactive terminal")
+		}
+		item, err = selectItem(ctx, campaignRoot, resolver)
+		if err != nil {
+			return err
+		}
+	}
+
+	pass := passthroughFlags(cmd)
+	return dispatch(ctx, item, campaignRoot, target, interactive, pass)
+}
+
+func resolveItem(ctx context.Context, campaignRoot string, resolver *paths.Resolver, args []string) (workitem.WorkItem, bool, error) {
+	pool, err := promotablePool(ctx, campaignRoot, resolver)
+	if err != nil {
+		return workitem.WorkItem{}, false, err
+	}
+
+	if len(args) == 1 {
+		for _, it := range pool {
+			if it.SourceID == args[0] || it.Key == args[0] || it.StableID == args[0] {
+				return it, true, nil
+			}
+		}
+		return workitem.WorkItem{}, false, camperrors.Wrapf(camperrors.New("not a promotable item"), "id %q", args[0])
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return workitem.WorkItem{}, false, camperrors.Wrap(err, "getting current directory")
+	}
+	if loc, derr := locate.DetectFromCwd(campaignRoot, cwd); derr == nil {
+		for _, it := range pool {
+			if it.WorkflowType == workitem.WorkflowTypeIntent || it.WorkflowType == workitem.WorkflowTypeFestival {
+				continue
+			}
+			if filepath.Base(it.RelativePath) == loc.Slug {
+				return it, true, nil
+			}
+		}
+	}
+	return workitem.WorkItem{}, false, nil
+}
+
+func dispatch(ctx context.Context, item workitem.WorkItem, campaignRoot, target string, interactive bool, pass []string) error {
+	kind := kindForType(item.WorkflowType)
+
+	if target == "" && interactive {
+		picked, perr := pickTarget(ctx, kind)
+		if perr != nil {
+			return perr
+		}
+		target = picked
+	}
+
+	switch kind {
+	case kindFestival:
+		status, ok := festivalTarget(target)
+		if !ok {
+			return camperrors.New("festival target must be next, completed, archived, or someday")
+		}
+		return dispatchFestival(ctx, item.AbsPath(campaignRoot), festPassthrough(status, pass))
+	case kindIntent:
+		if target == "" {
+			return camperrors.New("--target is required in non-interactive mode")
+		}
+		return dispatchIntent(ctx, item.SourceID, target, pass)
+	case kindWorkitem:
+		if target == "" {
+			return camperrors.New("--target is required in non-interactive mode")
+		}
+		return dispatchWorkitem(ctx, item.AbsPath(campaignRoot), target, pass)
+	}
+	return camperrors.New("unknown promote kind")
+}
+
+func festivalTarget(target string) (string, bool) {
+	switch target {
+	case "", "next":
+		return "", true
+	case "completed", "archived", "someday":
+		return target, true
+	}
+	return "", false
+}
+
+func passthroughFlags(cmd *cobra.Command) []string {
+	var pass []string
+	for _, name := range []string{"force", "dry-run", "no-commit", "keep", "json"} {
+		if cmd.Flags().Changed(name) {
+			pass = append(pass, "--"+name)
+		}
+	}
+	for _, name := range []string{"dest", "goal"} {
+		if cmd.Flags().Changed(name) {
+			v, _ := cmd.Flags().GetString(name)
+			pass = append(pass, "--"+name, v)
+		}
+	}
+	return pass
+}

--- a/cmd/camp/promote/router_test.go
+++ b/cmd/camp/promote/router_test.go
@@ -66,7 +66,7 @@ func TestDispatchArgv(t *testing.T) {
 		runner = rec
 		t.Cleanup(func() { runner = orig })
 
-		if err := dispatchIntent(context.Background(), "add-dark", "festival", io.Discard); err != nil {
+		if err := dispatchIntent(context.Background(), "add-dark", "festival", nil, io.Discard); err != nil {
 			t.Fatalf("dispatchIntent: %v", err)
 		}
 		want := []string{"intent", "promote", "add-dark", "--target", "festival"}
@@ -182,6 +182,26 @@ func TestRouterNonInteractiveGuard(t *testing.T) {
 	}
 }
 
+func TestRouterNonInteractiveRejectsCwdResolution(t *testing.T) {
+	root := promoteFixture(t)
+	t.Chdir(filepath.Join(root, "workflow", "design", "sample"))
+
+	rec := &recordingRunner{}
+	orig := runner
+	runner = rec
+	t.Cleanup(func() { runner = orig })
+
+	cmd := newRouterCmd()
+	cmd.SetArgs([]string{"--json", "--target", "doc"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "no item in context") {
+		t.Fatalf("err = %v, want contains %q", err, "no item in context")
+	}
+	if rec.args != nil {
+		t.Fatalf("non-interactive cwd promote must not dispatch, got args %v", rec.args)
+	}
+}
+
 func TestRouterDryRunDoesNotDispatch(t *testing.T) {
 	root := promoteFixture(t)
 	t.Chdir(root)
@@ -235,6 +255,39 @@ func TestDispatchIntentJSONEmitsEnvelopeNotChildText(t *testing.T) {
 	}
 	if got.Kind != "intent" || !got.OK || got.Target != "ready" {
 		t.Fatalf("envelope = %+v, want kind=intent ok=true target=ready", got)
+	}
+}
+
+func TestDispatchIntentForwardsSafeFlags(t *testing.T) {
+	for _, jsonOut := range []bool{false, true} {
+		name := "text"
+		if jsonOut {
+			name = "json"
+		}
+		t.Run(name, func(t *testing.T) {
+			rec := &recordingRunner{}
+			orig := runner
+			runner = rec
+			t.Cleanup(func() { runner = orig })
+
+			cmd := newRouterCmd()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			item := workitem.WorkItem{
+				WorkflowType: workitem.WorkflowTypeIntent,
+				SourceID:     "add-dark",
+				Key:          "intent:add-dark",
+				Title:        "Add dark mode",
+			}
+			pass := []string{"--force", "--no-commit", "--json"}
+			if err := dispatch(cmd, item, filepath.FromSlash("/camp"), "ready", false, false, jsonOut, pass); err != nil {
+				t.Fatalf("dispatch: %v", err)
+			}
+			want := []string{"intent", "promote", "add-dark", "--target", "ready", "--force", "--no-commit"}
+			if !reflect.DeepEqual(rec.args, want) {
+				t.Fatalf("intent argv = %v, want %v (forward --force/--no-commit, drop --json)", rec.args, want)
+			}
+		})
 	}
 }
 
@@ -315,7 +368,7 @@ func TestResolveItemDisambiguatesByWorkflowType(t *testing.T) {
 	}
 	resolver := paths.NewResolverFromConfig(cRoot, cfg)
 
-	item, resolved, err := resolveItem(ctx, cRoot, resolver, nil)
+	item, resolved, err := resolveItem(ctx, cRoot, resolver, nil, true)
 	if err != nil {
 		t.Fatalf("resolveItem: %v", err)
 	}

--- a/cmd/camp/promote/router_test.go
+++ b/cmd/camp/promote/router_test.go
@@ -3,6 +3,8 @@ package promote
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -22,7 +24,7 @@ type recordingRunner struct {
 	args []string
 }
 
-func (r *recordingRunner) run(_ context.Context, dir, bin string, args []string) error {
+func (r *recordingRunner) run(_ context.Context, dir, bin string, args []string, _ io.Writer) error {
 	r.dir, r.bin, r.args = dir, bin, args
 	return nil
 }
@@ -64,7 +66,7 @@ func TestDispatchArgv(t *testing.T) {
 		runner = rec
 		t.Cleanup(func() { runner = orig })
 
-		if err := dispatchIntent(context.Background(), "add-dark", "festival"); err != nil {
+		if err := dispatchIntent(context.Background(), "add-dark", "festival", io.Discard); err != nil {
 			t.Fatalf("dispatchIntent: %v", err)
 		}
 		want := []string{"intent", "promote", "add-dark", "--target", "festival"}
@@ -80,7 +82,7 @@ func TestDispatchArgv(t *testing.T) {
 		t.Cleanup(func() { runner = orig })
 
 		dir := filepath.FromSlash("/camp/workflow/design/x")
-		if err := dispatchWorkitem(context.Background(), dir, "doc", []string{"--no-commit"}); err != nil {
+		if err := dispatchWorkitem(context.Background(), dir, "doc", []string{"--no-commit"}, io.Discard); err != nil {
 			t.Fatalf("dispatchWorkitem: %v", err)
 		}
 		want := []string{"workitem", "promote", "--target", "doc", "--no-commit"}
@@ -101,7 +103,7 @@ func TestDispatchArgv(t *testing.T) {
 		t.Cleanup(func() { runner = origR; festLookup = origF })
 
 		dir := filepath.FromSlash("/camp/festivals/planning/f")
-		if err := dispatchFestival(context.Background(), dir, festPassthrough("archived", nil)); err != nil {
+		if err := dispatchFestival(context.Background(), dir, festPassthrough("archived", nil), io.Discard); err != nil {
 			t.Fatalf("dispatchFestival: %v", err)
 		}
 		want := []string{"promote", "--dungeon", "archived"}
@@ -121,7 +123,7 @@ func TestDispatchArgv(t *testing.T) {
 		festLookup = func() (string, error) { return "fest", nil }
 		t.Cleanup(func() { runner = origR; festLookup = origF })
 
-		if err := dispatchFestival(context.Background(), "/x", festPassthrough("", nil)); err != nil {
+		if err := dispatchFestival(context.Background(), "/x", festPassthrough("", nil), io.Discard); err != nil {
 			t.Fatalf("dispatchFestival: %v", err)
 		}
 		want := []string{"promote"}
@@ -201,6 +203,98 @@ func TestRouterDryRunDoesNotDispatch(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "dry-run") {
 		t.Fatalf("stdout = %q, want dry-run notice", out.String())
+	}
+}
+
+func TestDispatchIntentJSONEmitsEnvelopeNotChildText(t *testing.T) {
+	rec := &recordingRunner{}
+	orig := runner
+	runner = rec
+	t.Cleanup(func() { runner = orig })
+
+	cmd := newRouterCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	item := workitem.WorkItem{
+		WorkflowType: workitem.WorkflowTypeIntent,
+		SourceID:     "add-dark",
+		Key:          "intent:add-dark",
+		Title:        "Add dark mode",
+	}
+	if err := dispatch(cmd, item, filepath.FromSlash("/camp"), "ready", false, false, true, nil); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+
+	wantArgs := []string{"intent", "promote", "add-dark", "--target", "ready"}
+	if !reflect.DeepEqual(rec.args, wantArgs) {
+		t.Fatalf("intent argv = %v, want %v (must not forward --json)", rec.args, wantArgs)
+	}
+	var got routerResult
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not a single JSON object: %v (raw %q)", err, out.String())
+	}
+	if got.Kind != "intent" || !got.OK || got.Target != "ready" {
+		t.Fatalf("envelope = %+v, want kind=intent ok=true target=ready", got)
+	}
+}
+
+func TestDispatchDryRunJSONEmitsEnvelope(t *testing.T) {
+	rec := &recordingRunner{}
+	orig := runner
+	runner = rec
+	t.Cleanup(func() { runner = orig })
+
+	cmd := newRouterCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	item := workitem.WorkItem{
+		WorkflowType: workitem.WorkflowTypeDesign,
+		Key:          "design:workflow/design/x",
+		Title:        "X",
+	}
+	if err := dispatch(cmd, item, filepath.FromSlash("/camp"), "doc", false, true, true, nil); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if rec.args != nil {
+		t.Fatalf("dry-run must not dispatch, got args %v", rec.args)
+	}
+	var got routerResult
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not a single JSON object: %v (raw %q)", err, out.String())
+	}
+	if !got.DryRun || !got.OK || got.Target != "doc" {
+		t.Fatalf("envelope = %+v, want dry_run=true ok=true target=doc", got)
+	}
+}
+
+func TestRouterWorkitemJSONForwardsToChild(t *testing.T) {
+	root := promoteFixture(t)
+	t.Chdir(root)
+
+	rec := &recordingRunner{}
+	orig := runner
+	runner = rec
+	t.Cleanup(func() { runner = orig })
+
+	cmd := newRouterCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"design:workflow/design/sample", "--target", "doc", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	foundJSON := false
+	for _, a := range rec.args {
+		if a == "--json" {
+			foundJSON = true
+		}
+	}
+	if !foundJSON {
+		t.Fatalf("workitem dispatch must forward --json, got %v", rec.args)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("router must delegate JSON to the workitem child, but emitted %q", out.String())
 	}
 }
 

--- a/cmd/camp/promote/router_test.go
+++ b/cmd/camp/promote/router_test.go
@@ -1,6 +1,7 @@
 package promote
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -10,6 +11,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/workitem"
 )
 
@@ -61,7 +64,7 @@ func TestDispatchArgv(t *testing.T) {
 		runner = rec
 		t.Cleanup(func() { runner = orig })
 
-		if err := dispatchIntent(context.Background(), "add-dark", "festival", nil); err != nil {
+		if err := dispatchIntent(context.Background(), "add-dark", "festival"); err != nil {
 			t.Fatalf("dispatchIntent: %v", err)
 		}
 		want := []string{"intent", "promote", "add-dark", "--target", "festival"}
@@ -174,6 +177,59 @@ func TestRouterNonInteractiveGuard(t *testing.T) {
 				t.Fatalf("err = %v, want contains %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestRouterDryRunDoesNotDispatch(t *testing.T) {
+	root := promoteFixture(t)
+	t.Chdir(root)
+
+	rec := &recordingRunner{}
+	orig := runner
+	runner = rec
+	t.Cleanup(func() { runner = orig })
+
+	cmd := newRouterCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"design:workflow/design/sample", "--target", "doc", "--dry-run"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	if rec.args != nil {
+		t.Fatalf("dry-run must not dispatch, got args %v", rec.args)
+	}
+	if !strings.Contains(out.String(), "dry-run") {
+		t.Fatalf("stdout = %q, want dry-run notice", out.String())
+	}
+}
+
+func TestResolveItemDisambiguatesByWorkflowType(t *testing.T) {
+	root := t.TempDir()
+	writeFixtureFile(t, filepath.Join(root, ".campaign", "campaign.yaml"), "id: t\nname: T\ntype: product\n")
+	for _, wt := range []string{"design", "explore"} {
+		dir := filepath.Join(root, "workflow", wt, "dup")
+		writeFixtureFile(t, filepath.Join(dir, ".workitem"), "version: v1alpha6\nkind: workitem\nid: "+wt+"-dup\ntype: "+wt+"\ntitle: Dup\n")
+		writeFixtureFile(t, filepath.Join(dir, "README.md"), "# Dup\n\nbody\n")
+	}
+	t.Chdir(filepath.Join(root, "workflow", "explore", "dup"))
+
+	ctx := context.Background()
+	cfg, cRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	resolver := paths.NewResolverFromConfig(cRoot, cfg)
+
+	item, resolved, err := resolveItem(ctx, cRoot, resolver, nil)
+	if err != nil {
+		t.Fatalf("resolveItem: %v", err)
+	}
+	if !resolved {
+		t.Fatal("expected cwd resolution to find the explore workitem")
+	}
+	if string(item.WorkflowType) != "explore" {
+		t.Fatalf("resolved %s/dup, want explore/dup (basename collision must disambiguate by type)", item.WorkflowType)
 	}
 }
 

--- a/cmd/camp/promote/router_test.go
+++ b/cmd/camp/promote/router_test.go
@@ -1,0 +1,203 @@
+package promote
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+type recordingRunner struct {
+	bin  string
+	dir  string
+	args []string
+}
+
+func (r *recordingRunner) run(_ context.Context, dir, bin string, args []string) error {
+	r.dir, r.bin, r.args = dir, bin, args
+	return nil
+}
+
+func writeFixtureFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func promoteFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFixtureFile(t, filepath.Join(root, ".campaign", "campaign.yaml"), "id: test-campaign\nname: Test\ntype: product\n")
+	dir := filepath.Join(root, "workflow", "design", "sample")
+	writeFixtureFile(t, filepath.Join(dir, ".workitem"), "version: v1alpha6\nkind: workitem\nid: design-sample-fixed\ntype: design\ntitle: Sample\n")
+	writeFixtureFile(t, filepath.Join(dir, "README.md"), "# Sample\n\nbody\n")
+	return root
+}
+
+func newRouterCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "promote [id]", Args: cobra.MaximumNArgs(1), RunE: runRouter}
+	addPromoteRouterFlags(cmd)
+	cmd.ValidArgsFunction = completePromotable
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetContext(context.Background())
+	return cmd
+}
+
+func TestDispatchArgv(t *testing.T) {
+	t.Run("intent forwards id and target", func(t *testing.T) {
+		rec := &recordingRunner{}
+		orig := runner
+		runner = rec
+		t.Cleanup(func() { runner = orig })
+
+		if err := dispatchIntent(context.Background(), "add-dark", "festival", nil); err != nil {
+			t.Fatalf("dispatchIntent: %v", err)
+		}
+		want := []string{"intent", "promote", "add-dark", "--target", "festival"}
+		if !reflect.DeepEqual(rec.args, want) {
+			t.Fatalf("args = %v, want %v", rec.args, want)
+		}
+	})
+
+	t.Run("workitem dispatches via cwd dir without id", func(t *testing.T) {
+		rec := &recordingRunner{}
+		orig := runner
+		runner = rec
+		t.Cleanup(func() { runner = orig })
+
+		dir := filepath.FromSlash("/camp/workflow/design/x")
+		if err := dispatchWorkitem(context.Background(), dir, "doc", []string{"--no-commit"}); err != nil {
+			t.Fatalf("dispatchWorkitem: %v", err)
+		}
+		want := []string{"workitem", "promote", "--target", "doc", "--no-commit"}
+		if !reflect.DeepEqual(rec.args, want) {
+			t.Fatalf("args = %v, want %v", rec.args, want)
+		}
+		if rec.dir != dir {
+			t.Fatalf("dir = %q, want %q", rec.dir, dir)
+		}
+	})
+
+	t.Run("festival dungeon target maps to --dungeon", func(t *testing.T) {
+		rec := &recordingRunner{}
+		origR := runner
+		runner = rec
+		origF := festLookup
+		festLookup = func() (string, error) { return "fest", nil }
+		t.Cleanup(func() { runner = origR; festLookup = origF })
+
+		dir := filepath.FromSlash("/camp/festivals/planning/f")
+		if err := dispatchFestival(context.Background(), dir, festPassthrough("archived", nil)); err != nil {
+			t.Fatalf("dispatchFestival: %v", err)
+		}
+		want := []string{"promote", "--dungeon", "archived"}
+		if !reflect.DeepEqual(rec.args, want) {
+			t.Fatalf("args = %v, want %v", rec.args, want)
+		}
+		if rec.dir != dir || rec.bin != "fest" {
+			t.Fatalf("dir/bin = %q/%q, want %q/fest", rec.dir, rec.bin, dir)
+		}
+	})
+
+	t.Run("festival next stage forwards bare promote", func(t *testing.T) {
+		rec := &recordingRunner{}
+		origR := runner
+		runner = rec
+		origF := festLookup
+		festLookup = func() (string, error) { return "fest", nil }
+		t.Cleanup(func() { runner = origR; festLookup = origF })
+
+		if err := dispatchFestival(context.Background(), "/x", festPassthrough("", nil)); err != nil {
+			t.Fatalf("dispatchFestival: %v", err)
+		}
+		want := []string{"promote"}
+		if !reflect.DeepEqual(rec.args, want) {
+			t.Fatalf("args = %v, want %v", rec.args, want)
+		}
+	})
+}
+
+func TestIsPromotable(t *testing.T) {
+	tests := []struct {
+		name string
+		item workitem.WorkItem
+		want bool
+	}{
+		{"intent active excluded", workitem.WorkItem{WorkflowType: workitem.WorkflowTypeIntent, LifecycleStage: workitem.LifecycleStageActive}, false},
+		{"intent inbox", workitem.WorkItem{WorkflowType: workitem.WorkflowTypeIntent, LifecycleStage: workitem.LifecycleStageInbox}, true},
+		{"intent ready", workitem.WorkItem{WorkflowType: workitem.WorkflowTypeIntent, LifecycleStage: workitem.LifecycleStageReady}, true},
+		{"festival planning", workitem.WorkItem{WorkflowType: workitem.WorkflowTypeFestival, LifecycleStage: workitem.LifecycleStagePlanning}, true},
+		{"festival active", workitem.WorkItem{WorkflowType: workitem.WorkflowTypeFestival, LifecycleStage: workitem.LifecycleStageActive}, true},
+		{"festival none excluded", workitem.WorkItem{WorkflowType: workitem.WorkflowTypeFestival, LifecycleStage: workitem.LifecycleStageNone}, false},
+		{"design none kept", workitem.WorkItem{WorkflowType: workitem.WorkflowTypeDesign, LifecycleStage: workitem.LifecycleStageNone}, true},
+		{"explore none kept", workitem.WorkItem{WorkflowType: workitem.WorkflowTypeExplore, LifecycleStage: workitem.LifecycleStageNone}, true},
+		{"custom type kept", workitem.WorkItem{WorkflowType: workitem.WorkflowType("feature"), LifecycleStage: workitem.LifecycleStageNone}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPromotable(tt.item); got != tt.want {
+				t.Fatalf("isPromotable = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRouterNonInteractiveGuard(t *testing.T) {
+	root := promoteFixture(t)
+	t.Chdir(root)
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"json no id", []string{"--json"}, "no item in context"},
+		{"id no target json", []string{"design:workflow/design/sample", "--json"}, "target is required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newRouterCmd()
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("err = %v, want contains %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompletePromotable(t *testing.T) {
+	root := promoteFixture(t)
+	t.Chdir(root)
+
+	cmd := newRouterCmd()
+	got, directive := completePromotable(cmd, nil, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("directive = %v", directive)
+	}
+	found := false
+	for _, id := range got {
+		if id == "design:workflow/design/sample" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected the design workitem id in completions, got %v", got)
+	}
+
+	none, _ := completePromotable(cmd, nil, "zzz-no-match")
+	if len(none) != 0 {
+		t.Fatalf("prefix should match nothing, got %v", none)
+	}
+}

--- a/cmd/camp/promote/selector.go
+++ b/cmd/camp/promote/selector.go
@@ -1,0 +1,190 @@
+package promote
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"golang.org/x/term"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/intent/tui"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	"github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+type selectorModel struct {
+	items    []workitem.WorkItem
+	selected int
+	picked   bool
+	aborted  bool
+	value    workitem.WorkItem
+}
+
+func (m selectorModel) Init() tea.Cmd { return nil }
+
+func (m selectorModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch key.String() {
+	case "ctrl+c":
+		m.aborted = true
+		return m, tea.Quit
+	case "esc", "q":
+		return m, tea.Quit
+	case "enter":
+		if len(m.items) > 0 {
+			m.value = m.items[m.selected]
+			m.picked = true
+			return m, tea.Quit
+		}
+	case "down", "j", "tab":
+		if len(m.items) > 0 {
+			m.selected = (m.selected + 1) % len(m.items)
+		}
+	case "up", "k", "shift+tab":
+		if len(m.items) > 0 {
+			m.selected = (m.selected - 1 + len(m.items)) % len(m.items)
+		}
+	}
+	return m, nil
+}
+
+func (m selectorModel) View() string {
+	var b strings.Builder
+	b.WriteString(tui.TitleStyle.Render("Promote") + "\n\n")
+	for i, it := range m.items {
+		marker := "  "
+		if i == m.selected {
+			marker = "> "
+		}
+		b.WriteString(marker + selectorLabel(it) + "\n")
+	}
+	b.WriteString("\n" + tui.HelpStyle.Render("j/k: navigate . Enter: select . Esc: cancel"))
+	return b.String()
+}
+
+func selectorLabel(it workitem.WorkItem) string {
+	return fmt.Sprintf("%-9s %s (%s)", string(it.WorkflowType), it.Title, string(it.LifecycleStage))
+}
+
+func selectItem(ctx context.Context, campaignRoot string, resolver *paths.Resolver) (workitem.WorkItem, error) {
+	pool, err := promotablePool(ctx, campaignRoot, resolver)
+	if err != nil {
+		return workitem.WorkItem{}, err
+	}
+	if len(pool) == 0 {
+		return workitem.WorkItem{}, camperrors.New("nothing promotable found")
+	}
+
+	final, rerr := runPicker(ctx, selectorModel{items: pool})
+	if rerr != nil {
+		return workitem.WorkItem{}, camperrors.Wrap(rerr, "running promote selector")
+	}
+	sm, ok := final.(selectorModel)
+	if !ok || sm.aborted || !sm.picked {
+		return workitem.WorkItem{}, camperrors.New("promote cancelled")
+	}
+	return sm.value, nil
+}
+
+type targetModel struct {
+	title    string
+	options  []string
+	selected int
+	picked   bool
+	aborted  bool
+	value    string
+}
+
+func (m targetModel) Init() tea.Cmd { return nil }
+
+func (m targetModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch key.String() {
+	case "ctrl+c":
+		m.aborted = true
+		return m, tea.Quit
+	case "esc", "q":
+		return m, tea.Quit
+	case "enter":
+		if len(m.options) > 0 {
+			m.value = m.options[m.selected]
+			m.picked = true
+			return m, tea.Quit
+		}
+	case "down", "j", "tab":
+		if len(m.options) > 0 {
+			m.selected = (m.selected + 1) % len(m.options)
+		}
+	case "up", "k", "shift+tab":
+		if len(m.options) > 0 {
+			m.selected = (m.selected - 1 + len(m.options)) % len(m.options)
+		}
+	}
+	return m, nil
+}
+
+func (m targetModel) View() string {
+	var b strings.Builder
+	b.WriteString(tui.TitleStyle.Render(m.title) + "\n\n")
+	for i, opt := range m.options {
+		marker := "  "
+		if i == m.selected {
+			marker = "> "
+		}
+		b.WriteString(marker + opt + "\n")
+	}
+	b.WriteString("\n" + tui.HelpStyle.Render("j/k: navigate . Enter: select . Esc: cancel"))
+	return b.String()
+}
+
+func targetsForKind(kind promoteKind) []string {
+	switch kind {
+	case kindIntent:
+		return []string{"ready", "festival", "design"}
+	case kindWorkitem:
+		return []string{"festival", "doc", "completed", "archived", "someday"}
+	case kindFestival:
+		return []string{"next", "completed", "archived", "someday"}
+	}
+	return nil
+}
+
+func pickTarget(ctx context.Context, kind promoteKind) (string, error) {
+	options := targetsForKind(kind)
+	if len(options) == 0 {
+		return "", camperrors.New("no targets available for item")
+	}
+	final, rerr := runPicker(ctx, targetModel{title: "Promote target", options: options})
+	if rerr != nil {
+		return "", camperrors.Wrap(rerr, "running target picker")
+	}
+	tm, ok := final.(targetModel)
+	if !ok || tm.aborted || !tm.picked {
+		return "", camperrors.New("promote cancelled")
+	}
+	return tm.value, nil
+}
+
+func runPicker(ctx context.Context, model tea.Model) (tea.Model, error) {
+	opts := []tea.ProgramOption{tea.WithContext(ctx), tea.WithAltScreen()}
+	var tty *os.File
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		if f, oerr := os.OpenFile("/dev/tty", os.O_RDWR, 0); oerr == nil {
+			tty = f
+			opts = append(opts, tea.WithInput(tty), tea.WithOutput(tty))
+		}
+	}
+	if tty != nil {
+		defer func() { _ = tty.Close() }()
+	}
+	return tea.NewProgram(model, opts...).Run()
+}

--- a/cmd/camp/root.go
+++ b/cmd/camp/root.go
@@ -231,6 +231,7 @@ func init() {
 	rootCmd.AddCommand(dungeonpkg.Cmd)
 	rootCmd.AddCommand(intentpkg.Cmd)
 	rootCmd.AddCommand(promotepkg.Cmd)
+	rootCmd.AddCommand(promotepkg.RouterCmd)
 	rootCmd.AddCommand(leveragepkg.Cmd)
 	rootCmd.AddCommand(worktreespkg.Cmd)
 	rootCmd.AddCommand(refspkg.Cmd)

--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -31,6 +31,7 @@ var manifestAgentAllowedReasons = map[string]string{
 	"log":                 "Read-only git log",
 	"project list":        "Read-only project listing",
 	"project remote list": "Read-only project remote listing",
+	"promote":             "Routes to a type-specific promote; needs an explicit id and --target in non-interactive use",
 	"quest archive":       "Non-interactive quest archive with explicit selector",
 	"quest complete":      "Non-interactive quest completion with explicit selector",
 	"quest create":        "Non-interactive quest creation with explicit arguments",


### PR DESCRIPTION
## Summary

Adds the top-level `camp promote` router: the single discoverable front door over the three promotion pipelines. It resolves an item from `[id]` or cwd, detects its kind (intent / workitem / festival), and dispatches to the existing `camp intent promote`, `camp workitem promote`, or `fest promote`. With no context in an interactive terminal it opens a selector over promotable intents (inbox/ready), active workitems, and festivals (planning/ready/active), then routes the choice through a per-kind target picker. Adds shell completion over the promotable pool and a non-interactive guard requiring an explicit id and `--target`.

## Design

Implements the unified promotion router from the `camp-workitem-promote-2026-06-16` design (campaign workitem `WI-c62894`), specifically the `camp promote` router/selector in `03-command-spec.md`. Issue 2 of the three-issue breakdown in festival `camp-workitem-promote-CW0004`.

## Stacking base (D003)

**This PR is stacked on Issue 1 (#339, `workitem-promote`), which is still open.** It is based on `workitem-promote` so the diff shows only the router delta. **Retarget the base to `main` after #339 merges** (GitHub usually auto-retargets on merge).

## Implementation notes

- Workflow workitems carry no `SourceID`, so they dispatch via `cmd.Dir` cwd-resolution (reliable) rather than an id; intents dispatch by `SourceID`; festivals run `fest promote` in the festival dir (`--dungeon <status>` for dungeon targets, bare `promote` for the next stage).
- Dispatch goes through a stubbable runner seam.

## Tests

- Dispatch argv tests (stubbed runner) for all three kinds.
- Pool-correctness table (`isPromotable`): inbox/ready intents, active workitems incl. custom types, planning/ready/active festivals; excludes terminal/none-staged.
- Non-interactive guard test (no id, or id without target under `--json`).
- Shell-completion test. `just build` / `just test` / `just lint` green.