### PR TITLE
refactor(git): collapse workitem tag prefix from WI-WI- to WI-

### DIFF
--- a/docs/workitem-commit-reference.md
+++ b/docs/workitem-commit-reference.md
@@ -118,7 +118,7 @@ skipped:
   <path> (out of scope)
   <path> (submodule pointer; use --include-submodule-pointer)
   <path> (--exclude)
-tag:    [<campaign-name>:<8hex>[-qst_<...>][-FE-<festival-ref>][-WI-WI-<6hex>]]
+tag:    [<campaign-name>:<8hex>[-qst_<...>][-FE-<festival-ref>][-WI-<6hex>]]
 ```
 
 `S` marks files already in the index (from `--staged` mode). `A` marks files
@@ -196,8 +196,8 @@ Results are sorted newest first across all repos before `--limit` and
 
 ```
 REPO    SHA       DATE        SUBJECT
-.       a1b2c3d4  2026-05-25  [obey-campaign:2736169c-WI-WI-def123] feat: ...
-projects/camp  e5f6a7b8  2026-05-24  [obey-campaign:2736169c-WI-WI-def123] fix: ...
+.       a1b2c3d4  2026-05-25  [obey-campaign:2736169c-WI-def123] feat: ...
+projects/camp  e5f6a7b8  2026-05-24  [obey-campaign:2736169c-WI-def123] fix: ...
 ```
 
 Per-repo errors are reported on stderr as a summary warning. Under `--json`,
@@ -211,7 +211,7 @@ Every commit produced by `camp workitem commit` (and `camp commit` / `camp p
 commit` when run in a workitem context) carries a tag with this structure:
 
 ```
-[<campaign-name>:<campaign-id>[-<quest-id>][-FE-<festival-ref>][-WI-WI-<workitem-ref>]]
+[<campaign-name>:<campaign-id>[-<quest-id>][-FE-<festival-ref>][-<workitem-ref>]]
 ```
 
 Segment rules:
@@ -228,12 +228,10 @@ Segment rules:
 - `<quest-id>` matches `qst_<digits>_<alphanum>` when a quest is active.
 - `<festival-ref>` is the festival slug when the commit is scoped to a
   festival workitem.
-- `<workitem-ref>` is the canonical `WI-<6 lowercase hex>` ref. Because the
-  ref already starts with `WI-`, the segment marker adds a second `WI-`,
-  producing the `WI-WI-` double prefix. This is intentional. The segment
-  marker and the ref are distinct: flattening to a single prefix breaks the
-  parser's segment-boundary detection (see the segment walker in
-  `ParseTagDetailed`, `internal/git/campaign_tag.go`).
+- `<workitem-ref>` is the canonical `WI-<6 lowercase hex>` ref, embedded
+  verbatim. It is self-identifying via its own `WI-` prefix, the same way quest
+  ids lead with `qst_`. The parser also accepts the historical doubled
+  `WI-WI-<6 hex>` form for commits written before this was simplified.
 
 When the campaign name cannot be resolved or slugifies to nothing, the tag
 falls back to the legacy `[OBEY-CAMPAIGN-<campaign-id>...]` form. The parser
@@ -244,15 +242,14 @@ Concrete examples:
 
 ```
 [obey-campaign:2736169c] feat: no workitem
