### PR TITLE
test(integration): fix stale WI-WI- commit-tag assertions (green integration suite)

### DIFF
--- a/tests/integration/commit_tags_test.go
+++ b/tests/integration/commit_tags_test.go
@@ -68,7 +68,7 @@ func TestIntegration_CommitTags_CampCommit(t *testing.T) {
 	require.NoError(t, err, "camp commit: %s", out)
 
 	subject := lastCommitSubject(t, tc, dir)
-	assert.Contains(t, subject, "WI-"+ref, "subject should include WI-<ref>: %s", subject)
+	assert.Contains(t, subject, ref, "subject should include the WI-<ref>: %s", subject)
 	assert.Contains(t, subject, "design: timeline contract", "subject = %s", subject)
 }
 
@@ -90,7 +90,7 @@ func TestIntegration_CommitTags_CampPCommit(t *testing.T) {
 	require.NoError(t, err, "camp p commit: %s", out)
 
 	subject := lastCommitSubject(t, tc, dir+"/projects/camp-timeline")
-	assert.Contains(t, subject, "WI-"+ref, "subject should include WI-<ref>: %s", subject)
+	assert.Contains(t, subject, ref, "subject should include WI-<ref>: %s", subject)
 	assert.Contains(t, subject, "feat: stub", "subject = %s", subject)
 }
 
