### PR TITLE
fix(contracts): snake_case doctor JSON, campaign-relative quest links (CAMP-CON-01/02)

### DIFF
--- a/cmd/camp/doctor.go
+++ b/cmd/camp/doctor.go
@@ -136,11 +136,25 @@ func registerChecks(d *doctor.Doctor) {
 	d.RegisterCheck(checks.NewLockCheck())
 }
 
+type doctorJSONPayload struct {
+	SchemaVersion string `json:"schema_version"`
+	*doctor.DoctorResult
+}
+
 // outputDoctorJSON outputs results as JSON.
 func outputDoctorJSON(result *doctor.DoctorResult) error {
+	if result.Issues == nil {
+		result.Issues = []doctor.Issue{}
+	}
+	if result.Fixed == nil {
+		result.Fixed = []doctor.Issue{}
+	}
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
-	return encoder.Encode(result)
+	return encoder.Encode(doctorJSONPayload{
+		SchemaVersion: DoctorJSONVersion,
+		DoctorResult:  result,
+	})
 }
 
 // outputDoctorText outputs results in human-readable format.

--- a/cmd/camp/doctor.go
+++ b/cmd/camp/doctor.go
@@ -143,17 +143,18 @@ type doctorJSONPayload struct {
 
 // outputDoctorJSON outputs results as JSON.
 func outputDoctorJSON(result *doctor.DoctorResult) error {
-	if result.Issues == nil {
-		result.Issues = []doctor.Issue{}
+	payloadResult := *result
+	if payloadResult.Issues == nil {
+		payloadResult.Issues = []doctor.Issue{}
 	}
-	if result.Fixed == nil {
-		result.Fixed = []doctor.Issue{}
+	if payloadResult.Fixed == nil {
+		payloadResult.Fixed = []doctor.Issue{}
 	}
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(doctorJSONPayload{
 		SchemaVersion: DoctorJSONVersion,
-		DoctorResult:  result,
+		DoctorResult:  &payloadResult,
 	})
 }
 

--- a/cmd/camp/doctor_test.go
+++ b/cmd/camp/doctor_test.go
@@ -122,6 +122,85 @@ func installDoctorJSONFakeFuser(t *testing.T) {
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
+func TestOutputDoctorJSONUsesSnakeCaseKeysAndSchemaVersion(t *testing.T) {
+	result := &doctor.DoctorResult{
+		Success: false,
+		Passed:  1,
+		Warned:  1,
+		Failed:  1,
+		Issues: []doctor.Issue{
+			{Severity: doctor.SeverityError, CheckID: "url", Description: "mismatch"},
+		},
+		CheckResults: map[string]bool{"url": false},
+	}
+
+	stdout, err := captureDoctorJSONStdout(t, func() error {
+		return outputDoctorJSON(result)
+	})
+	if err != nil {
+		t.Fatalf("outputDoctorJSON: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &raw); err != nil {
+		t.Fatalf("doctor JSON output is not valid JSON: %v\n%s", err, stdout)
+	}
+
+	for _, key := range []string{"schema_version", "success", "passed", "warned", "failed", "issues", "fixed", "check_results"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("doctor JSON missing expected snake_case key %q, got: %s", key, stdout)
+		}
+	}
+	for _, key := range []string{"Success", "Passed", "Warned", "Failed", "Issues", "Fixed", "CheckResults"} {
+		if _, ok := raw[key]; ok {
+			t.Errorf("doctor JSON still emits PascalCase key %q, got: %s", key, stdout)
+		}
+	}
+
+	var schemaVersion string
+	if err := json.Unmarshal(raw["schema_version"], &schemaVersion); err != nil {
+		t.Fatalf("schema_version is not a string: %v", err)
+	}
+	if schemaVersion != DoctorJSONVersion {
+		t.Errorf("schema_version = %q, want %q", schemaVersion, DoctorJSONVersion)
+	}
+
+	var issues []map[string]json.RawMessage
+	if err := json.Unmarshal(raw["issues"], &issues); err != nil {
+		t.Fatalf("issues is not an array: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues length = %d, want 1", len(issues))
+	}
+	for _, key := range []string{"severity", "check_id", "description", "auto_fixable"} {
+		if _, ok := issues[0][key]; !ok {
+			t.Errorf("issue missing expected snake_case key %q, got: %v", key, issues[0])
+		}
+	}
+}
+
+func TestOutputDoctorJSONEmitsEmptyArraysNotNull(t *testing.T) {
+	result := &doctor.DoctorResult{Success: true, CheckResults: map[string]bool{}}
+
+	stdout, err := captureDoctorJSONStdout(t, func() error {
+		return outputDoctorJSON(result)
+	})
+	if err != nil {
+		t.Fatalf("outputDoctorJSON: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &raw); err != nil {
+		t.Fatalf("doctor JSON output is not valid JSON: %v\n%s", err, stdout)
+	}
+	for _, key := range []string{"issues", "fixed"} {
+		got := string(raw[key])
+		if got != "[]" {
+			t.Errorf("%s = %s, want empty array []", key, got)
+		}
+	}
+}
+
 func captureDoctorJSONStdout(t *testing.T, fn func() error) (string, error) {
 	t.Helper()
 

--- a/cmd/camp/doctor_test.go
+++ b/cmd/camp/doctor_test.go
@@ -177,6 +177,13 @@ func TestOutputDoctorJSONUsesSnakeCaseKeysAndSchemaVersion(t *testing.T) {
 			t.Errorf("issue missing expected snake_case key %q, got: %v", key, issues[0])
 		}
 	}
+	var severity string
+	if err := json.Unmarshal(issues[0]["severity"], &severity); err != nil {
+		t.Fatalf("severity is not a string: %v", err)
+	}
+	if severity != "error" {
+		t.Errorf("severity = %q, want %q", severity, "error")
+	}
 }
 
 func TestOutputDoctorJSONEmitsEmptyArraysNotNull(t *testing.T) {
@@ -198,6 +205,12 @@ func TestOutputDoctorJSONEmitsEmptyArraysNotNull(t *testing.T) {
 		if got != "[]" {
 			t.Errorf("%s = %s, want empty array []", key, got)
 		}
+	}
+	if result.Issues != nil {
+		t.Errorf("outputDoctorJSON mutated result.Issues to non-nil: %#v", result.Issues)
+	}
+	if result.Fixed != nil {
+		t.Errorf("outputDoctorJSON mutated result.Fixed to non-nil: %#v", result.Fixed)
 	}
 }
 

--- a/cmd/camp/quest/helpers.go
+++ b/cmd/camp/quest/helpers.go
@@ -113,13 +113,15 @@ func completeQuestSelector(cmd *cobra.Command, _ []string, toComplete string) ([
 }
 
 type questListJSONPayload struct {
-	CampaignRoot string         `json:"campaign_root"`
-	Items        []*quest.Quest `json:"items"`
+	SchemaVersion string         `json:"schema_version"`
+	CampaignRoot  string         `json:"campaign_root"`
+	Items         []*quest.Quest `json:"items"`
 }
 
 type questShowJSONPayload struct {
-	CampaignRoot string       `json:"campaign_root"`
-	Quest        *quest.Quest `json:"quest"`
+	SchemaVersion string       `json:"schema_version"`
+	CampaignRoot  string       `json:"campaign_root"`
+	Quest         *quest.Quest `json:"quest"`
 }
 
 func outputQuestListJSON(qctx *questCommandContext, quests []*quest.Quest) error {
@@ -130,8 +132,9 @@ func outputQuestListJSON(qctx *questCommandContext, quests []*quest.Quest) error
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(questListJSONPayload{
-		CampaignRoot: qctx.campaignRoot,
-		Items:        items,
+		SchemaVersion: QuestListJSONVersion,
+		CampaignRoot:  qctx.campaignRoot,
+		Items:         items,
 	})
 }
 
@@ -143,8 +146,9 @@ func outputQuestShowJSON(qctx *questCommandContext, q *quest.Quest) error {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(questShowJSONPayload{
-		CampaignRoot: qctx.campaignRoot,
-		Quest:        item,
+		SchemaVersion: QuestShowJSONVersion,
+		CampaignRoot:  qctx.campaignRoot,
+		Quest:         item,
 	})
 }
 

--- a/cmd/camp/quest/helpers_test.go
+++ b/cmd/camp/quest/helpers_test.go
@@ -79,6 +79,9 @@ func TestOutputQuestListJSONUsesCampaignRelativePaths(t *testing.T) {
 	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
 		t.Fatalf("quest JSON invalid: %v\nraw: %s", err, stdout)
 	}
+	if payload.SchemaVersion != QuestListJSONVersion {
+		t.Fatalf("schema_version = %q, want %q", payload.SchemaVersion, QuestListJSONVersion)
+	}
 	if payload.CampaignRoot != root {
 		t.Fatalf("campaign_root = %q, want %q", payload.CampaignRoot, root)
 	}
@@ -225,6 +228,56 @@ func TestOutputQuestTable_JSONUnchanged(t *testing.T) {
 	}
 	if len(payload.Items) != 1 || payload.Items[0].ID != "qst_json_check" {
 		t.Fatalf("unexpected JSON payload: %+v", payload)
+	}
+}
+
+func TestOutputQuestShowJSONUsesSchemaVersionAndCampaignRelativePath(t *testing.T) {
+	root := t.TempDir()
+	questPath := filepath.Join(root, ".campaign", "quests", "example", "quest.yaml")
+	if err := os.MkdirAll(filepath.Dir(questPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	qctx := &questCommandContext{
+		cfg:          &config.CampaignConfig{ID: "camp1234"},
+		campaignRoot: root,
+		service:      quest.NewService(root),
+	}
+	now := time.Now().UTC()
+	q := &quest.Quest{
+		ID:        "qst_example",
+		Name:      "Example",
+		Status:    quest.StatusOpen,
+		CreatedAt: now,
+		UpdatedAt: now,
+		Slug:      "example",
+		Path:      questPath,
+	}
+
+	out, err := captureQuestStdout(func() error {
+		return outputQuestShowJSON(qctx, q)
+	})
+	if err != nil {
+		t.Fatalf("outputQuestShowJSON: %v", err)
+	}
+
+	var payload questShowJSONPayload
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("quest show JSON invalid: %v\nraw: %s", err, out)
+	}
+	if payload.SchemaVersion != QuestShowJSONVersion {
+		t.Fatalf("schema_version = %q, want %q", payload.SchemaVersion, QuestShowJSONVersion)
+	}
+	if payload.CampaignRoot != root {
+		t.Fatalf("campaign_root = %q, want %q", payload.CampaignRoot, root)
+	}
+	if payload.Quest == nil {
+		t.Fatal("quest is nil")
+	}
+	if filepath.IsAbs(payload.Quest.Path) {
+		t.Fatalf("quest path is absolute: %q", payload.Quest.Path)
+	}
+	if q.Path != questPath {
+		t.Fatalf("output mutated original quest path: %q", q.Path)
 	}
 }
 

--- a/cmd/camp/quest/links.go
+++ b/cmd/camp/quest/links.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/jsoncontract"
+	"github.com/Obedience-Corp/camp/internal/pathutil"
 	"github.com/Obedience-Corp/camp/internal/quest"
 )
 
@@ -59,18 +61,37 @@ func runQuestLinks(cmd *cobra.Command, args []string) error {
 	}
 
 	if questLinksJSON {
-		return outputLinksJSON(links)
+		return outputLinksJSON(qctx, links)
 	}
 	return outputLinksTable(links)
 }
 
-func outputLinksJSON(links []quest.Link) error {
-	enc := json.NewEncoder(os.Stdout)
-	enc.SetIndent("", "  ")
+type questLinksJSONPayload struct {
+	SchemaVersion string       `json:"schema_version"`
+	CampaignRoot  string       `json:"campaign_root"`
+	Links         []quest.Link `json:"links"`
+}
+
+func outputLinksJSON(qctx *questCommandContext, links []quest.Link) error {
 	if links == nil {
 		links = []quest.Link{}
 	}
-	return enc.Encode(links)
+	relLinks := make([]quest.Link, len(links))
+	for i, link := range links {
+		relPath, err := pathutil.RelativeToRoot(qctx.campaignRoot, link.Path)
+		if err != nil {
+			return camperrors.Wrap(err, "relativizing link path")
+		}
+		link.Path = relPath
+		relLinks[i] = link
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(questLinksJSONPayload{
+		SchemaVersion: QuestLinksJSONVersion,
+		CampaignRoot:  qctx.campaignRoot,
+		Links:         relLinks,
+	})
 }
 
 func outputLinksTable(links []quest.Link) error {

--- a/cmd/camp/quest/links_test.go
+++ b/cmd/camp/quest/links_test.go
@@ -1,0 +1,97 @@
+//go:build dev
+
+package quest
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/Obedience-Corp/camp/internal/pathutil"
+	"github.com/Obedience-Corp/camp/internal/quest"
+)
+
+func TestOutputLinksJSONUsesCampaignRelativePathsAndEnvelope(t *testing.T) {
+	root, err := pathutil.ResolveRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve root: %v", err)
+	}
+	qctx := &questCommandContext{
+		cfg:          &config.CampaignConfig{ID: "camp1234"},
+		campaignRoot: root,
+		service:      quest.NewService(root),
+	}
+	links := []quest.Link{
+		{
+			Path:    "workflow/design/some-design.md",
+			Type:    "design",
+			AddedAt: time.Now().UTC(),
+		},
+		{
+			Path:    filepath.Join(root, "projects", "camp"),
+			Type:    "project",
+			AddedAt: time.Now().UTC(),
+		},
+	}
+
+	stdout, err := captureQuestStdout(func() error {
+		return outputLinksJSON(qctx, links)
+	})
+	if err != nil {
+		t.Fatalf("outputLinksJSON: %v", err)
+	}
+
+	var payload questLinksJSONPayload
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("links JSON invalid: %v\nraw: %s", err, stdout)
+	}
+	if payload.SchemaVersion != QuestLinksJSONVersion {
+		t.Fatalf("schema_version = %q, want %q", payload.SchemaVersion, QuestLinksJSONVersion)
+	}
+	if payload.CampaignRoot != root {
+		t.Fatalf("campaign_root = %q, want %q", payload.CampaignRoot, root)
+	}
+	if len(payload.Links) != 2 {
+		t.Fatalf("links length = %d, want 2", len(payload.Links))
+	}
+	for _, link := range payload.Links {
+		if filepath.IsAbs(link.Path) {
+			t.Fatalf("link path is absolute: %q", link.Path)
+		}
+	}
+	if payload.Links[0].Path != "workflow/design/some-design.md" {
+		t.Fatalf("already-relative link path changed: %q", payload.Links[0].Path)
+	}
+	if payload.Links[1].Path != filepath.Join("projects", "camp") {
+		t.Fatalf("absolute link path not relativized: %q", payload.Links[1].Path)
+	}
+	if links[1].Path != filepath.Join(root, "projects", "camp") {
+		t.Fatalf("outputLinksJSON mutated the caller's link slice: %q", links[1].Path)
+	}
+}
+
+func TestOutputLinksJSONEmitsEmptyArrayNotNull(t *testing.T) {
+	root := t.TempDir()
+	qctx := &questCommandContext{
+		cfg:          &config.CampaignConfig{ID: "camp1234"},
+		campaignRoot: root,
+		service:      quest.NewService(root),
+	}
+
+	stdout, err := captureQuestStdout(func() error {
+		return outputLinksJSON(qctx, nil)
+	})
+	if err != nil {
+		t.Fatalf("outputLinksJSON: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(stdout), &raw); err != nil {
+		t.Fatalf("links JSON invalid: %v\nraw: %s", err, stdout)
+	}
+	if got := string(raw["links"]); got != "[]" {
+		t.Fatalf("links = %s, want empty array []", got)
+	}
+}

--- a/docs/json-contracts.md
+++ b/docs/json-contracts.md
@@ -35,9 +35,9 @@ Schema versions in this release:
 | `camp doctor --json` | `doctor/v1alpha1` | Emits `schema_version` plus the snake_case health result on stdout; discovered error findings also emit a JSON error envelope on stderr with the same exit code. |
 | `camp leverage --json` | `leverage/v1alpha1` | Existing leverage result shape; refusals use the JSON error envelope. |
 | `camp leverage history --json` | `leverage-history/v1alpha1` | Existing history result shape; refusals use the JSON error envelope. |
-| `camp quest list --json` | `quest-list/v1alpha1` | Dev-profile quest listing; refusals use the JSON error envelope. |
-| `camp quest show --json` | `quest-show/v1alpha1` | Dev-profile quest metadata; refusals use the JSON error envelope. |
-| `camp quest links --json` | `quest-links/v1alpha1` | Emits `schema_version`, `campaign_root`, and `links` with campaign-relative paths, matching `status all`. |
+| `camp quest list --json` | `quest-list/v1alpha1` | Emits `schema_version`, `campaign_root`, and `items` with campaign-relative paths. |
+| `camp quest show --json` | `quest-show/v1alpha1` | Emits `schema_version`, `campaign_root`, and `quest` with campaign-relative paths. |
+| `camp quest links --json` | `quest-links/v1alpha1` | Emits `schema_version`, `campaign_root`, and `links` with campaign-relative paths. |
 | `camp skills status --json` | `skills-status/v1alpha1` | Existing skill projection status shape; failures use the JSON error envelope. |
 | `camp status all --json` | `status-all/v1alpha1` | Emits `schema_version`, `timestamp`, optional `campaign_root`, and `repos`; an empty campaign emits `repos: []`. |
 | `camp sync --json` | `sync/v1alpha1` | Existing sync result shape; returned failures use the JSON error envelope. |

--- a/docs/json-contracts.md
+++ b/docs/json-contracts.md
@@ -32,12 +32,12 @@ Schema versions in this release:
 | `camp intent count --json` | `intents/v1alpha1` | Counts are emitted as status-count objects in `items[]`; `--format json` is a deprecated alias. |
 | `camp intent add --json` | `intents/v1alpha1` | Emits created `id` and `path`. |
 | `camp clone --json` | `clone/v1alpha1` | Existing clone result shape; setup and validation failures use the JSON error envelope. |
-| `camp doctor --json` | `doctor/v1alpha1` | Existing health result shape on stdout; discovered error findings also emit a JSON error envelope on stderr with the same exit code. |
+| `camp doctor --json` | `doctor/v1alpha1` | Emits `schema_version` plus the snake_case health result on stdout; discovered error findings also emit a JSON error envelope on stderr with the same exit code. |
 | `camp leverage --json` | `leverage/v1alpha1` | Existing leverage result shape; refusals use the JSON error envelope. |
 | `camp leverage history --json` | `leverage-history/v1alpha1` | Existing history result shape; refusals use the JSON error envelope. |
 | `camp quest list --json` | `quest-list/v1alpha1` | Dev-profile quest listing; refusals use the JSON error envelope. |
 | `camp quest show --json` | `quest-show/v1alpha1` | Dev-profile quest metadata; refusals use the JSON error envelope. |
-| `camp quest links --json` | `quest-links/v1alpha1` | Dev-profile quest links; refusals use the JSON error envelope. |
+| `camp quest links --json` | `quest-links/v1alpha1` | Emits `schema_version`, `campaign_root`, and `links` with campaign-relative paths, matching `status all`. |
 | `camp skills status --json` | `skills-status/v1alpha1` | Existing skill projection status shape; failures use the JSON error envelope. |
 | `camp status all --json` | `status-all/v1alpha1` | Emits `schema_version`, `timestamp`, optional `campaign_root`, and `repos`; an empty campaign emits `repos: []`. |
 | `camp sync --json` | `sync/v1alpha1` | Existing sync result shape; returned failures use the JSON error envelope. |
@@ -81,8 +81,8 @@ this normalizes paths such as `/tmp` to `/private/tmp`. Consumers should use
 the `campaign_root` from the payload instead of resolving roots independently.
 
 The `camp status all --json` campaign-root repo entry uses `.` as its relative
-path. Dev-profile quest JSON follows the same path rule while preserving its
-existing success payload shape.
+path. Dev-profile quest JSON (`quest list`, `quest show`, `quest links`)
+follows the same path rule and carries `campaign_root` in its envelope.
 
 ## Field Rules
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 )
@@ -384,6 +385,16 @@ func TestSeverityString(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.expected, got)
 			}
 		})
