### PR TITLE
Superseded quest metadata update command

### DIFF
--- a/cmd/camp/quest/update.go
+++ b/cmd/camp/quest/update.go
@@ -1,0 +1,77 @@
+//go:build dev
+
+package quest
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git/commit"
+	questsvc "github.com/Obedience-Corp/camp/internal/quest"
+)
+
+var questUpdateCmd = &cobra.Command{
+	Use:   "update <quest>",
+	Short: "Update quest metadata",
+	Long: `Update quest metadata without opening an editor.
+
+Omitted fields are left unchanged. Provide an empty value to clear a field.
+
+Examples:
+  camp quest update platform-launch --purpose "harden launch path"
+  camp quest update platform-launch --description ""
+  camp quest update platform-launch --purpose "..." --description "..."`,
+	Args: cobra.ExactArgs(1),
+	Annotations: map[string]string{
+		"agent_allowed": "true",
+		"agent_reason":  "Non-interactive quest metadata update",
+	},
+	RunE: runQuestUpdate,
+}
+
+func init() {
+	Cmd.AddCommand(questUpdateCmd)
+	flags := questUpdateCmd.Flags()
+	flags.String("purpose", "", "Short purpose statement")
+	flags.String("description", "", "Full description")
+	flags.Bool("no-commit", false, "Don't create a git commit")
+	questUpdateCmd.ValidArgsFunction = completeQuestSelector
+}
+
+func runQuestUpdate(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	noCommit, _ := cmd.Flags().GetBool("no-commit")
+
+	var opts questsvc.MetadataUpdateOptions
+	if cmd.Flags().Changed("purpose") {
+		purpose, _ := cmd.Flags().GetString("purpose")
+		opts.Purpose = &purpose
+	}
+	if cmd.Flags().Changed("description") {
+		description, _ := cmd.Flags().GetString("description")
+		opts.Description = &description
+	}
+	if opts.Purpose == nil && opts.Description == nil {
+		return camperrors.New("at least one of --purpose or --description is required")
+	}
+
+	qctx, err := loadQuestCommandContext(ctx, false)
+	if err != nil {
+		return err
+	}
+
+	result, err := qctx.service.UpdateMetadata(ctx, args[0], opts)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("✓ Quest updated: %s\n", result.Quest.Name)
+	if !noCommit {
+		if err := autoCommitQuest(ctx, qctx, commit.QuestUpdate, result, "Updated quest metadata"); err != nil {
+			return camperrors.Wrap(err, "quest updated, but auto-commit failed")
+		}
+	}
+	return nil
+}

