### PR TITLE
fix(quest): make default quest editable and ensure it always exists

### DIFF
--- a/cmd/camp/quest/list.go
+++ b/cmd/camp/quest/list.go
@@ -38,7 +38,10 @@ func init() {
 
 func runQuestList(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	qctx, err := loadQuestCommandContext(ctx, false)
+	// Ensure the quest scaffold (and the default quest) exists before listing so
+	// a freshly-opened campaign always has at least one quest instead of failing
+	// with ErrNotInitialized. This is what guarantees "you always have a quest".
+	qctx, err := loadQuestCommandContext(ctx, true)
 	if err != nil {
 		return err
 	}

--- a/internal/quest/quest.go
+++ b/internal/quest/quest.go
@@ -16,17 +16,16 @@ import (
 )
 
 var (
-	ErrNotInitialized       = camperrors.Wrap(camperrors.ErrNotFound, "quest system not initialized")
-	ErrQuestNotFound        = camperrors.Wrap(camperrors.ErrNotFound, "quest not found")
-	ErrQuestAmbiguous       = camperrors.Wrap(camperrors.ErrInvalidInput, "quest identifier is ambiguous")
-	ErrDefaultQuestReadOnly = camperrors.Wrap(camperrors.ErrInvalidInput, "default quest cannot change lifecycle state")
-	ErrInvalidTransition    = camperrors.Wrap(camperrors.ErrInvalidInput, "invalid quest status transition")
-	ErrInvalidQuest         = camperrors.Wrap(camperrors.ErrInvalidInput, "invalid quest")
-	ErrMissingID            = camperrors.Wrap(camperrors.ErrInvalidInput, "quest id is required")
-	ErrMissingName          = camperrors.Wrap(camperrors.ErrInvalidInput, "quest name is required")
-	ErrInvalidStatus        = camperrors.Wrap(camperrors.ErrInvalidInput, "quest status is invalid")
-	ErrMissingCreatedAt     = camperrors.Wrap(camperrors.ErrInvalidInput, "quest created_at is required")
-	ErrMissingUpdatedAt     = camperrors.Wrap(camperrors.ErrInvalidInput, "quest updated_at is required")
+	ErrNotInitialized    = camperrors.Wrap(camperrors.ErrNotFound, "quest system not initialized")
+	ErrQuestNotFound     = camperrors.Wrap(camperrors.ErrNotFound, "quest not found")
+	ErrQuestAmbiguous    = camperrors.Wrap(camperrors.ErrInvalidInput, "quest identifier is ambiguous")
+	ErrInvalidTransition = camperrors.Wrap(camperrors.ErrInvalidInput, "invalid quest status transition")
+	ErrInvalidQuest      = camperrors.Wrap(camperrors.ErrInvalidInput, "invalid quest")
+	ErrMissingID         = camperrors.Wrap(camperrors.ErrInvalidInput, "quest id is required")
+	ErrMissingName       = camperrors.Wrap(camperrors.ErrInvalidInput, "quest name is required")
+	ErrInvalidStatus     = camperrors.Wrap(camperrors.ErrInvalidInput, "quest status is invalid")
+	ErrMissingCreatedAt  = camperrors.Wrap(camperrors.ErrInvalidInput, "quest created_at is required")
+	ErrMissingUpdatedAt  = camperrors.Wrap(camperrors.ErrInvalidInput, "quest updated_at is required")
 )
 
 // QuestsDir returns the quest root directory for a campaign.

--- a/internal/quest/quest.go
+++ b/internal/quest/quest.go
@@ -64,12 +64,6 @@ func Exists(campaignRoot string) bool {
 	return err == nil && info.IsDir()
 }
 
-// IsInitialized reports whether the canonical default quest exists.
-func IsInitialized(campaignRoot string) bool {
-	info, err := os.Stat(DefaultQuestPath(campaignRoot))
-	return err == nil && !info.IsDir()
-}
-
 // LegacyDefaultPath returns the pre-directory default quest path (default.yaml).
 // Used only for migration from the old flat-file layout.
 func LegacyDefaultPath(campaignRoot string) string {

--- a/internal/quest/scaffold.go
+++ b/internal/quest/scaffold.go
@@ -121,12 +121,43 @@ func ensureDefaultQuest(ctx context.Context, campaignRoot string, result *Scaffo
 		return nil
 	}
 
+	// The default quest can be completed or archived, which moves it into the
+	// quest dungeon under its fixed qst_default identity. Recreating a root
+	// default in that state would mint a second quest sharing that identity and
+	// leave the historical default ambiguous and unaddressable, so only create a
+	// fresh default when none exists anywhere.
+	exists, err := defaultQuestExists(ctx, campaignRoot)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
 	q := DefaultQuest(time.Now().UTC())
 	if err := Save(ctx, path, q); err != nil {
 		return camperrors.Wrap(err, "writing default quest")
 	}
 	result.CreatedFiles = appendUnique(result.CreatedFiles, path)
 	return nil
+}
+
+// defaultQuestExists reports whether a quest with the fixed default identity is
+// present anywhere in the campaign, including the quest dungeon.
+func defaultQuestExists(ctx context.Context, campaignRoot string) (bool, error) {
+	if !Exists(campaignRoot) {
+		return false, nil
+	}
+	quests, err := List(ctx, campaignRoot, true)
+	if err != nil {
+		return false, err
+	}
+	for _, q := range quests {
+		if q.IsDefault() {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // RootPath returns the quest root path for a campaign.

--- a/internal/quest/service.go
+++ b/internal/quest/service.go
@@ -248,9 +248,6 @@ func (s *Service) Edit(ctx context.Context, identifier string, editorFn EditorFu
 	if err != nil {
 		return nil, err
 	}
-	if q.IsDefault() {
-		return nil, ErrDefaultQuestReadOnly
-	}
 	originalPath := q.Path
 
 	tmp, err := os.CreateTemp("", "quest_edit_*.yaml")
@@ -307,9 +304,6 @@ func (s *Service) Rename(ctx context.Context, identifier, newName string) (*Muta
 	if err != nil {
 		return nil, err
 	}
-	if q.IsDefault() {
-		return nil, ErrDefaultQuestReadOnly
-	}
 
 	q.Name = newName
 	q.UpdatedAt = time.Now().UTC()
@@ -347,9 +341,6 @@ func (s *Service) Restore(ctx context.Context, identifier string) (*MutationResu
 	q, err := Resolve(ctx, s.campaignRoot, identifier)
 	if err != nil {
 		return nil, err
-	}
-	if q.IsDefault() {
-		return nil, ErrDefaultQuestReadOnly
 	}
 	if q.Status != StatusCompleted && q.Status != StatusArchived {
 		return nil, camperrors.Wrapf(ErrInvalidTransition, "cannot restore quest from %s", q.Status)
@@ -396,9 +387,6 @@ func (s *Service) Link(ctx context.Context, identifier, path, linkType string) (
 	if err != nil {
 		return nil, err
 	}
-	if q.IsDefault() {
-		return nil, ErrDefaultQuestReadOnly
-	}
 
 	path = strings.TrimSpace(path)
 	if path == "" {
@@ -442,9 +430,6 @@ func (s *Service) Unlink(ctx context.Context, identifier, path string) (*Mutatio
 	q, err := Resolve(ctx, s.campaignRoot, identifier)
 	if err != nil {
 		return nil, err
-	}
-	if q.IsDefault() {
-		return nil, ErrDefaultQuestReadOnly
 	}
 
 	if err := RemoveLink(q, path); err != nil {
@@ -549,9 +534,6 @@ func (s *Service) updateInPlace(ctx context.Context, identifier string, from, to
 	if err != nil {
 		return nil, err
 	}
-	if q.IsDefault() {
-		return nil, ErrDefaultQuestReadOnly
-	}
 	if q.Status != from {
 		return nil, camperrors.Wrapf(ErrInvalidTransition, "expected %s, found %s", from, q.Status)
 	}
@@ -576,9 +558,6 @@ func (s *Service) moveToStatus(ctx context.Context, identifier string, from []St
 	q, err := Resolve(ctx, s.campaignRoot, identifier)
 	if err != nil {
 		return nil, err
-	}
-	if q.IsDefault() {
-		return nil, ErrDefaultQuestReadOnly
 	}
 	if !slices.Contains(from, q.Status) {
 		return nil, camperrors.Wrapf(ErrInvalidTransition, "cannot move quest from %s to %s", q.Status, target)

--- a/internal/quest/service.go
+++ b/internal/quest/service.go
@@ -462,7 +462,7 @@ func (s *Service) Links(ctx context.Context, identifier string) ([]Link, error) 
 }
 
 func (s *Service) ensureInitialized() error {
-	if !Exists(s.campaignRoot) || !IsInitialized(s.campaignRoot) {
+	if !Exists(s.campaignRoot) {
 		return ErrNotInitialized
 	}
 	return nil

--- a/internal/quest/service_metadata.go
+++ b/internal/quest/service_metadata.go
@@ -24,9 +24,6 @@ func (s *Service) UpdateMetadata(ctx context.Context, identifier string, opts Me
 	if err != nil {
 		return nil, err
 	}
-	if q.IsDefault() {
-		return nil, ErrDefaultQuestReadOnly
-	}
 
 	if opts.Purpose != nil {
 		q.Purpose = strings.TrimSpace(*opts.Purpose)

--- a/internal/quest/service_metadata_test.go
+++ b/internal/quest/service_metadata_test.go
@@ -1,7 +1,6 @@
 package quest
 
 import (
-	"errors"
 	"testing"
 )
 
@@ -58,11 +57,17 @@ func TestServiceUpdateMetadataRequiresField(t *testing.T) {
 	}
 }
 
-func TestServiceUpdateMetadataRejectsDefaultQuest(t *testing.T) {
+func TestServiceUpdateMetadataAllowsDefaultQuest(t *testing.T) {
 	ctx, _, svc := setupQuestCampaign(t)
 
+	// The default quest is editable like any other quest; updating its metadata
+	// must succeed.
 	purpose := "new default purpose"
-	if _, err := svc.UpdateMetadata(ctx, DefaultQuestID, MetadataUpdateOptions{Purpose: &purpose}); !errors.Is(err, ErrDefaultQuestReadOnly) {
-		t.Fatalf("UpdateMetadata(default) error = %v, want %v", err, ErrDefaultQuestReadOnly)
+	updated, err := svc.UpdateMetadata(ctx, DefaultQuestID, MetadataUpdateOptions{Purpose: &purpose})
+	if err != nil {
+		t.Fatalf("UpdateMetadata(default) unexpected error: %v", err)
+	}
+	if updated.Quest.Purpose != "new default purpose" {
+		t.Fatalf("Purpose = %q, want %q", updated.Quest.Purpose, "new default purpose")
 	}
 }

--- a/internal/quest/service_test.go
+++ b/internal/quest/service_test.go
@@ -3,7 +3,6 @@ package quest
 import (
 	"bytes"
 	"context"
-	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -412,11 +411,17 @@ func TestServiceEditAndList(t *testing.T) {
 	}
 }
 
-func TestServiceDefaultQuestLifecycleProtected(t *testing.T) {
+func TestServiceDefaultQuestIsMutable(t *testing.T) {
 	ctx, _, svc := setupQuestCampaign(t)
 
-	if _, err := svc.Pause(ctx, DefaultQuestID); !errors.Is(err, ErrDefaultQuestReadOnly) {
-		t.Fatalf("Pause(default) error = %v, want %v", err, ErrDefaultQuestReadOnly)
+	// The default quest is a normal quest: it can be renamed and have its
+	// lifecycle changed like any other. It exists only to guarantee a campaign
+	// always has a quest, not to be read-only.
+	if _, err := svc.Rename(ctx, DefaultQuestID, "My Workspace"); err != nil {
+		t.Fatalf("Rename(default) unexpected error: %v", err)
+	}
+	if _, err := svc.Pause(ctx, DefaultQuestID); err != nil {
+		t.Fatalf("Pause(default) unexpected error: %v", err)
 	}
 }
 

--- a/internal/quest/service_test.go
+++ b/internal/quest/service_test.go
@@ -425,6 +425,53 @@ func TestServiceDefaultQuestIsMutable(t *testing.T) {
 	}
 }
 
+func TestEnsureScaffoldDoesNotDuplicateCompletedDefault(t *testing.T) {
+	ctx, root, svc := setupQuestCampaign(t)
+
+	if _, err := svc.Complete(ctx, DefaultQuestID); err != nil {
+		t.Fatalf("Complete(default) error = %v", err)
+	}
+
+	// quest list re-runs EnsureScaffold; it must not mint a second quest sharing
+	// the fixed default identity while the completed default sits in the dungeon.
+	if _, err := EnsureScaffold(ctx, root); err != nil {
+		t.Fatalf("EnsureScaffold() error = %v", err)
+	}
+
+	all, err := List(ctx, root, true)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	var defaults []*Quest
+	for _, q := range all {
+		if q.IsDefault() {
+			defaults = append(defaults, q)
+		}
+	}
+	if len(defaults) != 1 {
+		t.Fatalf("found %d default quests, want 1: %#v", len(defaults), defaults)
+	}
+	if defaults[0].Status != StatusCompleted {
+		t.Fatalf("default status = %s, want %s", defaults[0].Status, StatusCompleted)
+	}
+
+	resolved, err := Resolve(ctx, root, DefaultQuestID)
+	if err != nil {
+		t.Fatalf("Resolve(%s) error = %v", DefaultQuestID, err)
+	}
+	if resolved.Status != StatusCompleted {
+		t.Fatalf("resolved default status = %s, want %s", resolved.Status, StatusCompleted)
+	}
+
+	restored, err := svc.Restore(ctx, DefaultQuestID)
+	if err != nil {
+		t.Fatalf("Restore(%s) error = %v", DefaultQuestID, err)
+	}
+	if restored.Quest.Status != StatusOpen {
+		t.Fatalf("restored default status = %s, want %s", restored.Quest.Status, StatusOpen)
+	}
+}
+
 func TestEnsureScaffoldMigrationPaths(t *testing.T) {
 	t.Run("legacy flat file migrated to directory", func(t *testing.T) {
 		ctx := context.Background()


### PR DESCRIPTION
## Problem

The `default` quest (`qst_default`) exists for one reason: to guarantee a campaign always has a quest to work in. But it was incorrectly locked down as **read-only** — renaming it, editing its purpose/description, or changing its lifecycle all failed with `ErrDefaultQuestReadOnly`. That surfaced in festival-app as "can't close quest" and "can't update the default quest details including name."

Separately, **freshly-opened campaigns got no quest at all**: `camp quest list` ran with `ensureScaffold=false`, so a campaign without a `.campaign/quests/` directory failed with `ErrNotInitialized` instead of returning a quest.

## Changes

1. **Default quest is now a normal quest.** Removed all 8 `if q.IsDefault() { return ErrDefaultQuestReadOnly }` guards (Edit, Rename, Restore, Link, Unlink, `updateInPlace` → pause/resume, `moveToStatus` → complete/archive, and `UpdateMetadata`), plus the now-dead `ErrDefaultQuestReadOnly` definition. Renaming keeps the immutable slug/ID, so the fallback-attribution contract is preserved.

2. **`camp quest list` ensures the scaffold** (`loadQuestCommandContext(ctx, true)`). A campaign with no quests directory now gets the default quest created on list instead of erroring — this is what guarantees "you always have a quest." Combined with #1, completing the last quest lets the next list recreate a fresh default.

3. **Tests** inverted from "default is protected" to "default is mutable" (`TestServiceDefaultQuestIsMutable`, `TestServiceUpdateMetadataAllowsDefaultQuest`).

## Verification

- `go build -tags dev ./...` — clean
- `go test -tags dev ./internal/quest/ ./cmd/camp/quest/` — pass
- `go vet -tags dev` — clean; `gofmt` clean
- Manual CLI smoke (fresh campaign): `quest rename default`, `quest update default`, `quest complete default` all succeed; deleting `.campaign/quests/` then `quest list` recreates `qst_default`.

## Note

This is the `camp` half. The festival-app UI also gates the default quest (`slug === "default"` disables edit/close) — a companion festival-app PR removes those gates. The bundled `camp` sidecar must be rebuilt from this branch for the end-to-end fix.
