### PR TITLE
feat(flow): demote camp flow to internal primitive; document promotion front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Campaign workspace manager — group every project, tool, and piece of context y
 
 - **Navigation** — Category shortcuts, fuzzy finding, pins, and a cached index for instant project lookups (`go`, `pin`, `shortcuts`, `cache`)
 - **Project Management** — Git submodules, linked local workspaces, worktrees, and scaffolding (`project add/link/list/new/remote/remove/run/unlink/worktree/prune`)
-- **Planning** — Intents, status flows, dungeon for deprioritized work, and a unified work-item dashboard (`intent`, `flow`, `dungeon`, `gather`, `workitem`)
+- **Planning** — Intents, promotion, dungeon for deprioritized work, and a unified work-item dashboard (`intent`, `promote`, `dungeon`, `gather`, `workitem`)
 - **Productivity** — Leverage scoring to identify high-impact work (`leverage`)
 - **Git Integration** — Campaign-level git operations with submodule fan-out (`stage`, `commit`, `log`, `push [all]`, `pull [all]`, `status [all]`, `fresh [all]`, `refs-sync`)
 - **Campaign Ops** — Health checks, file operations, cross-campaign tools (`doctor`, `copy`, `move`, `sync`, `transfer`)
@@ -22,7 +22,7 @@ Campaign workspace manager — group every project, tool, and piece of context y
 - **Tab Completion** — Smart completion for categories, projects, and paths
 - **Plugins** — Discover camp plugins on `PATH` (`plugins`)
 
-Note: `flow` is a dev-channel command and is not available in stable builds.
+Note: `flow` is a hidden low-level status engine. Use `camp promote` for lifecycle promotion.
 
 ## Installation
 
@@ -198,7 +198,7 @@ cgo external-repo
 
 ### Planning
 