-[obey-campaign:2736169c-WI-WI-861089] fix: workitem only
-[obey-campaign:2736169c-qst_1_alpha-WI-WI-861089] fix: with quest
-[obey-campaign:2736169c-FE-CW0003-WI-WI-861089] feat: festival + workitem
+[obey-campaign:2736169c-WI-861089] fix: workitem only
+[obey-campaign:2736169c-qst_1_alpha-WI-861089] fix: with quest
+[obey-campaign:2736169c-FE-CW0003-WI-861089] feat: festival + workitem
 [OBEY-CAMPAIGN-2736169c] feat: legacy fallback (name unavailable)
 ```
 
-The full composer is `FormatContextTagsFull` in
-`internal/git/campaign_tag.go`. The public re-export is
-`commitkit.FormatContextTagsFull` in `pkg/commitkit/`.
+The composers are `FormatContextTagsFull` / `FormatContextTagsFullNamed` in
+`pkg/commitkit/`, wrapping `internal/git/campaign_tag.go`.
 
 ### ParseTag
 

--- a/internal/commands/workitem/commits.go
+++ b/internal/commands/workitem/commits.go
@@ -271,7 +271,10 @@ func queryRepo(ctx context.Context, campaignRoot, repo, ref string) ([]CommitRec
 	if !ok {
 		return nil, nil
 	}
-	grep := "-WI-" + ref
+	// The ref already starts with WI-, so "-"+ref anchors on the segment
+	// separator and matches both the single-prefix (-WI-abc123) and the
+	// historical doubled (-WI-WI-abc123) subject forms.
+	grep := "-" + ref
 	cmd := exec.CommandContext(cctx, "git",
 		"-C", repo,
 		"log", "--all",

--- a/internal/commands/workitem/testdata/plans/campaign_root.txt
+++ b/internal/commands/workitem/testdata/plans/campaign_root.txt
@@ -5,4 +5,4 @@ staging:
 skipped:
   README.md (out of scope)
   projects/camp-timeline (submodule pointer; use --include-submodule-pointer)
-tag:    [obey-campaign:8deed8b4-WI-WI-abc123]
+tag:    [obey-campaign:8deed8b4-WI-abc123]

--- a/internal/commands/workitem/testdata/plans/festival_scope.txt
+++ b/internal/commands/workitem/testdata/plans/festival_scope.txt
@@ -5,4 +5,4 @@ staging:
   M  .campaign/workitems/links.yaml
 skipped:
   festivals/active/camp-workitem-linking-and-commits-CW0003/.fest/state.json (out of scope)
-tag:    [obey-campaign:8deed8b4-qst_active-FE-CW0003-WI-WI-def456]
+tag:    [obey-campaign:8deed8b4-qst_active-FE-CW0003-WI-def456]

--- a/internal/commands/workitem/testdata/plans/linked_project.txt
+++ b/internal/commands/workitem/testdata/plans/linked_project.txt
@@ -5,4 +5,4 @@ staging:
   A  internal/timeline/render_test.go
 skipped:
   scratch.txt (gitignored)
-tag:    [obey-campaign:8deed8b4-WI-WI-abc123]
+tag:    [obey-campaign:8deed8b4-WI-abc123]

--- a/internal/commands/workitem/testdata/plans/submodule_pointer_explicit.txt
+++ b/internal/commands/workitem/testdata/plans/submodule_pointer_explicit.txt
@@ -4,4 +4,4 @@ staging:
   M  projects/camp-timeline
   M  workflow/design/timeline/plan.md
 skipped:
-tag:    [obey-campaign:8deed8b4-WI-WI-abc123]
+tag:    [obey-campaign:8deed8b4-WI-abc123]

--- a/internal/commands/workitem/testdata/plans/workitem_dir.txt
+++ b/internal/commands/workitem/testdata/plans/workitem_dir.txt
@@ -6,4 +6,4 @@ staging:
   M  .campaign/workitems/links.yaml
 skipped:
   workflow/design/timeline/scratch.tmp (gitignored)
-tag:    [obey-campaign:8deed8b4-WI-WI-abc123]
+tag:    [obey-campaign:8deed8b4-WI-abc123]

--- a/internal/git/campaign_tag.go
+++ b/internal/git/campaign_tag.go
@@ -47,9 +47,9 @@ func FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemR
 		if !strings.HasPrefix(workitemRef, "WI-") {
 			workitemRef = "WI-" + workitemRef
 		}
-		// The ref already starts with WI-, so the WI- segment marker produces
-		// the intentional WI-WI- double prefix.
-		parts = append(parts, "WI-"+workitemRef)
+		// The ref already carries WI-, so it is self-identifying and embedded
+		// verbatim (no extra marker).
+		parts = append(parts, workitemRef)
 	}
 	return "[" + strings.Join(parts, "-") + "]"
 }
@@ -199,20 +199,24 @@ func ParseTagDetailed(subject string) (TagComponents, []TagParseWarning) {
 			}
 			rest = after
 		case strings.HasPrefix(rest, "WI-"):
-			// WI- is always the last segment, so the remainder is the ref.
-			payload := rest[len("WI-"):]
-			if !tagWorkitemRefRe.MatchString(payload) {
+			// WI- is the last segment. Accept the single-prefix ref (WI-abcdef)
+			// and the historical doubled form (WI-WI-abcdef).
+			ref := rest
+			if strings.HasPrefix(ref, "WI-WI-") {
+				ref = ref[len("WI-"):]
+			}
+			if !tagWorkitemRefRe.MatchString(ref) {
 				warnings = append(warnings, TagParseWarning{
-					Field: "workitem_ref", Value: payload,
+					Field: "workitem_ref", Value: ref,
 					Reason: "shape check failed (want WI-<6 hex>)",
 				})
 			} else if out.WorkitemRef != "" {
 				warnings = append(warnings, TagParseWarning{
-					Field: "workitem_ref", Value: payload,
+					Field: "workitem_ref", Value: ref,
 					Reason: "duplicate workitem_ref segment",
 				})
 			} else {
-				out.WorkitemRef = payload
+				out.WorkitemRef = ref
 			}
 			rest = ""
 		default:

--- a/internal/git/campaign_tag_full_test.go
+++ b/internal/git/campaign_tag_full_test.go
@@ -34,7 +34,7 @@ func TestFormatContextTagsFull_AllCombinations(t *testing.T) {
 		{
 			name:     "campaign + workitem",
 			campaign: "8deed8b4", workitem: "WI-abcdef",
-			want: "[OBEY-CAMPAIGN-8deed8b4-WI-WI-abcdef]",
+			want: "[OBEY-CAMPAIGN-8deed8b4-WI-abcdef]",
 		},
 		{
 			name:     "campaign + quest + festival",
@@ -44,27 +44,27 @@ func TestFormatContextTagsFull_AllCombinations(t *testing.T) {
 		{
 			name:     "campaign + quest + workitem",
 			campaign: "8deed8b4", quest: "qst_abc", workitem: "WI-abcdef",
-			want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc-WI-WI-abcdef]",
+			want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc-WI-abcdef]",
 		},
 		{
 			name:     "campaign + festival + workitem",
 			campaign: "8deed8b4", fest: "CW0003", workitem: "WI-abcdef",
-			want: "[OBEY-CAMPAIGN-8deed8b4-FE-CW0003-WI-WI-abcdef]",
+			want: "[OBEY-CAMPAIGN-8deed8b4-FE-CW0003-WI-abcdef]",
 		},
 		{
 			name:     "all four components",
 			campaign: "8deed8b4", quest: "qst_abc", fest: "CW0003", workitem: "WI-abcdef",
-			want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc-FE-CW0003-WI-WI-abcdef]",
+			want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc-FE-CW0003-WI-abcdef]",
 		},
 		{
 			name:     "campaign id truncated to 8 chars",
 			campaign: "8deed8b4abcdef", workitem: "WI-abcdef",
-			want: "[OBEY-CAMPAIGN-8deed8b4-WI-WI-abcdef]",
+			want: "[OBEY-CAMPAIGN-8deed8b4-WI-abcdef]",
 		},
 		{
 			name:     "workitem ref normalized",
 			campaign: "8deed8b4", workitem: "abcdef",
-			want: "[OBEY-CAMPAIGN-8deed8b4-WI-WI-abcdef]",
+			want: "[OBEY-CAMPAIGN-8deed8b4-WI-abcdef]",
 		},
 		{
 			name:  "name only",
@@ -74,7 +74,7 @@ func TestFormatContextTagsFull_AllCombinations(t *testing.T) {
 		{
 			name:  "name + all components",
 			cname: "obey-campaign", campaign: "8deed8b4", quest: "qst_abc", fest: "CW0003", workitem: "WI-abcdef",
-			want: "[obey-campaign:8deed8b4-qst_abc-FE-CW0003-WI-WI-abcdef]",
+			want: "[obey-campaign:8deed8b4-qst_abc-FE-CW0003-WI-abcdef]",
 		},
 		{
 			name:  "name slugified (spaces and case)",
@@ -158,6 +158,18 @@ func TestParseTag_KnownCombinations(t *testing.T) {
 		{
 			subject:      "[brainshare-planning:8deed8b4-WI-WI-abcdef] x",
 			wantCampaign: "8deed8b4", wantName: "brainshare-planning", wantWorkitem: "WI-abcdef",
+		},
+		{
+			subject:      "[OBEY-CAMPAIGN-8deed8b4-WI-abcdef] single-prefix legacy",
+			wantCampaign: "8deed8b4", wantWorkitem: "WI-abcdef",
+		},
+		{
+			subject:      "[obey-campaign:8deed8b4-WI-abcdef] single-prefix name",
+			wantCampaign: "8deed8b4", wantName: "obey-campaign", wantWorkitem: "WI-abcdef",
+		},
+		{
+			subject:      "[obey-campaign:8deed8b4-qst_abc-FE-CW0003-WI-abcdef] all single",
+			wantCampaign: "8deed8b4", wantName: "obey-campaign", wantQuest: "qst_abc", wantFest: "CW0003", wantWorkitem: "WI-abcdef",
 		},
 		{
 			subject:      "no tag here at all",
@@ -258,6 +270,7 @@ func TestParseTag_AnchoringAdversarial(t *testing.T) {
 	}{
 		{name: "happy path leading legacy tag", subject: "[OBEY-CAMPAIGN-abcd1234-WI-WI-deadbe] feat: X", wantParsed: true, wantID: "abcd1234", wantWIRef: "WI-deadbe"},
 		{name: "happy path leading name tag", subject: "[obey-campaign:abcd1234-WI-WI-deadbe] feat: X", wantParsed: true, wantID: "abcd1234", wantWIRef: "WI-deadbe"},
+		{name: "single-prefix name tag", subject: "[obey-campaign:abcd1234-WI-deadbe] feat: X", wantParsed: true, wantID: "abcd1234", wantWIRef: "WI-deadbe"},
 		{name: "revert legacy subject", subject: `Revert "[OBEY-CAMPAIGN-abcd1234] feat: X"`, wantParsed: false},
 		{name: "revert name subject", subject: `Revert "[obey-campaign:abcd1234] feat: X"`, wantParsed: false},
 		{name: "leading whitespace", subject: " [OBEY-CAMPAIGN-abcd1234] x", wantParsed: false},

--- a/pkg/commitkit/commitkit_tags_test.go
+++ b/pkg/commitkit/commitkit_tags_test.go
@@ -20,7 +20,7 @@ func TestPrependContextTagsFull_Legacy(t *testing.T) {
 			name:     "id only emits legacy marker",
 			campaign: "8deed8b4", quest: "qst_abc", fest: "CW0003", workitem: "WI-abcdef",
 			msg:  "full",
-			want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc-FE-CW0003-WI-WI-abcdef] full",
+			want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc-FE-CW0003-WI-abcdef] full",
 		},
 	}
 	for _, tc := range cases {
@@ -35,7 +35,7 @@ func TestPrependContextTagsFull_Legacy(t *testing.T) {
 
 func TestPrependContextTagsFullNamed(t *testing.T) {
 	got := commitkit.PrependContextTagsFullNamed("obey-campaign", "8deed8b4", "qst_abc", "CW0003", "WI-abcdef", "full")
-	want := "[obey-campaign:8deed8b4-qst_abc-FE-CW0003-WI-WI-abcdef] full"
+	want := "[obey-campaign:8deed8b4-qst_abc-FE-CW0003-WI-abcdef] full"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}

--- a/tests/integration/commit_tags_test.go
+++ b/tests/integration/commit_tags_test.go
@@ -157,7 +157,7 @@ title: legacy
 		"stderr must warn user about the auto-backfill: %s", out)
 
 	subject := lastCommitSubject(t, tc, dir)
-	assert.Regexp(t, `WI-WI-[0-9a-f]{6}`, subject,
+	assert.Regexp(t, `-WI-[0-9a-f]{6}`, subject,
 		"backfilled ref must appear in commit subject: %s", subject)
 
 	body, err := tc.ReadFile(wiDir + "/.workitem")

--- a/tests/integration/staging_test.go
+++ b/tests/integration/staging_test.go
@@ -77,7 +77,7 @@ func TestIntegration_ComputePlan_WorkitemDirAncestor(t *testing.T) {
 	plan := runStagingPlan(t, tc, dir+"/workflow/design/example")
 	assert.Equal(t, "workitem directory", plan.Context, "context: %+v", plan)
 	assert.Contains(t, plan.Stage, "workflow/design/example/notes.md", "stage missing notes.md: %+v", plan)
-	assert.Contains(t, plan.Tag, "WI-WI-abc123", "tag missing ref: %s", plan.Tag)
+	assert.Contains(t, plan.Tag, "WI-abc123", "tag missing ref: %s", plan.Tag)
 }
 
 func TestIntegration_ComputePlan_AutoIncludedLinkRegistryAnnotated(t *testing.T) {


### PR DESCRIPTION
Follow-up to #358. **Targets the #358 branch** (`tag-use-campaign-name`); GitHub will retarget this to `main` once #358 merges.

## What

The workitem segment of the commit tag was doubled: `WI-WI-abcdef`. The workitem ref is already self-identifying (it starts with `WI-`, per `internal/workitem/ref.go::Derive`), so the extra `WI-` segment marker was redundant. This emits the ref verbatim as a single `WI-` segment, the same way quest ids lead with `qst_`.

- **Before:** `[obey-campaign:8deed8b4-WI-WI-abcdef]`
- **After:** `[obey-campaign:8deed8b4-WI-abcdef]`

## Backward compatibility

The parser accepts **both** the new single-prefix `WI-abcdef` and the historical doubled `WI-WI-abcdef`, so every commit written before this change still resolves. `TagComponents.WorkitemRef` is unchanged (`WI-abcdef`) for both forms.

## Tests / gates

- `go build ./...`, `go test ./...`, dev build, integration compile, and `just lint` (0 issues) all green.
- Tag tests keep the doubled-form parse cases (back-compat) and add single-form format + parse + round-trip coverage.
- Integration assertions and plan fixtures updated to the single-prefix form.