### PR TITLE
feat(switch): add org-aware campaign selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,8 +289,9 @@ Campaigns carry three orthogonal organizational axes in the registry
 - **tags**: a single global pool of labels; a campaign can carry any number,
   and the same tag crosses orgs freely.
 - **status**: lifecycle, one of `active` / `inactive` / `reference`. The default
-  `camp list` shows only `active`; the command is `camp lifecycle`, not
-  `camp status` (which stays the git-status wrapper).
+  `camp list` and `camp switch` surfaces show only `active`; use `--all` or
+  `--status` to include inactive/reference campaigns. The lifecycle command is
+  `camp lifecycle`, not `camp status` (which stays the git-status wrapper).
 
 A campaign at its defaults (org `default`, no tags, `active`) stores no extra
 keys, so existing registries are untouched until you organize something.

--- a/cmd/camp/cmdutil/campaign_scope.go
+++ b/cmd/camp/cmdutil/campaign_scope.go
@@ -1,0 +1,187 @@
+package cmdutil
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/nav/fuzzy"
+)
+
+// CampaignScope describes the candidate set for switch resolution.
+type CampaignScope struct {
+	Org    string
+	Status string
+	All    bool
+}
+
+// ParsedSwitchSelector is the parsed campaign[@tab] or org/campaign[@tab]
+// selector accepted by camp switch.
+type ParsedSwitchSelector struct {
+	Org      string
+	Campaign string
+	Tab      string
+	HasTab   bool
+}
+
+// ParseSwitchSelector splits the switch selector into org, campaign, and tab
+// parts. Validation that depends on completion/direct mode stays with callers.
+func ParseSwitchSelector(raw string) ParsedSwitchSelector {
+	left := raw
+	parsed := ParsedSwitchSelector{}
+	if at := strings.IndexByte(raw, '@'); at >= 0 {
+		left = raw[:at]
+		parsed.Tab = raw[at+1:]
+		parsed.HasTab = true
+	}
+	if slash := strings.IndexByte(left, '/'); slash >= 0 {
+		parsed.Org = left[:slash]
+		parsed.Campaign = left[slash+1:]
+		return parsed
+	}
+	parsed.Campaign = left
+	return parsed
+}
+
+// FilterCampaigns returns the registry entries visible under scope. Direct
+// switch, picker, and completion all default to active campaigns unless --all or
+// --status changes the lifecycle policy.
+func FilterCampaigns(reg *config.Registry, scope CampaignScope) []config.RegisteredCampaign {
+	all := reg.ListAll()
+	out := make([]config.RegisteredCampaign, 0, len(all))
+	fallbackOrg := reg.FallbackOrg()
+	for _, c := range all {
+		if c.Org == "" {
+			c.Org = fallbackOrg
+		}
+		if c.Status == "" {
+			c.Status = config.StatusActive
+		}
+		if scope.Org != "" && c.Org != scope.Org {
+			continue
+		}
+		if scope.Status != "" {
+			if c.Status != scope.Status {
+				continue
+			}
+		} else if !scope.All && c.Status != config.StatusActive {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// ResolveCampaignSelectionScoped applies the existing switch lookup order
+// inside the filtered candidate set: exact ID, unique ID prefix, exact name, and
+// fuzzy name.
+func ResolveCampaignSelectionScoped(query string, reg *config.Registry, scope CampaignScope, matchWriter io.Writer) (config.RegisteredCampaign, error) {
+	candidates := FilterCampaigns(reg, scope)
+	return resolveCampaignFromCandidates(query, candidates, scope, matchWriter)
+}
+
+func resolveCampaignFromCandidates(query string, candidates []config.RegisteredCampaign, scope CampaignScope, matchWriter io.Writer) (config.RegisteredCampaign, error) {
+	if query == "" {
+		return config.RegisteredCampaign{}, camperrors.New("campaign name required" + scopeDescription(scope))
+	}
+
+	for _, c := range candidates {
+		if c.ID == query {
+			return c, nil
+		}
+	}
+
+	var idPrefixMatches []config.RegisteredCampaign
+	for _, c := range candidates {
+		if strings.HasPrefix(c.ID, query) {
+			idPrefixMatches = append(idPrefixMatches, c)
+		}
+	}
+	switch len(idPrefixMatches) {
+	case 1:
+		return idPrefixMatches[0], nil
+	case 0:
+	default:
+		return config.RegisteredCampaign{}, camperrors.New(fmt.Sprintf("campaign ID prefix %q is ambiguous%s: %s",
+			query, scopeDescription(scope), campaignIDs(idPrefixMatches)))
+	}
+
+	var exactNameMatches []config.RegisteredCampaign
+	for _, c := range candidates {
+		if c.Name == query {
+			exactNameMatches = append(exactNameMatches, c)
+		}
+	}
+	switch len(exactNameMatches) {
+	case 1:
+		return exactNameMatches[0], nil
+	case 0:
+	default:
+		return config.RegisteredCampaign{}, camperrors.New(fmt.Sprintf("campaign name %q is ambiguous%s: %s",
+			query, scopeDescription(scope), campaignIDs(exactNameMatches)))
+	}
+
+	names := campaignNames(candidates)
+	matches := fuzzy.Filter(names, query)
+	if len(matches) == 0 {
+		return config.RegisteredCampaign{}, camperrors.New(fmt.Sprintf("campaign %q not found%s", query, scopeDescription(scope)))
+	}
+
+	bestName := matches[0].Target
+	var fuzzyMatches []config.RegisteredCampaign
+	for _, c := range candidates {
+		if c.Name == bestName {
+			fuzzyMatches = append(fuzzyMatches, c)
+		}
+	}
+	if len(fuzzyMatches) != 1 {
+		return config.RegisteredCampaign{}, camperrors.New(fmt.Sprintf("campaign name %q is ambiguous%s: %s",
+			bestName, scopeDescription(scope), campaignIDs(fuzzyMatches)))
+	}
+
+	if matchWriter != nil {
+		_, _ = fmt.Fprintf(matchWriter, "Matched: %s -> %s\n", query, fuzzyMatches[0].Name)
+	}
+	return fuzzyMatches[0], nil
+}
+
+func campaignNames(campaigns []config.RegisteredCampaign) []string {
+	names := make([]string, 0, len(campaigns))
+	seen := make(map[string]struct{}, len(campaigns))
+	for _, c := range campaigns {
+		if _, ok := seen[c.Name]; ok {
+			continue
+		}
+		seen[c.Name] = struct{}{}
+		names = append(names, c.Name)
+	}
+	return names
+}
+
+func campaignIDs(campaigns []config.RegisteredCampaign) string {
+	ids := make([]string, 0, len(campaigns))
+	for _, c := range campaigns {
+		ids = append(ids, c.ID)
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ", ")
+}
+
+func scopeDescription(scope CampaignScope) string {
+	var parts []string
+	if scope.Org != "" {
+		parts = append(parts, fmt.Sprintf("org %q", scope.Org))
+	}
+	if scope.Status != "" {
+		parts = append(parts, fmt.Sprintf("status %q", scope.Status))
+	} else if !scope.All {
+		parts = append(parts, fmt.Sprintf("status %q", config.StatusActive))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " in " + strings.Join(parts, ", ")
+}

--- a/cmd/camp/cmdutil/campaign_scope_test.go
+++ b/cmd/camp/cmdutil/campaign_scope_test.go
@@ -1,0 +1,71 @@
+package cmdutil
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+)
+
+func testRegistry(campaigns ...config.RegisteredCampaign) *config.Registry {
+	reg := config.NewRegistry()
+	for _, c := range campaigns {
+		if c.Org == "" {
+			c.Org = config.DefaultOrg
+		}
+		if c.Status == "" {
+			c.Status = config.StatusActive
+		}
+		reg.Campaigns[c.ID] = c
+	}
+	return reg
+}
+
+func TestResolveCampaignSelection_AmbiguousIDPrefixErrors(t *testing.T) {
+	reg := testRegistry(
+		config.RegisteredCampaign{ID: "same-alpha", Name: "alpha", Path: "/tmp/alpha"},
+		config.RegisteredCampaign{ID: "same-beta", Name: "beta", Path: "/tmp/beta"},
+	)
+
+	_, err := ResolveCampaignSelection("same", reg, nil)
+	if err == nil {
+		t.Fatal("expected ambiguous ID prefix error")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("error = %q, want ambiguous", err.Error())
+	}
+}
+
+func TestResolveCampaignSelection_DuplicateExactNamesError(t *testing.T) {
+	reg := testRegistry(
+		config.RegisteredCampaign{ID: "id-alpha", Name: "shared", Path: "/tmp/alpha"},
+		config.RegisteredCampaign{ID: "id-beta", Name: "shared", Path: "/tmp/beta"},
+	)
+
+	_, err := ResolveCampaignSelection("shared", reg, nil)
+	if err == nil {
+		t.Fatal("expected duplicate exact name error")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("error = %q, want ambiguous", err.Error())
+	}
+}
+
+func TestResolveCampaignSelection_LegacyCallersSeeAllStatuses(t *testing.T) {
+	reg := testRegistry(
+		config.RegisteredCampaign{
+			ID:     "inactive-campaign",
+			Name:   "archive",
+			Path:   "/tmp/archive",
+			Status: config.StatusInactive,
+		},
+	)
+
+	got, err := ResolveCampaignSelection("archive", reg, nil)
+	if err != nil {
+		t.Fatalf("ResolveCampaignSelection inactive: %v", err)
+	}
+	if got.ID != "inactive-campaign" {
+		t.Fatalf("resolved ID = %q, want inactive-campaign", got.ID)
+	}
+}

--- a/cmd/camp/cmdutil/campaign_selection.go
+++ b/cmd/camp/cmdutil/campaign_selection.go
@@ -38,7 +38,7 @@ func PickCampaign(ctx context.Context, reg *config.Registry) (config.RegisteredC
 func PickCampaignWithOptions(ctx context.Context, reg *config.Registry, opts PickCampaignOptions) (config.RegisteredCampaign, error) {
 	all := FilterCampaigns(reg, opts.Scope)
 	if len(all) == 0 {
-		return config.RegisteredCampaign{}, fmt.Errorf("no campaigns found%s", scopeDescription(opts.Scope))
+		return config.RegisteredCampaign{}, camperrors.New(fmt.Sprintf("no campaigns found%s", scopeDescription(opts.Scope)))
 	}
 
 	sort.Slice(all, func(i, j int) bool {

--- a/cmd/camp/cmdutil/campaign_selection.go
+++ b/cmd/camp/cmdutil/campaign_selection.go
@@ -13,39 +13,33 @@ import (
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
-	"github.com/Obedience-Corp/camp/internal/nav/fuzzy"
 )
 
 // ResolveCampaignSelection applies the same exact/prefix/name/fuzzy registry
 // lookup behavior used by `camp switch`.
 func ResolveCampaignSelection(query string, reg *config.Registry, matchWriter io.Writer) (config.RegisteredCampaign, error) {
-	c, ok := reg.Get(query)
-	if ok {
-		return c, nil
-	}
-
-	names := reg.List()
-	matches := fuzzy.Filter(names, query)
-	if len(matches) == 0 {
-		return config.RegisteredCampaign{}, fmt.Errorf("campaign %q not found in registry", query)
-	}
-
-	bestName := matches[0].Target
-	c, ok = reg.GetByName(bestName)
-	if !ok {
-		return config.RegisteredCampaign{}, fmt.Errorf("campaign %q not found in registry", query)
-	}
-
-	if matchWriter != nil {
-		_, _ = fmt.Fprintf(matchWriter, "Matched: %s -> %s\n", query, c.Name)
-	}
-
-	return c, nil
+	return resolveCampaignFromCandidates(query, reg.ListAll(), CampaignScope{All: true}, matchWriter)
 }
 
-// PickCampaign opens the shared campaign picker UI used by `camp switch`.
+// PickCampaignOptions controls candidate filtering and display for the shared
+// campaign picker UI used by `camp switch`.
+type PickCampaignOptions struct {
+	Scope CampaignScope
+}
+
+// PickCampaign opens the shared campaign picker UI used by callers that want
+// the legacy all-campaign picker behavior.
 func PickCampaign(ctx context.Context, reg *config.Registry) (config.RegisteredCampaign, error) {
-	all := reg.ListAll()
+	return PickCampaignWithOptions(ctx, reg, PickCampaignOptions{Scope: CampaignScope{All: true}})
+}
+
+// PickCampaignWithOptions opens the shared campaign picker UI used by
+// `camp switch` with scoped candidate filtering.
+func PickCampaignWithOptions(ctx context.Context, reg *config.Registry, opts PickCampaignOptions) (config.RegisteredCampaign, error) {
+	all := FilterCampaigns(reg, opts.Scope)
+	if len(all) == 0 {
+		return config.RegisteredCampaign{}, fmt.Errorf("no campaigns found%s", scopeDescription(opts.Scope))
+	}
 
 	sort.Slice(all, func(i, j int) bool {
 		return all[i].LastAccess.After(all[j].LastAccess)
@@ -71,10 +65,14 @@ func PickCampaign(ctx context.Context, reg *config.Registry) (config.RegisteredC
 		all,
 		func(i int) string {
 			c := all[i]
+			prefix := "  "
 			if c.Path == currentPath {
-				return "* " + c.Name
+				prefix = "* "
 			}
-			return "  " + c.Name
+			if opts.Scope.Org == "" {
+				return prefix + c.Org + "/" + c.Name
+			}
+			return prefix + c.Name
 		},
 		fuzzyfinder.WithPreviewWindow(func(i, w, h int) string {
 			if i < 0 || i >= len(all) {

--- a/cmd/camp/switch.go
+++ b/cmd/camp/switch.go
@@ -85,6 +85,8 @@ Use campaign@tab to navigate to a specific location in the target campaign:
 	},
 }
 
+const switchSchemaVersion = "camp-switch/v1"
+
 func init() {
 	rootCmd.AddCommand(switchCmd)
 	switchCmd.GroupID = "global"
@@ -370,7 +372,7 @@ func emitSwitchSelection(cmd *cobra.Command, selected config.RegisteredCampaign,
 	}
 	if jsonOut {
 		out := switchOutput{
-			SchemaVersion: "camp-switch/v1",
+			SchemaVersion: switchSchemaVersion,
 			Campaign: switchCampaignOutput{
 				ID:     selected.ID,
 				Name:   selected.Name,

--- a/cmd/camp/switch.go
+++ b/cmd/camp/switch.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -12,7 +14,7 @@ import (
 	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/nav"
-	"github.com/Obedience-Corp/camp/internal/nav/fuzzy"
+	navfuzzy "github.com/Obedience-Corp/camp/internal/nav/fuzzy"
 	"github.com/Obedience-Corp/camp/internal/nav/tui"
 )
 
@@ -23,23 +25,29 @@ var switchCmd = &cobra.Command{
 
 Without arguments, opens an interactive picker to select a campaign.
 With an argument, looks up the campaign by name or ID prefix.
+Use --org or org/campaign to resolve inside one organization.
 
 Use with the cgo shell function for instant navigation:
   cgo switch                 # Interactive campaign picker
   cgo switch my-campaign     # Switch by name
   cgo switch a1b2             # Switch by ID prefix
+  cgo switch obey/platform    # Switch by org-scoped selector
 
 The --print flag outputs just the path for shell integration:
   cd "$(camp switch --print)"
 
 Use campaign@tab to navigate to a specific location in the target campaign:
   camp switch obey-campaign@p    # Switch and navigate to projects/
-  camp switch obey-campaign@f    # Switch and navigate to festivals/`,
+  camp switch obey/platform@f    # Switch inside org and navigate to festivals/`,
 	Example: `  camp switch                        # Interactive picker
   camp switch obey-campaign          # Switch by name
+  camp switch --org obey platform    # Switch by name within an org
+  camp switch obey/platform          # Switch by scoped selector
   camp switch a1b2                   # Switch by ID prefix
   camp switch --print                # Picker, output path only
-  camp switch obey-campaign@p        # Switch and navigate to projects/`,
+  camp switch obey-campaign@p        # Switch and navigate to projects/
+  camp switch --all old-reference    # Include inactive/reference campaigns
+  camp switch --org obey platform --json`,
 	Aliases: []string{"sw"},
 	Args:    cobra.MaximumNArgs(1),
 	Annotations: map[string]string{
@@ -57,11 +65,15 @@ Use campaign@tab to navigate to a specific location in the target campaign:
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
+		scope, err := switchScopeFromFlags(cmd)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
 
 		if at := strings.IndexByte(toComplete, '@'); at >= 0 {
 			campaignQuery := toComplete[:at]
 			tabPrefix := toComplete[at+1:]
-			tabs := completeSwitchTabs(ctx, reg, campaignQuery, tabPrefix)
+			tabs := completeSwitchTabs(ctx, reg, campaignQuery, tabPrefix, scope)
 			completions := make([]string, len(tabs))
 			for i, t := range tabs {
 				completions[i] = campaignQuery + "@" + t
@@ -69,12 +81,7 @@ Use campaign@tab to navigate to a specific location in the target campaign:
 			return completions, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		names := reg.List()
-		if toComplete == "" {
-			return names, cobra.ShellCompDirectiveNoFileComp
-		}
-		matches := fuzzy.Filter(names, toComplete)
-		return matches.Targets(), cobra.ShellCompDirectiveNoFileComp
+		return completeSwitchCampaigns(reg, scope, toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 }
 
@@ -82,6 +89,12 @@ func init() {
 	rootCmd.AddCommand(switchCmd)
 	switchCmd.GroupID = "global"
 	switchCmd.Flags().Bool("print", false, "Print path only (for shell integration)")
+	switchCmd.Flags().String("org", "", "Only switch among campaigns in this org")
+	switchCmd.Flags().String("status", "", "Only switch among campaigns with this lifecycle status")
+	switchCmd.Flags().Bool("all", false, "Include inactive and reference campaigns")
+	switchCmd.Flags().Bool("json", false, "Output selected campaign and target path as JSON")
+	_ = switchCmd.RegisterFlagCompletionFunc("org", completeSwitchOrgFlag)
+	_ = switchCmd.RegisterFlagCompletionFunc("status", completeSwitchStatusFlag)
 }
 
 func resolveTabInCampaign(ctx context.Context, c config.RegisteredCampaign, tabKey string) (string, error) {
@@ -103,18 +116,17 @@ func resolveTabInCampaign(ctx context.Context, c config.RegisteredCampaign, tabK
 	return filepath.Join(c.Path, relativePath), nil
 }
 
-func completeSwitchTabs(ctx context.Context, reg *config.Registry, campaignQuery, tabPrefix string) []string {
-	c, ok := reg.GetByName(campaignQuery)
-	if !ok {
-		names := reg.List()
-		matches := fuzzy.Filter(names, campaignQuery)
-		if len(matches) == 0 {
+func completeSwitchTabs(ctx context.Context, reg *config.Registry, campaignQuery, tabPrefix string, scope cmdutil.CampaignScope) []string {
+	parsed := cmdutil.ParseSwitchSelector(campaignQuery)
+	if parsed.Org != "" {
+		if scope.Org != "" && scope.Org != parsed.Org {
 			return nil
 		}
-		c, ok = reg.GetByName(matches[0].Target)
-		if !ok {
-			return nil
-		}
+		scope.Org = parsed.Org
+	}
+	c, err := cmdutil.ResolveCampaignSelectionScoped(parsed.Campaign, reg, scope, nil)
+	if err != nil {
+		return nil
 	}
 
 	cfg, err := config.LoadCampaignConfig(ctx, c.Path)
@@ -136,9 +148,106 @@ func completeSwitchTabs(ctx context.Context, reg *config.Registry, campaignQuery
 	return filtered
 }
 
+func completeSwitchCampaigns(reg *config.Registry, scope cmdutil.CampaignScope, toComplete string) []string {
+	if slash := strings.IndexByte(toComplete, '/'); slash >= 0 {
+		orgPart := toComplete[:slash]
+		campaignPrefix := toComplete[slash+1:]
+		orgs := switchOrgs(reg)
+		if !hasString(orgs, orgPart) {
+			return filterStrings(withSlash(orgs), orgPart)
+		}
+		if scope.Org != "" && scope.Org != orgPart {
+			return nil
+		}
+		scope.Org = orgPart
+		return prefixedCampaignCompletions(reg, scope, orgPart+"/", campaignPrefix)
+	}
+
+	if scope.Org != "" {
+		return prefixedCampaignCompletions(reg, scope, "", toComplete)
+	}
+
+	var candidates []string
+	candidates = append(candidates, withSlash(switchOrgs(reg))...)
+	for _, c := range cmdutil.FilterCampaigns(reg, scope) {
+		candidates = append(candidates, c.Name)
+	}
+	return filterStrings(candidates, toComplete)
+}
+
+func prefixedCampaignCompletions(reg *config.Registry, scope cmdutil.CampaignScope, prefix, campaignPrefix string) []string {
+	var candidates []string
+	for _, c := range cmdutil.FilterCampaigns(reg, scope) {
+		candidates = append(candidates, prefix+c.Name)
+	}
+	return filterStrings(candidates, prefix+campaignPrefix)
+}
+
+func filterStrings(candidates []string, query string) []string {
+	sort.Strings(candidates)
+	if query == "" {
+		return candidates
+	}
+	matches := navfuzzy.Filter(candidates, query)
+	return matches.Targets()
+}
+
+func switchOrgs(reg *config.Registry) []string {
+	seen := map[string]struct{}{}
+	for _, c := range reg.ListAll() {
+		if c.Org == "" {
+			c.Org = reg.FallbackOrg()
+		}
+		seen[c.Org] = struct{}{}
+	}
+	orgs := make([]string, 0, len(seen))
+	for org := range seen {
+		orgs = append(orgs, org)
+	}
+	sort.Strings(orgs)
+	return orgs
+}
+
+func withSlash(values []string) []string {
+	out := make([]string, len(values))
+	for i, v := range values {
+		out[i] = v + "/"
+	}
+	return out
+}
+
+func hasString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func completeSwitchOrgFlag(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	reg, err := config.LoadRegistry(cmd.Context())
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	return filterStrings(switchOrgs(reg), toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeSwitchStatusFlag(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return filterStrings(config.ValidStatuses(), toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
 func runSwitch(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	printOnly, _ := cmd.Flags().GetBool("print")
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	if printOnly && jsonOut {
+		return camperrors.New("cannot use --json with --print")
+	}
+	scope, err := switchScopeFromFlags(cmd)
+	if err != nil {
+		return err
+	}
 
 	reg, err := config.LoadRegistry(ctx)
 	if err != nil {
@@ -149,41 +258,41 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 	}
 
 	var selected config.RegisteredCampaign
+	targetPath := ""
+	targetTab := ""
 
 	if len(args) == 1 {
-		arg := args[0]
-		if at := strings.IndexByte(arg, '@'); at >= 0 {
-			campaignQuery := arg[:at]
-			tabKey := arg[at+1:]
-			c, err := cmdutil.ResolveCampaignSelection(campaignQuery, reg, cmd.ErrOrStderr())
-			if err != nil {
-				return err
-			}
-			tabPath, err := resolveTabInCampaign(ctx, c, tabKey)
-			if err != nil {
-				return err
-			}
-			if printOnly {
-				fmt.Println(tabPath)
-			} else {
-				fmt.Printf("cd %s\n", tabPath)
-			}
-			return nil
+		parsed, err := parseSwitchArg(args[0], scope)
+		if err != nil {
+			return err
 		}
-		c, err := cmdutil.ResolveCampaignSelection(arg, reg, cmd.ErrOrStderr())
+		if parsed.Org != "" {
+			scope.Org = parsed.Org
+		}
+		c, err := cmdutil.ResolveCampaignSelectionScoped(parsed.Campaign, reg, scope, cmd.ErrOrStderr())
 		if err != nil {
 			return err
 		}
 		selected = c
+		if parsed.HasTab {
+			targetTab = parsed.Tab
+			targetPath, err = resolveTabInCampaign(ctx, c, parsed.Tab)
+			if err != nil {
+				return err
+			}
+		}
 	} else {
 		if !tui.IsTerminal() {
 			return camperrors.New("campaign name required in non-interactive mode (use 'camp switch <name>' or run interactively)")
 		}
-		c, err := cmdutil.PickCampaign(ctx, reg)
+		c, err := cmdutil.PickCampaignWithOptions(ctx, reg, cmdutil.PickCampaignOptions{Scope: scope})
 		if err != nil {
 			return err
 		}
 		selected = c
+	}
+	if targetPath == "" {
+		targetPath = selected.Path
 	}
 
 	if err := config.UpdateRegistry(ctx, func(reg *config.Registry) error {
@@ -193,10 +302,91 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "camp: warning: failed to update last access: %v\n", err)
 	}
 
-	if printOnly {
-		fmt.Println(selected.Path)
-	} else {
-		fmt.Printf("cd %s\n", selected.Path)
+	return emitSwitchSelection(cmd, selected, targetPath, targetTab, printOnly, jsonOut)
+}
+
+func switchScopeFromFlags(cmd *cobra.Command) (cmdutil.CampaignScope, error) {
+	org, _ := cmd.Flags().GetString("org")
+	status, _ := cmd.Flags().GetString("status")
+	all, _ := cmd.Flags().GetBool("all")
+	if org != "" {
+		if err := config.ValidateName("org", org); err != nil {
+			return cmdutil.CampaignScope{}, err
+		}
 	}
-	return nil
+	if status != "" {
+		if err := config.ValidateStatus(status); err != nil {
+			return cmdutil.CampaignScope{}, err
+		}
+	}
+	if status != "" && all {
+		return cmdutil.CampaignScope{}, camperrors.New("cannot use --status with --all")
+	}
+	return cmdutil.CampaignScope{Org: org, Status: status, All: all}, nil
+}
+
+func parseSwitchArg(raw string, scope cmdutil.CampaignScope) (cmdutil.ParsedSwitchSelector, error) {
+	parsed := cmdutil.ParseSwitchSelector(raw)
+	if parsed.Org != "" {
+		if err := config.ValidateName("org", parsed.Org); err != nil {
+			return parsed, err
+		}
+		if strings.Contains(parsed.Campaign, "/") {
+			return parsed, camperrors.New("switch selector may contain at most one org separator")
+		}
+		if parsed.Campaign == "" {
+			return parsed, camperrors.New("campaign name required after org selector")
+		}
+		if scope.Org != "" && scope.Org != parsed.Org {
+			return parsed, camperrors.New(fmt.Sprintf("selector org %q conflicts with --org %q", parsed.Org, scope.Org))
+		}
+	}
+	return parsed, nil
+}
+
+type switchOutput struct {
+	SchemaVersion string               `json:"schema_version"`
+	Campaign      switchCampaignOutput `json:"campaign"`
+	Target        switchTargetOutput   `json:"target"`
+}
+
+type switchCampaignOutput struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Org    string `json:"org"`
+	Status string `json:"status"`
+	Path   string `json:"path"`
+}
+
+type switchTargetOutput struct {
+	Tab  string `json:"tab,omitempty"`
+	Path string `json:"path"`
+}
+
+func emitSwitchSelection(cmd *cobra.Command, selected config.RegisteredCampaign, targetPath, targetTab string, printOnly, jsonOut bool) error {
+	if printOnly {
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), targetPath)
+		return err
+	}
+	if jsonOut {
+		out := switchOutput{
+			SchemaVersion: "camp-switch/v1",
+			Campaign: switchCampaignOutput{
+				ID:     selected.ID,
+				Name:   selected.Name,
+				Org:    selected.Org,
+				Status: selected.Status,
+				Path:   selected.Path,
+			},
+			Target: switchTargetOutput{
+				Tab:  targetTab,
+				Path: targetPath,
+			},
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+	_, err := fmt.Fprintf(cmd.OutOrStdout(), "cd %s\n", targetPath)
+	return err
 }

--- a/cmd/camp/switch_test.go
+++ b/cmd/camp/switch_test.go
@@ -1,20 +1,38 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"sort"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/nav/fuzzy"
+	"github.com/spf13/cobra"
 )
 
 func newTestRegistry(campaigns ...config.RegisteredCampaign) *config.Registry {
 	reg := config.NewRegistry()
 	for _, c := range campaigns {
 		_ = reg.Register(c.ID, c.Name, c.Path, c.Type)
+	}
+	return reg
+}
+
+func newSwitchScopedRegistry(campaigns ...config.RegisteredCampaign) *config.Registry {
+	reg := config.NewRegistry()
+	for _, c := range campaigns {
+		if c.Org == "" {
+			c.Org = config.DefaultOrg
+		}
+		if c.Status == "" {
+			c.Status = config.StatusActive
+		}
+		reg.Campaigns[c.ID] = c
 	}
 	return reg
 }
@@ -209,6 +227,116 @@ func TestSwitchExactMatchPreserved(t *testing.T) {
 	}
 }
 
+func TestParseSwitchSelector(t *testing.T) {
+	tests := []struct {
+		input        string
+		wantOrg      string
+		wantCampaign string
+		wantTab      string
+		wantHasTab   bool
+	}{
+		{input: "platform", wantCampaign: "platform"},
+		{input: "platform@p", wantCampaign: "platform", wantTab: "p", wantHasTab: true},
+		{input: "obey/platform", wantOrg: "obey", wantCampaign: "platform"},
+		{input: "obey/platform@p", wantOrg: "obey", wantCampaign: "platform", wantTab: "p", wantHasTab: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := cmdutil.ParseSwitchSelector(tt.input)
+			if got.Org != tt.wantOrg || got.Campaign != tt.wantCampaign || got.Tab != tt.wantTab || got.HasTab != tt.wantHasTab {
+				t.Fatalf("ParseSwitchSelector(%q) = %#v, want org=%q campaign=%q tab=%q hasTab=%v",
+					tt.input, got, tt.wantOrg, tt.wantCampaign, tt.wantTab, tt.wantHasTab)
+			}
+		})
+	}
+}
+
+func TestSwitchScopedFilteringAndResolution(t *testing.T) {
+	reg := newSwitchScopedRegistry(
+		config.RegisteredCampaign{ID: "default-alpha", Name: "alpha", Path: "/tmp/alpha", Org: config.DefaultOrg, Status: config.StatusActive},
+		config.RegisteredCampaign{ID: "obey-platform", Name: "platform", Path: "/tmp/obey-platform", Org: "obey", Status: config.StatusActive},
+		config.RegisteredCampaign{ID: "obey-content", Name: "content", Path: "/tmp/obey-content", Org: "obey", Status: config.StatusInactive},
+		config.RegisteredCampaign{ID: "acme-platform", Name: "platform", Path: "/tmp/acme-platform", Org: "client-acme", Status: config.StatusActive},
+		config.RegisteredCampaign{ID: "acme-archive", Name: "archive", Path: "/tmp/acme-archive", Org: "client-acme", Status: config.StatusReference},
+	)
+
+	got := cmdutil.FilterCampaigns(reg, cmdutil.CampaignScope{Org: "obey"})
+	if names := campaignNamesForTest(got); strings.Join(names, ",") != "platform" {
+		t.Fatalf("active obey candidates = %v, want [platform]", names)
+	}
+
+	_, err := cmdutil.ResolveCampaignSelectionScoped("content", reg, cmdutil.CampaignScope{Org: "obey"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "status \"active\"") {
+		t.Fatalf("inactive default resolve error = %v, want active-status not found", err)
+	}
+
+	c, err := cmdutil.ResolveCampaignSelectionScoped("content", reg, cmdutil.CampaignScope{Org: "obey", All: true}, nil)
+	if err != nil {
+		t.Fatalf("--all inactive resolve: %v", err)
+	}
+	if c.ID != "obey-content" {
+		t.Fatalf("--all resolved %q, want obey-content", c.ID)
+	}
+
+	c, err = cmdutil.ResolveCampaignSelectionScoped("plat", reg, cmdutil.CampaignScope{Org: "client-acme"}, nil)
+	if err != nil {
+		t.Fatalf("scoped fuzzy resolve: %v", err)
+	}
+	if c.ID != "acme-platform" {
+		t.Fatalf("scoped fuzzy resolved %q, want acme-platform", c.ID)
+	}
+}
+
+func TestSwitchCompletionScopedByOrgAndStatus(t *testing.T) {
+	reg := newSwitchScopedRegistry(
+		config.RegisteredCampaign{ID: "obey-platform", Name: "platform", Path: "/tmp/obey-platform", Org: "obey", Status: config.StatusActive},
+		config.RegisteredCampaign{ID: "obey-content", Name: "content", Path: "/tmp/obey-content", Org: "obey", Status: config.StatusInactive},
+		config.RegisteredCampaign{ID: "acme-platform", Name: "platform", Path: "/tmp/acme-platform", Org: "client-acme", Status: config.StatusActive},
+	)
+
+	got := completeSwitchCampaigns(reg, cmdutil.CampaignScope{}, "obey/")
+	if strings.Join(got, ",") != "obey/platform" {
+		t.Fatalf("obey/ completion = %v, want [obey/platform]", got)
+	}
+
+	got = completeSwitchCampaigns(reg, cmdutil.CampaignScope{Org: "obey"}, "")
+	if strings.Join(got, ",") != "platform" {
+		t.Fatalf("--org obey completion = %v, want [platform]", got)
+	}
+
+	got = completeSwitchCampaigns(reg, cmdutil.CampaignScope{Org: "obey", All: true}, "")
+	if strings.Join(got, ",") != "content,platform" {
+		t.Fatalf("--org obey --all completion = %v, want [content platform]", got)
+	}
+
+	got = completeSwitchCampaigns(reg, cmdutil.CampaignScope{}, "obe")
+	if !containsString(got, "obey/") {
+		t.Fatalf("org namespace completion = %v, want obey/", got)
+	}
+}
+
+func TestSwitchJSONOutput(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := switchCommandForTest(&buf)
+	selected := config.RegisteredCampaign{
+		ID:     "obey-platform",
+		Name:   "platform",
+		Org:    "obey",
+		Status: config.StatusActive,
+		Path:   "/tmp/platform",
+	}
+	if err := emitSwitchSelection(cmd, selected, "/tmp/platform/projects", "p", false, true); err != nil {
+		t.Fatalf("emitSwitchSelection: %v", err)
+	}
+	var got switchOutput
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("json output: %v\n%s", err, buf.String())
+	}
+	if got.SchemaVersion != "camp-switch/v1" || got.Campaign.Org != "obey" || got.Target.Tab != "p" || got.Target.Path != "/tmp/platform/projects" {
+		t.Fatalf("json output = %#v", got)
+	}
+}
+
 func TestSwitchTabCompletionFuzzy(t *testing.T) {
 	names := []string{"obey-platform-monorepo", "side-project", "research-ai"}
 
@@ -255,6 +383,37 @@ func TestSwitchTabCompletionFuzzy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func campaignNamesForTest(campaigns []config.RegisteredCampaign) []string {
+	names := make([]string, len(campaigns))
+	for i, c := range campaigns {
+		names[i] = c.Name
+	}
+	sort.Strings(names)
+	return names
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func switchCommandForTest(out *bytes.Buffer) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.Flags().Bool("print", false, "")
+	cmd.Flags().Bool("json", false, "")
+	cmd.Flags().String("org", "", "")
+	cmd.Flags().String("status", "", "")
+	cmd.Flags().Bool("all", false, "")
+	return cmd
 }
 
 func TestResolveTabInCampaign(t *testing.T) {
@@ -393,7 +552,7 @@ func TestCompleteSwitchTabs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			got := completeSwitchTabs(ctx, reg, tt.campaignQuery, tt.tabPrefix)
+			got := completeSwitchTabs(ctx, reg, tt.campaignQuery, tt.tabPrefix, cmdutil.CampaignScope{All: true})
 			if tt.wantEmpty {
 				if len(got) != 0 {
 					t.Errorf("expected empty result, got %v", got)

--- a/cmd/camp/switch_test.go
+++ b/cmd/camp/switch_test.go
@@ -332,7 +332,7 @@ func TestSwitchJSONOutput(t *testing.T) {
 	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
 		t.Fatalf("json output: %v\n%s", err, buf.String())
 	}
-	if got.SchemaVersion != "camp-switch/v1" || got.Campaign.Org != "obey" || got.Target.Tab != "p" || got.Target.Path != "/tmp/platform/projects" {
+	if got.SchemaVersion != switchSchemaVersion || got.Campaign.Org != "obey" || got.Target.Tab != "p" || got.Target.Path != "/tmp/platform/projects" {
 		t.Fatalf("json output = %#v", got)
 	}
 }

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -5253,18 +5253,20 @@ Switch to a registered campaign by name or ID.
 
 Without arguments, opens an interactive picker to select a campaign.
 With an argument, looks up the campaign by name or ID prefix.
+Use --org or org/campaign to resolve inside one organization.
 
 Use with the cgo shell function for instant navigation:
   cgo switch                 # Interactive campaign picker
   cgo switch my-campaign     # Switch by name
   cgo switch a1b2             # Switch by ID prefix
+  cgo switch obey/platform    # Switch by org-scoped selector
 
 The --print flag outputs just the path for shell integration:
   cd "$(camp switch --print)"
 
 Use campaign@tab to navigate to a specific location in the target campaign:
   camp switch obey-campaign@p    # Switch and navigate to projects/
-  camp switch obey-campaign@f    # Switch and navigate to festivals/
+  camp switch obey/platform@f    # Switch inside org and navigate to festivals/
 
 ```
 camp switch [campaign] [flags]
@@ -5275,16 +5277,24 @@ camp switch [campaign] [flags]
 ```
   camp switch                        # Interactive picker
   camp switch obey-campaign          # Switch by name
+  camp switch --org obey platform    # Switch by name within an org
+  camp switch obey/platform          # Switch by scoped selector
   camp switch a1b2                   # Switch by ID prefix
   camp switch --print                # Picker, output path only
   camp switch obey-campaign@p        # Switch and navigate to projects/
+  camp switch --all old-reference    # Include inactive/reference campaigns
+  camp switch --org obey platform --json
 ```
 
 ### Options
 
 ```
-  -h, --help    help for switch
-      --print   Print path only (for shell integration)
+      --all             Include inactive and reference campaigns
+  -h, --help            help for switch
+      --json            Output selected campaign and target path as JSON
+      --org string      Only switch among campaigns in this org
+      --print           Print path only (for shell integration)
+      --status string   Only switch among campaigns with this lifecycle status
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_switch.md
+++ b/docs/cli-reference/camp_switch.md
@@ -8,18 +8,20 @@ Switch to a registered campaign by name or ID.
 
 Without arguments, opens an interactive picker to select a campaign.
 With an argument, looks up the campaign by name or ID prefix.
+Use --org or org/campaign to resolve inside one organization.
 
 Use with the cgo shell function for instant navigation:
   cgo switch                 # Interactive campaign picker
   cgo switch my-campaign     # Switch by name
   cgo switch a1b2             # Switch by ID prefix
+  cgo switch obey/platform    # Switch by org-scoped selector
 
 The --print flag outputs just the path for shell integration:
   cd "$(camp switch --print)"
 
 Use campaign@tab to navigate to a specific location in the target campaign:
   camp switch obey-campaign@p    # Switch and navigate to projects/
-  camp switch obey-campaign@f    # Switch and navigate to festivals/
+  camp switch obey/platform@f    # Switch inside org and navigate to festivals/
 
 ```
 camp switch [campaign] [flags]
@@ -30,16 +32,24 @@ camp switch [campaign] [flags]
 ```
   camp switch                        # Interactive picker
   camp switch obey-campaign          # Switch by name
+  camp switch --org obey platform    # Switch by name within an org
+  camp switch obey/platform          # Switch by scoped selector
   camp switch a1b2                   # Switch by ID prefix
   camp switch --print                # Picker, output path only
   camp switch obey-campaign@p        # Switch and navigate to projects/
+  camp switch --all old-reference    # Include inactive/reference campaigns
+  camp switch --org obey platform --json
 ```
 
 ### Options
 
 ```
-  -h, --help    help for switch
-      --print   Print path only (for shell integration)
+      --all             Include inactive and reference campaigns
+  -h, --help            help for switch
+      --json            Output selected campaign and target path as JSON
+      --org string      Only switch among campaigns in this org
+      --print           Print path only (for shell integration)
+      --status string   Only switch among campaigns with this lifecycle status
 ```
 
 ### Options inherited from parent commands

--- a/docs/migrations/switch-org-aware-navigation-2026-07.md
+++ b/docs/migrations/switch-org-aware-navigation-2026-07.md
@@ -1,0 +1,58 @@
+# Switch Org-Aware Navigation Upgrade Guide (July 2026)
+
+This note covers rollout guidance for the org-aware `camp switch` behavior
+introduced in July 2026.
+
+## What Changed
+
+`camp switch` now understands the same org and lifecycle axes already used by
+`camp list`:
+
+```bash
+camp switch --org obey platform
+camp switch obey/platform
+camp switch obey/platform@p
+```
+
+The command also adds:
+
+- `--org <org>` to filter direct resolution, picker candidates, and completion.
+- `--status <active|inactive|reference>` to switch within one lifecycle status.
+- `--all` to include inactive and reference campaigns.
+- `--json` for a structured selected-campaign payload.
+
+Fuzzy matching is preserved. Org and lifecycle filters reduce the candidate set
+before the existing fuzzy matching behavior runs.
+
+## User-Visible Default
+
+`camp switch <name>` now resolves active campaigns by default. Inactive and
+reference campaigns remain reachable, but they must be requested explicitly:
+
+```bash
+camp switch --all old-reference
+camp switch --status reference old-reference
+camp switch --org obey --all archive
+```
+
+This matches the existing `camp list` default and keeps parked/reference
+campaigns out of high-frequency switch completion and picker flows.
+
+## Compatibility Expectations
+
+Existing unscoped active-campaign workflows continue to work:
+
+```bash
+camp switch campaign
+camp switch campaign@p
+camp switch campaign --print
+```
+
+For inactive/reference campaigns, update scripts and shell habits to include
+`--all` or explicit `--status`.
+
+## Reference Links
+
+CLI reference:
+
+- `docs/cli-reference/camp_switch.md`


### PR DESCRIPTION
## Summary

Implements org-aware `camp switch` selection for `WI-cdfacb`.

- Adds scoped selector parsing for `org/campaign` and `org/campaign@tab`.
- Adds `--org`, `--status`, `--all`, and `--json` to `camp switch`.
- Filters direct switch, picker candidates, and completion candidates by org/status before applying the existing fuzzy matching behavior.
- Keeps inactive/reference campaigns out of default switch resolution; they are reachable via `--all` or explicit `--status`.
- Regenerates CLI reference docs.

## User impact

Users with many registered campaigns can narrow switch resolution and completion by organization without losing the fuzzy matching behavior they already use. Agents can use `camp switch --org <org> <campaign> --json` for a structured selected-campaign payload.

## Validation

- `go test ./cmd/camp ./cmd/camp/cmdutil`
- `just docs`
- `just gate-push`
