### PR TITLE
fix: reduce camp fmt.Errorf surface

### DIFF
--- a/cmd/camp/cmdutil/campaign_selection.go
+++ b/cmd/camp/cmdutil/campaign_selection.go
@@ -88,7 +88,7 @@ func PickCampaignWithOptions(ctx context.Context, reg *config.Registry, opts Pic
 	)
 	if err != nil {
 		if errors.Is(err, fuzzyfinder.ErrAbort) {
-			return config.RegisteredCampaign{}, fmt.Errorf("cancelled")
+			return config.RegisteredCampaign{}, camperrors.Newf("cancelled")
 		}
 		return config.RegisteredCampaign{}, camperrors.Wrap(err, "picker")
 	}

--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -109,7 +109,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	}
 
 	if commitAutoWrite && commitMessage != "" {
-		return fmt.Errorf("--auto-write cannot be used with --message")
+		return camperrors.Newf("--auto-write cannot be used with --message")
 	}
 	if commitNoEdit && !commitAmend {
 		return camperrors.New("--no-edit requires --amend")

--- a/cmd/camp/dungeon/context.go
+++ b/cmd/camp/dungeon/context.go
@@ -3,7 +3,6 @@ package dungeon
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -34,7 +33,7 @@ func resolveDungeonCommandContext(ctx context.Context) (*dungeonCommandContext, 
 	dungeonCtx, err := intdungeon.ResolveContext(ctx, campaignRoot, cwd)
 	if err != nil {
 		if errors.Is(err, intdungeon.ErrDungeonContextNotFound) {
-			return nil, fmt.Errorf(
+			return nil, camperrors.Newf(
 				"no dungeon context found from %s to campaign root; run 'camp dungeon add' in the target directory",
 				cwd,
 			)

--- a/cmd/camp/dungeon/move.go
+++ b/cmd/camp/dungeon/move.go
@@ -226,27 +226,27 @@ func stageTrackedMoveSourceDeletions(ctx context.Context, campaignRoot string, s
 func WrapDungeonMoveError(err error, itemName, status string) error {
 	switch {
 	case errors.Is(err, intdungeon.ErrAlreadyExists):
-		return fmt.Errorf(
+		return camperrors.Newf(
 			"cannot move %q to %q because destination already exists; choose another status or rename the item: %w",
 			itemName,
 			status,
 			err,
 		)
 	case errors.Is(err, intdungeon.ErrInvalidStatus):
-		return fmt.Errorf(
+		return camperrors.Newf(
 			"invalid status %q for %q; use a single directory name like completed, archived, or someday: %w",
 			status,
 			itemName,
 			err,
 		)
 	case errors.Is(err, intdungeon.ErrInvalidItemPath):
-		return fmt.Errorf(
+		return camperrors.Newf(
 			"invalid item path %q; use a direct child file or directory name from the current dungeon context (no slashes or traversal). Run 'camp dungeon list --triage' or 'camp dungeon list' to confirm available items: %w",
 			itemName,
 			err,
 		)
 	case errors.Is(err, intdungeon.ErrNotFound):
-		return fmt.Errorf(
+		return camperrors.Newf(
 			"item %q was not found in the resolved context; run 'camp dungeon list --triage' or 'camp dungeon list' to confirm available items: %w",
 			itemName,
 			err,
@@ -259,26 +259,26 @@ func WrapDungeonMoveError(err error, itemName, status string) error {
 func wrapDungeonDocsRouteError(err error, itemName, destination string) error {
 	switch {
 	case errors.Is(err, intdungeon.ErrAlreadyExists):
-		return fmt.Errorf(
+		return camperrors.Newf(
 			"cannot route %q to docs/%s because destination already exists; choose another docs destination or rename the item: %w",
 			itemName,
 			destination,
 			err,
 		)
 	case errors.Is(err, intdungeon.ErrInvalidDocsDestination):
-		return fmt.Errorf(
+		return camperrors.Newf(
 			"invalid docs destination %q; use an existing subdirectory under campaign-root docs/ (for example: --to-docs architecture/api): %w",
 			destination,
 			err,
 		)
 	case errors.Is(err, intdungeon.ErrInvalidItemPath):
-		return fmt.Errorf(
+		return camperrors.Newf(
 			"invalid item path %q; use a direct child file or directory name from the resolved triage context (no slashes or traversal). Run 'camp dungeon list --triage' to confirm available items: %w",
 			itemName,
 			err,
 		)
 	case errors.Is(err, intdungeon.ErrNotFound):
-		return fmt.Errorf(
+		return camperrors.Newf(
 			"item %q was not found in the resolved triage context; run 'camp dungeon list --triage' to confirm available items: %w",
 			itemName,
 			err,

--- a/cmd/camp/dungeon/workitem_move.go
+++ b/cmd/camp/dungeon/workitem_move.go
@@ -98,7 +98,7 @@ func moveWorkitemToDungeon(ctx context.Context, cmd *cobra.Command, target, stat
 func selectWorkitemDungeonTarget(campaignRoot string, items []wkitem.WorkItem, target string) (wkitem.WorkItem, error) {
 	raw := strings.TrimSpace(target)
 	if raw == "" {
-		return wkitem.WorkItem{}, fmt.Errorf("workitem target must not be empty")
+		return wkitem.WorkItem{}, camperrors.Newf("workitem target must not be empty")
 	}
 
 	matchStages := []struct {
@@ -131,11 +131,11 @@ func selectWorkitemDungeonTarget(campaignRoot string, items []wkitem.WorkItem, t
 			return matches[0], nil
 		}
 		if len(matches) > 1 {
-			return wkitem.WorkItem{}, fmt.Errorf("workitem target %q is ambiguous by %s; matches: %s", raw, stage.name, formatWorkitemMatches(matches))
+			return wkitem.WorkItem{}, camperrors.Newf("workitem target %q is ambiguous by %s; matches: %s", raw, stage.name, formatWorkitemMatches(matches))
 		}
 	}
 
-	return wkitem.WorkItem{}, fmt.Errorf("workitem %q not found; run 'camp workitem --json' to inspect available workitems", raw)
+	return wkitem.WorkItem{}, camperrors.Newf("workitem %q not found; run 'camp workitem --json' to inspect available workitems", raw)
 }
 
 func matchingWorkitems(items []wkitem.WorkItem, match func(wkitem.WorkItem) bool) []wkitem.WorkItem {
@@ -182,13 +182,13 @@ func normalizeRelativeWorkitemPath(path string) string {
 
 func resolveWorkitemDungeonTarget(campaignRoot string, item wkitem.WorkItem) (*resolvedWorkitemDungeonTarget, error) {
 	if item.ItemKind != wkitem.ItemKindDirectory {
-		return nil, fmt.Errorf("workitem %q resolves to %s, but only directory workitems under workflow/<type>/<slug> can be moved with --workitem", item.RelativePath, item.ItemKind)
+		return nil, camperrors.Newf("workitem %q resolves to %s, but only directory workitems under workflow/<type>/<slug> can be moved with --workitem", item.RelativePath, item.ItemKind)
 	}
 
 	rel := normalizeRelativeWorkitemPath(item.RelativePath)
 	parts := strings.Split(rel, "/")
 	if len(parts) != 3 || parts[0] != "workflow" || parts[1] == "" || parts[2] == "" || parts[1] == "dungeon" || parts[2] == "dungeon" {
-		return nil, fmt.Errorf("workitem %q is not under workflow/<type>/<slug>; only directory workitems under workflow/<type>/<slug> can be moved with --workitem", item.RelativePath)
+		return nil, camperrors.Newf("workitem %q is not under workflow/<type>/<slug>; only directory workitems under workflow/<type>/<slug> can be moved with --workitem", item.RelativePath)
 	}
 
 	parentRel := filepath.FromSlash(strings.Join(parts[:2], "/"))

--- a/cmd/camp/gendocs.go
+++ b/cmd/camp/gendocs.go
@@ -77,7 +77,7 @@ func runGendocs(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Fprintf(os.Stderr, "YAML docs written to %s\n", gendocsOutput)
 	default:
-		return fmt.Errorf("unknown format %q (use markdown or yaml)", gendocsFormat)
+		return camperrors.Newf("unknown format %q (use markdown or yaml)", gendocsFormat)
 	}
 
 	if gendocsSingle && gendocsFormat == "markdown" {

--- a/cmd/camp/intent/archive.go
+++ b/cmd/camp/intent/archive.go
@@ -47,7 +47,7 @@ func runIntentArchive(cmd *cobra.Command, args []string) error {
 	reason, _ := cmd.Flags().GetString("reason")
 	reason = strings.TrimSpace(reason)
 	if reason == "" {
-		return fmt.Errorf("--reason is required when archiving an intent")
+		return camperrors.Newf("--reason is required when archiving an intent")
 	}
 
 	// Find campaign root
@@ -66,7 +66,7 @@ func runIntentArchive(cmd *cobra.Command, args []string) error {
 	// Get intent title for commit message (before archiving)
 	i, err := svc.Find(ctx, id)
 	if err != nil {
-		return fmt.Errorf("intent not found: %s", id)
+		return camperrors.Newf("intent not found: %s", id)
 	}
 	intentTitle := i.Title
 	sourcePath := i.Path

--- a/cmd/camp/intent/gather.go
+++ b/cmd/camp/intent/gather.go
@@ -3,8 +3,9 @@ package intent
 import (
 	"context"
 	"fmt"
-	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/spf13/cobra"
 
@@ -129,12 +130,12 @@ func runIntentGather(cmd *cobra.Command, args []string) error {
 	ids = deduplicateIDs(ids)
 
 	if len(ids) < 2 {
-		return fmt.Errorf("need at least 2 intents to gather, found %d", len(ids))
+		return camperrors.Newf("need at least 2 intents to gather, found %d", len(ids))
 	}
 
 	// Title is required
 	if gatherTitle == "" {
-		return fmt.Errorf("--title is required")
+		return camperrors.Newf("--title is required")
 	}
 
 	// Capture source file paths before gather potentially moves them.
@@ -259,11 +260,11 @@ func discoverIntentsToGather(ctx context.Context, svc *gather.Service, intentSvc
 	}
 
 	if methods == 0 {
-		return nil, fmt.Errorf("specify intent IDs or use --tag, --hashtag, or --similar")
+		return nil, camperrors.Newf("specify intent IDs or use --tag, --hashtag, or --similar")
 	}
 
 	if methods > 1 {
-		return nil, fmt.Errorf("use only one discovery method: IDs, --tag, --hashtag, or --similar")
+		return nil, camperrors.Newf("use only one discovery method: IDs, --tag, --hashtag, or --similar")
 	}
 
 	// By explicit IDs — filter out dungeon intents
@@ -317,7 +318,7 @@ func discoverIntentsToGather(ctx context.Context, svc *gather.Service, intentSvc
 			return nil, camperrors.Wrapf(err, "reference intent %q not found", gatherSimilar)
 		}
 		if refIntent.Status.InDungeon() {
-			return nil, fmt.Errorf("reference intent %q is in %s status — only inbox/active/ready intents can be gathered", gatherSimilar, refIntent.Status)
+			return nil, camperrors.Newf("reference intent %q is in %s status — only inbox/active/ready intents can be gathered", gatherSimilar, refIntent.Status)
 		}
 
 		similar, err := svc.FindSimilar(ctx, gatherSimilar, gatherMinScore)
@@ -332,7 +333,7 @@ func discoverIntentsToGather(ctx context.Context, svc *gather.Service, intentSvc
 		return ids, nil
 	}
 
-	return nil, fmt.Errorf("no discovery method specified")
+	return nil, camperrors.Newf("no discovery method specified")
 }
 
 func showDryRun(ctx context.Context, svc *intent.IntentService, ids []string, title string) error {

--- a/cmd/camp/intent/move.go
+++ b/cmd/camp/intent/move.go
@@ -67,7 +67,7 @@ func runIntentMove(cmd *cobra.Command, args []string) error {
 
 	// Require reason for dungeon moves
 	if status.InDungeon() && reason == "" {
-		return fmt.Errorf("--reason is required when moving to a dungeon status (%s)", status)
+		return camperrors.Newf("--reason is required when moving to a dungeon status (%s)", status)
 	}
 
 	// Find campaign root
@@ -88,7 +88,7 @@ func runIntentMove(cmd *cobra.Command, args []string) error {
 	// Get intent title for commit message (before moving)
 	i, err := svc.Find(ctx, id)
 	if err != nil {
-		return fmt.Errorf("intent not found: %s", id)
+		return camperrors.Newf("intent not found: %s", id)
 	}
 	intentTitle := i.Title
 	sourcePath := i.Path

--- a/cmd/camp/intent/promote.go
+++ b/cmd/camp/intent/promote.go
@@ -70,7 +70,7 @@ func runIntentPromote(cmd *cobra.Command, args []string) error {
 	case "design":
 		target = promote.TargetDesign
 	default:
-		return fmt.Errorf("invalid target: %s (use ready, festival, or design)", targetStr)
+		return camperrors.Newf("invalid target: %s (use ready, festival, or design)", targetStr)
 	}
 
 	// Find campaign root
@@ -89,7 +89,7 @@ func runIntentPromote(cmd *cobra.Command, args []string) error {
 	// Find the intent
 	i, err := svc.Find(ctx, id)
 	if err != nil {
-		return fmt.Errorf("intent not found: %s", id)
+		return camperrors.Newf("intent not found: %s", id)
 	}
 
 	// Dry run mode

--- a/cmd/camp/intent/show.go
+++ b/cmd/camp/intent/show.go
@@ -65,7 +65,7 @@ func runIntentShow(cmd *cobra.Command, args []string) error {
 
 	// Validate format
 	if format != "text" && format != "json" && format != "yaml" {
-		return fmt.Errorf("invalid format: %s (use text, json, or yaml)", format)
+		return camperrors.Newf("invalid format: %s (use text, json, or yaml)", format)
 	}
 
 	// Find campaign root
@@ -86,7 +86,7 @@ func runIntentShow(cmd *cobra.Command, args []string) error {
 	// Find the intent (supports partial matching)
 	i, err := svc.Find(ctx, id)
 	if err != nil {
-		return fmt.Errorf("intent not found: %s", id)
+		return camperrors.Newf("intent not found: %s", id)
 	}
 
 	// Format and output

--- a/cmd/camp/intent/status.go
+++ b/cmd/camp/intent/status.go
@@ -1,8 +1,9 @@
 package intent
 
 import (
-	"fmt"
 	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/Obedience-Corp/camp/internal/intent"
 )
@@ -24,6 +25,6 @@ func parseIntentStatus(raw string) (intent.Status, error) {
 	case "someday", string(intent.StatusSomeday):
 		return intent.StatusSomeday, nil
 	default:
-		return "", fmt.Errorf("invalid status: %s (use inbox, ready, active, done, killed, archived, someday, or dungeon/<status>)", raw)
+		return "", camperrors.Newf("invalid status: %s (use inbox, ready, active, done, killed, archived, someday, or dungeon/<status>)", raw)
 	}
 }

--- a/cmd/camp/leverage/config.go
+++ b/cmd/camp/leverage/config.go
@@ -184,7 +184,7 @@ func updateProjectInclusion(cmd *cobra.Command, ctx context.Context, root, confi
 		name, _ := cmd.Flags().GetString("exclude")
 		entry, exists := cfg.Projects[name]
 		if !exists {
-			return fmt.Errorf("project %q not found in config", name)
+			return camperrors.Newf("project %q not found in config", name)
 		}
 		entry.Include = false
 		cfg.Projects[name] = entry
@@ -195,7 +195,7 @@ func updateProjectInclusion(cmd *cobra.Command, ctx context.Context, root, confi
 		name, _ := cmd.Flags().GetString("include")
 		entry, exists := cfg.Projects[name]
 		if !exists {
-			return fmt.Errorf("project %q not found in config", name)
+			return camperrors.Newf("project %q not found in config", name)
 		}
 		entry.Include = true
 		cfg.Projects[name] = entry
@@ -221,7 +221,7 @@ func updateLeverageConfig(cmd *cobra.Command, configPath string, peopleChanged, 
 	if peopleChanged {
 		people, _ := cmd.Flags().GetInt("people")
 		if people < 0 {
-			return fmt.Errorf("people must be >= 0 (0 = auto-detect from git)")
+			return camperrors.Newf("people must be >= 0 (0 = auto-detect from git)")
 		}
 		cfg.ActualPeople = people
 	}
@@ -244,7 +244,7 @@ func updateLeverageConfig(cmd *cobra.Command, configPath string, peopleChanged, 
 		cocomoType, _ := cmd.Flags().GetString("cocomo-type")
 		valid := map[string]bool{"organic": true, "semi-detached": true, "embedded": true}
 		if !valid[cocomoType] {
-			return fmt.Errorf("invalid COCOMO type %q: must be organic, semi-detached, or embedded", cocomoType)
+			return camperrors.Newf("invalid COCOMO type %q: must be organic, semi-detached, or embedded", cocomoType)
 		}
 		cfg.COCOMOProjectType = cocomoType
 	}

--- a/cmd/camp/leverage/main_command.go
+++ b/cmd/camp/leverage/main_command.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/jsoncontract"
 	intleverage "github.com/Obedience-Corp/camp/internal/leverage"
 	"github.com/spf13/cobra"
@@ -38,7 +40,7 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 	if targetDir != "" {
 		projectFilter, _ := cmd.Flags().GetString("project")
 		if projectFilter != "" {
-			return fmt.Errorf("--project and --dir (or positional directory) are mutually exclusive")
+			return camperrors.Newf("--project and --dir (or positional directory) are mutually exclusive")
 		}
 		return runLeverageDir(cmd, targetDir)
 	}
@@ -116,7 +118,7 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 	}
 
 	if projectFilter != "" && len(scores) == 0 {
-		return fmt.Errorf("project not found: %s", projectFilter)
+		return camperrors.Newf("project not found: %s", projectFilter)
 	}
 
 	effectivePeople := cfg.ActualPeople

--- a/cmd/camp/leverage/snapshot.go
+++ b/cmd/camp/leverage/snapshot.go
@@ -106,7 +106,7 @@ func runLeverageSnapshot(cmd *cobra.Command, args []string) error {
 	}
 
 	if projectFilter != "" && count == 0 {
-		return fmt.Errorf("project not found: %s", projectFilter)
+		return camperrors.Newf("project not found: %s", projectFilter)
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Saved %d snapshots to .campaign/leverage/snapshots/\n", count)

--- a/cmd/camp/mv.go
+++ b/cmd/camp/mv.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"os"
 	"path/filepath"
 	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
@@ -183,7 +184,7 @@ func runMove(cmd *cobra.Command, args []string) error {
 
 	if !force {
 		if _, err := os.Stat(dest); err == nil {
-			return fmt.Errorf("destination %q already exists (use --force to overwrite)", dest)
+			return camperrors.Newf("destination %q already exists (use --force to overwrite)", dest)
 		}
 	}
 

--- a/cmd/camp/navigation/go.go
+++ b/cmd/camp/navigation/go.go
@@ -3,11 +3,12 @@ package navigation
 import (
 	"context"
 	"fmt"
-	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
 	"github.com/Obedience-Corp/camp/internal/config"
@@ -299,13 +300,13 @@ func handleToggle(ctx context.Context, campaignRoot string, printOnly bool) erro
 
 	lastLoc, err := state.GetLastLocation(ctx, campaignRoot)
 	if err != nil || lastLoc == "" {
-		return fmt.Errorf("no previous location in history")
+		return camperrors.Newf("no previous location in history")
 	}
 
 	cwdReal, _ := evalSymlinks(cwd)
 	lastReal, _ := evalSymlinks(lastLoc)
 	if cwdReal == lastReal {
-		return fmt.Errorf("already at last visited location")
+		return camperrors.Newf("already at last visited location")
 	}
 
 	// Save current location so calling toggle again bounces back

--- a/cmd/camp/navigation/shortcuts.go
+++ b/cmd/camp/navigation/shortcuts.go
@@ -294,7 +294,7 @@ func runShortcutsAdd(cmd *cobra.Command, args []string) error {
 		result, err := shortcuts.RunAddSubShortcutTUI(ctx, root)
 		if err != nil {
 			if errors.Is(err, shortcuts.ErrAborted) {
-				return fmt.Errorf("shortcut creation cancelled")
+				return camperrors.Newf("shortcut creation cancelled")
 			}
 			return err
 		}
@@ -306,13 +306,13 @@ func runShortcutsAdd(cmd *cobra.Command, args []string) error {
 		shortcutName = args[1]
 		shortcutPath = args[2]
 	} else {
-		return fmt.Errorf("expected 0, 2, or 3 arguments, got %d\n  2 args: camp shortcuts add <name> <path> (campaign shortcut)\n  3 args: camp shortcuts add <project> <name> <path> (project sub-shortcut)", len(args))
+		return camperrors.Newf("expected 0, 2, or 3 arguments, got %d\n  2 args: camp shortcuts add <name> <path> (campaign shortcut)\n  3 args: camp shortcuts add <project> <name> <path> (project sub-shortcut)", len(args))
 	}
 
 	// Find the project (fuzzy match)
 	projectIdx := findProjectIndex(cfg.Projects, projectName)
 	if projectIdx == -1 {
-		return fmt.Errorf("project %q not found (run 'camp project list' to see available projects)", projectName)
+		return camperrors.Newf("project %q not found (run 'camp project list' to see available projects)", projectName)
 	}
 
 	project := &cfg.Projects[projectIdx]
@@ -320,7 +320,7 @@ func runShortcutsAdd(cmd *cobra.Command, args []string) error {
 	// Validate path exists
 	fullPath := filepath.Join(root, project.Path, shortcutPath)
 	if stat, err := os.Stat(fullPath); err != nil || !stat.IsDir() {
-		return fmt.Errorf("path does not exist or is not a directory: %s", fullPath)
+		return camperrors.Newf("path does not exist or is not a directory: %s", fullPath)
 	}
 
 	// Initialize shortcuts map if nil
@@ -376,18 +376,18 @@ func runShortcutsRemove(cmd *cobra.Command, args []string) error {
 	// Find the project (fuzzy match)
 	projectIdx := findProjectIndex(cfg.Projects, projectName)
 	if projectIdx == -1 {
-		return fmt.Errorf("project %q not found (run 'camp project list' to see available projects)", projectName)
+		return camperrors.Newf("project %q not found (run 'camp project list' to see available projects)", projectName)
 	}
 
 	project := &cfg.Projects[projectIdx]
 
 	// Check if shortcut exists
 	if project.Shortcuts == nil {
-		return fmt.Errorf("project '%s' has no shortcuts configured", project.Name)
+		return camperrors.Newf("project '%s' has no shortcuts configured", project.Name)
 	}
 
 	if _, ok := project.Shortcuts[shortcutName]; !ok {
-		return fmt.Errorf("shortcut '%s' not found in project '%s'", shortcutName, project.Name)
+		return camperrors.Newf("shortcut '%s' not found in project '%s'", shortcutName, project.Name)
 	}
 
 	// Remove the shortcut
@@ -424,7 +424,7 @@ func runShortcutsList(cmd *cobra.Command, args []string) error {
 	// Find the project (fuzzy match)
 	projectIdx := findProjectIndex(cfg.Projects, projectName)
 	if projectIdx == -1 {
-		return fmt.Errorf("project %q not found (run 'camp project list' to see available projects)", projectName)
+		return camperrors.Newf("project %q not found (run 'camp project list' to see available projects)", projectName)
 	}
 
 	project := cfg.Projects[projectIdx]
@@ -490,7 +490,7 @@ func runShortcutsAddJump(cmd *cobra.Command, args []string) error {
 		result, err := shortcuts.RunAddJumpTUI(ctx, root)
 		if err != nil {
 			if errors.Is(err, shortcuts.ErrAborted) {
-				return fmt.Errorf("shortcut creation cancelled")
+				return camperrors.Newf("shortcut creation cancelled")
 			}
 			return err
 		}
@@ -558,7 +558,7 @@ func runShortcutsDiff(cmd *cobra.Command, _ []string) error {
 
 	cfg, _, err := config.LoadCampaignConfigFromCwd(ctx)
 	if err != nil {
-		return fmt.Errorf("not in a campaign: %w", err)
+		return camperrors.Newf("not in a campaign: %w", err)
 	}
 
 	current := cfg.Shortcuts()
@@ -634,7 +634,7 @@ func runShortcutsReset(cmd *cobra.Command, _ []string) error {
 
 	_, root, err := config.LoadCampaignConfigFromCwd(ctx)
 	if err != nil {
-		return fmt.Errorf("not in a campaign: %w", err)
+		return camperrors.Newf("not in a campaign: %w", err)
 	}
 
 	plan, err := shortcuts.PrepareReset(ctx, root)
@@ -756,12 +756,12 @@ func runShortcutsRemoveJump(cmd *cobra.Command, args []string) error {
 
 	// Check if jumps config exists
 	if jumps == nil || jumps.Shortcuts == nil {
-		return fmt.Errorf("no shortcuts configured")
+		return camperrors.Newf("no shortcuts configured")
 	}
 
 	// Check if shortcut exists
 	if _, ok := jumps.Shortcuts[shortcutName]; !ok {
-		return fmt.Errorf("shortcut '%s' not found", shortcutName)
+		return camperrors.Newf("shortcut '%s' not found", shortcutName)
 	}
 
 	// Remove the shortcut

--- a/cmd/camp/pins.go
+++ b/cmd/camp/pins.go
@@ -149,7 +149,7 @@ func runPin(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrapf(err, "path %q does not exist", absPath)
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("path %q is not a directory", absPath)
+		return camperrors.Newf("path %q is not a directory", absPath)
 	}
 
 	store, campaignRoot, err := loadPinStore(cmd)
@@ -242,7 +242,7 @@ func runUnpin(cmd *cobra.Command, args []string) error {
 		}
 		pin, ok := findPinForCwd(store, cwd, campaignRoot)
 		if !ok {
-			return fmt.Errorf("directory not pinned: %s", cwd)
+			return camperrors.Newf("directory not pinned: %s", cwd)
 		}
 		name = pin.Name
 	}

--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"path/filepath"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
 	"github.com/Obedience-Corp/camp/internal/campaign"
@@ -100,7 +101,7 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 	}
 
 	if projectCommitAutoWrite && projectCommitMessage != "" {
-		return fmt.Errorf("--auto-write cannot be used with --message")
+		return camperrors.Newf("--auto-write cannot be used with --message")
 	}
 
 	// Get commit message - prompt if not provided

--- a/cmd/camp/push.go
+++ b/cmd/camp/push.go
@@ -3,11 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
-	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/git"
@@ -224,7 +225,7 @@ func runPushAll(ctx context.Context, campRoot string, gitArgs []string, noRecurs
 	}
 
 	if failed > 0 {
-		return fmt.Errorf("%d repo(s) failed to push", failed)
+		return camperrors.Newf("%d repo(s) failed to push", failed)
 	}
 	return nil
 }

--- a/cmd/camp/quest/lifecycle.go
+++ b/cmd/camp/quest/lifecycle.go
@@ -125,7 +125,7 @@ func runQuestLifecycle(cmd *cobra.Command, selector, action string) error {
 		commitType = commit.QuestRestore
 		desc = "Restored quest"
 	default:
-		return fmt.Errorf("unknown quest action: %s", action)
+		return camperrors.Newf("unknown quest action: %s", action)
 	}
 	if err != nil {
 		return err

--- a/cmd/camp/refs/commands.go
+++ b/cmd/camp/refs/commands.go
@@ -62,7 +62,7 @@ func runRefsSync(cmd *cobra.Command, args []string) error {
 	if !refsSyncOpts.force {
 		stagedCmd := exec.CommandContext(ctx, "git", "-C", campRoot, "diff", "--cached", "--quiet")
 		if err := stagedCmd.Run(); err != nil {
-			return fmt.Errorf("campaign root has staged changes; use --force to override")
+			return camperrors.Newf("campaign root has staged changes; use --force to override")
 		}
 	}
 

--- a/cmd/camp/shell_init.go
+++ b/cmd/camp/shell_init.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/shell"
 	"github.com/spf13/cobra"
 )
@@ -66,7 +68,7 @@ func runShellInit(cmd *cobra.Command, args []string) error {
 	shellType := strings.ToLower(args[0])
 
 	if !shell.IsSupported(shellType) {
-		return fmt.Errorf("unsupported shell: %s\nSupported: %s",
+		return camperrors.Newf("unsupported shell: %s\nSupported: %s",
 			shellType, strings.Join(shell.SupportedShells, ", "))
 	}
 

--- a/cmd/camp/skills/link.go
+++ b/cmd/camp/skills/link.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	intskills "github.com/Obedience-Corp/camp/internal/skills"
 	"github.com/spf13/cobra"
@@ -56,7 +58,7 @@ func runSkillsLink(cmd *cobra.Command, _ []string) error {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 
 	if tool != "" && destPath != "" {
-		return fmt.Errorf("--tool and --path are mutually exclusive; use one or the other")
+		return camperrors.Newf("--tool and --path are mutually exclusive; use one or the other")
 	}
 
 	skillsDir, err := intskills.FindSkillsDir(ctx)
@@ -113,7 +115,7 @@ func runSkillsLink(cmd *cobra.Command, _ []string) error {
 	}
 
 	if summary.Conflicts > 0 {
-		return fmt.Errorf(
+		return camperrors.Newf(
 			"projection incomplete: %d conflicting skill path(s) exist and were not overwritten: %v",
 			summary.Conflicts,
 			summary.ConflictNames,
@@ -145,7 +147,7 @@ func linkAllTools(out, errOut io.Writer, root, skillsDir string, force, dryRun b
 	var conflictNames []string
 	for _, res := range results {
 		if res.Err != nil {
-			return fmt.Errorf("link %s: %w", res.Tool, res.Err)
+			return camperrors.Newf("link %s: %w", res.Tool, res.Err)
 		}
 		s := res.Summary
 		if _, err := fmt.Fprintf(out, "%s %d skill bundle(s) into %s (created=%d replaced=%d unchanged=%d)\n",
@@ -157,7 +159,7 @@ func linkAllTools(out, errOut io.Writer, root, skillsDir string, force, dryRun b
 	}
 
 	if conflicts > 0 {
-		return fmt.Errorf("projection incomplete: %d conflicting skill path(s) exist and were not overwritten: %v", conflicts, conflictNames)
+		return camperrors.Newf("projection incomplete: %d conflicting skill path(s) exist and were not overwritten: %v", conflicts, conflictNames)
 	}
 
 	return nil

--- a/cmd/camp/skills/status.go
+++ b/cmd/camp/skills/status.go
@@ -62,7 +62,7 @@ func runSkillsStatus(cmd *cobra.Command, _ []string) error {
 
 	skillsDir := filepath.Join(root, campaign.CampaignDir, intskills.SkillsSubdir)
 	if _, err := os.Stat(skillsDir); err != nil {
-		return fmt.Errorf(".campaign/skills/ not found: run 'camp init' or create the directory")
+		return camperrors.Newf(".campaign/skills/ not found: run 'camp init' or create the directory")
 	}
 
 	slugs, err := intskills.DiscoverSkillSlugs(skillsDir)
@@ -190,7 +190,7 @@ func runSkillsStatus(cmd *cobra.Command, _ []string) error {
 
 	strict, _ := cmd.Flags().GetBool("strict")
 	if hasAttention && strict {
-		return fmt.Errorf("one or more skill projection targets need attention")
+		return camperrors.Newf("one or more skill projection targets need attention")
 	}
 
 	return nil

--- a/cmd/camp/skills/unlink.go
+++ b/cmd/camp/skills/unlink.go
@@ -3,6 +3,8 @@ package skills
 import (
 	"fmt"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	intskills "github.com/Obedience-Corp/camp/internal/skills"
 	"github.com/spf13/cobra"
@@ -47,10 +49,10 @@ func runSkillsUnlink(cmd *cobra.Command, _ []string) error {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 
 	if tool != "" && destPath != "" {
-		return fmt.Errorf("--tool and --path are mutually exclusive; use one or the other")
+		return camperrors.Newf("--tool and --path are mutually exclusive; use one or the other")
 	}
 	if tool == "" && destPath == "" {
-		return fmt.Errorf("specify --tool <name> or --path <destination>\n\nAvailable tools: claude, agents")
+		return camperrors.Newf("specify --tool <name> or --path <destination>\n\nAvailable tools: claude, agents")
 	}
 
 	root, err := campaign.DetectCached(ctx)
@@ -95,7 +97,7 @@ func runSkillsUnlink(cmd *cobra.Command, _ []string) error {
 		}
 		return nil
 	case intskills.TypeFile, intskills.TypeSymlink:
-		return fmt.Errorf("destination is not a projection directory: %s", dest)
+		return camperrors.Newf("destination is not a projection directory: %s", dest)
 	}
 
 	removed, err := intskills.RemoveProjectedSkillEntries(dest, skillsDir, slugs, dryRun)

--- a/cmd/camp/switch.go
+++ b/cmd/camp/switch.go
@@ -256,7 +256,7 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "load registry")
 	}
 	if reg.Len() == 0 {
-		return fmt.Errorf("no campaigns registered (use 'camp init' to create one)")
+		return camperrors.Newf("no campaigns registered (use 'camp init' to create one)")
 	}
 
 	var selected config.RegisteredCampaign

--- a/cmd/camp/transfer.go
+++ b/cmd/camp/transfer.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"os"
 	"path/filepath"
 	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
@@ -78,7 +79,7 @@ func runTransfer(cmd *cobra.Command, args []string) error {
 
 	if !force {
 		if _, err := os.Stat(destPath); err == nil {
-			return fmt.Errorf("destination %q already exists (use --force to overwrite)", destPath)
+			return camperrors.Newf("destination %q already exists (use --force to overwrite)", destPath)
 		}
 	}
 

--- a/cmd/camp/unregister.go
+++ b/cmd/camp/unregister.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/spf13/cobra"
@@ -60,7 +62,7 @@ func runUnregister(cmd *cobra.Command, args []string) error {
 	// Find campaign by ID, ID prefix, or name
 	campaign, exists := reg.Get(query)
 	if !exists {
-		return fmt.Errorf("campaign %q not found in registry\n"+
+		return camperrors.Newf("campaign %q not found in registry\n"+
 			"Hint: Run '%s' to see registered campaigns", query, ui.Accent("camp list"))
 	}
 

--- a/cmd/camp/worktrees/commit.go
+++ b/cmd/camp/worktrees/commit.go
@@ -3,6 +3,7 @@ package worktrees
 import (
 	"errors"
 	"fmt"
+
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
@@ -93,7 +94,7 @@ func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 	}
 
 	if wtCommitAutoWrite && wtCommitMessage != "" {
-		return fmt.Errorf("--auto-write cannot be used with --message")
+		return camperrors.Newf("--auto-write cannot be used with --message")
 	}
 
 	// Get commit message - prompt if not provided
@@ -104,7 +105,7 @@ func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 			return camperrors.Wrap(err, "prompt failed")
 		}
 		if message == "" {
-			return fmt.Errorf("commit cancelled")
+			return camperrors.Newf("commit cancelled")
 		}
 	}
 

--- a/cmd/camp/worktrees/info.go
+++ b/cmd/camp/worktrees/info.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
@@ -99,9 +100,9 @@ func runWorktreesInfo(cmd *cobra.Command, args []string) error {
 
 	if err != nil {
 		if infoPath == "" {
-			return fmt.Errorf("not inside a worktree (use --path to specify)")
+			return camperrors.Newf("not inside a worktree (use --path to specify)")
 		}
-		return fmt.Errorf("not a valid worktree: %s", infoPath)
+		return camperrors.Newf("not a valid worktree: %s", infoPath)
 	}
 
 	// Build detailed info

--- a/internal/buildutil/main.go
+++ b/internal/buildutil/main.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"time"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/buildutil/tasks"
 	"github.com/Obedience-Corp/camp/internal/buildutil/ui"
 )
@@ -62,31 +64,30 @@ func main() {
 
 		fmt.Println("\n🧹 Cleaning...")
 		if cleanErr := tasks.Clean(verbose); cleanErr != nil {
-			errors = append(errors, fmt.Errorf("clean failed: %w", cleanErr))
+			errors = append(errors, camperrors.Newf("clean failed: %w", cleanErr))
 		}
 
 		fmt.Println("\n🔨 Building...")
 		if buildErr := tasks.Build(verbose); buildErr != nil {
-			errors = append(errors, fmt.Errorf("build failed: %w", buildErr))
 			// Don't continue if build fails - can't test broken code
-			err = fmt.Errorf("stopping due to build failure: %w", buildErr)
+			err = camperrors.Newf("stopping due to build failure: %w", buildErr)
 			break
 		}
 
 		fmt.Println("\n🧪 Testing...")
 		if testErr := tasks.Test(verbose); testErr != nil {
-			errors = append(errors, fmt.Errorf("tests failed: %w", testErr))
+			errors = append(errors, camperrors.Newf("tests failed: %w", testErr))
 			// Continue to integration tests even if unit tests fail
 		}
 
 		fmt.Println("\n🔗 Integration Testing...")
 		if integrationErr := tasks.Integration(verbose); integrationErr != nil {
-			errors = append(errors, fmt.Errorf("integration tests failed: %w", integrationErr))
+			errors = append(errors, camperrors.Newf("integration tests failed: %w", integrationErr))
 		}
 
 		// Set overall error if any step failed
 		if len(errors) > 0 {
-			err = fmt.Errorf("%d tasks failed", len(errors))
+			err = camperrors.Newf("%d tasks failed", len(errors))
 		}
 
 		// Show overall summary

--- a/internal/buildutil/tasks/build.go
+++ b/internal/buildutil/tasks/build.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/buildutil/ui"
 )
 
@@ -79,7 +81,7 @@ func Build(verbose bool) error {
 
 	packages, err := discoverPackages()
 	if err != nil {
-		return fmt.Errorf("failed to discover packages: %w", err)
+		return camperrors.Newf("failed to discover packages: %w", err)
 	}
 
 	if verbose {
@@ -229,7 +231,7 @@ func Build(verbose bool) error {
 				failedPackages = append(failedPackages, r.Package)
 			}
 		}
-		return fmt.Errorf("build failed for packages: %s", strings.Join(failedPackages, ", "))
+		return camperrors.Newf("build failed for packages: %s", strings.Join(failedPackages, ", "))
 	}
 
 	return nil
@@ -293,7 +295,7 @@ func BuildOnly(verbose bool) error {
 
 	// Create bin directory
 	if err := os.MkdirAll("bin", 0o755); err != nil {
-		return fmt.Errorf("failed to create bin directory: %w", err)
+		return camperrors.Newf("failed to create bin directory: %w", err)
 	}
 
 	ui.Task("Building", "camp binary")
@@ -307,7 +309,7 @@ func BuildOnly(verbose bool) error {
 
 	if err := cmd.Run(); err != nil {
 		ui.TaskFail()
-		return fmt.Errorf("failed to build camp binary: %w", err)
+		return camperrors.Newf("failed to build camp binary: %w", err)
 	}
 
 	ui.TaskPass()

--- a/internal/buildutil/tasks/integration.go
+++ b/internal/buildutil/tasks/integration.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"time"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/buildutil/ui"
 )
 
@@ -62,7 +64,7 @@ func Integration(verbose bool) error {
 	ui.Task("Building", "Linux binary for Docker tests")
 	if err := os.MkdirAll("bin/linux", 0o755); err != nil {
 		ui.TaskFail()
-		return fmt.Errorf("failed to create bin/linux directory: %w", err)
+		return camperrors.Newf("failed to create bin/linux directory: %w", err)
 	}
 
 	cmd := exec.Command("go", "build", "-ldflags", "-s -w", "-o", "bin/linux/camp", "./cmd/camp")
@@ -73,13 +75,13 @@ func Integration(verbose bool) error {
 	}
 	if err := cmd.Run(); err != nil {
 		ui.TaskFail()
-		return fmt.Errorf("failed to build Linux binary: %w", err)
+		return camperrors.Newf("failed to build Linux binary: %w", err)
 	}
 	ui.TaskPass()
 
 	suites, err := discoverIntegrationSuites()
 	if err != nil {
-		return fmt.Errorf("failed to discover integration test suites: %w", err)
+		return camperrors.Newf("failed to discover integration test suites: %w", err)
 	}
 
 	if len(suites) == 0 {
@@ -126,11 +128,11 @@ func Integration(verbose bool) error {
 			cmd.Env = dockerEnv
 			stdout, err := cmd.StdoutPipe()
 			if err != nil {
-				return fmt.Errorf("failed to create stdout pipe: %w", err)
+				return camperrors.Newf("failed to create stdout pipe: %w", err)
 			}
 
 			if err := cmd.Start(); err != nil {
-				return fmt.Errorf("failed to start test: %w", err)
+				return camperrors.Newf("failed to start test: %w", err)
 			}
 
 			// Track state for progress display
@@ -327,7 +329,7 @@ func Integration(verbose bool) error {
 	ui.SummaryCardWithStatus("Integration Test Summary", rows, fmt.Sprintf("%.2fs", totalTime.Seconds()), success, successMsg, failMsg)
 
 	if failures > 0 {
-		return fmt.Errorf("%d integration test suites failed", failures)
+		return camperrors.Newf("%d integration test suites failed", failures)
 	}
 
 	return nil

--- a/internal/buildutil/tasks/test.go
+++ b/internal/buildutil/tasks/test.go
@@ -14,6 +14,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/buildutil/ui"
 )
 
@@ -44,7 +46,7 @@ func Test(verbose bool) error {
 
 	packages, err := discoverTestPackages()
 	if err != nil {
-		return fmt.Errorf("failed to discover test packages: %w", err)
+		return camperrors.Newf("failed to discover test packages: %w", err)
 	}
 
 	if verbose {
@@ -216,7 +218,7 @@ func Test(verbose bool) error {
 	ui.SummaryCardWithStatus(title, rows, fmt.Sprintf("%.2fs", wallTime.Seconds()), success, successMsg, failMsg)
 
 	if pkgFailures > 0 {
-		return fmt.Errorf("%d packages had test failures (%d tests failed)", pkgFailures, totalTestsFailed)
+		return camperrors.Newf("%d packages had test failures (%d tests failed)", pkgFailures, totalTestsFailed)
 	}
 
 	return nil

--- a/internal/campaign/errors.go
+++ b/internal/campaign/errors.go
@@ -3,7 +3,6 @@ package campaign
 
 import (
 	"errors"
-	"fmt"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
@@ -16,8 +15,8 @@ var (
 		"Hint: Run 'camp init' to create a campaign, or navigate to an existing one")
 
 	// ErrCampaignExists is returned when trying to initialize a campaign that already exists.
-	ErrCampaignExists = fmt.Errorf("campaign already exists in this directory: %w", camperrors.ErrAlreadyExists)
+	ErrCampaignExists = camperrors.Newf("campaign already exists in this directory: %w", camperrors.ErrAlreadyExists)
 
 	// ErrInvalidCampaign is returned when the campaign directory is corrupted or invalid.
-	ErrInvalidCampaign = fmt.Errorf("invalid campaign directory: %w", camperrors.ErrInvalidInput)
+	ErrInvalidCampaign = camperrors.Newf("invalid campaign directory: %w", camperrors.ErrInvalidInput)
 )

--- a/internal/commands/flow/add.go
+++ b/internal/commands/flow/add.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"io"
 	"os"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
@@ -189,16 +190,16 @@ func collectFlowAddInput(cmd *cobra.Command, flowAddJSON, flowAddName, flowAddDe
 
 	if err := theme.RunForm(ctx, form); err != nil {
 		if theme.IsCancelled(err) {
-			return nil, fmt.Errorf("initialization cancelled")
+			return nil, camperrors.Newf("initialization cancelled")
 		}
 		return nil, camperrors.Wrap(err, "failed to collect workflow info")
 	}
 
 	if name == "" {
-		return nil, fmt.Errorf("workflow name is required")
+		return nil, camperrors.Newf("workflow name is required")
 	}
 	if description == "" {
-		return nil, fmt.Errorf("workflow description is required")
+		return nil, camperrors.Newf("workflow description is required")
 	}
 
 	return &flowAddInput{Name: name, Description: description}, nil
@@ -224,10 +225,10 @@ func parseFlowAddJSON(value string) (*flowAddInput, error) {
 	}
 
 	if input.Name == "" {
-		return nil, fmt.Errorf("JSON input requires \"name\" field")
+		return nil, camperrors.Newf("JSON input requires \"name\" field")
 	}
 	if input.Description == "" {
-		return nil, fmt.Errorf("JSON input requires \"description\" field")
+		return nil, camperrors.Newf("JSON input requires \"description\" field")
 	}
 
 	return &input, nil

--- a/internal/commands/flow/run.go
+++ b/internal/commands/flow/run.go
@@ -1,7 +1,6 @@
 package flow
 
 import (
-	"fmt"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/spf13/cobra"
@@ -41,7 +40,7 @@ Examples:
 
 			flowDef, ok := registry.Get(flowName)
 			if !ok {
-				return fmt.Errorf("flow %q not found\n\nAvailable flows: %v", flowName, registry.List())
+				return camperrors.Newf("flow %q not found\n\nAvailable flows: %v", flowName, registry.List())
 			}
 
 			runner := flow.NewRunner(campaignRoot)

--- a/internal/commands/fresh/all.go
+++ b/internal/commands/fresh/all.go
@@ -105,7 +105,7 @@ Examples:
 			}
 
 			if failed > 0 {
-				return fmt.Errorf("%d project(s) failed", failed)
+				return camperrors.Newf("%d project(s) failed", failed)
 			}
 			return nil
 		},

--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -152,7 +152,7 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 	// Step 1: Checkout default branch
 	defaultBranch := git.DefaultBranch(ctx, path)
 	if defaultBranch == "" {
-		return fmt.Errorf("could not determine default branch for %s", name)
+		return camperrors.Newf("could not determine default branch for %s", name)
 	}
 
 	currentBranch := git.CurrentBranch(ctx, path)
@@ -394,12 +394,12 @@ func freshSafetyChecks(ctx context.Context, path string, dryRun bool) error {
 
 	// Check for merge in progress
 	if git.IsMergeInProgress(ctx, path) {
-		return fmt.Errorf("merge in progress — complete or abort first")
+		return camperrors.Newf("merge in progress — complete or abort first")
 	}
 
 	// Check for rebase in progress
 	if git.IsRebaseInProgress(ctx, path) {
-		return fmt.Errorf("rebase in progress — complete or abort first")
+		return camperrors.Newf("rebase in progress — complete or abort first")
 	}
 
 	// Check for uncommitted changes
@@ -408,7 +408,7 @@ func freshSafetyChecks(ctx context.Context, path string, dryRun bool) error {
 		return camperrors.Wrap(err, "checking for uncommitted changes")
 	}
 	if hasChanges {
-		return fmt.Errorf("uncommitted changes — commit or stash first")
+		return camperrors.Newf("uncommitted changes — commit or stash first")
 	}
 
 	return nil

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -123,7 +123,7 @@ Examples:
 			case !interactive:
 				// Non-interactive --print/--path-output: output first item path directly.
 				if len(items) == 0 {
-					return fmt.Errorf("no work items found")
+					return camperrors.Newf("no work items found")
 				}
 				return outputSelectedPath(items[0], flagPrint, flagPathOutput)
 			case flagPathOutput != "":
@@ -227,7 +227,7 @@ func runSelectedAction(ctx context.Context, item wkitem.WorkItem, printOnly bool
 func openSelectedItem(ctx context.Context, item wkitem.WorkItem, campaignRoot string) error {
 	path := selectedOpenPath(item, campaignRoot)
 	if path == "" {
-		return fmt.Errorf("selected work item has no path to open")
+		return camperrors.Newf("selected work item has no path to open")
 	}
 	editorName := editor.GetEditor(ctx)
 	cmd := editor.BuildEditorCommand(ctx, editorName, path)
@@ -327,7 +327,7 @@ func categoryVocabulary(cfg *config.CampaignConfig) []wkitem.CategoryVocabEntry 
 
 func runTUI(ctx context.Context, items []wkitem.WorkItem, printOnly bool, pathOutput string, campaignRoot string, resolver *paths.Resolver, store *priority.Store, storePath string, showParked bool, categoryForType func(string) string) error {
 	if len(items) == 0 {
-		return fmt.Errorf("no work items found")
+		return camperrors.Newf("no work items found")
 	}
 
 	model := wktui.New(ctx, items, campaignRoot, resolver, store, storePath, showParked)

--- a/internal/concept/service.go
+++ b/internal/concept/service.go
@@ -3,7 +3,6 @@ package concept
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -337,7 +336,7 @@ func (s *DefaultService) ResolvePath(ctx context.Context, path string) (*Item, e
 	info, err := os.Stat(fullPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("path not found: %s", path)
+			return nil, camperrors.Newf("path not found: %s", path)
 		}
 		return nil, camperrors.Wrap(err, "checking path")
 	}
@@ -377,7 +376,7 @@ func (s *DefaultService) ConceptForPath(ctx context.Context, path string) (*Conc
 		}
 	}
 
-	return nil, fmt.Errorf("path not within any concept: %s", path)
+	return nil, camperrors.Newf("path not within any concept: %s", path)
 }
 
 // hasPathPrefix checks if path starts with prefix as a proper path prefix.

--- a/internal/crawl/picker.go
+++ b/internal/crawl/picker.go
@@ -35,7 +35,7 @@ type pickerModel struct {
 
 func newPickerModel(item Item, options []Option) (pickerModel, error) {
 	if len(options) == 0 {
-		return pickerModel{}, fmt.Errorf("no destination options provided")
+		return pickerModel{}, camperrors.Newf("no destination options provided")
 	}
 	return pickerModel{
 		item:    item,
@@ -194,7 +194,7 @@ func runDestinationPicker(ctx context.Context, item Item, options []Option) (Opt
 
 	pm, ok := finalModel.(pickerModel)
 	if !ok {
-		return Option{}, fmt.Errorf("unexpected picker model type %T", finalModel)
+		return Option{}, camperrors.Newf("unexpected picker model type %T", finalModel)
 	}
 	if pm.aborted {
 		return Option{}, ErrAborted

--- a/internal/doctor/checks/commits.go
+++ b/internal/doctor/checks/commits.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/doctor"
 )
 
@@ -51,7 +53,7 @@ func (c *CommitsCheck) Run(ctx context.Context, repoRoot string) (*doctor.CheckR
 	// Get submodule paths
 	submodules, err := c.listSubmodules(ctx, repoRoot)
 	if err != nil {
-		return nil, fmt.Errorf("list submodules: %w", err)
+		return nil, camperrors.Newf("list submodules: %w", err)
 	}
 
 	result.Total = len(submodules)
@@ -141,7 +143,7 @@ func (c *CommitsCheck) listSubmodules(ctx context.Context, repoRoot string) ([]s
 			// No submodules configured
 			return nil, nil
 		}
-		return nil, fmt.Errorf("list submodules: %w", err)
+		return nil, camperrors.Newf("list submodules: %w", err)
 	}
 
 	var paths []string
@@ -162,14 +164,14 @@ func (c *CommitsCheck) getExpectedCommit(ctx context.Context, repoRoot, subPath 
 	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "ls-tree", "HEAD", subPath)
 	output, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("ls-tree: %w", err)
+		return "", camperrors.Newf("ls-tree: %w", err)
 	}
 
 	// Format: "mode type hash\tpath"
 	// Example: "160000 commit a1b2c3d4e5f6...\tprojects/camp"
 	fields := strings.Fields(strings.TrimSpace(string(output)))
 	if len(fields) < 3 {
-		return "", fmt.Errorf("unexpected ls-tree output: %q", string(output))
+		return "", camperrors.Newf("unexpected ls-tree output: %q", string(output))
 	}
 
 	return fields[2], nil
@@ -180,7 +182,7 @@ func (c *CommitsCheck) getActualCommit(ctx context.Context, subPath string) (str
 	cmd := exec.CommandContext(ctx, "git", "-C", subPath, "rev-parse", "HEAD")
 	output, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("rev-parse: %w", err)
+		return "", camperrors.Newf("rev-parse: %w", err)
 	}
 
 	return strings.TrimSpace(string(output)), nil

--- a/internal/doctor/checks/head.go
+++ b/internal/doctor/checks/head.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/doctor"
 )
 
@@ -51,7 +53,7 @@ func (c *HeadCheck) Run(ctx context.Context, repoRoot string) (*doctor.CheckResu
 	// Get submodule paths
 	submodules, err := c.listSubmodules(ctx, repoRoot)
 	if err != nil {
-		return nil, fmt.Errorf("list submodules: %w", err)
+		return nil, camperrors.Newf("list submodules: %w", err)
 	}
 
 	result.Total = len(submodules)
@@ -99,7 +101,7 @@ func (c *HeadCheck) listSubmodules(ctx context.Context, repoRoot string) ([]stri
 			// No submodules configured
 			return nil, nil
 		}
-		return nil, fmt.Errorf("list submodules: %w", err)
+		return nil, camperrors.Newf("list submodules: %w", err)
 	}
 
 	var paths []string

--- a/internal/doctor/checks/integrity.go
+++ b/internal/doctor/checks/integrity.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/doctor"
 )
 
@@ -52,7 +54,7 @@ func (c *IntegrityCheck) Run(ctx context.Context, repoRoot string) (*doctor.Chec
 	// Get submodule paths
 	submodules, err := c.getSubmodulePaths(ctx, repoRoot)
 	if err != nil {
-		return nil, fmt.Errorf("list submodules: %w", err)
+		return nil, camperrors.Newf("list submodules: %w", err)
 	}
 
 	result.Total = len(submodules)
@@ -121,7 +123,7 @@ func (c *IntegrityCheck) getSubmodulePaths(ctx context.Context, repoRoot string)
 			// No submodules configured
 			return nil, nil
 		}
-		return nil, fmt.Errorf("list submodules: %w", err)
+		return nil, camperrors.Newf("list submodules: %w", err)
 	}
 
 	paths := make(map[string]string)

--- a/internal/doctor/checks/lock.go
+++ b/internal/doctor/checks/lock.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"os"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/doctor"
 	"github.com/Obedience-Corp/camp/internal/git"
 )
@@ -49,7 +51,7 @@ func (c *LockCheck) Run(ctx context.Context, repoRoot string) (*doctor.CheckResu
 	// Find all lock files in the repository
 	locks, err := git.FindLocksInRepository(ctx, repoRoot)
 	if err != nil {
-		return nil, fmt.Errorf("find lock files: %w", err)
+		return nil, camperrors.Newf("find lock files: %w", err)
 	}
 
 	result.Total = len(locks)
@@ -61,7 +63,7 @@ func (c *LockCheck) Run(ctx context.Context, repoRoot string) (*doctor.CheckResu
 	// Check staleness of each lock
 	stale, active, err := git.CheckLocksStaleness(ctx, locks)
 	if err != nil {
-		return nil, fmt.Errorf("check lock staleness: %w", err)
+		return nil, camperrors.Newf("check lock staleness: %w", err)
 	}
 
 	// Report stale locks as errors (auto-fixable)
@@ -134,7 +136,7 @@ func (c *LockCheck) Fix(ctx context.Context, repoRoot string, issues []doctor.Is
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	removed, _, _, err := git.RemoveStaleLocks(ctx, stalePaths, logger)
 	if err != nil {
-		return nil, fmt.Errorf("remove stale locks: %w", err)
+		return nil, camperrors.Newf("remove stale locks: %w", err)
 	}
 
 	// Map removed paths back to their issues

--- a/internal/doctor/checks/orphan.go
+++ b/internal/doctor/checks/orphan.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/doctor"
 	"github.com/Obedience-Corp/camp/internal/git"
 )
@@ -47,7 +49,7 @@ func (c *OrphanCheck) Run(ctx context.Context, repoRoot string) (*doctor.CheckRe
 
 	orphans, err := git.ListOrphanedGitlinks(ctx, repoRoot)
 	if err != nil {
-		return nil, fmt.Errorf("detect orphaned gitlinks: %w", err)
+		return nil, camperrors.Newf("detect orphaned gitlinks: %w", err)
 	}
 
 	result.Total = len(orphans)
@@ -96,7 +98,7 @@ func (c *OrphanCheck) Fix(ctx context.Context, repoRoot string, issues []doctor.
 
 	removed, err := git.RemoveOrphanedGitlinks(ctx, repoRoot, orphans)
 	if err != nil {
-		return nil, fmt.Errorf("remove orphaned gitlinks: %w", err)
+		return nil, camperrors.Newf("remove orphaned gitlinks: %w", err)
 	}
 
 	// Map removed paths back to fixed issues

--- a/internal/doctor/checks/url.go
+++ b/internal/doctor/checks/url.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"strings"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/doctor"
 	"github.com/Obedience-Corp/camp/internal/git"
 )
@@ -51,7 +53,7 @@ func (c *URLCheck) Run(ctx context.Context, repoRoot string) (*doctor.CheckResul
 	// Get list of submodules
 	submodules, err := c.listSubmodules(ctx, repoRoot)
 	if err != nil {
-		return nil, fmt.Errorf("list submodules: %w", err)
+		return nil, camperrors.Newf("list submodules: %w", err)
 	}
 
 	result.Total = len(submodules)
@@ -102,7 +104,7 @@ func (c *URLCheck) Fix(ctx context.Context, repoRoot string, issues []doctor.Iss
 	// Run git submodule sync --recursive to fix all URL mismatches at once
 	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "submodule", "sync", "--recursive")
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("git submodule sync: %w", err)
+		return nil, camperrors.Newf("git submodule sync: %w", err)
 	}
 
 	// All issues should be fixed after sync
@@ -125,7 +127,7 @@ func (c *URLCheck) listSubmodules(ctx context.Context, repoRoot string) ([]strin
 			// No submodules configured
 			return nil, nil
 		}
-		return nil, fmt.Errorf("list submodules: %w", err)
+		return nil, camperrors.Newf("list submodules: %w", err)
 	}
 
 	var paths []string

--- a/internal/doctor/checks/working.go
+++ b/internal/doctor/checks/working.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/doctor"
 )
 
@@ -51,7 +53,7 @@ func (c *WorkingCheck) Run(ctx context.Context, repoRoot string) (*doctor.CheckR
 	// Get submodule paths
 	submodules, err := c.listSubmodules(ctx, repoRoot)
 	if err != nil {
-		return nil, fmt.Errorf("list submodules: %w", err)
+		return nil, camperrors.Newf("list submodules: %w", err)
 	}
 
 	result.Total = len(submodules)
@@ -117,7 +119,7 @@ func (c *WorkingCheck) listSubmodules(ctx context.Context, repoRoot string) ([]s
 			// No submodules configured
 			return nil, nil
 		}
-		return nil, fmt.Errorf("list submodules: %w", err)
+		return nil, camperrors.Newf("list submodules: %w", err)
 	}
 
 	var paths []string
@@ -138,7 +140,7 @@ func (c *WorkingCheck) getUncommittedChanges(ctx context.Context, repoPath strin
 	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "status", "--porcelain")
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("git status: %w", err)
+		return nil, camperrors.Newf("git status: %w", err)
 	}
 
 	var changes []string

--- a/internal/dungeon/crawl.go
+++ b/internal/dungeon/crawl.go
@@ -34,7 +34,7 @@ func statusDirsToOptions(dirs []StatusDir) []crawl.Option {
 // or empty string if the user backed out (esc).
 func promptStatusSelection(ctx context.Context, prompt crawl.Prompt, itemName string, dirs []StatusDir) (string, error) {
 	if len(dirs) == 0 {
-		return "", fmt.Errorf("no status directories found (run 'camp dungeon add' to create defaults)")
+		return "", camperrors.Newf("no status directories found (run 'camp dungeon add' to create defaults)")
 	}
 	chosen, err := prompt.SelectDestination(ctx, crawl.Item{ID: itemName, Title: itemName}, statusDirsToOptions(dirs))
 	if err != nil {

--- a/internal/dungeon/docs_browser.go
+++ b/internal/dungeon/docs_browser.go
@@ -704,7 +704,7 @@ func runDocsBrowser(ctx context.Context, itemName, campaignRoot string) (string,
 
 	browserModel, ok := finalModel.(docsBrowserModel)
 	if !ok {
-		return "", fmt.Errorf("unexpected docs browser model type %T", finalModel)
+		return "", camperrors.Newf("unexpected docs browser model type %T", finalModel)
 	}
 	if browserModel.err != nil {
 		return "", browserModel.err

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -4,12 +4,13 @@ package editor
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/obey-shared/procutil"
@@ -97,32 +98,32 @@ func MoveFile(src, dst string) error {
 	// Fall back to copy + delete (cross-filesystem)
 	srcFile, err := os.Open(src)
 	if err != nil {
-		return fmt.Errorf("opening source file %q: %w", src, err)
+		return camperrors.Newf("opening source file %q: %w", src, err)
 	}
 	defer srcFile.Close()
 
 	// Get source file info for permissions
 	srcInfo, err := srcFile.Stat()
 	if err != nil {
-		return fmt.Errorf("getting source file info %q: %w", src, err)
+		return camperrors.Newf("getting source file info %q: %w", src, err)
 	}
 
 	dstFile, err := os.Create(dst)
 	if err != nil {
-		return fmt.Errorf("creating destination file %q: %w", dst, err)
+		return camperrors.Newf("creating destination file %q: %w", dst, err)
 	}
 	defer dstFile.Close()
 
 	// Copy contents
 	if _, err := io.Copy(dstFile, srcFile); err != nil {
 		os.Remove(dst) // Clean up partial copy
-		return fmt.Errorf("copying file from %q to %q: %w", src, dst, err)
+		return camperrors.Newf("copying file from %q to %q: %w", src, dst, err)
 	}
 
 	// Sync to ensure data is written
 	if err := dstFile.Sync(); err != nil {
 		os.Remove(dst) // Clean up on sync failure
-		return fmt.Errorf("syncing destination file %q: %w", dst, err)
+		return camperrors.Newf("syncing destination file %q: %w", dst, err)
 	}
 
 	// Set permissions to match source
@@ -200,7 +201,7 @@ func OpenEditor(ctx context.Context, editor, path string) error {
 	cmd.Stderr = os.Stderr
 
 	if err := procutil.RunWithCleanup(ctx, cmd); err != nil {
-		return fmt.Errorf("running editor %q with %q: %w", editor, path, err)
+		return camperrors.Newf("running editor %q with %q: %w", editor, path, err)
 	}
 
 	return nil

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -275,6 +275,25 @@ func TestWrapf(t *testing.T) {
 	}
 }
 
+func TestNewf(t *testing.T) {
+	t.Run("formats message", func(t *testing.T) {
+		err := Newf("invalid %s %d", "value", 7)
+		if err == nil {
+			t.Fatal("Newf() returned nil")
+		}
+		if got := err.Error(); got != "invalid value 7" {
+			t.Errorf("Newf().Error() = %q, want %q", got, "invalid value 7")
+		}
+	})
+
+	t.Run("wraps with percent w", func(t *testing.T) {
+		err := Newf("outer: %w", io.EOF)
+		if !Is(err, io.EOF) {
+			t.Error("Newf() should preserve %w wrapping")
+		}
+	})
+}
+
 func TestWrapJoin(t *testing.T) {
 	sentinel := New("sentinel")
 	cause := New("cause")

--- a/internal/errors/wrap.go
+++ b/internal/errors/wrap.go
@@ -20,7 +20,7 @@ func Wrapf(err error, format string, args ...any) error {
 	if err == nil {
 		return nil
 	}
-	return fmt.Errorf("%s: %w", fmt.Sprintf(format, args...), err)
+	return Wrap(err, fmt.Sprintf(format, args...))
 }
 
 // WrapJoin creates an error that wraps both sentinel and cause in the error chain.
@@ -54,6 +54,9 @@ func Is(err, target error) bool { return errors.Is(err, target) }
 
 // New delegates to errors.New for convenience.
 func New(text string) error { return errors.New(text) }
+
+// Newf returns a formatted error.
+func Newf(format string, args ...any) error { return fmt.Errorf(format, args...) }
 
 // Join delegates to errors.Join for convenience.
 func Join(errs ...error) error { return errors.Join(errs...) }

--- a/internal/flow/registry.go
+++ b/internal/flow/registry.go
@@ -5,10 +5,11 @@
 package flow
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/Obedience-Corp/camp/internal/fsutil"
 	"gopkg.in/yaml.v3"
@@ -48,12 +49,12 @@ func LoadRegistry(campaignRoot string) (*Registry, error) {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading registry file: %w", err)
+		return nil, camperrors.Newf("reading registry file: %w", err)
 	}
 
 	var registry Registry
 	if err := yaml.Unmarshal(data, &registry); err != nil {
-		return nil, fmt.Errorf("parsing registry YAML: %w", err)
+		return nil, camperrors.Newf("parsing registry YAML: %w", err)
 	}
 
 	if registry.Flows == nil {
@@ -69,16 +70,16 @@ func SaveRegistry(campaignRoot string, registry *Registry) error {
 
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("creating registry directory: %w", err)
+		return camperrors.Newf("creating registry directory: %w", err)
 	}
 
 	data, err := yaml.Marshal(registry)
 	if err != nil {
-		return fmt.Errorf("marshaling registry to YAML: %w", err)
+		return camperrors.Newf("marshaling registry to YAML: %w", err)
 	}
 
 	if err := fsutil.WriteFileAtomically(path, data, 0644); err != nil {
-		return fmt.Errorf("writing registry file: %w", err)
+		return camperrors.Newf("writing registry file: %w", err)
 	}
 
 	return nil

--- a/internal/flow/runner.go
+++ b/internal/flow/runner.go
@@ -2,11 +2,12 @@ package flow
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 
 // Runner executes workflow flows with proper context handling,
@@ -24,7 +25,7 @@ func NewRunner(campaignRoot string) *Runner {
 // Commands are executed via "sh -c" with inherited stdio.
 func (r *Runner) Run(ctx context.Context, f Flow, extraArgs []string) error {
 	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("context cancelled: %w", err)
+		return camperrors.Newf("context cancelled: %w", err)
 	}
 
 	workDir := r.resolveWorkDir(f.WorkDir)
@@ -44,7 +45,7 @@ func (r *Runner) Run(ctx context.Context, f Flow, extraArgs []string) error {
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("executing flow command: %w", err)
+		return camperrors.Newf("executing flow command: %w", err)
 	}
 
 	return nil

--- a/internal/git/branches.go
+++ b/internal/git/branches.go
@@ -3,7 +3,6 @@ package git
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os/exec"
 	"strings"
 
@@ -153,7 +152,7 @@ func MergedBranchesFromRef(ctx context.Context, repoPath, baseRef string) ([]str
 		return nil, ctx.Err()
 	}
 	if strings.TrimSpace(baseRef) == "" {
-		return nil, fmt.Errorf("base ref is required")
+		return nil, camperrors.Newf("base ref is required")
 	}
 
 	currentBranch := CurrentBranch(ctx, repoPath)

--- a/internal/git/lock.go
+++ b/internal/git/lock.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"context"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -27,7 +26,7 @@ func FindIndexLocks(ctx context.Context, gitDir string) ([]string, error) {
 		return nil, camperrors.Wrapf(err, "git directory not accessible: %s", gitDir)
 	}
 	if !info.IsDir() {
-		return nil, fmt.Errorf("path is not a directory: %s", gitDir)
+		return nil, camperrors.Newf("path is not a directory: %s", gitDir)
 	}
 
 	// Check main index.lock
@@ -112,7 +111,7 @@ func ResolveGitDir(repoRoot string) (string, error) {
 func parseGitdirFile(repoRoot, content string) (string, error) {
 	content = strings.TrimSpace(content)
 	if !strings.HasPrefix(content, "gitdir: ") {
-		return "", fmt.Errorf("invalid .git file format: %s", content)
+		return "", camperrors.Newf("invalid .git file format: %s", content)
 	}
 
 	relPath := strings.TrimPrefix(content, "gitdir: ")

--- a/internal/git/resolve.go
+++ b/internal/git/resolve.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -86,7 +85,7 @@ func resolveFromCwd(_ context.Context, campaignRoot string) (*TargetResult, erro
 	}
 
 	if !isSubmodule {
-		return nil, fmt.Errorf("current directory is in a git repository but not a submodule of the campaign")
+		return nil, camperrors.Newf("current directory is in a git repository but not a submodule of the campaign")
 	}
 
 	return &TargetResult{

--- a/internal/git/submodule.go
+++ b/internal/git/submodule.go
@@ -71,7 +71,7 @@ func FindProjectRoot(path string) (string, error) {
 		parent := filepath.Dir(current)
 		if parent == current {
 			// Reached filesystem root
-			return "", fmt.Errorf("not inside a git repository: %s", path)
+			return "", camperrors.Newf("not inside a git repository: %s", path)
 		}
 		current = parent
 	}
@@ -126,7 +126,7 @@ func GetSubmoduleInfo(path string) (*SubmoduleInfo, error) {
 	}
 
 	if !isSubmodule {
-		return nil, fmt.Errorf("path is not in a submodule: %s", path)
+		return nil, camperrors.Newf("path is not in a submodule: %s", path)
 	}
 
 	gitDir, err := GetSubmoduleGitDir(root)
@@ -158,7 +158,7 @@ func GetDeclaredURL(ctx context.Context, repoRoot, submodulePath string) (string
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
-			return "", fmt.Errorf("submodule %q not found in .gitmodules", submodulePath)
+			return "", camperrors.Newf("submodule %q not found in .gitmodules", submodulePath)
 		}
 		return "", camperrors.Wrapf(err, "get declared URL for %s", submodulePath)
 	}

--- a/internal/intent/crawl/runner.go
+++ b/internal/intent/crawl/runner.go
@@ -2,7 +2,6 @@ package crawl
 
 import (
 	"context"
-	"fmt"
 
 	sharedcrawl "github.com/Obedience-Corp/camp/internal/crawl"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -269,7 +268,7 @@ func processOne(
 			return appliedMove, sourcePath, moveDest{target: dest.Target}, nil
 		}
 
-		return appliedNone, "", moveDest{}, fmt.Errorf("intent crawl: unhandled action %q", action)
+		return appliedNone, "", moveDest{}, camperrors.Newf("intent crawl: unhandled action %q", action)
 	}
 }
 

--- a/internal/intent/feedback/scanner.go
+++ b/internal/intent/feedback/scanner.go
@@ -152,7 +152,7 @@ func (s *Scanner) readGoalFrontmatter(festDir string) (*FestivalInfo, error) {
 	}
 
 	if fm.ID == "" {
-		return nil, fmt.Errorf("FESTIVAL_GOAL.md missing fest_id")
+		return nil, camperrors.Newf("FESTIVAL_GOAL.md missing fest_id")
 	}
 
 	return &FestivalInfo{
@@ -188,12 +188,12 @@ func parseFrontmatter(data []byte) (*GoalFrontmatter, error) {
 
 	// Find frontmatter delimiters
 	if !strings.HasPrefix(content, "---\n") {
-		return nil, fmt.Errorf("no frontmatter found")
+		return nil, camperrors.Newf("no frontmatter found")
 	}
 
 	end := strings.Index(content[4:], "\n---")
 	if end < 0 {
-		return nil, fmt.Errorf("unterminated frontmatter")
+		return nil, camperrors.Newf("unterminated frontmatter")
 	}
 
 	fmContent := content[4 : 4+end]

--- a/internal/intent/gather/gather.go
+++ b/internal/intent/gather/gather.go
@@ -155,11 +155,11 @@ func (s *Service) Gather(ctx context.Context, ids []string, opts GatherOptions) 
 	}
 
 	if len(ids) < 2 {
-		return nil, fmt.Errorf("need at least 2 intents to gather, got %d", len(ids))
+		return nil, camperrors.Newf("need at least 2 intents to gather, got %d", len(ids))
 	}
 
 	if opts.Title == "" {
-		return nil, fmt.Errorf("title is required for gathered intent")
+		return nil, camperrors.Newf("title is required for gathered intent")
 	}
 
 	// Load source intents

--- a/internal/intent/merge.go
+++ b/internal/intent/merge.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 
 // MergeOptions configures the gather/merge operation.
@@ -27,11 +29,11 @@ type GatherResult struct {
 // The sources are not modified; the caller is responsible for archiving them.
 func MergeIntents(sources []*Intent, opts MergeOptions) (*Intent, error) {
 	if len(sources) < 2 {
-		return nil, fmt.Errorf("need at least 2 intents to gather, got %d", len(sources))
+		return nil, camperrors.Newf("need at least 2 intents to gather, got %d", len(sources))
 	}
 
 	if opts.Title == "" {
-		return nil, fmt.Errorf("title is required for gathered intent")
+		return nil, camperrors.Newf("title is required for gathered intent")
 	}
 
 	now := time.Now()

--- a/internal/intent/tui/explorer/utils.go
+++ b/internal/intent/tui/explorer/utils.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"time"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/Obedience-Corp/camp/internal/editor"
@@ -55,7 +57,7 @@ func openInEditor(ctx context.Context, filePath string) tea.Cmd {
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		return func() tea.Msg {
 			return editorFinishedMsg{
-				err:  fmt.Errorf("file no longer exists: %s", filepath.Base(filePath)),
+				err:  camperrors.Newf("file no longer exists: %s", filepath.Base(filePath)),
 				path: filePath,
 			}
 		}
@@ -82,7 +84,7 @@ func openWithSystem(filePath string) tea.Cmd {
 		case "windows":
 			cmd = exec.Command("cmd", "/c", "start", "", filePath)
 		default:
-			return openFinishedMsg{err: fmt.Errorf("unsupported platform: %s", runtime.GOOS)}
+			return openFinishedMsg{err: camperrors.Newf("unsupported platform: %s", runtime.GOOS)}
 		}
 		err := cmd.Start()
 		return openFinishedMsg{err: err}
@@ -104,7 +106,7 @@ func revealInFileManager(filePath string) tea.Cmd {
 			// Windows: explorer /select, highlights the file
 			cmd = exec.Command("explorer", "/select,", filePath)
 		default:
-			return openFinishedMsg{err: fmt.Errorf("unsupported platform: %s", runtime.GOOS)}
+			return openFinishedMsg{err: camperrors.Newf("unsupported platform: %s", runtime.GOOS)}
 		}
 		err := cmd.Start()
 		return openFinishedMsg{err: err}

--- a/internal/intent/tui/viewer_actions.go
+++ b/internal/intent/tui/viewer_actions.go
@@ -1,11 +1,12 @@
 package tui
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/Obedience-Corp/camp/internal/editor"
 	"github.com/Obedience-Corp/camp/internal/intent"
@@ -17,7 +18,7 @@ func (m IntentViewerModel) openInEditor() tea.Cmd {
 	if _, err := os.Stat(m.intent.Path); os.IsNotExist(err) {
 		return func() tea.Msg {
 			return ViewerEditorFinishedMsg{
-				Err:  fmt.Errorf("file no longer exists: %s", filepath.Base(m.intent.Path)),
+				Err:  camperrors.Newf("file no longer exists: %s", filepath.Base(m.intent.Path)),
 				Path: m.intent.Path,
 			}
 		}

--- a/internal/leverage/authors.go
+++ b/internal/leverage/authors.go
@@ -3,7 +3,6 @@ package leverage
 import (
 	"bufio"
 	"context"
-	"fmt"
 	"os/exec"
 	"runtime"
 	"sort"
@@ -325,7 +324,7 @@ func AuthorDateRange(ctx context.Context, gitDir, authorEmail string) (first, la
 
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
 	if len(lines) == 0 || lines[0] == "" {
-		return time.Time{}, time.Time{}, fmt.Errorf("no commits by %s in %s", authorEmail, gitDir)
+		return time.Time{}, time.Time{}, camperrors.Newf("no commits by %s in %s", authorEmail, gitDir)
 	}
 
 	for _, line := range lines {
@@ -346,7 +345,7 @@ func AuthorDateRange(ctx context.Context, gitDir, authorEmail string) (first, la
 	}
 
 	if first.IsZero() {
-		return time.Time{}, time.Time{}, fmt.Errorf("no valid commit dates by %s in %s", authorEmail, gitDir)
+		return time.Time{}, time.Time{}, camperrors.Newf("no valid commit dates by %s in %s", authorEmail, gitDir)
 	}
 
 	return first, last, nil

--- a/internal/leverage/config.go
+++ b/internal/leverage/config.go
@@ -3,7 +3,6 @@ package leverage
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -193,7 +192,7 @@ func latestCommitDate(ctx context.Context, repoPath string) (time.Time, error) {
 
 	dateStr := strings.TrimSpace(string(output))
 	if dateStr == "" {
-		return time.Time{}, fmt.Errorf("no commits in %s", repoPath)
+		return time.Time{}, camperrors.Newf("no commits in %s", repoPath)
 	}
 
 	t, err := time.Parse(time.RFC3339, dateStr)
@@ -219,7 +218,7 @@ func earliestCommitDate(ctx context.Context, repoPath string) (time.Time, error)
 
 	dateStr := strings.TrimSpace(string(output))
 	if dateStr == "" {
-		return time.Time{}, fmt.Errorf("no commits in %s", repoPath)
+		return time.Time{}, camperrors.Newf("no commits in %s", repoPath)
 	}
 
 	// There may be multiple root commits (merged unrelated histories).
@@ -240,7 +239,7 @@ func earliestCommitDate(ctx context.Context, repoPath string) (time.Time, error)
 	}
 
 	if earliest.IsZero() {
-		return time.Time{}, fmt.Errorf("no valid commit dates in %s", repoPath)
+		return time.Time{}, camperrors.Newf("no valid commit dates in %s", repoPath)
 	}
 
 	return earliest, nil

--- a/internal/leverage/projects.go
+++ b/internal/leverage/projects.go
@@ -2,7 +2,6 @@ package leverage
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"sort"
 
@@ -159,7 +158,7 @@ func resolveFromConfig(ctx context.Context, campaignRoot string, projects map[st
 		}
 
 		if entry.Path == "" {
-			return nil, fmt.Errorf("project %q: path is required", name)
+			return nil, camperrors.Newf("project %q: path is required", name)
 		}
 
 		sccDir := filepath.Join(campaignRoot, entry.Path)
@@ -228,7 +227,7 @@ func FilterByName(projects []ResolvedProject, name string) ([]ResolvedProject, e
 		}
 	}
 	if len(filtered) == 0 {
-		return nil, fmt.Errorf("project not found: %s", name)
+		return nil, camperrors.Newf("project not found: %s", name)
 	}
 	return filtered, nil
 }

--- a/internal/leverage/scc.go
+++ b/internal/leverage/scc.go
@@ -3,7 +3,6 @@ package leverage
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os/exec"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -44,7 +43,7 @@ type SCCRunner struct {
 func NewSCCRunner(cocomoType string) (*SCCRunner, error) {
 	path, err := exec.LookPath("scc")
 	if err != nil {
-		return nil, fmt.Errorf("scc not found: install with 'brew install scc' or visit https://github.com/boyter/scc")
+		return nil, camperrors.Newf("scc not found: install with 'brew install scc' or visit https://github.com/boyter/scc")
 	}
 	return &SCCRunner{binaryPath: path, cocomoType: cocomoType}, nil
 }
@@ -75,7 +74,7 @@ func (r *SCCRunner) Run(ctx context.Context, dir string, excludeDirs []string) (
 			return nil, camperrors.Wrap(ctx.Err(), "scc cancelled")
 		}
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("scc failed on %s: %w\nstderr: %s", dir, err, exitErr.Stderr)
+			return nil, camperrors.Newf("scc failed on %s: %w\nstderr: %s", dir, err, exitErr.Stderr)
 		}
 		return nil, camperrors.Wrapf(err, "scc failed on %s", dir)
 	}

--- a/internal/leverage/snapshot.go
+++ b/internal/leverage/snapshot.go
@@ -3,7 +3,6 @@ package leverage
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -120,7 +119,7 @@ func DefaultSnapshotDir(campaignRoot string) string {
 // validateProjectName ensures a project name is safe for filesystem paths.
 func validateProjectName(name string) error {
 	if name == "" || strings.Contains(name, "/") || strings.Contains(name, "\\") || strings.Contains(name, "..") {
-		return fmt.Errorf("invalid project name %q: must not be empty or contain path separators", name)
+		return camperrors.Newf("invalid project name %q: must not be empty or contain path separators", name)
 	}
 	return nil
 }

--- a/internal/nav/direct.go
+++ b/internal/nav/direct.go
@@ -2,7 +2,6 @@ package nav
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -134,13 +133,13 @@ func JumpToPathFromRoot(ctx context.Context, root string, relativePath string) (
 	// Verify directory exists
 	info, err := os.Stat(absPath)
 	if os.IsNotExist(err) {
-		return nil, fmt.Errorf("path does not exist: %s", relativePath)
+		return nil, camperrors.Newf("path does not exist: %s", relativePath)
 	}
 	if err != nil {
 		return nil, camperrors.Wrapf(err, "failed to stat path %s", relativePath)
 	}
 	if !info.IsDir() {
-		return nil, fmt.Errorf("path is not a directory: %s", relativePath)
+		return nil, camperrors.Newf("path is not a directory: %s", relativePath)
 	}
 
 	return &DirectJumpResult{

--- a/internal/nav/errors.go
+++ b/internal/nav/errors.go
@@ -12,7 +12,7 @@ import (
 // to enable cross-package errors.Is() matching.
 var (
 	// ErrCategoryNotFound is returned when a category directory does not exist.
-	ErrCategoryNotFound = fmt.Errorf("category directory not found: %w", camperrors.ErrNotFound)
+	ErrCategoryNotFound = camperrors.Newf("category directory not found: %w", camperrors.ErrNotFound)
 
 	// ErrNotADirectory is returned when a category path exists but is not a directory.
 	ErrNotADirectory = errors.New("category path is not a directory")

--- a/internal/nav/index/cache.go
+++ b/internal/nav/index/cache.go
@@ -32,7 +32,7 @@ func CachePath(campaignRoot string) string {
 // The write is atomic (write to temp file, then rename) to prevent corruption.
 func Save(idx *Index, campaignRoot string) error {
 	if idx == nil {
-		return fmt.Errorf("cannot save nil index")
+		return camperrors.Newf("cannot save nil index")
 	}
 
 	path := CachePath(campaignRoot)
@@ -40,17 +40,17 @@ func Save(idx *Index, campaignRoot string) error {
 	// Ensure cache directory exists
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("failed to create cache directory: %w", err)
+		return camperrors.Newf("failed to create cache directory: %w", err)
 	}
 
 	// Marshal to JSON with indentation for readability
 	data, err := json.MarshalIndent(idx, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to marshal index: %w", err)
+		return camperrors.Newf("failed to marshal index: %w", err)
 	}
 
 	if err := fsutil.WriteFileAtomically(path, data, 0o644); err != nil {
-		return fmt.Errorf("failed to write cache file: %w", err)
+		return camperrors.Newf("failed to write cache file: %w", err)
 	}
 
 	return nil
@@ -66,12 +66,12 @@ func Load(campaignRoot string) (*Index, error) {
 		return nil, nil // Cache doesn't exist
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to read cache file: %w", err)
+		return nil, camperrors.Newf("failed to read cache file: %w", err)
 	}
 
 	var idx Index
 	if err := json.Unmarshal(data, &idx); err != nil {
-		return nil, fmt.Errorf("failed to parse cache file: %w", err)
+		return nil, camperrors.Newf("failed to parse cache file: %w", err)
 	}
 
 	return &idx, nil
@@ -252,7 +252,7 @@ func GetOrBuild(ctx context.Context, campaignRoot string, forceRebuild bool) (*I
 	builder := NewBuilder(campaignRoot).WithProjects(projects)
 	idx, err := builder.Build(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build index: %w", err)
+		return nil, camperrors.Newf("failed to build index: %w", err)
 	}
 
 	// Save to cache (don't fail if save fails)
@@ -323,7 +323,7 @@ func Info(campaignRoot string) (*CacheInfo, error) {
 		return info, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to stat cache file: %w", err)
+		return nil, camperrors.Newf("failed to stat cache file: %w", err)
 	}
 
 	info.Exists = true

--- a/internal/nav/index/resolve.go
+++ b/internal/nav/index/resolve.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/Obedience-Corp/camp/internal/nav"
 	"github.com/Obedience-Corp/camp/internal/nav/fuzzy"
 )
@@ -60,7 +62,7 @@ func Resolve(ctx context.Context, opts ResolveOptions) (*ResolveResult, error) {
 	}
 
 	if opts.CampaignRoot == "" {
-		return nil, fmt.Errorf("campaign root is required")
+		return nil, camperrors.Newf("campaign root is required")
 	}
 
 	// No query - direct category path
@@ -92,7 +94,7 @@ func resolveWithQuery(ctx context.Context, opts ResolveOptions) (*ResolveResult,
 	// Get or build index
 	idx, err := GetOrBuild(ctx, opts.CampaignRoot, false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build index: %w", err)
+		return nil, camperrors.Newf("failed to build index: %w", err)
 	}
 
 	// Query the index
@@ -100,7 +102,7 @@ func resolveWithQuery(ctx context.Context, opts ResolveOptions) (*ResolveResult,
 	targets := query.ByCategory(opts.Category)
 
 	if len(targets) == 0 {
-		return nil, fmt.Errorf("no targets in category %s", opts.Category)
+		return nil, camperrors.Newf("no targets in category %s", opts.Category)
 	}
 
 	// First try exact match
@@ -129,7 +131,7 @@ func resolveWithQuery(ctx context.Context, opts ResolveOptions) (*ResolveResult,
 
 	// If exact only requested, fail
 	if opts.ExactOnly {
-		return nil, fmt.Errorf("no exact match for %q in category %s", opts.Query, opts.Category)
+		return nil, camperrors.Newf("no exact match for %q in category %s", opts.Query, opts.Category)
 	}
 
 	// Fuzzy search
@@ -140,7 +142,7 @@ func resolveWithQuery(ctx context.Context, opts ResolveOptions) (*ResolveResult,
 
 	matches := fuzzy.Filter(names, opts.Query)
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("no targets matching %q in category %s", opts.Query, opts.Category)
+		return nil, camperrors.Newf("no targets matching %q in category %s", opts.Query, opts.Category)
 	}
 
 	// Build matched targets list

--- a/internal/project/new.go
+++ b/internal/project/new.go
@@ -85,7 +85,7 @@ func initProjectRepo(ctx context.Context, path, name string) error {
 	// git init
 	cmd := exec.CommandContext(ctx, "git", "init", path)
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git init failed: %w (output: %s)", err, string(output))
+		return camperrors.Newf("git init failed: %w (output: %s)", err, string(output))
 	}
 
 	// Write README
@@ -97,12 +97,12 @@ func initProjectRepo(ctx context.Context, path, name string) error {
 	// git add + commit
 	cmd = exec.CommandContext(ctx, "git", "-C", path, "add", ".")
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git add failed: %w (output: %s)", err, string(output))
+		return camperrors.Newf("git add failed: %w (output: %s)", err, string(output))
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "-C", path, "commit", "-m", "Initial commit")
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git commit failed: %w (output: %s)", err, string(output))
+		return camperrors.Newf("git commit failed: %w (output: %s)", err, string(output))
 	}
 
 	return nil

--- a/internal/project/url.go
+++ b/internal/project/url.go
@@ -1,7 +1,6 @@
 package project
 
 import (
-	"fmt"
 	"net/url"
 	"strings"
 
@@ -36,7 +35,7 @@ type ParsedGitURL struct {
 func ParseGitURL(rawURL string) (*ParsedGitURL, error) {
 	rawURL = strings.TrimSpace(rawURL)
 	if rawURL == "" {
-		return nil, fmt.Errorf("URL cannot be empty")
+		return nil, camperrors.Newf("URL cannot be empty")
 	}
 
 	// Check for SSH URLs (git@host:path or ssh://...)
@@ -63,7 +62,7 @@ func ParseGitURL(rawURL string) (*ParsedGitURL, error) {
 		}, nil
 	}
 
-	return nil, fmt.Errorf("invalid git URL format: %s\nExpected formats:\n  SSH:   git@github.com:org/repo.git\n  HTTPS: https://github.com/org/repo.git\n  Local: /path/to/repo or ./repo", rawURL)
+	return nil, camperrors.Newf("invalid git URL format: %s\nExpected formats:\n  SSH:   git@github.com:org/repo.git\n  HTTPS: https://github.com/org/repo.git\n  Local: /path/to/repo or ./repo", rawURL)
 }
 
 // parseSSHURL parses SSH URLs in the format git@host:path
@@ -71,23 +70,23 @@ func parseSSHURL(rawURL string) (*ParsedGitURL, error) {
 	// Format: git@github.com:org/repo.git
 	parts := strings.SplitN(rawURL, "@", 2)
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid SSH URL format: %s\nExpected: git@host:org/repo.git", rawURL)
+		return nil, camperrors.Newf("invalid SSH URL format: %s\nExpected: git@host:org/repo.git", rawURL)
 	}
 
 	hostPath := parts[1]
 	colonIdx := strings.Index(hostPath, ":")
 	if colonIdx == -1 {
-		return nil, fmt.Errorf("invalid SSH URL format: %s\nExpected: git@host:org/repo.git", rawURL)
+		return nil, camperrors.Newf("invalid SSH URL format: %s\nExpected: git@host:org/repo.git", rawURL)
 	}
 
 	host := hostPath[:colonIdx]
 	path := hostPath[colonIdx+1:]
 
 	if host == "" {
-		return nil, fmt.Errorf("invalid SSH URL: host cannot be empty")
+		return nil, camperrors.Newf("invalid SSH URL: host cannot be empty")
 	}
 	if path == "" {
-		return nil, fmt.Errorf("invalid SSH URL: repository path cannot be empty")
+		return nil, camperrors.Newf("invalid SSH URL: repository path cannot be empty")
 	}
 
 	return &ParsedGitURL{
@@ -112,10 +111,10 @@ func parseSSHProtocolURL(rawURL string) (*ParsedGitURL, error) {
 	}
 
 	if u.Host == "" {
-		return nil, fmt.Errorf("invalid SSH URL: host cannot be empty")
+		return nil, camperrors.Newf("invalid SSH URL: host cannot be empty")
 	}
 	if u.Path == "" || u.Path == "/" {
-		return nil, fmt.Errorf("invalid SSH URL: repository path cannot be empty")
+		return nil, camperrors.Newf("invalid SSH URL: repository path cannot be empty")
 	}
 
 	return &ParsedGitURL{
@@ -134,10 +133,10 @@ func parseHTTPSURL(rawURL string) (*ParsedGitURL, error) {
 	}
 
 	if u.Host == "" {
-		return nil, fmt.Errorf("invalid HTTPS URL: host cannot be empty")
+		return nil, camperrors.Newf("invalid HTTPS URL: host cannot be empty")
 	}
 	if u.Path == "" || u.Path == "/" {
-		return nil, fmt.Errorf("invalid HTTPS URL: repository path cannot be empty")
+		return nil, camperrors.Newf("invalid HTTPS URL: repository path cannot be empty")
 	}
 
 	return &ParsedGitURL{

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -1,7 +1,9 @@
 // Package shell provides shell integration scripts for camp.
 package shell
 
-import "fmt"
+import (
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
 
 // SupportedShells lists all shells with integration support.
 var SupportedShells = []string{"zsh", "bash", "fish"}
@@ -16,7 +18,7 @@ func Generate(shellType string) (string, error) {
 	case "fish":
 		return generateFish(), nil
 	default:
-		return "", fmt.Errorf("unsupported shell: %s (supported: zsh, bash, fish)", shellType)
+		return "", camperrors.Newf("unsupported shell: %s (supported: zsh, bash, fish)", shellType)
 	}
 }
 

--- a/internal/shortcuts/tui.go
+++ b/internal/shortcuts/tui.go
@@ -95,7 +95,7 @@ func RunAddSubShortcutTUI(ctx context.Context, root string) (*AddSubShortcutResu
 					// Validate path exists
 					fullPath := filepath.Join(projectPath, s)
 					if stat, err := os.Stat(fullPath); err != nil || !stat.IsDir() {
-						return fmt.Errorf("path does not exist: %s", s)
+						return camperrors.Newf("path does not exist: %s", s)
 					}
 					return nil
 				}),
@@ -155,7 +155,7 @@ func RunAddJumpTUI(ctx context.Context, root string) (*AddJumpResult, error) {
 					// Validate path exists if provided
 					fullPath := filepath.Join(root, s)
 					if stat, err := os.Stat(fullPath); err != nil || !stat.IsDir() {
-						return fmt.Errorf("path does not exist: %s", s)
+						return camperrors.Newf("path does not exist: %s", s)
 					}
 					return nil
 				}),

--- a/internal/skills/projection.go
+++ b/internal/skills/projection.go
@@ -131,13 +131,13 @@ func EnsureProjectionDirectory(destDir string, dryRun bool, errOut io.Writer) er
 		return nil
 
 	case TypeFile:
-		return fmt.Errorf("destination exists and is a file: %s", destDir)
+		return camperrors.Newf("destination exists and is a file: %s", destDir)
 
 	case TypeSymlink:
-		return fmt.Errorf("destination exists as a symlink; camp skills now projects individual skill bundles into a directory: %s", destDir)
+		return camperrors.Newf("destination exists as a symlink; camp skills now projects individual skill bundles into a directory: %s", destDir)
 	}
 
-	return fmt.Errorf("unsupported destination type for %s", destDir)
+	return camperrors.Newf("unsupported destination type for %s", destDir)
 }
 
 // CreateSkillProjectionLink creates a relative symlink from linkPath to sourcePath.

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -3,7 +3,6 @@ package skills
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -74,7 +73,7 @@ func FindSkillsDir(ctx context.Context) (string, error) {
 		return "", camperrors.Wrap(err, "find skills dir")
 	}
 	if !info.IsDir() {
-		return "", fmt.Errorf("find skills dir: %s is not a directory", skillsDir)
+		return "", camperrors.Newf("find skills dir: %s is not a directory", skillsDir)
 	}
 
 	return skillsDir, nil
@@ -180,7 +179,7 @@ func DiscoverSkillSlugs(skillsDir string) ([]string, error) {
 func ResolveToolPath(tool string) (string, error) {
 	p, ok := toolPaths[tool]
 	if !ok {
-		return "", fmt.Errorf("unknown tool %q: valid tools are: %s", tool, strings.Join(ToolNames(), ", "))
+		return "", camperrors.Newf("unknown tool %q: valid tools are: %s", tool, strings.Join(ToolNames(), ", "))
 	}
 	return p, nil
 }
@@ -203,10 +202,10 @@ const (
 // campaign root, .campaign/, filesystem root, or paths outside the campaign.
 func ValidateDestination(dest, campaignRoot string) error {
 	if strings.TrimSpace(dest) == "" {
-		return fmt.Errorf("destination path cannot be empty")
+		return camperrors.Newf("destination path cannot be empty")
 	}
 	if strings.TrimSpace(campaignRoot) == "" {
-		return fmt.Errorf("campaign root cannot be empty")
+		return camperrors.Newf("campaign root cannot be empty")
 	}
 
 	// Resolve both paths through existing parent symlinks. This ensures a path
@@ -222,23 +221,23 @@ func ValidateDestination(dest, campaignRoot string) error {
 
 	// Reject filesystem root
 	if resolvedDest == string(filepath.Separator) {
-		return fmt.Errorf("refusing to use filesystem root as destination")
+		return camperrors.Newf("refusing to use filesystem root as destination")
 	}
 
 	// Reject campaign root itself
 	if resolvedDest == resolvedRoot {
-		return fmt.Errorf("refusing to use campaign root as destination: %s", resolvedDest)
+		return camperrors.Newf("refusing to use campaign root as destination: %s", resolvedDest)
 	}
 
 	// Reject .campaign/ directory
 	campaignDir := filepath.Join(resolvedRoot, campaign.CampaignDir)
 	if resolvedDest == campaignDir || isSubpath(resolvedDest, campaignDir) {
-		return fmt.Errorf("refusing to use .campaign/ directory as destination: %s", resolvedDest)
+		return camperrors.Newf("refusing to use .campaign/ directory as destination: %s", resolvedDest)
 	}
 
 	// Reject paths outside the campaign root
 	if !isSubpath(resolvedDest, resolvedRoot) {
-		return fmt.Errorf("destination must be inside campaign root: %s", resolvedDest)
+		return camperrors.Newf("destination must be inside campaign root: %s", resolvedDest)
 	}
 
 	return nil

--- a/internal/state/location.go
+++ b/internal/state/location.go
@@ -49,7 +49,7 @@ func LoadHistory(ctx context.Context, campaignRoot string) ([]NavigationEntry, e
 		if os.IsNotExist(err) {
 			return []NavigationEntry{}, nil
 		}
-		return nil, fmt.Errorf("failed to open state file %s: %w", stateFile, err)
+		return nil, camperrors.Newf("failed to open state file %s: %w", stateFile, err)
 	}
 	defer file.Close()
 
@@ -71,7 +71,7 @@ func LoadHistory(ctx context.Context, campaignRoot string) ([]NavigationEntry, e
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("failed to read state file: %w", err)
+		return nil, camperrors.Newf("failed to read state file: %w", err)
 	}
 
 	return entries, nil
@@ -89,7 +89,7 @@ func SaveEntry(ctx context.Context, campaignRoot string, entry NavigationEntry) 
 
 	// Ensure cache directory exists
 	if err := os.MkdirAll(stateDir, 0755); err != nil {
-		return fmt.Errorf("failed to create cache directory: %w", err)
+		return camperrors.Newf("failed to create cache directory: %w", err)
 	}
 
 	// Load existing entries
@@ -111,7 +111,7 @@ func SaveEntry(ctx context.Context, campaignRoot string, entry NavigationEntry) 
 	enc := json.NewEncoder(&buf)
 	for _, e := range entries {
 		if err := enc.Encode(e); err != nil {
-			return fmt.Errorf("failed to marshal entry: %w", err)
+			return camperrors.Newf("failed to marshal entry: %w", err)
 		}
 	}
 
@@ -169,7 +169,7 @@ func SetLastLocation(ctx context.Context, campaignRoot, location string) error {
 
 	// Validate that the location exists
 	if info, err := os.Stat(location); err != nil || !info.IsDir() {
-		return fmt.Errorf("invalid location: %s does not exist or is not a directory", location)
+		return camperrors.Newf("invalid location: %s does not exist or is not a directory", location)
 	}
 
 	entry := NavigationEntry{
@@ -192,7 +192,7 @@ func ClearState(ctx context.Context, campaignRoot string) error {
 		if os.IsNotExist(err) {
 			return nil // Idempotent - no state to clear
 		}
-		return fmt.Errorf("failed to remove state file: %w", err)
+		return camperrors.Newf("failed to remove state file: %w", err)
 	}
 
 	return nil

--- a/internal/transfer/copy.go
+++ b/internal/transfer/copy.go
@@ -1,34 +1,35 @@
 package transfer
 
 import (
-	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 
 // CopyFile copies a single file from src to dest, preserving permissions.
 func CopyFile(src, dest string) error {
 	srcFile, err := os.Open(src)
 	if err != nil {
-		return fmt.Errorf("open source: %w", err)
+		return camperrors.Newf("open source: %w", err)
 	}
 	defer srcFile.Close()
 
 	info, err := srcFile.Stat()
 	if err != nil {
-		return fmt.Errorf("stat source: %w", err)
+		return camperrors.Newf("stat source: %w", err)
 	}
 
 	destFile, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
 	if err != nil {
-		return fmt.Errorf("create destination: %w", err)
+		return camperrors.Newf("create destination: %w", err)
 	}
 	defer destFile.Close()
 
 	if _, err := io.Copy(destFile, srcFile); err != nil {
-		return fmt.Errorf("write data: %w", err)
+		return camperrors.Newf("write data: %w", err)
 	}
 	return nil
 }
@@ -37,14 +38,14 @@ func CopyFile(src, dest string) error {
 func CopyDir(src, dest string) error {
 	srcInfo, err := os.Stat(src)
 	if err != nil {
-		return fmt.Errorf("stat source: %w", err)
+		return camperrors.Newf("stat source: %w", err)
 	}
 	if !srcInfo.IsDir() {
-		return fmt.Errorf("source is not a directory: %s", src)
+		return camperrors.Newf("source is not a directory: %s", src)
 	}
 
 	if err := os.MkdirAll(dest, srcInfo.Mode()); err != nil {
-		return fmt.Errorf("create destination directory: %w", err)
+		return camperrors.Newf("create destination directory: %w", err)
 	}
 
 	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
@@ -54,14 +55,14 @@ func CopyDir(src, dest string) error {
 
 		rel, err := filepath.Rel(src, path)
 		if err != nil {
-			return fmt.Errorf("compute relative path: %w", err)
+			return camperrors.Newf("compute relative path: %w", err)
 		}
 		target := filepath.Join(dest, rel)
 
 		if d.IsDir() {
 			info, err := d.Info()
 			if err != nil {
-				return fmt.Errorf("stat directory: %w", err)
+				return camperrors.Newf("stat directory: %w", err)
 			}
 			return os.MkdirAll(target, info.Mode())
 		}

--- a/internal/transfer/resolve.go
+++ b/internal/transfer/resolve.go
@@ -2,10 +2,11 @@ package transfer
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/Obedience-Corp/camp/internal/config"
 )
@@ -36,12 +37,12 @@ func ResolveCrossCampaignPath(ctx context.Context, currentCampRoot, spec string)
 	// Look up campaign in registry
 	reg, err := config.LoadRegistry(ctx)
 	if err != nil {
-		return "", fmt.Errorf("load campaign registry: %w", err)
+		return "", camperrors.Newf("load campaign registry: %w", err)
 	}
 
 	entry, ok := reg.Get(campaign)
 	if !ok {
-		return "", fmt.Errorf("campaign %q not found in registry", campaign)
+		return "", camperrors.Newf("campaign %q not found in registry", campaign)
 	}
 
 	resolved := filepath.Join(entry.Path, relPath)
@@ -51,7 +52,7 @@ func ResolveCrossCampaignPath(ctx context.Context, currentCampRoot, spec string)
 // ValidatePathExists checks that the resolved path exists on disk.
 func ValidatePathExists(path string) error {
 	if _, err := os.Stat(path); err != nil {
-		return fmt.Errorf("path does not exist: %s", path)
+		return camperrors.Newf("path does not exist: %s", path)
 	}
 	return nil
 }
@@ -89,7 +90,7 @@ func ResolveAtPrefix(campRoot, path string, shortcuts map[string]string) (string
 		for k := range shortcuts {
 			keys = append(keys, "@"+k)
 		}
-		return "", fmt.Errorf("unknown shortcut: @%s (valid: %s)", key, strings.Join(keys, ", "))
+		return "", camperrors.Newf("unknown shortcut: @%s (valid: %s)", key, strings.Join(keys, ", "))
 	}
 
 	resolved := filepath.Join(campRoot, dir)
@@ -107,7 +108,7 @@ func ResolveCwdRelative(path string) (string, error) {
 	}
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("get working directory: %w", err)
+		return "", camperrors.Newf("get working directory: %w", err)
 	}
 	return filepath.Join(cwd, path), nil
 }

--- a/internal/ui/commit_prompt.go
+++ b/internal/ui/commit_prompt.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"strings"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
 	"github.com/charmbracelet/huh"
 
 	"github.com/Obedience-Corp/camp/internal/git"
@@ -117,7 +119,7 @@ func PromptCommitMessageMultiline(ctx context.Context, executor git.GitExecutor,
 // validateCommitMessage ensures the message isn't empty.
 func validateCommitMessage(s string) error {
 	if strings.TrimSpace(s) == "" {
-		return fmt.Errorf("commit message cannot be empty")
+		return camperrors.Newf("commit message cannot be empty")
 	}
 	return nil
 }

--- a/internal/workflow/service_sync_migrate.go
+++ b/internal/workflow/service_sync_migrate.go
@@ -181,7 +181,7 @@ func (s *Service) migrateV1ToV2(ctx context.Context, dryRun bool, moveItem workf
 	}
 
 	if s.schema.Version == 2 {
-		return nil, fmt.Errorf("workflow is already v2")
+		return nil, camperrors.Newf("workflow is already v2")
 	}
 
 	result := &MigrateV1ToV2Result{}


### PR DESCRIPTION
## Summary
- Adds `camperrors.Newf` and routes production camp formatting errors through the central camperrors package.
- Leaves `fmt.Errorf` only inside the central error helpers where `%w` wrapping is implemented.

## Validation
- go test ./internal/errors
- go test ./...
- just lint-no-fmt-errorf
- just lint
- just gate-fast
