### PR TITLE
fix(commit): skip worktrees exclude pathspec when gitignore already covers it

### DIFF
--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -245,7 +245,17 @@ func worktreesExcludeSpec(ctx context.Context, campRoot string) string {
 			worktreesPath = wt
 		}
 	}
-	return strings.Trim(strings.TrimSpace(worktreesPath), "/")
+	spec := strings.Trim(strings.TrimSpace(worktreesPath), "/")
+	if spec == "" {
+		return ""
+	}
+	// git add rejects pathspecs naming gitignored paths, even exclude-magic
+	// ones. When gitignore already covers the worktrees dir the exclusion is
+	// redundant; only keep it for campaigns without the ignore rule.
+	if ignored, err := git.PathIgnored(ctx, campRoot, spec); err == nil && ignored {
+		return ""
+	}
+	return spec
 }
 
 func effectiveCommitAll(cmd *cobra.Command, amend, all bool) bool {

--- a/cmd/camp/stage.go
+++ b/cmd/camp/stage.go
@@ -85,6 +85,9 @@ func runStage(cmd *cobra.Command, args []string) error {
 		if pathErr != nil {
 			return pathErr
 		}
+		if spec := worktreesExcludeSpec(ctx, campRoot); spec != "" {
+			paths = append(paths, spec)
+		}
 		if err := git.StageAllExcluding(ctx, target.Path, paths); err != nil {
 			return err
 		}

--- a/internal/git/ignore.go
+++ b/internal/git/ignore.go
@@ -1,0 +1,22 @@
+package git
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// PathIgnored reports whether path is excluded by gitignore rules in repoPath.
+func PathIgnored(ctx context.Context, repoPath, path string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "check-ignore", "-q", "--", path)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, camperrors.NewGit("check-ignore", "", "", strings.TrimSpace(string(output)), err)
+	}
+	return true, nil
+}

--- a/tests/integration/commit_worktrees_test.go
+++ b/tests/integration/commit_worktrees_test.go
@@ -1,0 +1,104 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_CommitSucceedsWithGitignoredWorktrees(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	const campaignDir = "/campaigns/commit-worktrees-ignored"
+	_, err := tc.InitCampaign(campaignDir, "Worktrees Ignored", "product")
+	require.NoError(t, err)
+
+	ignoreCheck := tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		git check-ignore -q -- projects/worktrees && echo RULE_PRESENT
+	`, campaignDir))
+	require.Contains(t, ignoreCheck, "RULE_PRESENT",
+		"camp init should have written the worktrees gitignore rule")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p projects/worktrees/feature-x
+		printf 'wt content' > projects/worktrees/feature-x/file.txt
+		printf 'root content' > root.txt
+	`, campaignDir))
+
+	output, err := tc.RunCampInDir(campaignDir, "commit", "-m", "root content")
+	require.NoError(t, err,
+		"camp commit must not fail when the worktrees dir is gitignored; output:\n%s", output)
+
+	committed := strings.Fields(tc.GitOutput(t, campaignDir, "show", "--name-only", "--format=", "HEAD"))
+	require.Contains(t, committed, "root.txt")
+	for _, path := range committed {
+		require.NotContains(t, path, "projects/worktrees")
+	}
+}
+
+func TestIntegration_CommitExcludesWorktreesWithoutIgnoreRule(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	const campaignDir = "/campaigns/commit-worktrees-unignored"
+	_, err := tc.InitCampaign(campaignDir, "Worktrees Unignored", "product")
+	require.NoError(t, err)
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		sed -i '/orktree/d' .gitignore
+		git add .gitignore
+		git commit -q -m 'drop worktrees ignore rule'
+		mkdir -p projects/worktrees/feature-x
+		printf 'wt content' > projects/worktrees/feature-x/file.txt
+		printf 'root content' > root.txt
+	`, campaignDir))
+
+	output, err := tc.RunCampInDir(campaignDir, "commit", "-m", "root content")
+	require.NoError(t, err, "camp commit should succeed; output:\n%s", output)
+
+	committed := strings.Fields(tc.GitOutput(t, campaignDir, "show", "--name-only", "--format=", "HEAD"))
+	require.Contains(t, committed, "root.txt")
+	for _, path := range committed {
+		require.NotContains(t, path, "projects/worktrees",
+			"worktrees content must stay excluded from root commits even without an ignore rule")
+	}
+
+	status := tc.GitOutput(t, campaignDir, "status", "--porcelain")
+	require.Contains(t, status, "?? projects/worktrees/",
+		"worktrees content should remain untracked, not staged")
+}
+
+func TestIntegration_StageExcludesWorktreesWithoutIgnoreRule(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	const campaignDir = "/campaigns/stage-worktrees-unignored"
+	_, err := tc.InitCampaign(campaignDir, "Stage Worktrees Unignored", "product")
+	require.NoError(t, err)
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		sed -i '/orktree/d' .gitignore
+		git add .gitignore
+		git commit -q -m 'drop worktrees ignore rule'
+		mkdir -p projects/worktrees/feature-x
+		printf 'wt content' > projects/worktrees/feature-x/file.txt
+		printf 'notes' > notes.md
+	`, campaignDir))
+
+	output, err := tc.RunCampInDir(campaignDir, "stage")
+	require.NoError(t, err, "camp stage should succeed; output:\n%s", output)
+
+	staged := strings.Fields(tc.GitOutput(t, campaignDir, "diff", "--cached", "--name-only"))
+	require.Contains(t, staged, "notes.md")
+	for _, path := range staged {
+		require.NotContains(t, path, "projects/worktrees",
+			"worktrees content must stay excluded from root staging even without an ignore rule")
+	}
+}


