### PR TITLE
feat(workitem): add 'init' alias for 'adopt'

### DIFF
--- a/internal/commands/workitem/adopt.go
+++ b/internal/commands/workitem/adopt.go
@@ -18,8 +18,9 @@ import (
 func newAdoptCommand() *cobra.Command {
 	var typeFlag, title, idOverride, questSelector string
 	cmd := &cobra.Command{
-		Use:   "adopt <dir>",
-		Short: "Attach .workitem metadata to an existing directory",
+		Use:     "adopt <dir>",
+		Aliases: []string{"init"},
+		Short:   "Attach .workitem metadata to an existing directory",
 		Long: `Attach workitem metadata to an existing campaign directory without moving it.
 
 The target directory must already exist and must not already contain a

--- a/internal/commands/workitem/create_test.go
+++ b/internal/commands/workitem/create_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -93,6 +94,21 @@ func TestQuestFlagHelpTextMatchesProfile(t *testing.T) {
 		default:
 			t.Fatalf("unexpected version.Profile %q", version.Profile)
 		}
+	}
+}
+
+func TestAdoptCommandHasInitAlias(t *testing.T) {
+	if !slices.Contains(newAdoptCommand().Aliases, "init") {
+		t.Fatal("adopt command missing init alias")
+	}
+
+	parent := NewWorkitemCommand()
+	found, _, err := parent.Find([]string{"init"})
+	if err != nil {
+		t.Fatalf("Find init: %v", err)
+	}
+	if found.Name() != "adopt" {
+		t.Fatalf("init resolved to %q, want adopt", found.Name())
 	}
 }
 


### PR DESCRIPTION
## What

Adds `init` as an alias for `camp workitem adopt`, so `camp workitem init <dir>` now does the same thing as `camp workitem adopt <dir>` (attach `.workitem` metadata to an existing directory).

## Why

`adopt` is accurate but slightly jargon-y for new users. `init` is the near-universal verb for "turn this existing directory into a tracked thing":

- `git init`, `npm init`, `cargo init`, `terraform init` all operate on an existing directory to set up tracking. That is exactly what `adopt` does.
- It is internally consistent with camp's own conventions:
  - `camp init` makes an existing directory a tracked **campaign**.
  - `camp flow add` already ships `Aliases: []string{"init"}` ("Add workflow tracking to current directory") — `internal/commands/flow/add.go:30`.
  - So `camp workitem init` (make an existing directory a tracked **workitem**) reads as the same verb at a smaller scope.

The split stays clean: `create` is the "make a brand-new one" verb (like `cargo new`), `adopt`/`init` is the "attach to an existing dir" verb (like `cargo init`). No collision with top-level `camp init` — they live at different command levels.

## Scope

Pure additive alias. **No behavior change**, no new flags, no change to `adopt`'s required `<dir>` argument. (Defaulting to the current directory like `git init` would be a separate behavior change and is intentionally not part of this PR.)

## Changes

- `internal/commands/workitem/adopt.go`: add `Aliases: []string{"init"}` to the adopt command.
- `internal/commands/workitem/create_test.go`: `TestAdoptCommandHasInitAlias` asserts the alias is present and that `init` resolves to the `adopt` command through the `workitem` parent.

## Verification

```
$ camp workitem adopt --help
Usage:
  camp workitem adopt <dir> [flags]

Aliases:
  adopt, init
```

- `go build ./...` — clean
- `go test ./internal/commands/workitem/` — pass
- `just lint` — 0 issues; `lint-no-fmt-errorf` and `lint-no-host-fs-tests` ratchets clean