@@ -131,7 +131,7 @@ func TestIntegration_CommitTags_ExplicitOverride(t *testing.T) {
 	require.NoError(t, err, "camp commit --workitem: %s", out)
 
 	subject := lastCommitSubject(t, tc, dir)
-	assert.Contains(t, subject, "WI-"+ref, "explicit override should win: %s", subject)
+	assert.Contains(t, subject, ref, "explicit override should win: %s", subject)
 }
 
 func TestIntegration_CommitTags_BackfillsV1Alpha5WorkitemOnCommit(t *testing.T) {
@@ -211,7 +211,7 @@ func TestIntegration_CommitTags_NoteInheritsWorkitemContext(t *testing.T) {
 	require.NoError(t, err, "camp intent note: %s", out)
 
 	subject := lastCommitSubject(t, tc, dir)
-	assert.Contains(t, subject, "WI-"+ref,
+	assert.Contains(t, subject, ref,
 		"note captured inside a workitem should inherit its WI-<ref>: %s", subject)
 	assert.Contains(t, subject, "check the daemon socket path",
 		"note commit subject should carry the note title: %s", subject)

--- a/tests/integration/workitem_commit_test.go
+++ b/tests/integration/workitem_commit_test.go
@@ -76,7 +76,7 @@ func TestIntegration_WorkitemCommit_WorkitemDirContext(t *testing.T) {
 	require.NoError(t, err, "camp workitem commit: %s", out)
 
 	subject := lastCommitSubject(t, tc, dir)
-	assert.Contains(t, subject, "WI-"+ref, "subject = %s", subject)
+	assert.Contains(t, subject, ref, "subject = %s", subject)
 
 	changed := headChangedPaths(t, tc, dir)
 	assert.Contains(t, changed, "workflow/design/timeline/notes.md")
@@ -107,7 +107,7 @@ func TestIntegration_WorkitemCommit_LinkedProject(t *testing.T) {
 	require.NoError(t, err, "camp workitem commit: %s", out)
 
 	subject := lastCommitSubject(t, tc, dir+"/projects/camp-timeline")
-	assert.Contains(t, subject, "WI-"+ref, "project subject = %s", subject)
+	assert.Contains(t, subject, ref, "project subject = %s", subject)
 
 	rootHeadAfter, _, herr := tc.ExecCommand("git", "-C", dir, "rev-parse", "HEAD")
 	require.NoError(t, herr)
@@ -138,7 +138,7 @@ func TestIntegration_WorkitemCommit_FestivalContextFromCwd(t *testing.T) {
 	assert.Equal(t, "festival", plan.Context)
 	assert.Equal(t, "CT0001", plan.FestivalRef)
 	assert.Contains(t, plan.Tag, "FE-CT0001")
-	assert.Contains(t, plan.Tag, "WI-"+ref)
+	assert.Contains(t, plan.Tag, ref)
 	assert.Contains(t, plan.Stage, "festivals/active/CT0001/FESTIVAL_GOAL.md")
 
 	out, err := tc.RunCampInDir(festDir,
@@ -147,7 +147,7 @@ func TestIntegration_WorkitemCommit_FestivalContextFromCwd(t *testing.T) {
 
 	subject := lastCommitSubject(t, tc, dir)
 	assert.Contains(t, subject, "FE-CT0001", "subject = %s", subject)
-	assert.Contains(t, subject, "WI-"+ref, "subject = %s", subject)
+	assert.Contains(t, subject, ref, "subject = %s", subject)
 	changed := headChangedPaths(t, tc, dir)
 	assert.Contains(t, changed, "festivals/active/CT0001/FESTIVAL_GOAL.md")
 	assert.Contains(t, changed, ".campaign/workitems/links.yaml")
@@ -182,7 +182,7 @@ func TestIntegration_WorkitemCommit_MultiFestivalStagesResolvedScope(t *testing.
 
 	assert.Equal(t, "ZZ0002", plan.FestivalRef)
 	assert.Contains(t, plan.Tag, "FE-ZZ0002")
-	assert.Contains(t, plan.Tag, "WI-"+ref)
+	assert.Contains(t, plan.Tag, ref)
 	assert.Contains(t, plan.Stage, "festivals/active/ZZ0002/FESTIVAL_GOAL.md",
 		"committing from ZZ0002 must stage ZZ0002 files: %v", plan.Stage)
 	assert.NotContains(t, plan.Stage, "festivals/active/AA0001/FESTIVAL_GOAL.md",
@@ -435,7 +435,7 @@ func TestIntegration_WorkitemCommit_StagedLinkedProject(t *testing.T) {
 
 	projHead, _, herr := tc.ExecCommand("git", "-C", projDir, "log", "-1", "--pretty=%H %s")
 	require.NoError(t, herr)
-	assert.Contains(t, projHead, "WI-"+ref,
+	assert.Contains(t, projHead, ref,
 		"submodule HEAD must include WI-<ref>: %s", projHead)
 
 	rootHeadAfter, _, herr := tc.ExecCommand("git", "-C", dir, "rev-parse", "HEAD")
@@ -512,7 +512,7 @@ func TestIntegration_WorkitemCommit_SymlinkedCampaignRoot(t *testing.T) {
 	require.NoError(t, err, "camp workitem commit via symlink: %s", out)
 
 	subject := lastCommitSubject(t, tc, real+"/projects/camp-timeline")
-	assert.Contains(t, subject, "WI-"+ref,
+	assert.Contains(t, subject, ref,
 		"project subject must include WI-<ref> after symlinked-cwd commit: %s", subject)
 
 	rootHeadAfter, _, herr := tc.ExecCommand("git", "-C", real, "rev-parse", "HEAD")


### PR DESCRIPTION
## Summary

Fixes the 10 red integration tests in the `commit-tag` / `workitem-commit` area on `main`. No production code change — the tests were stale.

## Root cause

`seedDesignWorkitemWithRef` parses the workitem ref from the `ref: WI-<hex>` line of `camp workitem create` output, so the string it returns **already carries the `WI-` prefix** (as of a9ad141, "collapse workitem tag prefix from WI-WI- to WI-"). But the assertions still did `assert.Contains(subject, "WI-"+ref)`, prepending a second `WI-` and expecting the legacy **`WI-WI-`** doubled form that the composer no longer emits:

```
"[workitem-commit:de7c4495-WI-d72f04] ... feat: stub" does not contain "WI-WI-d72f04"
```

The composer output (`WI-d72f04`) is correct and matches the parser (`^WI-[0-9a-f]{6}$`) and the sibling `assert.Equal(ref, commit.Tag.WorkitemRef)` check in the same file. Because CI is paused and the containerized integration suite runs outside the fast PR gate, these merged red on 2026-06-30 unnoticed.

## Change

Assert against the prefix-inclusive `ref` directly (dropping the extra `"WI-"`), across `commit_tags_test.go` and `workitem_commit_test.go` (11 sites). The 2 `*_FestCommit` / `*_QuestAndWorkitem` tests stay `t.Skip`-ped pending the camp release + fest go.mod bump — unchanged.

## Verification

`just test integration-verbose` on this branch: **0 failures, 388 pass, 8 skip** (was 10 failures on main). gofmt clean; `go vet -tags integration ./tests/integration/` clean.
