### PR TITLE
fix(buildutil): bump per-package test timeout to 300s

### DIFF
--- a/internal/buildutil/tasks/test.go
+++ b/internal/buildutil/tasks/test.go
@@ -223,7 +223,7 @@ func Test(verbose bool) error {
 }
 
 func goTestArgs(pkg string) []string {
-	args := []string{"test", "-count=1", "-json", "-short", "-timeout", "120s"}
+	args := []string{"test", "-count=1", "-json", "-short", "-timeout", "300s"}
 	return append(args, appendBuildTags(pkg)...)
 }
 

--- a/internal/buildutil/tasks/test_test.go
+++ b/internal/buildutil/tasks/test_test.go
@@ -15,7 +15,7 @@ func TestGoTestArgsHonorsBuildTags(t *testing.T) {
 		"-json",
 		"-short",
 		"-timeout",
-		"120s",
+		"300s",
 		"-tags",
 		"dev",
 		"./cmd/camp",
@@ -36,7 +36,7 @@ func TestGoTestArgsOmitsEmptyBuildTags(t *testing.T) {
 		"-json",
 		"-short",
 		"-timeout",
-		"120s",
+		"300s",
 		"./cmd/camp",
 	}
 


### PR DESCRIPTION
## Problem

The gate runs ~92 packages in parallel with `-timeout 120s` each. The two subprocess-heavy packages (`internal/git`, `internal/doctor-checks`, 22-65s standalone) blow the cap when the machine is loaded with concurrent builds/agents. `go test` kills the package with **zero counted test failures**, failing the gate and blocking releases. Seen 3x on 2026-07-01 blocking v0.2.16.

## Fix

Bump the per-package timeout to 300s. Per the existing comment in `runTests`, this timeout is a hang-detection safety net, not a perf gate; 300s keeps true-hang detection while giving loaded-machine headroom.

## Testing

- `go test ./internal/buildutil/...` green (arg expectations updated).

Closes intent `fix-flaky-camp-gate-120s-20260701-163858` (timeout half; the colon-title template bug is split into its own PR).