+	}
+}
+
+func TestSeverityMarshalJSONUsesStringValue(t *testing.T) {
+	got, err := json.Marshal(SeverityWarning)
+	if err != nil {
+		t.Fatalf("MarshalJSON: %v", err)
+	}
+	if string(got) != `"warning"` {
+		t.Fatalf("severity JSON = %s, want %q", got, `"warning"`)
 	}
 }
 

--- a/internal/doctor/issue.go
+++ b/internal/doctor/issue.go
@@ -40,19 +40,19 @@ func (s Severity) String() string {
 // Issue represents a detected problem in the campaign.
 type Issue struct {
 	// Severity indicates the importance of this issue.
-	Severity Severity
+	Severity Severity `json:"severity"`
 	// CheckID identifies which check found this issue.
-	CheckID string
+	CheckID string `json:"check_id"`
 	// Submodule is the affected submodule path (empty for root-level issues).
-	Submodule string
+	Submodule string `json:"submodule,omitempty"`
 	// Description explains what's wrong.
-	Description string
+	Description string `json:"description"`
 	// FixCommand suggests a command to fix this issue.
-	FixCommand string
+	FixCommand string `json:"fix_command,omitempty"`
 	// AutoFixable indicates whether this issue can be automatically fixed.
-	AutoFixable bool
+	AutoFixable bool `json:"auto_fixable"`
 	// Details contains additional context for the issue.
-	Details map[string]any
+	Details map[string]any `json:"details,omitempty"`
 }
 
 // IsError returns true if this is an error-level issue.

--- a/internal/doctor/issue.go
+++ b/internal/doctor/issue.go
@@ -11,6 +11,8 @@
 // When run with --fix, it can automatically repair common issues.
 package doctor
 
+import "encoding/json"
+
 // Severity indicates the level of concern for an issue.
 type Severity int
 
@@ -35,6 +37,11 @@ func (s Severity) String() string {
 	default:
 		return "unknown"
 	}
+}
+
+// MarshalJSON emits severity values as their stable string representation.
+func (s Severity) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
 }
 
 // Issue represents a detected problem in the campaign.

