### PR TITLE
fix(worktrees): keep git worktrees out of campaign status and commits

### DIFF
--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -153,6 +153,9 @@ func runCommit(cmd *cobra.Command, args []string) error {
 			if pathErr != nil {
 				return pathErr
 			}
+			if spec := worktreesExcludeSpec(ctx, campRoot); spec != "" {
+				paths = append(paths, spec)
+			}
 			if err := git.StageAllExcluding(ctx, target.Path, paths); err != nil {
 				return err
 			}
@@ -233,6 +236,16 @@ func runCommit(cmd *cobra.Command, args []string) error {
 
 	fmt.Println(ui.Success("Changes committed successfully"))
 	return nil
+}
+
+func worktreesExcludeSpec(ctx context.Context, campRoot string) string {
+	worktreesPath := config.DefaultCampaignPaths().Worktrees
+	if cfg, err := config.LoadCampaignConfig(ctx, campRoot); err == nil {
+		if wt := cfg.Paths().Worktrees; wt != "" {
+			worktreesPath = wt
+		}
+	}
+	return strings.Trim(strings.TrimSpace(worktreesPath), "/")
 }
 
 func effectiveCommitAll(cmd *cobra.Command, amend, all bool) bool {

--- a/cmd/camp/commit_test.go
+++ b/cmd/camp/commit_test.go
@@ -1,10 +1,18 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
+
+func TestWorktreesExcludeSpec_FallsBackToDefaultOutsideCampaign(t *testing.T) {
+	got := worktreesExcludeSpec(context.Background(), t.TempDir())
+	if got != "projects/worktrees" {
+		t.Fatalf("worktreesExcludeSpec() = %q, want %q (default, no trailing slash)", got, "projects/worktrees")
+	}
+}
 
 func TestEffectiveCommitAll_AmendDefaultsNoAutoStage(t *testing.T) {
 	cmd := &cobra.Command{Use: "commit"}

--- a/cmd/camp/init/command.go
+++ b/cmd/camp/init/command.go
@@ -331,6 +331,14 @@ func RunFlow(ctx context.Context, p Params, w Writers, isInteractive bool) error
 		}
 	}
 
+	if len(result.FilesModified) > 0 {
+		writeLine(w.HumanOut)
+		writeLine(w.HumanOut, ui.Subheader("Files updated:"))
+		for _, f := range result.FilesModified {
+			writef(w.HumanOut, "  %s %s\n", ui.SuccessIcon(), ui.Value(f))
+		}
+	}
+
 	if len(result.Skipped) > 0 && p.VerboseOutput {
 		writeLine(w.HumanOut)
 		writeLine(w.HumanOut, ui.Subheader("Skipped (already exist):"))

--- a/cmd/camp/init/repair.go
+++ b/cmd/camp/init/repair.go
@@ -17,7 +17,7 @@ import (
 // or replaced during repair; they must be staged explicitly because the repair
 // commit uses a selective file list.
 func commitRepairChanges(ctx context.Context, initResult *scaffold.InitResult, plan *scaffold.RepairPlan, migrationCount int, skillPaths []string, w Writers) {
-	hasChanges := len(initResult.DirsCreated) > 0 || len(initResult.FilesCreated) > 0 || migrationCount > 0 || len(skillPaths) > 0
+	hasChanges := len(initResult.DirsCreated) > 0 || len(initResult.FilesCreated) > 0 || len(initResult.FilesModified) > 0 || migrationCount > 0 || len(skillPaths) > 0
 	if plan != nil && len(plan.IntentMigrations) > 0 {
 		hasChanges = true
 	}
@@ -54,8 +54,9 @@ func commitRepairChanges(ctx context.Context, initResult *scaffold.InitResult, p
 }
 
 func buildRepairCommitFiles(initResult *scaffold.InitResult, plan *scaffold.RepairPlan, skillPaths []string) []string {
-	files := make([]string, 0, len(initResult.FilesCreated)+len(initResult.DirsCreated)+len(skillPaths))
+	files := make([]string, 0, len(initResult.FilesCreated)+len(initResult.FilesModified)+len(initResult.DirsCreated)+len(skillPaths))
 	files = append(files, initResult.FilesCreated...)
+	files = append(files, initResult.FilesModified...)
 	files = append(files, initResult.DirsCreated...)
 	files = append(files, skillPaths...)
 
@@ -107,6 +108,14 @@ func buildRepairCommitMessage(initResult *scaffold.InitResult, plan *scaffold.Re
 	if len(initResult.FilesCreated) > 0 {
 		fmt.Fprintf(&b, "Files created:\n")
 		for _, f := range initResult.FilesCreated {
+			fmt.Fprintf(&b, "  - %s\n", f)
+		}
+		b.WriteString("\n")
+	}
+
+	if len(initResult.FilesModified) > 0 {
+		fmt.Fprintf(&b, "Files updated:\n")
+		for _, f := range initResult.FilesModified {
 			fmt.Fprintf(&b, "  - %s\n", f)
 		}
 		b.WriteString("\n")

--- a/cmd/camp/init/repair_backfill_commit_test.go
+++ b/cmd/camp/init/repair_backfill_commit_test.go
@@ -22,6 +22,32 @@ func TestBuildRepairCommitFiles_IncludesQuestDateBackfill(t *testing.T) {
 	}
 }
 
+func TestBuildRepairCommitFiles_IncludesModifiedGitignore(t *testing.T) {
+	result := &scaffold.InitResult{
+		CampaignRoot:  "/campaign",
+		FilesModified: []string{"/campaign/.gitignore"},
+	}
+
+	files := buildRepairCommitFiles(result, nil, nil)
+	got := strings.Join(files, "\n")
+	if !strings.Contains(got, ".gitignore") {
+		t.Fatalf("commit files missing modified .gitignore: %v", files)
+	}
+}
+
+func TestBuildRepairCommitMessage_IncludesFilesModified(t *testing.T) {
+	msg := buildRepairCommitMessage(&scaffold.InitResult{
+		FilesModified: []string{"/campaign/.gitignore"},
+	}, nil, 0, nil)
+
+	if !strings.Contains(msg, "Files updated:") {
+		t.Fatalf("commit message missing updated-files summary: %q", msg)
+	}
+	if !strings.Contains(msg, ".gitignore") {
+		t.Fatalf("commit message missing modified path: %q", msg)
+	}
+}
+
 func TestBuildRepairCommitMessage_IncludesQuestDateBackfill(t *testing.T) {
 	msg := buildRepairCommitMessage(&scaffold.InitResult{}, &scaffold.RepairPlan{
 		QuestDateBackfill: &scaffold.QuestDateBackfill{

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -363,6 +363,20 @@ workitems/current.yaml
 		}
 	}
 
+	if !opts.DryRun {
+		worktreesPath := jumps.Paths.Worktrees
+		if worktreesPath == "" {
+			worktreesPath = config.DefaultCampaignPaths().Worktrees
+		}
+		created, _, giErr := ensureRootGitignoreWorktrees(absDir, worktreesPath)
+		if giErr != nil {
+			return nil, giErr
+		}
+		if created {
+			result.FilesCreated = append(result.FilesCreated, filepath.Join(absDir, ".gitignore"))
+		}
+	}
+
 	// Create CLAUDE.md symlink to AGENTS.md (AGENTS.md is the source of truth)
 	claudePath := filepath.Join(absDir, "CLAUDE.md")
 

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -67,6 +67,8 @@ type InitResult struct {
 	DirsCreated []string
 	// FilesCreated lists files that were created.
 	FilesCreated []string
+	// FilesModified lists existing files that were modified in place.
+	FilesModified []string
 	// Skipped lists items that were skipped (already exist).
 	Skipped []string
 	// GitInitialized indicates if a git repository was initialized.
@@ -368,12 +370,15 @@ workitems/current.yaml
 		if worktreesPath == "" {
 			worktreesPath = config.DefaultCampaignPaths().Worktrees
 		}
-		created, _, giErr := ensureRootGitignoreWorktrees(absDir, worktreesPath)
+		created, modified, giErr := ensureRootGitignoreWorktrees(absDir, worktreesPath)
 		if giErr != nil {
 			return nil, giErr
 		}
+		gitignoreAbs := filepath.Join(absDir, ".gitignore")
 		if created {
-			result.FilesCreated = append(result.FilesCreated, filepath.Join(absDir, ".gitignore"))
+			result.FilesCreated = append(result.FilesCreated, gitignoreAbs)
+		} else if modified {
+			result.FilesModified = append(result.FilesModified, gitignoreAbs)
 		}
 	}
 

--- a/internal/scaffold/init_repair_test.go
+++ b/internal/scaffold/init_repair_test.go
@@ -7,6 +7,8 @@ import (
 
 	"path/filepath"
 
+	"strings"
+
 	"testing"
 
 	"time"
@@ -61,6 +63,62 @@ func TestInit_RepairPreservesMission(t *testing.T) {
 
 	if cfg.Mission != "Original mission" {
 		t.Errorf("Mission = %q, want %q (should preserve existing)", cfg.Mission, "Original mission")
+	}
+}
+
+func TestInit_RepairRecordsModifiedRootGitignore(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpDir, _ = filepath.EvalSymlinks(tmpDir)
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	campaignDir := filepath.Join(tmpDir, "repair-gitignore")
+	mustMkdirAll(t, filepath.Join(campaignDir, config.CampaignDir))
+
+	ctx := context.Background()
+
+	initialCfg := &config.CampaignConfig{
+		ID:        "test-id",
+		Name:      "repair-gitignore",
+		Type:      config.CampaignTypeProduct,
+		CreatedAt: time.Now(),
+	}
+	if err := config.SaveCampaignConfig(ctx, campaignDir, initialCfg); err != nil {
+		t.Fatalf("SaveCampaignConfig() error = %v", err)
+	}
+
+	rootGitignore := filepath.Join(campaignDir, ".gitignore")
+	if err := os.WriteFile(rootGitignore, []byte("*.log\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Init(ctx, campaignDir, InitOptions{
+		Name:       "repair-gitignore",
+		Repair:     true,
+		NoRegister: true,
+	})
+	if err != nil {
+		t.Fatalf("Init() with repair error = %v", err)
+	}
+
+	foundModified := false
+	for _, f := range result.FilesModified {
+		if strings.HasSuffix(f, ".gitignore") {
+			foundModified = true
+		}
+	}
+	if !foundModified {
+		t.Fatalf("expected root .gitignore recorded in FilesModified, got %v", result.FilesModified)
+	}
+
+	content, err := os.ReadFile(rootGitignore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !gitignoreIgnoresWorktrees(string(content), config.DefaultCampaignPaths().Worktrees) {
+		t.Fatalf("worktrees rule not appended to existing root .gitignore:\n%s", content)
+	}
+	if !strings.HasPrefix(string(content), "*.log\n") {
+		t.Fatalf("existing content not preserved:\n%s", content)
 	}
 }
 

--- a/internal/scaffold/repair.go
+++ b/internal/scaffold/repair.go
@@ -634,6 +634,9 @@ func computeMiscFileChanges(absDir string, plan *RepairPlan) {
 
 	rootGitignorePath := filepath.Join(absDir, ".gitignore")
 	worktreesPath := config.DefaultCampaignPaths().Worktrees
+	if plan.MergedJumps != nil && plan.MergedJumps.Paths.Worktrees != "" {
+		worktreesPath = plan.MergedJumps.Paths.Worktrees
+	}
 	if raw, err := os.ReadFile(rootGitignorePath); os.IsNotExist(err) {
 		plan.Changes = append(plan.Changes, RepairChange{
 			Type:        RepairAdd,

--- a/internal/scaffold/repair.go
+++ b/internal/scaffold/repair.go
@@ -632,6 +632,24 @@ func computeMiscFileChanges(absDir string, plan *RepairPlan) {
 		}
 	}
 
+	rootGitignorePath := filepath.Join(absDir, ".gitignore")
+	worktreesPath := config.DefaultCampaignPaths().Worktrees
+	if raw, err := os.ReadFile(rootGitignorePath); os.IsNotExist(err) {
+		plan.Changes = append(plan.Changes, RepairChange{
+			Type:        RepairAdd,
+			Category:    "file",
+			Key:         ".gitignore",
+			Description: "missing worktrees ignore rule",
+		})
+	} else if err == nil && !gitignoreIgnoresWorktrees(string(raw), worktreesPath) {
+		plan.Changes = append(plan.Changes, RepairChange{
+			Type:        RepairModify,
+			Category:    "file",
+			Key:         ".gitignore",
+			Description: "missing worktrees ignore rule",
+		})
+	}
+
 	claudePath := filepath.Join(absDir, "CLAUDE.md")
 	if _, err := os.Lstat(claudePath); os.IsNotExist(err) {
 		plan.Changes = append(plan.Changes, RepairChange{
@@ -686,6 +704,70 @@ func gitignoreHasRule(content, entry string) bool {
 		}
 	}
 	return false
+}
+
+const rootGitignoreWorktreesComment = "# Git worktrees (machine-local)"
+
+func ensureRootGitignoreWorktrees(absDir, worktreesPath string) (created, modified bool, err error) {
+	rule := rootGitignoreWorktreeRule(worktreesPath)
+	gitignorePath := filepath.Join(absDir, ".gitignore")
+
+	raw, readErr := os.ReadFile(gitignorePath)
+	if os.IsNotExist(readErr) {
+		content := rootGitignoreWorktreesComment + "\n" + rule + "\n"
+		if writeErr := fsutil.WriteFileAtomically(gitignorePath, []byte(content), 0o644); writeErr != nil {
+			return false, false, camperrors.Wrap(writeErr, "create root .gitignore")
+		}
+		return true, false, nil
+	}
+	if readErr != nil {
+		return false, false, camperrors.Wrap(readErr, "read root .gitignore")
+	}
+
+	if gitignoreIgnoresWorktrees(string(raw), worktreesPath) {
+		return false, false, nil
+	}
+
+	suffix := "\n"
+	if len(raw) > 0 && raw[len(raw)-1] != '\n' {
+		suffix = "\n\n"
+	}
+	addition := suffix + rootGitignoreWorktreesComment + "\n" + rule + "\n"
+	if writeErr := fsutil.WriteFileAtomically(gitignorePath, append(raw, []byte(addition)...), 0o644); writeErr != nil {
+		return false, false, camperrors.Wrap(writeErr, "update root .gitignore")
+	}
+	return false, true, nil
+}
+
+func rootGitignoreWorktreeRule(worktreesPath string) string {
+	p := normalizeWorktreesPath(worktreesPath)
+	return "/" + p + "/"
+}
+
+func gitignoreIgnoresWorktrees(content, worktreesPath string) bool {
+	p := normalizeWorktreesPath(worktreesPath)
+	base := p
+	if idx := strings.LastIndex(p, "/"); idx >= 0 {
+		base = p[idx+1:]
+	}
+	for _, candidate := range []string{
+		"/" + p + "/", "/" + p,
+		p + "/", p,
+		base + "/", base,
+	} {
+		if gitignoreHasRule(content, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeWorktreesPath(worktreesPath string) string {
+	p := strings.Trim(strings.TrimSpace(worktreesPath), "/")
+	if p == "" {
+		p = strings.Trim(config.DefaultCampaignPaths().Worktrees, "/")
+	}
+	return p
 }
 
 // isUserDefined returns true if a shortcut was added by the user (not auto-generated).

--- a/internal/scaffold/repair_test.go
+++ b/internal/scaffold/repair_test.go
@@ -300,6 +300,31 @@ func TestComputeMiscFileChanges_FilesExist(t *testing.T) {
 	}
 }
 
+func TestComputeMiscFileChanges_CustomWorktreesPath(t *testing.T) {
+	dir := t.TempDir()
+	setupCampaignDir(t, dir)
+
+	rootGitignorePath := filepath.Join(dir, ".gitignore")
+	if err := os.WriteFile(rootGitignorePath, []byte("/projects/worktrees/\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	jumps := config.DefaultJumpsConfig()
+	jumps.Paths.Worktrees = "custom/wt/"
+	plan := &RepairPlan{MergedJumps: &jumps}
+	computeMiscFileChanges(dir, plan)
+
+	found := false
+	for _, c := range plan.Changes {
+		if c.Key == ".gitignore" && c.Type == RepairModify {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected .gitignore modify for custom worktrees path, got changes: %+v", plan.Changes)
+	}
+}
+
 func TestComputeRepairPlan_CancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/scaffold/repair_test.go
+++ b/internal/scaffold/repair_test.go
@@ -278,7 +278,11 @@ func TestComputeMiscFileChanges_FilesExist(t *testing.T) {
 
 	// Create the files
 	gitignorePath := filepath.Join(dir, config.CampaignDir, ".gitignore")
-	if err := os.WriteFile(gitignorePath, []byte("state.yaml\n"), 0644); err != nil {
+	if err := os.WriteFile(gitignorePath, []byte("state.yaml\nworkitems/current.yaml\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rootGitignorePath := filepath.Join(dir, ".gitignore")
+	if err := os.WriteFile(rootGitignorePath, []byte("/projects/worktrees/\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	claudePath := filepath.Join(dir, "CLAUDE.md")

--- a/internal/scaffold/worktree_gitignore_test.go
+++ b/internal/scaffold/worktree_gitignore_test.go
@@ -1,0 +1,138 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRootGitignoreWorktreeRule(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "default when empty", path: "", want: "/projects/worktrees/"},
+		{name: "anchors configured path", path: "projects/worktrees/", want: "/projects/worktrees/"},
+		{name: "trims surrounding slashes", path: "/custom/wt/", want: "/custom/wt/"},
+		{name: "trims whitespace", path: "  projects/worktrees  ", want: "/projects/worktrees/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rootGitignoreWorktreeRule(tc.path); got != tc.want {
+				t.Errorf("rootGitignoreWorktreeRule(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGitignoreIgnoresWorktrees(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		path    string
+		want    bool
+	}{
+		{name: "anchored directory rule", content: "/projects/worktrees/\n", path: "projects/worktrees/", want: true},
+		{name: "unanchored directory rule", content: "projects/worktrees/\n", path: "projects/worktrees/", want: true},
+		{name: "bare directory rule", content: "worktrees/\n", path: "projects/worktrees/", want: true},
+		{name: "bare directory no slash", content: "worktrees\n", path: "projects/worktrees/", want: true},
+		{name: "absent", content: "state.yaml\n*.db\n", path: "projects/worktrees/", want: false},
+		{name: "commented out is not a rule", content: "# worktrees/\n", path: "projects/worktrees/", want: false},
+		{name: "default path when empty", content: "/projects/worktrees/\n", path: "", want: true},
+		{name: "custom path matched", content: "/custom/wt/\n", path: "custom/wt/", want: true},
+		{name: "custom path absent", content: "worktrees/\n", path: "custom/wt/", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := gitignoreIgnoresWorktrees(tc.content, tc.path); got != tc.want {
+				t.Errorf("gitignoreIgnoresWorktrees(%q, %q) = %v, want %v", tc.content, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEnsureRootGitignoreWorktreesCreatesFile(t *testing.T) {
+	dir := t.TempDir()
+
+	created, modified, err := ensureRootGitignoreWorktrees(dir, "projects/worktrees/")
+	if err != nil {
+		t.Fatalf("ensureRootGitignoreWorktrees() error = %v", err)
+	}
+	if !created || modified {
+		t.Fatalf("first call: got created=%v modified=%v, want created=true modified=false", created, modified)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !gitignoreIgnoresWorktrees(string(content), "projects/worktrees/") {
+		t.Fatalf("root .gitignore missing worktrees rule:\n%s", content)
+	}
+	if !strings.Contains(string(content), "machine-local") {
+		t.Fatalf("root .gitignore missing explanatory comment:\n%s", content)
+	}
+
+	created, modified, err = ensureRootGitignoreWorktrees(dir, "projects/worktrees/")
+	if err != nil {
+		t.Fatalf("second ensureRootGitignoreWorktrees() error = %v", err)
+	}
+	if created || modified {
+		t.Fatalf("second call should be a no-op: got created=%v modified=%v", created, modified)
+	}
+}
+
+func TestEnsureRootGitignoreWorktreesAppendsWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	existing := ".env\n*.db\n"
+	if err := os.WriteFile(gitignorePath, []byte(existing), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	created, modified, err := ensureRootGitignoreWorktrees(dir, "projects/worktrees/")
+	if err != nil {
+		t.Fatalf("ensureRootGitignoreWorktrees() error = %v", err)
+	}
+	if created || !modified {
+		t.Fatalf("got created=%v modified=%v, want created=false modified=true", created, modified)
+	}
+
+	content, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(content), existing) {
+		t.Fatalf("existing content not preserved:\n%s", content)
+	}
+	if !gitignoreIgnoresWorktrees(string(content), "projects/worktrees/") {
+		t.Fatalf("worktrees rule not appended:\n%s", content)
+	}
+}
+
+func TestEnsureRootGitignoreWorktreesHonorsExistingBareRule(t *testing.T) {
+	dir := t.TempDir()
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	existing := "# Worktrees directory\nworktrees/\n"
+	if err := os.WriteFile(gitignorePath, []byte(existing), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	created, modified, err := ensureRootGitignoreWorktrees(dir, "projects/worktrees/")
+	if err != nil {
+		t.Fatalf("ensureRootGitignoreWorktrees() error = %v", err)
+	}
+	if created || modified {
+		t.Fatalf("existing bare rule should be honored: got created=%v modified=%v", created, modified)
+	}
+
+	content, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != existing {
+		t.Fatalf("file should be unchanged:\ngot:\n%s\nwant:\n%s", content, existing)
+	}
+}


### PR DESCRIPTION
## Problem

In a campaign, `camp status` and `camp commit` at the campaign root surfaced and staged git worktrees living under `projects/worktrees/`.

Root cause: nothing ignored the worktrees directory at the campaign root.

- `camp status` just runs `git status` on the root (`cmd/camp/status.go`). Worktrees are ordinary untracked directories in the superproject working tree, so git reports them.
- `camp commit` at the root stages with `git add -- . :(exclude,literal)<submodule>` (`internal/git/commit.go` `StageAllExcluding`). The exclude list is only registered submodules, so worktrees got swept in and staged as **embedded git repositories**.
- The scaffold never writes a root `.gitignore`, so a fresh `camp init` campaign has no worktrees ignore rule at all. Campaigns that don't show this (e.g. the obey campaign) only avoid it via a hand-added `worktrees/` line.

## Fix

Make the fix git-native (one rule fixes status, commit, add, and raw git) plus a defense-in-depth guard on commit:

1. **`camp init` ensures the campaign root `.gitignore` ignores the worktrees directory** with an anchored rule (`/projects/worktrees/`, derived from the configured worktrees path). It creates the file when absent and honors any existing equivalent rule (anchored, unanchored, or a bare `worktrees/`) so it never duplicates.
2. **`camp init --repair` backfills the rule** for existing campaigns (added to the repair plan + applied on init).
3. **`camp commit` excludes the worktrees directory from root staging** as defense-in-depth for campaigns with a customized worktrees path or a hand-edited ignore file.

`camp status` is fixed transitively by the gitignore rule; its git-flag passthrough is left untouched.

## Tests

- `internal/scaffold/worktree_gitignore_test.go`: rule formatting, equivalence detection across rule forms, and create/append/no-op/idempotency for the ensure helper.
- `cmd/camp/commit_test.go`: `worktreesExcludeSpec` default fallback.
- Updated `TestComputeMiscFileChanges_FilesExist` fixture to include the root `.gitignore`.

`just gate` green (gate-fast: stable+dev build, vet, fmt, lint; plus stable unit tests). All 2902 tests pass.

## Notes

Existing campaigns surfacing worktrees today are fixed by running `camp init --repair`, which writes the missing rule.