-Intents, status flows, and the dungeon provide lightweight planning tools:
+Intents, promotion, and the dungeon provide lightweight planning tools:
 
 ```bash
 # Intents - capture ideas, goals, and work items
@@ -206,8 +206,8 @@ camp intent                # Manage campaign intents
 camp intent add --campaign other-campaign "Capture idea"  # Cross-campaign capture (add only)
 camp gather                # Import external data into the intent system
 
-# Flows - track work status
-camp flow                  # Manage status workflows for organizing work (dev channel only; not available in stable builds)
+# Promotion - move intents, workitems, and festivals through lifecycle stages
+camp promote               # Resolve context and dispatch to the right promote command
 
 # Dungeon - archive deprioritized work
 camp dungeon               # Move items to/from the dungeon

--- a/cmd/camp/manifest.go
+++ b/cmd/camp/manifest.go
@@ -54,8 +54,9 @@ func walkCommands(cmd *cobra.Command, prefix string, entries *[]CommandEntry) {
 			path = prefix + " " + child.Name()
 		}
 
-		// Hidden commands (e.g. the deprecated shelve alias) are not advertised
-		// in the agent manifest, mirroring their absence from --help.
+		// Hidden commands (e.g. deprecated aliases and demoted internal engines)
+		// are not advertised in the agent manifest, mirroring their absence from
+		// --help.
 		if child.Hidden {
 			continue
 		}

--- a/cmd/camp/manifest_test.go
+++ b/cmd/camp/manifest_test.go
@@ -17,11 +17,6 @@ func findCmd(path ...string) *cobra.Command {
 	return cmd
 }
 
-func flowCommandsRegistered() bool {
-	cmd, _, err := rootCmd.Find([]string{"flow"})
-	return err == nil && cmd != nil && cmd.Name() == "flow"
-}
-
 func questCommandsRegistered() bool {
 	cmd, _, err := rootCmd.Find([]string{"quest"})
 	return err == nil && cmd != nil && cmd.Name() == "quest"
@@ -78,6 +73,34 @@ func TestManifestCommand_CoversVisibleCommandTree(t *testing.T) {
 	}
 }
 
+func TestManifestCommand_HiddenCommandsOmitted(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"__manifest"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("__manifest command failed: %v", err)
+	}
+
+	var manifest Manifest
+	if err := json.Unmarshal(buf.Bytes(), &manifest); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	visible := map[string]bool{}
+	for _, cmd := range manifest.Commands {
+		visible[cmd.Path] = true
+	}
+
+	var hidden []string
+	collectHiddenCommandPaths(rootCmd, "", &hidden)
+	for _, path := range hidden {
+		if visible[path] {
+			t.Errorf("hidden command %q should not be emitted in the agent manifest", path)
+		}
+	}
+}
+
 func walkMissingManifestAnnotations(cmd *cobra.Command, prefix string, missing *[]string) {
 	for _, child := range cmd.Commands() {
 		path := child.Name()
@@ -91,6 +114,20 @@ func walkMissingManifestAnnotations(cmd *cobra.Command, prefix string, missing *
 			*missing = append(*missing, path)
 		}
 		walkMissingManifestAnnotations(child, path, missing)
+	}
+}
+
+func collectHiddenCommandPaths(cmd *cobra.Command, prefix string, hidden *[]string) {
+	for _, child := range cmd.Commands() {
+		path := child.Name()
+		if prefix != "" {
+			path = prefix + " " + child.Name()
+		}
+		if child.Hidden {
+			*hidden = append(*hidden, path)
+			continue
+		}
+		collectHiddenCommandPaths(child, path, hidden)
 	}
 }
 
@@ -128,11 +165,6 @@ func TestManifestCommand_AllRestrictedCommandsPresent(t *testing.T) {
 		"skills link":   false,
 		"skills status": false,
 		"skills unlink": false,
-	}
-	if flowCommandsRegistered() {
-		expectedCommands["flow"] = false
-		expectedCommands["flow add"] = false
-		expectedCommands["flow migrate"] = false
 	}
 	if questCommandsRegistered() {
 		expectedCommands["quest archive"] = false
@@ -254,10 +286,6 @@ func TestManifestCommand_InteractiveFlags(t *testing.T) {
 		"skills link":   true,
 		"skills status": true,
 		"skills unlink": true,
-	}
-	if flowCommandsRegistered() {
-		nonInteractiveCommands["flow add"] = true
-		nonInteractiveCommands["flow migrate"] = true
 	}
 	if questCommandsRegistered() {
 		nonInteractiveCommands["quest archive"] = true

--- a/cmd/camp/release_profile_dev_test.go
+++ b/cmd/camp/release_profile_dev_test.go
@@ -29,3 +29,16 @@ func TestReleaseProfileDev_VersionProfile(t *testing.T) {
 		t.Fatalf("version.Profile = %q, want %q", version.Profile, "dev")
 	}
 }
+
+func TestReleaseProfileDev_FlowCommandHiddenButRegistered(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"flow"})
+	if err != nil {
+		t.Fatalf("expected flow command: %v", err)
+	}
+	if cmd == nil || cmd.Name() != "flow" {
+		t.Fatalf("expected flow command, got %#v", cmd)
+	}
+	if !cmd.Hidden {
+		t.Fatal("flow should be hidden from the primary help surface")
+	}
+}

--- a/docs/architecture/command-conventions.md
+++ b/docs/architecture/command-conventions.md
@@ -20,3 +20,5 @@ Tree A (package-level vars plus `init()`) exists in older code under `cmd/camp/`
 `internal/flow` is a shell-command registry/runner (`.campaign/flows/registry.yaml`).
 The CLI command `camp flow` is mostly backed by `internal/workflow`; `camp workflow` manages workflow collections.
 These names are inverted relative to what a reader expects. Until they are renamed, both packages carry a doc comment cross-referencing the other.
+
+`camp flow` is hidden from `camp --help`; it is the low-level engine, and `camp promote` is the user-facing front door.

--- a/docs/tribal-knowledge/camp-promote-is-the-front-door.md
+++ b/docs/tribal-knowledge/camp-promote-is-the-front-door.md
@@ -1,0 +1,21 @@
+# camp promote is the promotion front door
+
+Promotion is the same verb across the three things that move through lifecycles
+in a campaign, and `camp promote` is the single discoverable entrypoint over all
+of them:
+
+| Kind | Type-specific command | Targets |
+|---|---|---|
+| intent | `camp intent promote <id> --target <t>` | ready, festival, design |
+| workitem | `camp workitem promote <id> --target <t>` | festival, doc, completed, archived, someday |
+| festival | `fest promote [--dungeon <s>] [--force]` | next lifecycle stage, or dungeon status |
+
+`camp promote` resolves the item in context (or opens a selector over promotable
+intents, workitems, and festivals) and dispatches to the right type-specific
+command. Scriptable callers use the type-specific commands directly.
+
+`camp flow` is NOT a promotion command. It is the low-level `.workflow.yaml`
+status engine and is hidden from `camp --help`. Its dungeon move
+(`internal/dungeon.Service.MoveToDungeonStatus`) is the primitive that the
+`camp workitem promote` dungeon targets and the deprecated `camp shelve` alias
+build on. Reach for `camp promote`, not `camp flow`.

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -16,6 +16,13 @@ state machine driven by `camp flow` and `.workflow.yaml`, is unrelated.
 | Workflow collection (this doc) | `workflow/<type>/` | User-created collection of workitems of one type, with navigation config |
 | Flow status | `.workflow.yaml` per workitem | Per-workitem lifecycle state machine, owned by `camp flow` |
 
+> `camp flow` is the low-level `.workflow.yaml` status engine. The dungeon move
+> it performs (active -> dungeon/completed|archived|someday) is the primitive that
+> `camp shelve` and `camp workitem promote --target {completed,archived,someday}`
+> build on. It is intentionally hidden from `camp --help`: the user-facing surface
+> for moving work forward is `camp promote` (and `camp intent promote` /
+> `fest promote`), not `camp flow`.
+
 A workflow collection is not:
 
 - a workitem (a single tracked unit of work)

--- a/internal/commands/flow/flow.go
+++ b/internal/commands/flow/flow.go
@@ -17,6 +17,7 @@ func NewFlowCommand() *cobra.Command {
 	flowCmd := &cobra.Command{
 		Use:     "flow",
 		Aliases: []string{"wf"},
+		Hidden:  true,
 		Short:   "Manage status workflows for organizing work",
 		Long: `Manage status workflows for organizing work.
 


