### PR TITLE
fix(scaffold): campaign-commit skill taught raw git commit at campaign root

### DIFF
--- a/internal/scaffold/campaign/templates/.campaign/skills/campaign-commit/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/campaign-commit/SKILL.md.tmpl
@@ -1,6 +1,6 @@
 ---
 name: campaign-commit
-description: Choose the correct commit command in a campaign workspace. Use when you are about to commit and need to select `camp p commit`, `fest commit`, root `git commit`, or intentional root pointer sync via `camp refs-sync`.
+description: Choose the correct commit command in a campaign workspace. Use when you are about to commit and need to select `camp commit`, `camp p commit`, `fest commit`, or intentional root pointer sync via `camp refs-sync`.
 ---
 
 # Campaign Commit Decision
@@ -9,12 +9,13 @@ description: Choose the correct commit command in a campaign workspace. Use when
 
 - Project submodule change: `camp p commit -m "msg"`
 - Festival task execution: `fest commit -m "msg"`
-- Campaign root files: `git commit -m "msg"`
+- Campaign root files: `camp commit -m "msg"` (stages all root-level changes; submodule refs excluded by default)
+- Campaign root, scoped to specific paths: `git add <paths>` then `camp commit --all=false -m "msg"` (commits only what is staged)
 - Intentional root pointer sync: `camp refs-sync [submodule...]`
 
 ## Rules
 
+- Never run raw `git commit` anywhere in a campaign workspace; staging with `git add` is fine.
 - Keep submodule commits and root pointer sync as separate, explicit actions.
-- Avoid raw `git commit` in submodules when campaign tooling is available.
 - Do not add agent co-author trailers unless explicitly requested.
 - Do not bypass hooks with `--no-verify` without clear justification.

--- a/internal/scaffold/campaign/templates/.campaign/skills/campaign-commit/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/campaign-commit/SKILL.md.tmpl
@@ -7,7 +7,7 @@ description: Choose the correct commit command in a campaign workspace. Use when
 
 ## Decision
 
-- Project submodule change: `camp p commit -m "msg"`
+- Project change (submodule, linked project, or worktree): `camp p commit -m "msg"`
 - Festival task execution: `fest commit -m "msg"`
 - Campaign root files: `camp commit -m "msg"` (stages all root-level changes; submodule refs excluded by default)
 - Campaign root, scoped to specific paths: `git add <paths>` then `camp commit --all=false -m "msg"` (commits only what is staged)


### PR DESCRIPTION
## Problem

The scaffolded `campaign-commit` skill (`.campaign/skills/campaign-commit/SKILL.md`) has told agents to use **raw `git commit`** for campaign root files since the template was first authored:

```
- Campaign root files: `git commit -m "msg"`
```

This directly contradicts campaign commit discipline (root commits go through `camp commit`), and it survived `camp init --repair` regeneration because the template source itself carries the error. An agent that follows the skill literally loses the `[<CAMPAIGN>-<id>]` context tag prefix, the accidental-submodule-ref staging guard, and stale-lock handling.

The skill was also silent on the scoped-commit case (one artifact at root amid unrelated dirty files), which is what pushed agents toward raw git in practice — even though `camp commit --all=false` already commits staged-only and has existed since early in the command's history.

## Change

Rewrite the decision table in the skill template:

- Campaign root files: `camp commit -m "msg"` (stages all root-level changes; submodule refs excluded by default)
- Campaign root, scoped: `git add <paths>` then `camp commit --all=false -m "msg"` (commits only what is staged)
- New rule: never run raw `git commit` anywhere in a campaign workspace; staging with `git add` is fine.

Frontmatter description updated to stop advertising `root git commit` as an option.

## Verification

- `go build ./...` clean, `go test ./internal/scaffold/...` passes (tests assert skill presence, not content).
- `camp commit --all=false` staged-only behavior verified empirically in an isolated scratch repo: with one path staged and another dirty, the commit contained only the staged path and still received the context tag prefix (`effectiveCommitAll` gating in `cmd/camp/commit.go`).

Content-only template change; no code paths touched.