### PR TITLE
feat(org,list): interactive org browser, org create, and list --sort org

### DIFF
--- a/cmd/camp/list.go
+++ b/cmd/camp/list.go
@@ -45,12 +45,14 @@ Sorting options:
   accessed - Most recently accessed first (default)
   name     - Alphabetically by name
   type     - Alphabetically by type
+  org      - By org (fallback first, then alphabetical), then by name
 
 Examples:
   camp list                  List all campaigns
   camp list --json           Output as JSON
   camp list --format json    Output as JSON
   camp list --sort name      Sort by name
+  camp list --sort org       Sort by org, then name
   camp list --format simple  Names only for scripting
   camp list --count          Print only the total number of campaigns`,
 	Aliases: []string{"ls"},
@@ -69,7 +71,7 @@ func init() {
 	listCmd.Flags().StringP("format", "f", "table", "Output format (table, simple, json)")
 	listCmd.Flags().BoolVar(&listJSON, "json", false, "Output as JSON (shorthand for --format json)")
 	listCmd.Flags().BoolVar(&listCount, "count", false, "Print only the total number of campaigns")
-	listCmd.Flags().StringP("sort", "s", "accessed", "Sort by (name, accessed, type)")
+	listCmd.Flags().StringP("sort", "s", "accessed", "Sort by (name, accessed, type, org)")
 	listCmd.Flags().Bool("verify-verbose", false, "Show detailed verification output")
 	listCmd.Flags().String("org", "", "Only campaigns in this org")
 	listCmd.Flags().StringSlice("tag", nil, "Only campaigns carrying this tag (repeat for AND)")
@@ -125,7 +127,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 
 	sortBy, _ := cmd.Flags().GetString("sort")
-	campaigns := filterEntries(sortCampaigns(reg.Campaigns, sortBy), filter)
+	campaigns := filterEntries(sortCampaigns(reg.Campaigns, sortBy, reg.FallbackOrg()), filter)
 
 	if listCount {
 		if formatStr == "json" {
@@ -158,7 +160,7 @@ func runList(cmd *cobra.Command, args []string) error {
 }
 
 // sortCampaigns converts the registry map to a sorted slice.
-func sortCampaigns(campaigns map[string]config.RegisteredCampaign, by string) []campaignEntry {
+func sortCampaigns(campaigns map[string]config.RegisteredCampaign, by, fallbackOrg string) []campaignEntry {
 	entries := make([]campaignEntry, 0, len(campaigns))
 	for id, c := range campaigns {
 		tags := c.Tags
@@ -189,6 +191,17 @@ func sortCampaigns(campaigns map[string]config.RegisteredCampaign, by string) []
 			}
 			return entries[i].Type < entries[j].Type
 		})
+	case "org":
+		sort.Slice(entries, func(i, j int) bool {
+			oi, oj := entries[i].Org, entries[j].Org
+			if (oi == fallbackOrg) != (oj == fallbackOrg) {
+				return oi == fallbackOrg
+			}
+			if oi != oj {
+				return oi < oj
+			}
+			return entries[i].Name < entries[j].Name
+		})
 	default: // "accessed"
 		sort.Slice(entries, func(i, j int) bool {
 			return entries[i].LastAccess.After(entries[j].LastAccess)
@@ -214,13 +227,13 @@ func outputCampaigns(out io.Writer, campaigns []campaignEntry, format string) er
 		return nil
 	default: // table
 		w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
-			ui.Label("ID"), ui.Label("NAME"), ui.Label("TYPE"), ui.Label("PATH")); err != nil {
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			ui.Label("ID"), ui.Label("NAME"), ui.Label("ORG"), ui.Label("TYPE"), ui.Label("PATH")); err != nil {
 			return err
 		}
 		for _, c := range campaigns {
-			id, name, typ, path := campaignTableCells(c)
-			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", id, name, typ, path); err != nil {
+			id, name, org, typ, path := campaignTableCells(c)
+			if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", id, name, org, typ, path); err != nil {
 				return err
 			}
 		}

--- a/cmd/camp/list_org_test.go
+++ b/cmd/camp/list_org_test.go
@@ -192,11 +192,11 @@ func TestList_GroupedOutput(t *testing.T) {
 		ent("BBBBBBBB2222", "beta", "campaign", "obey", "active"),
 	}
 	out := captureListStdout(t, func() error { return outputGrouped(entries, "table", "default") })
-	const golden = "default\n" +
+	const golden = "default (1 campaign)\n" +
 		"  ID        NAME   TYPE      PATH\n" +
 		"  AAAAAAAA  alpha  campaign  /tmp/alpha\n" +
 		"\n" +
-		"obey\n" +
+		"obey (1 campaign)\n" +
 		"  ID        NAME  TYPE      PATH\n" +
 		"  BBBBBBBB  beta  campaign  /tmp/beta\n" +
 		"\n" +

--- a/cmd/camp/list_org_test.go
+++ b/cmd/camp/list_org_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -96,6 +97,45 @@ func TestShouldGroupAndOrgOrder(t *testing.T) {
 	}
 }
 
+func TestSortCampaigns_ByOrg(t *testing.T) {
+	campaigns := map[string]config.RegisteredCampaign{
+		"A-1": {Name: "alpha", Org: "obey", Status: "active"},
+		"B-2": {Name: "beta", Org: "default", Status: "active"},
+		"C-3": {Name: "gamma", Org: "acme", Status: "active"},
+		"D-4": {Name: "delta", Org: "obey", Status: "active"},
+	}
+	got := names(sortCampaigns(campaigns, "org", "default"))
+	want := []string{"beta", "gamma", "alpha", "delta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("--sort org = %v, want %v (fallback first, then org alphabetical, then name)", got, want)
+	}
+}
+
+func TestSortCampaigns_ByOrg_CustomFallback(t *testing.T) {
+	campaigns := map[string]config.RegisteredCampaign{
+		"A-1": {Name: "alpha", Org: "obey", Status: "active"},
+		"B-2": {Name: "beta", Org: "acme", Status: "active"},
+	}
+	got := names(sortCampaigns(campaigns, "org", "obey"))
+	want := []string{"alpha", "beta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("--sort org (fallback=obey) = %v, want %v (custom fallback sorts first)", got, want)
+	}
+}
+
+func TestSortCampaigns_InvalidSortFallsToAccessed(t *testing.T) {
+	now := time.Now()
+	campaigns := map[string]config.RegisteredCampaign{
+		"A-1": {Name: "old", Org: "default", Status: "active", LastAccess: now.Add(-time.Hour)},
+		"B-2": {Name: "new", Org: "default", Status: "active", LastAccess: now},
+	}
+	got := names(sortCampaigns(campaigns, "bogus", "default"))
+	want := []string{"new", "old"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("--sort bogus = %v, want %v (falls through to accessed: most recent first)", got, want)
+	}
+}
+
 func TestList_JSONShape(t *testing.T) {
 	ui.SetNoColor(true)
 	entries := []campaignEntry{
@@ -135,9 +175,9 @@ func TestList_GoldenSingleOrgActive(t *testing.T) {
 		t.Fatal("single-org entries must not group")
 	}
 	out := captureListStdout(t, func() error { return outputCampaigns(os.Stdout, entries, "table") })
-	const golden = "ID        NAME   TYPE      PATH\n" +
-		"AAAAAAAA  alpha  campaign  /tmp/alpha\n" +
-		"BBBBBBBB  beta   product   /tmp/beta\n" +
+	const golden = "ID        NAME   ORG      TYPE      PATH\n" +
+		"AAAAAAAA  alpha  default  campaign  /tmp/alpha\n" +
+		"BBBBBBBB  beta   default  product   /tmp/beta\n" +
 		"\n" +
 		"2 campaigns\n"
 	if out != golden {

--- a/cmd/camp/list_render.go
+++ b/cmd/camp/list_render.go
@@ -23,7 +23,7 @@ func campaignTableCells(c campaignEntry) (id, name, org, typ, path string) {
 		orgCell = "-"
 	}
 	typeStyle := ui.GetCampaignTypeStyle(c.Type)
-	return ui.Dim(shortID), ui.Value(c.Name), ui.Dim(orgCell), typeStyle.Render(campaignType), ui.Dim(c.Path)
+	return ui.Dim(shortID), ui.Value(c.Name), ui.Accent(orgCell), typeStyle.Render(campaignType), ui.Dim(c.Path)
 }
 
 func outputGrouped(entries []campaignEntry, format, fallbackOrg string) error {
@@ -35,7 +35,7 @@ func outputGrouped(entries []campaignEntry, format, fallbackOrg string) error {
 		if i > 0 {
 			fmt.Println()
 		}
-		fmt.Println(org)
+		fmt.Printf("%s %s\n", ui.Accent(org), ui.Dim(fmt.Sprintf("(%s)", ui.CountLabel(len(byOrg[org]), "campaign", "campaigns"))))
 		if err := writeGroupSection(byOrg[org], format); err != nil {
 			return err
 		}

--- a/cmd/camp/list_render.go
+++ b/cmd/camp/list_render.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/ui"
 )
 
-func campaignTableCells(c campaignEntry) (id, name, typ, path string) {
+func campaignTableCells(c campaignEntry) (id, name, org, typ, path string) {
 	campaignType := c.Type
 	if campaignType == "" {
 		campaignType = "-"
@@ -18,8 +18,12 @@ func campaignTableCells(c campaignEntry) (id, name, typ, path string) {
 	if len(shortID) > 8 {
 		shortID = shortID[:8]
 	}
+	orgCell := c.Org
+	if orgCell == "" {
+		orgCell = "-"
+	}
 	typeStyle := ui.GetCampaignTypeStyle(c.Type)
-	return ui.Dim(shortID), ui.Value(c.Name), typeStyle.Render(campaignType), ui.Dim(c.Path)
+	return ui.Dim(shortID), ui.Value(c.Name), ui.Dim(orgCell), typeStyle.Render(campaignType), ui.Dim(c.Path)
 }
 
 func outputGrouped(entries []campaignEntry, format, fallbackOrg string) error {
@@ -70,7 +74,7 @@ func writeGroupSection(entries []campaignEntry, format string) error {
 		return err
 	}
 	for _, c := range entries {
-		id, name, typ, path := campaignTableCells(c)
+		id, name, _, typ, path := campaignTableCells(c)
 		if _, err := fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n", id, name, typ, path); err != nil {
 			return err
 		}

--- a/cmd/camp/org/create.go
+++ b/cmd/camp/org/create.go
@@ -1,0 +1,75 @@
+package org
+
+import (
+	"context"
+
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/spf13/cobra"
+)
+
+var orgCreateCmd = &cobra.Command{
+	Use:   "create <org> [campaign...]",
+	Short: "Create an org by joining campaigns (the current campaign if none named)",
+	Long: `Create an org by joining campaigns to it.
+
+Run inside a campaign with no campaign arguments to add the current campaign:
+  camp org create obey
+
+Or name the campaigns explicitly:
+  camp org create obey obey-campaign obey-content
+
+Orgs remain derived: "create" assigns membership and never makes an empty org.
+Joining an org that already has members is allowed; there is no "already exists"
+error, and a campaign already in the org is reported as unchanged.`,
+	Example: `  camp org create obey
+  camp org create client-acme acme-site other-site`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: runOrgCreate,
+}
+
+func init() {
+	Cmd.AddCommand(orgCreateCmd)
+	orgCreateCmd.Flags().Bool("json", false, "Output as JSON")
+}
+
+func runOrgCreate(cmd *cobra.Command, args []string) error {
+	org := args[0]
+	if err := validateOrgName(org); err != nil {
+		return err
+	}
+	asJSON, _ := cmd.Flags().GetBool("json")
+
+	campaignArgs := args[1:]
+	if len(campaignArgs) == 0 {
+		id, err := currentCampaignID(cmd.Context())
+		if err != nil {
+			return err
+		}
+		campaignArgs = []string{id}
+	}
+	return reassignOrg(cmd, func(*config.Registry) string { return org }, campaignArgs, asJSON)
+}
+
+func currentCampaignID(ctx context.Context) (string, error) {
+	root, err := campaign.DetectCached(ctx)
+	if err != nil {
+		return "", camperrors.NewValidation("campaign",
+			"not inside a campaign; name a campaign: camp org create <org> <campaign>", err)
+	}
+	cfg, err := config.LoadCampaignConfig(ctx, root)
+	if err != nil {
+		return "", err
+	}
+	reg, err := config.LoadRegistry(ctx)
+	if err != nil {
+		return "", camperrors.Wrap(err, "failed to load registry")
+	}
+	c, ok := reg.GetByID(cfg.ID)
+	if !ok {
+		return "", camperrors.NewValidation("campaign",
+			"current campaign is not registered; name a campaign: camp org create <org> <campaign>", nil)
+	}
+	return c.ID, nil
+}

--- a/cmd/camp/org/create_test.go
+++ b/cmd/camp/org/create_test.go
@@ -1,0 +1,87 @@
+package org
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/campaign"
+)
+
+func TestOrgCreate_WithCampaignArgs(t *testing.T) {
+	setOrgRegistry(t, orgFixture)
+	if _, err := execOrg(t, runOrgCreate, false, "newco", "alpha"); err != nil {
+		t.Fatalf("org create: %v", err)
+	}
+	if got := orgOf(t, "A-1"); got != "newco" {
+		t.Errorf("alpha org = %q, want newco", got)
+	}
+}
+
+func TestOrgCreate_ExistingOrg_Idempotent(t *testing.T) {
+	setOrgRegistry(t, orgFixture)
+	if _, err := execOrg(t, runOrgCreate, false, "obey", "alpha"); err != nil {
+		t.Fatalf("org create into existing org: %v", err)
+	}
+	if got := orgOf(t, "A-1"); got != "obey" {
+		t.Errorf("alpha org = %q, want obey", got)
+	}
+}
+
+func TestOrgCreate_AlreadyMember_NoOp(t *testing.T) {
+	setOrgRegistry(t, orgFixture)
+	out, err := execOrg(t, runOrgCreate, false, "obey", "beta")
+	if err != nil {
+		t.Fatalf("org create: %v", err)
+	}
+	if !strings.Contains(out, "no changes") {
+		t.Errorf("expected no-op message, got: %s", out)
+	}
+}
+
+func TestOrgCreate_InvalidOrgName_NoWrite(t *testing.T) {
+	path := setOrgRegistry(t, orgFixture)
+	before, _ := os.ReadFile(path)
+	if _, err := execOrg(t, runOrgCreate, false, "Bad Org", "alpha"); err == nil {
+		t.Fatal("expected error for invalid org name")
+	}
+	after, _ := os.ReadFile(path)
+	if !bytes.Equal(before, after) {
+		t.Error("registry modified after invalid org name")
+	}
+}
+
+func TestOrgCreate_CurrentCampaign_NoArgs(t *testing.T) {
+	root := makeOrgTestCampaign(t, "A-1")
+	t.Chdir(root)
+	t.Setenv(campaign.EnvCacheDisable, "1")
+	setOrgRegistry(t, orgFixture)
+
+	if _, err := execOrg(t, runOrgCreate, false, "obey"); err != nil {
+		t.Fatalf("org create (current campaign): %v", err)
+	}
+	if got := orgOf(t, "A-1"); got != "obey" {
+		t.Errorf("current campaign org = %q, want obey", got)
+	}
+}
+
+func TestOrgCreate_NotInCampaign_Errors(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv(campaign.EnvCacheDisable, "1")
+	setOrgRegistry(t, orgFixture)
+	if _, err := execOrg(t, runOrgCreate, false, "obey"); err == nil {
+		t.Error("expected error: no campaign args outside a campaign")
+	}
+}
+
+func TestOrgCreate_UnregisteredCurrent_Errors(t *testing.T) {
+	root := makeOrgTestCampaign(t, "ZZZ-unregistered")
+	t.Chdir(root)
+	t.Setenv(campaign.EnvCacheDisable, "1")
+	setOrgRegistry(t, orgFixture)
+	if _, err := execOrg(t, runOrgCreate, false, "obey"); err == nil {
+		t.Error("expected error: current campaign not registered")
+	}
+}

--- a/cmd/camp/org/org_test.go
+++ b/cmd/camp/org/org_test.go
@@ -306,7 +306,47 @@ func TestOrgShow_MembersAndUnknown(t *testing.T) {
 	}
 }
 
+func forceNoTTY(t *testing.T) {
+	t.Helper()
+	prev := stdoutIsTTY
+	stdoutIsTTY = func() bool { return false }
+	t.Cleanup(func() { stdoutIsTTY = prev })
+}
+
+func TestShouldOpenOrgTUI(t *testing.T) {
+	cases := []struct {
+		json, interactive, tty, want bool
+	}{
+		{false, false, true, true},   // bare in a terminal opens the TUI
+		{false, false, false, false}, // bare piped prints the org
+		{false, true, false, true},   // -i forces the TUI even when piped
+		{true, false, true, false},   // --json never opens the TUI
+		{true, true, true, false},    // --json wins over -i
+	}
+	for _, c := range cases {
+		if got := shouldOpenOrgTUI(c.json, c.interactive, c.tty); got != c.want {
+			t.Errorf("shouldOpenOrgTUI(json=%v, i=%v, tty=%v) = %v, want %v", c.json, c.interactive, c.tty, got, c.want)
+		}
+	}
+}
+
+func TestOrgWhich_PrintsCurrentOrg(t *testing.T) {
+	root := makeOrgTestCampaign(t, "B-2")
+	t.Chdir(root)
+	t.Setenv(campaign.EnvCacheDisable, "1")
+	setOrgRegistry(t, orgFixture)
+
+	out, err := execOrg(t, runOrgWhich, false)
+	if err != nil {
+		t.Fatalf("org which: %v", err)
+	}
+	if strings.TrimSpace(out) != "obey" {
+		t.Errorf("org which = %q, want obey", strings.TrimSpace(out))
+	}
+}
+
 func TestOrgBare_PrintsCurrentOrg(t *testing.T) {
+	forceNoTTY(t)
 	root := makeOrgTestCampaign(t, "B-2")
 	t.Chdir(root)
 	t.Setenv(campaign.EnvCacheDisable, "1")

--- a/cmd/camp/org/root.go
+++ b/cmd/camp/org/root.go
@@ -12,15 +12,18 @@ Every campaign belongs to exactly one org (default "default"). Orgs are derived:
 an org exists because a campaign names it, and disappears when its last member
 leaves.
 
-Run 'camp org -i' to browse orgs and their members interactively and move,
-rename, or return campaigns without leaving the screen.
+In a terminal, 'camp org' (no arguments) opens an interactive browser of orgs
+and their members where you can move, create, rename, and return campaigns. When
+piped or with --json it prints the current campaign's org instead; use
+'camp org which' to print the org unconditionally.
 
 Commands:
+  which   Print the current campaign's org
   create  Create an org by joining campaigns (the current campaign if none named)
   add     Assign campaigns to an org (also reassigns; single-membership)
   remove  Return campaigns to the default org`,
