### PR TITLE
Infer dungeon move triage source

### DIFF
--- a/cmd/camp/dungeon/move.go
+++ b/cmd/camp/dungeon/move.go
@@ -22,8 +22,10 @@ var dungeonMoveCmd = &cobra.Command{
 	Short: "Move dungeon items between statuses",
 	Long: `Move items within the dungeon or from the parent directory into the dungeon.
 
-Without --triage, moves an item already in the dungeon root to a status directory.
-With --triage, moves an item from the parent directory into the dungeon.
+By default, moves an item already in the dungeon root to a status directory.
+When the item exists in the parent directory and not in the dungeon root, the
+command automatically treats it as triage work and moves it into the dungeon.
+Use --triage to force a parent-directory move.
 With --triage and --to-docs, routes an item to an existing campaign-root docs/<subdirectory>.
 With --workitem, resolves a campaign workitem from anywhere and moves its directory
 into the workitem type's local dungeon.
@@ -96,6 +98,13 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	svc := intdungeon.NewService(cmdCtx.CampaignRoot, cmdCtx.Dungeon.DungeonPath)
+	if !triageMode {
+		inferred, err := inferDungeonMoveTriageMode(ctx, svc, cmdCtx.Dungeon, itemName)
+		if err != nil {
+			return err
+		}
+		triageMode = inferred
+	}
 
 	var description string
 	var sourcePaths []string
@@ -167,6 +176,51 @@ func runDungeonMove(cmd *cobra.Command, args []string) error {
 		DestinationPaths: destinationPaths,
 		RewrittenFiles:   svc.RewrittenLinkFiles(),
 	})
+}
+
+func inferDungeonMoveTriageMode(ctx context.Context, svc *intdungeon.Service, dungeonCtx intdungeon.Context, itemName string) (bool, error) {
+	cleanItem, ok := dungeonMoveDirectChildName(itemName)
+	if !ok {
+		return false, nil
+	}
+
+	dungeonRootExists := false
+	if _, err := os.Stat(filepath.Join(dungeonCtx.DungeonPath, cleanItem)); err == nil {
+		dungeonRootExists = true
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, camperrors.Wrapf(err, "checking dungeon item %s", cleanItem)
+	}
+
+	parentEligible := false
+	items, err := svc.ListParentItems(ctx, dungeonCtx.ParentPath)
+	if err != nil {
+		return false, camperrors.Wrap(err, "checking parent triage items")
+	}
+	for _, item := range items {
+		if item.Name == cleanItem {
+			parentEligible = true
+			break
+		}
+	}
+	return shouldInferDungeonMoveTriageMode(cleanItem, dungeonRootExists, parentEligible), nil
+}
+
+func shouldInferDungeonMoveTriageMode(itemName string, dungeonRootExists, parentEligible bool) bool {
+	if _, ok := dungeonMoveDirectChildName(itemName); !ok {
+		return false
+	}
+	return !dungeonRootExists && parentEligible
+}
+
+func dungeonMoveDirectChildName(itemName string) (string, bool) {
+	cleanItem := strings.TrimSpace(itemName)
+	if cleanItem == "" || cleanItem != itemName || filepath.Clean(cleanItem) != cleanItem || filepath.Base(cleanItem) != cleanItem {
+		return "", false
+	}
+	if strings.Contains(cleanItem, "/") || strings.Contains(cleanItem, "\\") {
+		return "", false
+	}
+	return cleanItem, true
 }
 
 type DungeonMoveCommitOutcome struct {

--- a/cmd/camp/dungeon/move_test.go
+++ b/cmd/camp/dungeon/move_test.go
@@ -36,6 +36,57 @@ func TestDungeonMove_NoCommitFlagRemoved(t *testing.T) {
 	}
 }
 
+func TestShouldInferDungeonMoveTriageMode(t *testing.T) {
+	tests := []struct {
+		name              string
+		itemName          string
+		dungeonRootExists bool
+		parentEligible    bool
+		want              bool
+	}{
+		{
+			name:           "parent item",
+			itemName:       "finished.md",
+			parentEligible: true,
+			want:           true,
+		},
+		{
+			name:              "dungeon root wins",
+			itemName:          "same.md",
+			dungeonRootExists: true,
+			parentEligible:    true,
+			want:              false,
+		},
+		{
+			name:           "not an eligible parent item",
+			itemName:       "projects",
+			parentEligible: false,
+			want:           false,
+		},
+		{
+			name:           "path traversal is not inferred",
+			itemName:       "../secret.md",
+			parentEligible: true,
+			want:           false,
+		},
+		{
+			name:           "nested path is not inferred",
+			itemName:       "group/finished.md",
+			parentEligible: true,
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldInferDungeonMoveTriageMode(tt.itemName, tt.dungeonRootExists, tt.parentEligible)
+			if got != tt.want {
+				t.Fatalf("shouldInferDungeonMoveTriageMode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWrapDungeonDocsRouteError_InvalidItemPath(t *testing.T) {
 	err := wrapDungeonDocsRouteError(intdungeon.ErrInvalidItemPath, "../secret.md", "architecture")
 	if err == nil {


### PR DESCRIPTION
## Summary

- Teach `camp dungeon move <item> [status]` to infer parent-directory triage mode when the item exists beside the resolved dungeon and is not already in the dungeon root.
- Preserve existing inner-dungeon behavior when a same-named item exists in the dungeon root, and keep explicit `--triage`, `--to-docs`, and `--workitem` paths unchanged.
- Update command help and add pure decision tests for the inference rules.

## Why

`camp dungeon move` had all of the service plumbing needed to move parent workitems into a dungeon status directory, but the non-interactive command required users to remember `--triage`. Running from a workflow parent directory with `camp dungeon move completed-item completed` incorrectly tried to move from the dungeon root first.

## Validation

- `go test ./cmd/camp/dungeon ./internal/dungeon`
- `just gate-push`
- Manual smoke: in a throwaway campaign, `camp dungeon move done.md completed` from `workflow/design/` moved `workflow/design/done.md` to `workflow/design/dungeon/completed/2026-06-25/done.md` without `--triage`.