### PR DESCRIPTION
## Summary

Demotes `camp flow` from a user-facing command to a hidden internal primitive, per decision D4 of the camp-workitem-promote design. The `camp flow` parent command is marked `Hidden: true` so it no longer appears in `camp --help`, while every subcommand stays registered and reachable by explicit path for power users and repair.

This is now rebased on current `main` after #341, so the docs can correctly point users at the new `camp promote` front door. The README planning surface now advertises promotion instead of flow, and generated CLI-reference churn unrelated to flow demotion was removed from the PR.

## What changed

- `internal/commands/flow/flow.go`: parent flow command marked `Hidden: true`.
- `cmd/camp/manifest.go`: the agent `__manifest` skips hidden commands so demoted/internal commands are not advertised to agents.
- Tests: dev-profile test asserts `flow` is hidden but still registered; manifest test asserts hidden commands are omitted.
- Docs: README and workflow docs describe `camp promote` as the user-facing promotion surface and `camp flow` as the low-level engine.

## Verification

- `go test ./cmd/camp -run 'TestManifestCommand|TestReleaseProfileDev'`
- `go test -tags dev ./cmd/camp -run 'TestManifestCommand|TestReleaseProfileDev_FlowCommandHiddenButRegistered'`
- `just build default-build`
- `just test unit`
- `just lint`

## Design

camp-workitem-promote design (campaign root): `workflow/design/camp-workitem-promote-2026-06-16/` (see `04-shelve-and-camp-flow.md`, decision D4). Issue 3 of festival `camp-workitem-promote-CW0004`.