### PR TITLE
feat(git): use campaign name in commit tags instead of hardcoded OBEY-CAMPAIGN

### DIFF
--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -200,7 +200,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	// includes WI-<ref> when one is in context.
 	if cfg, cfgErr := config.LoadCampaignConfig(ctx, campRoot); cfgErr == nil && message != "" {
 		questID, workitemRef := resolveCommitContext(ctx, campRoot, commitWorkitem)
-		message = commitkit.PrependContextTagsFull(cfg.ID, questID, "", workitemRef, message)
+		message = commitkit.PrependContextTagsFull(cfg.Name, cfg.ID, questID, "", workitemRef, message)
 	}
 
 	// Perform commit

--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -200,7 +200,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	// includes WI-<ref> when one is in context.
 	if cfg, cfgErr := config.LoadCampaignConfig(ctx, campRoot); cfgErr == nil && message != "" {
 		questID, workitemRef := resolveCommitContext(ctx, campRoot, commitWorkitem)
-		message = commitkit.PrependContextTagsFull(cfg.Name, cfg.ID, questID, "", workitemRef, message)
+		message = commitkit.PrependContextTagsFullNamed(cfg.Name, cfg.ID, questID, "", workitemRef, message)
 	}
 
 	// Perform commit

--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -155,7 +155,7 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 	// project is linked.
 	if cfg != nil {
 		questID, workitemRef := resolveProjectCommitContext(ctx, campRoot, resolvedPath, projectCommitWorkitem)
-		message = commitkit.PrependContextTagsFull(cfg.Name, cfg.ID, questID, "", workitemRef, message)
+		message = commitkit.PrependContextTagsFullNamed(cfg.Name, cfg.ID, questID, "", workitemRef, message)
 	}
 
 	// Commit

--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -155,7 +155,7 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 	// project is linked.
 	if cfg != nil {
 		questID, workitemRef := resolveProjectCommitContext(ctx, campRoot, resolvedPath, projectCommitWorkitem)
-		message = commitkit.PrependContextTagsFull(cfg.ID, questID, "", workitemRef, message)
+		message = commitkit.PrependContextTagsFull(cfg.Name, cfg.ID, questID, "", workitemRef, message)
 	}
 
 	// Commit
