### PR TITLE
feat: campaign workflow categories

### DIFF
--- a/docs/campaign-settings-files.md
+++ b/docs/campaign-settings-files.md
@@ -136,6 +136,7 @@ It stores:
 - Human context: `description`, `mission`
 - Project entries under `projects`
 - Picker concepts under `concepts`
+- Workflow categories under `workflows`
 
 Navigation paths and shortcuts do not live here anymore; those live in
 `.campaign/settings/jumps.yaml`.
@@ -144,6 +145,43 @@ Navigation paths and shortcuts do not live here anymore; those live in
 the workflow type. The entry name is the workflow type slug and the path
 points to `workflow/<type>/`. Use `--replace` to overwrite a concept entry
 that already exists under the same name.
+
+#### `workflows` (categories)
+
+The `workflows` block classifies workflow/workitem types into broad categories
+so `camp workitem` can filter and group by kind of work. It is written by
+`camp init` and backfilled by `camp init --repair` (repair preserves your edits).
+
+```yaml
+workflows:
+  categories:
+    plan:
+      label: Plan
+      description: Planning, design, intents, festivals, and structured execution work
+    research:
+      label: Research
+    pipeline:
+      label: Pipeline
+    review:
+      label: Review
+  category_by_type:
+    intent: plan
+    design: plan
+    explore: research
+    festival: plan
+    code_reviews: review
+    pipelines: pipeline
+```
+
+- `categories` defines the vocabulary and display metadata. The shipped set is
+  `plan`, `research`, `pipeline`, `review`; add your own as needed.
+- `category_by_type` maps a workflow/workitem type key to a category key. Any
+  slug-safe type may be mapped, even before a matching item exists. Types with
+  no mapping resolve to `uncategorized` and still appear in listings.
+- `camp workflow create <type> --category <cat>` writes the mapping for you; the
+  category must already exist under `categories`.
+- Category is derived at read time; it is never stored in `.workitem` files, so
+  changing a mapping reclassifies every item of that type at once.
 
 ### `.campaign/settings/jumps.yaml`
 

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -958,29 +958,42 @@ By default, moves an item already in the dungeon root to a status directory.
 When the item exists in the parent directory and not in the dungeon root, the
 command automatically treats it as triage work and moves it into the dungeon.
 Use --triage to force a parent-directory move.
-With --triage and --to-docs, routes an item to an existing campaign-root docs/<subdirectory>.
+With --triage and --to-docs, routes items to an existing campaign-root docs/<subdirectory>.
 With --workitem, resolves a campaign workitem from anywhere and moves its directory
 into the workitem type's local dungeon.
 Moves are always auto-committed so dungeon history remains auditable.
 
 Statuses: completed, archived, someday
 
+Batch: pass several items followed by one shared status to move them together
+(default, --triage, and --to-docs modes). Every item is validated before any
+move is applied, so an invalid item aborts the whole sweep. --workitem accepts a
+single item per invocation.
+
+Dry run: --dry-run resolves and validates exactly as a real move would, prints
+the source -> destination for each item, and exits without touching the
+filesystem or creating a commit. Add --json for a machine-readable plan.
+
 Examples:
   camp dungeon move old-feature archived         Move dungeon item to archived
   camp dungeon move stale-doc completed          Move dungeon item to completed
+  camp dungeon move a b c archived               Move three items to archived (batch)
+  camp dungeon move a b c completed --dry-run    Preview the sweep, change nothing
   camp dungeon move old-project --triage         Move parent item into dungeon root
   camp dungeon move old-project archived --triage Move parent item directly to archived
   camp dungeon move stale-note.md --triage --to-docs architecture/api Route to docs subdirectory
   camp dungeon move feature-slug archived --workitem Move workitem directory to its local archive
 
 ```
-camp dungeon move <item> [status] [flags]
+camp dungeon move <item>... [status] [flags]
 ```
 
 ### Options
 
 ```
+      --dry-run          Preview the move(s) without touching the filesystem or creating a commit
   -h, --help             help for move
+      --json             Emit the dry-run plan as JSON (requires --dry-run)
       --to-docs string   Route triage item into an existing campaign-root docs/<subdir> (requires --triage)
       --triage           Move from parent directory (not from dungeon root)
       --workitem         Resolve item as a campaign workitem and move its directory to the local dungeon
@@ -5704,6 +5717,7 @@ camp workflow create <type> [flags]
 ### Options
 
 ```
+      --category string   workflow category for filtering (default plan; must exist under workflows.categories in campaign.yaml)
       --dry-run           report planned writes without modifying the filesystem
   -h, --help              help for create
       --json              emit a structured JSON result
@@ -5928,8 +5942,9 @@ camp workitem [flags]
 
 ```
       --attention-stage stringArray   Filter by attention stage (current, next, active, parked)
+      --category stringArray          Filter by workflow category (builtin: plan, research, pipeline, review, uncategorized; or any category defined under workflows in campaign.yaml)
       --group stringArray             Filter by workitem group
-      --group-by string               Group JSON/list sections by attention_stage, group, or type; --list defaults to group unless set (default "attention_stage")
+      --group-by string               Group JSON/list sections by attention_stage, group, type, or category; --list defaults to group unless set (default "attention_stage")
   -h, --help                          help for workitem
       --json                          Output as JSON
       --limit int                     Maximum number of items to return

--- a/docs/cli-reference/camp_dungeon_move.md
+++ b/docs/cli-reference/camp_dungeon_move.md
@@ -10,29 +10,42 @@ By default, moves an item already in the dungeon root to a status directory.
 When the item exists in the parent directory and not in the dungeon root, the
 command automatically treats it as triage work and moves it into the dungeon.
 Use --triage to force a parent-directory move.
-With --triage and --to-docs, routes an item to an existing campaign-root docs/<subdirectory>.
+With --triage and --to-docs, routes items to an existing campaign-root docs/<subdirectory>.
 With --workitem, resolves a campaign workitem from anywhere and moves its directory
 into the workitem type's local dungeon.
 Moves are always auto-committed so dungeon history remains auditable.
 
 Statuses: completed, archived, someday
 
+Batch: pass several items followed by one shared status to move them together
+(default, --triage, and --to-docs modes). Every item is validated before any
+move is applied, so an invalid item aborts the whole sweep. --workitem accepts a
+single item per invocation.
+
+Dry run: --dry-run resolves and validates exactly as a real move would, prints
+the source -> destination for each item, and exits without touching the
+filesystem or creating a commit. Add --json for a machine-readable plan.
+
 Examples:
   camp dungeon move old-feature archived         Move dungeon item to archived
   camp dungeon move stale-doc completed          Move dungeon item to completed
+  camp dungeon move a b c archived               Move three items to archived (batch)
+  camp dungeon move a b c completed --dry-run    Preview the sweep, change nothing
   camp dungeon move old-project --triage         Move parent item into dungeon root
   camp dungeon move old-project archived --triage Move parent item directly to archived
   camp dungeon move stale-note.md --triage --to-docs architecture/api Route to docs subdirectory
   camp dungeon move feature-slug archived --workitem Move workitem directory to its local archive
 
 ```
-camp dungeon move <item> [status] [flags]
+camp dungeon move <item>... [status] [flags]
 ```
 
 ### Options
 
 ```
+      --dry-run          Preview the move(s) without touching the filesystem or creating a commit
   -h, --help             help for move
+      --json             Emit the dry-run plan as JSON (requires --dry-run)
       --to-docs string   Route triage item into an existing campaign-root docs/<subdir> (requires --triage)
       --triage           Move from parent directory (not from dungeon root)
       --workitem         Resolve item as a campaign workitem and move its directory to the local dungeon

--- a/docs/cli-reference/camp_workflow_create.md
+++ b/docs/cli-reference/camp_workflow_create.md
@@ -19,6 +19,7 @@ camp workflow create <type> [flags]
 ### Options
 
 ```
+      --category string   workflow category for filtering (default plan; must exist under workflows.categories in campaign.yaml)
       --dry-run           report planned writes without modifying the filesystem
   -h, --help              help for create
       --json              emit a structured JSON result

--- a/docs/cli-reference/camp_workitem.md
+++ b/docs/cli-reference/camp_workitem.md
@@ -24,8 +24,9 @@ camp workitem [flags]
 
 ```
       --attention-stage stringArray   Filter by attention stage (current, next, active, parked)
+      --category stringArray          Filter by workflow category (builtin: plan, research, pipeline, review, uncategorized; or any category defined under workflows in campaign.yaml)
       --group stringArray             Filter by workitem group
-      --group-by string               Group JSON/list sections by attention_stage, group, or type; --list defaults to group unless set (default "attention_stage")
+      --group-by string               Group JSON/list sections by attention_stage, group, type, or category; --list defaults to group unless set (default "attention_stage")
   -h, --help                          help for workitem
       --json                          Output as JSON
       --limit int                     Maximum number of items to return

--- a/docs/json-contracts.md
+++ b/docs/json-contracts.md
@@ -16,7 +16,7 @@ Schema versions in this release:
 
 | Command | Schema version | Notes |
 | --- | --- | --- |
-| `camp workitem --json` | `workitems/v1alpha6` | Workitem dashboard contract with `stage_vocabulary`, explicit `none` stage, ritual/chains festivals, and non-omitempty workflow counters/booleans. |
+| `camp workitem --json` | `workitems/v1alpha8` | Workitem dashboard contract. Each item carries a config-derived `workflow_category` (omitempty); the payload adds `category_vocabulary` (ordered categories with labels), `category_counts`, `category` in `grouping.available_group_by`, and a `category` field on section rows. Filter with `--category` and group with `--group-by category`. |
 | `camp workitem create --json` | `workitem-create/v1alpha1` | Create response with next-step hint. |
 | `camp workitem link --json` | `workitem-links/v1alpha1` | Emits one `link`. |
 | `camp workitem unlink --json` | `workitem-links/v1alpha1` | Emits `removed`. |
@@ -43,9 +43,9 @@ Schema versions in this release:
 | `camp sync --json` | `sync/v1alpha1` | Existing sync result shape; returned failures use the JSON error envelope. |
 | `camp worktrees info --json` | `worktrees-info/v1alpha1` | Deprecated compatibility surface; failures use the JSON error envelope. |
 | `camp worktrees list --json` | `worktrees-list/v1alpha1` | Deprecated compatibility surface; failures use the JSON error envelope. |
-| `camp workflow create --json` | `workflow/v1` | Existing workflow collection contract. |
-| `camp workflow list --json` | `workflow/v1` | Existing workflow collection contract. |
-| `camp workflow show --json` | `workflow/v1` | Existing workflow collection contract. |
+| `camp workflow create --json` | `workflow/v1` | Workflow collection contract; `category` object reports the planned `category_by_type` mapping. |
+| `camp workflow list --json` | `workflow/v1` | Workflow collection contract; each entry includes its `category`. |
+| `camp workflow show --json` | `workflow/v1` | Workflow collection contract; includes the collection `category`. |
 | `camp workflow shortcut add --json` | `workflow/v1` | Existing workflow collection contract. |
 | `camp workflow doctor --json` | `workflow/v1` | Emits findings; exits 2 when error findings exist. |
 | `camp workflow sync --json` | `workflow/v1` | Existing workflow repair-plan contract. |

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -41,7 +41,7 @@ completion.
 ### 1. Create
 
 ```
-camp workflow create research --shortcut re --title "Research"
+camp workflow create research --shortcut re --title "Research" --category research
 ```
 
 Output on first run:
@@ -50,9 +50,15 @@ Output on first run:
 created workflow/research
   shortcut: re -> workflow/research/
   workitem type: research
