### PR TITLE
feat(workitem-tui): bind custom workflow types to filter keys 5-9

### DIFF
--- a/internal/workitem/tui/model.go
+++ b/internal/workitem/tui/model.go
@@ -3,6 +3,8 @@ package tui
 
 import (
 	"context"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,14 +20,45 @@ import (
 // Update this if the layout structure changes.
 const chromeHeight = 3
 
-// typeFilterKeys maps keyboard shortcuts to workflow type filter values.
-// Empty string means "show all".
-var typeFilterKeys = map[string]string{
-	"0": "",
-	"1": "intent",
-	"2": "design",
-	"3": "explore",
-	"4": "festival",
+// builtinFilterTypes pins keys 1-4 to the builtin workflow types.
+var builtinFilterTypes = []string{
+	string(workitem.WorkflowTypeIntent),
+	string(workitem.WorkflowTypeDesign),
+	string(workitem.WorkflowTypeExplore),
+	string(workitem.WorkflowTypeFestival),
+}
+
+// maxCustomFilterTypes caps custom type bindings so keys stay within 5-9.
+const maxCustomFilterTypes = 5
+
+// typeFilterBinding pairs a digit key with the workflow type it filters.
+type typeFilterBinding struct {
+	key      string
+	workflow string
+}
+
+// customTypes returns the distinct non-builtin workflow types in items,
+// sorted alphabetically and capped at maxCustomFilterTypes.
+func customTypes(items []workitem.WorkItem) []string {
+	builtin := make(map[string]bool, len(builtinFilterTypes))
+	for _, t := range builtinFilterTypes {
+		builtin[t] = true
+	}
+	seen := make(map[string]bool)
+	var out []string
+	for _, item := range items {
+		t := string(item.WorkflowType)
+		if t == "" || builtin[t] || seen[t] {
+			continue
+		}
+		seen[t] = true
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	if len(out) > maxCustomFilterTypes {
+		out = out[:maxCustomFilterTypes]
+	}
+	return out
 }
 
 // Model is the Bubble Tea model for the workitem dashboard.
@@ -49,8 +82,9 @@ type Model struct {
 	savedSearchQuery string // snapshot of committed query when search mode starts
 
 	// Filters
-	typeFilter string // empty = all, or "intent"/"design"/"explore"/"festival"
-	showParked bool
+	typeFilter        string // empty = all, or any workflow type bound to a filter key
+	customFilterTypes []string
+	showParked        bool
 
 	// Preview
 	showPreview    bool
@@ -92,17 +126,55 @@ func New(ctx context.Context, items []workitem.WorkItem, campaignRoot string, re
 	}
 
 	return Model{
-		allItems:      items,
-		filteredItems: items,
-		searchInput:   ti,
-		showPreview:   true,
-		ctx:           ctx,
-		campaignRoot:  campaignRoot,
-		resolver:      resolver,
-		priorityStore: store,
-		storePath:     storePath,
-		showParked:    includeParked,
+		allItems:          items,
+		filteredItems:     items,
+		customFilterTypes: customTypes(items),
+		searchInput:       ti,
+		showPreview:       true,
+		ctx:               ctx,
+		campaignRoot:      campaignRoot,
+		resolver:          resolver,
+		priorityStore:     store,
+		storePath:         storePath,
+		showParked:        includeParked,
 	}
+}
+
+// typeFilterFor resolves a pressed key to a type filter value.
+// "0" clears the filter; 1-4 are builtins; 5-9 are custom type slots.
+func (m Model) typeFilterFor(key string) (string, bool) {
+	if key == "0" {
+		return "", true
+	}
+	if len(key) != 1 || key[0] < '1' || key[0] > '9' {
+		return "", false
+	}
+	idx := int(key[0] - '1')
+	if idx < len(builtinFilterTypes) {
+		return builtinFilterTypes[idx], true
+	}
+	idx -= len(builtinFilterTypes)
+	if idx < len(m.customFilterTypes) {
+		return m.customFilterTypes[idx], true
+	}
+	return "", false
+}
+
+// typeFilterBindings returns the active key-to-type mappings in key order.
+func (m Model) typeFilterBindings() []typeFilterBinding {
+	bindings := make([]typeFilterBinding, 0, len(builtinFilterTypes)+len(m.customFilterTypes))
+	for i, t := range builtinFilterTypes {
+		bindings = append(bindings, typeFilterBinding{key: strconv.Itoa(i + 1), workflow: t})
+	}
+	for i, t := range m.customFilterTypes {
+		bindings = append(bindings, typeFilterBinding{key: strconv.Itoa(len(builtinFilterTypes) + i + 1), workflow: t})
+	}
+	return bindings
+}
+
+// maxTypeFilterKey returns the highest bound filter digit.
+func (m Model) maxTypeFilterKey() int {
+	return len(builtinFilterTypes) + len(m.customFilterTypes)
 }
 
 func (m Model) Init() tea.Cmd {

--- a/internal/workitem/tui/model_test.go
+++ b/internal/workitem/tui/model_test.go
@@ -121,6 +121,158 @@ func TestModel_TypeFilter(t *testing.T) {
 	}
 }
 
+func TestCustomTypes(t *testing.T) {
+	tests := []struct {
+		name  string
+		types []string
+		want  []string
+	}{
+		{"builtins only", []string{"intent", "design", "explore", "festival"}, nil},
+		{"sorted", []string{"feature", "bug"}, []string{"bug", "feature"}},
+		{"dedup", []string{"bug", "bug", "feature"}, []string{"bug", "feature"}},
+		{"skips builtins and empty", []string{"festival", "", "chore"}, []string{"chore"}},
+		{"caps at five", []string{"f", "e", "d", "c", "b", "a"}, []string{"a", "b", "c", "d", "e"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			items := make([]workitem.WorkItem, len(tt.types))
+			for i, typ := range tt.types {
+				items[i] = workitem.WorkItem{WorkflowType: workitem.WorkflowType(typ)}
+			}
+			got := customTypes(items)
+			if len(got) != len(tt.want) {
+				t.Fatalf("customTypes = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("customTypes = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestModel_CustomTypeFilter(t *testing.T) {
+	items := []workitem.WorkItem{
+		{WorkflowType: workitem.WorkflowTypeIntent, Title: "intent"},
+		{WorkflowType: "feature", Title: "feature item"},
+		{WorkflowType: "bug", Title: "bug one"},
+		{WorkflowType: "bug", Title: "bug two"},
+	}
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+	m = result.(Model)
+	if len(m.filteredItems) != 2 {
+		t.Fatalf("after '5': %d items, want 2", len(m.filteredItems))
+	}
+	for _, item := range m.filteredItems {
+		if item.WorkflowType != "bug" {
+			t.Errorf("filtered type = %q, want 'bug'", item.WorkflowType)
+		}
+	}
+
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
+	m = result.(Model)
+	if len(m.filteredItems) != 1 || m.filteredItems[0].Title != "feature item" {
+		t.Fatalf("after '6': %d items, want only the feature item", len(m.filteredItems))
+	}
+
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'0'}})
+	m = result.(Model)
+	if len(m.filteredItems) != 4 {
+		t.Errorf("after '0': %d items, want 4", len(m.filteredItems))
+	}
+}
+
+func TestModel_UnboundFilterKeyIsNoop(t *testing.T) {
+	items := []workitem.WorkItem{
+		{WorkflowType: workitem.WorkflowTypeIntent, Title: "intent"},
+		{WorkflowType: "bug", Title: "bug"},
+	}
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+	m = result.(Model)
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'7'}})
+	m = result.(Model)
+
+	if m.typeFilter != "bug" {
+		t.Errorf("typeFilter = %q, want 'bug' after unbound key", m.typeFilter)
+	}
+	if len(m.filteredItems) != 1 {
+		t.Errorf("filtered = %d, want 1", len(m.filteredItems))
+	}
+}
+
+func TestModel_RefreshRebindsCustomTypes(t *testing.T) {
+	items := []workitem.WorkItem{
+		{Key: "test:intent", WorkflowType: workitem.WorkflowTypeIntent, Title: "intent"},
+		{Key: "test:bug", WorkflowType: "bug", Title: "bug"},
+	}
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+	m = result.(Model)
+	if len(m.filteredItems) != 1 || m.filteredItems[0].Title != "bug" {
+		t.Fatalf("after '5': %d items, want only the bug item", len(m.filteredItems))
+	}
+
+	refreshed := []workitem.WorkItem{
+		{Key: "test:intent", WorkflowType: workitem.WorkflowTypeIntent, Title: "intent"},
+		{Key: "test:chore", WorkflowType: "chore", Title: "chore"},
+	}
+	result, _ = m.Update(refreshMsg{items: refreshed})
+	m = result.(Model)
+
+	if len(m.filteredItems) != 0 {
+		t.Errorf("stale 'bug' filter: %d items, want 0", len(m.filteredItems))
+	}
+
+	result, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+	m = result.(Model)
+	if len(m.filteredItems) != 1 || m.filteredItems[0].Title != "chore" {
+		t.Fatalf("after refresh + '5': %d items, want only the chore item", len(m.filteredItems))
+	}
+}
+
+func TestModel_HelpListsCustomTypeFilters(t *testing.T) {
+	items := []workitem.WorkItem{
+		{WorkflowType: workitem.WorkflowTypeIntent, Title: "intent"},
+		{WorkflowType: "bug", Title: "bug"},
+		{WorkflowType: "feature", Title: "feature"},
+	}
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
+	m.width = 80
+	m.height = 24
+	m.ready = true
+	m.helpVisible = true
+
+	help := m.View()
+	for _, want := range []string{"Filter: intent", "Filter: bug", "Filter: feature"} {
+		if !strings.Contains(help, want) {
+			t.Errorf("help missing %q", want)
+		}
+	}
+}
+
+func TestModel_FooterShowsDynamicFilterRange(t *testing.T) {
+	items := []workitem.WorkItem{
+		{WorkflowType: workitem.WorkflowTypeIntent, Title: "intent"},
+		{WorkflowType: "bug", Title: "bug"},
+		{WorkflowType: "feature", Title: "feature"},
+	}
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
+	m.width = 120
+	m.height = 24
+	m.ready = true
+
+	footer := m.renderFooter()
+	if !strings.Contains(footer, "1-6 filter") {
+		t.Errorf("footer = %q, want it to contain '1-6 filter'", footer)
+	}
+}
+
 func TestModel_EnterSelectsItem(t *testing.T) {
 	items := makeTestItems(3)
 	m := New(context.Background(), items, "", nil, priority.NewStore(), "")

--- a/internal/workitem/tui/update.go
+++ b/internal/workitem/tui/update.go
@@ -35,6 +35,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			workitem.Sort(items)
 			m.allItems = items
+			m.customFilterTypes = customTypes(items)
 			m.refilter()
 			m.preserveSelection(selectedKey)
 		}
@@ -78,8 +79,8 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	m.lastKeyWasG = false
 
-	// Type filter keys (0-4) — handled via lookup table
-	if filter, ok := typeFilterKeys[key]; ok {
+	// Type filter keys (0-9) — builtins pinned to 1-4, custom types on 5-9
+	if filter, ok := m.typeFilterFor(key); ok {
 		m.typeFilter = filter
 		m.refilter()
 		return m, nil

--- a/internal/workitem/tui/view.go
+++ b/internal/workitem/tui/view.go
@@ -99,9 +99,10 @@ func (m Model) renderFooter() string {
 		return footerStyle.Render("stage: c current  s next  a active  p parked  0 clear  Esc cancel")
 	}
 	count := fmt.Sprintf("%d items", len(m.filteredItems))
-	keys := "j/k move  / search  1-4 filter  0 all  S stage  P priority  tab preview  r refresh  ? help  q quit"
+	filterRange := fmt.Sprintf("1-%d", m.maxTypeFilterKey())
+	keys := fmt.Sprintf("j/k move  / search  %s filter  0 all  S stage  P priority  tab preview  r refresh  ? help  q quit", filterRange)
 	if len(keys)+len(count)+2 > m.width {
-		keys = "j/k / 1-4 P tab r ? q"
+		keys = fmt.Sprintf("j/k / %s P tab r ? q", filterRange)
 	}
 	return footerStyle.Render(fmt.Sprintf("%s  %s", count, keys))
 }
@@ -413,6 +414,15 @@ func (m Model) renderHelp() string {
 	b.WriteString("  " + previewSepStyle.Render("───────────────────────"))
 	b.WriteString("\n\n")
 
+	searchFilterKeys := [][2]string{
+		{"/", "Start search"},
+		{"Esc", "Clear search / close overlay"},
+		{"0", "Show all types"},
+	}
+	for _, binding := range m.typeFilterBindings() {
+		searchFilterKeys = append(searchFilterKeys, [2]string{binding.key, "Filter: " + binding.workflow})
+	}
+
 	sections := []struct {
 		title string
 		keys  [][2]string
@@ -423,15 +433,7 @@ func (m Model) renderHelp() string {
 			{"g g", "Jump to top"},
 			{"G", "Jump to bottom"},
 		}},
-		{"Search & Filter", [][2]string{
-			{"/", "Start search"},
-			{"Esc", "Clear search / close overlay"},
-			{"0", "Show all types"},
-			{"1", "Filter: intent"},
-			{"2", "Filter: design"},
-			{"3", "Filter: explore"},
-			{"4", "Filter: festival"},
-		}},
+		{"Search & Filter", searchFilterKeys},
 		{"Actions", [][2]string{
 			{"Enter", "Open intents or jump to directories"},
 			{"e", "Open primary doc in $EDITOR"},


### PR DESCRIPTION
## Problem

The `camp workitem` TUI can only filter by the four builtin workflow types (intent, design, explore, festival) via hardcoded keys 1-4. Campaigns tracking custom workitem types (`camp workitem create --type bug`) show those items in the all-items view but offer no way to filter down to them. The CLI `--type` flag already accepts custom slugs; the TUI key layer was the only closed surface.

Intent: `camp-workitems-filtering-only-filters-20260701-145447` (obey-campaign)
Design: `workflow/design/workitem-tui-custom-type-filters` (obey-campaign, WI-26efc9)

## Approach

- Keys `1-4` stay pinned to the builtins in canonical order, preserving muscle memory and existing docs.
- Custom types discovered in the loaded item set bind to keys `5-9` in deterministic alphabetical order, recomputed whenever a refresh replaces the item set.
- Footer hint becomes dynamic (`1-6 filter` with two custom types) and the help screen renders one row per bound key from the same binding source the key handler uses, so help cannot drift from behavior.
- Unbound digits are no-ops. A refresh that removes the actively filtered type keeps the filter (empty list + visible pill) rather than silently reshuffling under the cursor.

## Tradeoffs

- Digits cap custom bindings at five. Campaigns with more custom types get the first five alphabetically; the rest stay reachable via `/` search and CLI `--type`. A picker overlay can be layered on later if real campaigns outgrow this.
- Bindings for custom types can shift when the custom type set itself changes between refreshes; the help screen always shows current truth.

## Testing

- New model tests: custom key filtering, binding determinism/dedup/cap (table-driven), unbound-digit no-op, refresh rebinding, help and footer rendering.
- `just gate-push` green (build, vet, lint ratchets, full test suite).