### PR TITLE
feat(list): interactive campaign browser, lifecycle toggle, and tilde paths

### DIFF
--- a/cmd/camp/list.go
+++ b/cmd/camp/list.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"io"
 	"os"
 	"sort"
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -106,31 +107,12 @@ func renderListTable(cmd *cobra.Command) error {
 		return err
 	}
 
-	reg, err := config.LoadRegistry(ctx)
+	reg, report, err := loadVerifiedListRegistry(ctx)
 	if err != nil {
 		return err
 	}
 
-	// Verify and self-heal registry
-	report, err := reg.VerifyAndRepair(ctx)
-	if err != nil {
-		return camperrors.Wrap(err, "registry verification failed")
-	}
-
-	// Save if changes made
 	if report.HasChanges() {
-		if err := config.UpdateRegistry(ctx, func(locked *config.Registry) error {
-			updatedReport, err := locked.VerifyAndRepair(ctx)
-			if err != nil {
-				return err
-			}
-			reg = locked
-			report = updatedReport
-			return nil
-		}); err != nil {
-			return camperrors.Wrap(err, "failed to save registry")
-		}
-
 		verbose, _ := cmd.Flags().GetBool("verify-verbose")
 		if verbose {
 			printVerificationDetails(report)
@@ -170,6 +152,36 @@ func renderListTable(cmd *cobra.Command) error {
 		return outputGrouped(campaigns, formatStr, reg.FallbackOrg())
 	}
 	return outputCampaigns(os.Stdout, campaigns, formatStr)
+}
+
+func loadVerifiedListRegistry(ctx context.Context) (*config.Registry, *config.VerificationReport, error) {
+	reg, err := config.LoadRegistry(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	report, err := reg.VerifyAndRepair(ctx)
+	if err != nil {
+		return nil, nil, camperrors.Wrap(err, "registry verification failed")
+	}
+
+	if !report.HasChanges() {
+		return reg, report, nil
+	}
+
+	if err := config.UpdateRegistry(ctx, func(locked *config.Registry) error {
+		updatedReport, err := locked.VerifyAndRepair(ctx)
+		if err != nil {
+			return err
+		}
+		reg = locked
+		report = updatedReport
+		return nil
+	}); err != nil {
+		return nil, nil, camperrors.Wrap(err, "failed to save registry")
+	}
+
+	return reg, report, nil
 }
 
 // sortCampaigns converts the registry map to a sorted slice.
@@ -261,8 +273,7 @@ func outputCampaigns(out io.Writer, campaigns []campaignEntry, format string) er
 	}
 }
 
