### PR TITLE
docs(skills): document workitem --category filter and category grouping

### DIFF
--- a/internal/scaffold/campaign/templates/.campaign/skills/camp-workitems/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/camp-workitems/SKILL.md.tmpl
@@ -1,6 +1,6 @@
 ---
 name: camp-workitems
-description: Find, filter, choose, create, or adopt campaign work items with `camp workitem`, `camp wi`, or `camp workitems`. Use when a user wants current active work across intents, designs, explore notes, festivals, or tracked workflow directories; when agents need safe `camp workitem --json` output; or when creating/adopting tracked workflow folders.
+description: Find, filter, choose, create, or adopt campaign work items with `camp workitem`, `camp wi`, or `camp workitems`. Use when a user wants current active work across intents, designs, explore notes, festivals, or tracked workflow directories; when filtering or grouping work by workflow category (plan, research, pipeline, review); when agents need safe `camp workitem --json` output; or when creating/adopting tracked workflow folders.
 ---
 
 # Camp Workitems
@@ -18,6 +18,7 @@ Agents and scripts should prefer JSON:
 camp workitem --json
 camp workitem --json --type design --query auth
 camp workitem --json --type intent --stage ready --limit 5
+camp workitem --json --category review
 ```
 
 Use path output only when shell integration needs a destination:
@@ -31,9 +32,20 @@ Non-interactive use requires `--json` or `--print`.
 Useful filters:
 
 - `--type intent|design|explore|festival|<custom>`
+- `--category plan|research|pipeline|review|uncategorized|<custom>`
 - `--stage inbox|active|ready|planning`
 - `--query <text>`
 - `--limit <n>`
+
+Categories group workflow types into a few buckets for at-a-glance triage.
+They are derived from the `workflows` block in `campaign.yaml`, never stored
+per item. Types with no mapping resolve to `uncategorized` and still appear.
+Group any view by category for a campaign dashboard:
+
+```bash
+camp workitem --json --group-by category
+camp workitem --list --group-by category
+```
 
 ## Interactive
 


### PR DESCRIPTION
## Summary

Follow-up to #374 (campaign workflow categories). That PR shipped the `--category` filter and `--group-by category` for `camp workitem`, but the `camp-workitems` agent skill template was never updated, so agents don't discover the new surface.

This updates `internal/scaffold/campaign/templates/.campaign/skills/camp-workitems/SKILL.md.tmpl` to document:

- `--category plan|research|pipeline|review|uncategorized|<custom>` filter, with a JSON example.
- `--group-by category` for an at-a-glance campaign dashboard (`--json` and `--list`).
- How categories work: derived from the `workflows` block in `campaign.yaml`, never stored per item; unmapped types resolve to `uncategorized` and still appear in listings.
- Trigger phrasing added to the skill `description` frontmatter so it surfaces when a user wants to filter/group work by category.

## Scope

Docs/skill-template only. No code or behavior change.

## Verification

- Rebuilt `camp` and ran `camp init` in a throwaway campaign; the rendered `SKILL.md` includes the new filter, grouping examples, and category explanation.
- `git diff --stat`: 1 file, +13/-1.
- The `init_skills_test.go` integration test asserts skill-file existence and symlink resolution only (not content), so this change does not affect it.