### PR TITLE
fix(intent): quote title in intent/note frontmatter templates

### DIFF
--- a/internal/intent/service_test.go
+++ b/internal/intent/service_test.go
@@ -1230,7 +1230,7 @@ func TestIntentService_Edit_ValidationError(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		modified := strings.Replace(string(content), "title: Validation Error Test", "title:", 1)
+		modified := strings.Replace(string(content), `title: "Validation Error Test"`, "title:", 1)
 		return os.WriteFile(path, []byte(modified), 0644)
 	}
 
@@ -1333,7 +1333,7 @@ func TestIntentService_CreateWithEditor_ValidationFails(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		modified := strings.Replace(string(content), "title: Validation Fail", "title:", 1)
+		modified := strings.Replace(string(content), `title: "Validation Fail"`, "title:", 1)
 		modified = modified + "\n# Modified"
 		return os.WriteFile(path, []byte(modified), 0644)
 	}

--- a/internal/intent/template.go
+++ b/internal/intent/template.go
@@ -3,11 +3,18 @@ package intent
 import (
 	"bytes"
 	_ "embed"
+	"strconv"
 	"text/template"
 	"time"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
+
+// templateFuncs quotes frontmatter scalars so titles containing YAML
+// metacharacters (colons especially) stay parseable.
+var templateFuncs = template.FuncMap{
+	"yamlQuote": strconv.Quote,
+}
 
 //go:embed templates/intent.md.tmpl
 var intentTemplateContent string
@@ -38,7 +45,7 @@ type TemplateData struct {
 func RenderTemplate(data TemplateData) (string, error) {
 	// Parse template on first use (lazy initialization)
 	if intentTemplate == nil {
-		tmpl, err := template.New("intent").Parse(intentTemplateContent)
+		tmpl, err := template.New("intent").Funcs(templateFuncs).Parse(intentTemplateContent)
 		if err != nil {
 			return "", camperrors.Wrap(err, "parsing intent template")
 		}
@@ -57,7 +64,7 @@ func RenderTemplate(data TemplateData) (string, error) {
 // carry no type, concept, or promotion metadata; tags organize them.
 func RenderNote(data TemplateData) (string, error) {
 	if noteTemplate == nil {
-		tmpl, err := template.New("note").Parse(noteTemplateContent)
+		tmpl, err := template.New("note").Funcs(templateFuncs).Parse(noteTemplateContent)
 		if err != nil {
 			return "", camperrors.Wrap(err, "parsing note template")
 		}

--- a/internal/intent/template_test.go
+++ b/internal/intent/template_test.go
@@ -32,7 +32,7 @@ func TestRenderTemplate(t *testing.T) {
 					}
 				},
 				func(t *testing.T, output string) {
-					if !strings.Contains(output, "title: Test Intent") {
+					if !strings.Contains(output, `title: "Test Intent"`) {
 						t.Error("missing title in output")
 					}
 				},
@@ -111,7 +111,7 @@ func TestRenderTemplate(t *testing.T) {
 					}
 				},
 				func(t *testing.T, output string) {
-					if !strings.Contains(output, "title: Minimal Intent") {
+					if !strings.Contains(output, `title: "Minimal Intent"`) {
 						t.Error("missing title in output")
 					}
 				},
@@ -220,6 +220,14 @@ func TestRenderTemplate(t *testing.T) {
 
 			if tt.wantErr {
 				return
+			}
+
+			parsed, err := ParseIntent([]byte(output))
+			if err != nil {
+				t.Fatalf("ParseIntent() on rendered output = %v", err)
+			}
+			if parsed.Title != tt.data.Title {
+				t.Errorf("round-trip Title = %q, want %q", parsed.Title, tt.data.Title)
 			}
 
 			for _, check := range tt.checks {

--- a/internal/intent/templates/intent.md.tmpl
+++ b/internal/intent/templates/intent.md.tmpl
@@ -1,6 +1,6 @@
 ---
 id: {{ .ID }}
-title: {{ .Title }}
+title: {{ yamlQuote .Title }}
 type: {{ .Type }}
 concept: {{ .Concept }}
 status: {{ .Status }}

--- a/internal/intent/templates/note.md.tmpl
+++ b/internal/intent/templates/note.md.tmpl
@@ -1,6 +1,6 @@
 ---
 id: {{ .ID }}
-title: {{ .Title }}
+title: {{ yamlQuote .Title }}
 status: {{ .Status }}
 created_at: {{ .CreatedAt }}
 author: {{ .Author }}


### PR DESCRIPTION
## Problem

`intent.md.tmpl` and `note.md.tmpl` emit `title: {{ .Title }}` unquoted. A title containing a colon (`Fix: login timeout`) produces invalid YAML, so `camp intent add` writes a file that fails to parse. Captured in intent `fix-flaky-camp-gate-120s-20260701-163858` (second half; the timeout half is #378).

## Fix

- Add a `yamlQuote` template func (`strconv.Quote`; Go escaping is a subset of YAML double-quoted scalar escaping) and quote `title:` in both templates.
- The existing `title with colon` test passed on a raw `strings.Contains` while the output was unparseable. The test runner now round-trips every rendered template through `ParseIntent` and compares the parsed title, so metacharacter titles fail loudly.

## Testing

- `go test ./... -short` green across the repo (two service-test mock editors updated for the quoted form).
- `just lint` green (0 issues, custom lints clean).