-// printVerificationSummary prints a brief summary of verification changes.
-func printVerificationSummary(r *config.VerificationReport) {
+func verificationSummaryText(r *config.VerificationReport) string {
 	var parts []string
 	if len(r.Removed) > 0 {
 		parts = append(parts, fmt.Sprintf("removed %d", len(r.Removed)))
@@ -273,7 +284,12 @@ func printVerificationSummary(r *config.VerificationReport) {
 	if len(r.Updated) > 0 {
 		parts = append(parts, fmt.Sprintf("updated %d", len(r.Updated)))
 	}
-	fmt.Printf("%s Registry cleaned: %s\n\n", ui.SuccessIcon(), strings.Join(parts, ", "))
+	return strings.Join(parts, ", ")
+}
+
+// printVerificationSummary prints a brief summary of verification changes.
+func printVerificationSummary(r *config.VerificationReport) {
+	fmt.Printf("%s Registry cleaned: %s\n\n", ui.SuccessIcon(), verificationSummaryText(r))
 }
 
 // printVerificationDetails prints detailed information about verification changes.

--- a/cmd/camp/list.go
+++ b/cmd/camp/list.go
@@ -36,6 +36,11 @@ var listCmd = &cobra.Command{
 Campaigns are registered when created with 'camp init' or manually
 with 'camp register'. The registry lives at ~/.obey/campaign/registry.json.
 
+In a terminal, 'camp list' (with no flags) opens an interactive browser where you
+can deactivate/reactivate campaigns (cycle lifecycle status), reassign their org,
+and copy paths. Piped, with --json/--count, or with any filter/sort flag it
+prints the table instead. Home paths display as '~'.
+
 Output formats:
   table   - Aligned columns with headers (default)
   simple  - Campaign names only, one per line
@@ -79,9 +84,17 @@ func init() {
 	listCmd.Flags().Bool("all", false, "Show all statuses (default hides inactive/reference)")
 	listCmd.Flags().Bool("group", false, "Force org grouping")
 	listCmd.Flags().Bool("no-group", false, "Suppress org grouping")
+	listCmd.Flags().BoolP("interactive", "i", false, "Open the interactive campaign browser (prints the table when stdout is not a terminal)")
 }
 
 func runList(cmd *cobra.Command, args []string) error {
+	if listTUIRequested(cmd, stdoutIsTTY()) {
+		return runListTUI(cmd)
+	}
+	return renderListTable(cmd)
+}
+
+func renderListTable(cmd *cobra.Command) error {
 	ctx := cmd.Context()
 	formatStr, _ := cmd.Flags().GetString("format")
 	if listJSON {

--- a/cmd/camp/list.go
+++ b/cmd/camp/list.go
@@ -17,7 +17,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// campaignEntry represents a campaign for display purposes.
 type campaignEntry struct {
 	ID         string    `json:"id"`
 	Name       string    `json:"name"`
@@ -184,7 +183,6 @@ func loadVerifiedListRegistry(ctx context.Context) (*config.Registry, *config.Ve
 	return reg, report, nil
 }
 
-// sortCampaigns converts the registry map to a sorted slice.
 func sortCampaigns(campaigns map[string]config.RegisteredCampaign, by, fallbackOrg string) []campaignEntry {
 	entries := make([]campaignEntry, 0, len(campaigns))
 	for id, c := range campaigns {
@@ -236,7 +234,6 @@ func sortCampaigns(campaigns map[string]config.RegisteredCampaign, by, fallbackO
 	return entries
 }
 
-// outputCampaigns writes campaigns to out in the specified format.
 func outputCampaigns(out io.Writer, campaigns []campaignEntry, format string) error {
 	switch format {
 	case "json":
@@ -287,12 +284,10 @@ func verificationSummaryText(r *config.VerificationReport) string {
 	return strings.Join(parts, ", ")
 }
 
-// printVerificationSummary prints a brief summary of verification changes.
 func printVerificationSummary(r *config.VerificationReport) {
 	fmt.Printf("%s Registry cleaned: %s\n\n", ui.SuccessIcon(), verificationSummaryText(r))
 }
 
-// printVerificationDetails prints detailed information about verification changes.
 func printVerificationDetails(r *config.VerificationReport) {
 	fmt.Println("Registry verification:")
 	for _, e := range r.Removed {

--- a/cmd/camp/list_render.go
+++ b/cmd/camp/list_render.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"text/tabwriter"
 
+	"github.com/Obedience-Corp/camp/internal/pathutil"
 	"github.com/Obedience-Corp/camp/internal/ui"
 )
 
@@ -23,7 +24,7 @@ func campaignTableCells(c campaignEntry) (id, name, org, typ, path string) {
 		orgCell = "-"
 	}
 	typeStyle := ui.GetCampaignTypeStyle(c.Type)
-	return ui.Dim(shortID), ui.Value(c.Name), ui.Accent(orgCell), typeStyle.Render(campaignType), ui.Dim(c.Path)
+	return ui.Dim(shortID), ui.Value(c.Name), ui.Accent(orgCell), typeStyle.Render(campaignType), ui.Dim(pathutil.AbbreviateHome(c.Path))
 }
 
 func outputGrouped(entries []campaignEntry, format, fallbackOrg string) error {

--- a/cmd/camp/list_tui.go
+++ b/cmd/camp/list_tui.go
@@ -18,8 +18,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// stdoutIsTTY reports whether stdout is an interactive terminal. A package var so
-// the dispatch is deterministic under test.
+// Overridden in tests so dispatch does not depend on the runner's terminal.
 var stdoutIsTTY = func() bool { return term.IsTerminal(int(os.Stdout.Fd())) }
 
 type listOverlay int
@@ -33,8 +32,8 @@ type listTUIModel struct {
 	ctx context.Context
 
 	fallback   string
-	all        []campaignEntry // every campaign, org-major sorted
-	visible    []campaignEntry // after the activeOnly filter
+	all        []campaignEntry
+	visible    []campaignEntry
 	cursor     int
 	activeOnly bool
 
@@ -70,8 +69,6 @@ func listTUIRequested(cmd *cobra.Command, isTTY bool) bool {
 	return isTTY
 }
 
-// runListTUI launches the browser, degrading to the table when stdout is not a
-// terminal (bubbletea needs a TTY).
 func runListTUI(cmd *cobra.Command) error {
 	ctx := cmd.Context()
 	if !term.IsTerminal(int(os.Stdout.Fd())) {
@@ -144,8 +141,6 @@ func (m *listTUIModel) reload() error {
 
 func (m listTUIModel) Init() tea.Cmd { return textinput.Blink }
 
-// cycleStatus advances the selected campaign active -> inactive -> reference ->
-// active through the shared atomic registry write path.
 func (m *listTUIModel) cycleStatus() error {
 	e := m.visible[m.cursor]
 	next := nextLifecycleStatus(e.Status)
@@ -186,8 +181,7 @@ func (m *listTUIModel) mutate(id string, apply func(*config.RegisteredCampaign))
 	return m.reload()
 }
 
-// writeClipboard copies s to the system clipboard. A package var so tests can
-// intercept it instead of touching the real clipboard.
+// Package var so tests do not touch the real clipboard.
 var writeClipboard = func(s string) error {
 	var c *exec.Cmd
 	switch runtime.GOOS {

--- a/cmd/camp/list_tui.go
+++ b/cmd/camp/list_tui.go
@@ -77,11 +77,15 @@ func runListTUI(cmd *cobra.Command) error {
 	if !term.IsTerminal(int(os.Stdout.Fd())) {
 		return renderListTable(cmd)
 	}
-	reg, err := config.LoadRegistry(ctx)
+	reg, report, err := loadVerifiedListRegistry(ctx)
 	if err != nil {
 		return camperrors.Wrap(err, "failed to load registry")
 	}
-	prog := tea.NewProgram(newListTUIModel(ctx, reg), tea.WithContext(ctx), tea.WithAltScreen())
+	model := newListTUIModel(ctx, reg)
+	if report.HasChanges() {
+		model.setStatus("registry cleaned: "+verificationSummaryText(report), false)
+	}
+	prog := tea.NewProgram(model, tea.WithContext(ctx), tea.WithAltScreen())
 	if _, err := prog.Run(); err != nil {
 		return camperrors.Wrap(err, "running campaign browser")
 	}

--- a/cmd/camp/list_tui.go
+++ b/cmd/camp/list_tui.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"golang.org/x/term"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/pathutil"
+	"github.com/spf13/cobra"
+)
+
+// stdoutIsTTY reports whether stdout is an interactive terminal. A package var so
+// the dispatch is deterministic under test.
+var stdoutIsTTY = func() bool { return term.IsTerminal(int(os.Stdout.Fd())) }
+
+type listOverlay int
+
+const (
+	listOverlayNone listOverlay = iota
+	listOverlayMove
+)
+
+type listTUIModel struct {
+	ctx context.Context
+
+	fallback   string
+	all        []campaignEntry // every campaign, org-major sorted
+	visible    []campaignEntry // after the activeOnly filter
+	cursor     int
+	activeOnly bool
+
+	overlay listOverlay
+	input   textinput.Model
+
+	status    string
+	statusErr bool
+
+	width    int
+	height   int
+	quitting bool
+}
+
+// listTUIRequested decides whether bare `camp list` opens the browser. Machine or
+// text output (--json, --count, non-table --format) never does; -i forces;
+// otherwise an interactive terminal with no shaping flag opens it.
+func listTUIRequested(cmd *cobra.Command, isTTY bool) bool {
+	if listJSON || listCount {
+		return false
+	}
+	if format, _ := cmd.Flags().GetString("format"); format != "table" {
+		return false
+	}
+	if interactive, _ := cmd.Flags().GetBool("interactive"); interactive {
+		return true
+	}
+	for _, f := range []string{"sort", "org", "tag", "status", "all", "group", "no-group"} {
+		if cmd.Flags().Changed(f) {
+			return false
+		}
+	}
+	return isTTY
+}
+
+// runListTUI launches the browser, degrading to the table when stdout is not a
+// terminal (bubbletea needs a TTY).
+func runListTUI(cmd *cobra.Command) error {
+	ctx := cmd.Context()
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		return renderListTable(cmd)
+	}
+	reg, err := config.LoadRegistry(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "failed to load registry")
+	}
+	prog := tea.NewProgram(newListTUIModel(ctx, reg), tea.WithContext(ctx), tea.WithAltScreen())
+	if _, err := prog.Run(); err != nil {
+		return camperrors.Wrap(err, "running campaign browser")
+	}
+	return nil
+}
+
+func newListTUIModel(ctx context.Context, reg *config.Registry) listTUIModel {
+	ti := textinput.New()
+	ti.Prompt = "> "
+	m := listTUIModel{ctx: ctx, input: ti}
+	m.loadFromRegistry(reg)
+	return m
+}
+
+func (m *listTUIModel) loadFromRegistry(reg *config.Registry) {
+	m.fallback = reg.FallbackOrg()
+	m.all = sortCampaigns(reg.Campaigns, "org", m.fallback)
+	m.rebuildVisible()
+}
+
+func (m *listTUIModel) rebuildVisible() {
+	if !m.activeOnly {
+		m.visible = m.all
+	} else {
+		out := make([]campaignEntry, 0, len(m.all))
+		for _, e := range m.all {
+			if e.Status == config.StatusActive {
+				out = append(out, e)
+			}
+		}
+		m.visible = out
+	}
+	m.cursor = clampIdx(m.cursor, len(m.visible))
+}
+
+func (m *listTUIModel) reload() error {
+	selID := ""
+	if m.cursor < len(m.visible) {
+		selID = m.visible[m.cursor].ID
+	}
+	reg, err := config.LoadRegistry(m.ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "failed to reload registry")
+	}
+	m.loadFromRegistry(reg)
+	if selID != "" {
+		for i, e := range m.visible {
+			if e.ID == selID {
+				m.cursor = i
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func (m listTUIModel) Init() tea.Cmd { return textinput.Blink }
+
+// cycleStatus advances the selected campaign active -> inactive -> reference ->
+// active through the shared atomic registry write path.
+func (m *listTUIModel) cycleStatus() error {
+	e := m.visible[m.cursor]
+	next := nextLifecycleStatus(e.Status)
+	if err := config.ValidateStatus(next); err != nil {
+		return err
+	}
+	if err := m.mutate(e.ID, func(c *config.RegisteredCampaign) { c.Status = next }); err != nil {
+		return err
+	}
+	m.setStatus(fmt.Sprintf("set %q %s", e.Name, next), false)
+	return nil
+}
+
+func (m *listTUIModel) assignOrg(id, name, org string) error {
+	if err := config.ValidateName("org", org); err != nil {
+		return err
+	}
+	if err := m.mutate(id, func(c *config.RegisteredCampaign) { c.Org = org }); err != nil {
+		return err
+	}
+	m.setStatus(fmt.Sprintf("moved %q to org %q", name, org), false)
+	return nil
+}
+
+func (m *listTUIModel) mutate(id string, apply func(*config.RegisteredCampaign)) error {
+	err := config.UpdateRegistry(m.ctx, func(reg *config.Registry) error {
+		c, ok := reg.Campaigns[id]
+		if !ok {
+			return camperrors.NewNotFound("campaign", id, nil)
+		}
+		apply(&c)
+		reg.Campaigns[id] = c
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return m.reload()
+}
+
+// writeClipboard copies s to the system clipboard. A package var so tests can
+// intercept it instead of touching the real clipboard.
+var writeClipboard = func(s string) error {
+	var c *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		c = exec.Command("pbcopy")
+	default:
+		c = exec.Command("xclip", "-selection", "clipboard")
+	}
+	c.Stdin = strings.NewReader(s)
+	return c.Run()
+}
+
+func (m *listTUIModel) copyPath() error {
+	return writeClipboard(pathutil.AbbreviateHome(m.visible[m.cursor].Path))
+}
+
+func (m *listTUIModel) setStatus(s string, isErr bool) {
+	m.status = s
+	m.statusErr = isErr
+}
+
+func (m *listTUIModel) setError(err error) {
+	m.status = err.Error()
+	m.statusErr = true
+}
+
+func nextLifecycleStatus(s string) string {
+	switch s {
+	case config.StatusActive:
+		return config.StatusInactive
+	case config.StatusInactive:
+		return config.StatusReference
+	default:
+		return config.StatusActive
+	}
+}
+
+func (m listTUIModel) orgNamesCSV() string {
+	seen := map[string]bool{}
+	var names []string
+	for _, e := range m.all {
+		if !seen[e.Org] {
+			seen[e.Org] = true
+			names = append(names, e.Org)
+		}
+	}
+	return strings.Join(names, ", ")
+}
+
+func clampIdx(v, n int) int {
+	if n <= 0 {
+		return 0
+	}
+	if v < 0 {
+		return 0
+	}
+	if v > n-1 {
+		return n - 1
+	}
+	return v
+}

--- a/cmd/camp/list_tui_test.go
+++ b/cmd/camp/list_tui_test.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+)
+
+const listFixture = `{
+  "version": 2,
+  "campaigns": {
+    "A-1": {"name":"alpha","path":"/tmp/a","type":"product","org":"default","status":"active","last_access":"2026-06-16T10:00:00Z"},
+    "B-2": {"name":"beta","path":"/tmp/b","type":"product","org":"obey","status":"active","last_access":"2026-06-16T10:00:00Z"},
+    "C-3": {"name":"gamma","path":"/tmp/c","type":"product","org":"obey","status":"inactive","last_access":"2026-06-16T10:00:00Z"}
+  }
+}`
+
+func setListRegistry(t *testing.T) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "registry.json")
+	t.Setenv("CAMP_REGISTRY_PATH", path)
+	if err := os.WriteFile(path, []byte(listFixture), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}
+
+func newTestListModel(t *testing.T) listTUIModel {
+	t.Helper()
+	setListRegistry(t)
+	reg, err := config.LoadRegistry(context.Background())
+	if err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	return newListTUIModel(context.Background(), reg)
+}
+
+func lkey(m listTUIModel, s string) listTUIModel {
+	var msg tea.KeyMsg
+	switch s {
+	case "enter":
+		msg = tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		msg = tea.KeyMsg{Type: tea.KeyEsc}
+	default:
+		msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+	next, _ := m.Update(msg)
+	return next.(listTUIModel)
+}
+
+func campaignStatus(t *testing.T, id string) string {
+	t.Helper()
+	reg, err := config.LoadRegistry(context.Background())
+	if err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	return reg.Campaigns[id].Status
+}
+
+func campaignOrg(t *testing.T, id string) string {
+	t.Helper()
+	reg, _ := config.LoadRegistry(context.Background())
+	return reg.Campaigns[id].Org
+}
+
+func listTestCmd() *cobra.Command {
+	c := &cobra.Command{}
+	c.Flags().String("format", "table", "")
+	c.Flags().BoolP("interactive", "i", false, "")
+	c.Flags().String("sort", "accessed", "")
+	c.Flags().String("org", "", "")
+	c.Flags().StringSlice("tag", nil, "")
+	c.Flags().String("status", "", "")
+	c.Flags().Bool("all", false, "")
+	c.Flags().Bool("group", false, "")
+	c.Flags().Bool("no-group", false, "")
+	return c
+}
+
+func TestListTUIRequested(t *testing.T) {
+	defer func() { listJSON, listCount = false, false }()
+
+	t.Run("tty no flags opens", func(t *testing.T) {
+		listJSON, listCount = false, false
+		if !listTUIRequested(listTestCmd(), true) {
+			t.Error("bare camp list in a TTY should open the browser")
+		}
+	})
+	t.Run("piped no flags prints", func(t *testing.T) {
+		listJSON, listCount = false, false
+		if listTUIRequested(listTestCmd(), false) {
+			t.Error("piped camp list should print the table")
+		}
+	})
+	t.Run("json never opens", func(t *testing.T) {
+		listJSON, listCount = true, false
+		if listTUIRequested(listTestCmd(), true) {
+			t.Error("--json must never open the browser")
+		}
+	})
+	t.Run("count never opens", func(t *testing.T) {
+		listJSON, listCount = false, true
+		if listTUIRequested(listTestCmd(), true) {
+			t.Error("--count must never open the browser")
+		}
+	})
+	t.Run("non-table format never opens", func(t *testing.T) {
+		listJSON, listCount = false, false
+		c := listTestCmd()
+		_ = c.Flags().Set("format", "simple")
+		if listTUIRequested(c, true) {
+			t.Error("--format simple must not open the browser")
+		}
+	})
+	t.Run("interactive forces even when piped", func(t *testing.T) {
+		listJSON, listCount = false, false
+		c := listTestCmd()
+		_ = c.Flags().Set("interactive", "true")
+		if !listTUIRequested(c, false) {
+			t.Error("-i should request the browser even when piped")
+		}
+	})
+	t.Run("shaping flag in a TTY prints table", func(t *testing.T) {
+		listJSON, listCount = false, false
+		c := listTestCmd()
+		_ = c.Flags().Set("org", "obey")
+		if listTUIRequested(c, true) {
+			t.Error("a shaping flag should print the table, not open the browser")
+		}
+	})
+}
+
+func TestListTUI_OpensOrgMajorAllStatuses(t *testing.T) {
+	m := newTestListModel(t)
+	if len(m.visible) != 3 {
+		t.Fatalf("visible = %d, want 3 (all statuses by default)", len(m.visible))
+	}
+	if m.visible[0].Name != "alpha" {
+		t.Errorf("first row = %q, want alpha (default org first)", m.visible[0].Name)
+	}
+}
+
+func TestListTUI_CycleStatus_Deactivate(t *testing.T) {
+	m := newTestListModel(t) // cursor 0 = alpha (active)
+	m = lkey(m, "s")
+	if m.statusErr {
+		t.Fatalf("unexpected error: %s", m.status)
+	}
+	if got := campaignStatus(t, "A-1"); got != "inactive" {
+		t.Errorf("alpha status = %q, want inactive after one cycle", got)
+	}
+	if len(m.visible) != 3 {
+		t.Error("deactivated campaign should stay visible in show-all mode")
+	}
+}
+
+func TestListTUI_Filter_HidesInactive(t *testing.T) {
+	m := newTestListModel(t)
+	m = lkey(m, "f") // active only
+	for _, e := range m.visible {
+		if e.Status != "active" {
+			t.Errorf("active-only filter still shows %q (%s)", e.Name, e.Status)
+		}
+	}
+	if len(m.visible) != 2 {
+		t.Errorf("active-only visible = %d, want 2", len(m.visible))
+	}
+	m = lkey(m, "f") // back to all
+	if len(m.visible) != 3 {
+		t.Errorf("show-all visible = %d, want 3", len(m.visible))
+	}
+}
+
+func TestListTUI_MoveOrg(t *testing.T) {
+	m := newTestListModel(t) // cursor 0 = alpha
+	m = lkey(m, "m")
+	if m.overlay != listOverlayMove {
+		t.Fatal("expected move overlay")
+	}
+	m = lkey(m, "newco")
+	m = lkey(m, "enter")
+	if m.statusErr {
+		t.Fatalf("unexpected error: %s", m.status)
+	}
+	if got := campaignOrg(t, "A-1"); got != "newco" {
+		t.Errorf("alpha org = %q, want newco", got)
+	}
+}
+
+func TestListTUI_MoveOrg_InvalidName_NoMutation(t *testing.T) {
+	m := newTestListModel(t)
+	m = lkey(m, "m")
+	m = lkey(m, "Bad Org")
+	m = lkey(m, "enter")
+	if !m.statusErr {
+		t.Errorf("expected error status for invalid org name, got %q", m.status)
+	}
+	if got := campaignOrg(t, "A-1"); got != "default" {
+		t.Errorf("alpha org = %q, want default (unchanged)", got)
+	}
+}
+
+func TestListTUI_CopyPath_UsesTilde(t *testing.T) {
+	prev := writeClipboard
+	var copied string
+	writeClipboard = func(s string) error { copied = s; return nil }
+	defer func() { writeClipboard = prev }()
+
+	m := newTestListModel(t)
+	m = lkey(m, "y")
+	if m.statusErr {
+		t.Fatalf("copy failed: %s", m.status)
+	}
+	if copied != "/tmp/a" {
+		t.Errorf("copied %q, want /tmp/a (fixture path, not under home)", copied)
+	}
+	if m.status != "copied!" {
+		t.Errorf("status = %q, want copied!", m.status)
+	}
+}
+
+func TestListTUI_Quit(t *testing.T) {
+	m := newTestListModel(t)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if !next.(listTUIModel).quitting {
+		t.Error("q should set quitting")
+	}
+	if cmd == nil {
+		t.Error("q should return a quit command")
+	}
+}
+
+func TestListTUI_ViewSmoke(t *testing.T) {
+	m := newTestListModel(t)
+	m.width, m.height = 100, 30
+	out := m.View()
+	for _, want := range []string{"Campaigns", "alpha", "active", "obey"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("view missing %q:\n%s", want, out)
+		}
+	}
+	m.width, m.height = 40, 10 // narrow/short must still render
+	if m.View() == "" {
+		t.Error("constrained view should not be empty")
+	}
+}

--- a/cmd/camp/list_tui_test.go
+++ b/cmd/camp/list_tui_test.go
@@ -199,7 +199,7 @@ func TestListTUI_OpensOrgMajorAllStatuses(t *testing.T) {
 }
 
 func TestListTUI_CycleStatus_Deactivate(t *testing.T) {
-	m := newTestListModel(t) // cursor 0 = alpha (active)
+	m := newTestListModel(t)
 	m = lkey(m, "s")
 	if m.statusErr {
 		t.Fatalf("unexpected error: %s", m.status)
@@ -214,7 +214,7 @@ func TestListTUI_CycleStatus_Deactivate(t *testing.T) {
 
 func TestListTUI_Filter_HidesInactive(t *testing.T) {
 	m := newTestListModel(t)
-	m = lkey(m, "f") // active only
+	m = lkey(m, "f")
 	for _, e := range m.visible {
 		if e.Status != "active" {
 			t.Errorf("active-only filter still shows %q (%s)", e.Name, e.Status)
@@ -223,14 +223,14 @@ func TestListTUI_Filter_HidesInactive(t *testing.T) {
 	if len(m.visible) != 2 {
 		t.Errorf("active-only visible = %d, want 2", len(m.visible))
 	}
-	m = lkey(m, "f") // back to all
+	m = lkey(m, "f")
 	if len(m.visible) != 3 {
 		t.Errorf("show-all visible = %d, want 3", len(m.visible))
 	}
 }
 
 func TestListTUI_MoveOrg(t *testing.T) {
-	m := newTestListModel(t) // cursor 0 = alpha
+	m := newTestListModel(t)
 	m = lkey(m, "m")
 	if m.overlay != listOverlayMove {
 		t.Fatal("expected move overlay")
@@ -297,7 +297,7 @@ func TestListTUI_ViewSmoke(t *testing.T) {
 			t.Errorf("view missing %q:\n%s", want, out)
 		}
 	}
-	m.width, m.height = 40, 10 // narrow/short must still render
+	m.width, m.height = 40, 10
 	if m.View() == "" {
 		t.Error("constrained view should not be empty")
 	}

--- a/cmd/camp/list_tui_test.go
+++ b/cmd/camp/list_tui_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -135,6 +136,56 @@ func TestListTUIRequested(t *testing.T) {
 			t.Error("a shaping flag should print the table, not open the browser")
 		}
 	})
+}
+
+func TestLoadVerifiedListRegistry_RepairsBeforeBrowser(t *testing.T) {
+	dir := t.TempDir()
+	registryPath := filepath.Join(dir, "registry.json")
+	campaignRoot := filepath.Join(dir, "actual")
+	if err := os.MkdirAll(filepath.Join(campaignRoot, ".campaign"), 0o755); err != nil {
+		t.Fatalf("create campaign dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(campaignRoot, ".campaign", "campaign.yaml"),
+		[]byte("id: actual-id\nname: fresh-name\ntype: research\n"), 0o644); err != nil {
+		t.Fatalf("write campaign config: %v", err)
+	}
+
+	t.Setenv("CAMP_REGISTRY_PATH", registryPath)
+	registry := `{
+  "version": 2,
+  "campaigns": {
+    "wrong-id": {"name":"stale-name","path":` + strconv.Quote(campaignRoot) + `,"type":"product","status":"active"},
+    "missing-id": {"name":"missing","path":` + strconv.Quote(filepath.Join(dir, "missing")) + `,"type":"product","status":"active"}
+  }
+}`
+	if err := os.WriteFile(registryPath, []byte(registry), 0o644); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+
+	reg, report, err := loadVerifiedListRegistry(context.Background())
+	if err != nil {
+		t.Fatalf("loadVerifiedListRegistry: %v", err)
+	}
+	if !report.HasChanges() {
+		t.Fatal("expected registry repair changes")
+	}
+	if _, ok := reg.Campaigns["wrong-id"]; ok {
+		t.Fatal("wrong ID should be removed")
+	}
+	if _, ok := reg.Campaigns["missing-id"]; ok {
+		t.Fatal("missing path should be removed")
+	}
+	if got := reg.Campaigns["actual-id"]; got.Name != "fresh-name" || got.Type != config.CampaignTypeResearch {
+		t.Fatalf("actual campaign not repaired from campaign.yaml: %+v", got)
+	}
+
+	persisted, err := config.LoadRegistry(context.Background())
+	if err != nil {
+		t.Fatalf("reload registry: %v", err)
+	}
+	if _, ok := persisted.Campaigns["actual-id"]; !ok {
+		t.Fatal("repaired registry was not persisted")
+	}
 }
 
 func TestListTUI_OpensOrgMajorAllStatuses(t *testing.T) {

--- a/cmd/camp/list_tui_update.go
+++ b/cmd/camp/list_tui_update.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func (m listTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		if m.overlay != listOverlayNone {
+			return m.updateOverlay(msg)
+		}
+		return m.updateBrowse(msg)
+	}
+	return m, nil
+}
+
+func (m listTUIModel) updateBrowse(key tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.status = ""
+	switch key.String() {
+	case "ctrl+c", "q", "esc":
+		m.quitting = true
+		return m, tea.Quit
+	case "down", "j":
+		if len(m.visible) > 0 {
+			m.cursor = (m.cursor + 1) % len(m.visible)
+		}
+		return m, nil
+	case "up", "k":
+		if len(m.visible) > 0 {
+			m.cursor = (m.cursor - 1 + len(m.visible)) % len(m.visible)
+		}
+		return m, nil
+	case "s":
+		if len(m.visible) > 0 {
+			if err := m.cycleStatus(); err != nil {
+				m.setError(err)
+			}
+		}
+		return m, nil
+	case "m":
+		if len(m.visible) > 0 {
+			m.overlay = listOverlayMove
+			m.input.SetValue("")
+			m.input.Placeholder = "target org"
+			m.input.Focus()
+		}
+		return m, nil
+	case "y":
+		if len(m.visible) > 0 {
+			if err := m.copyPath(); err != nil {
+				m.setStatus("copy failed: "+err.Error(), true)
+			} else {
+				m.setStatus("copied!", false)
+			}
+		}
+		return m, nil
+	case "f":
+		m.activeOnly = !m.activeOnly
+		m.rebuildVisible()
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m listTUIModel) updateOverlay(key tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch key.String() {
+	case "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "esc":
+		m.overlay = listOverlayNone
+		m.input.Blur()
+		return m, nil
+	case "enter":
+		value := strings.TrimSpace(m.input.Value())
+		if value != "" && len(m.visible) > 0 {
+			e := m.visible[m.cursor]
+			if err := m.assignOrg(e.ID, e.Name, value); err != nil {
+				m.setError(err)
+			}
+		}
+		m.overlay = listOverlayNone
+		m.input.Blur()
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(key)
+	return m, cmd
+}

--- a/cmd/camp/list_tui_view.go
+++ b/cmd/camp/list_tui_view.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	tuistyles "github.com/Obedience-Corp/camp/internal/intent/tui"
+	"github.com/Obedience-Corp/camp/internal/pathutil"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/internal/ui/theme"
+)
+
+var listPal = theme.TUI()
+
+var (
+	listTitleStyle = tuistyles.TitleStyle
+	listHelpStyle  = tuistyles.HelpStyle
+	listErrStyle   = tuistyles.ErrorStyle
+	listOkStyle    = tuistyles.SuccessStyle
+	listOrgHeader  = lipgloss.NewStyle().Foreground(listPal.AccentAlt).Bold(true)
+	listSelStyle   = lipgloss.NewStyle().Foreground(listPal.Accent).Bold(true)
+	listNameStyle  = lipgloss.NewStyle().Foreground(listPal.TextPrimary)
+	listMutedStyle = lipgloss.NewStyle().Foreground(listPal.TextMuted)
+	listBadgeOn    = lipgloss.NewStyle().Foreground(listPal.Success)
+	listBadgeOff   = lipgloss.NewStyle().Foreground(listPal.Warning)
+	listBadgeRef   = lipgloss.NewStyle().Foreground(listPal.AccentAlt)
+	listBox        = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(listPal.BorderFocus).Padding(0, 1)
+)
+
+func listStatusCell(status string) string {
+	padded := fmt.Sprintf("%-10s", status)
+	switch status {
+	case config.StatusActive:
+		return listBadgeOn.Render(padded)
+	case config.StatusInactive:
+		return listBadgeOff.Render(padded)
+	case config.StatusReference:
+		return listBadgeRef.Render(padded)
+	default:
+		return listMutedStyle.Render(padded)
+	}
+}
+
+func (m listTUIModel) View() string {
+	if m.quitting {
+		return ""
+	}
+	if m.overlay != listOverlayNone {
+		return m.overlayView()
+	}
+
+	var b strings.Builder
+	b.WriteString(m.topBar() + "\n\n")
+
+	if len(m.visible) == 0 {
+		b.WriteString(listMutedStyle.Render("no campaigns to show") + "\n")
+	}
+
+	start, end := m.windowBounds()
+	prevOrg := ""
+	for i := start; i < end; i++ {
+		e := m.visible[i]
+		if e.Org != prevOrg {
+			b.WriteString(listOrgHeader.Render(e.Org) + "\n")
+			prevOrg = e.Org
+		}
+		cursor := "  "
+		name := fmt.Sprintf("%-22s", e.Name)
+		if i == m.cursor {
+			cursor = "> "
+			name = listSelStyle.Render(name)
+		} else {
+			name = listNameStyle.Render(name)
+		}
+		path := listMutedStyle.Render(pathutil.AbbreviateHome(e.Path))
+		b.WriteString("  " + cursor + name + "  " + listStatusCell(e.Status) + "  " + path + "\n")
+	}
+	if end < len(m.visible) || start > 0 {
+		b.WriteString(listMutedStyle.Render(fmt.Sprintf("  [%d-%d of %d]", start+1, end, len(m.visible))) + "\n")
+	}
+
+	b.WriteString("\n" + m.statusLine() + m.footer())
+	return listBox.Render(strings.TrimRight(b.String(), "\n")) + "\n"
+}
+
+// windowBounds returns the slice of m.visible to render, keeping the cursor in
+// view. When the terminal height is unknown (tests) it shows everything.
+func (m listTUIModel) windowBounds() (int, int) {
+	total := len(m.visible)
+	capacity := m.height - 7
+	if m.height <= 0 || capacity >= total {
+		return 0, total
+	}
+	if capacity < 3 {
+		capacity = 3
+	}
+	start := m.cursor - capacity/2
+	if start < 0 {
+		start = 0
+	}
+	end := start + capacity
+	if end > total {
+		end = total
+		start = end - capacity
+	}
+	if start < 0 {
+		start = 0
+	}
+	return start, end
+}
+
+func (m listTUIModel) topBar() string {
+	mode := "all"
+	if m.activeOnly {
+		mode = "active only"
+	}
+	return listTitleStyle.Render("Campaigns") + "  " +
+		listMutedStyle.Render(fmt.Sprintf("%s  .  showing: %s", ui.CountLabel(len(m.all), "campaign", "campaigns"), mode))
+}
+
+func (m listTUIModel) footer() string {
+	return listHelpStyle.Render("j/k: move . s: status . m: move org . y: copy . f: filter . q: quit")
+}
+
+func (m listTUIModel) statusLine() string {
+	if m.status == "" {
+		return ""
+	}
+	if m.statusErr {
+		return listErrStyle.Render(m.status) + "\n"
+	}
+	return listOkStyle.Render(m.status) + "\n"
+}
+
+func (m listTUIModel) overlayView() string {
+	e := m.visible[m.cursor]
+	box := listTitleStyle.Render(fmt.Sprintf("Move %q to org:", e.Name)) + "\n\n" +
+		m.input.View() + "\n\n" +
+		listMutedStyle.Render("existing orgs: "+m.orgNamesCSV()) + "\n\n" +
+		listHelpStyle.Render("enter: confirm . esc: cancel")
+	return listBox.Render(box) + "\n"
+}

--- a/internal/pathutil/home.go
+++ b/internal/pathutil/home.go
@@ -1,0 +1,23 @@
+package pathutil
+
+import (
+	"os"
+	"strings"
+)
+
+// AbbreviateHome replaces a leading $HOME in path with "~" for display. It
+// returns path unchanged when HOME is unknown or path is not under it. An exact
+// home match returns "~". This is display-only; "~" re-expands in any shell.
+func AbbreviateHome(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return path
+	}
+	if path == home {
+		return "~"
+	}
+	if strings.HasPrefix(path, home+string(os.PathSeparator)) {
+		return "~" + path[len(home):]
+	}
+	return path
+}

--- a/internal/pathutil/home_test.go
+++ b/internal/pathutil/home_test.go
@@ -1,0 +1,36 @@
+package pathutil
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestAbbreviateHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"under home", filepath.Join(home, "Dev", "x"), "~" + string(filepath.Separator) + filepath.Join("Dev", "x")},
+		{"exact home", home, "~"},
+		{"not under home", "/tmp/x", "/tmp/x"},
+		{"sibling prefix", home + "-other/x", home + "-other/x"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := AbbreviateHome(tc.in); got != tc.want {
+				t.Errorf("AbbreviateHome(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAbbreviateHome_EmptyHome(t *testing.T) {
+	t.Setenv("HOME", "")
+	if got := AbbreviateHome("/some/path"); got != "/some/path" {
+		t.Errorf("with empty HOME, AbbreviateHome should be a no-op, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Three improvements to `camp list`, all surfaced while using it. Designed in `workflow/design/camp-list-tui-and-tilde-paths/`. Every mutation routes through the existing `config.UpdateRegistry` atomic write path; no new persistence, no schema change, no database.

### 1. Interactive campaign browser
Bare `camp list` in a terminal opens an interactive browser (grouped by org), mirroring the `camp org` browser from #345.
- **Dispatch:** opens only for a plain, interactive invocation. `--json`, `--count`, a non-table `--format`, **or any filter/sort flag** (`--org/--tag/--status/--all/--sort/--group/--no-group`) prints the table unchanged. `-i` forces, degrading to the table when stdout is not a terminal. Behind a `listTUIRequested` helper + `stdoutIsTTY` var, fully unit-tested.
- Shows **all statuses by default** (so a just-deactivated campaign doesn't vanish), with color-coded badges (active=green, inactive=amber, reference=blue) and windowed scrolling that keeps the cursor in view.

### 2. Lifecycle toggle (the discoverable deactivation UX)
`camp lifecycle set <campaign> inactive` already existed but was buried and couldn't be done while browsing. In the browser, **`s`** cycles the selected campaign's status active → inactive → reference → active. One keypress to deactivate. `f` toggles an active-only filter.

Also in the browser: **`m`** reassigns the campaign's org (implicit-create on a new name, like `camp org add`); **`y`** copies the path to the clipboard.

### 3. Tilde paths
Home paths display as `~/Dev/...` instead of `/Users/<name>/Dev/...` — shorter and doesn't leak the username, and `~` re-expands. Via a new tested `pathutil.AbbreviateHome`. **Display-only**: the registry and `--json` keep absolute paths. Applied to the static `camp list` table (flat + grouped) and the browser; paths outside `$HOME` (e.g. `/srv/...`) stay absolute.

## Tests
- `pathutil.AbbreviateHome`: under-home, exact-home, not-under-home, sibling-prefix (no false match), empty-HOME.
- Dispatch matrix (`listTUIRequested`): TTY/piped, `--json`, `--count`, non-table format, `-i` force, shaping-flag-prints-table.
- Browser model (synthetic keys): opens org-major all-statuses, cycle-status deactivation persists and stays visible, active-only filter, move-org (valid + invalid-name-no-mutation), copy-uses-tilde (clipboard injected), quit, and a constrained-size View smoke.
- Full suite green; `just lint` clean (0 issues); gofmt clean; no `fmt.Errorf` or host-fs-test regressions.

## Notes for reviewers
- The browser lives in `package main` (`cmd/camp/list_tui*.go`), reusing `campaignEntry`/`sortCampaigns`/`filterEntries` and writing status/org via `config.UpdateRegistry` + `config.ValidateStatus`/`ValidateName` directly (no cross-package access to the unexported `lifecycle`/`org` handlers needed). Matches how `cmd/camp/status_all.go` already hosts a TUI.
- `writeClipboard` is a package var so tests don't touch the real clipboard.
- Per the design, this surfaces deactivation **only** in the TUI (no `camp deactivate` alias) and the browser does lifecycle/org/copy (no open/`cd` picker) — both deferred by choice.
- Remaining manual acceptance item: a human eyeball of the browser under each terminal theme (model + View tests cover structure; rendered frames look consistent with the org browser).