@@ -202,7 +202,7 @@ func syncParentRef(ctx context.Context, campRoot, relPath string, cfg *config.Ca
 	projName := filepath.Base(relPath)
 	msg := fmt.Sprintf("update %s submodule ref", projName)
 	if cfg != nil {
-		msg = git.PrependCampaignTag(cfg.ID, msg)
+		msg = git.PrependContextTagsFull(cfg.Name, cfg.ID, "", "", "", msg)
 	}
 
 	opts := &git.CommitOptions{Message: msg}

--- a/cmd/camp/refs/commands.go
+++ b/cmd/camp/refs/commands.go
@@ -96,7 +96,7 @@ func runRefsSync(cmd *cobra.Command, args []string) error {
 	cfg, _ := config.LoadCampaignConfig(ctx, campRoot)
 	msg := fmt.Sprintf("sync submodule refs: %s", strings.Join(names, ", "))
 	if cfg != nil {
-		msg = git.PrependCampaignTag(cfg.ID, msg)
+		msg = git.PrependContextTagsFull(cfg.Name, cfg.ID, "", "", "", msg)
 	}
 	if err := git.CommitScoped(ctx, campRoot, toSync, &git.CommitOptions{Message: msg}); err != nil {
 		return camperrors.Wrap(err, "commit")

--- a/cmd/camp/worktrees/commit.go
+++ b/cmd/camp/worktrees/commit.go
@@ -140,7 +140,7 @@ func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 
 	// Prepend campaign/workitem context tag.
 	questID, workitemRef := resolveWorktreeCommitContext(ctx, campRoot, wtCtx.WorktreePath, wtCommitWorkitem)
-	message = commitkit.PrependContextTagsFull(cfg.Name, cfg.ID, questID, "", workitemRef, message)
+	message = commitkit.PrependContextTagsFullNamed(cfg.Name, cfg.ID, questID, "", workitemRef, message)
 
 	// Commit
 	fmt.Println(ui.Info("Committing changes..."))

--- a/cmd/camp/worktrees/commit.go
+++ b/cmd/camp/worktrees/commit.go
@@ -140,7 +140,7 @@ func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 
 	// Prepend campaign/workitem context tag.
 	questID, workitemRef := resolveWorktreeCommitContext(ctx, campRoot, wtCtx.WorktreePath, wtCommitWorkitem)
-	message = commitkit.PrependContextTagsFull(cfg.ID, questID, "", workitemRef, message)
+	message = commitkit.PrependContextTagsFull(cfg.Name, cfg.ID, questID, "", workitemRef, message)
 
 	// Commit
 	fmt.Println(ui.Info("Committing changes..."))

--- a/docs/workitem-commit-reference.md
+++ b/docs/workitem-commit-reference.md
@@ -118,7 +118,7 @@ skipped:
   <path> (out of scope)
   <path> (submodule pointer; use --include-submodule-pointer)
   <path> (--exclude)
-tag:    [OBEY-CAMPAIGN-<8hex>[-qst_<...>][-FE-<festival-ref>][-WI-WI-<6hex>]]
+tag:    [<campaign-name>:<8hex>[-qst_<...>][-FE-<festival-ref>][-WI-WI-<6hex>]]
 ```
 
 `S` marks files already in the index (from `--staged` mode). `A` marks files
@@ -196,8 +196,8 @@ Results are sorted newest first across all repos before `--limit` and
 
 ```
 REPO    SHA       DATE        SUBJECT
-.       a1b2c3d4  2026-05-25  [OBEY-CAMPAIGN-abc-WI-WI-def123] feat: ...
-projects/camp  e5f6a7b8  2026-05-24  [OBEY-CAMPAIGN-abc-WI-WI-def123] fix: ...
+.       a1b2c3d4  2026-05-25  [obey-campaign:2736169c-WI-WI-def123] feat: ...
+projects/camp  e5f6a7b8  2026-05-24  [obey-campaign:2736169c-WI-WI-def123] fix: ...
 ```
 
 Per-repo errors are reported on stderr as a summary warning. Under `--json`,
@@ -211,12 +211,18 @@ Every commit produced by `camp workitem commit` (and `camp commit` / `camp p
 commit` when run in a workitem context) carries a tag with this structure:
 
 ```
-[OBEY-CAMPAIGN-<campaign-id>[-<quest-id>][-FE-<festival-ref>][-WI-WI-<workitem-ref>]]
+[<campaign-name>:<campaign-id>[-<quest-id>][-FE-<festival-ref>][-WI-WI-<workitem-ref>]]
 ```
 
 Segment rules:
 
-- All four components appear in fixed order inside the bracket. Absent
+- The leading token is the slugified campaign name followed by `:` and the
+  short campaign id. The colon separates the name (which may itself contain
+  hyphens) from the rest of the tag, which uses `-` between components.
+- `<campaign-name>` is the campaign's name, lowercased and slugified (spaces
+  and other separators become hyphens) via the shared `internal/slug`
+  generator.
+- All remaining components appear in fixed order inside the bracket. Absent
   components are omitted entirely; their separators do not appear.
 - `<campaign-id>` is the first 8 hex characters of the campaign UUID.
 - `<quest-id>` matches `qst_<digits>_<alphanum>` when a quest is active.
@@ -226,16 +232,22 @@ Segment rules:
   ref already starts with `WI-`, the segment marker adds a second `WI-`,
   producing the `WI-WI-` double prefix. This is intentional. The segment
   marker and the ref are distinct: flattening to a single prefix breaks the
-  parser's segment-boundary detection (see `indexOfNextPrefix` in
-  `internal/git/campaign_tag.go`).
+  parser's segment-boundary detection (see the segment walker in
+  `ParseTagDetailed`, `internal/git/campaign_tag.go`).
+
+When the campaign name cannot be resolved or slugifies to nothing, the tag
+falls back to the legacy `[OBEY-CAMPAIGN-<campaign-id>...]` form. The parser
+recognizes both forms, so the entire pre-existing commit history still
+resolves correctly.
 
 Concrete examples:
 
 ```
-[OBEY-CAMPAIGN-2736169c] feat: no workitem
-[OBEY-CAMPAIGN-2736169c-WI-WI-861089] fix: workitem only
-[OBEY-CAMPAIGN-2736169c-qst_1_alpha-WI-WI-861089] fix: with quest
-[OBEY-CAMPAIGN-2736169c-FE-CW0003-WI-WI-861089] feat: festival + workitem
+[obey-campaign:2736169c] feat: no workitem
+[obey-campaign:2736169c-WI-WI-861089] fix: workitem only
+[obey-campaign:2736169c-qst_1_alpha-WI-WI-861089] fix: with quest
+[obey-campaign:2736169c-FE-CW0003-WI-WI-861089] feat: festival + workitem
+[OBEY-CAMPAIGN-2736169c] feat: legacy fallback (name unavailable)
 ```
 
 The full composer is `FormatContextTagsFull` in

--- a/internal/commands/workitem/commit.go
+++ b/internal/commands/workitem/commit.go
@@ -122,6 +122,7 @@ func runCommit(ctx context.Context, cmd *cobra.Command, flags commitFlags) error
 		StagedOnly:              flags.Staged,
 		IncludeSubmodulePointer: flags.IncludeSubmodulePointer,
 		CampaignID:              cfg.ID,
+		CampaignName:            cfg.Name,
 	})
 	if err != nil {
 		if errors.Is(err, ErrNoWorkitemContext) {
@@ -173,6 +174,7 @@ func runCommit(ctx context.Context, cmd *cobra.Command, flags commitFlags) error
 		Options: commit.Options{
 			CampaignRoot:  plan.RepoRoot,
 			CampaignID:    cfg.ID,
+			CampaignName:  cfg.Name,
 			Files:         plan.Stage,
 			PreStaged:     plan.PreStaged,
 			SelectiveOnly: true,

--- a/internal/commands/workitem/staging.go
+++ b/internal/commands/workitem/staging.go
@@ -46,6 +46,7 @@ type PlanOptions struct {
 	IncludeSubmodulePointer bool     // --include-submodule-pointer
 	FestivalID              string   // --festival <id>, or inferred from cwd
 	CampaignID              string
+	CampaignName            string    // campaign name; slugified into the commit tag
 	Stderr                  io.Writer // for warning lines from ref backfill (default: os.Stderr)
 }
 
@@ -126,7 +127,7 @@ func ComputePlan(ctx context.Context, campaignRoot string, opts PlanOptions) (*S
 		WorkitemRef: ref,
 		QuestID:     res.QuestID,
 		FestivalRef: festivalRef,
-		Tag:         commitkit.FormatContextTagsFull(opts.CampaignID, res.QuestID, festivalRef, ref),
+		Tag:         commitkit.FormatContextTagsFull(opts.CampaignName, opts.CampaignID, res.QuestID, festivalRef, ref),
 	}
 	if ref == "" && wi != nil && wi.ItemKind == wkitem.ItemKindDirectory && wi.StableID != "" {
 		plan.Warnings = append(plan.Warnings,

--- a/internal/commands/workitem/staging.go
+++ b/internal/commands/workitem/staging.go
@@ -127,7 +127,7 @@ func ComputePlan(ctx context.Context, campaignRoot string, opts PlanOptions) (*S
 		WorkitemRef: ref,
 		QuestID:     res.QuestID,
 		FestivalRef: festivalRef,
-		Tag:         commitkit.FormatContextTagsFull(opts.CampaignName, opts.CampaignID, res.QuestID, festivalRef, ref),
+		Tag:         commitkit.FormatContextTagsFullNamed(opts.CampaignName, opts.CampaignID, res.QuestID, festivalRef, ref),
 	}
 	if ref == "" && wi != nil && wi.ItemKind == wkitem.ItemKindDirectory && wi.StableID != "" {
 		plan.Warnings = append(plan.Warnings,

--- a/internal/commands/workitem/testdata/plans/campaign_root.txt
+++ b/internal/commands/workitem/testdata/plans/campaign_root.txt
@@ -5,4 +5,4 @@ staging:
 skipped:
   README.md (out of scope)
   projects/camp-timeline (submodule pointer; use --include-submodule-pointer)
-tag:    [OBEY-CAMPAIGN-8deed8b4-WI-WI-abc123]
+tag:    [obey-campaign:8deed8b4-WI-WI-abc123]

--- a/internal/commands/workitem/testdata/plans/festival_scope.txt
+++ b/internal/commands/workitem/testdata/plans/festival_scope.txt
@@ -5,4 +5,4 @@ staging:
   M  .campaign/workitems/links.yaml
 skipped:
   festivals/active/camp-workitem-linking-and-commits-CW0003/.fest/state.json (out of scope)
-tag:    [OBEY-CAMPAIGN-8deed8b4-qst_active-FE-CW0003-WI-WI-def456]
+tag:    [obey-campaign:8deed8b4-qst_active-FE-CW0003-WI-WI-def456]

--- a/internal/commands/workitem/testdata/plans/linked_project.txt
+++ b/internal/commands/workitem/testdata/plans/linked_project.txt
@@ -5,4 +5,4 @@ staging:
   A  internal/timeline/render_test.go
 skipped:
   scratch.txt (gitignored)
-tag:    [OBEY-CAMPAIGN-8deed8b4-WI-WI-abc123]
+tag:    [obey-campaign:8deed8b4-WI-WI-abc123]

--- a/internal/commands/workitem/testdata/plans/submodule_pointer_explicit.txt
+++ b/internal/commands/workitem/testdata/plans/submodule_pointer_explicit.txt
@@ -4,4 +4,4 @@ staging:
   M  projects/camp-timeline
   M  workflow/design/timeline/plan.md
 skipped:
-tag:    [OBEY-CAMPAIGN-8deed8b4-WI-WI-abc123]
+tag:    [obey-campaign:8deed8b4-WI-WI-abc123]

--- a/internal/commands/workitem/testdata/plans/workitem_dir.txt
+++ b/internal/commands/workitem/testdata/plans/workitem_dir.txt
@@ -6,4 +6,4 @@ staging:
   M  .campaign/workitems/links.yaml
 skipped:
   workflow/design/timeline/scratch.tmp (gitignored)
-tag:    [OBEY-CAMPAIGN-8deed8b4-WI-WI-abc123]
+tag:    [obey-campaign:8deed8b4-WI-WI-abc123]

--- a/internal/git/campaign_tag.go
+++ b/internal/git/campaign_tag.go
@@ -28,8 +28,11 @@ func FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemR
 		shortID = shortID[:campaignTagMaxIDLen]
 	}
 
+	// Only emit the name-style head when shortID has the hex shape the parser
+	// requires (isNameStyleHead); otherwise fall back to the legacy form so the
+	// emit and parse sides cannot diverge.
 	head := legacyTagMarker + "-" + shortID
-	if nameSlug := slug.Generate(campaignName); nameSlug != "" {
+	if nameSlug := slug.Generate(campaignName); nameSlug != "" && tagNameStyleIDRe.MatchString(shortID) {
 		head = nameSlug + ":" + shortID
 	}
 

--- a/internal/git/campaign_tag.go
+++ b/internal/git/campaign_tag.go
@@ -3,18 +3,31 @@ package git
 import (
 	"regexp"
 	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/slug"
 )
 
 const campaignTagMaxIDLen = 8
 
-// FormatContextTagsFull composes the consolidated campaign tag from any
-// subset of the four components. Component order inside the bracket is
-// fixed: campaign id, then quest id (qst_<...>), then festival ref
-// (FE-<ref>), then workitem ref (WI-<ref>). Absent components are
-// omitted entirely; their separators do not appear in the output.
+// legacyTagMarker is the fixed leading token campaign tags carried before they
+// embedded the campaign name. Tags formatted without a resolvable campaign name
+// fall back to "[<legacyTagMarker>-<id>...]", and ParseTag still recognizes this
+// form so the entire pre-existing commit history resolves correctly.
+const legacyTagMarker = "OBEY-CAMPAIGN"
+
+// FormatContextTagsFull composes the consolidated campaign tag from any subset
+// of (campaign name, campaign id, quest id, festival ref, workitem ref).
+//
+// The leading token is the slugified campaign name followed by ":" and the
+// short campaign id, e.g. "[obey-campaign:8deed8b4]". When campaignName has no
+// usable slug (empty or unslugifiable), it falls back to the legacy
+// "[OBEY-CAMPAIGN-<id>]" form. After the leading token the component order is
+// fixed: quest id (qst_<...>), then festival ref (FE-<ref>), then workitem ref
+// (WI-<ref>). Absent components are omitted entirely; their separators do not
+// appear in the output.
 //
 // Returns "" when campaignID is empty (no tag without a campaign).
-func FormatContextTagsFull(campaignID, questID, festRef, workitemRef string) string {
+func FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef string) string {
 	if campaignID == "" {
 		return ""
 	}
@@ -22,7 +35,13 @@ func FormatContextTagsFull(campaignID, questID, festRef, workitemRef string) str
 	if len(shortID) > campaignTagMaxIDLen {
 		shortID = shortID[:campaignTagMaxIDLen]
 	}
-	parts := []string{"OBEY-CAMPAIGN", shortID}
+
+	head := legacyTagMarker + "-" + shortID
+	if nameSlug := slug.Generate(campaignName); nameSlug != "" {
+		head = nameSlug + ":" + shortID
+	}
+
+	parts := []string{head}
 	if questID != "" {
 		parts = append(parts, questID)
 	}
@@ -41,70 +60,87 @@ func FormatContextTagsFull(campaignID, questID, festRef, workitemRef string) str
 	return "[" + strings.Join(parts, "-") + "]"
 }
 
-// FormatCampaignTag returns the "[OBEY-CAMPAIGN-{id}]" prefix string.
-// If a questID is provided, it is appended inside the same bracket:
-// "[OBEY-CAMPAIGN-{id}-{questID}]".
-// Truncates campaignID to 8 characters. Returns empty string if campaignID is empty.
+// FormatCampaignTag returns the legacy "[OBEY-CAMPAIGN-{id}]" prefix string for
+// callers that only have a campaign id (e.g. the public id-only API consumed by
+// fest). If a questID is provided it is appended inside the same bracket:
+// "[OBEY-CAMPAIGN-{id}-{questID}]". Truncates campaignID to 8 characters.
+// Returns empty string if campaignID is empty.
 func FormatCampaignTag(campaignID string, questID ...string) string {
 	qid := ""
 	if len(questID) > 0 {
 		qid = questID[0]
 	}
-	return FormatContextTagsFull(campaignID, qid, "", "")
+	return FormatContextTagsFull("", campaignID, qid, "", "")
 }
 
-// PrependCampaignTag prepends the campaign tag to a commit message.
-// If campaignID is empty, returns the message unchanged.
+// PrependCampaignTag prepends the legacy id-only campaign tag to a commit
+// message. If campaignID is empty, returns the message unchanged.
 func PrependCampaignTag(campaignID, message string) string {
-	return PrependContextTags(campaignID, "", message)
+	return PrependContextTagsFull("", campaignID, "", "", "", message)
 }
 
 // FormatContextTags returns the combined campaign/quest tag prefix string.
-// When questID is non-empty, produces "[OBEY-CAMPAIGN-{id}-{questID}]".
-func FormatContextTags(campaignID, questID string) string {
-	return FormatContextTagsFull(campaignID, questID, "", "")
+func FormatContextTags(campaignName, campaignID, questID string) string {
+	return FormatContextTagsFull(campaignName, campaignID, questID, "", "")
 }
 
 // PrependContextTags prepends the campaign and optional quest tag to a message.
-func PrependContextTags(campaignID, questID, message string) string {
-	tag := FormatContextTags(campaignID, questID)
+func PrependContextTags(campaignName, campaignID, questID, message string) string {
+	return PrependContextTagsFull(campaignName, campaignID, questID, "", "", message)
+}
+
+// PrependContextTagsFull prepends the consolidated campaign tag to a commit
+// message. If campaignID is empty, returns the message unchanged (no tag
+// without a campaign).
+func PrependContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef, message string) string {
+	tag := FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef)
 	if tag == "" {
 		return message
 	}
 	return tag + " " + message
 }
 
-// TagComponents are the parsed pieces of a `[OBEY-CAMPAIGN-...]` tag.
-// Empty fields indicate the component was absent.
+// TagComponents are the parsed pieces of a campaign tag. Empty fields indicate
+// the component was absent.
 type TagComponents struct {
-	CampaignID  string `json:"campaign_id"`  // short form, max 8 chars
-	QuestID     string `json:"quest_id"`     // quest id component, when present
-	FestRef     string `json:"fest_ref"`     // festival ref component, when present
-	WorkitemRef string `json:"workitem_ref"` // includes the leading "WI-" prefix (e.g. "WI-abcdef")
+	CampaignID   string `json:"campaign_id"`             // short form, max 8 chars
+	CampaignName string `json:"campaign_name,omitempty"` // slug, present only on name-style tags
+	QuestID      string `json:"quest_id"`                // quest id component, when present
+	FestRef      string `json:"fest_ref"`                // festival ref component, when present
+	WorkitemRef  string `json:"workitem_ref"`            // includes the leading "WI-" prefix (e.g. "WI-abcdef")
 }
 
-// leadingTagRegex anchors the tag match to the start of the subject. This is
-// the contract ParseTag enforces: a tag is only what FormatContextTagsFull
-// produces at position 0. Embedded mentions in revert subjects, code
-// samples, or appended notes are intentionally ignored.
-var leadingTagRegex = regexp.MustCompile(`^\[OBEY-CAMPAIGN-([^\]]+)\]`)
+// leadingTagRegex captures the leading bracket content. The campaign-tag
+// contract is anchored to position 0: a tag is only what FormatContextTagsFull
+// produces at the start of the subject. Embedded mentions in revert subjects,
+// code samples, or appended notes are intentionally ignored. The captured
+// content is classified as a name-style tag, a legacy tag, or not-a-tag by
+// ParseTagDetailed.
+var leadingTagRegex = regexp.MustCompile(`^\[([^\]]+)\]`)
 
 // tagBodyScanRegex is the unanchored form, retained for callers that
-// intentionally scan commit bodies for tag mentions (e.g. body-grep paths
-// that surface "this commit references campaign X" attributions). Do NOT
-// use this in ParseTag; the contract there is "leading tag only".
-var tagBodyScanRegex = regexp.MustCompile(`\[OBEY-CAMPAIGN-([^\]]+)\]`)
+// intentionally scan commit bodies for tag mentions (e.g. body-grep paths that
+// surface "this commit references campaign X" attributions). It matches both
+// the name-style and legacy forms. Do NOT use this in ParseTag; the contract
+// there is "leading tag only".
+var tagBodyScanRegex = regexp.MustCompile(`\[(?:` + legacyTagMarker + `-[^\]]+|[a-z0-9][a-z0-9-]*:[0-9a-f]{1,8}[^\]]*)\]`)
 
 var (
 	tagWorkitemRefRe = regexp.MustCompile(`^WI-[0-9a-f]{6}$`)
 	tagQuestIDRe     = regexp.MustCompile(`^qst_[A-Za-z0-9_]{1,40}$`)
 	tagFestRefRe     = regexp.MustCompile(`^[A-Za-z0-9]{1,32}$`)
+	// tagNameStyleIDRe gates the id segment of a name-style tag. Real campaign
+	// ids are derived from a UUID, so they are always lowercase hex; requiring
+	// that shape lets the parser reject ordinary bracketed prefixes such as
+	// "[wip]" or "[scope:msg]" instead of mistaking them for campaign tags.
+	tagNameStyleIDRe  = regexp.MustCompile(`^[0-9a-f]{1,8}$`)
+	tagCampaignNameRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 )
 
 // TagParseWarning records a degraded parse: a component whose shape check
-// failed (and was zeroed out) or an unknown segment encountered between
-// known prefixes. ParseTagDetailed returns these so callers can decide
-// whether to log, surface, or treat as a hard error.
+// failed (and was zeroed out) or an unknown segment encountered between known
+// prefixes. ParseTagDetailed returns these so callers can decide whether to
+// log, surface, or treat as a hard error.
 type TagParseWarning struct {
 	Field  string
 	Value  string
@@ -120,36 +156,50 @@ type TagParseWarning struct {
 //
 // ParseTag assumes quest IDs match `qst_[0-9]+_[a-z0-9]+` per
 // internal/quest/slug.go. If that alphabet is extended to include "-",
-// update indexOfNextPrefix and add adversarial quest-id cases.
-//
-// Two-stage parse: regex strips the bracket and the OBEY-CAMPAIGN prefix,
-// then the inner string is walked once to peel off quest, festival, and
-// workitem segments in their fixed order. Each peeled segment is anchored
-// on its prefix (`qst_`, `FE-`, `WI-`); whatever is left between the
-// previous prefix and the next belongs to the previous segment. This
-// matches FormatContextTagsFull's grammar exactly.
+// update the segment walker and add adversarial quest-id cases.
 func ParseTag(subject string) TagComponents {
 	tc, _ := ParseTagDetailed(subject)
 	return tc
 }
 
-// ParseTagDetailed is the warnings-aware peer of ParseTag. It continues
-// scanning past unknown segments, applies shape checks to extracted
-// component values, zeros out failures, and records each fixup in the
-// returned warnings slice.
+// ParseTagDetailed is the warnings-aware peer of ParseTag. It recognizes both
+// the name-style tag ("[<name>:<id>...]") and the legacy tag
+// ("[OBEY-CAMPAIGN-<id>...]"), then walks the inner string once to peel off
+// quest, festival, and workitem segments in their fixed order. Each peeled
+// segment is anchored on its prefix (`qst_`, `FE-`, `WI-`); whatever is left
+// between the previous prefix and the next belongs to the previous segment.
+// This matches FormatContextTagsFull's grammar exactly. It continues scanning
+// past unknown segments, applies shape checks to extracted component values,
+// zeros out failures, and records each fixup in the returned warnings slice.
 func ParseTagDetailed(subject string) (TagComponents, []TagParseWarning) {
 	m := leadingTagRegex.FindStringSubmatch(subject)
 	if m == nil {
 		return TagComponents{}, nil
 	}
 	inner := m[1]
+
+	var out TagComponents
+	switch {
+	case isNameStyleHead(inner):
+		colon := strings.IndexByte(inner, ':')
+		out.CampaignName = inner[:colon]
+		inner = inner[colon+1:]
+	case strings.HasPrefix(inner, legacyTagMarker+"-"):
+		inner = inner[len(legacyTagMarker)+1:]
+	default:
+		// A leading bracket that is neither a name-style nor a legacy campaign
+		// tag (e.g. "[wip]", "[scope: note]") is not our tag.
+		return TagComponents{}, nil
+	}
+
 	var warnings []TagParseWarning
 
 	idEnd := strings.Index(inner, "-")
 	if idEnd < 0 {
-		return TagComponents{CampaignID: inner}, nil
+		out.CampaignID = inner
+		return out, warnings
 	}
-	out := TagComponents{CampaignID: inner[:idEnd]}
+	out.CampaignID = inner[:idEnd]
 	rest := inner[idEnd+1:]
 
 	for rest != "" {
@@ -219,6 +269,22 @@ func ParseTagDetailed(subject string) (TagComponents, []TagParseWarning) {
 	return out, warnings
 }
 
+// isNameStyleHead reports whether inner leads with a "<name-slug>:<id>" head,
+// i.e. a name-style campaign tag. It requires a non-empty slug name before the
+// first colon and a hex id immediately after it so that ordinary bracketed
+// subject prefixes are not misread as campaign tags.
+func isNameStyleHead(inner string) bool {
+	colon := strings.IndexByte(inner, ':')
+	if colon <= 0 {
+		return false
+	}
+	if !tagCampaignNameRe.MatchString(inner[:colon]) {
+		return false
+	}
+	id, _ := splitAtDash(inner[colon+1:])
+	return tagNameStyleIDRe.MatchString(id)
+}
+
 // splitAtDash returns the substring up to the next "-" and the remainder
 // after the dash. If no dash is present, returns (s, "").
 func splitAtDash(s string) (string, string) {
@@ -227,4 +293,3 @@ func splitAtDash(s string) (string, string) {
 	}
 	return s, ""
 }
-

--- a/internal/git/campaign_tag.go
+++ b/internal/git/campaign_tag.go
@@ -9,24 +9,16 @@ import (
 
 const campaignTagMaxIDLen = 8
 
-// legacyTagMarker is the fixed leading token campaign tags carried before they
-// embedded the campaign name. Tags formatted without a resolvable campaign name
-// fall back to "[<legacyTagMarker>-<id>...]", and ParseTag still recognizes this
-// form so the entire pre-existing commit history resolves correctly.
+// legacyTagMarker is the leading token used before tags embedded the campaign
+// name. It remains the fallback when no name resolves, and ParseTag still
+// recognizes it so historical commits resolve.
 const legacyTagMarker = "OBEY-CAMPAIGN"
 
-// FormatContextTagsFull composes the consolidated campaign tag from any subset
-// of (campaign name, campaign id, quest id, festival ref, workitem ref).
-//
-// The leading token is the slugified campaign name followed by ":" and the
-// short campaign id, e.g. "[obey-campaign:8deed8b4]". When campaignName has no
-// usable slug (empty or unslugifiable), it falls back to the legacy
-// "[OBEY-CAMPAIGN-<id>]" form. After the leading token the component order is
-// fixed: quest id (qst_<...>), then festival ref (FE-<ref>), then workitem ref
-// (WI-<ref>). Absent components are omitted entirely; their separators do not
-// appear in the output.
-//
-// Returns "" when campaignID is empty (no tag without a campaign).
+// FormatContextTagsFull builds the campaign tag. The leading token is the
+// slugified campaign name plus the short id ("[obey-campaign:8deed8b4]"),
+// falling back to "[OBEY-CAMPAIGN-<id>]" when campaignName has no slug. The
+// remaining components follow in fixed order: quest, festival, workitem.
+// Returns "" when campaignID is empty.
 func FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef string) string {
 	if campaignID == "" {
 		return ""
@@ -52,19 +44,15 @@ func FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemR
 		if !strings.HasPrefix(workitemRef, "WI-") {
 			workitemRef = "WI-" + workitemRef
 		}
-		// Workitem refs already carry the WI- prefix per
-		// internal/workitem/ref.go::Derive. Embed verbatim so the bracket
-		// reads `WI-WI-abcdef`, matching the documented tag grammar.
+		// The ref already starts with WI-, so the WI- segment marker produces
+		// the intentional WI-WI- double prefix.
 		parts = append(parts, "WI-"+workitemRef)
 	}
 	return "[" + strings.Join(parts, "-") + "]"
 }
 
-// FormatCampaignTag returns the legacy "[OBEY-CAMPAIGN-{id}]" prefix string for
-// callers that only have a campaign id (e.g. the public id-only API consumed by
-// fest). If a questID is provided it is appended inside the same bracket:
-// "[OBEY-CAMPAIGN-{id}-{questID}]". Truncates campaignID to 8 characters.
-// Returns empty string if campaignID is empty.
+// FormatCampaignTag returns the legacy id-only "[OBEY-CAMPAIGN-{id}]" prefix,
+// optionally appending a quest id. Truncates campaignID to 8 chars.
 func FormatCampaignTag(campaignID string, questID ...string) string {
 	qid := ""
 	if len(questID) > 0 {
@@ -73,25 +61,23 @@ func FormatCampaignTag(campaignID string, questID ...string) string {
 	return FormatContextTagsFull("", campaignID, qid, "", "")
 }
 
-// PrependCampaignTag prepends the legacy id-only campaign tag to a commit
-// message. If campaignID is empty, returns the message unchanged.
+// PrependCampaignTag prepends the legacy id-only tag to a message.
 func PrependCampaignTag(campaignID, message string) string {
 	return PrependContextTagsFull("", campaignID, "", "", "", message)
 }
 
-// FormatContextTags returns the combined campaign/quest tag prefix string.
+// FormatContextTags returns the campaign/quest tag prefix.
 func FormatContextTags(campaignName, campaignID, questID string) string {
 	return FormatContextTagsFull(campaignName, campaignID, questID, "", "")
 }
 
-// PrependContextTags prepends the campaign and optional quest tag to a message.
+// PrependContextTags prepends the campaign/quest tag to a message.
 func PrependContextTags(campaignName, campaignID, questID, message string) string {
 	return PrependContextTagsFull(campaignName, campaignID, questID, "", "", message)
 }
 
-// PrependContextTagsFull prepends the consolidated campaign tag to a commit
-// message. If campaignID is empty, returns the message unchanged (no tag
-// without a campaign).
+// PrependContextTagsFull prepends the full campaign tag to a message,
+// returning it unchanged when campaignID is empty.
 func PrependContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef, message string) string {
 	tag := FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef)
 	if tag == "" {
@@ -100,77 +86,51 @@ func PrependContextTagsFull(campaignName, campaignID, questID, festRef, workitem
 	return tag + " " + message
 }
 
-// TagComponents are the parsed pieces of a campaign tag. Empty fields indicate
-// the component was absent.
+// TagComponents are the parsed pieces of a campaign tag; empty fields were absent.
 type TagComponents struct {
-	CampaignID   string `json:"campaign_id"`             // short form, max 8 chars
-	CampaignName string `json:"campaign_name,omitempty"` // slug, present only on name-style tags
-	QuestID      string `json:"quest_id"`                // quest id component, when present
-	FestRef      string `json:"fest_ref"`                // festival ref component, when present
-	WorkitemRef  string `json:"workitem_ref"`            // includes the leading "WI-" prefix (e.g. "WI-abcdef")
+	CampaignID   string `json:"campaign_id"`
+	CampaignName string `json:"campaign_name,omitempty"` // slug, name-style tags only
+	QuestID      string `json:"quest_id"`
+	FestRef      string `json:"fest_ref"`
+	WorkitemRef  string `json:"workitem_ref"` // carries the WI- prefix
 }
 
-// leadingTagRegex captures the leading bracket content. The campaign-tag
-// contract is anchored to position 0: a tag is only what FormatContextTagsFull
-// produces at the start of the subject. Embedded mentions in revert subjects,
-// code samples, or appended notes are intentionally ignored. The captured
-// content is classified as a name-style tag, a legacy tag, or not-a-tag by
-// ParseTagDetailed.
+// leadingTagRegex captures the leading bracket content; tags are only honored
+// at position 0 (see ParseTagDetailed).
 var leadingTagRegex = regexp.MustCompile(`^\[([^\]]+)\]`)
 
-// tagBodyScanRegex is the unanchored form, retained for callers that
-// intentionally scan commit bodies for tag mentions (e.g. body-grep paths that
-// surface "this commit references campaign X" attributions). It matches both
-// the name-style and legacy forms. Do NOT use this in ParseTag; the contract
-// there is "leading tag only".
+// tagBodyScanRegex matches name-style or legacy tags anywhere in a string, for
+// body-grep callers only. ParseTag uses leadingTagRegex instead.
 var tagBodyScanRegex = regexp.MustCompile(`\[(?:` + legacyTagMarker + `-[^\]]+|[a-z0-9][a-z0-9-]*:[0-9a-f]{1,8}[^\]]*)\]`)
 
 var (
 	tagWorkitemRefRe = regexp.MustCompile(`^WI-[0-9a-f]{6}$`)
 	tagQuestIDRe     = regexp.MustCompile(`^qst_[A-Za-z0-9_]{1,40}$`)
 	tagFestRefRe     = regexp.MustCompile(`^[A-Za-z0-9]{1,32}$`)
-	// tagNameStyleIDRe gates the id segment of a name-style tag. Real campaign
-	// ids are derived from a UUID, so they are always lowercase hex; requiring
-	// that shape lets the parser reject ordinary bracketed prefixes such as
-	// "[wip]" or "[scope:msg]" instead of mistaking them for campaign tags.
+	// Real campaign ids are UUID-derived hex; gating on it rejects ordinary
+	// bracket prefixes like "[scope:msg]".
 	tagNameStyleIDRe  = regexp.MustCompile(`^[0-9a-f]{1,8}$`)
 	tagCampaignNameRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 )
 
-// TagParseWarning records a degraded parse: a component whose shape check
-// failed (and was zeroed out) or an unknown segment encountered between known
-// prefixes. ParseTagDetailed returns these so callers can decide whether to
-// log, surface, or treat as a hard error.
+// TagParseWarning records a degraded parse: a component that failed its shape
+// check (and was zeroed) or an unknown segment.
 type TagParseWarning struct {
 	Field  string
 	Value  string
 	Reason string
 }
 
-// ParseTag extracts the components of a campaign tag from a commit subject.
-// Returns a zero-valued TagComponents when no tag is present.
-//
-// ParseTag matches only the leading bracket; embedded mentions in revert
-// subjects or code samples are intentionally ignored. Callers that need
-// body-grep semantics must use tagBodyScanRegex directly.
-//
-// ParseTag assumes quest IDs match `qst_[0-9]+_[a-z0-9]+` per
-// internal/quest/slug.go. If that alphabet is extended to include "-",
-// update the segment walker and add adversarial quest-id cases.
+// ParseTag extracts the components of a leading campaign tag, returning a
+// zero value when none is present.
 func ParseTag(subject string) TagComponents {
 	tc, _ := ParseTagDetailed(subject)
 	return tc
 }
 
-// ParseTagDetailed is the warnings-aware peer of ParseTag. It recognizes both
-// the name-style tag ("[<name>:<id>...]") and the legacy tag
-// ("[OBEY-CAMPAIGN-<id>...]"), then walks the inner string once to peel off
-// quest, festival, and workitem segments in their fixed order. Each peeled
-// segment is anchored on its prefix (`qst_`, `FE-`, `WI-`); whatever is left
-// between the previous prefix and the next belongs to the previous segment.
-// This matches FormatContextTagsFull's grammar exactly. It continues scanning
-// past unknown segments, applies shape checks to extracted component values,
-// zeros out failures, and records each fixup in the returned warnings slice.
+// ParseTagDetailed is the warnings-aware peer of ParseTag. It accepts both the
+// name-style and legacy tag forms, then peels quest/festival/workitem segments
+// by their prefixes, zeroing and reporting any that fail their shape check.
 func ParseTagDetailed(subject string) (TagComponents, []TagParseWarning) {
 	m := leadingTagRegex.FindStringSubmatch(subject)
 	if m == nil {
@@ -187,8 +147,6 @@ func ParseTagDetailed(subject string) (TagComponents, []TagParseWarning) {
 	case strings.HasPrefix(inner, legacyTagMarker+"-"):
 		inner = inner[len(legacyTagMarker)+1:]
 	default:
-		// A leading bracket that is neither a name-style nor a legacy campaign
-		// tag (e.g. "[wip]", "[scope: note]") is not our tag.
 		return TagComponents{}, nil
 	}
 
@@ -238,10 +196,7 @@ func ParseTagDetailed(subject string) (TagComponents, []TagParseWarning) {
 			}
 			rest = after
 		case strings.HasPrefix(rest, "WI-"):
-			// Per the tag grammar, WI- is always the last segment, so the
-			// rest of the payload IS the workitem ref. Anything that does
-			// not match the canonical shape is rejected wholesale rather
-			// than peeled apart into multiple unknown segments.
+			// WI- is always the last segment, so the remainder is the ref.
 			payload := rest[len("WI-"):]
 			if !tagWorkitemRefRe.MatchString(payload) {
 				warnings = append(warnings, TagParseWarning{
@@ -269,10 +224,7 @@ func ParseTagDetailed(subject string) (TagComponents, []TagParseWarning) {
 	return out, warnings
 }
 
-// isNameStyleHead reports whether inner leads with a "<name-slug>:<id>" head,
-// i.e. a name-style campaign tag. It requires a non-empty slug name before the
-// first colon and a hex id immediately after it so that ordinary bracketed
-// subject prefixes are not misread as campaign tags.
+// isNameStyleHead reports whether inner leads with a "<name-slug>:<hex-id>" head.
 func isNameStyleHead(inner string) bool {
 	colon := strings.IndexByte(inner, ':')
 	if colon <= 0 {
@@ -285,8 +237,7 @@ func isNameStyleHead(inner string) bool {
 	return tagNameStyleIDRe.MatchString(id)
 }
 
-// splitAtDash returns the substring up to the next "-" and the remainder
-// after the dash. If no dash is present, returns (s, "").
+// splitAtDash splits s at the first "-", returning (s, "") when none is present.
 func splitAtDash(s string) (string, string) {
 	if i := strings.Index(s, "-"); i >= 0 {
 		return s[:i], s[i+1:]

--- a/internal/git/campaign_tag_full_test.go
+++ b/internal/git/campaign_tag_full_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestFormatContextTagsFull_AllCombinations(t *testing.T) {
 	cases := []struct {
-		name                                  string
-		campaign, quest, fest, workitem, want string
+		name                                         string
+		cname, campaign, quest, fest, workitem, want string
 	}{
 		{
 			name:     "empty campaign returns empty",
@@ -66,10 +66,30 @@ func TestFormatContextTagsFull_AllCombinations(t *testing.T) {
 			campaign: "8deed8b4", workitem: "abcdef",
 			want: "[OBEY-CAMPAIGN-8deed8b4-WI-WI-abcdef]",
 		},
+		{
+			name:  "name only",
+			cname: "obey-campaign", campaign: "8deed8b4",
+			want: "[obey-campaign:8deed8b4]",
+		},
+		{
+			name:  "name + all components",
+			cname: "obey-campaign", campaign: "8deed8b4", quest: "qst_abc", fest: "CW0003", workitem: "WI-abcdef",
+			want: "[obey-campaign:8deed8b4-qst_abc-FE-CW0003-WI-WI-abcdef]",
+		},
+		{
+			name:  "name slugified (spaces and case)",
+			cname: "Brainshare Planning", campaign: "8deed8b4",
+			want: "[brainshare-planning:8deed8b4]",
+		},
+		{
+			name:  "unslugifiable name falls back to legacy marker",
+			cname: "!!!", campaign: "8deed8b4",
+			want: "[OBEY-CAMPAIGN-8deed8b4]",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := FormatContextTagsFull(tc.campaign, tc.quest, tc.fest, tc.workitem)
+			got := FormatContextTagsFull(tc.cname, tc.campaign, tc.quest, tc.fest, tc.workitem)
 			if got != tc.want {
 				t.Fatalf("FormatContextTagsFull = %q, want %q", got, tc.want)
 			}
@@ -99,8 +119,8 @@ func TestFormatCampaignTag_BackwardCompat(t *testing.T) {
 
 func TestParseTag_KnownCombinations(t *testing.T) {
 	cases := []struct {
-		subject                                         string
-		wantCampaign, wantQuest, wantFest, wantWorkitem string
+		subject                                                   string
+		wantCampaign, wantName, wantQuest, wantFest, wantWorkitem string
 	}{
 		{
 			subject:      "[OBEY-CAMPAIGN-8deed8b4] feat: thing",
@@ -123,11 +143,35 @@ func TestParseTag_KnownCombinations(t *testing.T) {
 			wantCampaign: "8deed8b4", wantQuest: "qst_abc", wantFest: "CW0003", wantWorkitem: "WI-abcdef",
 		},
 		{
+			subject:      "[obey-campaign:8deed8b4] feat: thing",
+			wantCampaign: "8deed8b4", wantName: "obey-campaign",
+		},
+		{
+			subject:      "[shrapnel:8deed8b4-qst_abc-FE-CW0003-WI-WI-abcdef] all",
+			wantCampaign: "8deed8b4", wantName: "shrapnel", wantQuest: "qst_abc", wantFest: "CW0003", wantWorkitem: "WI-abcdef",
+		},
+		{
+			subject:      "[brainshare-planning:8deed8b4-WI-WI-abcdef] x",
+			wantCampaign: "8deed8b4", wantName: "brainshare-planning", wantWorkitem: "WI-abcdef",
+		},
+		{
 			subject:      "no tag here at all",
 			wantCampaign: "",
 		},
 		{
+			subject:      "[wip] feat: thing",
+			wantCampaign: "",
+		},
+		{
+			subject:      "[scope:msg] not a campaign tag",
+			wantCampaign: "",
+		},
+		{
 			subject:      `Revert "[OBEY-CAMPAIGN-8deed8b4-WI-WI-fake01] feat: x"`,
+			wantCampaign: "",
+		},
+		{
+			subject:      `Revert "[obey-campaign:8deed8b4] feat: x"`,
 			wantCampaign: "",
 		},
 		{
@@ -145,6 +189,9 @@ func TestParseTag_KnownCombinations(t *testing.T) {
 			if got.CampaignID != tc.wantCampaign {
 				t.Fatalf("CampaignID = %q, want %q", got.CampaignID, tc.wantCampaign)
 			}
+			if got.CampaignName != tc.wantName {
+				t.Fatalf("CampaignName = %q, want %q", got.CampaignName, tc.wantName)
+			}
 			if got.QuestID != tc.wantQuest {
 				t.Fatalf("QuestID = %q, want %q", got.QuestID, tc.wantQuest)
 			}
@@ -161,6 +208,7 @@ func TestParseTag_KnownCombinations(t *testing.T) {
 func TestParseTag_RoundTripProperty(t *testing.T) {
 	const iterations = 100
 	for i := 0; i < iterations; i++ {
+		cname := "c" + randHex(t, 2)
 		campaign := randHex(t, 4)
 		quest := ""
 		fest := ""
@@ -175,8 +223,11 @@ func TestParseTag_RoundTripProperty(t *testing.T) {
 			workitem = "WI-" + randHex(t, 3)
 		}
 
-		tag := FormatContextTagsFull(campaign, quest, fest, workitem)
+		tag := FormatContextTagsFull(cname, campaign, quest, fest, workitem)
 		got := ParseTag(tag)
+		if got.CampaignName != cname {
+			t.Fatalf("iter %d: name round-trip broke: %q -> %q (tag %q)", i, cname, got.CampaignName, tag)
+		}
 		if got.CampaignID != campaign {
 			t.Fatalf("iter %d: campaign round-trip broke: %q -> %q", i, campaign, got.CampaignID)
 		}
@@ -200,8 +251,10 @@ func TestParseTag_AnchoringAdversarial(t *testing.T) {
 		wantID     string
 		wantWIRef  string
 	}{
-		{name: "happy path leading tag", subject: "[OBEY-CAMPAIGN-abcd1234-WI-WI-deadbe] feat: X", wantParsed: true, wantID: "abcd1234", wantWIRef: "WI-deadbe"},
-		{name: "revert subject", subject: `Revert "[OBEY-CAMPAIGN-abcd1234] feat: X"`, wantParsed: false},
+		{name: "happy path leading legacy tag", subject: "[OBEY-CAMPAIGN-abcd1234-WI-WI-deadbe] feat: X", wantParsed: true, wantID: "abcd1234", wantWIRef: "WI-deadbe"},
+		{name: "happy path leading name tag", subject: "[obey-campaign:abcd1234-WI-WI-deadbe] feat: X", wantParsed: true, wantID: "abcd1234", wantWIRef: "WI-deadbe"},
+		{name: "revert legacy subject", subject: `Revert "[OBEY-CAMPAIGN-abcd1234] feat: X"`, wantParsed: false},
+		{name: "revert name subject", subject: `Revert "[obey-campaign:abcd1234] feat: X"`, wantParsed: false},
 		{name: "leading whitespace", subject: " [OBEY-CAMPAIGN-abcd1234] x", wantParsed: false},
 		{name: "embedded mid-subject", subject: "fix: tag was [OBEY-CAMPAIGN-abcd1234] in old log", wantParsed: false},
 		{name: "tag inside backticks", subject: "docs: example `[OBEY-CAMPAIGN-abcd1234]`", wantParsed: false},
@@ -229,6 +282,7 @@ func TestParseTagDetailed_RejectsSilentMerge(t *testing.T) {
 		name             string
 		subject          string
 		wantCampaign     string
+		wantName         string
 		wantQuest        string
 		wantFest         string
 		wantWorkitem     string
@@ -269,12 +323,23 @@ func TestParseTagDetailed_RejectsSilentMerge(t *testing.T) {
 			wantWorkitem:     "WI-aaa111",
 			wantWarningField: []string{"unknown"},
 		},
+		{
+			name:             "name-style tag warns on duplicate FE",
+			subject:          "[obey-campaign:abcdef12-FE-CW0003-FE-SE0001] x",
+			wantCampaign:     "abcdef12",
+			wantName:         "obey-campaign",
+			wantFest:         "CW0003",
+			wantWarningField: []string{"fest_ref"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got, warnings := ParseTagDetailed(tc.subject)
 			if got.CampaignID != tc.wantCampaign {
 				t.Errorf("CampaignID = %q, want %q", got.CampaignID, tc.wantCampaign)
+			}
+			if got.CampaignName != tc.wantName {
+				t.Errorf("CampaignName = %q, want %q", got.CampaignName, tc.wantName)
 			}
 			if got.QuestID != tc.wantQuest {
 				t.Errorf("QuestID = %q, want %q", got.QuestID, tc.wantQuest)
@@ -299,12 +364,12 @@ func TestParseTagDetailed_RejectsSilentMerge(t *testing.T) {
 }
 
 func TestTagBodyScanRegex_FindsEmbedded(t *testing.T) {
-	subject := "body has [OBEY-CAMPAIGN-aaa] and [OBEY-CAMPAIGN-bbb]"
+	subject := "body has [OBEY-CAMPAIGN-aaa] and [obey-campaign:8deed8b4] tags"
 	matches := tagBodyScanRegex.FindAllString(subject, -1)
 	if len(matches) != 2 {
 		t.Fatalf("expected 2 matches from body-scan regex, got %d: %v", len(matches), matches)
 	}
-	want := []string{"[OBEY-CAMPAIGN-aaa]", "[OBEY-CAMPAIGN-bbb]"}
+	want := []string{"[OBEY-CAMPAIGN-aaa]", "[obey-campaign:8deed8b4]"}
 	for i, m := range matches {
 		if m != want[i] {
 			t.Errorf("match[%d] = %q, want %q", i, m, want[i])

--- a/internal/git/campaign_tag_full_test.go
+++ b/internal/git/campaign_tag_full_test.go
@@ -86,6 +86,11 @@ func TestFormatContextTagsFull_AllCombinations(t *testing.T) {
 			cname: "!!!", campaign: "8deed8b4",
 			want: "[OBEY-CAMPAIGN-8deed8b4]",
 		},
+		{
+			name:  "non-hex id falls back to legacy marker",
+			cname: "obey-campaign", campaign: "zzzzzzzz",
+			want: "[OBEY-CAMPAIGN-zzzzzzzz]",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/git/commit/commit.go
+++ b/internal/git/commit/commit.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/git"
 )
 
@@ -20,6 +21,7 @@ type Result struct {
 type Options struct {
 	CampaignRoot  string   // Path to campaign root
 	CampaignID    string   // Campaign ID (truncated to 8 chars)
+	CampaignName  string   // Optional campaign name; when empty it is resolved from CampaignRoot
 	QuestID       string   // Optional quest ID for additive commit context
 	FestivalRef   string   // Optional festival ref for additive commit context
 	WorkitemRef   string   // Optional workitem ref (WI-<6 hex>) for additive commit context
@@ -28,12 +30,28 @@ type Options struct {
 	SelectiveOnly bool     // When true, never fall back to CommitAll; no-op if Files is empty
 }
 
+// resolveCampaignName returns the campaign name used to build the commit tag.
+// It prefers an explicitly supplied opts.CampaignName and otherwise reads it
+// from the campaign config at opts.CampaignRoot. A failed load is non-fatal:
+// the tag formatter falls back to the legacy id-only form when the name is
+// empty.
+func resolveCampaignName(ctx context.Context, opts Options) string {
+	if opts.CampaignName != "" {
+		return opts.CampaignName
+	}
+	cfg, err := config.LoadCampaignConfig(ctx, opts.CampaignRoot)
+	if err != nil {
+		return ""
+	}
+	return cfg.Name
+}
+
 // doCommit stages all changes and commits with standardized format.
 // Commit failures are non-fatal and reported via Result.
 //
 // Commit message format:
 //
-//	[OBEY-CAMPAIGN-{id}] Action: Subject
+//	[{campaign-name}:{id}] Action: Subject
 //
 //	Optional description body
 func doCommit(ctx context.Context, opts Options, action, subject, description string) Result {
@@ -45,7 +63,7 @@ func doCommit(ctx context.Context, opts Options, action, subject, description st
 	}
 
 	commitMsg := fmt.Sprintf("%s %s: %s",
-		git.FormatContextTagsFull(opts.CampaignID, opts.QuestID, opts.FestivalRef, opts.WorkitemRef),
+		git.FormatContextTagsFull(resolveCampaignName(ctx, opts), opts.CampaignID, opts.QuestID, opts.FestivalRef, opts.WorkitemRef),
 		action,
 		subject,
 	)

--- a/internal/git/commit/commit.go
+++ b/internal/git/commit/commit.go
@@ -30,11 +30,8 @@ type Options struct {
 	SelectiveOnly bool     // When true, never fall back to CommitAll; no-op if Files is empty
 }
 
-// resolveCampaignName returns the campaign name used to build the commit tag.
-// It prefers an explicitly supplied opts.CampaignName and otherwise reads it
-// from the campaign config at opts.CampaignRoot. A failed load is non-fatal:
-// the tag formatter falls back to the legacy id-only form when the name is
-// empty.
+// resolveCampaignName prefers opts.CampaignName, else loads it from the config
+// at opts.CampaignRoot. A failed load yields "" (formatter falls back to legacy).
 func resolveCampaignName(ctx context.Context, opts Options) string {
 	if opts.CampaignName != "" {
 		return opts.CampaignName

--- a/pkg/commitkit/commitkit.go
+++ b/pkg/commitkit/commitkit.go
@@ -31,15 +31,16 @@ type CommitOptions struct {
 	Author     string // Optional: "Name <email>"
 }
 
-// FormatCampaignTag returns the "[OBEY-CAMPAIGN-{id}]" prefix string.
-// Truncates campaignID to 8 characters. Returns empty string if campaignID
-// is empty.
+// FormatCampaignTag returns the legacy id-only "[OBEY-CAMPAIGN-{id}]" prefix
+// string. Truncates campaignID to 8 characters. Returns empty string if
+// campaignID is empty. Callers that have the campaign name should use
+// FormatContextTagsFull to emit a name-style "[{name}:{id}]" tag instead.
 func FormatCampaignTag(campaignID string) string {
 	return git.FormatCampaignTag(campaignID)
 }
 
-// PrependCampaignTag prepends the campaign tag to a commit message.
-// If campaignID is empty, returns the message unchanged.
+// PrependCampaignTag prepends the legacy id-only campaign tag to a commit
+// message. If campaignID is empty, returns the message unchanged.
 func PrependCampaignTag(campaignID, message string) string {
 	return git.PrependCampaignTag(campaignID, message)
 }
@@ -49,17 +50,20 @@ func PrependCampaignTag(campaignID, message string) string {
 type TagComponents = git.TagComponents
 
 // FormatContextTagsFull composes the consolidated campaign tag from any
-// subset of (campaign id, quest id, festival ref, workitem ref). Component
-// order is fixed: campaign → quest → festival → workitem.
-func FormatContextTagsFull(campaignID, questID, festRef, workitemRef string) string {
-	return git.FormatContextTagsFull(campaignID, questID, festRef, workitemRef)
+// subset of (campaign name, campaign id, quest id, festival ref, workitem
+// ref). The leading token is the slugified campaign name plus the short id
+// ("[{name}:{id}]"), falling back to the legacy "[OBEY-CAMPAIGN-{id}]" form
+// when campaignName is empty. Remaining order is fixed: quest → festival →
+// workitem.
+func FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef string) string {
+	return git.FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef)
 }
 
 // PrependContextTagsFull prepends the consolidated campaign tag to a commit
 // message. If campaignID is empty, returns the message unchanged (no tag
 // without a campaign).
-func PrependContextTagsFull(campaignID, questID, festRef, workitemRef, message string) string {
-	tag := FormatContextTagsFull(campaignID, questID, festRef, workitemRef)
+func PrependContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef, message string) string {
+	tag := FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef)
 	if tag == "" {
 		return message
 	}

--- a/pkg/commitkit/commitkit.go
+++ b/pkg/commitkit/commitkit.go
@@ -31,43 +31,40 @@ type CommitOptions struct {
 	Author     string // Optional: "Name <email>"
 }
 
-// FormatCampaignTag returns the legacy id-only "[OBEY-CAMPAIGN-{id}]" prefix
-// string. Truncates campaignID to 8 characters. Returns empty string if
-// campaignID is empty. Callers that have the campaign name should use
-// FormatContextTagsFull to emit a name-style "[{name}:{id}]" tag instead.
+// FormatCampaignTag returns the legacy id-only "[OBEY-CAMPAIGN-{id}]" prefix.
 func FormatCampaignTag(campaignID string) string {
 	return git.FormatCampaignTag(campaignID)
 }
 
-// PrependCampaignTag prepends the legacy id-only campaign tag to a commit
-// message. If campaignID is empty, returns the message unchanged.
+// PrependCampaignTag prepends the legacy id-only tag to a message.
 func PrependCampaignTag(campaignID, message string) string {
 	return git.PrependCampaignTag(campaignID, message)
 }
 
-// TagComponents is the parsed form of a campaign tag. Re-exported from
-// internal/git so callers do not need to import the internal package.
+// TagComponents is the parsed form of a campaign tag.
 type TagComponents = git.TagComponents
 
-// FormatContextTagsFull composes the consolidated campaign tag from any
-// subset of (campaign name, campaign id, quest id, festival ref, workitem
-// ref). The leading token is the slugified campaign name plus the short id
-// ("[{name}:{id}]"), falling back to the legacy "[OBEY-CAMPAIGN-{id}]" form
-// when campaignName is empty. Remaining order is fixed: quest → festival →
-// workitem.
-func FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef string) string {
+// FormatContextTagsFull composes the legacy id-only tag from any subset of
+// (campaign id, quest id, festival ref, workitem ref). Use FormatContextTagsFullNamed
+// to emit a name-style "[{name}:{id}]" tag.
+func FormatContextTagsFull(campaignID, questID, festRef, workitemRef string) string {
+	return git.FormatContextTagsFull("", campaignID, questID, festRef, workitemRef)
+}
+
+// FormatContextTagsFullNamed is FormatContextTagsFull with the campaign name as
+// the leading token, falling back to the legacy form when campaignName is empty.
+func FormatContextTagsFullNamed(campaignName, campaignID, questID, festRef, workitemRef string) string {
 	return git.FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef)
 }
 
-// PrependContextTagsFull prepends the consolidated campaign tag to a commit
-// message. If campaignID is empty, returns the message unchanged (no tag
-// without a campaign).
-func PrependContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef, message string) string {
-	tag := FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef)
-	if tag == "" {
-		return message
-	}
-	return tag + " " + message
+// PrependContextTagsFull prepends the legacy id-only tag to a message.
+func PrependContextTagsFull(campaignID, questID, festRef, workitemRef, message string) string {
+	return git.PrependContextTagsFull("", campaignID, questID, festRef, workitemRef, message)
+}
+
+// PrependContextTagsFullNamed prepends the name-style tag to a message.
+func PrependContextTagsFullNamed(campaignName, campaignID, questID, festRef, workitemRef, message string) string {
+	return git.PrependContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef, message)
 }
 
 // ParseTag extracts the components of a campaign tag from a commit subject.

--- a/pkg/commitkit/commitkit_tags_test.go
+++ b/pkg/commitkit/commitkit_tags_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestPrependContextTagsFull(t *testing.T) {
 	cases := []struct {
-		name                                            string
-		campaign, quest, fest, workitem, msg, want      string
+		name                                              string
+		cname, campaign, quest, fest, workitem, msg, want string
 	}{
 		{
 			name:     "no campaign returns message unchanged",
@@ -17,20 +17,20 @@ func TestPrependContextTagsFull(t *testing.T) {
 			msg: "hello", want: "hello",
 		},
 		{
-			name:     "campaign only",
+			name:     "campaign id only falls back to legacy marker",
 			campaign: "8deed8b4", msg: "feat: thing",
 			want: "[OBEY-CAMPAIGN-8deed8b4] feat: thing",
 		},
 		{
-			name:     "all four components",
-			campaign: "8deed8b4", quest: "qst_abc", fest: "CW0003", workitem: "WI-abcdef",
-			msg: "full",
-			want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc-FE-CW0003-WI-WI-abcdef] full",
+			name:  "name + all components",
+			cname: "obey-campaign", campaign: "8deed8b4", quest: "qst_abc", fest: "CW0003", workitem: "WI-abcdef",
+			msg:  "full",
+			want: "[obey-campaign:8deed8b4-qst_abc-FE-CW0003-WI-WI-abcdef] full",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := commitkit.PrependContextTagsFull(tc.campaign, tc.quest, tc.fest, tc.workitem, tc.msg)
+			got := commitkit.PrependContextTagsFull(tc.cname, tc.campaign, tc.quest, tc.fest, tc.workitem, tc.msg)
 			if got != tc.want {
 				t.Fatalf("got %q, want %q", got, tc.want)
 			}
@@ -39,9 +39,9 @@ func TestPrependContextTagsFull(t *testing.T) {
 }
 
 func TestCommitkit_ParseTag_RoundTrip(t *testing.T) {
-	tag := commitkit.PrependContextTagsFull("8deed8b4", "qst_abc", "CW0003", "WI-abcdef", "subject")
+	tag := commitkit.PrependContextTagsFull("obey-campaign", "8deed8b4", "qst_abc", "CW0003", "WI-abcdef", "subject")
 	got := commitkit.ParseTag(tag)
-	if got.CampaignID != "8deed8b4" || got.QuestID != "qst_abc" || got.FestRef != "CW0003" || got.WorkitemRef != "WI-abcdef" {
+	if got.CampaignName != "obey-campaign" || got.CampaignID != "8deed8b4" || got.QuestID != "qst_abc" || got.FestRef != "CW0003" || got.WorkitemRef != "WI-abcdef" {
 		t.Fatalf("parse round-trip broke: %#v", got)
 	}
 }

--- a/pkg/commitkit/commitkit_tags_test.go
+++ b/pkg/commitkit/commitkit_tags_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/Obedience-Corp/camp/pkg/commitkit"
 )
 
-func TestPrependContextTagsFull(t *testing.T) {
+func TestPrependContextTagsFull_Legacy(t *testing.T) {
 	cases := []struct {
-		name                                              string
-		cname, campaign, quest, fest, workitem, msg, want string
+		name                                       string
+		campaign, quest, fest, workitem, msg, want string
 	}{
 		{
 			name:     "no campaign returns message unchanged",
@@ -17,20 +17,15 @@ func TestPrependContextTagsFull(t *testing.T) {
 			msg: "hello", want: "hello",
 		},
 		{
-			name:     "campaign id only falls back to legacy marker",
-			campaign: "8deed8b4", msg: "feat: thing",
-			want: "[OBEY-CAMPAIGN-8deed8b4] feat: thing",
-		},
-		{
-			name:  "name + all components",
-			cname: "obey-campaign", campaign: "8deed8b4", quest: "qst_abc", fest: "CW0003", workitem: "WI-abcdef",
+			name:     "id only emits legacy marker",
+			campaign: "8deed8b4", quest: "qst_abc", fest: "CW0003", workitem: "WI-abcdef",
 			msg:  "full",
-			want: "[obey-campaign:8deed8b4-qst_abc-FE-CW0003-WI-WI-abcdef] full",
+			want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc-FE-CW0003-WI-WI-abcdef] full",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := commitkit.PrependContextTagsFull(tc.cname, tc.campaign, tc.quest, tc.fest, tc.workitem, tc.msg)
+			got := commitkit.PrependContextTagsFull(tc.campaign, tc.quest, tc.fest, tc.workitem, tc.msg)
 			if got != tc.want {
 				t.Fatalf("got %q, want %q", got, tc.want)
 			}
@@ -38,8 +33,16 @@ func TestPrependContextTagsFull(t *testing.T) {
 	}
 }
 
+func TestPrependContextTagsFullNamed(t *testing.T) {
+	got := commitkit.PrependContextTagsFullNamed("obey-campaign", "8deed8b4", "qst_abc", "CW0003", "WI-abcdef", "full")
+	want := "[obey-campaign:8deed8b4-qst_abc-FE-CW0003-WI-WI-abcdef] full"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
 func TestCommitkit_ParseTag_RoundTrip(t *testing.T) {
-	tag := commitkit.PrependContextTagsFull("obey-campaign", "8deed8b4", "qst_abc", "CW0003", "WI-abcdef", "subject")
+	tag := commitkit.PrependContextTagsFullNamed("obey-campaign", "8deed8b4", "qst_abc", "CW0003", "WI-abcdef", "subject")
 	got := commitkit.ParseTag(tag)
 	if got.CampaignName != "obey-campaign" || got.CampaignID != "8deed8b4" || got.QuestID != "qst_abc" || got.FestRef != "CW0003" || got.WorkitemRef != "WI-abcdef" {
 		t.Fatalf("parse round-trip broke: %#v", got)

--- a/tests/integration/commit_tags_test.go
+++ b/tests/integration/commit_tags_test.go
@@ -110,7 +110,7 @@ func TestIntegration_CommitTags_NoContext(t *testing.T) {
 	subject := lastCommitSubject(t, tc, dir)
 	assert.NotContains(t, subject, "WI-", "no-context commit must not include WI-: %s", subject)
 	assert.NotContains(t, subject, "qst_", "no-context commit must not include qst_: %s", subject)
-	assert.Regexp(t, `^\[OBEY-CAMPAIGN-[0-9a-f]{1,8}\]`, subject,
+	assert.Regexp(t, `^\[commit-tags:[0-9a-f]{1,8}\]`, subject,
 		"subject should still carry the campaign tag: %s", subject)
 }
 
@@ -231,7 +231,7 @@ func TestIntegration_CommitTags_NoteNoContext(t *testing.T) {
 	assert.NotContains(t, subject, "WI-", "no-context note must not include WI-: %s", subject)
 	assert.NotContains(t, subject, "qst_", "no-context note must not include qst_: %s", subject)
 	assert.NotContains(t, subject, "FE-", "no-context note must not include FE-: %s", subject)
-	assert.Regexp(t, `^\[OBEY-CAMPAIGN-[0-9a-f]{1,8}\]`, subject,
+	assert.Regexp(t, `^\[commit-tags:[0-9a-f]{1,8}\]`, subject,
 		"note should still carry the campaign tag: %s", subject)
 }
 

--- a/tests/integration/project_linked_test.go
+++ b/tests/integration/project_linked_test.go
@@ -172,7 +172,7 @@ func TestProject_Commit_LinkedGitRepo(t *testing.T) {
 	logOutput, exitCode, err := tc.ExecCommand("sh", "-c", "cd "+linkedPath+" && git log -1 --pretty=%s")
 	require.NoError(t, err)
 	assert.Equal(t, 0, exitCode)
-	assert.Contains(t, strings.TrimSpace(logOutput), "[OBEY-CAMPAIGN-")
+	assert.Contains(t, strings.TrimSpace(logOutput), "[proj-link-commit:")
 	assert.Contains(t, strings.TrimSpace(logOutput), "linked change")
 }
 

--- a/tests/integration/refs_sync_test.go
+++ b/tests/integration/refs_sync_test.go
@@ -26,6 +26,8 @@ func TestIntegration_RefsSyncAtomic(t *testing.T) {
 	require.Equal(t, before+1, after, "refs-sync should create exactly one campaign root commit")
 
 	subject := tc.GitOutput(t, campaignDir, "log", "-1", "--pretty=%s")
+	require.Regexp(t, `^\[refs-sync:[0-9a-f]{1,8}\]`, subject,
+		"refs-sync commit must carry the campaign-name tag: %s", subject)
 	require.Contains(t, subject, "alpha")
 	require.Contains(t, subject, "beta")
 

--- a/tests/integration/workitem_commits_query_test.go
+++ b/tests/integration/workitem_commits_query_test.go
@@ -104,7 +104,7 @@ func TestIntegration_WorkitemCommits_FiltersFalsePositives(t *testing.T) {
 
 	got := runCommitsJSON(t, tc, dir, "example")
 	for _, c := range got.Commits {
-		assert.True(t, strings.Contains(c.Subject, "[OBEY-CAMPAIGN-"),
+		assert.True(t, strings.Contains(c.Subject, "[commit-tags:"),
 			"non-tagged commit leaked into results: %+v", c)
 	}
 }


### PR DESCRIPTION
## What

The campaign commit tag's leading token was the hardcoded literal `OBEY-CAMPAIGN`, so every campaign produced `[OBEY-CAMPAIGN-<id>]` regardless of its actual name. This makes the tag use the **campaign name** instead.

- **Before:** `[OBEY-CAMPAIGN-8deed8b4] Update navigation`
- **After:** `[obey-campaign:8deed8b4] Update navigation` (and e.g. `[shrapnel:a1b2c3d4]`, `[job-search:...]`)

## Tag format

```
[<campaign-name-slug>:<id8>[-qst_<...>][-FE-<ref>][-WI-WI-<ref>]]
```

- The leading token is the slugified campaign name (via the shared `internal/slug` generator), followed by `:` and the short campaign id.
- The **colon** separates the name from the structured remainder. Campaign names legitimately contain hyphens (`job-search`, `brainshare-planning`), so a `-` boundary would be ambiguous. An explicit delimiter is the right call per the repo's "explicit formats over heuristics" rule.
- The **short id is kept** after the colon. It is the stable machine identity (names can change, the registry keys on id) and is what every existing commit in history carries.

## Backward compatibility

- The parser recognizes **both** the new `[<name>:<id>...]` form and the legacy `[OBEY-CAMPAIGN-<id>...]` form, so the entire pre-existing commit history still resolves correctly (verified by the `camp workitem commits` query path).
- When the campaign name is unavailable or slugifies to nothing, the formatter **falls back to the legacy form**.
- The new-style parse gates the id on `[0-9a-f]{1,8}` (real ids are UUID-derived), so ordinary bracket prefixes like `[wip]` or `[scope: note]` are not misread as campaign tags.

## Implementation

- `internal/git/campaign_tag.go`: `FormatContextTagsFull` now takes `campaignName`; parser handles both forms; `TagComponents` gains an additive `CampaignName` field (`--json` gets a new `campaign_name`, omitempty).
- `internal/git/commit/commit.go`: `Options.CampaignName` (new) is resolved from the campaign config at `CampaignRoot` when callers don't supply it, so the ~18 `doCommit` call sites pick up the name with no per-site edits.
- The direct `commitkit` callers (`camp commit`, `camp p commit`, worktree commit, workitem staging) and the submodule-ref / refs-sync paths thread `cfg.Name` explicitly.
- `pkg/commitkit` public **id-only** functions (`FormatCampaignTag` / `PrependCampaignTag`, consumed by `fest`) keep their signatures and emit the legacy form. **Follow-up:** thread the name through `fest` so its commits also use the name-style tag.

## Tests / gates

- `go build ./...`, `go test ./...`, dev build, and integration-test compilation all green.
- `just lint`: 0 issues.
- Tag contract tests extended with name-style + negative (non-tag bracket) + legacy-fallback cases; round-trip property test now exercises the name.
- Integration assertions updated for the new prefix (`[commit-tags:...]`, `[proj-link-commit:...]`).