### PR TITLE
Add settings navigation shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Navigate instantly with single-letter shortcuts:
 | `w`      | workflow/              | Workflow directory     |
 | `d`      | docs/                  | Human documentation    |
 | `i`      | .campaign/intents/     | Intents via `camp intent` |
+| `settings` | .campaign/          | Campaign settings directory |
 | `wt`     | projects/worktrees/    | Git worktrees          |
 | `du`     | dungeon/               | Archived work          |
 | `cr`     | workflow/code_reviews/ | Code review materials  |

--- a/docs/SHORTCUTS.md
+++ b/docs/SHORTCUTS.md
@@ -102,7 +102,8 @@ These defaults are written by `camp init` and can be overridden per campaign:
 | `pi` | `workflow/pipelines/` | navigation only |
 | `de` | `workflow/design/` | navigation only |
 | `ex` | `workflow/explore/` | navigation only |
-| `cfg` | no path | command expansion only |
+| `settings` | `.campaign/` | navigation only |
+| `cfg` | `.campaign/` | navigation plus command expansion |
 
 `camp go i` and `cgo i` remain available as operator shortcuts, but the primary
 human interface for this state is `camp intent`.

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -55,6 +55,7 @@ cgo f fest    # festivals/*fest* (fuzzy match)
 | p        | projects/      | Project directories     |
 | f        | festivals/     | Festival planning       |
 | i        | .campaign/intents/ | Intents via `camp intent` |
+| settings | .campaign/ | Campaign settings directory |
 | d        | docs/          | Documentation           |
 | w        | workflow/      | Workflow resources      |
 | wt       | projects/worktrees/ | Git worktrees     |

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -81,13 +81,14 @@ func DefaultNavigationShortcuts() map[string]ShortcutConfig {
 		"wt": {Path: "projects/worktrees/", Concept: "project worktree", Description: "Project worktree directory and commands", Source: ShortcutSourceAuto},
 
 		// Navigation-only shortcuts (no command expansion)
-		"w":  {Path: "workflow/", Description: "Jump to workflow directory", Source: ShortcutSourceAuto},
-		"d":  {Path: "docs/", Description: "Jump to docs directory", Source: ShortcutSourceAuto},
-		"du": {Path: "dungeon/", Description: "Jump to dungeon directory (navigation only)", Source: ShortcutSourceAuto},
-		"cr": {Path: "workflow/code_reviews/", Description: "Jump to code reviews", Source: ShortcutSourceAuto},
-		"pi": {Path: "workflow/pipelines/", Description: "Jump to pipelines", Source: ShortcutSourceAuto},
-		"de": {Path: "workflow/design/", Description: "Jump to design", Source: ShortcutSourceAuto},
-		"ex": {Path: "workflow/explore/", Description: "Jump to explore", Source: ShortcutSourceAuto},
+		"w":        {Path: "workflow/", Description: "Jump to workflow directory", Source: ShortcutSourceAuto},
+		"d":        {Path: "docs/", Description: "Jump to docs directory", Source: ShortcutSourceAuto},
+		"du":       {Path: "dungeon/", Description: "Jump to dungeon directory (navigation only)", Source: ShortcutSourceAuto},
+		"cr":       {Path: "workflow/code_reviews/", Description: "Jump to code reviews", Source: ShortcutSourceAuto},
+		"pi":       {Path: "workflow/pipelines/", Description: "Jump to pipelines", Source: ShortcutSourceAuto},
+		"de":       {Path: "workflow/design/", Description: "Jump to design", Source: ShortcutSourceAuto},
+		"ex":       {Path: "workflow/explore/", Description: "Jump to explore", Source: ShortcutSourceAuto},
+		"settings": {Path: ".campaign/", Description: "Jump to campaign settings directory", Source: ShortcutSourceAuto},
 
 		// Navigation + command expansion
 		"cfg": {Path: ".campaign/", Concept: "config", Description: "Campaign config directory and commands", Source: ShortcutSourceAuto},

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -210,3 +210,19 @@ paths:
 		t.Fatalf("Paths.Projects = %q, want %q", got, "projects/")
 	}
 }
+
+func TestDefaultNavigationShortcuts_SettingsShortcut(t *testing.T) {
+	shortcut, ok := DefaultNavigationShortcuts()["settings"]
+	if !ok {
+		t.Fatal("settings shortcut missing from defaults")
+	}
+	if shortcut.Path != ".campaign/" {
+		t.Fatalf("settings shortcut path = %q, want %q", shortcut.Path, ".campaign/")
+	}
+	if shortcut.Concept != "" {
+		t.Fatalf("settings shortcut concept = %q, want empty so camp settings is not expanded", shortcut.Concept)
+	}
+	if !shortcut.IsNavigation() {
+		t.Fatal("settings shortcut should be navigation-capable")
+	}
+}

--- a/tests/integration/navigation_test.go
+++ b/tests/integration/navigation_test.go
@@ -298,11 +298,17 @@ func TestShortcuts_OnlyFromConfig(t *testing.T) {
 	require.NoError(t, err, "shortcut 'p' should work when defined in jumps.yaml")
 	assert.Contains(t, output, "projects", "shortcut 'p' should resolve to projects/")
 
+	// Verify long-form settings shortcut works for .campaign/
+	output, err = tc.RunCampInDir("/campaigns/shortcuts-test", "go", "settings", "--print")
+	require.NoError(t, err, "shortcut 'settings' should work when defined in jumps.yaml")
+	assert.Contains(t, output, "/campaigns/shortcuts-test/.campaign", "shortcut 'settings' should resolve to .campaign/")
+
 	// Read jumps.yaml to verify shortcuts are there
 	config, err := tc.ReadFile("/campaigns/shortcuts-test/.campaign/settings/jumps.yaml")
 	require.NoError(t, err)
 	assert.Contains(t, config, "shortcuts:", "jumps.yaml should have shortcuts section")
 	assert.Contains(t, config, "p:", "jumps.yaml should have 'p' shortcut")
+	assert.Contains(t, config, "settings:", "jumps.yaml should have 'settings' shortcut")
 }
 
 // TestShortcuts_HelpShowsConfigOnly verifies that --help shows shortcuts from jumps.yaml


### PR DESCRIPTION
## Summary

Adds a default `settings` navigation shortcut that resolves to `.campaign/`, so `camp go settings` and `cgo settings` jump to the campaign settings directory.

Updates the shortcut docs and adds regression coverage to keep the shortcut navigation-only so the existing `camp settings` command is not rewritten by shortcut expansion.

## Validation

- `go test ./internal/config ./internal/nav ./internal/shell ./cmd/camp/navigation`
- `go test -tags=integration ./tests/integration -run TestShortcuts_OnlyFromConfig -count=1`
- `just build-camp`
- `just test unit`