### PR TITLE
fix(list-tui): make camp list TUI responsive at small terminal sizes

### DIFF
--- a/cmd/camp/list_tui_responsive_test.go
+++ b/cmd/camp/list_tui_responsive_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+)
+
+func responsiveModel() listTUIModel {
+	ti := textinput.New()
+	ti.Prompt = "> "
+	entries := []campaignEntry{
+		{ID: "A", Name: "alpha", Org: "default", Status: config.StatusActive, Path: "/tmp/a"},
+		{ID: "B", Name: "this-is-an-extremely-long-campaign-name-that-should-truncate", Org: "obey", Status: config.StatusInactive, Path: "/Users/someone/very/deep/nested/directory/structure/inside/project-repo"},
+		{ID: "C", Name: "gamma", Org: "obey", Status: config.StatusReference, Path: "/Users/someone/work/gamma"},
+		{ID: "D", Name: "delta", Org: "platform", Status: config.StatusActive, Path: "/srv/delta"},
+		{ID: "E", Name: "epsilon", Org: "platform", Status: config.StatusActive, Path: "/srv/epsilon/really/long/path/segment/that/keeps/going/on"},
+		{ID: "F", Name: "zeta", Org: "research", Status: config.StatusInactive, Path: "/opt/zeta"},
+	}
+	return listTUIModel{ctx: context.Background(), fallback: "default", all: entries, visible: entries, input: ti}
+}
+
+func sized(m listTUIModel, w, h int) listTUIModel {
+	next, _ := m.Update(tea.WindowSizeMsg{Width: w, Height: h})
+	return next.(listTUIModel)
+}
+
+func viewLines(s string) []string {
+	return strings.Split(strings.TrimRight(s, "\n"), "\n")
+}
+
+func assertBounded(t *testing.T, out string, w, h int) {
+	t.Helper()
+	lines := viewLines(out)
+	if len(lines) > h {
+		t.Fatalf("%dx%d: rendered %d lines, exceeds height %d:\n%s", w, h, len(lines), h, out)
+	}
+	for i, ln := range lines {
+		if got := lipgloss.Width(ln); got > w {
+			t.Fatalf("%dx%d: line %d width %d exceeds terminal width %d: %q", w, h, i, got, w, ln)
+		}
+	}
+}
+
+func TestListView_BoundedAtEverySize(t *testing.T) {
+	sizes := []struct{ w, h int }{
+		{120, 40}, {80, 24}, {60, 20}, {40, 10}, {30, 8}, {24, 6}, {20, 5}, {15, 6},
+	}
+	for _, s := range sizes {
+		m := sized(responsiveModel(), s.w, s.h)
+		m.cursor = 3
+		assertBounded(t, m.View(), s.w, s.h)
+	}
+}
+
+func TestListView_SelectionVisibleWhenScrolled(t *testing.T) {
+	m := sized(responsiveModel(), 40, 10)
+	m.cursor = len(m.visible) - 1
+	out := m.View()
+	assertBounded(t, out, 40, 10)
+	if !strings.Contains(out, "> ") {
+		t.Fatalf("selected row cursor not rendered at 40x10:\n%s", out)
+	}
+}
+
+func TestListView_NoPanicAtAbsurdSizes(t *testing.T) {
+	sizes := []struct{ w, h int }{
+		{10, 3}, {8, 2}, {5, 2}, {3, 3}, {1, 1}, {2, 1}, {0, 0}, {40, 1}, {1, 40},
+	}
+	for _, s := range sizes {
+		m := sized(responsiveModel(), s.w, s.h)
+		m.cursor = 2
+		out := m.View()
+		if out == "" {
+			t.Fatalf("%dx%d produced empty view", s.w, s.h)
+		}
+		if s.w > 0 && s.h > 0 {
+			assertBounded(t, out, s.w, s.h)
+		}
+	}
+}
+
+func TestListView_EmptyListBounded(t *testing.T) {
+	m := responsiveModel()
+	m.all = nil
+	m.visible = nil
+	for _, s := range []struct{ w, h int }{{80, 24}, {20, 5}, {10, 3}} {
+		mm := sized(m, s.w, s.h)
+		out := mm.View()
+		if !strings.Contains(out, "no camp") {
+			t.Fatalf("%dx%d empty view missing placeholder:\n%s", s.w, s.h, out)
+		}
+		if s.w > 0 && s.h > 0 {
+			assertBounded(t, out, s.w, s.h)
+		}
+	}
+}
+
+func TestListView_OverlayBounded(t *testing.T) {
+	for _, s := range []struct{ w, h int }{{80, 24}, {40, 10}, {20, 5}, {10, 3}} {
+		m := sized(responsiveModel(), s.w, s.h)
+		m.cursor = 1
+		m.overlay = listOverlayMove
+		out := m.View()
+		if out == "" {
+			t.Fatalf("%dx%d overlay empty", s.w, s.h)
+		}
+		if s.w > 0 && s.h > 0 {
+			assertBounded(t, out, s.w, s.h)
+		}
+	}
+}
+
+func TestListView_FooterCollapsesWithWidth(t *testing.T) {
+	wide := sized(responsiveModel(), 120, 40).footer(116)
+	if !strings.Contains(wide, "copy") {
+		t.Fatalf("wide footer should show the full help, got %q", wide)
+	}
+	narrow := sized(responsiveModel(), 30, 8).footer(26)
+	if lipgloss.Width(narrow) > 26 {
+		t.Fatalf("narrow footer width %d exceeds 26: %q", lipgloss.Width(narrow), narrow)
+	}
+	if strings.Contains(narrow, "copy") {
+		t.Fatalf("narrow footer should have collapsed, got %q", narrow)
+	}
+}
+
+func TestListColumns_NeverExceedsRemaining(t *testing.T) {
+	for rem := 0; rem <= 120; rem++ {
+		nameW, statusOn, pathW := listColumns(rem)
+		used := nameW
+		if statusOn {
+			used += 2 + listStatusW
+		}
+		if pathW > 0 {
+			used += 2 + pathW
+		}
+		if used > rem {
+			t.Fatalf("rem=%d: columns use %d (name=%d status=%v path=%d)", rem, used, nameW, statusOn, pathW)
+		}
+		if nameW < 0 || pathW < 0 {
+			t.Fatalf("rem=%d: negative width name=%d path=%d", rem, nameW, pathW)
+		}
+	}
+}
+
+func TestWindowRange_KeepsCursorVisible(t *testing.T) {
+	for total := 1; total <= 20; total++ {
+		for capacity := 1; capacity <= total+2; capacity++ {
+			for cursor := 0; cursor < total; cursor++ {
+				start, end := windowRange(cursor, total, capacity)
+				if start < 0 || end > total || start > end {
+					t.Fatalf("total=%d cap=%d cur=%d: bad range [%d,%d)", total, capacity, cursor, start, end)
+				}
+				if end-start > capacity {
+					t.Fatalf("total=%d cap=%d cur=%d: window %d exceeds capacity", total, capacity, cursor, end-start)
+				}
+				if cursor < start || cursor >= end {
+					t.Fatalf("total=%d cap=%d cur=%d: cursor outside [%d,%d)", total, capacity, cursor, start, end)
+				}
+			}
+		}
+	}
+}
+
+func TestTruncate_Ellipsis(t *testing.T) {
+	if got := truncate("hello-world", 8); got != "hello..." {
+		t.Fatalf("truncate = %q, want hello...", got)
+	}
+	if got := truncate("short", 10); got != "short" {
+		t.Fatalf("truncate should leave short strings, got %q", got)
+	}
+	if got := truncate("abcdef", 0); got != "" {
+		t.Fatalf("truncate to 0 should be empty, got %q", got)
+	}
+}
+
+func TestTruncate_MultibyteSafe(t *testing.T) {
+	if got := truncate("héllo-wörld-日本語", 8); got != "héllo..." {
+		t.Fatalf("truncate = %q, want héllo...", got)
+	}
+	if got := truncate("日本語テスト", 3); got != "日本語" {
+		t.Fatalf("truncate = %q, want 日本語", got)
+	}
+}

