### PR TITLE
feat(intent): inherit ambient workitem context on intent and note commits

### DIFF
--- a/cmd/camp/intent/add.go
+++ b/cmd/camp/intent/add.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
+	wkcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/concept"
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/editor"
@@ -494,10 +495,15 @@ func finalizeCreatedIntentWithOutput(ctx context.Context, result *intent.Intent,
 	// Auto-commit (unless --no-commit)
 	if !noCommit {
 		files := commit.NormalizeFiles(campaignRoot, result.Path, audit.FilePath(intentsDir))
+		cwd, _ := os.Getwd()
+		cc := wkcmd.ResolveCommitContext(ctx, campaignRoot, cwd, os.Stderr)
 		commitResult := commit.Intent(ctx, commit.IntentOptions{
 			Options: commit.Options{
 				CampaignRoot:  campaignRoot,
 				CampaignID:    cfg.ID,
+				QuestID:       cc.QuestID,
+				FestivalRef:   cc.FestivalRef,
+				WorkitemRef:   cc.WorkitemRef,
 				Files:         files,
 				SelectiveOnly: true,
 			},

--- a/cmd/camp/intent/note.go
+++ b/cmd/camp/intent/note.go
@@ -3,10 +3,12 @@ package intent
 import (
 	"context"
 	"fmt"
+	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 
+	wkcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/concept"
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -189,10 +191,15 @@ func finalizeCreatedNote(ctx context.Context, result *intent.Intent, intentsDir 
 
 	if !noCommit {
 		files := commit.NormalizeFiles(campaignRoot, result.Path, audit.FilePath(intentsDir))
+		cwd, _ := os.Getwd()
+		cc := wkcmd.ResolveCommitContext(ctx, campaignRoot, cwd, os.Stderr)
 		commitResult := commit.Intent(ctx, commit.IntentOptions{
 			Options: commit.Options{
 				CampaignRoot:  campaignRoot,
 				CampaignID:    cfg.ID,
+				QuestID:       cc.QuestID,
+				FestivalRef:   cc.FestivalRef,
+				WorkitemRef:   cc.WorkitemRef,
 				Files:         files,
 				SelectiveOnly: true,
 			},

--- a/internal/commands/workitem/commit_context.go
+++ b/internal/commands/workitem/commit_context.go
@@ -1,0 +1,60 @@
+package workitem
+
+import (
+	"context"
+	"io"
+	"os"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
+)
+
+// CommitContext carries the ambient campaign-tag components resolved from the
+// caller's working directory: the active quest, festival, and workitem. Any
+// field may be empty when its resolution tier does not match.
+type CommitContext struct {
+	QuestID     string
+	FestivalRef string
+	WorkitemRef string
+}
+
+// ResolveCommitContext resolves the ambient quest/festival/workitem context
+// for a commit tag, mirroring how `camp workitem commit` derives the FE-/WI-/
+// qst_ segments but without the staging machinery. It is the shared entry
+// point for auto-commit paths (intent and note capture) that want
+// `camp commit`-style context inheritance.
+//
+// Resolution is best-effort: any failure yields a zero-valued field rather
+// than an error, so callers always fall back to a bare campaign tag. cwd
+// defaults to the process working directory when empty; errw defaults to
+// os.Stderr and receives ref-backfill warnings.
+func ResolveCommitContext(ctx context.Context, campaignRoot, cwd string, errw io.Writer) CommitContext {
+	if errw == nil {
+		errw = os.Stderr
+	}
+
+	festivalID := inferFestivalIDFromCwd(campaignRoot, cwd)
+	res, err := resolver.Resolve(ctx, campaignRoot, resolver.Options{
+		Cwd:        cwd,
+		FestivalID: festivalID,
+	})
+	if err != nil || res == nil || res.Workitem == nil {
+		return CommitContext{}
+	}
+
+	ref, ensureErr := wkitem.EnsureRefForCommit(ctx, campaignRoot, res.Workitem, errw)
+	if ensureErr != nil {
+		ref = wkitem.RefOf(res.Workitem)
+	}
+
+	festivalRef := ""
+	if res.Source == resolver.SourceFestival {
+		festivalRef = festivalRefFromString(festivalID)
+	}
+
+	return CommitContext{
+		QuestID:     res.QuestID,
+		FestivalRef: festivalRef,
+		WorkitemRef: ref,
+	}
+}

--- a/internal/commands/workitem/commit_context_test.go
+++ b/internal/commands/workitem/commit_context_test.go
@@ -1,0 +1,78 @@
+package workitem
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeCommitContextCampaign(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".campaign"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".campaign", "campaign.yaml"),
+		[]byte("id: test-campaign\nname: Test\ntype: product\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func seedDesignWorkitemMarker(t *testing.T, root, ref string) string {
+	t.Helper()
+	wiDir := filepath.Join(root, "workflow", "design", "example")
+	if err := os.MkdirAll(wiDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := "version: v1alpha6\nkind: workitem\nid: design-example-2026-05-24\ntype: design\ntitle: Example\nref: " + ref + "\n"
+	if err := os.WriteFile(filepath.Join(wiDir, ".workitem"), []byte(marker), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return wiDir
+}
+
+func TestResolveCommitContext_InheritsAncestorWorkitemRef(t *testing.T) {
+	const ref = "WI-abc123"
+	root := writeCommitContextCampaign(t)
+	wiDir := seedDesignWorkitemMarker(t, root, ref)
+
+	var errw bytes.Buffer
+	cc := ResolveCommitContext(context.Background(), root, wiDir, &errw)
+
+	if cc.WorkitemRef != ref {
+		t.Errorf("WorkitemRef = %q, want %q (errw=%q)", cc.WorkitemRef, ref, errw.String())
+	}
+	if cc.FestivalRef != "" {
+		t.Errorf("FestivalRef = %q, want empty for a non-festival source", cc.FestivalRef)
+	}
+	if cc.QuestID != "" {
+		t.Errorf("QuestID = %q, want empty", cc.QuestID)
+	}
+}
+
+func TestResolveCommitContext_NoContextIsZero(t *testing.T) {
+	root := writeCommitContextCampaign(t)
+
+	cc := ResolveCommitContext(context.Background(), root, root, nil)
+
+	if cc != (CommitContext{}) {
+		t.Errorf("expected zero CommitContext when no workitem resolves, got %+v", cc)
+	}
+}
+
+func TestResolveCommitContext_CancelledContextIsZero(t *testing.T) {
+	const ref = "WI-abc123"
+	root := writeCommitContextCampaign(t)
+	wiDir := seedDesignWorkitemMarker(t, root, ref)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cc := ResolveCommitContext(ctx, root, wiDir, nil)
+	if cc != (CommitContext{}) {
+		t.Errorf("expected zero CommitContext on cancelled context, got %+v", cc)
+	}
+}

--- a/tests/integration/commit_tags_test.go
+++ b/tests/integration/commit_tags_test.go
@@ -197,6 +197,44 @@ ref: NOT-A-VALID-REF-12345
 		"output must not echo hand-edited junk ref: %s", out)
 }
 
+func TestIntegration_CommitTags_NoteInheritsWorkitemContext(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/commit-tags-note-context"
+	initCommitTagsCampaign(t, tc, dir)
+	ref := seedDesignWorkitemWithRef(t, tc, dir, "notectx")
+
+	// A note captured from inside a workitem directory should inherit that
+	// workitem's WI-<ref> in its commit tag, even though the note file itself
+	// is written under .campaign/intents/notes/.
+	wiDir := dir + "/workflow/design/notectx"
+	out, err := tc.RunCampInDir(wiDir, "intent", "note", "check the daemon socket path")
+	require.NoError(t, err, "camp intent note: %s", out)
+
+	subject := lastCommitSubject(t, tc, dir)
+	assert.Contains(t, subject, "WI-"+ref,
+		"note captured inside a workitem should inherit its WI-<ref>: %s", subject)
+	assert.Contains(t, subject, "check the daemon socket path",
+		"note commit subject should carry the note title: %s", subject)
+}
+
+func TestIntegration_CommitTags_NoteNoContext(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/commit-tags-note-no-context"
+	initCommitTagsCampaign(t, tc, dir)
+
+	// No workitems and no ambient context: a note from the campaign root gets
+	// the bare campaign tag with no WI-/qst_/FE- segments.
+	out, err := tc.RunCampInDir(dir, "intent", "note", "loose thought")
+	require.NoError(t, err, "camp intent note: %s", out)
+
+	subject := lastCommitSubject(t, tc, dir)
+	assert.NotContains(t, subject, "WI-", "no-context note must not include WI-: %s", subject)
+	assert.NotContains(t, subject, "qst_", "no-context note must not include qst_: %s", subject)
+	assert.NotContains(t, subject, "FE-", "no-context note must not include FE-: %s", subject)
+	assert.Regexp(t, `^\[OBEY-CAMPAIGN-[0-9a-f]{1,8}\]`, subject,
+		"note should still carry the campaign tag: %s", subject)
+}
+
 func TestIntegration_AutoWriteEnv(t *testing.T) {
 	tc := GetSharedContainer(t)
 	dir := "/test/commit-tags-autowrite"


### PR DESCRIPTION
## Problem

Intent and note auto-commits go through `commit.Intent` (internal/git/commit/intent.go), which only populates `CampaignRoot` / `CampaignID` / `Files`. It never sets `QuestID`, `FestivalRef`, or `WorkitemRef`, so every intent and note commit emits only the bare `[OBEY-CAMPAIGN-<id>]` tag.

By contrast `camp commit` resolves ambient context (cmd/camp/commit_workitem.go) and `camp workitem commit` sets the fields directly (internal/git/commit/workitem.go). Those carry the FE-/WI-/qst_ segments; the intent path did not. A note captured with `cnote` while working inside an active festival/quest/workitem recorded none of that context.

This also surfaced that notes are not workitems and therefore have no `WI-` ref of their own. This PR makes intent/note commits inherit the *ambient* context. Giving notes their own `NT-` segment, and deriving the `OBEY-CAMPAIGN` prefix from config, are tracked as separate intents.

## Change

- Add `ResolveCommitContext` in `internal/commands/workitem` (commit_context.go): a staging-free resolver returning the ambient `QuestID` / `FestivalRef` / `WorkitemRef`, mirroring how `camp workitem commit` derives those segments. Resolution is best-effort: any failure yields zero-valued fields so callers fall back to the bare campaign tag.
- Wire it into the note capture path (cmd/camp/intent/note.go) and the intent-add path (cmd/camp/intent/add.go).

## Verification

Manual smoke test on a throwaway campaign:

```
# note captured inside a workitem dir
[OBEY-CAMPAIGN-fe270033-WI-WI-2f47a0] Create: check the daemon socket path
# note captured at campaign root (no context)
[OBEY-CAMPAIGN-fe270033] Create: loose thought
```

- `just lint` clean (golangci-lint, host-fs ratchet, fmt-errorf ratchet, `go vet -tags=integration`).
- Unit tests: `ResolveCommitContext` ancestor-ref, no-context, and cancelled-context cases.
- Integration tests: a note inside a workitem carries `WI-<ref>`; a root note stays bare. These compile under `-tags=integration` but were not executed locally (Docker unavailable in this environment; CI Actions are paused).

## Scope notes

Only the note + intent-add capture paths are wired here. The remaining `commit.Intent` call sites (edit/move/archive/promote/gather/rename/convert/crawl) are trivial one-line follow-ups using the same helper.