+  category: research
   dungeon dirs: dungeon/completed/, dungeon/archived/, dungeon/someday/
 next: camp workitem create <slug> --type research
 ```
+
+`--category` sets the workflow category (default `plan`). The category must
+already exist under `workflows.categories` in `campaign.yaml` (shipped:
+`plan`, `research`, `pipeline`, `review`); unknown categories are rejected. On
+apply it writes `workflows.category_by_type.<type>`.
 
 What `create` writes:
 
@@ -86,9 +92,9 @@ camp workflow list
 ```
 
 ```
-TYPE        SHORTCUT  ITEMS  UPDATED
-research    re        4      2026-05-20T14:32:00Z
-feature     fe        12     2026-05-22T09:01:00Z
+TYPE        CATEGORY  SHORTCUT  ITEMS  UPDATED
+research    research  re        4      2026-05-20T14:32:00Z
+feature     plan      fe        12     2026-05-22T09:01:00Z
 ```
 
 Lists every user-created workflow collection. Builtin types (`intent`, `design`,

--- a/internal/commands/workflow/create.go
+++ b/internal/commands/workflow/create.go
@@ -24,7 +24,7 @@ var terminalDungeonDirs = []string{
 }
 
 func newCreateCommand() *cobra.Command {
-	var shortcut, title string
+	var shortcut, title, category string
 	var replace, dryRun, jsonOut bool
 
 	cmd := &cobra.Command{
@@ -43,6 +43,7 @@ machine-readable planning or apply results.`,
 				Type:     args[0],
 				Shortcut: shortcut,
 				Title:    title,
+				Category: category,
 				Replace:  replace,
 				DryRun:   dryRun,
 				JSON:     jsonOut,
@@ -53,6 +54,7 @@ machine-readable planning or apply results.`,
 
 	cmd.Flags().StringVar(&shortcut, "shortcut", "", "navigation shortcut for this workflow")
 	cmd.Flags().StringVar(&title, "title", "", "human-readable workflow title")
+	cmd.Flags().StringVar(&category, "category", "", "workflow category for filtering (default plan; must exist under workflows.categories in campaign.yaml)")
 	cmd.Flags().BoolVar(&replace, "replace", false, "replace an existing shortcut or concept with the same name")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "report planned writes without modifying the filesystem")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a structured JSON result")
@@ -64,6 +66,7 @@ type createOptions struct {
 	Type     string
 	Shortcut string
 	Title    string
+	Category string
 	Replace  bool
 	DryRun   bool
 	JSON     bool
@@ -75,6 +78,14 @@ type shortcutPlan struct {
 	Path     string `json:"path"`
 	Existing string `json:"existing,omitempty"`
 	Replaced bool   `json:"replaced"`
+	NoChange bool   `json:"no_change"`
+}
+
+// categoryPlan describes the planned mutation to the workflow category mapping
+// (workflows.category_by_type.<type>).
+type categoryPlan struct {
+	Category string `json:"category"`
+	Existing string `json:"existing,omitempty"`
 	NoChange bool   `json:"no_change"`
 }
 
@@ -102,6 +113,7 @@ type createPlan struct {
 
 	Shortcut shortcutPlan
 	Concept  conceptPlan
+	Category categoryPlan
 
 	Replaced  []string // shortcut keys removed under --replace (e.g. case variants)
 	NoChanges bool     // every action would be a no-op

--- a/internal/commands/workflow/create.go
+++ b/internal/commands/workflow/create.go
@@ -81,8 +81,7 @@ type shortcutPlan struct {
 	NoChange bool   `json:"no_change"`
 }
 
-// categoryPlan describes the planned mutation to the workflow category mapping
-// (workflows.category_by_type.<type>).
+// categoryPlan describes the planned category_by_type mutation.
 type categoryPlan struct {
 	Category string `json:"category"`
 	Existing string `json:"existing,omitempty"`

--- a/internal/commands/workflow/create_apply.go
+++ b/internal/commands/workflow/create_apply.go
@@ -39,7 +39,22 @@ func applyCreatePlan(ctx context.Context, cmd *cobra.Command, campaignRoot strin
 	if err := upsertConcept(ctx, campaignRoot, cfg, plan.Type, plan.WorkflowRel, plan.Title, plan.Concept.Replaced); err != nil {
 		return err
 	}
+	if !plan.Category.NoChange {
+		if err := upsertCategoryMapping(ctx, campaignRoot, cfg, plan.Type, plan.Category.Category); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// upsertCategoryMapping records workflows.category_by_type.<type> = category in
+// campaign.yaml so the collection's workitems classify under that category.
+func upsertCategoryMapping(ctx context.Context, campaignRoot string, cfg *config.CampaignConfig, workflowType, category string) error {
+	if cfg.Workflows.CategoryByType == nil {
+		cfg.Workflows.CategoryByType = make(map[string]string)
+	}
+	cfg.Workflows.CategoryByType[workflowType] = category
+	return config.SaveCampaignConfig(ctx, campaignRoot, cfg)
 }
 
 func writeWorkflowScaffold(plan *createPlan) error {

--- a/internal/commands/workflow/create_apply.go
+++ b/internal/commands/workflow/create_apply.go
@@ -47,8 +47,6 @@ func applyCreatePlan(ctx context.Context, cmd *cobra.Command, campaignRoot strin
 	return nil
 }
 
-// upsertCategoryMapping records workflows.category_by_type.<type> = category in
-// campaign.yaml so the collection's workitems classify under that category.
 func upsertCategoryMapping(ctx context.Context, campaignRoot string, cfg *config.CampaignConfig, workflowType, category string) error {
 	if cfg.Workflows.CategoryByType == nil {
 		cfg.Workflows.CategoryByType = make(map[string]string)

--- a/internal/commands/workflow/create_emit.go
+++ b/internal/commands/workflow/create_emit.go
@@ -47,6 +47,9 @@ func emitCreateHuman(cmd *cobra.Command, plan *createPlan, opts createOptions) e
 	if _, err := fmt.Fprintf(w, "  workitem type: %s\n", plan.Type); err != nil {
 		return err
 	}
+	if _, err := fmt.Fprintf(w, "  category: %s\n", plan.Category.Category); err != nil {
+		return err
+	}
 	if _, err := fmt.Fprintf(w, "  dungeon dirs: %s\n", strings.Join(statusDirsForOutput(), ", ")); err != nil {
 		return err
 	}
@@ -116,6 +119,15 @@ func planActionLines(plan *createPlan) []string {
 		lines = append(lines, "create concept "+plan.Concept.Name+" -> "+plan.Concept.Path)
 	}
 
+	switch {
+	case plan.Category.NoChange:
+		lines = append(lines, "no-op category "+plan.Type+" -> "+plan.Category.Category)
+	case plan.Category.Existing != "":
+		lines = append(lines, "update category "+plan.Type+" -> "+plan.Category.Category+" (was "+plan.Category.Existing+")")
+	default:
+		lines = append(lines, "map category "+plan.Type+" -> "+plan.Category.Category)
+	}
+
 	for _, key := range plan.Replaced {
 		lines = append(lines, "remove shortcut "+key+" (replaced under --replace)")
 	}
@@ -134,6 +146,7 @@ func emitCreateJSON(cmd *cobra.Command, plan *createPlan, opts createOptions) er
 		OBEYWritten   bool         `json:"obey_written"`
 		Shortcut      shortcutPlan `json:"shortcut"`
 		Concept       conceptPlan  `json:"concept"`
+		Category      categoryPlan `json:"category"`
 		Replaced      []string     `json:"replaced"`
 		NoChanges     bool         `json:"no_changes"`
 		DryRun        bool         `json:"dry_run"`
@@ -148,6 +161,7 @@ func emitCreateJSON(cmd *cobra.Command, plan *createPlan, opts createOptions) er
 		OBEYWritten:   plan.OBEYWrite && !opts.DryRun,
 		Shortcut:      plan.Shortcut,
 		Concept:       plan.Concept,
+		Category:      plan.Category,
 		Replaced:      append([]string(nil), plan.Replaced...),
 		NoChanges:     plan.NoChanges,
 		DryRun:        opts.DryRun,

--- a/internal/commands/workflow/create_flags_test.go
+++ b/internal/commands/workflow/create_flags_test.go
@@ -46,6 +46,55 @@ func TestRunCreateDefaultOutputMatchesGolden(t *testing.T) {
 	}
 }
 
+func TestRunCreateWritesCategoryMapping(t *testing.T) {
+	root := newWorkflowTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := runCreate(context.Background(), cmd, createOptions{
+		Type:     "interviews",
+		Shortcut: "iv",
+		Title:    "Interviews",
+		Category: "research",
+	}); err != nil {
+		t.Fatalf("runCreate: %v", err)
+	}
+
+	cfg, _, err := config.LoadCampaignConfigFromCwd(context.Background())
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if got := cfg.WorkflowCategoryForType("interviews"); got != "research" {
+		t.Fatalf("category for interviews = %q, want research", got)
+	}
+	if got := cfg.Workflows.CategoryByType["interviews"]; got != "research" {
+		t.Fatalf("category_by_type[interviews] = %q, want research", got)
+	}
+}
+
+func TestRunCreateRejectsUnknownCategory(t *testing.T) {
+	root := newWorkflowTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := runCreate(context.Background(), cmd, createOptions{
+		Type:     "interviews",
+		Shortcut: "iv",
+		Category: "bogus",
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown category, got nil")
+	}
+}
+
 func TestRunCreateScaffoldsTerminalDungeonDirsWithGitkeep(t *testing.T) {
 	root := newWorkflowTestCampaign(t)
 	restore := chdir(t, root)

--- a/internal/commands/workflow/create_plan.go
+++ b/internal/commands/workflow/create_plan.go
@@ -68,6 +68,9 @@ func computeCreatePlan(campaignRoot string, cfg *config.CampaignConfig, opts cre
 	if err := planConcept(cfg, plan, opts); err != nil {
 		return nil, err
 	}
+	if err := planCategory(cfg, plan, opts); err != nil {
+		return nil, err
+	}
 
 	plan.NoChanges = !plan.WorkflowDirCreate &&
 		len(plan.MissingScaffoldDirs) == 0 &&
@@ -75,9 +78,33 @@ func computeCreatePlan(campaignRoot string, cfg *config.CampaignConfig, opts cre
 		!plan.OBEYWrite &&
 		plan.Shortcut.NoChange &&
 		plan.Concept.NoChange &&
+		plan.Category.NoChange &&
 		len(plan.Replaced) == 0
 
 	return plan, nil
+}
+
+// planCategory resolves the workflow category (default plan) and plans the
+// workflows.category_by_type.<type> mapping. The category must already exist in
+// the effective vocabulary (defaults plus user config); unknown categories are
+// rejected to prevent typo-taxonomy rather than silently created.
+func planCategory(cfg *config.CampaignConfig, plan *createPlan, opts createOptions) error {
+	category := opts.Category
+	if category == "" {
+		category = config.WorkflowCategoryPlan
+	}
+	if _, ok := cfg.WorkflowCategories()[category]; !ok {
+		return camperrors.NewValidation("category",
+			"unknown category "+category+"; define it under workflows.categories in campaign.yaml or use one of: "+strings.Join(cfg.OrderedWorkflowCategoryKeys(), ", "), nil)
+	}
+
+	plan.Category.Category = category
+	existing, ok := cfg.Workflows.CategoryByType[opts.Type]
+	if ok {
+		plan.Category.Existing = existing
+	}
+	plan.Category.NoChange = ok && existing == category
+	return nil
 }
 
 func planShortcut(cfg *config.CampaignConfig, plan *createPlan, opts createOptions) error {

--- a/internal/commands/workflow/create_plan.go
+++ b/internal/commands/workflow/create_plan.go
@@ -84,10 +84,6 @@ func computeCreatePlan(campaignRoot string, cfg *config.CampaignConfig, opts cre
 	return plan, nil
 }
 
-// planCategory resolves the workflow category (default plan) and plans the
-// workflows.category_by_type.<type> mapping. The category must already exist in
-// the effective vocabulary (defaults plus user config); unknown categories are
-// rejected to prevent typo-taxonomy rather than silently created.
 func planCategory(cfg *config.CampaignConfig, plan *createPlan, opts createOptions) error {
 	category := opts.Category
 	if category == "" {

--- a/internal/commands/workflow/internal.go
+++ b/internal/commands/workflow/internal.go
@@ -37,6 +37,7 @@ type workflowEntry struct {
 	Type          string
 	Path          string // relative, with trailing slash, e.g. "workflow/research/"
 	Title         string
+	Category      string
 	HasConcept    bool
 	HasDir        bool
 	ShortcutKey   string
@@ -116,6 +117,7 @@ func enumerateWorkflowEntries(campaignRoot string, cfg *config.CampaignConfig) (
 
 	shortcuts := cfg.Shortcuts()
 	for _, entry := range entries {
+		entry.Category = cfg.WorkflowCategoryForType(entry.Type)
 		if key, ok := findShortcutByPath(shortcuts, entry.Path); ok {
 			entry.HasShortcut = true
 			entry.ShortcutKey = key

--- a/internal/commands/workflow/list.go
+++ b/internal/commands/workflow/list.go
@@ -63,7 +63,7 @@ func emitListHuman(w io.Writer, entries []workflowEntry) error {
 		return err
 	}
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	if _, err := fmt.Fprintln(tw, "TYPE\tSHORTCUT\tITEMS\tUPDATED"); err != nil {
+	if _, err := fmt.Fprintln(tw, "TYPE\tCATEGORY\tSHORTCUT\tITEMS\tUPDATED"); err != nil {
 		return err
 	}
 	for _, e := range entries {
@@ -71,11 +71,15 @@ func emitListHuman(w io.Writer, entries []workflowEntry) error {
 		if shortcut == "" {
 			shortcut = "-"
 		}
+		category := e.Category
+		if category == "" {
+			category = "-"
+		}
 		updated := "-"
 		if !e.LastModified.IsZero() {
 			updated = e.LastModified.Format(time.RFC3339)
 		}
-		if _, err := fmt.Fprintf(tw, "%s\t%s\t%d\t%s\n", e.Type, shortcut, e.WorkitemCount, updated); err != nil {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\n", e.Type, category, shortcut, e.WorkitemCount, updated); err != nil {
 			return err
 		}
 	}
@@ -85,6 +89,7 @@ func emitListHuman(w io.Writer, entries []workflowEntry) error {
 type listJSONEntry struct {
 	Type          string    `json:"type"`
 	Path          string    `json:"path"`
+	Category      string    `json:"category,omitempty"`
 	Shortcut      string    `json:"shortcut,omitempty"`
 	WorkitemCount int       `json:"workitem_count"`
 	HasConcept    bool      `json:"has_concept"`
@@ -107,6 +112,7 @@ func emitListJSON(w io.Writer, entries []workflowEntry) error {
 		out.Workflows = append(out.Workflows, listJSONEntry{
 			Type:          e.Type,
 			Path:          e.Path,
+			Category:      e.Category,
 			Shortcut:      e.ShortcutKey,
 			WorkitemCount: e.WorkitemCount,
 			HasConcept:    e.HasConcept,

--- a/internal/commands/workflow/show.go
+++ b/internal/commands/workflow/show.go
@@ -165,6 +165,11 @@ func emitShowHuman(w io.Writer, entry workflowEntry, recent []recentItem) error 
 	if _, err := fmt.Fprintf(w, "  path: %s\n", entry.Path); err != nil {
 		return err
 	}
+	if entry.Category != "" {
+		if _, err := fmt.Fprintf(w, "  category: %s\n", entry.Category); err != nil {
+			return err
+		}
+	}
 	if entry.HasShortcut {
 		if _, err := fmt.Fprintf(w, "  shortcut: %s -> %s\n", entry.ShortcutKey, entry.ShortcutPath); err != nil {
 			return err
@@ -206,6 +211,7 @@ func emitShowJSON(w io.Writer, entry workflowEntry, recent []recentItem) error {
 		Type          string       `json:"type"`
 		Title         string       `json:"title,omitempty"`
 		Path          string       `json:"path"`
+		Category      string       `json:"category,omitempty"`
 		Shortcut      string       `json:"shortcut,omitempty"`
 		ShortcutPath  string       `json:"shortcut_path,omitempty"`
 		HasConcept    bool         `json:"has_concept"`
@@ -219,6 +225,7 @@ func emitShowJSON(w io.Writer, entry workflowEntry, recent []recentItem) error {
 		Type:          entry.Type,
 		Title:         entry.Title,
 		Path:          entry.Path,
+		Category:      entry.Category,
 		Shortcut:      entry.ShortcutKey,
 		ShortcutPath:  entry.ShortcutPath,
 		HasConcept:    entry.HasConcept,

--- a/internal/commands/workflow/testdata/create_research_human.golden
+++ b/internal/commands/workflow/testdata/create_research_human.golden
@@ -1,5 +1,6 @@
 created workflow/research
   shortcut: re -> workflow/research/
   workitem type: research
+  category: plan
   dungeon dirs: dungeon/completed/, dungeon/archived/, dungeon/someday/
 next: camp workitem create <slug> --type research

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -127,11 +127,11 @@ Examples:
 				}
 				return outputSelectedPath(items[0], flagPrint, flagPathOutput)
 			case flagPathOutput != "":
-				return runTUI(ctx, items, false, flagPathOutput, campaignRoot, resolver, store, storePath, flagShowParked)
+				return runTUI(ctx, items, false, flagPathOutput, campaignRoot, resolver, store, storePath, flagShowParked, cfg.WorkflowCategoryForType)
 			case flagPrint:
-				return runTUI(ctx, items, true, "", campaignRoot, resolver, store, storePath, flagShowParked)
+				return runTUI(ctx, items, true, "", campaignRoot, resolver, store, storePath, flagShowParked, cfg.WorkflowCategoryForType)
 			default:
-				return runTUI(ctx, items, false, "", campaignRoot, resolver, store, storePath, flagShowParked)
+				return runTUI(ctx, items, false, "", campaignRoot, resolver, store, storePath, flagShowParked, cfg.WorkflowCategoryForType)
 			}
 		}),
 	}
@@ -325,12 +325,13 @@ func categoryVocabulary(cfg *config.CampaignConfig) []wkitem.CategoryVocabEntry 
 	return out
 }
 
-func runTUI(ctx context.Context, items []wkitem.WorkItem, printOnly bool, pathOutput string, campaignRoot string, resolver *paths.Resolver, store *priority.Store, storePath string, showParked bool) error {
+func runTUI(ctx context.Context, items []wkitem.WorkItem, printOnly bool, pathOutput string, campaignRoot string, resolver *paths.Resolver, store *priority.Store, storePath string, showParked bool, categoryForType func(string) string) error {
 	if len(items) == 0 {
 		return fmt.Errorf("no work items found")
 	}
 
 	model := wktui.New(ctx, items, campaignRoot, resolver, store, storePath, showParked)
+	model.SetCategoryResolver(categoryForType)
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	result, err := p.Run()
 	if err != nil {

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -29,6 +29,7 @@ func NewWorkitemCommand() *cobra.Command {
 		flagPrint           bool
 		flagPathOutput      string
 		flagTypes           []string
+		flagCategories      []string
 		flagStages          []string
 		flagAttentionStages []string
 		flagGroups          []string
@@ -60,7 +61,7 @@ Examples:
 		RunE: jsoncontract.RunE(wkitem.SchemaVersion, func() bool { return flagJSON }, func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
-			if err := validateFlags(flagJSON, flagList, flagPrint, flagPathOutput, flagTypes, flagStages, flagAttentionStages, flagGroups, flagGroupBy); err != nil {
+			if err := validateFlags(flagJSON, flagList, flagPrint, flagPathOutput, flagTypes, flagCategories, flagStages, flagAttentionStages, flagGroups, flagGroupBy); err != nil {
 				return err
 			}
 
@@ -83,6 +84,7 @@ Examples:
 			if err != nil {
 				return camperrors.Wrap(err, "discovering work items")
 			}
+			items = wkitem.ApplyWorkflowCategories(items, cfg.WorkflowCategoryForType)
 
 			// Load priority store read-only; pruning happens only in explicit write paths.
 			storePath := priority.StorePath(campaignRoot)
@@ -97,6 +99,7 @@ Examples:
 
 			items = wkitem.FilterAdvanced(items, wkitem.FilterOptions{
 				Types:           flagTypes,
+				Categories:      flagCategories,
 				LifecycleStages: flagStages,
 				AttentionStages: flagAttentionStages,
 				Groups:          flagGroups,
@@ -116,7 +119,7 @@ Examples:
 			case flagList:
 				return outputList(cmd.OutOrStdout(), items, displayGroupBy)
 			case flagJSON:
-				return outputJSON(campaignRoot, items, displayGroupBy)
+				return outputJSON(campaignRoot, cfg, items, displayGroupBy)
 			case !interactive:
 				// Non-interactive --print/--path-output: output first item path directly.
 				if len(items) == 0 {
@@ -140,10 +143,11 @@ Examples:
 	cmd.Flags().StringVar(&flagPathOutput, "path-output", "", "Write selected relative path to file (shell integration)")
 	_ = cmd.Flags().MarkHidden("path-output")
 	cmd.Flags().StringArrayVar(&flagTypes, "type", nil, "Filter by workflow type (builtin: intent, design, explore, festival; or any slug-safe custom type produced by 'camp workitem create --type <name>')")
+	cmd.Flags().StringArrayVar(&flagCategories, "category", nil, "Filter by workflow category (builtin: plan, research, pipeline, review, uncategorized; or any category defined under workflows in campaign.yaml)")
 	cmd.Flags().StringArrayVar(&flagStages, "stage", nil, "Filter by lifecycle stage (none, inbox, active, ready, planning, ritual, chains)")
 	cmd.Flags().StringArrayVar(&flagAttentionStages, "attention-stage", nil, "Filter by attention stage (current, next, active, parked)")
 	cmd.Flags().StringArrayVar(&flagGroups, "group", nil, "Filter by workitem group")
-	cmd.Flags().StringVar(&flagGroupBy, "group-by", "attention_stage", "Group JSON/list sections by attention_stage, group, or type; --list defaults to group unless set")
+	cmd.Flags().StringVar(&flagGroupBy, "group-by", "attention_stage", "Group JSON/list sections by attention_stage, group, type, or category; --list defaults to group unless set")
 	cmd.Flags().BoolVar(&flagShowParked, "show-parked", false, "include parked attention-stage workitems in default output")
 	cmd.Flags().IntVar(&flagLimit, "limit", 0, "Maximum number of items to return")
 	cmd.Flags().StringVar(&flagQuery, "query", "", "Search query to filter items")
@@ -244,11 +248,17 @@ func isInteractive() bool {
 	return fi.Mode()&os.ModeCharDevice != 0
 }
 
-func validateFlags(jsonMode, listMode, printMode bool, pathOutput string, types, stages, attentionStages, groups []string, groupBy string) error {
+func validateFlags(jsonMode, listMode, printMode bool, pathOutput string, types, categories, stages, attentionStages, groups []string, groupBy string) error {
 	for _, t := range types {
 		if err := validateSlug(t); err != nil {
 			return camperrors.NewValidation("type",
 				fmt.Sprintf("invalid --type value %q: must be a path-safe workflow type (no '/', '\\', whitespace, or control chars; no leading '.' or '-'; max 80 chars)", t), nil)
+		}
+	}
+	for _, c := range categories {
+		if err := validateSlug(c); err != nil {
+			return camperrors.NewValidation("category",
+				fmt.Sprintf("invalid --category value %q: must be a path-safe workflow category (no '/', '\\', whitespace, or control chars; no leading '.' or '-'; max 80 chars)", c), nil)
 		}
 	}
 	for _, s := range stages {
@@ -270,10 +280,10 @@ func validateFlags(jsonMode, listMode, printMode bool, pathOutput string, types,
 		}
 	}
 	switch groupBy {
-	case "", "attention_stage", "group", "type":
+	case "", "attention_stage", "group", "type", "category":
 	default:
 		return camperrors.NewValidation("group_by",
-			fmt.Sprintf("unknown --group-by value %q (valid: attention_stage, group, type)", groupBy), nil)
+			fmt.Sprintf("unknown --group-by value %q (valid: attention_stage, group, type, category)", groupBy), nil)
 	}
 	if jsonMode && printMode {
 		return camperrors.NewValidation("output_mode", "--json and --print are mutually exclusive", nil)
@@ -296,11 +306,23 @@ func validateFlags(jsonMode, listMode, printMode bool, pathOutput string, types,
 	return nil
 }
 
-func outputJSON(campaignRoot string, items []wkitem.WorkItem, groupBy string) error {
+func outputJSON(campaignRoot string, cfg *config.CampaignConfig, items []wkitem.WorkItem, groupBy string) error {
 	payload := wkitem.NewPayloadWithGrouping(campaignRoot, items, groupBy)
+	payload.CategoryVocabulary = categoryVocabulary(cfg)
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(payload)
+}
+
+func categoryVocabulary(cfg *config.CampaignConfig) []wkitem.CategoryVocabEntry {
+	cats := cfg.WorkflowCategories()
+	keys := cfg.OrderedWorkflowCategoryKeys()
+	out := make([]wkitem.CategoryVocabEntry, 0, len(keys))
+	for _, k := range keys {
+		c := cats[k]
+		out = append(out, wkitem.CategoryVocabEntry{Key: k, Label: c.Label, Description: c.Description})
+	}
+	return out
 }
 
 func runTUI(ctx context.Context, items []wkitem.WorkItem, printOnly bool, pathOutput string, campaignRoot string, resolver *paths.Resolver, store *priority.Store, storePath string, showParked bool) error {

--- a/internal/commands/workitem/workitem_test.go
+++ b/internal/commands/workitem/workitem_test.go
@@ -80,19 +80,19 @@ func TestSelectedOpenPathUsesPrimaryDoc(t *testing.T) {
 }
 
 func TestValidateFlagsAcceptsStageNoneForNoStageTypes(t *testing.T) {
-	if err := validateFlags(true, false, false, "", []string{"design"}, []string{"none"}, nil, nil, "attention_stage"); err != nil {
+	if err := validateFlags(true, false, false, "", []string{"design"}, nil, []string{"none"}, nil, nil, "attention_stage"); err != nil {
 		t.Fatalf("validateFlags(design, none) error = %v", err)
 	}
-	if err := validateFlags(true, false, false, "", []string{"explore"}, []string{"none"}, nil, nil, "attention_stage"); err != nil {
+	if err := validateFlags(true, false, false, "", []string{"explore"}, nil, []string{"none"}, nil, nil, "attention_stage"); err != nil {
 		t.Fatalf("validateFlags(explore, none) error = %v", err)
 	}
 }
 
 func TestValidateFlagsRejectsStageForWrongType(t *testing.T) {
-	if err := validateFlags(true, false, false, "", []string{"intent"}, []string{"planning"}, nil, nil, "attention_stage"); err == nil {
+	if err := validateFlags(true, false, false, "", []string{"intent"}, nil, []string{"planning"}, nil, nil, "attention_stage"); err == nil {
 		t.Fatal("validateFlags(intent, planning) error = nil, want invalid stage")
 	}
-	if err := validateFlags(true, false, false, "", []string{"design"}, []string{"inbox"}, nil, nil, "attention_stage"); err == nil {
+	if err := validateFlags(true, false, false, "", []string{"design"}, nil, []string{"inbox"}, nil, nil, "attention_stage"); err == nil {
 		t.Fatal("validateFlags(design, inbox) error = nil, want invalid stage")
 	}
 }
@@ -264,7 +264,7 @@ func TestValidateFlagsAcceptsBuiltinAndCustomTypes(t *testing.T) {
 	}
 	for _, tname := range cases {
 		t.Run(tname, func(t *testing.T) {
-			if err := validateFlags(false, false, false, "", []string{tname}, nil, nil, nil, "attention_stage"); err != nil {
+			if err := validateFlags(false, false, false, "", []string{tname}, nil, nil, nil, nil, "attention_stage"); err != nil {
 				t.Fatalf("validateFlags(--type=%q) = %v, want nil", tname, err)
 			}
 		})
@@ -275,7 +275,7 @@ func TestValidateFlagsRejectsInvalidTypeSlugs(t *testing.T) {
 	cases := []string{"with space", "has/slash", "-leading", ".hidden", ""}
 	for _, tname := range cases {
 		t.Run(tname, func(t *testing.T) {
-			if err := validateFlags(false, false, false, "", []string{tname}, nil, nil, nil, "attention_stage"); err == nil {
+			if err := validateFlags(false, false, false, "", []string{tname}, nil, nil, nil, nil, "attention_stage"); err == nil {
 				t.Fatalf("validateFlags(--type=%q) = nil, want validation error", tname)
 			}
 		})
@@ -294,7 +294,7 @@ func TestValidateFlagsRejectsPathOutputConflicts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateFlags(tt.jsonMode, false, tt.printMode, "selected-path", nil, nil, nil, nil, "attention_stage")
+			err := validateFlags(tt.jsonMode, false, tt.printMode, "selected-path", nil, nil, nil, nil, nil, "attention_stage")
 			if err == nil {
 				t.Fatal("validateFlags() error = nil, want conflict")
 			}
@@ -316,7 +316,7 @@ func TestValidateFlagsRejectsListConflicts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateFlags(tt.jsonMode, true, tt.printMode, tt.pathOutput, nil, nil, nil, nil, "attention_stage")
+			err := validateFlags(tt.jsonMode, true, tt.printMode, tt.pathOutput, nil, nil, nil, nil, nil, "attention_stage")
 			if err == nil {
 				t.Fatal("validateFlags() error = nil, want conflict")
 			}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -43,6 +43,8 @@ type CampaignConfig struct {
 	Hooks HooksConfig `yaml:"hooks,omitempty"`
 	// Intents holds intent-specific campaign settings (e.g. the tag list).
 	Intents IntentsConfig `yaml:"intents,omitempty"`
+	// Workflows holds the campaign workflow-category taxonomy.
+	Workflows WorkflowsConfig `yaml:"workflows,omitempty"`
 
 	// Jumps holds the loaded jumps configuration (from .campaign/settings/jumps.yaml).
 	// This field is not serialized to campaign.yaml - it's loaded separately.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -42,6 +42,10 @@ func ValidateCampaignConfig(cfg *CampaignConfig) error {
 		}
 	}
 
+	if err := ValidateWorkflowsConfig(&cfg.Workflows); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/config/workflows.go
+++ b/internal/config/workflows.go
@@ -65,6 +65,25 @@ func DefaultWorkflowCategoryByType() map[string]string {
 	}
 }
 
+// DefaultWorkflowsConfig returns the workflows block written into a fresh
+// campaign.yaml (and backfilled by init --repair). It ships the full category
+// vocabulary plus explicit mappings for camp's own built-in types so the block
+// is a readable, editable starting point. Custom types default to
+// WorkflowCategoryUncategorized via WorkflowCategoryForType until mapped.
+func DefaultWorkflowsConfig() WorkflowsConfig {
+	return WorkflowsConfig{
+		Categories: DefaultWorkflowCategories(),
+		CategoryByType: map[string]string{
+			"intent":       WorkflowCategoryPlan,
+			"design":       WorkflowCategoryPlan,
+			"explore":      WorkflowCategoryResearch,
+			"festival":     WorkflowCategoryPlan,
+			"code_reviews": WorkflowCategoryReview,
+			"pipelines":    WorkflowCategoryPipeline,
+		},
+	}
+}
+
 // WorkflowCategories returns the effective category vocabulary: built-in
 // defaults merged with, and overridden by, user categories. It never mutates
 // the loaded config.

--- a/internal/config/workflows.go
+++ b/internal/config/workflows.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"maps"
+	"sort"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/pathutil"
+)
+
+const (
+	WorkflowCategoryPlan     = "plan"
+	WorkflowCategoryResearch = "research"
+	WorkflowCategoryPipeline = "pipeline"
+	WorkflowCategoryReview   = "review"
+
+	WorkflowCategoryUncategorized = "uncategorized"
+)
+
+// WorkflowsConfig is the campaign workflow-category taxonomy stored under the
+// `workflows:` block in .campaign/campaign.yaml. Categories classify workflow
+// and workitem type keys into broad families so camp workitem, the TUI, and
+// downstream consumers can filter and group by kind of work without changing
+// the workitem type contract.
+type WorkflowsConfig struct {
+	Categories     map[string]WorkflowCategoryConfig `yaml:"categories,omitempty"`
+	CategoryByType map[string]string                 `yaml:"category_by_type,omitempty"`
+}
+
+// WorkflowCategoryConfig is the display metadata for a single category.
+type WorkflowCategoryConfig struct {
+	Label       string `yaml:"label,omitempty"`
+	Description string `yaml:"description,omitempty"`
+}
+
+// DefaultWorkflowCategories returns the built-in category vocabulary. The set is
+// intentionally generic so any custom workflow type can be mapped into one of it.
+func DefaultWorkflowCategories() map[string]WorkflowCategoryConfig {
+	return map[string]WorkflowCategoryConfig{
+		WorkflowCategoryPlan:     {Label: "Plan", Description: "Planning, design, intents, festivals, and structured execution work"},
+		WorkflowCategoryResearch: {Label: "Research", Description: "Exploration, comparison, discovery, and investigation"},
+		WorkflowCategoryPipeline: {Label: "Pipeline", Description: "Structured campaign data movement, compilation, ingestion, or export"},
+		WorkflowCategoryReview:   {Label: "Review", Description: "Review-style work such as code reviews and quality passes"},
+	}
+}
+
+// DefaultWorkflowCategoryByType returns the built-in type->category mapping.
+// Common `camp workitem create` types (feature, bug, chore) are included so
+// freshly created items are not uncategorized.
+func DefaultWorkflowCategoryByType() map[string]string {
+	return map[string]string{
+		"intent":       WorkflowCategoryPlan,
+		"design":       WorkflowCategoryPlan,
+		"explore":      WorkflowCategoryResearch,
+		"festival":     WorkflowCategoryPlan,
+		"feature":      WorkflowCategoryPlan,
+		"bug":          WorkflowCategoryPlan,
+		"chore":        WorkflowCategoryPlan,
+		"code_reviews": WorkflowCategoryReview,
+		"review":       WorkflowCategoryReview,
+		"pipeline":     WorkflowCategoryPipeline,
+		"pipelines":    WorkflowCategoryPipeline,
+		"research":     WorkflowCategoryResearch,
+		"experiment":   WorkflowCategoryResearch,
+	}
+}
+
+// WorkflowCategories returns the effective category vocabulary: built-in
+// defaults merged with, and overridden by, user categories. It never mutates
+// the loaded config.
+func (c *CampaignConfig) WorkflowCategories() map[string]WorkflowCategoryConfig {
+	merged := DefaultWorkflowCategories()
+	maps.Copy(merged, c.Workflows.Categories)
+	return merged
+}
+
+// WorkflowCategoryForType returns the category key for a workflow type. User
+// mappings take precedence over defaults; unmapped types return
+// WorkflowCategoryUncategorized.
+func (c *CampaignConfig) WorkflowCategoryForType(workflowType string) string {
+	if cat, ok := c.Workflows.CategoryByType[workflowType]; ok && cat != "" {
+		return cat
+	}
+	if cat, ok := DefaultWorkflowCategoryByType()[workflowType]; ok {
+		return cat
+	}
+	return WorkflowCategoryUncategorized
+}
+
+// OrderedWorkflowCategoryKeys returns category keys in a deterministic order:
+// the built-in defaults first (plan, research, pipeline, review), then any
+// custom categories alphabetically.
+func (c *CampaignConfig) OrderedWorkflowCategoryKeys() []string {
+	ordered := []string{WorkflowCategoryPlan, WorkflowCategoryResearch, WorkflowCategoryPipeline, WorkflowCategoryReview}
+	seen := make(map[string]bool, len(ordered))
+	for _, k := range ordered {
+		seen[k] = true
+	}
+	var custom []string
+	for k := range c.WorkflowCategories() {
+		if !seen[k] {
+			custom = append(custom, k)
+		}
+	}
+	sort.Strings(custom)
+	return append(ordered, custom...)
+}
+
+// ValidateWorkflowsConfig validates the workflows block. Category keys and
+// mapped type keys must be slug-safe (same contract as workitem types). Each
+// category_by_type value must resolve to a category that exists in the effective
+// (default plus user) vocabulary. Unknown type keys are allowed so a type can be
+// mapped before any matching workitem exists.
+func ValidateWorkflowsConfig(cfg *WorkflowsConfig) error {
+	if cfg == nil {
+		return nil
+	}
+
+	for _, key := range sortedKeys(cfg.Categories) {
+		if err := pathutil.ValidateSegment("workflow category", key); err != nil {
+			return err
+		}
+	}
+
+	effective := DefaultWorkflowCategories()
+	maps.Copy(effective, cfg.Categories)
+
+	for _, typeKey := range sortedKeys(cfg.CategoryByType) {
+		if err := pathutil.ValidateSegment("workflow type", typeKey); err != nil {
+			return err
+		}
+		cat := cfg.CategoryByType[typeKey]
+		if err := pathutil.ValidateSegment("workflow category", cat); err != nil {
+			return err
+		}
+		if _, ok := effective[cat]; !ok {
+			return camperrors.NewValidation("category_by_type",
+				"type "+typeKey+" maps to unknown category "+cat, nil)
+		}
+	}
+	return nil
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/config/workflows.go
+++ b/internal/config/workflows.go
@@ -17,24 +17,16 @@ const (
 	WorkflowCategoryUncategorized = "uncategorized"
 )
 
-// WorkflowsConfig is the campaign workflow-category taxonomy stored under the
-// `workflows:` block in .campaign/campaign.yaml. Categories classify workflow
-// and workitem type keys into broad families so camp workitem, the TUI, and
-// downstream consumers can filter and group by kind of work without changing
-// the workitem type contract.
 type WorkflowsConfig struct {
 	Categories     map[string]WorkflowCategoryConfig `yaml:"categories,omitempty"`
 	CategoryByType map[string]string                 `yaml:"category_by_type,omitempty"`
 }
 
-// WorkflowCategoryConfig is the display metadata for a single category.
 type WorkflowCategoryConfig struct {
 	Label       string `yaml:"label,omitempty"`
 	Description string `yaml:"description,omitempty"`
 }
 
-// DefaultWorkflowCategories returns the built-in category vocabulary. The set is
-// intentionally generic so any custom workflow type can be mapped into one of it.
 func DefaultWorkflowCategories() map[string]WorkflowCategoryConfig {
 	return map[string]WorkflowCategoryConfig{
 		WorkflowCategoryPlan:     {Label: "Plan", Description: "Planning, design, intents, festivals, and structured execution work"},
@@ -44,9 +36,6 @@ func DefaultWorkflowCategories() map[string]WorkflowCategoryConfig {
 	}
 }
 
-// DefaultWorkflowCategoryByType maps camp's shipped workflow types to categories.
-// Only types that ship with camp are mapped; every other type (custom workflow
-// collections, etc.) is uncategorized until the user maps it.
 func DefaultWorkflowCategoryByType() map[string]string {
 	return map[string]string{
 		"intent":       WorkflowCategoryPlan,
@@ -58,10 +47,6 @@ func DefaultWorkflowCategoryByType() map[string]string {
 	}
 }
 
-// DefaultWorkflowsConfig is the workflows block written by camp init and
-// backfilled by init --repair: the category vocabulary plus the shipped-type
-// mappings. It reuses DefaultWorkflowCategoryByType so there are no mappings
-// hidden from what init writes to campaign.yaml.
 func DefaultWorkflowsConfig() WorkflowsConfig {
 	return WorkflowsConfig{
 		Categories:     DefaultWorkflowCategories(),
@@ -69,18 +54,12 @@ func DefaultWorkflowsConfig() WorkflowsConfig {
 	}
 }
 
-// WorkflowCategories returns the effective category vocabulary: built-in
-// defaults merged with, and overridden by, user categories. It never mutates
-// the loaded config.
 func (c *CampaignConfig) WorkflowCategories() map[string]WorkflowCategoryConfig {
 	merged := DefaultWorkflowCategories()
 	maps.Copy(merged, c.Workflows.Categories)
 	return merged
 }
 
-// WorkflowCategoryForType returns the category key for a workflow type. User
-// mappings take precedence over defaults; unmapped types return
-// WorkflowCategoryUncategorized.
 func (c *CampaignConfig) WorkflowCategoryForType(workflowType string) string {
 	if cat, ok := c.Workflows.CategoryByType[workflowType]; ok && cat != "" {
 		return cat
@@ -91,9 +70,6 @@ func (c *CampaignConfig) WorkflowCategoryForType(workflowType string) string {
 	return WorkflowCategoryUncategorized
 }
 
-// OrderedWorkflowCategoryKeys returns category keys in a deterministic order:
-// the built-in defaults first (plan, research, pipeline, review), then any
-// custom categories alphabetically.
 func (c *CampaignConfig) OrderedWorkflowCategoryKeys() []string {
 	ordered := []string{WorkflowCategoryPlan, WorkflowCategoryResearch, WorkflowCategoryPipeline, WorkflowCategoryReview}
 	seen := make(map[string]bool, len(ordered))
@@ -110,11 +86,6 @@ func (c *CampaignConfig) OrderedWorkflowCategoryKeys() []string {
 	return append(ordered, custom...)
 }
 
-// ValidateWorkflowsConfig validates the workflows block. Category keys and
-// mapped type keys must be slug-safe (same contract as workitem types). Each
-// category_by_type value must resolve to a category that exists in the effective
-// (default plus user) vocabulary. Unknown type keys are allowed so a type can be
-// mapped before any matching workitem exists.
 func ValidateWorkflowsConfig(cfg *WorkflowsConfig) error {
 	if cfg == nil {
 		return nil

--- a/internal/config/workflows.go
+++ b/internal/config/workflows.go
@@ -44,43 +44,28 @@ func DefaultWorkflowCategories() map[string]WorkflowCategoryConfig {
 	}
 }
 
-// DefaultWorkflowCategoryByType returns the built-in type->category mapping.
-// Common `camp workitem create` types (feature, bug, chore) are included so
-// freshly created items are not uncategorized.
+// DefaultWorkflowCategoryByType maps camp's shipped workflow types to categories.
+// Only types that ship with camp are mapped; every other type (custom workflow
+// collections, etc.) is uncategorized until the user maps it.
 func DefaultWorkflowCategoryByType() map[string]string {
 	return map[string]string{
 		"intent":       WorkflowCategoryPlan,
 		"design":       WorkflowCategoryPlan,
 		"explore":      WorkflowCategoryResearch,
 		"festival":     WorkflowCategoryPlan,
-		"feature":      WorkflowCategoryPlan,
-		"bug":          WorkflowCategoryPlan,
-		"chore":        WorkflowCategoryPlan,
 		"code_reviews": WorkflowCategoryReview,
-		"review":       WorkflowCategoryReview,
-		"pipeline":     WorkflowCategoryPipeline,
 		"pipelines":    WorkflowCategoryPipeline,
-		"research":     WorkflowCategoryResearch,
-		"experiment":   WorkflowCategoryResearch,
 	}
 }
 
-// DefaultWorkflowsConfig returns the workflows block written into a fresh
-// campaign.yaml (and backfilled by init --repair). It ships the full category
-// vocabulary plus explicit mappings for camp's own built-in types so the block
-// is a readable, editable starting point. Custom types default to
-// WorkflowCategoryUncategorized via WorkflowCategoryForType until mapped.
+// DefaultWorkflowsConfig is the workflows block written by camp init and
+// backfilled by init --repair: the category vocabulary plus the shipped-type
+// mappings. It reuses DefaultWorkflowCategoryByType so there are no mappings
+// hidden from what init writes to campaign.yaml.
 func DefaultWorkflowsConfig() WorkflowsConfig {
 	return WorkflowsConfig{
-		Categories: DefaultWorkflowCategories(),
-		CategoryByType: map[string]string{
-			"intent":       WorkflowCategoryPlan,
-			"design":       WorkflowCategoryPlan,
-			"explore":      WorkflowCategoryResearch,
-			"festival":     WorkflowCategoryPlan,
-			"code_reviews": WorkflowCategoryReview,
-			"pipelines":    WorkflowCategoryPipeline,
-		},
+		Categories:     DefaultWorkflowCategories(),
+		CategoryByType: DefaultWorkflowCategoryByType(),
 	}
 }
 

--- a/internal/config/workflows_test.go
+++ b/internal/config/workflows_test.go
@@ -1,0 +1,161 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestCampaignConfigOmitsEmptyWorkflows(t *testing.T) {
+	cfg := DefaultCampaignConfig("test")
+	data, err := yaml.Marshal(&cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "workflows:") {
+		t.Fatalf("empty workflows should be omitted from campaign.yaml, got:\n%s", data)
+	}
+}
+
+func TestWorkflowCategoriesDefaults(t *testing.T) {
+	c := &CampaignConfig{}
+	got := c.WorkflowCategories()
+
+	for _, key := range []string{WorkflowCategoryPlan, WorkflowCategoryResearch, WorkflowCategoryPipeline, WorkflowCategoryReview} {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("expected default category %q present", key)
+		}
+	}
+	if got[WorkflowCategoryReview].Label != "Review" {
+		t.Fatalf("expected Review label, got %q", got[WorkflowCategoryReview].Label)
+	}
+}
+
+func TestWorkflowCategoriesUserOverride(t *testing.T) {
+	c := &CampaignConfig{
+		Workflows: WorkflowsConfig{
+			Categories: map[string]WorkflowCategoryConfig{
+				WorkflowCategoryPlan: {Label: "Build", Description: "custom"},
+				"ops":                {Label: "Ops"},
+			},
+		},
+	}
+	got := c.WorkflowCategories()
+
+	if got[WorkflowCategoryPlan].Label != "Build" {
+		t.Fatalf("expected user label to override default, got %q", got[WorkflowCategoryPlan].Label)
+	}
+	if got["ops"].Label != "Ops" {
+		t.Fatalf("expected custom category present")
+	}
+	if got[WorkflowCategoryResearch].Label != "Research" {
+		t.Fatalf("expected untouched default retained, got %q", got[WorkflowCategoryResearch].Label)
+	}
+}
+
+func TestWorkflowCategoryForType(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      WorkflowsConfig
+		typeKey  string
+		expected string
+	}{
+		{"builtin design", WorkflowsConfig{}, "design", WorkflowCategoryPlan},
+		{"builtin explore", WorkflowsConfig{}, "explore", WorkflowCategoryResearch},
+		{"builtin code_reviews", WorkflowsConfig{}, "code_reviews", WorkflowCategoryReview},
+		{"unknown type", WorkflowsConfig{}, "customthing", WorkflowCategoryUncategorized},
+		{
+			name:     "user override wins",
+			cfg:      WorkflowsConfig{CategoryByType: map[string]string{"design": WorkflowCategoryResearch}},
+			typeKey:  "design",
+			expected: WorkflowCategoryResearch,
+		},
+		{
+			name:     "user maps custom type",
+			cfg:      WorkflowsConfig{CategoryByType: map[string]string{"customthing": WorkflowCategoryReview}},
+			typeKey:  "customthing",
+			expected: WorkflowCategoryReview,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &CampaignConfig{Workflows: tt.cfg}
+			if got := c.WorkflowCategoryForType(tt.typeKey); got != tt.expected {
+				t.Fatalf("WorkflowCategoryForType(%q) = %q, want %q", tt.typeKey, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestOrderedWorkflowCategoryKeys(t *testing.T) {
+	c := &CampaignConfig{
+		Workflows: WorkflowsConfig{
+			Categories: map[string]WorkflowCategoryConfig{
+				"ops":   {Label: "Ops"},
+				"admin": {Label: "Admin"},
+			},
+		},
+	}
+	got := c.OrderedWorkflowCategoryKeys()
+	want := []string{WorkflowCategoryPlan, WorkflowCategoryResearch, WorkflowCategoryPipeline, WorkflowCategoryReview, "admin", "ops"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("OrderedWorkflowCategoryKeys() = %v, want %v", got, want)
+	}
+}
+
+func TestValidateWorkflowsConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *WorkflowsConfig
+		wantErr bool
+	}{
+		{"nil", nil, false},
+		{"empty", &WorkflowsConfig{}, false},
+		{
+			name:    "valid mapping to default category",
+			cfg:     &WorkflowsConfig{CategoryByType: map[string]string{"customthing": WorkflowCategoryResearch}},
+			wantErr: false,
+		},
+		{
+			name: "valid mapping to user category",
+			cfg: &WorkflowsConfig{
+				Categories:     map[string]WorkflowCategoryConfig{"ops": {Label: "Ops"}},
+				CategoryByType: map[string]string{"deploy": "ops"},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "mapping to unknown category",
+			cfg:     &WorkflowsConfig{CategoryByType: map[string]string{"deploy": "nope"}},
+			wantErr: true,
+		},
+		{
+			name:    "invalid category key",
+			cfg:     &WorkflowsConfig{Categories: map[string]WorkflowCategoryConfig{"bad/key": {Label: "x"}}},
+			wantErr: true,
+		},
+		{
+			name:    "invalid type key",
+			cfg:     &WorkflowsConfig{CategoryByType: map[string]string{"bad key": WorkflowCategoryPlan}},
+			wantErr: true,
+		},
+		{
+			name:    "empty mapped category",
+			cfg:     &WorkflowsConfig{CategoryByType: map[string]string{"deploy": ""}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateWorkflowsConfig(tt.cfg)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/scaffold/campaign_yaml.go
+++ b/internal/scaffold/campaign_yaml.go
@@ -74,6 +74,7 @@ func CreateCampaignConfig(ctx context.Context, campaignRoot string, opts InitOpt
 		Description: fmt.Sprintf("Campaign: %s", opts.Name),
 		ConceptList: config.DefaultConcepts(),
 		Intents:     config.IntentsConfig{Tags: config.DefaultIntentTags()},
+		Workflows:   config.DefaultWorkflowsConfig(),
 	}
 
 	// Apply defaults

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -284,8 +284,7 @@ func Init(ctx context.Context, dir string, opts InitOptions) (*InitResult, error
 		} else if len(existingCfg.ConceptList) > 0 {
 			cfg.ConceptList = existingCfg.ConceptList
 		}
-		// Use merged workflows from repair plan (backfills missing default
-		// categories/mappings, preserving user definitions).
+		// Use merged workflows from repair plan (backfills defaults, preserves user mappings).
 		if opts.RepairPlan != nil && opts.RepairPlan.MergedWorkflows != nil {
 			cfg.Workflows = *opts.RepairPlan.MergedWorkflows
 		} else {

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -258,6 +258,7 @@ func Init(ctx context.Context, dir string, opts InitOptions) (*InitResult, error
 		Mission:     opts.Mission,
 		ConceptList: config.DefaultConcepts(),
 		Intents:     config.IntentsConfig{Tags: config.DefaultIntentTags()},
+		Workflows:   config.DefaultWorkflowsConfig(),
 	}
 
 	// In repair mode, preserve existing config values and merge concepts
@@ -282,6 +283,13 @@ func Init(ctx context.Context, dir string, opts InitOptions) (*InitResult, error
 			cfg.ConceptList = opts.RepairPlan.MergedConcepts
 		} else if len(existingCfg.ConceptList) > 0 {
 			cfg.ConceptList = existingCfg.ConceptList
+		}
+		// Use merged workflows from repair plan (backfills missing default
+		// categories/mappings, preserving user definitions).
+		if opts.RepairPlan != nil && opts.RepairPlan.MergedWorkflows != nil {
+			cfg.Workflows = *opts.RepairPlan.MergedWorkflows
+		} else {
+			cfg.Workflows = existingCfg.Workflows
 		}
 	}
 

--- a/internal/scaffold/repair.go
+++ b/internal/scaffold/repair.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -72,6 +73,9 @@ type RepairPlan struct {
 	MergedJumps *config.JumpsConfig
 	// MergedConcepts is the computed concept list after repair (updating stale default paths).
 	MergedConcepts []config.ConceptEntry
+	// MergedWorkflows is the computed workflows config after repair (backfilling
+	// missing default categories/mappings while preserving user definitions).
+	MergedWorkflows *config.WorkflowsConfig
 	// Migrations lists directories whose contents need to be moved.
 	Migrations []MigrationAction
 	// IntentMigrations lists legacy intent-root moves handled internally by Init.
@@ -131,6 +135,11 @@ func ComputeRepairPlan(ctx context.Context, dir string, opts InitOptions) (*Repa
 
 	// Phase 3: Compute jumps.yaml changes (shortcuts with user-defined preservation).
 	if err := computeJumpsChanges(ctx, absDir, plan); err != nil {
+		return nil, err
+	}
+
+	// Phase 3b: Backfill missing default workflow categories/mappings.
+	if err := computeWorkflowsChanges(ctx, absDir, plan); err != nil {
 		return nil, err
 	}
 
@@ -539,6 +548,55 @@ func conceptListsEqual(a, b []config.ConceptEntry) bool {
 		}
 	}
 	return true
+}
+
+// computeWorkflowsChanges backfills missing default workflow categories and
+// type mappings into an existing campaign, preserving user definitions. It is
+// idempotent: a campaign already carrying the defaults yields no changes and no
+// MergedWorkflows override.
+func computeWorkflowsChanges(ctx context.Context, absDir string, plan *RepairPlan) error {
+	existing, err := config.LoadCampaignConfig(ctx, absDir)
+	if err != nil || existing == nil {
+		return nil // No campaign.yaml yet; init writes the default block.
+	}
+
+	defaults := config.DefaultWorkflowsConfig()
+
+	merged := config.WorkflowsConfig{
+		Categories:     make(map[string]config.WorkflowCategoryConfig, len(existing.Workflows.Categories)),
+		CategoryByType: make(map[string]string, len(existing.Workflows.CategoryByType)),
+	}
+	maps.Copy(merged.Categories, existing.Workflows.Categories)
+	maps.Copy(merged.CategoryByType, existing.Workflows.CategoryByType)
+
+	for _, key := range sortedMapKeys(defaults.Categories) {
+		if _, ok := merged.Categories[key]; ok {
+			continue
+		}
+		merged.Categories[key] = defaults.Categories[key]
+		plan.Changes = append(plan.Changes, RepairChange{
+			Type:        RepairAdd,
+			Category:    "workflow_category",
+			Key:         key,
+			Description: "missing default workflow category",
+		})
+	}
+
+	for _, typeKey := range sortedMapKeys(defaults.CategoryByType) {
+		if _, ok := merged.CategoryByType[typeKey]; ok {
+			continue
+		}
+		merged.CategoryByType[typeKey] = defaults.CategoryByType[typeKey]
+		plan.Changes = append(plan.Changes, RepairChange{
+			Type:        RepairAdd,
+			Category:    "workflow_mapping",
+			Key:         typeKey,
+			Description: "missing default category mapping",
+		})
+	}
+
+	plan.MergedWorkflows = &merged
+	return nil
 }
 
 // computeJumpsChanges compares existing jumps.yaml shortcuts with defaults,
@@ -1040,6 +1098,16 @@ func removeEmptySourceDir(dir string) {
 
 // sortedKeys returns map keys in sorted order.
 func sortedKeys(m map[string]config.ShortcutConfig) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// sortedMapKeys returns keys of any string-keyed map in sorted order.
+func sortedMapKeys[V any](m map[string]V) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)

--- a/internal/scaffold/repair.go
+++ b/internal/scaffold/repair.go
@@ -73,8 +73,7 @@ type RepairPlan struct {
 	MergedJumps *config.JumpsConfig
 	// MergedConcepts is the computed concept list after repair (updating stale default paths).
 	MergedConcepts []config.ConceptEntry
-	// MergedWorkflows is the computed workflows config after repair (backfilling
-	// missing default categories/mappings while preserving user definitions).
+	// MergedWorkflows is the computed workflows config after repair (backfills defaults, preserves user).
 	MergedWorkflows *config.WorkflowsConfig
 	// Migrations lists directories whose contents need to be moved.
 	Migrations []MigrationAction
@@ -550,10 +549,8 @@ func conceptListsEqual(a, b []config.ConceptEntry) bool {
 	return true
 }
 
-// computeWorkflowsChanges backfills missing default workflow categories and
-// type mappings into an existing campaign, preserving user definitions. It is
-// idempotent: a campaign already carrying the defaults yields no changes and no
-// MergedWorkflows override.
+// computeWorkflowsChanges backfills missing default categories/mappings into an
+// existing campaign, preserving user definitions.
 func computeWorkflowsChanges(ctx context.Context, absDir string, plan *RepairPlan) error {
 	existing, err := config.LoadCampaignConfig(ctx, absDir)
 	if err != nil || existing == nil {

--- a/internal/scaffold/repair_test.go
+++ b/internal/scaffold/repair_test.go
@@ -388,6 +388,58 @@ func TestComputeJumpsChanges_OnlyUserEntries(t *testing.T) {
 	}
 }
 
+func TestComputeWorkflowsChanges_BackfillsPreservingUser(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	setupCampaignDir(t, dir)
+
+	existing := &config.CampaignConfig{
+		Name: "test",
+		Type: config.CampaignTypeProduct,
+		Workflows: config.WorkflowsConfig{
+			Categories: map[string]config.WorkflowCategoryConfig{
+				"plan":     {Label: "Plan"},
+				"research": {Label: "Research"},
+			},
+			CategoryByType: map[string]string{
+				"design":  "research",
+				"explore": "research",
+			},
+		},
+	}
+	if err := config.SaveCampaignConfig(ctx, dir, existing); err != nil {
+		t.Fatal(err)
+	}
+
+	plan := &RepairPlan{}
+	if err := computeWorkflowsChanges(ctx, dir, plan); err != nil {
+		t.Fatal(err)
+	}
+	if plan.MergedWorkflows == nil {
+		t.Fatal("expected MergedWorkflows to be set")
+	}
+
+	if got := plan.MergedWorkflows.CategoryByType["design"]; got != "research" {
+		t.Fatalf("design override = %q, want research (preserved)", got)
+	}
+	if _, ok := plan.MergedWorkflows.Categories["review"]; !ok {
+		t.Fatal("expected review category backfilled")
+	}
+	if got := plan.MergedWorkflows.CategoryByType["code_reviews"]; got != "review" {
+		t.Fatalf("code_reviews mapping = %q, want review (backfilled)", got)
+	}
+
+	var addedReview bool
+	for _, c := range plan.Changes {
+		if c.Category == "workflow_category" && c.Key == "review" && c.Type == RepairAdd {
+			addedReview = true
+		}
+	}
+	if !addedReview {
+		t.Fatal("expected a repair change adding the review category")
+	}
+}
+
 func TestComputeMigrationChanges_DetectsMisplacedCompleted(t *testing.T) {
 	dir := t.TempDir()
 	today := time.Now().Format("2006-01-02")

--- a/internal/workitem/category.go
+++ b/internal/workitem/category.go
@@ -1,9 +1,5 @@
 package workitem
 
-// ApplyWorkflowCategories sets WorkflowCategory on each item from categoryForType,
-// which maps a workflow type key to a category key. The category is derived at
-// read time from campaign config; enrichment never changes which items exist or
-// any other field. Items are enriched in place and the same slice is returned.
 func ApplyWorkflowCategories(items []WorkItem, categoryForType func(string) string) []WorkItem {
 	if categoryForType == nil {
 		return items

--- a/internal/workitem/category.go
+++ b/internal/workitem/category.go
@@ -1,0 +1,15 @@
+package workitem
+
+// ApplyWorkflowCategories sets WorkflowCategory on each item from categoryForType,
+// which maps a workflow type key to a category key. The category is derived at
+// read time from campaign config; enrichment never changes which items exist or
+// any other field. Items are enriched in place and the same slice is returned.
+func ApplyWorkflowCategories(items []WorkItem, categoryForType func(string) string) []WorkItem {
+	if categoryForType == nil {
+		return items
+	}
+	for i := range items {
+		items[i].WorkflowCategory = categoryForType(string(items[i].WorkflowType))
+	}
+	return items
+}

--- a/internal/workitem/category_test.go
+++ b/internal/workitem/category_test.go
@@ -1,0 +1,40 @@
+package workitem
+
+import "testing"
+
+func TestApplyWorkflowCategories(t *testing.T) {
+	categoryForType := func(wt string) string {
+		switch wt {
+		case "design", "festival":
+			return "plan"
+		case "explore":
+			return "research"
+		default:
+			return "uncategorized"
+		}
+	}
+
+	items := []WorkItem{
+		{WorkflowType: WorkflowTypeDesign},
+		{WorkflowType: WorkflowTypeExplore},
+		{WorkflowType: WorkflowTypeFestival},
+		{WorkflowType: WorkflowType("customthing")},
+	}
+
+	got := ApplyWorkflowCategories(items, categoryForType)
+
+	want := []string{"plan", "research", "plan", "uncategorized"}
+	for i, w := range want {
+		if got[i].WorkflowCategory != w {
+			t.Fatalf("item %d category = %q, want %q", i, got[i].WorkflowCategory, w)
+		}
+	}
+}
+
+func TestApplyWorkflowCategoriesNilFunc(t *testing.T) {
+	items := []WorkItem{{WorkflowType: WorkflowTypeDesign}}
+	got := ApplyWorkflowCategories(items, nil)
+	if got[0].WorkflowCategory != "" {
+		t.Fatalf("expected empty category with nil func, got %q", got[0].WorkflowCategory)
+	}
+}

--- a/internal/workitem/filter.go
+++ b/internal/workitem/filter.go
@@ -10,6 +10,7 @@ func Filter(items []WorkItem, types, stages []string, query string) []WorkItem {
 
 type FilterOptions struct {
 	Types           []string
+	Categories      []string
 	LifecycleStages []string
 	AttentionStages []string
 	Groups          []string
@@ -18,11 +19,12 @@ type FilterOptions struct {
 }
 
 func FilterAdvanced(items []WorkItem, opts FilterOptions) []WorkItem {
-	if len(opts.Types) == 0 && len(opts.LifecycleStages) == 0 && len(opts.AttentionStages) == 0 && len(opts.Groups) == 0 && opts.Query == "" && opts.ShowParked {
+	if len(opts.Types) == 0 && len(opts.Categories) == 0 && len(opts.LifecycleStages) == 0 && len(opts.AttentionStages) == 0 && len(opts.Groups) == 0 && opts.Query == "" && opts.ShowParked {
 		return items
 	}
 
 	typeSet := toSet(opts.Types)
+	categorySet := toSet(opts.Categories)
 	stageSet := toSet(opts.LifecycleStages)
 	attentionSet := toSet(opts.AttentionStages)
 	groupSet := toSet(opts.Groups)
@@ -31,6 +33,9 @@ func FilterAdvanced(items []WorkItem, opts FilterOptions) []WorkItem {
 	var result []WorkItem
 	for _, item := range items {
 		if len(typeSet) > 0 && !typeSet[string(item.WorkflowType)] {
+			continue
+		}
+		if len(categorySet) > 0 && !categorySet[item.WorkflowCategory] {
 			continue
 		}
 		if len(stageSet) > 0 && !stageSet[string(item.LifecycleStage)] {
@@ -69,5 +74,6 @@ func matchesQuery(item WorkItem, query string) bool {
 		strings.Contains(strings.ToLower(item.RelativePath), query) ||
 		strings.Contains(strings.ToLower(item.Summary), query) ||
 		strings.Contains(strings.ToLower(item.SourceID), query) ||
-		strings.Contains(strings.ToLower(item.Group), query)
+		strings.Contains(strings.ToLower(item.Group), query) ||
+		strings.Contains(strings.ToLower(item.WorkflowCategory), query)
 }

--- a/internal/workitem/filter_test.go
+++ b/internal/workitem/filter_test.go
@@ -94,6 +94,47 @@ func TestFilter_NoFilters(t *testing.T) {
 	}
 }
 
+func TestFilter_ByCategory(t *testing.T) {
+	items := []WorkItem{
+		{WorkflowType: WorkflowTypeDesign, WorkflowCategory: "plan", Title: "d"},
+		{WorkflowType: WorkflowTypeExplore, WorkflowCategory: "research", Title: "e"},
+		{WorkflowType: WorkflowType("code_reviews"), WorkflowCategory: "review", Title: "r"},
+	}
+
+	got := FilterAdvanced(items, FilterOptions{Categories: []string{"research"}, ShowParked: true})
+	if len(got) != 1 || got[0].Title != "e" {
+		t.Fatalf("category filter = %v, want single research item", got)
+	}
+
+	got = FilterAdvanced(items, FilterOptions{Categories: []string{"plan", "review"}, ShowParked: true})
+	if len(got) != 2 {
+		t.Fatalf("multi-category filter len = %d, want 2", len(got))
+	}
+}
+
+func TestFilter_CategoryCombinesWithType(t *testing.T) {
+	items := []WorkItem{
+		{WorkflowType: WorkflowTypeDesign, WorkflowCategory: "plan", Title: "d"},
+		{WorkflowType: WorkflowTypeFestival, WorkflowCategory: "plan", Title: "f"},
+		{WorkflowType: WorkflowTypeExplore, WorkflowCategory: "research", Title: "e"},
+	}
+	got := FilterAdvanced(items, FilterOptions{Types: []string{"festival"}, Categories: []string{"plan"}, ShowParked: true})
+	if len(got) != 1 || got[0].Title != "f" {
+		t.Fatalf("type+category filter = %v, want festival plan item", got)
+	}
+}
+
+func TestFilter_QueryMatchesCategory(t *testing.T) {
+	items := []WorkItem{
+		{WorkflowType: WorkflowTypeExplore, WorkflowCategory: "research", Title: "alpha"},
+		{WorkflowType: WorkflowTypeDesign, WorkflowCategory: "plan", Title: "beta"},
+	}
+	got := FilterAdvanced(items, FilterOptions{Query: "research", ShowParked: true})
+	if len(got) != 1 || got[0].Title != "alpha" {
+		t.Fatalf("query on category = %v, want the research item", got)
+	}
+}
+
 func TestFilter_PreservesOrder(t *testing.T) {
 	items := []WorkItem{
 		{WorkflowType: WorkflowTypeIntent, Title: "first"},

--- a/internal/workitem/json.go
+++ b/internal/workitem/json.go
@@ -24,20 +24,17 @@ import (
 //     metadata is present.
 //   - v1alpha7: add attention_stage/attention_stage_source/group fields,
 //     attention/group vocabularies, grouping metadata, and reusable section rows.
-//   - v1alpha8: add config-derived workflow_category on each item, category to
-//     available_group_by and section row fields, category_vocabulary, and
-//     category_counts. workflow_category is omitempty; items are enriched at read
-//     time, so unenriched payloads serialize byte-identically except for this
-//     constant and the always-present category_vocabulary/category_counts.
+//   - v1alpha8: add config-derived workflow_category per item, category_vocabulary,
+//     category_counts, and category in available_group_by and section rows.
 const SchemaVersion = "workitems/v1alpha8"
 
 // Payload is the top-level JSON output for camp workitem --json.
 type Payload struct {
-	SchemaVersion            string              `json:"schema_version"`
-	GeneratedAt              time.Time           `json:"generated_at"`
-	CampaignRoot             string              `json:"campaign_root"`
-	Sort                     SortInfo            `json:"sort"`
-	Grouping                 listview.Grouping   `json:"grouping"`
+	SchemaVersion            string               `json:"schema_version"`
+	GeneratedAt              time.Time            `json:"generated_at"`
+	CampaignRoot             string               `json:"campaign_root"`
+	Sort                     SortInfo             `json:"sort"`
+	Grouping                 listview.Grouping    `json:"grouping"`
 	Items                    []WorkItem           `json:"items"`
 	Sections                 []listview.Section   `json:"sections,omitempty"`
 	Counts                   Counts               `json:"counts"`
@@ -48,8 +45,6 @@ type Payload struct {
 	CategoryVocabulary       []CategoryVocabEntry `json:"category_vocabulary"`
 }
 
-// CategoryVocabEntry is a workflow category with display metadata, listed in the
-// deterministic order returned by config (defaults first, then custom).
 type CategoryVocabEntry struct {
 	Key         string `json:"key"`
 	Label       string `json:"label,omitempty"`

--- a/internal/workitem/json.go
+++ b/internal/workitem/json.go
@@ -24,7 +24,12 @@ import (
 //     metadata is present.
 //   - v1alpha7: add attention_stage/attention_stage_source/group fields,
 //     attention/group vocabularies, grouping metadata, and reusable section rows.
-const SchemaVersion = "workitems/v1alpha7"
+//   - v1alpha8: add config-derived workflow_category on each item, category to
+//     available_group_by and section row fields, category_vocabulary, and
+//     category_counts. workflow_category is omitempty; items are enriched at read
+//     time, so unenriched payloads serialize byte-identically except for this
+//     constant and the always-present category_vocabulary/category_counts.
+const SchemaVersion = "workitems/v1alpha8"
 
 // Payload is the top-level JSON output for camp workitem --json.
 type Payload struct {
@@ -33,12 +38,22 @@ type Payload struct {
 	CampaignRoot             string              `json:"campaign_root"`
 	Sort                     SortInfo            `json:"sort"`
 	Grouping                 listview.Grouping   `json:"grouping"`
-	Items                    []WorkItem          `json:"items"`
-	Sections                 []listview.Section  `json:"sections,omitempty"`
-	Counts                   Counts              `json:"counts"`
-	StageVocabulary          map[string][]string `json:"stage_vocabulary"`
-	AttentionStageVocabulary []string            `json:"attention_stage_vocabulary"`
-	GroupVocabulary          []string            `json:"group_vocabulary"`
+	Items                    []WorkItem           `json:"items"`
+	Sections                 []listview.Section   `json:"sections,omitempty"`
+	Counts                   Counts               `json:"counts"`
+	CategoryCounts           map[string]int       `json:"category_counts"`
+	StageVocabulary          map[string][]string  `json:"stage_vocabulary"`
+	AttentionStageVocabulary []string             `json:"attention_stage_vocabulary"`
+	GroupVocabulary          []string             `json:"group_vocabulary"`
+	CategoryVocabulary       []CategoryVocabEntry `json:"category_vocabulary"`
+}
+
+// CategoryVocabEntry is a workflow category with display metadata, listed in the
+// deterministic order returned by config (defaults first, then custom).
+type CategoryVocabEntry struct {
+	Key         string `json:"key"`
+	Label       string `json:"label,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 // SortInfo describes the ordering applied to items.
@@ -64,6 +79,7 @@ func NewPayload(campaignRoot string, items []WorkItem) Payload {
 
 func NewPayloadWithGrouping(campaignRoot string, items []WorkItem, groupBy string) Payload {
 	counts := Counts{Total: len(items)}
+	categoryCounts := map[string]int{}
 	for _, item := range items {
 		switch item.WorkflowType {
 		case WorkflowTypeIntent:
@@ -74,6 +90,9 @@ func NewPayloadWithGrouping(campaignRoot string, items []WorkItem, groupBy strin
 			counts.Explore++
 		case WorkflowTypeFestival:
 			counts.Festival++
+		}
+		if item.WorkflowCategory != "" {
+			categoryCounts[item.WorkflowCategory]++
 		}
 	}
 
@@ -96,14 +115,16 @@ func NewPayloadWithGrouping(campaignRoot string, items []WorkItem, groupBy strin
 		},
 		Grouping: listview.Grouping{
 			GroupBy:          groupBy,
-			AvailableGroupBy: []string{"attention_stage", "group", "type"},
+			AvailableGroupBy: []string{"attention_stage", "group", "type", "category"},
 		},
 		Items:                    items,
 		Sections:                 sections,
 		Counts:                   counts,
+		CategoryCounts:           categoryCounts,
 		StageVocabulary:          StageVocabulary(),
 		AttentionStageVocabulary: []string{"current", "next", "active", "parked"},
 		GroupVocabulary:          GroupVocabulary(items),
+		CategoryVocabulary:       []CategoryVocabEntry{},
 	}
 }
 
@@ -127,6 +148,7 @@ func ListRows(items []WorkItem) []listview.Row {
 				"attention_stage": item.AttentionStage,
 				"group":           groupKey,
 				"type":            string(item.WorkflowType),
+				"category":        item.WorkflowCategory,
 			},
 		})
 	}

--- a/internal/workitem/json_test.go
+++ b/internal/workitem/json_test.go
@@ -154,9 +154,9 @@ func TestWorkItemWorkflow_ZeroValuesAreEmitted(t *testing.T) {
 	}
 }
 
-func TestSchemaVersion_IsV1Alpha7(t *testing.T) {
-	if SchemaVersion != "workitems/v1alpha7" {
-		t.Errorf("SchemaVersion = %q, want workitems/v1alpha7", SchemaVersion)
+func TestSchemaVersion_IsV1Alpha8(t *testing.T) {
+	if SchemaVersion != "workitems/v1alpha8" {
+		t.Errorf("SchemaVersion = %q, want workitems/v1alpha8", SchemaVersion)
 	}
 }
 
@@ -177,6 +177,57 @@ func TestNewPayload_AttentionAndSections(t *testing.T) {
 	}
 	if len(p.Sections) != 2 {
 		t.Fatalf("len(sections) = %d, want 2", len(p.Sections))
+	}
+}
+
+func TestNewPayload_CategoryGroupingAndCounts(t *testing.T) {
+	items := []WorkItem{
+		{Key: "a", Title: "A", WorkflowType: WorkflowTypeDesign, WorkflowCategory: "plan"},
+		{Key: "b", Title: "B", WorkflowType: WorkflowTypeExplore, WorkflowCategory: "research"},
+		{Key: "c", Title: "C", WorkflowType: WorkflowTypeFestival, WorkflowCategory: "plan"},
+	}
+	p := NewPayloadWithGrouping("/tmp", items, "category")
+
+	if p.CategoryCounts["plan"] != 2 || p.CategoryCounts["research"] != 1 {
+		t.Fatalf("category_counts = %#v, want plan:2 research:1", p.CategoryCounts)
+	}
+	if !containsString(p.Grouping.AvailableGroupBy, "category") {
+		t.Fatalf("available_group_by missing category: %#v", p.Grouping.AvailableGroupBy)
+	}
+	if len(p.Sections) != 2 {
+		t.Fatalf("category sections = %d, want 2", len(p.Sections))
+	}
+}
+
+func TestNewPayload_CategoryFieldsNonNull(t *testing.T) {
+	p := NewPayload("/tmp", nil)
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if string(raw["category_vocabulary"]) == "null" {
+		t.Error("category_vocabulary should be [] not null")
+	}
+	if string(raw["category_counts"]) == "null" {
+		t.Error("category_counts should be {} not null")
+	}
+}
+
+func TestWorkItem_WorkflowCategoryOmitEmpty(t *testing.T) {
+	item := WorkItem{Key: "design:foo"}
+	data, _ := json.Marshal(item)
+	if strings.Contains(string(data), "workflow_category") {
+		t.Error("workflow_category should be omitted when empty")
+	}
+
+	item.WorkflowCategory = "plan"
+	data, _ = json.Marshal(item)
+	if !strings.Contains(string(data), `"workflow_category":"plan"`) {
+		t.Errorf("workflow_category should be present, got: %s", data)
 	}
 }
 

--- a/internal/workitem/model.go
+++ b/internal/workitem/model.go
@@ -34,6 +34,7 @@ const (
 type WorkItem struct {
 	Key                  string         `json:"key"`
 	WorkflowType         WorkflowType   `json:"workflow_type"`
+	WorkflowCategory     string         `json:"workflow_category,omitempty"`
 	LifecycleStage       LifecycleStage `json:"lifecycle_stage"`
 	Title                string         `json:"title"`
 	RelativePath         string         `json:"relative_path"`

--- a/internal/workitem/tui/category_test.go
+++ b/internal/workitem/tui/category_test.go
@@ -1,0 +1,60 @@
+package tui
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
+)
+
+func TestCycleCategory(t *testing.T) {
+	items := []workitem.WorkItem{
+		{Key: "a", WorkflowType: workitem.WorkflowTypeDesign, WorkflowCategory: "plan"},
+		{Key: "b", WorkflowType: workitem.WorkflowTypeExplore, WorkflowCategory: "research"},
+		{Key: "c", WorkflowType: workitem.WorkflowType("code_reviews"), WorkflowCategory: "review"},
+	}
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
+	m.refilter()
+	if m.categoryFilter != "" || len(m.filteredItems) != 3 {
+		t.Fatalf("initial: category=%q items=%d", m.categoryFilter, len(m.filteredItems))
+	}
+
+	steps := []struct {
+		wantCategory string
+		wantKey      string
+	}{
+		{"plan", "a"},
+		{"research", "b"},
+		{"review", "c"},
+	}
+	for i, step := range steps {
+		m.cycleCategory()
+		if m.categoryFilter != step.wantCategory {
+			t.Fatalf("cycle %d: category=%q want %q", i+1, m.categoryFilter, step.wantCategory)
+		}
+		if len(m.filteredItems) != 1 || m.filteredItems[0].Key != step.wantKey {
+			t.Fatalf("cycle %d: filtered=%v want single %q", i+1, m.filteredItems, step.wantKey)
+		}
+	}
+
+	m.cycleCategory()
+	if m.categoryFilter != "" || len(m.filteredItems) != 3 {
+		t.Fatalf("wrap: category=%q items=%d want all", m.categoryFilter, len(m.filteredItems))
+	}
+}
+
+func TestCategoryFilterComposesWithType(t *testing.T) {
+	items := []workitem.WorkItem{
+		{Key: "a", WorkflowType: workitem.WorkflowTypeDesign, WorkflowCategory: "plan"},
+		{Key: "b", WorkflowType: workitem.WorkflowTypeFestival, WorkflowCategory: "plan"},
+		{Key: "c", WorkflowType: workitem.WorkflowTypeExplore, WorkflowCategory: "research"},
+	}
+	m := New(context.Background(), items, "", nil, priority.NewStore(), "")
+	m.typeFilter = "festival"
+	m.categoryFilter = "plan"
+	m.refilter()
+	if len(m.filteredItems) != 1 || m.filteredItems[0].Key != "b" {
+		t.Fatalf("type+category compose = %v, want single festival/plan item", m.filteredItems)
+	}
+}

--- a/internal/workitem/tui/category_test.go
+++ b/internal/workitem/tui/category_test.go
@@ -44,6 +44,38 @@ func TestCycleCategory(t *testing.T) {
 	}
 }
 
+func TestRefreshReappliesCategoryEnrichment(t *testing.T) {
+	m := New(context.Background(), nil, "", nil, priority.NewStore(), "")
+	m.SetCategoryResolver(func(wt string) string {
+		if wt == "explore" {
+			return "research"
+		}
+		return "plan"
+	})
+
+	// Refreshed items arrive raw (as from Discover), without workflow_category.
+	raw := []workitem.WorkItem{
+		{Key: "a", WorkflowType: workitem.WorkflowTypeDesign},
+		{Key: "b", WorkflowType: workitem.WorkflowTypeExplore},
+	}
+	updated, _ := m.Update(refreshMsg{items: raw})
+	rm := updated.(Model)
+
+	byKey := map[string]string{}
+	for _, it := range rm.allItems {
+		byKey[it.Key] = it.WorkflowCategory
+	}
+	if byKey["a"] != "plan" || byKey["b"] != "research" {
+		t.Fatalf("refresh did not re-enrich categories: %#v", byKey)
+	}
+
+	rm.categoryFilter = "research"
+	rm.refilter()
+	if len(rm.filteredItems) != 1 || rm.filteredItems[0].Key != "b" {
+		t.Fatalf("category filter broken after refresh: %v", rm.filteredItems)
+	}
+}
+
 func TestCategoryFilterComposesWithType(t *testing.T) {
 	items := []workitem.WorkItem{
 		{Key: "a", WorkflowType: workitem.WorkflowTypeDesign, WorkflowCategory: "plan"},

--- a/internal/workitem/tui/model.go
+++ b/internal/workitem/tui/model.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/priority"
@@ -25,6 +26,48 @@ var builtinFilterTypes = []string{
 	string(workitem.WorkflowTypeDesign),
 	string(workitem.WorkflowTypeExplore),
 	string(workitem.WorkflowTypeFestival),
+}
+
+// builtinFilterCategories pins the canonical category cycle order.
+var builtinFilterCategories = []string{
+	config.WorkflowCategoryPlan,
+	config.WorkflowCategoryResearch,
+	config.WorkflowCategoryPipeline,
+	config.WorkflowCategoryReview,
+}
+
+// deriveCategoryOptions returns the category cycle values: "" (all) first, then
+// builtin categories present in items in canonical order, then custom categories
+// (including uncategorized) alphabetically. ensure is always included so the
+// active filter is always a cycle stop.
+func deriveCategoryOptions(items []workitem.WorkItem, ensure string) []string {
+	builtin := make(map[string]bool, len(builtinFilterCategories))
+	for _, c := range builtinFilterCategories {
+		builtin[c] = true
+	}
+	present := make(map[string]bool, len(items))
+	for _, item := range items {
+		if c := item.WorkflowCategory; c != "" {
+			present[c] = true
+		}
+	}
+	if ensure != "" {
+		present[ensure] = true
+	}
+	opts := []string{""}
+	for _, c := range builtinFilterCategories {
+		if present[c] {
+			opts = append(opts, c)
+		}
+	}
+	var customs []string
+	for c := range present {
+		if !builtin[c] {
+			customs = append(customs, c)
+		}
+	}
+	sort.Strings(customs)
+	return append(opts, customs...)
 }
 
 // deriveFilterOptions returns the filter-mode chip values: "" (all) first,
@@ -83,6 +126,7 @@ type Model struct {
 
 	// Filters
 	typeFilter      string // empty = all, or any workflow type
+	categoryFilter  string // empty = all, or any workflow category
 	showParked      bool
 	filterMode      bool
 	filterOptions   []string // chip values while filter mode is active; "" = all
@@ -229,19 +273,48 @@ func (m Model) currentItem() workitem.WorkItem {
 // refilter applies current type filter and search query to allItems,
 // then clamps cursor and scrollOffset to stay within bounds.
 func (m *Model) refilter() {
-	var types []string
-	if m.typeFilter != "" {
-		types = []string{m.typeFilter}
-	}
-	m.filteredItems = workitem.FilterAdvanced(m.allItems, workitem.FilterOptions{
-		Types:      types,
-		Query:      m.searchQuery,
-		ShowParked: m.showParked,
-	})
+	m.filteredItems = workitem.FilterAdvanced(m.allItems, m.filterOptionsForState(m.searchQuery))
 	if m.cursor >= len(m.filteredItems) {
 		m.cursor = max(0, len(m.filteredItems)-1)
 	}
 	m.clampScroll()
+}
+
+// filterOptionsForState builds the FilterOptions for the current type/category
+// filters and the given query (committed or draft).
+func (m Model) filterOptionsForState(query string) workitem.FilterOptions {
+	var types []string
+	if m.typeFilter != "" {
+		types = []string{m.typeFilter}
+	}
+	var categories []string
+	if m.categoryFilter != "" {
+		categories = []string{m.categoryFilter}
+	}
+	return workitem.FilterOptions{
+		Types:      types,
+		Categories: categories,
+		Query:      query,
+		ShowParked: m.showParked,
+	}
+}
+
+// cycleCategory advances the category filter to the next value present in the
+// current view, wrapping through "" (all). Type filtering is unaffected.
+func (m *Model) cycleCategory() {
+	opts := deriveCategoryOptions(m.visibleBaseItems(), m.categoryFilter)
+	if len(opts) <= 1 {
+		return
+	}
+	idx := 0
+	for i, opt := range opts {
+		if opt == m.categoryFilter {
+			idx = i
+			break
+		}
+	}
+	m.categoryFilter = opts[(idx+1)%len(opts)]
+	m.refilter()
 }
 
 // clampScroll ensures scrollOffset is valid for the current item count and viewport.

--- a/internal/workitem/tui/model.go
+++ b/internal/workitem/tui/model.go
@@ -127,6 +127,7 @@ type Model struct {
 	// Filters
 	typeFilter      string // empty = all, or any workflow type
 	categoryFilter  string // empty = all, or any workflow category
+	categoryForType func(string) string // re-applies category enrichment on refresh
 	showParked      bool
 	filterMode      bool
 	filterOptions   []string // chip values while filter mode is active; "" = all
@@ -184,6 +185,12 @@ func New(ctx context.Context, items []workitem.WorkItem, campaignRoot string, re
 		storePath:     storePath,
 		showParked:    includeParked,
 	}
+}
+
+// SetCategoryResolver installs the type->category function so refreshed items
+// (re-discovered raw) are re-enriched with their workflow category.
+func (m *Model) SetCategoryResolver(fn func(string) string) {
+	m.categoryForType = fn
 }
 
 // typeFilterFor resolves a pressed key to a type filter value.

--- a/internal/workitem/tui/model.go
+++ b/internal/workitem/tui/model.go
@@ -36,10 +36,6 @@ var builtinFilterCategories = []string{
 	config.WorkflowCategoryReview,
 }
 
-// deriveCategoryOptions returns the category cycle values: "" (all) first, then
-// builtin categories present in items in canonical order, then custom categories
-// (including uncategorized) alphabetically. ensure is always included so the
-// active filter is always a cycle stop.
 func deriveCategoryOptions(items []workitem.WorkItem, ensure string) []string {
 	builtin := make(map[string]bool, len(builtinFilterCategories))
 	for _, c := range builtinFilterCategories {
@@ -127,7 +123,7 @@ type Model struct {
 	// Filters
 	typeFilter      string // empty = all, or any workflow type
 	categoryFilter  string // empty = all, or any workflow category
-	categoryForType func(string) string // re-applies category enrichment on refresh
+	categoryForType func(string) string
 	showParked      bool
 	filterMode      bool
 	filterOptions   []string // chip values while filter mode is active; "" = all
@@ -187,8 +183,6 @@ func New(ctx context.Context, items []workitem.WorkItem, campaignRoot string, re
 	}
 }
 
-// SetCategoryResolver installs the type->category function so refreshed items
-// (re-discovered raw) are re-enriched with their workflow category.
 func (m *Model) SetCategoryResolver(fn func(string) string) {
 	m.categoryForType = fn
 }
@@ -287,8 +281,6 @@ func (m *Model) refilter() {
 	m.clampScroll()
 }
 
-// filterOptionsForState builds the FilterOptions for the current type/category
-// filters and the given query (committed or draft).
 func (m Model) filterOptionsForState(query string) workitem.FilterOptions {
 	var types []string
 	if m.typeFilter != "" {
@@ -306,8 +298,6 @@ func (m Model) filterOptionsForState(query string) workitem.FilterOptions {
 	}
 }
 
-// cycleCategory advances the category filter to the next value present in the
-// current view, wrapping through "" (all). Type filtering is unaffected.
 func (m *Model) cycleCategory() {
 	opts := deriveCategoryOptions(m.visibleBaseItems(), m.categoryFilter)
 	if len(opts) <= 1 {

--- a/internal/workitem/tui/update.go
+++ b/internal/workitem/tui/update.go
@@ -29,7 +29,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.err = msg.err
 		} else {
 			selectedKey := m.currentItem().Key
-			items := msg.items
+			items := workitem.ApplyWorkflowCategories(msg.items, m.categoryForType)
 			if m.priorityStore != nil {
 				items = priority.Apply(m.priorityStore, items)
 			}

--- a/internal/workitem/tui/update.go
+++ b/internal/workitem/tui/update.go
@@ -186,6 +186,11 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "f":
 		m.enterFilterMode()
 
+	// Category filter — cycle through categories present in the current view
+	case "c":
+		m.cycleCategory()
+		return m, nil
+
 	// Quick actions (read-only)
 	case "e":
 		return m.openEditor()
@@ -207,6 +212,9 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else if m.searchQuery != "" {
 			m.searchQuery = ""
 			m.searchInput.SetValue("")
+			m.refilter()
+		} else if m.categoryFilter != "" {
+			m.categoryFilter = ""
 			m.refilter()
 		}
 	}
@@ -235,15 +243,7 @@ func (m Model) handleSearchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	m.searchInput, cmd = m.searchInput.Update(msg)
 	draftQuery := m.searchInput.Value()
-	var types []string
-	if m.typeFilter != "" {
-		types = []string{m.typeFilter}
-	}
-	m.filteredItems = workitem.FilterAdvanced(m.allItems, workitem.FilterOptions{
-		Types:      types,
-		Query:      draftQuery,
-		ShowParked: m.showParked,
-	})
+	m.filteredItems = workitem.FilterAdvanced(m.allItems, m.filterOptionsForState(draftQuery))
 	if m.cursor >= len(m.filteredItems) {
 		m.cursor = max(0, len(m.filteredItems)-1)
 	}

--- a/internal/workitem/tui/update.go
+++ b/internal/workitem/tui/update.go
@@ -186,7 +186,6 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "f":
 		m.enterFilterMode()
 
-	// Category filter — cycle through categories present in the current view
 	case "c":
 		m.cycleCategory()
 		return m, nil

--- a/internal/workitem/tui/view.go
+++ b/internal/workitem/tui/view.go
@@ -70,6 +70,9 @@ func (m Model) renderHeader() string {
 	if m.typeFilter != "" {
 		filters = append(filters, filterActiveStyle.Render("type:"+m.typeFilter))
 	}
+	if m.categoryFilter != "" {
+		filters = append(filters, filterActiveStyle.Render("category:"+m.categoryFilter))
+	}
 	if m.searchQuery != "" {
 		filters = append(filters, filterActiveStyle.Render("search:"+m.searchQuery))
 	}
@@ -102,9 +105,9 @@ func (m Model) renderFooter() string {
 		return m.renderFilterChips()
 	}
 	count := fmt.Sprintf("%d items", len(m.filteredItems))
-	keys := "j/k move  / search  f filter  0 all  S stage  P priority  tab preview  r refresh  ? help  q quit"
+	keys := "j/k move  / search  f filter  c category  0 all  S stage  P priority  tab preview  r refresh  ? help  q quit"
 	if len(keys)+len(count)+2 > m.width {
-		keys = "j/k / f P tab r ? q"
+		keys = "j/k / f c P tab r ? q"
 	}
 	return footerStyle.Render(fmt.Sprintf("%s  %s", count, keys))
 }


### PR DESCRIPTION
## Campaign workflow categories

Adds a campaign-level `workflow_category` classification layered over workitem
types, so `camp workitem` (and the TUI / festival app) can filter and group work
by *kind of work* at a glance without changing the existing `workflow_type` /
`--type` contract. Implements the `campaign-workflow-categories` design
(`design-campaign-workflow-categories-2026-07-01`, WI-4eca07).

### Model
- Categories are **config-derived per type**, never stored per-item, and never
  mutate the loaded config.
- Shipped vocabulary: **`plan` / `research` / `pipeline` / `review`** (`plan` is
  the catch-all; `code_reviews` maps to `review`). Unmapped types resolve to
  `uncategorized` and still appear in listings.
- **No forced setup ceremony:** custom tracked workflows are just
  `workflow/<type>/<slug>/` mkdir + `.workitem`; they're mapped with a one-line
  `category_by_type` edit or `camp workflow create --category`.
- Goal: `camp workitem` as a campaign dashboard, with category as the filter axis.

### What's included (whole feature)
- **Config** (`internal/config/workflows.go`): `WorkflowsConfig` on
  `CampaignConfig`, defaults, `WorkflowCategoryForType`, ordered keys, slug-safe
  validation (reuses `pathutil.ValidateSegment`), `DefaultWorkflowsConfig`.
- **Workitem** : `WorkItem.WorkflowCategory` (omitempty), `ApplyWorkflowCategories`
  enrichment, `FilterOptions.Categories` + query matching.
- **CLI**: `camp workitem --category` (repeatable) and `--group-by category`;
  enrichment wired into the command.
- **JSON `workitems/v1alpha8`**: `workflow_category` per item,
  `category_vocabulary`, `category_counts`, `category` in `available_group_by`
  and section rows (v1alpha7 output byte-stable until enrichment runs).
- **Workflow commands**: `camp workflow create --category` (default `plan`,
  validated, writes the mapping); `list` CATEGORY column; `show` category.
- **Init/repair**: `camp init` writes the default block; `camp init --repair`
  backfills missing defaults while preserving user overrides.
- **TUI**: `c` cycles the category filter (Esc clears; header shows
  `category:<x>`), composing with type filter + live search; type keys unchanged.
- **Docs**: json-contracts, campaign-settings-files, workflow-reference, and
  regenerated CLI reference.

### Verification
Driven end-to-end against real campaigns: item enrichment, `--category`
filtering, `--group-by category` sections, empty-but-valid category, invalid-input
errors, `workflow create --category` (+ unknown-category rejection),
`list`/`show` category, fresh-init block, and `init --repair` backfill with a
preserved `design: research` override.

`just gate-fast` green: stable + dev build, `go vet` (stable/dev/integration),
`just lint` (stable/dev), full unit suite (**2975/2975**).

### Notes
- The built-in `code_reviews` collection isn't discovered as workitems today, so
  `review` is forward-compatible but only populates once review work is tracked
  with `.workitem` markers — a separate follow-up, not a blocker.