--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -44,6 +44,7 @@ var manifestAgentAllowedReasons = map[string]string{
 	"quest resume":        "Non-interactive quest resume with explicit selector",
 	"quest show":          "Read-only quest detail",
 	"quest unlink":        "Non-interactive quest unlink operation",
+	"quest update":        "Non-interactive quest metadata update with explicit selector",
 	"registry check":      "Read-only registry integrity report",
 	"root":                "Read-only campaign root output",
 	"settings get":        "Read-only settings output with --json support",

--- a/internal/git/commit/quest.go
+++ b/internal/git/commit/quest.go
@@ -9,6 +9,7 @@ const (
 	QuestCreate   QuestAction = "QuestCreate"
 	QuestRename   QuestAction = "QuestRename"
 	QuestEdit     QuestAction = "QuestEdit"
+	QuestUpdate   QuestAction = "QuestUpdate"
 	QuestPause    QuestAction = "QuestPause"
 	QuestResume   QuestAction = "QuestResume"
 	QuestComplete QuestAction = "QuestComplete"

--- a/internal/quest/service.go
+++ b/internal/quest/service.go
@@ -36,6 +36,11 @@ type ListOptions struct {
 	Dungeon  bool
 }
 
+type MetadataUpdateOptions struct {
+	Purpose     *string
+	Description *string
+}
+
 // EditorFunc opens an editor on the provided path.
 type EditorFunc func(ctx context.Context, path string) error
 
@@ -312,6 +317,39 @@ func (s *Service) Rename(ctx context.Context, identifier, newName string) (*Muta
 	}
 
 	q.Name = newName
+	q.UpdatedAt = time.Now().UTC()
+	if err := Save(ctx, q.Path, q); err != nil {
+		return nil, err
+	}
+
+	return &MutationResult{
+		Quest: q,
+		Files: []string{q.Path},
+	}, nil
+}
+
+func (s *Service) UpdateMetadata(ctx context.Context, identifier string, opts MetadataUpdateOptions) (*MutationResult, error) {
+	if err := s.ensureInitialized(); err != nil {
+		return nil, err
+	}
+	if opts.Purpose == nil && opts.Description == nil {
+		return nil, errors.New("at least one quest metadata field is required")
+	}
+
+	q, err := Resolve(ctx, s.campaignRoot, identifier)
+	if err != nil {
+		return nil, err
+	}
+	if q.IsDefault() {
+		return nil, ErrDefaultQuestReadOnly
+	}
+
+	if opts.Purpose != nil {
+		q.Purpose = strings.TrimSpace(*opts.Purpose)
+	}
+	if opts.Description != nil {
+		q.Description = strings.TrimSpace(*opts.Description)
+	}
 	q.UpdatedAt = time.Now().UTC()
 	if err := Save(ctx, q.Path, q); err != nil {
 		return nil, err

--- a/internal/quest/service_test.go
+++ b/internal/quest/service_test.go
@@ -412,11 +412,69 @@ func TestServiceEditAndList(t *testing.T) {
 	}
 }
 
+func TestServiceUpdateMetadata(t *testing.T) {
+	ctx, _, svc := setupQuestCampaign(t)
+
+	created, err := svc.Create(ctx, "Metadata Quest", "Original purpose", "Original description", []string{"metadata"})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	originalUpdatedAt := created.Quest.UpdatedAt
+
+	purpose := "  Updated purpose  "
+	updated, err := svc.UpdateMetadata(ctx, created.Quest.ID, MetadataUpdateOptions{Purpose: &purpose})
+	if err != nil {
+		t.Fatalf("UpdateMetadata(purpose) error = %v", err)
+	}
+	if updated.Quest.Purpose != "Updated purpose" {
+		t.Fatalf("Purpose = %q, want trimmed update", updated.Quest.Purpose)
+	}
+	if updated.Quest.Description != "Original description" {
+		t.Fatalf("Description = %q, want preserved original", updated.Quest.Description)
+	}
+	if !updated.Quest.UpdatedAt.After(originalUpdatedAt) {
+		t.Fatalf("UpdatedAt = %s, want after %s", updated.Quest.UpdatedAt, originalUpdatedAt)
+	}
+	if len(updated.Files) != 1 || updated.Files[0] != created.Quest.Path {
+		t.Fatalf("Files = %#v, want quest path %q", updated.Files, created.Quest.Path)
+	}
+
+	description := ""
+	cleared, err := svc.UpdateMetadata(ctx, created.Quest.ID, MetadataUpdateOptions{Description: &description})
+	if err != nil {
+		t.Fatalf("UpdateMetadata(description clear) error = %v", err)
+	}
+	if cleared.Quest.Description != "" {
+		t.Fatalf("Description = %q, want cleared", cleared.Quest.Description)
+	}
+	if cleared.Quest.Purpose != "Updated purpose" {
+		t.Fatalf("Purpose = %q, want preserved update", cleared.Quest.Purpose)
+	}
+}
+
+func TestServiceUpdateMetadataRequiresField(t *testing.T) {
+	ctx, _, svc := setupQuestCampaign(t)
+
+	created, err := svc.Create(ctx, "Metadata Quest", "", "", nil)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if _, err := svc.UpdateMetadata(ctx, created.Quest.ID, MetadataUpdateOptions{}); err == nil {
+		t.Fatal("UpdateMetadata() error = nil, want required field error")
+	}
+}
+
 func TestServiceDefaultQuestLifecycleProtected(t *testing.T) {
 	ctx, _, svc := setupQuestCampaign(t)
 
 	if _, err := svc.Pause(ctx, DefaultQuestID); !errors.Is(err, ErrDefaultQuestReadOnly) {
 		t.Fatalf("Pause(default) error = %v, want %v", err, ErrDefaultQuestReadOnly)
+	}
+
+	purpose := "new default purpose"
+	if _, err := svc.UpdateMetadata(ctx, DefaultQuestID, MetadataUpdateOptions{Purpose: &purpose}); !errors.Is(err, ErrDefaultQuestReadOnly) {
+		t.Fatalf("UpdateMetadata(default) error = %v, want %v", err, ErrDefaultQuestReadOnly)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `camp quest update <quest>` for non-interactive purpose/description edits
- Preserve omitted fields and allow explicit empty values to clear metadata
- Keep default quest metadata protected and auto-commit updates by default

## Validation

- `BUILD_TAGS=dev just test unit`