-	Example: `  camp org                                       Print the current campaign's org
-  camp org -i                                    Browse and manage orgs interactively
+	Example: `  camp org                                       Browse and manage orgs interactively (TTY)
+  camp org which                                 Print the current campaign's org
   camp org create obey                           Add the current campaign to "obey"
   camp org add obey obey-campaign obey-content   Move campaigns into "obey"
   camp org remove obey-content                   Return a campaign to "default"`,

--- a/cmd/camp/org/root.go
+++ b/cmd/camp/org/root.go
@@ -10,12 +10,18 @@ var Cmd = &cobra.Command{
 
 Every campaign belongs to exactly one org (default "default"). Orgs are derived:
 an org exists because a campaign names it, and disappears when its last member
-leaves. There is no "org create".
+leaves.
+
+Run 'camp org -i' to browse orgs and their members interactively and move,
+rename, or return campaigns without leaving the screen.
 
 Commands:
+  create  Create an org by joining campaigns (the current campaign if none named)
   add     Assign campaigns to an org (also reassigns; single-membership)
   remove  Return campaigns to the default org`,
 	Example: `  camp org                                       Print the current campaign's org
+  camp org -i                                    Browse and manage orgs interactively
+  camp org create obey                           Add the current campaign to "obey"
   camp org add obey obey-campaign obey-content   Move campaigns into "obey"
   camp org remove obey-content                   Return a campaign to "default"`,
 	Args: cobra.NoArgs,