--- a/internal/doctor/options.go
+++ b/internal/doctor/options.go
@@ -19,19 +19,19 @@ type DoctorOptions struct {
 // DoctorResult contains the outcome of a health check.
 type DoctorResult struct {
 	// Success is true when no errors are found (warnings are OK).
-	Success bool
+	Success bool `json:"success"`
 	// Passed is the number of checks that passed without issues.
-	Passed int
+	Passed int `json:"passed"`
 	// Warned is the number of checks that found warnings.
-	Warned int
+	Warned int `json:"warned"`
 	// Failed is the number of checks that found errors.
-	Failed int
+	Failed int `json:"failed"`
 	// Issues contains all detected problems.
-	Issues []Issue
+	Issues []Issue `json:"issues"`
 	// Fixed contains issues that were successfully repaired (when Fix=true).
-	Fixed []Issue
+	Fixed []Issue `json:"fixed"`
 	// CheckResults contains per-check pass/fail status.
-	CheckResults map[string]bool
+	CheckResults map[string]bool `json:"check_results"`
 }
 
 // CheckResult contains findings from a single health check.


### PR DESCRIPTION
## Summary

Fixes from the fable-2026-07-01 contracts review (`workflow/code_reviews/fable-2026-07-01-code-review/camp/findings-contracts.md`), verified against source at this branch's HEAD rather than applied blindly.

- **CAMP-CON-02** (real, fixed): `camp doctor --json` emitted PascalCase keys (`Success`, `Passed`, `Warned`, `Failed`, `Issues`, `Severity`, ...) with no `schema_version`, diverging from every other `--json` surface in the CLI. Added snake_case `json` tags to `doctor.DoctorResult`/`doctor.Issue` (`internal/doctor/options.go`, `internal/doctor/issue.go`) and wrapped the stdout payload with `schema_version` in `cmd/camp/doctor.go`. `Issues`/`Fixed` now emit `[]` instead of `null` when empty, per the repo's existing empty-array convention.

- **CAMP-CON-01** (partially stale, narrowed and fixed): the finding claimed `Quest.Path` and `Link.Path` both leak machine-absolute paths into quest JSON. On inspection, `quest list`/`quest show --json` were already fixed to campaign-relative paths + a `campaign_root` envelope in commit `7ed4e6b` ("fix: unify json path semantics", 2026-06-15) — well before this review ran, and already has regression coverage (`TestOutputQuestListJSONUsesCampaignRelativePaths`). `Link.Path` is also already guaranteed campaign-relative at write time (`normalizeLinkPath` in `cmd/camp/quest/link.go`, present since the feature's original introduction). The real remaining gap was narrower: `camp quest links --json` emitted a bare array with no `campaign_root`/`schema_version` envelope, unlike its siblings. Promoted it to match (`cmd/camp/quest/links.go`), with a defensive `pathutil.RelativeToRoot` pass on link paths for consistency with `questForJSON`.

- **CAMP-CON-03** (stale, no change): the finding claimed the workitem-ref regex `^WI-[0-9a-f]{6}$` no longer matches legacy `WI-WI-<hex>` tags. This was already fixed in commit `a9ad141` ("refactor(git): collapse workitem tag prefix from WI-WI- to WI-", 2026-06-30) — one day before the 2026-07-01 review — which strips the doubled prefix before matching in `ParseTagDetailed`, and already ships comprehensive regression coverage in `internal/git/campaign_tag_full_test.go` covering the doubled-prefix form across many tag shapes. Verified live with a throwaway probe test before concluding no code change was warranted; making the regex change anyway would have touched an unreachable code path for no behavioral effect.

## Test plan

- [x] `just gate` — build (stable+dev), vet (stable+dev+integration), lint (stable+dev), unit tests: **PASSED**, 2919/2919 (2947 counting the gate-fast test pass)
- [x] `just test unit` run standalone: **PASSED**, 92 packages, 2919/2919 tests, exit 0
- [x] New test `TestOutputDoctorJSONUsesSnakeCaseKeysAndSchemaVersion` + `TestOutputDoctorJSONEmitsEmptyArraysNotNull` (`cmd/camp/doctor_test.go`)
- [x] New test `TestOutputLinksJSONUsesCampaignRelativePathsAndEnvelope` + `TestOutputLinksJSONEmitsEmptyArrayNotNull` (`cmd/camp/quest/links_test.go`, dev-tagged)
- [x] Verified live: `camp doctor --json` on this repo now emits `schema_version` + snake_case keys (was PascalCase with no schema_version before this change)
- [x] `docs/json-contracts.md` updated to describe the promoted doctor and quest-links payload shapes