### PR TITLE
feat(release-notes): group constituent commits under their PR

### DIFF
--- a/tools/release-notes/internal/notes/group.go
+++ b/tools/release-notes/internal/notes/group.go
@@ -66,13 +66,33 @@ func isNoiseSubject(subject string) bool {
 func LeafChanges(groups []Group) []Change {
 	var leaves []Change
 	for _, group := range groups {
-		if len(group.Children) == 0 {
-			leaves = append(leaves, group.Change)
-			continue
-		}
-		leaves = append(leaves, group.Children...)
+		leaves = append(leaves, groupLeaves(group)...)
 	}
 	return leaves
+}
+
+// groupLeaves returns the changes a group contributes to summary counts. A
+// headline only counts when no child restates its category, so grouped PRs
+// are counted by their constituents without losing a headline whose category
+// no child covers.
+func groupLeaves(group Group) []Change {
+	if len(group.Children) == 0 {
+		return []Change{group.Change}
+	}
+	leaves := make([]Change, 0, len(group.Children)+1)
+	if !hasCategory(group.Children, group.Change.Category) {
+		leaves = append(leaves, group.Change)
+	}
+	return append(leaves, group.Children...)
+}
+
+func hasCategory(changes []Change, category ChangeCategory) bool {
+	for _, change := range changes {
+		if change.Category == category {
+			return true
+		}
+	}
+	return false
 }
 
 func headlineChanges(groups []Group) []Change {
@@ -83,12 +103,31 @@ func headlineChanges(groups []Group) []Change {
 	return changes
 }
 
-func filterGroups(groups []Group, category ChangeCategory) []Group {
-	var filtered []Group
+// sectionGroups projects groups into one category's section: children of the
+// category render nested under their headline (repeated per section as
+// grouping context), and a headline appears bare only when it is itself a
+// counted leaf of the category. Section contents therefore always agree with
+// the LeafChanges counts.
+func sectionGroups(groups []Group, category ChangeCategory) []Group {
+	var out []Group
 	for _, group := range groups {
-		if group.Change.Category == category {
-			filtered = append(filtered, group)
+		children := filterChanges(group.Children, category)
+		switch {
+		case len(children) > 0:
+			out = append(out, Group{Change: group.Change, Children: children})
+		case group.Change.Category == category:
+			out = append(out, Group{Change: group.Change})
 		}
 	}
-	return filtered
+	return out
+}
+
+func filterChanges(changes []Change, category ChangeCategory) []Change {
+	var out []Change
+	for _, change := range changes {
+		if change.Category == category {
+			out = append(out, change)
+		}
+	}
+	return out
 }

--- a/tools/release-notes/internal/notes/group.go
+++ b/tools/release-notes/internal/notes/group.go
@@ -1,0 +1,94 @@
+package notes
+
+import "regexp"
+
+type RawEntry struct {
+	Subject       string
+	ChildSubjects []string
+	IsMerge       bool
+}
+
+type Group struct {
+	Change   Change
+	Children []Change
+}
+
+var statusChangeRe = regexp.MustCompile(`(?i)^chore\(fest\):\s*status change`)
+
+func BuildGroups(entries []RawEntry) []Group {
+	var groups []Group
+	for _, entry := range entries {
+		if isNoiseSubject(entry.Subject) {
+			continue
+		}
+		headline, ok := ParseCommitSubject(entry.Subject)
+		if !ok {
+			continue
+		}
+		group := Group{Change: headline}
+		if entry.IsMerge {
+			group.Children = buildChildren(entry.ChildSubjects, headline)
+		}
+		groups = append(groups, group)
+	}
+	return groups
+}
+
+func buildChildren(subjects []string, headline Change) []Change {
+	var children []Change
+	seen := map[string]struct{}{}
+	headlineKey := normalizedChangeKey(headline)
+	for _, subject := range subjects {
+		if isNoiseSubject(subject) {
+			continue
+		}
+		child, ok := ParseCommitSubject(subject)
+		if !ok {
+			continue
+		}
+		key := normalizedChangeKey(child)
+		if key == headlineKey {
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		children = append(children, child)
+	}
+	return children
+}
+
+func isNoiseSubject(subject string) bool {
+	return statusChangeRe.MatchString(stripBracketTags(subject))
+}
+
+func LeafChanges(groups []Group) []Change {
+	var leaves []Change
+	for _, group := range groups {
+		if len(group.Children) == 0 {
+			leaves = append(leaves, group.Change)
+			continue
+		}
+		leaves = append(leaves, group.Children...)
+	}
+	return leaves
+}
+
+func headlineChanges(groups []Group) []Change {
+	changes := make([]Change, 0, len(groups))
+	for _, group := range groups {
+		changes = append(changes, group.Change)
+	}
+	return changes
+}
+
+func filterGroups(groups []Group, category ChangeCategory) []Group {
+	var filtered []Group
+	for _, group := range groups {
+		if group.Change.Category == category {
+			filtered = append(filtered, group)
+		}
+	}
+	return filtered
+}

--- a/tools/release-notes/internal/notes/group_test.go
+++ b/tools/release-notes/internal/notes/group_test.go
@@ -145,3 +145,75 @@ func TestLeafChangesCountsChildrenNotHeadline(t *testing.T) {
 		}
 	}
 }
+
+func TestMixedCategoryPRCountsAndSectionsAgree(t *testing.T) {
+	t.Parallel()
+
+	groups := []Group{
+		{
+			Change: Change{Text: "Add release dashboard", PRNumber: 9, Category: CategoryFeature},
+			Children: []Change{
+				{Text: "Fix flaky dashboard test", Category: CategoryFix},
+				{Text: "Refactor dashboard data layer", Category: CategoryMaintenance},
+			},
+		},
+	}
+
+	leaves := LeafChanges(groups)
+	counts := map[ChangeCategory]int{}
+	for _, leaf := range leaves {
+		counts[leaf.Category]++
+	}
+	if counts[CategoryFeature] != 1 || counts[CategoryFix] != 1 || counts[CategoryMaintenance] != 1 {
+		t.Fatalf("counts = %v, want 1 feature (headline leaf), 1 fix, 1 maintenance", counts)
+	}
+
+	for category, wantChildren := range map[ChangeCategory]int{
+		CategoryFeature:     0,
+		CategoryFix:         1,
+		CategoryMaintenance: 1,
+	} {
+		entries := sectionGroups(groups, category)
+		if len(entries) != 1 {
+			t.Fatalf("%s: sectionGroups len = %d, want 1", category, len(entries))
+		}
+		if got := len(entries[0].Children); got != wantChildren {
+			t.Fatalf("%s: children = %d, want %d", category, got, wantChildren)
+		}
+		if entries[0].Change.Text != "Add release dashboard" {
+			t.Fatalf("%s: headline context missing, got %q", category, entries[0].Change.Text)
+		}
+	}
+
+	if entries := sectionGroups(groups, CategoryDocs); len(entries) != 0 {
+		t.Fatalf("docs section should be empty, got %d entries", len(entries))
+	}
+}
+
+func TestHeadlineNotLeafWhenChildRestatesCategory(t *testing.T) {
+	t.Parallel()
+
+	groups := []Group{
+		{
+			Change: Change{Text: "Add widgets", PRNumber: 4, Category: CategoryFeature},
+			Children: []Change{
+				{Text: "Add widget storage", Category: CategoryFeature},
+				{Text: "Fix widget save", Category: CategoryFix},
+			},
+		},
+	}
+
+	leaves := LeafChanges(groups)
+	if len(leaves) != 2 {
+		t.Fatalf("LeafChanges len = %d, want 2 (headline covered by feature child)", len(leaves))
+	}
+
+	features := sectionGroups(groups, CategoryFeature)
+	if len(features) != 1 || len(features[0].Children) != 1 {
+		t.Fatalf("features section should nest the single feature child under the headline")
+	}
+	fixes := sectionGroups(groups, CategoryFix)
+	if len(fixes) != 1 || len(fixes[0].Children) != 1 {
+		t.Fatalf("fixes section should nest the single fix child under the headline")
+	}
+}

--- a/tools/release-notes/internal/notes/group_test.go
+++ b/tools/release-notes/internal/notes/group_test.go
@@ -1,0 +1,147 @@
+package notes
+
+import "testing"
+
+func TestBuildGroupsNestsPRConstituents(t *testing.T) {
+	t.Parallel()
+
+	entries := []RawEntry{
+		{
+			Subject: "fix(worktrees): keep git worktrees out of campaign status and commits (#361)",
+			IsMerge: true,
+			ChildSubjects: []string{
+				"[obey-campaign:8deed8b4] fix(repair): commit in-place root .gitignore edits during repair",
+				"[obey-campaign:8deed8b4] fix(repair): derive worktrees .gitignore check from configured path",
+				"Merge branch 'main' into fix/worktrees-gitignore",
+				"[obey-campaign:8deed8b4] fix(worktrees): keep git worktrees out of campaign status and commits",
+			},
+		},
+		{
+			Subject: "feat(commitkit): expose campaign name accessors (#360)",
+			IsMerge: true,
+			ChildSubjects: []string{
+				"[obey-campaign:8deed8b4] feat(commitkit): expose campaign name accessors",
+			},
+		},
+	}
+
+	groups := BuildGroups(entries)
+
+	if len(groups) != 2 {
+		t.Fatalf("BuildGroups() len = %d, want 2", len(groups))
+	}
+
+	pr361 := groups[0]
+	if pr361.Change.PRNumber != 361 || pr361.Change.Category != CategoryFix {
+		t.Fatalf("group[0] headline = %+v, want #361 fix", pr361.Change)
+	}
+	if len(pr361.Children) != 2 {
+		t.Fatalf("group[0] children = %d, want 2 (Merge + PR-title-dup filtered)\n%+v", len(pr361.Children), pr361.Children)
+	}
+	if pr361.Children[0].Text != "Commit in-place root .gitignore edits during repair" {
+		t.Fatalf("group[0] child[0] = %q", pr361.Children[0].Text)
+	}
+	if pr361.Children[1].Text != "Derive worktrees .gitignore check from configured path" {
+		t.Fatalf("group[0] child[1] = %q", pr361.Children[1].Text)
+	}
+
+	pr360 := groups[1]
+	if pr360.Change.PRNumber != 360 || pr360.Change.Category != CategoryFeature {
+		t.Fatalf("group[1] headline = %+v, want #360 feature", pr360.Change)
+	}
+	if len(pr360.Children) != 0 {
+		t.Fatalf("group[1] children = %d, want 0 (lone commit equals PR title)", len(pr360.Children))
+	}
+}
+
+func TestBuildGroupsKeepsStandaloneCommits(t *testing.T) {
+	t.Parallel()
+
+	entries := []RawEntry{
+		{Subject: "fix(commit): unstage worktrees after staging instead of exclude pathspec"},
+	}
+
+	groups := BuildGroups(entries)
+	if len(groups) != 1 {
+		t.Fatalf("BuildGroups() len = %d, want 1", len(groups))
+	}
+	if len(groups[0].Children) != 0 {
+		t.Fatalf("standalone commit should have no children, got %d", len(groups[0].Children))
+	}
+	if groups[0].Change.Text != "Unstage worktrees after staging instead of exclude pathspec" {
+		t.Fatalf("standalone change text = %q", groups[0].Change.Text)
+	}
+}
+
+func TestBuildGroupsDropsStatusChangeBookkeeping(t *testing.T) {
+	t.Parallel()
+
+	entries := []RawEntry{
+		{Subject: "[OBEY-CAMPAIGN-8deed8b4] chore(fest): status change: festival-app-read-scaling-FA0019 (FA0019) ready -> active"},
+		{
+			Subject: "feat(x): real feature (#500)",
+			IsMerge: true,
+			ChildSubjects: []string{
+				"[OBEY-CAMPAIGN-8deed8b4] chore(fest): status change: something planning -> ready",
+				"feat(x): add the real thing",
+			},
+		},
+	}
+
+	groups := BuildGroups(entries)
+	if len(groups) != 1 {
+		t.Fatalf("BuildGroups() len = %d, want 1 (standalone status-change dropped)", len(groups))
+	}
+	if len(groups[0].Children) != 1 {
+		t.Fatalf("children = %d, want 1 (child status-change dropped)\n%+v", len(groups[0].Children), groups[0].Children)
+	}
+	if groups[0].Children[0].Text != "Add the real thing" {
+		t.Fatalf("child[0] = %q", groups[0].Children[0].Text)
+	}
+}
+
+func TestBuildGroupsDedupesChildrenWithinGroup(t *testing.T) {
+	t.Parallel()
+
+	entries := []RawEntry{
+		{
+			Subject: "fix(y): headline (#42)",
+			IsMerge: true,
+			ChildSubjects: []string{
+				"fix(y): apply the same tweak",
+				"fix(y): apply the same tweak",
+			},
+		},
+	}
+
+	groups := BuildGroups(entries)
+	if len(groups[0].Children) != 1 {
+		t.Fatalf("duplicate children should collapse to 1, got %d", len(groups[0].Children))
+	}
+}
+
+func TestLeafChangesCountsChildrenNotHeadline(t *testing.T) {
+	t.Parallel()
+
+	groups := []Group{
+		{Change: Change{Text: "Feature A", Category: CategoryFeature}},
+		{
+			Change: Change{Text: "PR headline", PRNumber: 7, Category: CategoryFix},
+			Children: []Change{
+				{Text: "Fix one", Category: CategoryFix},
+				{Text: "Fix two", Category: CategoryFix},
+				{Text: "Fix three", Category: CategoryFix},
+			},
+		},
+	}
+
+	leaves := LeafChanges(groups)
+	if len(leaves) != 4 {
+		t.Fatalf("LeafChanges() len = %d, want 4 (1 standalone + 3 children)", len(leaves))
+	}
+	for _, leaf := range leaves {
+		if leaf.Text == "PR headline" {
+			t.Fatalf("headline of a group with children must not be counted as a leaf")
+		}
+	}
+}

--- a/tools/release-notes/internal/notes/notes.go
+++ b/tools/release-notes/internal/notes/notes.go
@@ -219,7 +219,7 @@ func writeSections(write func(string), repo string, groups []Group) {
 	}
 
 	for _, section := range sections {
-		entries := filterGroups(groups, section.category)
+		entries := sectionGroups(groups, section.category)
 		if len(entries) == 0 {
 			continue
 		}

--- a/tools/release-notes/internal/notes/notes.go
+++ b/tools/release-notes/internal/notes/notes.go
@@ -105,14 +105,7 @@ func FindPreviousTag(target TagInfo, tags []string) string {
 }
 
 func ParseCommitSubject(subject string) (Change, bool) {
-	subject = strings.TrimSpace(subject)
-	for {
-		trimmed := bracketLeadRe.ReplaceAllString(subject, "")
-		if trimmed == subject {
-			break
-		}
-		subject = strings.TrimSpace(trimmed)
-	}
+	subject = stripBracketTags(subject)
 
 	if subject == "" || strings.HasPrefix(subject, "Merge ") {
 		return Change{}, false
@@ -148,47 +141,72 @@ func ParseCommitSubject(subject string) (Change, bool) {
 	}, true
 }
 
-func Render(repo string, current TagInfo, previousTag string, changes []Change) (string, error) {
+func stripBracketTags(subject string) string {
+	subject = strings.TrimSpace(subject)
+	for {
+		trimmed := bracketLeadRe.ReplaceAllString(subject, "")
+		if trimmed == subject {
+			break
+		}
+		subject = strings.TrimSpace(trimmed)
+	}
+	return subject
+}
+
+func Render(repo string, current TagInfo, previousTag string, groups []Group) (string, error) {
 	if repo == "" {
 		return "", fmt.Errorf("repo is required")
 	}
 
-	changes = dedupeChanges(changes)
-
 	var b strings.Builder
-	writeLine := func(s string) {
+	write := func(s string) {
 		b.WriteString(s)
 		b.WriteByte('\n')
 	}
 
-	writeLine("## Release " + current.Raw)
-	writeLine("")
-	writeLine(fmt.Sprintf("This %s release includes the following changes.", channelLabel(current.Mode)))
-	writeLine("")
+	write("## Release " + current.Raw)
+	write("")
+	write(fmt.Sprintf("This %s release includes the following changes.", channelLabel(current.Mode)))
+	write("")
 
-	if previousTag != "" {
-		writeLine("Summary:")
-		for _, line := range summaryLines(changes) {
-			writeLine("- " + line)
-		}
-		writeLine("")
-		writeLine(fmt.Sprintf("Compare: https://github.com/%s/compare/%s...%s", repo, previousTag, current.Raw))
-		writeLine("")
-	} else {
-		writeLine("This is the first release covered by the structured release-notes generator.")
-		writeLine("")
+	writeSummary(write, repo, current, previousTag, LeafChanges(groups))
+	writeHighlights(write, repo, headlineChanges(groups))
+	writeSections(write, repo, groups)
+
+	return strings.TrimSpace(b.String()) + "\n", nil
+}
+
+func writeSummary(write func(string), repo string, current TagInfo, previousTag string, leaves []Change) {
+	if previousTag == "" {
+		write("This is the first release covered by the structured release-notes generator.")
+		write("")
+		return
 	}
 
-	highlights := highlightChanges(changes)
-	if len(highlights) > 0 && !(len(highlights) == 1 && countUserFacing(changes) == 1) {
-		writeLine("## Highlights")
-		writeLine("")
-		for _, change := range highlights {
-			writeLine("- " + renderChange(repo, change))
-		}
-		writeLine("")
+	write("Summary:")
+	for _, line := range summaryLines(leaves) {
+		write("- " + line)
+	}
+	write("")
+	write(fmt.Sprintf("Compare: https://github.com/%s/compare/%s...%s", repo, previousTag, current.Raw))
+	write("")
+}
+
+func writeHighlights(write func(string), repo string, headlines []Change) {
+	highlights := highlightChanges(headlines)
+	if len(highlights) == 0 || (len(highlights) == 1 && countUserFacing(headlines) == 1) {
+		return
 	}
 
+	write("## Highlights")
+	write("")
+	for _, change := range highlights {
+		write("- " + renderChange(repo, change))
+	}
+	write("")
+}
+
+func writeSections(write func(string), repo string, groups []Group) {
 	sections := []struct {
 		title    string
 		category ChangeCategory
@@ -201,19 +219,27 @@ func Render(repo string, current TagInfo, previousTag string, changes []Change) 
 	}
 
 	for _, section := range sections {
-		entries := filterChanges(changes, section.category)
+		entries := filterGroups(groups, section.category)
 		if len(entries) == 0 {
 			continue
 		}
-		writeLine("## " + section.title)
-		writeLine("")
-		for _, change := range entries {
-			writeLine("- " + renderChange(repo, change))
+		write("## " + section.title)
+		write("")
+		for _, group := range entries {
+			for _, line := range renderGroup(repo, group) {
+				write(line)
+			}
 		}
-		writeLine("")
+		write("")
 	}
+}
 
-	return strings.TrimSpace(b.String()) + "\n", nil
+func renderGroup(repo string, group Group) []string {
+	lines := []string{"- " + renderChange(repo, group.Change)}
+	for _, child := range group.Children {
+		lines = append(lines, "  - "+renderChange(repo, child))
+	}
+	return lines
 }
 
 func findPreviousStable(target TagInfo, tags []string) string {
@@ -357,68 +383,8 @@ func highlightChanges(changes []Change) []Change {
 	return changes
 }
 
-func filterChanges(changes []Change, category ChangeCategory) []Change {
-	var filtered []Change
-	for _, change := range changes {
-		if change.Category == category {
-			filtered = append(filtered, change)
-		}
-	}
-	return filtered
-}
-
-func dedupeChanges(changes []Change) []Change {
-	if len(changes) < 2 {
-		return changes
-	}
-
-	var deduped []Change
-	indexByKey := map[string]int{}
-
-	for _, change := range changes {
-		key := normalizedChangeKey(change)
-		if idx, ok := indexByKey[key]; ok {
-			deduped[idx] = preferChange(deduped[idx], change)
-			continue
-		}
-
-		indexByKey[key] = len(deduped)
-		deduped = append(deduped, change)
-	}
-
-	return deduped
-}
-
 func normalizedChangeKey(change Change) string {
 	return strings.ToLower(strings.TrimSpace(change.Text))
-}
-
-func preferChange(current, candidate Change) Change {
-	switch {
-	case current.PRNumber == 0 && candidate.PRNumber != 0:
-		return candidate
-	case current.PRNumber != 0 && candidate.PRNumber == 0:
-		return current
-	case categoryRank(candidate.Category) < categoryRank(current.Category):
-		return candidate
-	default:
-		return current
-	}
-}
-
-func categoryRank(category ChangeCategory) int {
-	switch category {
-	case CategoryFeature:
-		return 0
-	case CategoryFix:
-		return 1
-	case CategoryDocs:
-		return 2
-	case CategoryMaintenance:
-		return 3
-	default:
-		return 4
-	}
 }
 
 func countUserFacing(changes []Change) int {

--- a/tools/release-notes/internal/notes/notes_test.go
+++ b/tools/release-notes/internal/notes/notes_test.go
@@ -90,9 +90,9 @@ func TestRender(t *testing.T) {
 		t.Fatalf("ParseTag() error = %v", err)
 	}
 
-	rendered, err := Render("Obedience-Corp/camp", tag, "v0.2.0", []Change{
-		{Text: "Verify actual remote in push all", PRNumber: 200, Category: CategoryFix},
-		{Text: "Make push-all remote fixture deterministic", Category: CategoryMaintenance},
+	rendered, err := Render("Obedience-Corp/camp", tag, "v0.2.0", []Group{
+		{Change: Change{Text: "Verify actual remote in push all", PRNumber: 200, Category: CategoryFix}},
+		{Change: Change{Text: "Make push-all remote fixture deterministic", Category: CategoryMaintenance}},
 	})
 	if err != nil {
 		t.Fatalf("Render() error = %v", err)
@@ -113,27 +113,65 @@ func TestRender(t *testing.T) {
 	}
 }
 
-func TestRenderDeduplicatesChangesByText(t *testing.T) {
+func TestRenderNestsPRChildrenUnderHeadline(t *testing.T) {
 	t.Parallel()
 
-	tag, err := ParseTag("v0.2.2")
+	tag, err := ParseTag("v0.2.15")
 	if err != nil {
 		t.Fatalf("ParseTag() error = %v", err)
 	}
 
-	rendered, err := Render("Obedience-Corp/camp", tag, "v0.2.0", []Change{
-		{Text: "Verify actual remote in push all", Category: CategoryFix},
-		{Text: "Verify actual remote in push all", PRNumber: 200, Category: CategoryFix},
+	rendered, err := Render("Obedience-Corp/camp", tag, "v0.2.14", []Group{
+		{
+			Change: Change{Text: "Keep git worktrees out of campaign status and commits", PRNumber: 361, Category: CategoryFix},
+			Children: []Change{
+				{Text: "Commit in-place root .gitignore edits during repair", Category: CategoryFix},
+				{Text: "Derive worktrees .gitignore check from configured path", Category: CategoryFix},
+			},
+		},
 	})
 	if err != nil {
 		t.Fatalf("Render() error = %v", err)
 	}
 
-	want := "Verify actual remote in push all ([#200](https://github.com/Obedience-Corp/camp/pull/200))"
-	if strings.Count(rendered, want) != 1 {
-		t.Fatalf("Render() should keep one PR-linked entry, got:\n%s", rendered)
+	wantSubstrings := []string{
+		"- Keep git worktrees out of campaign status and commits ([#361](https://github.com/Obedience-Corp/camp/pull/361))",
+		"  - Commit in-place root .gitignore edits during repair",
+		"  - Derive worktrees .gitignore check from configured path",
 	}
-	if strings.Count(rendered, "Verify actual remote in push all") != 1 {
-		t.Fatalf("Render() should suppress duplicate section entries when only one user-facing change exists, got:\n%s", rendered)
+	for _, want := range wantSubstrings {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("Render() missing nested line %q\n%s", want, rendered)
+		}
+	}
+}
+
+func TestRenderSummaryCountsLeafChanges(t *testing.T) {
+	t.Parallel()
+
+	tag, err := ParseTag("v0.2.15")
+	if err != nil {
+		t.Fatalf("ParseTag() error = %v", err)
+	}
+
+	rendered, err := Render("Obedience-Corp/camp", tag, "v0.2.14", []Group{
+		{Change: Change{Text: "Expose campaign name accessors", PRNumber: 360, Category: CategoryFeature}},
+		{
+			Change: Change{Text: "Keep git worktrees out of campaign status and commits", PRNumber: 361, Category: CategoryFix},
+			Children: []Change{
+				{Text: "Commit in-place root .gitignore edits during repair", Category: CategoryFix},
+				{Text: "Derive worktrees .gitignore check from configured path", Category: CategoryFix},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	if !strings.Contains(rendered, "- 1 feature") {
+		t.Fatalf("Render() summary should count the childless feature once\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "- 2 fixes") {
+		t.Fatalf("Render() summary should count the PR's two children, not the headline\n%s", rendered)
 	}
 }

--- a/tools/release-notes/main.go
+++ b/tools/release-notes/main.go
@@ -55,27 +55,14 @@ func run(args []string) error {
 		return err
 	}
 
-	subjects, err := commitSubjects(*tag, previousTag)
+	entries, err := commitGroups(*tag, previousTag)
 	if err != nil {
 		return err
 	}
 
-	var changes []notes.Change
-	seen := map[string]struct{}{}
-	for _, subject := range subjects {
-		change, ok := notes.ParseCommitSubject(subject)
-		if !ok {
-			continue
-		}
-		key := strings.ToLower(change.Text)
-		if _, exists := seen[key]; exists {
-			continue
-		}
-		seen[key] = struct{}{}
-		changes = append(changes, change)
-	}
+	groups := notes.BuildGroups(entries)
 
-	rendered, err := notes.Render(*repo, current, previousTag, changes)
+	rendered, err := notes.Render(*repo, current, previousTag, groups)
 	if err != nil {
 		return err
 	}
@@ -105,14 +92,34 @@ func run(args []string) error {
 	return nil
 }
 
-func commitSubjects(tag, previousTag string) ([]string, error) {
-	args := []string{"log", "--format=%s"}
-	if previousTag != "" {
-		args = append(args, previousTag+".."+tag)
-	} else {
+func commitGroups(tag, previousTag string) ([]notes.RawEntry, error) {
+	if previousTag == "" {
 		return nil, nil
 	}
-	return gitLines(args...)
+
+	spine, err := gitLines("log", "--first-parent", "--format=%H%x1f%P%x1f%s", previousTag+".."+tag)
+	if err != nil {
+		return nil, err
+	}
+
+	var entries []notes.RawEntry
+	for _, line := range spine {
+		fields := strings.Split(line, "\x1f")
+		if len(fields) != 3 {
+			continue
+		}
+		entry := notes.RawEntry{Subject: fields[2]}
+		if parents := strings.Fields(fields[1]); len(parents) == 2 {
+			children, err := gitLines("log", "--format=%s", parents[0]+".."+parents[1])
+			if err != nil {
+				return nil, err
+			}
+			entry.IsMerge = true
+			entry.ChildSubjects = children
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
 }
 
 func resolvePreviousTag(current notes.TagInfo, targetCommit string, tags []string) (string, error) {

--- a/tools/release-notes/main_test.go
+++ b/tools/release-notes/main_test.go
@@ -79,12 +79,12 @@ func TestResolvePreviousTagSkipsSameCommitTags(t *testing.T) {
 	}
 }
 
-func TestCommitSubjectsFirstReleaseSkipsHistory(t *testing.T) {
-	subjects, err := commitSubjects("v1.0.0", "")
+func TestCommitGroupsFirstReleaseSkipsHistory(t *testing.T) {
+	entries, err := commitGroups("v1.0.0", "")
 	if err != nil {
-		t.Fatalf("commitSubjects() error = %v", err)
+		t.Fatalf("commitGroups() error = %v", err)
 	}
-	if subjects != nil {
-		t.Fatalf("subjects = %#v, want nil for first release", subjects)
+	if entries != nil {
+		t.Fatalf("entries = %#v, want nil for first release", entries)
 	}
 }


### PR DESCRIPTION
## Problem

The release-notes generator (`tools/release-notes/`, invoked via `just release notes <tag>`) flattened every commit in a tag range into bare category bullets. That doesn't match how this repo actually ships: one PR routinely carries dozens of meaningful commits (festival commits are treated like PRs), and PRs land as merge commits whose branch commits are preserved on `main`.

Two concrete symptoms on `v0.2.15`:

- The three commits from PR #361 rendered as flat sibling bullets with no indication they belonged to one PR.
- Global dedupe collapsed the PR's headline branch commit into the merge title, so the grouping was invisible.

## Design

1. Collect the PR-level spine with `git log --first-parent` over `prevTag..tag` (full hashes + parents + subject, `%x1f`-delimited). For each spine commit that is a merge (2 parents), enumerate its constituent commits with `git log <merge^1>..<merge^2>`. Non-merge spine commits are standalone changes and render flat, as before.
2. Group model: a PR entry has a headline change (title, PR number, category classified from the headline) plus its child changes.
3. Render nested: category sections stay top-level; within a section a PR renders as a parent bullet (title + PR link) with its meaningful constituent commits indented beneath it. Standalone commits stay flat.
4. Noise filter (conservative): drop `Merge ...` subjects, `chore(fest): status change ...` bookkeeping, and children whose normalized text equals the PR title. When unsure, keep the commit.
5. Dedupe within a PR group only, not globally across groups.
6. Summary counts leaf changes, so a 20-commit PR is visible as ~20 changes (the whole point). A PR headline that has children is a grouping node, not a leaf; its children are the leaves.
7. Preserved: first-release path, rc/dev tag modes, CLI flags, justfile interface, offline git-only operation (no GitHub API).

All grouping, filtering, and rendering live in the pure `internal/notes` package (data in, data out). Only the git plumbing (`commitGroups`) stays in `main.go`.

## Before / after — `v0.2.15`

Generated with `go run ./tools/release-notes --repo Obedience-Corp/camp --tag v0.2.15`.

### Before

```
## Release v0.2.15

This stable release includes the following changes.

Summary:
- 1 feature
- 3 fixes

Compare: https://github.com/Obedience-Corp/camp/compare/v0.2.14...v0.2.15

## Highlights

- Keep git worktrees out of campaign status and commits ([#361](https://github.com/Obedience-Corp/camp/pull/361))
- Commit in-place root .gitignore edits during repair
- Derive worktrees .gitignore check from configured path

## Features

- Expose campaign name accessors ([#360](https://github.com/Obedience-Corp/camp/pull/360))

## Fixes

- Keep git worktrees out of campaign status and commits ([#361](https://github.com/Obedience-Corp/camp/pull/361))
- Commit in-place root .gitignore edits during repair
- Derive worktrees .gitignore check from configured path
```

### After

```
## Release v0.2.15

This stable release includes the following changes.

Summary:
- 1 feature
- 2 fixes

Compare: https://github.com/Obedience-Corp/camp/compare/v0.2.14...v0.2.15

## Highlights

- Keep git worktrees out of campaign status and commits ([#361](https://github.com/Obedience-Corp/camp/pull/361))
- Expose campaign name accessors ([#360](https://github.com/Obedience-Corp/camp/pull/360))

## Features

- Expose campaign name accessors ([#360](https://github.com/Obedience-Corp/camp/pull/360))

## Fixes

- Keep git worktrees out of campaign status and commits ([#361](https://github.com/Obedience-Corp/camp/pull/361))
  - Commit in-place root .gitignore edits during repair
  - Derive worktrees .gitignore check from configured path
```

#361's two repair commits now nest under the PR headline; the `Merge branch 'main'` commit and the branch-head commit (whose text equals the PR title) are filtered. The summary counts the two real fixes rather than double-counting the grouping headline.

## Testing

- New pure tests in `internal/notes/group_test.go`: PR-constituent nesting (mirrors the real #361/#360 data), standalone-commit passthrough, `chore(fest)` status-change filtering, within-group child dedupe, and leaf counting.
- Updated `internal/notes/notes_test.go` Render tests to the `[]Group` signature, plus new nesting and leaf-count assertions.
- `main_test.go` first-release test retargeted to `commitGroups` (no new host-FS behavior added; the file stays on the existing allowlist).
- No git-exec or `t.TempDir` in the new tests; grouping is exercised as data-in/data-out.
- `just gate` green: stable + dev build, vet (stable/dev/integration), lint (stable + dev, 0 issues, host-FS and fmt.Errorf ratchets clean), 2917/2917 dev unit tests, 2891/2891 stable unit tests.

## Notes / decisions beyond the spec

- Split the grouping model into `internal/notes/group.go` and extracted `Render` into `writeSummary`/`writeHighlights`/`writeSections` helpers to keep every function under the repo's size guidance; removed the now-unused global-dedupe helpers (`dedupeChanges`, `preferChange`, `categoryRank`, `filterChanges`).
- Highlights are now the top user-facing PR headlines (previously a mix of PR + loose constituent commits), which reads as "top PRs in this release."
- Octopus merges (>2 parents) fall back to standalone rendering, matching the "merge = 2 parents" definition.
- Verified against real history beyond the sample: `v0.1.1..v0.2.0` renders 99 leaf changes across many PRs with correct nesting; a release tagged at a branch tip before its merge commit existed (`v0.2.16`) renders that commit as a standalone bullet; and the empty `v0.2.16..v0.3.0-rc.1` range yields the same "no user-facing changes" output the old flat code produced (not a regression).