--- a/cmd/camp/list_tui_update.go
+++ b/cmd/camp/list_tui_update.go
@@ -10,6 +10,9 @@ func (m listTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
+		if msg.Width > 0 {
+			m.input.Width = max(msg.Width-8, 4)
+		}
 		return m, nil
 	case tea.KeyMsg:
 		if m.overlay != listOverlayNone {

--- a/cmd/camp/list_tui_view.go
+++ b/cmd/camp/list_tui_view.go
@@ -30,6 +30,19 @@ var (
 	listBox        = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(listPal.BorderFocus).Padding(0, 1)
 )
 
+const (
+	listNameMax   = 22
+	listNameMin   = 6
+	listPathMin   = 8
+	listStatusW   = 10
+	listRowPrefix = 4 // two leading spaces plus a two-column cursor
+
+	listBoxOverhead  = 4 // rounded border plus horizontal padding
+	listMinBoxWidth  = 30
+	listMinBoxHeight = 8
+	listMinFooterH   = 6
+)
+
 func listStatusCell(status string) string {
 	padded := fmt.Sprintf("%-10s", status)
 	switch status {
@@ -44,6 +57,45 @@ func listStatusCell(status string) string {
 	}
 }
 
+// listLayout captures the size-dependent shape of a render. cw and listRows of
+// zero or less mean "unbounded" (size not yet known), preserving the full-size
+// layout for tests and the first frame before a WindowSizeMsg arrives.
+type listLayout struct {
+	cw         int
+	boxed      bool
+	showFooter bool
+	listRows   int
+}
+
+func (m listTUIModel) layout() listLayout {
+	wKnown, hKnown := m.width > 0, m.height > 0
+	l := listLayout{
+		boxed:      (!wKnown || m.width >= listMinBoxWidth) && (!hKnown || m.height >= listMinBoxHeight),
+		showFooter: !hKnown || m.height >= listMinFooterH,
+	}
+	if wKnown {
+		l.cw = m.width
+		if l.boxed {
+			l.cw -= listBoxOverhead
+		}
+		l.cw = max(l.cw, 1)
+	}
+	if hKnown {
+		chrome := 2 // title plus blank separator
+		if l.boxed {
+			chrome += 2 // top and bottom border
+		}
+		if l.showFooter {
+			chrome += 2 // blank plus footer
+			if m.status != "" {
+				chrome++
+			}
+		}
+		l.listRows = max(m.height-chrome, 1)
+	}
+	return l
+}
+
 func (m listTUIModel) View() string {
 	if m.quitting {
 		return ""
@@ -52,52 +104,128 @@ func (m listTUIModel) View() string {
 		return m.overlayView()
 	}
 
-	var b strings.Builder
-	b.WriteString(m.topBar() + "\n\n")
+	lay := m.layout()
+	lines := []string{m.topBar(), ""}
+	lines = append(lines, m.bodyLines(lay)...)
+	if lay.showFooter {
+		lines = append(lines, "")
+		if s := m.statusLine(); s != "" {
+			lines = append(lines, s)
+		}
+		lines = append(lines, m.footer(lay.cw))
+	}
+	return m.frame(lines, lay)
+}
 
-	if len(m.visible) == 0 {
-		b.WriteString(listMutedStyle.Render("no campaigns to show") + "\n")
+// frame clamps content to the terminal, hard-capping the line count as a final
+// guard so an unexpectedly tall render can never overflow a short window, then
+// wraps it in the border when the size allows.
+func (m listTUIModel) frame(lines []string, lay listLayout) string {
+	if m.height > 0 {
+		budget := m.height
+		if lay.boxed {
+			budget -= 2
+		}
+		budget = max(budget, 1)
+		if len(lines) > budget {
+			lines = lines[:budget]
+		}
+	}
+	content := strings.Join(clampLines(lines, lay.cw), "\n")
+	if lay.boxed {
+		return listBox.Render(content) + "\n"
+	}
+	return content + "\n"
+}
+
+// bodyLines renders the campaign rows for the current window. Org headers are
+// kept while the whole list fits the height budget; once the list must scroll
+// it degrades to a flat, cursor-centered window with a position indicator so
+// the selection always stays on screen.
+func (m listTUIModel) bodyLines(lay listLayout) []string {
+	total := len(m.visible)
+	if total == 0 {
+		return []string{listMutedStyle.Render("no campaigns to show")}
 	}
 
-	start, end := m.windowBounds()
+	budget := lay.listRows
+	if budget <= 0 || total+m.distinctOrgs() <= budget {
+		return m.renderRange(0, total, true, lay.cw)
+	}
+
+	showIndicator := total > budget && budget >= 2
+	rows := budget
+	if showIndicator {
+		rows = budget - 1
+	}
+	start, end := windowRange(m.cursor, total, rows)
+	out := m.renderRange(start, end, false, lay.cw)
+	if showIndicator {
+		out = append(out, listMutedStyle.Render(fmt.Sprintf("  [%d-%d of %d]", start+1, end, total)))
+	}
+	return out
+}
+
+func (m listTUIModel) renderRange(start, end int, headers bool, cw int) []string {
+	var out []string
 	prevOrg := ""
 	for i := start; i < end; i++ {
 		e := m.visible[i]
-		if e.Org != prevOrg {
-			b.WriteString(listOrgHeader.Render(e.Org) + "\n")
+		if headers && e.Org != prevOrg {
+			out = append(out, listOrgHeader.Render(e.Org))
 			prevOrg = e.Org
 		}
-		cursor := "  "
-		name := fmt.Sprintf("%-22s", e.Name)
-		if i == m.cursor {
-			cursor = "> "
-			name = listSelStyle.Render(name)
-		} else {
-			name = listNameStyle.Render(name)
-		}
-		path := listMutedStyle.Render(pathutil.AbbreviateHome(e.Path))
-		b.WriteString("  " + cursor + name + "  " + listStatusCell(e.Status) + "  " + path + "\n")
+		out = append(out, m.rowLine(e, i == m.cursor, cw))
 	}
-	if end < len(m.visible) || start > 0 {
-		b.WriteString(listMutedStyle.Render(fmt.Sprintf("  [%d-%d of %d]", start+1, end, len(m.visible))) + "\n")
-	}
-
-	b.WriteString("\n" + m.statusLine() + m.footer())
-	return listBox.Render(strings.TrimRight(b.String(), "\n")) + "\n"
+	return out
 }
 
-// windowBounds returns the slice of m.visible to render, keeping the cursor in
-// view. When the terminal height is unknown (tests) it shows everything.
-func (m listTUIModel) windowBounds() (int, int) {
-	total := len(m.visible)
-	capacity := m.height - 7
-	if m.height <= 0 || capacity >= total {
+func (m listTUIModel) rowLine(e campaignEntry, selected bool, cw int) string {
+	prefix := "  " + cursorGlyph(selected)
+	if cw <= 0 {
+		name := styleName(fmt.Sprintf("%-*s", listNameMax, e.Name), selected)
+		return prefix + name + "  " + listStatusCell(e.Status) + "  " +
+			listMutedStyle.Render(pathutil.AbbreviateHome(e.Path))
+	}
+
+	rem := cw - listRowPrefix
+	if rem < 1 {
+		return prefix
+	}
+
+	nameW, statusOn, pathW := listColumns(rem)
+	row := prefix + styleName(fmt.Sprintf("%-*s", nameW, truncate(e.Name, nameW)), selected)
+	if statusOn {
+		row += "  " + listStatusCell(e.Status)
+	}
+	if pathW > 0 {
+		row += "  " + listMutedStyle.Render(truncate(pathutil.AbbreviateHome(e.Path), pathW))
+	}
+	return row
+}
+
+// listColumns splits the width remaining after the row prefix into a name
+// column, an optional status column, and an optional path column, dropping the
+// rightmost columns first as space runs out.
+func listColumns(rem int) (nameW int, statusOn bool, pathW int) {
+	if rem < listStatusW+2+listNameMin {
+		return min(rem, listNameMax), false, 0
+	}
+	nameBudget := rem - listStatusW - 2
+	if nameBudget < listNameMin+2+listPathMin {
+		return min(nameBudget, listNameMax), true, 0
+	}
+	nameW = min(nameBudget-2-listPathMin, listNameMax)
+	return nameW, true, nameBudget - 2 - nameW
+}
+
+// windowRange centers a capacity-sized window on the cursor within a list of
+// total items, clamping to the list bounds.
+func windowRange(cursor, total, capacity int) (int, int) {
+	if capacity >= total {
 		return 0, total
 	}
-	if capacity < 3 {
-		capacity = 3
-	}
-	start := m.cursor - capacity/2
+	start := cursor - capacity/2
 	if start < 0 {
 		start = 0
 	}
@@ -106,10 +234,15 @@ func (m listTUIModel) windowBounds() (int, int) {
 		end = total
 		start = end - capacity
 	}
-	if start < 0 {
-		start = 0
+	return max(start, 0), end
+}
+
+func (m listTUIModel) distinctOrgs() int {
+	seen := map[string]bool{}
+	for _, e := range m.visible {
+		seen[e.Org] = true
 	}
-	return start, end
+	return len(seen)
 }
 
 func (m listTUIModel) topBar() string {
@@ -121,8 +254,15 @@ func (m listTUIModel) topBar() string {
 		listMutedStyle.Render(fmt.Sprintf("%s  .  showing: %s", ui.CountLabel(len(m.all), "campaign", "campaigns"), mode))
 }
 
-func (m listTUIModel) footer() string {
-	return listHelpStyle.Render("g: go . j/k: move . s: status . m: org . y: copy . f: filter . q: quit")
+func (m listTUIModel) footer(cw int) string {
+	help := "g: go . j/k: move . s: status . m: org . y: copy . f: filter . q: quit"
+	if cw > 0 && lipgloss.Width(help) > cw {
+		help = "j/k move . g go . f filter . q quit"
+	}
+	if cw > 0 && lipgloss.Width(help) > cw {
+		help = "q quit"
+	}
+	return listHelpStyle.Render(help)
 }
 
 func (m listTUIModel) statusLine() string {
@@ -130,16 +270,73 @@ func (m listTUIModel) statusLine() string {
 		return ""
 	}
 	if m.statusErr {
-		return listErrStyle.Render(m.status) + "\n"
+		return listErrStyle.Render(m.status)
 	}
-	return listOkStyle.Render(m.status) + "\n"
+	return listOkStyle.Render(m.status)
 }
 
 func (m listTUIModel) overlayView() string {
-	e := m.visible[m.cursor]
-	box := listTitleStyle.Render(fmt.Sprintf("Move %q to org:", e.Name)) + "\n\n" +
-		m.input.View() + "\n\n" +
-		listMutedStyle.Render("existing orgs: "+m.orgNamesCSV()) + "\n\n" +
-		listHelpStyle.Render("enter: confirm . esc: cancel")
-	return listBox.Render(box) + "\n"
+	lay := m.layout()
+	title := "Move to org:"
+	if len(m.visible) > 0 && m.cursor < len(m.visible) {
+		title = fmt.Sprintf("Move %q to org:", m.visible[m.cursor].Name)
+	}
+	lines := []string{
+		listTitleStyle.Render(title),
+		"",
+		m.input.View(),
+		"",
+		listMutedStyle.Render("existing orgs: " + m.orgNamesCSV()),
+		"",
+		listHelpStyle.Render("enter: confirm . esc: cancel"),
+	}
+	return m.frame(lines, lay)
+}
+
+func cursorGlyph(selected bool) string {
+	if selected {
+		return "> "
+	}
+	return "  "
+}
+
+func styleName(s string, selected bool) string {
+	if selected {
+		return listSelStyle.Render(s)
+	}
+	return listNameStyle.Render(s)
+}
+
+func truncate(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	if n <= 3 {
+		return string(r[:n])
+	}
+	return string(r[:n-3]) + "..."
+}
+
+// clampWidth hard-limits a rendered line to w visible columns, truncating ANSI
+// styling safely. A width of zero or less leaves the line untouched.
+func clampWidth(s string, w int) string {
+	if w <= 0 {
+		return s
+	}
+	return lipgloss.NewStyle().MaxWidth(w).Render(s)
+}
+
+func clampLines(lines []string, w int) []string {
+	if w <= 0 {
+		return lines
+	}
+	out := make([]string, len(lines))
+	for i, l := range lines {
+		out[i] = clampWidth(l, w)
+	}
+	return out
 }


### PR DESCRIPTION
## Problem

The `camp list` TUI rendered a fixed-width layout regardless of terminal size: 22-char name columns, untruncated paths, a fixed footer, and a bordered frame were emitted even when the window was narrower or shorter than the content. In a small window or terminal split the picker wrapped, overflowed, and became unusable.

## Fix

All in `cmd/camp/list_tui_*.go` — the list TUI is self-contained (it does not use `internal/listview`, which serves the workitem list output paths), so the fix is scoped here.

- A per-render `layout()` derives content width, list row budget, and whether chrome fits: the rounded border drops below 30x8, the footer below 6 rows.
- Row width splits into name/status/path columns that clamp and truncate (rune-safe ellipsis), dropping rightmost columns first as space runs out.
- Org-grouped rendering degrades to a flat, cursor-centered scroll window with a `[x-y of N]` position indicator when the list exceeds the height budget - the selection always stays on screen.
- Footer help shortens progressively when wider than the content.
- A final `frame()` guard hard-caps rendered line count and ANSI-safe-clamps line widths (`lipgloss MaxWidth`), so no size can overflow the window.
- The move-org overlay is bounded by the same frame rules and no longer indexes `m.visible[m.cursor]` unguarded (latent panic with an empty filtered list).
- The filter input resizes with the window.

Behavior at full size is unchanged (unknown size = unbounded layout, preserving the first frame before WindowSizeMsg and existing tests).

## Testing

Pure in-memory model tests only (no host filesystem, no subprocesses): bounds asserted at every size from 120x40 down to 1x1 (line count <= height, `lipgloss.Width` <= width per line), cursor visibility when scrolled, empty-list rendering, overlay bounding, column budget invariants, exhaustive `windowRange` property sweep, rune-safe truncation incl. multibyte.

`just gate` green: stable+dev builds, vet, lints, 2921 dev + 2895 stable unit tests.

## Note

Started by a background agent that hit its session limit mid-task; reviewed, completed (rune-safe truncation + multibyte tests), and verified by the main session.