### PR DESCRIPTION
## Problem

`camp commit` at the campaign root fails on v0.2.15 whenever the worktrees directory exists with content and is gitignored:

```
Staging changes...
Error: git add failed: The following paths are ignored by one of your .gitignore files:
projects/worktrees
```

Root staging runs a single `git add -- . ':(exclude,literal)<submodule>'... ':(exclude,literal)projects/worktrees'`. git's `addIgnoredFile` safety check matches ignored paths against every pathspec item, **including exclude-magic ones**, and exits 1 (reproduced on git 2.54.0; disabling `advice.addIgnoredFile` only hides the hint, the exit code stays 1).

Since #361 also makes `camp init` and `camp init --repair` write the anchored `/projects/worktrees/` gitignore rule, the defense-in-depth exclusion added in the same PR breaks exactly the campaigns that rule now covers - i.e. fresh and repaired campaigns, as soon as `projects/worktrees/` is non-empty.

## Fix

- `worktreesExcludeSpec` now runs `git check-ignore` (new `git.PathIgnored` helper) and omits the exclude pathspec when gitignore already covers the worktrees dir - the exclusion is redundant there because `git add .` skips ignored paths. Campaigns **without** the ignore rule keep the exclusion, preserving the #361 protection for hand-edited ignores and customized paths.
- If `check-ignore` errors, the exclusion is kept (current behavior).
- `camp stage` gains the same exclusion: its help text promises "the same auto-staging logic as 'camp commit'" but #361 only patched commit, so stage would happily stage worktrees content in campaigns without the rule.

## Testing

- `just gate` green (stable+dev builds, vet, lint ratchets, 2880 unit tests).
- New containerized integration tests (`tests/integration/commit_worktrees_test.go`):
  - commit succeeds with the init-written ignore rule present and keeps worktrees out of the commit (**fails on main with the exact reported error** - verified by running it against unfixed sources);
  - commit still excludes worktrees content when the ignore rule is absent, leaving it untracked;
  - stage likewise excludes worktrees content when the rule is absent.

## Notes

This is a released regression (v0.2.15), so it's worth a fast patch release once merged.