### PR TITLE
feat(commitkit): expose campaign name accessors

### DIFF
--- a/pkg/commitkit/commitkit.go
+++ b/pkg/commitkit/commitkit.go
@@ -112,6 +112,33 @@ func LoadCampaignID(ctx context.Context, campaignRoot string) (string, error) {
 	return cfg.ID, nil
 }
 
+// DetectCampaignName is DetectCampaign for the campaign name, for callers that
+// build name-style tags (FormatContextTagsFullNamed).
+func DetectCampaignName(ctx context.Context) (string, error) {
+	root, err := campaign.DetectFromCwd(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	cfg, err := config.LoadCampaignConfig(ctx, root)
+	if err != nil {
+		return "", camperrors.Wrapf(err, "commitkit: load campaign config at %s", root)
+	}
+
+	return cfg.Name, nil
+}
+
+// LoadCampaignName reads the campaign name from the campaign.yaml located at
+// campaignRoot. campaignRoot must be the directory that contains .campaign/.
+func LoadCampaignName(ctx context.Context, campaignRoot string) (string, error) {
+	cfg, err := config.LoadCampaignConfig(ctx, campaignRoot)
+	if err != nil {
+		return "", camperrors.Wrapf(err, "commitkit: load campaign config at %s", campaignRoot)
+	}
+
+	return cfg.Name, nil
+}
+
 // StageAll stages all changes in the repository at repoPath.
 // Uses automatic lock retry with stale lock cleanup.
 func StageAll(ctx context.Context, repoPath string) error {

--- a/pkg/commitkit/commitkit_test.go
+++ b/pkg/commitkit/commitkit_test.go
@@ -220,6 +220,53 @@ func TestLoadCampaignID(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// LoadCampaignName / DetectCampaignName
+// ---------------------------------------------------------------------------
+
+func TestLoadCampaignName(t *testing.T) {
+	t.Run("returns name from valid campaign", func(t *testing.T) {
+		root := makeCampaign(t, "name-id-1234")
+		name, err := commitkit.LoadCampaignName(context.Background(), root)
+		require.NoError(t, err)
+		assert.Equal(t, "test-campaign", name)
+	})
+
+	t.Run("returns error when campaign.yaml missing", func(t *testing.T) {
+		root := t.TempDir()
+		_, err := commitkit.LoadCampaignName(context.Background(), root)
+		require.Error(t, err)
+	})
+}
+
+func TestDetectCampaignName(t *testing.T) {
+	t.Run("detects name from subdirectory", func(t *testing.T) {
+		root := makeCampaign(t, "detect-name-id")
+		sub := filepath.Join(root, "projects", "mypkg")
+		require.NoError(t, os.MkdirAll(sub, 0755))
+
+		origWd, err := os.Getwd()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.Chdir(origWd) })
+		require.NoError(t, os.Chdir(sub))
+
+		name, err := commitkit.DetectCampaignName(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "test-campaign", name)
+	})
+
+	t.Run("returns error when not inside a campaign", func(t *testing.T) {
+		bare := t.TempDir()
+		origWd, err := os.Getwd()
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = os.Chdir(origWd) })
+		require.NoError(t, os.Chdir(bare))
+
+		_, err = commitkit.DetectCampaignName(context.Background())
+		require.Error(t, err)
+	})
+}
+
+// ---------------------------------------------------------------------------
 // DetectCampaign
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why

After #358, `commitkit` can emit name-style tags via `FormatContextTagsFullNamed` / `PrependContextTagsFullNamed`, but it only exposes the campaign **id** (`DetectCampaign`, `LoadCampaignID`). External callers — specifically `fest commit` — have no public way to get the campaign **name**, so they can't build name-style tags.

This adds the missing accessors so `fest` can stop emitting the hardcoded `[OBEY-CAMPAIGN-...]` form.

## What

- `commitkit.DetectCampaignName(ctx)` — walks up from cwd, returns the campaign name (mirrors `DetectCampaign`).
- `commitkit.LoadCampaignName(ctx, campaignRoot)` — reads the name from `campaign.yaml` (mirrors `LoadCampaignID`).

Both are thin, additive wrappers over `config.LoadCampaignConfig`. No existing signatures change.

## Follow-up

This unblocks the `fest` PR: bump the camp dep to a commit containing this, then replace the four hardcoded tag sites (`internal/commands/commit/commit.go:471` + `:476`, `status/handlers_festival.go:507`, `ritual/run.go:200`) with name-aware calls.

## Tests / gates

`go test ./pkg/commitkit/...`, `go build ./...`, and `just lint` (0 issues) green. Added `TestLoadCampaignName` / `TestDetectCampaignName` mirroring the existing id-accessor tests.