--- a/cmd/camp/org/tui.go
+++ b/cmd/camp/org/tui.go
@@ -1,0 +1,191 @@
+package org
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"golang.org/x/term"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/spf13/cobra"
+)
+
+// orgTUIMinWide is the terminal width below which the two panes stack into a
+// single focused pane instead of rendering side by side.
+const orgTUIMinWide = 72
+
+type orgPane int
+
+const (
+	paneOrgs orgPane = iota
+	paneMembers
+)
+
+type orgOverlay int
+
+const (
+	overlayNone orgOverlay = iota
+	overlayMove
+	overlayRename
+)
+
+type orgTUIModel struct {
+	ctx context.Context
+
+	reg       *config.Registry
+	fallback  string
+	currentID string
+
+	orgs       []orgCount
+	members    []orgMember
+	focusedOrg string
+
+	pane      orgPane
+	orgCursor int
+	memCursor int
+
+	overlay orgOverlay
+	input   textinput.Model
+
+	status    string
+	statusErr bool
+
+	width    int
+	height   int
+	quitting bool
+}
+
+func newOrgTUIModel(ctx context.Context, reg *config.Registry) orgTUIModel {
+	ti := textinput.New()
+	ti.Prompt = "> "
+
+	m := orgTUIModel{ctx: ctx, input: ti}
+	if id, err := currentCampaignID(ctx); err == nil {
+		m.currentID = id
+	}
+	m.loadFromRegistry(reg)
+	return m
+}
+
+func (m *orgTUIModel) loadFromRegistry(reg *config.Registry) {
+	m.reg = reg
+	m.fallback = reg.FallbackOrg()
+	m.orgs = computeOrgCounts(reg)
+	m.orgCursor = clamp(m.orgCursor, 0, lastIndex(len(m.orgs)))
+	m.syncFocusedOrg()
+}
+
+func (m *orgTUIModel) syncFocusedOrg() {
+	if len(m.orgs) == 0 {
+		m.focusedOrg = ""
+		m.members = nil
+		m.memCursor = 0
+		return
+	}
+	m.focusedOrg = m.orgs[m.orgCursor].Org
+	m.members = buildOrgShow(m.reg, m.focusedOrg).Members
+	m.memCursor = clamp(m.memCursor, 0, lastIndex(len(m.members)))
+}
+
+func (m *orgTUIModel) reload() error {
+	reg, err := config.LoadRegistry(m.ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "failed to reload registry")
+	}
+	m.loadFromRegistry(reg)
+	return nil
+}
+
+func (m orgTUIModel) Init() tea.Cmd { return textinput.Blink }
+
+// runOrgTUI launches the interactive org browser. When stdout is not a terminal
+// it degrades to the flat `camp org list` output rather than erroring.
+func runOrgTUI(cmd *cobra.Command) error {
+	ctx := cmd.Context()
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		return runOrgList(cmd, nil)
+	}
+	reg, err := config.LoadRegistry(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "failed to load registry")
+	}
+	prog := tea.NewProgram(newOrgTUIModel(ctx, reg), tea.WithContext(ctx), tea.WithAltScreen())
+	if _, err := prog.Run(); err != nil {
+		return camperrors.Wrap(err, "running org browser")
+	}
+	return nil
+}
+
+func (m *orgTUIModel) setStatus(s string) {
+	m.status = s
+	m.statusErr = false
+}
+
+func (m *orgTUIModel) setError(err error) {
+	m.status = err.Error()
+	m.statusErr = true
+}
+
+// assignOrg moves a single campaign into targetOrg through the shared atomic
+// registry write path, then reloads the model from disk.
+func (m *orgTUIModel) assignOrg(campaignID, targetOrg string) error {
+	if err := validateOrgName(targetOrg); err != nil {
+		return err
+	}
+	err := config.UpdateRegistry(m.ctx, func(reg *config.Registry) error {
+		entry, ok := reg.Campaigns[campaignID]
+		if !ok {
+			return camperrors.NewNotFound("campaign", campaignID, nil)
+		}
+		entry.Org = targetOrg
+		reg.Campaigns[campaignID] = entry
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return m.reload()
+}
+
+func (m *orgTUIModel) renameOrg(oldOrg, newOrg string) error {
+	if err := validateOrgName(newOrg); err != nil {
+		return err
+	}
+	err := config.UpdateRegistry(m.ctx, func(reg *config.Registry) error {
+		_, rerr := renameOrgInRegistry(reg, oldOrg, newOrg)
+		return rerr
+	})
+	if err != nil {
+		return err
+	}
+	return m.reload()
+}
+
+func (m orgTUIModel) orgNamesCSV() string {
+	names := make([]string, 0, len(m.orgs))
+	for _, o := range m.orgs {
+		names = append(names, o.Org)
+	}
+	return strings.Join(names, ", ")
+}
+
+func clamp(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+func lastIndex(n int) int {
+	if n <= 0 {
+		return 0
+	}
+	return n - 1
+}

--- a/cmd/camp/org/tui.go
+++ b/cmd/camp/org/tui.go
@@ -31,6 +31,7 @@ const (
 	overlayNone orgOverlay = iota
 	overlayMove
 	overlayRename
+	overlayCreate
 )
 
 type orgTUIModel struct {
@@ -163,6 +164,15 @@ func (m *orgTUIModel) renameOrg(oldOrg, newOrg string) error {
 		return err
 	}
 	return m.reload()
+}
+
+func (m orgTUIModel) orgExists(name string) bool {
+	for _, o := range m.orgs {
+		if o.Org == name {
+			return true
+		}
+	}
+	return false
 }
 
 func (m orgTUIModel) orgNamesCSV() string {

--- a/cmd/camp/org/tui_test.go
+++ b/cmd/camp/org/tui_test.go
@@ -100,6 +100,32 @@ func TestOrgTUI_MoveToTypedNewOrg_Appears(t *testing.T) {
 	}
 }
 
+func TestOrgTUI_CreateOrg(t *testing.T) {
+	m := newTestOrgModel(t)
+	m = key(m, "enter") // default -> members (alpha)
+	m = key(m, "c")
+	if m.overlay != overlayCreate {
+		t.Fatal("expected create overlay")
+	}
+	m = key(m, "fresh")
+	m = key(m, "enter")
+	if m.statusErr {
+		t.Fatalf("unexpected error: %s", m.status)
+	}
+	if got := orgOf(t, "A-1"); got != "fresh" {
+		t.Errorf("alpha org = %q, want fresh", got)
+	}
+	found := false
+	for _, o := range m.orgs {
+		if o.Org == "fresh" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("new org 'fresh' not present after create: %v", m.orgs)
+	}
+}
+
 func TestOrgTUI_ReturnToDefault(t *testing.T) {
 	m := newTestOrgModel(t)
 	m = key(m, "j")     // obey

--- a/cmd/camp/org/tui_test.go
+++ b/cmd/camp/org/tui_test.go
@@ -1,0 +1,171 @@
+package org
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+)
+
+func newTestOrgModel(t *testing.T) orgTUIModel {
+	t.Helper()
+	setOrgRegistry(t, orgFixture)
+	reg, err := config.LoadRegistry(context.Background())
+	if err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	return newOrgTUIModel(context.Background(), reg)
+}
+
+func key(m orgTUIModel, s string) orgTUIModel {
+	var msg tea.KeyMsg
+	switch s {
+	case "enter":
+		msg = tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		msg = tea.KeyMsg{Type: tea.KeyEsc}
+	default:
+		msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+	next, _ := m.Update(msg)
+	return next.(orgTUIModel)
+}
+
+func TestOrgTUI_OpensFallbackFirst(t *testing.T) {
+	m := newTestOrgModel(t)
+	if len(m.orgs) == 0 || m.orgs[0].Org != "default" {
+		t.Fatalf("orgs = %v, want default first", m.orgs)
+	}
+	if m.focusedOrg != "default" {
+		t.Errorf("focusedOrg = %q, want default", m.focusedOrg)
+	}
+	if len(m.members) != 1 || m.members[0].Name != "alpha" {
+		t.Errorf("default members = %v, want [alpha]", m.members)
+	}
+}
+
+func TestOrgTUI_NavigateAndEnter(t *testing.T) {
+	m := newTestOrgModel(t)
+	m = key(m, "j")
+	if m.focusedOrg != "obey" {
+		t.Fatalf("after j, focusedOrg = %q, want obey", m.focusedOrg)
+	}
+	m = key(m, "enter")
+	if m.pane != paneMembers {
+		t.Error("enter should focus the member pane")
+	}
+	m = key(m, "esc")
+	if m.pane != paneOrgs {
+		t.Error("esc should return to the org pane")
+	}
+}
+
+func TestOrgTUI_MoveMember(t *testing.T) {
+	m := newTestOrgModel(t)
+	m = key(m, "enter") // default -> members (alpha)
+	m = key(m, "m")
+	if m.overlay != overlayMove {
+		t.Fatal("expected move overlay")
+	}
+	m = key(m, "newco")
+	m = key(m, "enter")
+	if m.overlay != overlayNone {
+		t.Error("overlay should close after commit")
+	}
+	if m.statusErr {
+		t.Fatalf("unexpected error: %s", m.status)
+	}
+	if got := orgOf(t, "A-1"); got != "newco" {
+		t.Errorf("alpha org = %q, want newco", got)
+	}
+}
+
+func TestOrgTUI_MoveToTypedNewOrg_Appears(t *testing.T) {
+	m := newTestOrgModel(t)
+	m = key(m, "enter")
+	m = key(m, "m")
+	m = key(m, "fresh")
+	m = key(m, "enter")
+	found := false
+	for _, o := range m.orgs {
+		if o.Org == "fresh" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("new org 'fresh' not present after move: %v", m.orgs)
+	}
+}
+
+func TestOrgTUI_ReturnToDefault(t *testing.T) {
+	m := newTestOrgModel(t)
+	m = key(m, "j")     // obey
+	m = key(m, "enter") // members: beta, gamma
+	m = key(m, "d")     // return beta to default
+	if m.statusErr {
+		t.Fatalf("unexpected error: %s", m.status)
+	}
+	if got := orgOf(t, "B-2"); got != "default" {
+		t.Errorf("beta org = %q, want default", got)
+	}
+}
+
+func TestOrgTUI_RenameOrg(t *testing.T) {
+	m := newTestOrgModel(t)
+	m = key(m, "j") // obey
+	m = key(m, "r")
+	if m.overlay != overlayRename {
+		t.Fatal("expected rename overlay")
+	}
+	m = key(m, "obedience")
+	m = key(m, "enter")
+	if m.statusErr {
+		t.Fatalf("unexpected error: %s", m.status)
+	}
+	if got := orgOf(t, "B-2"); got != "obedience" {
+		t.Errorf("beta org = %q, want obedience", got)
+	}
+}
+
+func TestOrgTUI_RenameError_SurfacedNoMutation(t *testing.T) {
+	m := newTestOrgModel(t)
+	m = key(m, "j") // obey
+	m = key(m, "r")
+	m = key(m, "obey") // renaming to the same name is rejected
+	m = key(m, "enter")
+	if !m.statusErr {
+		t.Errorf("expected error status surfaced, got status=%q", m.status)
+	}
+	if got := orgOf(t, "B-2"); got != "obey" {
+		t.Errorf("beta org = %q, want obey (unchanged after error)", got)
+	}
+}
+
+func TestOrgTUI_Quit(t *testing.T) {
+	m := newTestOrgModel(t)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if !next.(orgTUIModel).quitting {
+		t.Error("q should set quitting")
+	}
+	if cmd == nil {
+		t.Error("q should return a quit command")
+	}
+}
+
+func TestOrgTUI_ViewSmoke(t *testing.T) {
+	m := newTestOrgModel(t)
+	m.width = 100
+	out := m.View()
+	for _, want := range []string{"Orgs", "default", "obey", "rename"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("view missing %q:\n%s", want, out)
+		}
+	}
+	m.width = 40 // below the single-pane floor must still render
+	if m.View() == "" {
+		t.Error("narrow view should not be empty")
+	}
+}

--- a/cmd/camp/org/tui_update.go
+++ b/cmd/camp/org/tui_update.go
@@ -61,6 +61,11 @@ func (m orgTUIModel) updateBrowse(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.openOverlay(overlayMove, "target org")
 		}
 		return m, nil
+	case "c":
+		if m.pane == paneMembers && len(m.members) > 0 {
+			m.openOverlay(overlayCreate, "new org name")
+		}
+		return m, nil
 	case "d":
 		if m.pane == paneMembers && len(m.members) > 0 {
 			member := m.members[m.memCursor]
@@ -150,6 +155,16 @@ func (m orgTUIModel) commitOverlay() (tea.Model, tea.Cmd) {
 			m.setError(err)
 		} else {
 			m.setStatus(fmt.Sprintf("moved %q to org %q", member.Name, value))
+		}
+	case overlayCreate:
+		member := m.members[m.memCursor]
+		existed := m.orgExists(value)
+		if err := m.assignOrg(member.ID, value); err != nil {
+			m.setError(err)
+		} else if existed {
+			m.setStatus(fmt.Sprintf("added %q to existing org %q", member.Name, value))
+		} else {
+			m.setStatus(fmt.Sprintf("created org %q with %q", value, member.Name))
 		}
 	}
 	m.overlay = overlayNone

--- a/cmd/camp/org/tui_update.go
+++ b/cmd/camp/org/tui_update.go
@@ -69,9 +69,6 @@ func (m orgTUIModel) updateBrowse(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "d":
 		if m.pane == paneMembers && len(m.members) > 0 {
 			member := m.members[m.memCursor]
-			if member.Status == "" || m.fallback == "" {
-				return m, nil
-			}
 			if err := m.assignOrg(member.ID, m.fallback); err != nil {
 				m.setError(err)
 			} else {

--- a/cmd/camp/org/tui_update.go
+++ b/cmd/camp/org/tui_update.go
@@ -1,0 +1,158 @@
+package org
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func (m orgTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		if m.overlay != overlayNone {
+			return m.updateOverlay(msg)
+		}
+		return m.updateBrowse(msg)
+	}
+	return m, nil
+}
+
+func (m orgTUIModel) updateBrowse(key tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.status = ""
+	switch key.String() {
+	case "ctrl+c", "q":
+		m.quitting = true
+		return m, tea.Quit
+	case "esc":
+		if m.pane == paneMembers {
+			m.pane = paneOrgs
+			return m, nil
+		}
+		m.quitting = true
+		return m, tea.Quit
+	case "down", "j":
+		m.moveDown()
+		return m, nil
+	case "up", "k":
+		m.moveUp()
+		return m, nil
+	case "right", "l", "enter":
+		if m.pane == paneOrgs && len(m.members) > 0 {
+			m.pane = paneMembers
+			m.memCursor = 0
+		}
+		return m, nil
+	case "left", "h", "backspace":
+		if m.pane == paneMembers {
+			m.pane = paneOrgs
+		}
+		return m, nil
+	case "r":
+		if m.pane == paneOrgs && len(m.orgs) > 0 {
+			m.openOverlay(overlayRename, "new org name")
+		}
+		return m, nil
+	case "m":
+		if m.pane == paneMembers && len(m.members) > 0 {
+			m.openOverlay(overlayMove, "target org")
+		}
+		return m, nil
+	case "d":
+		if m.pane == paneMembers && len(m.members) > 0 {
+			member := m.members[m.memCursor]
+			if member.Status == "" || m.fallback == "" {
+				return m, nil
+			}
+			if err := m.assignOrg(member.ID, m.fallback); err != nil {
+				m.setError(err)
+			} else {
+				m.setStatus(fmt.Sprintf("returned %q to org %q", member.Name, m.fallback))
+			}
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m *orgTUIModel) moveDown() {
+	if m.pane == paneOrgs {
+		if len(m.orgs) == 0 {
+			return
+		}
+		m.orgCursor = (m.orgCursor + 1) % len(m.orgs)
+		m.memCursor = 0
+		m.syncFocusedOrg()
+		return
+	}
+	if len(m.members) == 0 {
+		return
+	}
+	m.memCursor = (m.memCursor + 1) % len(m.members)
+}
+
+func (m *orgTUIModel) moveUp() {
+	if m.pane == paneOrgs {
+		if len(m.orgs) == 0 {
+			return
+		}
+		m.orgCursor = (m.orgCursor - 1 + len(m.orgs)) % len(m.orgs)
+		m.memCursor = 0
+		m.syncFocusedOrg()
+		return
+	}
+	if len(m.members) == 0 {
+		return
+	}
+	m.memCursor = (m.memCursor - 1 + len(m.members)) % len(m.members)
+}
+
+func (m *orgTUIModel) openOverlay(kind orgOverlay, placeholder string) {
+	m.overlay = kind
+	m.input.SetValue("")
+	m.input.Placeholder = placeholder
+	m.input.Focus()
+}
+
+func (m orgTUIModel) updateOverlay(key tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch key.String() {
+	case "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "esc":
+		m.overlay = overlayNone
+		m.input.Blur()
+		return m, nil
+	case "enter":
+		return m.commitOverlay()
+	}
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(key)
+	return m, cmd
+}
+
+func (m orgTUIModel) commitOverlay() (tea.Model, tea.Cmd) {
+	value := strings.TrimSpace(m.input.Value())
+	switch m.overlay {
+	case overlayRename:
+		old := m.orgs[m.orgCursor].Org
+		if err := m.renameOrg(old, value); err != nil {
+			m.setError(err)
+		} else {
+			m.setStatus(fmt.Sprintf("renamed org %q to %q", old, value))
+		}
+	case overlayMove:
+		member := m.members[m.memCursor]
+		if err := m.assignOrg(member.ID, value); err != nil {
+			m.setError(err)
+		} else {
+			m.setStatus(fmt.Sprintf("moved %q to org %q", member.Name, value))
+		}
+	}
+	m.overlay = overlayNone
+	m.input.Blur()
+	return m, nil
+}

--- a/cmd/camp/org/tui_view.go
+++ b/cmd/camp/org/tui_view.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/Obedience-Corp/camp/internal/config"
 	tuistyles "github.com/Obedience-Corp/camp/internal/intent/tui"
+	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/Obedience-Corp/camp/internal/ui/theme"
 )
 
@@ -22,8 +24,28 @@ var (
 	orgSelStyle    = lipgloss.NewStyle().Foreground(orgPal.Accent).Bold(true)
 	orgRowStyle    = lipgloss.NewStyle().Foreground(orgPal.TextPrimary)
 	orgMutedStyle  = lipgloss.NewStyle().Foreground(orgPal.TextMuted)
-	orgHereStyle   = lipgloss.NewStyle().Foreground(orgPal.Success)
+	orgHereStyle   = lipgloss.NewStyle().Foreground(orgPal.Success).Bold(true)
+	orgCountStyle  = lipgloss.NewStyle().Foreground(orgPal.TextSecondary)
+	orgActiveStyle = lipgloss.NewStyle().Foreground(orgPal.Success)
+	orgBadgeActive = lipgloss.NewStyle().Foreground(orgPal.Success)
+	orgBadgeOff    = lipgloss.NewStyle().Foreground(orgPal.Warning)
+	orgBadgeRef    = lipgloss.NewStyle().Foreground(orgPal.AccentAlt)
+	orgHeaderBar   = lipgloss.NewStyle().Foreground(orgPal.TextMuted)
 )
+
+// styleMemberStatus renders a campaign lifecycle status as a colored badge.
+func styleMemberStatus(status string) string {
+	switch status {
+	case config.StatusActive:
+		return orgBadgeActive.Render(status)
+	case config.StatusInactive:
+		return orgBadgeOff.Render(status)
+	case config.StatusReference:
+		return orgBadgeRef.Render(status)
+	default:
+		return orgMutedStyle.Render(status)
+	}
+}
 
 func (m orgTUIModel) View() string {
 	if m.quitting {
@@ -49,7 +71,22 @@ func (m orgTUIModel) View() string {
 		body = lipgloss.JoinHorizontal(lipgloss.Top, m.renderOrgPane(), "  ", m.renderMemberPane())
 	}
 
-	return body + "\n" + m.statusLine() + m.footer() + "\n"
+	return m.topBar() + "\n" + body + "\n" + m.statusLine() + m.footer() + "\n"
+}
+
+func (m orgTUIModel) topBar() string {
+	return orgTitleStyle.Render("Campaign Orgs") + "  " +
+		orgHeaderBar.Render(fmt.Sprintf("%s . %s",
+			ui.CountLabel(len(m.orgs), "org", "orgs"),
+			ui.CountLabel(m.totalCampaigns(), "campaign", "campaigns")))
+}
+
+func (m orgTUIModel) totalCampaigns() int {
+	n := 0
+	for _, o := range m.orgs {
+		n += o.Campaigns
+	}
+	return n
 }
 
 func (m orgTUIModel) renderOrgPane() string {
@@ -57,18 +94,20 @@ func (m orgTUIModel) renderOrgPane() string {
 	b.WriteString(orgTitleStyle.Render("Orgs") + "\n")
 	for i, o := range m.orgs {
 		cursor := "  "
-		label := fmt.Sprintf("%-16s %d (%d active)", o.Org, o.Campaigns, o.Active)
+		name := fmt.Sprintf("%-16s", o.Org)
 		switch {
 		case i == m.orgCursor && m.pane == paneOrgs:
 			cursor = "> "
-			label = orgSelStyle.Render(label)
+			name = orgSelStyle.Render(name)
 		case i == m.orgCursor:
 			cursor = "> "
-			label = orgRowStyle.Render(label)
+			name = orgRowStyle.Render(name)
 		default:
-			label = orgMutedStyle.Render(label)
+			name = orgMutedStyle.Render(name)
 		}
-		b.WriteString(cursor + label + "\n")
+		counts := orgCountStyle.Render(fmt.Sprintf("%d", o.Campaigns)) + " " +
+			orgActiveStyle.Render(fmt.Sprintf("(%d active)", o.Active))
+		b.WriteString(cursor + name + "  " + counts + "\n")
 	}
 	return m.paneStyle(paneOrgs).Render(strings.TrimRight(b.String(), "\n"))
 }
@@ -89,18 +128,18 @@ func (m orgTUIModel) renderMemberPane() string {
 		if mem.ID == m.currentID && m.currentID != "" {
 			here = orgHereStyle.Render("* ")
 		}
-		label := fmt.Sprintf("%-24s %s", mem.Name, mem.Status)
+		name := fmt.Sprintf("%-24s", mem.Name)
 		switch {
 		case i == m.memCursor && m.pane == paneMembers:
 			cursor = "> "
-			label = orgSelStyle.Render(label)
+			name = orgSelStyle.Render(name)
 		case i == m.memCursor:
 			cursor = "> "
-			label = orgRowStyle.Render(label)
+			name = orgRowStyle.Render(name)
 		default:
-			label = orgMutedStyle.Render(label)
+			name = orgMutedStyle.Render(name)
 		}
-		b.WriteString(cursor + here + label + "\n")
+		b.WriteString(cursor + here + name + " " + styleMemberStatus(mem.Status) + "\n")
 	}
 	return m.paneStyle(paneMembers).Render(strings.TrimRight(b.String(), "\n"))
 }
@@ -116,7 +155,7 @@ func (m orgTUIModel) footer() string {
 	if m.pane == paneOrgs {
 		return orgHelpStyle.Render("j/k: orgs . l: members . r: rename . q: quit")
 	}
-	return orgHelpStyle.Render("j/k: members . h: orgs . m: move . d: default . esc: back . q: quit")
+	return orgHelpStyle.Render("j/k: members . h: orgs . m: move . c: create . d: default . q: quit")
 }
 
 func (m orgTUIModel) statusLine() string {
@@ -136,6 +175,8 @@ func (m orgTUIModel) overlayView() string {
 		prompt = fmt.Sprintf("Rename org %q to:", m.orgs[m.orgCursor].Org)
 	case overlayMove:
 		prompt = fmt.Sprintf("Move %q to org:", m.members[m.memCursor].Name)
+	case overlayCreate:
+		prompt = fmt.Sprintf("Create org and add %q:", m.members[m.memCursor].Name)
 	}
 	box := orgTitleStyle.Render(prompt) + "\n\n" +
 		m.input.View() + "\n\n" +

--- a/cmd/camp/org/tui_view.go
+++ b/cmd/camp/org/tui_view.go
@@ -1,0 +1,145 @@
+package org
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	tuistyles "github.com/Obedience-Corp/camp/internal/intent/tui"
+	"github.com/Obedience-Corp/camp/internal/ui/theme"
+)
+
+var orgPal = theme.TUI()
+
+var (
+	orgTitleStyle  = tuistyles.TitleStyle
+	orgHelpStyle   = tuistyles.HelpStyle
+	orgErrStyle    = tuistyles.ErrorStyle
+	orgOkStyle     = tuistyles.SuccessStyle
+	orgPaneFocused = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(orgPal.BorderFocus).Padding(0, 1)
+	orgPaneBlurred = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(orgPal.Border).Padding(0, 1)
+	orgSelStyle    = lipgloss.NewStyle().Foreground(orgPal.Accent).Bold(true)
+	orgRowStyle    = lipgloss.NewStyle().Foreground(orgPal.TextPrimary)
+	orgMutedStyle  = lipgloss.NewStyle().Foreground(orgPal.TextMuted)
+	orgHereStyle   = lipgloss.NewStyle().Foreground(orgPal.Success)
+)
+
+func (m orgTUIModel) View() string {
+	if m.quitting {
+		return ""
+	}
+	if len(m.orgs) == 0 {
+		return orgTitleStyle.Render("Orgs") + "\n\n" +
+			orgMutedStyle.Render("No campaigns registered yet. Run camp init or camp register.") + "\n\n" +
+			orgHelpStyle.Render("q: quit") + "\n"
+	}
+	if m.overlay != overlayNone {
+		return m.overlayView()
+	}
+
+	var body string
+	if m.width > 0 && m.width < orgTUIMinWide {
+		if m.pane == paneMembers {
+			body = m.renderMemberPane()
+		} else {
+			body = m.renderOrgPane()
+		}
+	} else {
+		body = lipgloss.JoinHorizontal(lipgloss.Top, m.renderOrgPane(), "  ", m.renderMemberPane())
+	}
+
+	return body + "\n" + m.statusLine() + m.footer() + "\n"
+}
+
+func (m orgTUIModel) renderOrgPane() string {
+	var b strings.Builder
+	b.WriteString(orgTitleStyle.Render("Orgs") + "\n")
+	for i, o := range m.orgs {
+		cursor := "  "
+		label := fmt.Sprintf("%-16s %d (%d active)", o.Org, o.Campaigns, o.Active)
+		switch {
+		case i == m.orgCursor && m.pane == paneOrgs:
+			cursor = "> "
+			label = orgSelStyle.Render(label)
+		case i == m.orgCursor:
+			cursor = "> "
+			label = orgRowStyle.Render(label)
+		default:
+			label = orgMutedStyle.Render(label)
+		}
+		b.WriteString(cursor + label + "\n")
+	}
+	return m.paneStyle(paneOrgs).Render(strings.TrimRight(b.String(), "\n"))
+}
+
+func (m orgTUIModel) renderMemberPane() string {
+	var b strings.Builder
+	title := "Members"
+	if m.focusedOrg != "" {
+		title = fmt.Sprintf("Members of %q", m.focusedOrg)
+	}
+	b.WriteString(orgTitleStyle.Render(title) + "\n")
+	if len(m.members) == 0 {
+		b.WriteString(orgMutedStyle.Render("no campaigns in this org") + "\n")
+	}
+	for i, mem := range m.members {
+		cursor := "  "
+		here := "  "
+		if mem.ID == m.currentID && m.currentID != "" {
+			here = orgHereStyle.Render("* ")
+		}
+		label := fmt.Sprintf("%-24s %s", mem.Name, mem.Status)
+		switch {
+		case i == m.memCursor && m.pane == paneMembers:
+			cursor = "> "
+			label = orgSelStyle.Render(label)
+		case i == m.memCursor:
+			cursor = "> "
+			label = orgRowStyle.Render(label)
+		default:
+			label = orgMutedStyle.Render(label)
+		}
+		b.WriteString(cursor + here + label + "\n")
+	}
+	return m.paneStyle(paneMembers).Render(strings.TrimRight(b.String(), "\n"))
+}
+
+func (m orgTUIModel) paneStyle(p orgPane) lipgloss.Style {
+	if m.pane == p {
+		return orgPaneFocused
+	}
+	return orgPaneBlurred
+}
+
+func (m orgTUIModel) footer() string {
+	if m.pane == paneOrgs {
+		return orgHelpStyle.Render("j/k: orgs . l: members . r: rename . q: quit")
+	}
+	return orgHelpStyle.Render("j/k: members . h: orgs . m: move . d: default . esc: back . q: quit")
+}
+
+func (m orgTUIModel) statusLine() string {
+	if m.status == "" {
+		return ""
+	}
+	if m.statusErr {
+		return orgErrStyle.Render(m.status) + "\n"
+	}
+	return orgOkStyle.Render(m.status) + "\n"
+}
+
+func (m orgTUIModel) overlayView() string {
+	var prompt string
+	switch m.overlay {
+	case overlayRename:
+		prompt = fmt.Sprintf("Rename org %q to:", m.orgs[m.orgCursor].Org)
+	case overlayMove:
+		prompt = fmt.Sprintf("Move %q to org:", m.members[m.memCursor].Name)
+	}
+	box := orgTitleStyle.Render(prompt) + "\n\n" +
+		m.input.View() + "\n\n" +
+		orgMutedStyle.Render("existing orgs: "+m.orgNamesCSV()) + "\n\n" +
+		orgHelpStyle.Render("enter: confirm . esc: cancel")
+	return orgPaneFocused.Render(box) + "\n"
+}

--- a/cmd/camp/org/views.go
+++ b/cmd/camp/org/views.go
@@ -95,7 +95,7 @@ func init() {
 	orgShowCmd.Flags().Bool("json", false, "Output as JSON")
 	orgWhichCmd.Flags().Bool("json", false, "Output as JSON")
 	Cmd.Flags().Bool("json", false, "Output as JSON")
-	Cmd.Flags().BoolP("interactive", "i", false, "Force the interactive org browser even when output is piped")
+	Cmd.Flags().BoolP("interactive", "i", false, "Open the interactive org browser (prints the org list when stdout is not a terminal)")
 }
 
 func runOrgRename(cmd *cobra.Command, args []string) error {

--- a/cmd/camp/org/views.go
+++ b/cmd/camp/org/views.go
@@ -4,15 +4,23 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 	"text/tabwriter"
 
+	"golang.org/x/term"
+
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/spf13/cobra"
 )
+
+// stdoutIsTTY reports whether stdout is an interactive terminal. It is a
+// package variable so tests can make the bare-org dispatch deterministic.
+var stdoutIsTTY = func() bool { return term.IsTerminal(int(os.Stdout.Fd())) }
 
 type orgRenameResult struct {
 	Old        string `json:"old"`
@@ -68,15 +76,26 @@ var orgShowCmd = &cobra.Command{
 	RunE:    runOrgShow,
 }
 
+var orgWhichCmd = &cobra.Command{
+	Use:     "which",
+	Aliases: []string{"current"},
+	Short:   "Print the current campaign's org",
+	Example: `  camp org which`,
+	Args:    cobra.NoArgs,
+	RunE:    runOrgWhich,
+}
+
 func init() {
 	Cmd.AddCommand(orgRenameCmd)
 	Cmd.AddCommand(orgListCmd)
 	Cmd.AddCommand(orgShowCmd)
+	Cmd.AddCommand(orgWhichCmd)
 	orgRenameCmd.Flags().Bool("json", false, "Output as JSON")
 	orgListCmd.Flags().Bool("json", false, "Output as JSON")
 	orgShowCmd.Flags().Bool("json", false, "Output as JSON")
+	orgWhichCmd.Flags().Bool("json", false, "Output as JSON")
 	Cmd.Flags().Bool("json", false, "Output as JSON")
-	Cmd.Flags().BoolP("interactive", "i", false, "Launch the interactive org browser")
+	Cmd.Flags().BoolP("interactive", "i", false, "Force the interactive org browser even when output is piped")
 }
 
 func runOrgRename(cmd *cobra.Command, args []string) error {
@@ -185,15 +204,33 @@ func computeOrgCounts(reg *config.Registry) []orgCount {
 
 func writeOrgCounts(w io.Writer, counts []orgCount) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "ORG\tCAMPAIGNS\tACTIVE"); err != nil {
+	if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", ui.Label("ORG"), ui.Label("CAMPAIGNS"), ui.Label("ACTIVE")); err != nil {
 		return err
 	}
 	for _, c := range counts {
-		if _, err := fmt.Fprintf(tw, "%s\t%d\t%d\n", c.Org, c.Campaigns, c.Active); err != nil {
+		active := ui.Dim(fmt.Sprintf("%d", c.Active))
+		if c.Active > 0 {
+			active = ui.Success(fmt.Sprintf("%d", c.Active))
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", ui.Accent(c.Org), ui.Value(fmt.Sprintf("%d", c.Campaigns)), active); err != nil {
 			return err
 		}
 	}
 	return tw.Flush()
+}
+
+// styleOrgStatus renders a campaign lifecycle status with a semantic color.
+func styleOrgStatus(status string) string {
+	switch status {
+	case config.StatusActive:
+		return ui.Success(status)
+	case config.StatusInactive:
+		return ui.Warning(status)
+	case config.StatusReference:
+		return ui.Info(status)
+	default:
+		return ui.Dim(status)
+	}
 }
 
 func runOrgShow(cmd *cobra.Command, args []string) error {
@@ -232,32 +269,56 @@ func buildOrgShow(reg *config.Registry, org string) orgShowResult {
 }
 
 func writeOrgShow(w io.Writer, r orgShowResult) error {
-	if _, err := fmt.Fprintf(w, "org: %s   (%d campaigns, %d active)\n\n", r.Org, r.Campaigns, r.Active); err != nil {
+	if _, err := fmt.Fprintf(w, "%s %s   %s\n\n",
+		ui.Label("org:"), ui.Accent(r.Org),
+		ui.Dim(fmt.Sprintf("(%d campaigns, %d active)", r.Campaigns, r.Active))); err != nil {
 		return err
 	}
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "  ID\tNAME\tSTATUS\tTAGS"); err != nil {
+	if _, err := fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n", ui.Label("ID"), ui.Label("NAME"), ui.Label("STATUS"), ui.Label("TAGS")); err != nil {
 		return err
 	}
 	for _, m := range r.Members {
-		tags := "-"
+		tags := ui.Dim("-")
 		if len(m.Tags) > 0 {
-			tags = strings.Join(m.Tags, ",")
+			tags = ui.Info(strings.Join(m.Tags, ","))
 		}
-		if _, err := fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n", m.ID, m.Name, m.Status, tags); err != nil {
+		if _, err := fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n", ui.Dim(m.ID), ui.Value(m.Name), styleOrgStatus(m.Status), tags); err != nil {
 			return err
 		}
 	}
 	return tw.Flush()
 }
 
+// runOrgBare is the default action for `camp org`. In an interactive terminal it
+// opens the org browser; otherwise (piped, or --json) it prints the current
+// campaign's org. Use `camp org which` to print the org unconditionally.
 func runOrgBare(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
-	if interactive, _ := cmd.Flags().GetBool("interactive"); interactive {
+	asJSON, _ := cmd.Flags().GetBool("json")
+	interactive, _ := cmd.Flags().GetBool("interactive")
+	if shouldOpenOrgTUI(asJSON, interactive, stdoutIsTTY()) {
 		return runOrgTUI(cmd)
 	}
-	asJSON, _ := cmd.Flags().GetBool("json")
+	return printCurrentOrg(cmd, asJSON)
+}
 
+// shouldOpenOrgTUI decides whether bare `camp org` opens the interactive
+// browser. --json always means machine output; otherwise an explicit -i or an
+// interactive terminal opens the TUI.
+func shouldOpenOrgTUI(asJSON, interactive, isTTY bool) bool {
+	if asJSON {
+		return false
+	}
+	return interactive || isTTY
+}
+
+func runOrgWhich(cmd *cobra.Command, _ []string) error {
+	asJSON, _ := cmd.Flags().GetBool("json")
+	return printCurrentOrg(cmd, asJSON)
+}
+
+func printCurrentOrg(cmd *cobra.Command, asJSON bool) error {
+	ctx := cmd.Context()
 	root, err := campaign.DetectCached(ctx)
 	if err != nil {
 		return err

--- a/cmd/camp/org/views.go
+++ b/cmd/camp/org/views.go
@@ -76,6 +76,7 @@ func init() {
 	orgListCmd.Flags().Bool("json", false, "Output as JSON")
 	orgShowCmd.Flags().Bool("json", false, "Output as JSON")
 	Cmd.Flags().Bool("json", false, "Output as JSON")
+	Cmd.Flags().BoolP("interactive", "i", false, "Launch the interactive org browser")
 }
 
 func runOrgRename(cmd *cobra.Command, args []string) error {
@@ -252,6 +253,9 @@ func writeOrgShow(w io.Writer, r orgShowResult) error {
 
 func runOrgBare(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
+	if interactive, _ := cmd.Flags().GetBool("interactive"); interactive {
+		return runOrgTUI(cmd)
+	}
 	asJSON, _ := cmd.Flags().GetBool("json")
 
 	root, err := campaign.DetectCached(ctx)


### PR DESCRIPTION
## Summary

Three UX follow-ons to the shipped org/tags/status feature (`camp org`, `camp tag`, `camp lifecycle`). Designed in `workflow/design/camp-org-tui-and-list-sort/`. Each thread routes through the existing registry write path; no new persistence, no schema change, no database.

### 1. Interactive org browser (TUI)
A two-pane bubbletea browser of orgs and their member campaigns:
- **Entry point:** bare `camp org` opens the browser **when run in a terminal**. Piped or with `--json` it prints the current campaign's org (script-safe). `camp org which` (alias `current`) prints the org unconditionally; `-i` opens the browser explicitly (and prints the org list when stdout is not a terminal, since bubbletea needs a TTY).
- Navigate orgs (left) with a live member preview (right); `enter`/`l` drills into members, `h`/`esc` backs out.
- `m` moves the selected campaign to another org, **`c` creates a new org** for it, `d` returns it to the fallback org, `r` renames the focused org.
- Every mutation goes through `config.UpdateRegistry` (the same atomic, file-locked path the flat commands use), then reloads from disk. Errors (rename collision, same-name) surface in a styled footer with no state change.
- Styling: top bar with org/campaign totals, colored campaign/active counts, semantic status badges (active=green, inactive=amber, reference=blue), accent-focused rounded pane borders, current-campaign marker, responsive single-pane collapse below a width floor, and explicit loading/empty/success/error states. Adaptive `theme.TUI()` palette, consistent with the intent/promote TUIs. Degrades to `camp org list` when stdout is not a TTY.

### 2. `camp org create <org>` — friendly create verb
- With no campaign args inside a campaign, it joins the **current** campaign to `<org>` (fills the gap that `camp org add` requires `MinimumNArgs(2)`).
- With campaign args, it behaves like `add`.
- Orgs stay **derived**: `create` only assigns membership, never persists an empty org. Idempotent (no "already exists" error); errors clearly outside a registered campaign. Reuses `reassignOrg`.

### 3. `camp list --sort org` + org-aware output
- New `--sort org`: org-major ordering (fallback org first, then alphabetical, then by name), matching the grouped-view ordering.
- The flat (ungrouped) table gains an accent-colored `ORG` column so `camp list --no-group` and single-org output are org-aware. Grouped headers are now styled and show a per-org count (e.g. `obey (3 campaigns)`). JSON shape is unchanged.
- `camp org list` / `camp org show` tables are also styled (accent org names, green active counts, status badges).

## Tests
- `camp list`: `--sort org` ordering (incl. custom fallback), invalid-sort fallthrough, updated flat-table and grouped goldens.
- `camp org create`: current-campaign join, explicit args, idempotent join, no-op when already a member, invalid name (no write), not-in-campaign and unregistered-current errors.
- Entry point: `shouldOpenOrgTUI` decision matrix (TTY / `-i` / `--json`), `camp org which`, bare-org print forced non-TTY.
- TUI: model-level tests driving `Update` with synthetic keys — open/navigate/enter, move (incl. typed new org), **create**, return-to-default, rename, error surfacing, quit, and a View render smoke test.
- Full suite green; `just lint` clean (0 issues), gofmt clean, no `fmt.Errorf` or host-fs-test regressions.

## Notes for reviewers
- The TUI lives in `package org` (`cmd/camp/org/tui*.go`) rather than a separate `internal/org/tui` package, so it can reuse the unexported `computeOrgCounts`/`buildOrgShow`/`renameOrgInRegistry`/`validateOrgName` directly — matching how `promote` keeps its selector inline.
- `camp org` help no longer states "There is no org create" (that contradicted the new verb); the derived-org model is preserved and documented in the `create` help instead.
- The TTY decision is behind a `stdoutIsTTY` package var + a pure `shouldOpenOrgTUI` helper so the dispatch is unit-tested without launching a real program.
- Remaining manual acceptance item from the design's experience bar: a human eyeball/screenshot of the TUI under each terminal theme at a real terminal (model + View tests cover structure; rendered frames look consistent with the existing camp TUIs).
