### PR TITLE
fix: improve intent action responsiveness

### DIFF
--- a/cmd/camp/intent/explore.go
+++ b/cmd/camp/intent/explore.go
@@ -1,10 +1,12 @@
 package intent
 
 import (
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
@@ -134,8 +136,31 @@ func runIntentExplore(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "running explorer")
 	}
 
+	// The explorer fires intent auto-commits asynchronously to keep the UI
+	// responsive, so drain any still in flight before returning; otherwise a
+	// change already written to disk could exit without ever being committed.
+	// A fast drain stays silent. If commits are still running (e.g. contending
+	// for the git lock) tell the user why the terminal is pausing, then wait a
+	// bounded amount so a wedged lock cannot hang the exit.
+	if !explorer.WaitForAutoCommits(quickDrainTimeout) {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Finalizing intent commits...")
+		if !explorer.WaitForAutoCommits(autoCommitDrainTimeout) {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning: some intent auto-commits did not finish; run 'camp status' to check for uncommitted intent changes")
+		}
+	}
+
 	return nil
 }
+
+// quickDrainTimeout is the silent grace period for in-flight auto-commits to
+// finish on exit before the user is told the shutdown is waiting on them.
+const quickDrainTimeout = 300 * time.Millisecond
+
+// autoCommitDrainTimeout bounds how long the explorer waits for background
+// auto-commits to finish on exit. The commit path retries on git lock
+// contention for several seconds (internal/git/retry.go), so this caps the wait
+// generously while still ensuring a wedged lock cannot hang process shutdown.
+const autoCommitDrainTimeout = 15 * time.Second
 
 // quietSlogDuringTUI swaps slog.Default with a handler that writes to a log
 // file under <campaignRoot>/.campaign/logs/ instead of stderr. It returns a

--- a/cmd/camp/intent/explore.go
+++ b/cmd/camp/intent/explore.go
@@ -1,12 +1,10 @@
 package intent
 
 import (
-	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
-	"time"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
@@ -127,50 +125,19 @@ func runIntentExplore(cmd *cobra.Command, args []string) error {
 	}
 	defer restoreLogger()
 
-	// The explorer fires intent auto-commits asynchronously to keep the UI
-	// responsive, so any still in flight must be drained before this function
-	// returns; otherwise a change already written to disk could exit without
-	// ever being committed. Deferred (not inline after p.Run) so the drain also
-	// covers error-exit paths, and registered after restoreLogger so LIFO runs
-	// it first, while slog is still routed to the TUI log file.
-	defer drainExplorerAutoCommits(cmd.ErrOrStderr())
-
-	// Create and run the TUI
 	model := explorer.NewModel(ctx, svc, conceptSvc, intentsDir, campaignRoot, cfg.ID, author, shortcuts).
 		WithAvailableTags(cfg.IntentTags())
-	p := tea.NewProgram(model, tea.WithAltScreen())
 
-	if _, err := p.Run(); err != nil {
+	// Deferred after restoreLogger so LIFO drains in-flight auto-commits (on both
+	// success and error exits) while slog is still routed to the TUI log file.
+	defer model.DrainAutoCommits(cmd.ErrOrStderr())
+
+	if _, err := tea.NewProgram(model, tea.WithAltScreen()).Run(); err != nil {
 		return camperrors.Wrap(err, "running explorer")
 	}
 
 	return nil
 }
-
-// drainExplorerAutoCommits waits for the explorer's background intent
-// auto-commits to finish on exit. A fast drain stays silent; if commits are
-// still running (e.g. contending for the git lock) it tells the user why the
-// terminal is pausing, then waits a bounded amount so a wedged lock cannot hang
-// the exit.
-func drainExplorerAutoCommits(w io.Writer) {
-	if explorer.WaitForAutoCommits(quickDrainTimeout) {
-		return
-	}
-	_, _ = fmt.Fprintln(w, "Finalizing intent commits...")
-	if !explorer.WaitForAutoCommits(autoCommitDrainTimeout) {
-		_, _ = fmt.Fprintln(w, "warning: some intent auto-commits did not finish; run 'camp status' to check for uncommitted intent changes")
-	}
-}
-
-// quickDrainTimeout is the silent grace period for in-flight auto-commits to
-// finish on exit before the user is told the shutdown is waiting on them.
-const quickDrainTimeout = 300 * time.Millisecond
-
-// autoCommitDrainTimeout bounds how long the explorer waits for background
-// auto-commits to finish on exit. The commit path retries on git lock
-// contention for several seconds (internal/git/retry.go), so this caps the wait
-// generously while still ensuring a wedged lock cannot hang process shutdown.
-const autoCommitDrainTimeout = 15 * time.Second
 
 // quietSlogDuringTUI swaps slog.Default with a handler that writes to a log
 // file under <campaignRoot>/.campaign/logs/ instead of stderr. It returns a

--- a/cmd/camp/intent/explore.go
+++ b/cmd/camp/intent/explore.go
@@ -127,6 +127,14 @@ func runIntentExplore(cmd *cobra.Command, args []string) error {
 	}
 	defer restoreLogger()
 
+	// The explorer fires intent auto-commits asynchronously to keep the UI
+	// responsive, so any still in flight must be drained before this function
+	// returns; otherwise a change already written to disk could exit without
+	// ever being committed. Deferred (not inline after p.Run) so the drain also
+	// covers error-exit paths, and registered after restoreLogger so LIFO runs
+	// it first, while slog is still routed to the TUI log file.
+	defer drainExplorerAutoCommits(cmd.ErrOrStderr())
+
 	// Create and run the TUI
 	model := explorer.NewModel(ctx, svc, conceptSvc, intentsDir, campaignRoot, cfg.ID, author, shortcuts).
 		WithAvailableTags(cfg.IntentTags())
@@ -136,20 +144,22 @@ func runIntentExplore(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "running explorer")
 	}
 
-	// The explorer fires intent auto-commits asynchronously to keep the UI
-	// responsive, so drain any still in flight before returning; otherwise a
-	// change already written to disk could exit without ever being committed.
-	// A fast drain stays silent. If commits are still running (e.g. contending
-	// for the git lock) tell the user why the terminal is pausing, then wait a
-	// bounded amount so a wedged lock cannot hang the exit.
-	if !explorer.WaitForAutoCommits(quickDrainTimeout) {
-		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Finalizing intent commits...")
-		if !explorer.WaitForAutoCommits(autoCommitDrainTimeout) {
-			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning: some intent auto-commits did not finish; run 'camp status' to check for uncommitted intent changes")
-		}
-	}
-
 	return nil
+}
+
+// drainExplorerAutoCommits waits for the explorer's background intent
+// auto-commits to finish on exit. A fast drain stays silent; if commits are
+// still running (e.g. contending for the git lock) it tells the user why the
+// terminal is pausing, then waits a bounded amount so a wedged lock cannot hang
+// the exit.
+func drainExplorerAutoCommits(w io.Writer) {
+	if explorer.WaitForAutoCommits(quickDrainTimeout) {
+		return
+	}
+	_, _ = fmt.Fprintln(w, "Finalizing intent commits...")
+	if !explorer.WaitForAutoCommits(autoCommitDrainTimeout) {
+		_, _ = fmt.Fprintln(w, "warning: some intent auto-commits did not finish; run 'camp status' to check for uncommitted intent changes")
+	}
 }
 
 // quickDrainTimeout is the silent grace period for in-flight auto-commits to

--- a/cmd/camp/intent/explore_test.go
+++ b/cmd/camp/intent/explore_test.go
@@ -104,15 +104,3 @@ func TestQuietSlogDuringTUI_FallsBackToDiscardOnDirError(t *testing.T) {
 	// Should not panic when emitting to the discard handler.
 	slog.Info("info-to-discard", "key", "value")
 }
-
-// TestDrainExplorerAutoCommits_SilentWhenNothingPending asserts the exit drain
-// returns without printing anything when no background auto-commits are in
-// flight, so a normal quit does not spam the terminal with "Finalizing..."
-// noise on every exit.
-func TestDrainExplorerAutoCommits_SilentWhenNothingPending(t *testing.T) {
-	var buf bytes.Buffer
-	drainExplorerAutoCommits(&buf)
-	if buf.Len() != 0 {
-		t.Fatalf("expected no output when no commits pending, got %q", buf.String())
-	}
-}

--- a/cmd/camp/intent/explore_test.go
+++ b/cmd/camp/intent/explore_test.go
@@ -104,3 +104,15 @@ func TestQuietSlogDuringTUI_FallsBackToDiscardOnDirError(t *testing.T) {
 	// Should not panic when emitting to the discard handler.
 	slog.Info("info-to-discard", "key", "value")
 }
+
+// TestDrainExplorerAutoCommits_SilentWhenNothingPending asserts the exit drain
+// returns without printing anything when no background auto-commits are in
+// flight, so a normal quit does not spam the terminal with "Finalizing..."
+// noise on every exit.
+func TestDrainExplorerAutoCommits_SilentWhenNothingPending(t *testing.T) {
+	var buf bytes.Buffer
+	drainExplorerAutoCommits(&buf)
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output when no commits pending, got %q", buf.String())
+	}
+}

--- a/internal/intent/tui/explorer/audit.go
+++ b/internal/intent/tui/explorer/audit.go
@@ -1,11 +1,16 @@
 package explorer
 
 import (
+	"context"
 	"strings"
 
 	"github.com/Obedience-Corp/camp/internal/git/commit"
 	"github.com/Obedience-Corp/camp/internal/intent/audit"
 )
+
+var runAutoCommitIntent = func(ctx context.Context, opts commit.IntentOptions) {
+	_ = commit.Intent(ctx, opts)
+}
 
 func (m *Model) auditActor() string {
 	actor := strings.TrimSpace(m.author)
@@ -29,12 +34,18 @@ func (m *Model) autoCommitFiles(files ...string) []string {
 	return commit.NormalizeFiles(m.campaignRoot, files...)
 }
 
-// autoCommitIntent performs a best-effort intent commit if campaign context is available.
+// autoCommitIntent starts a best-effort intent commit if campaign context is available.
 func (m *Model) autoCommitIntent(action commit.IntentAction, title, description string, files ...string) {
 	if m.campaignRoot == "" || m.campaignID == "" {
 		return
 	}
-	_ = commit.Intent(m.ctx, commit.IntentOptions{
+	ctx := m.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	} else {
+		ctx = context.WithoutCancel(ctx)
+	}
+	opts := commit.IntentOptions{
 		Options: commit.Options{
 			CampaignRoot:  m.campaignRoot,
 			CampaignID:    m.campaignID,
@@ -44,5 +55,6 @@ func (m *Model) autoCommitIntent(action commit.IntentAction, title, description 
 		Action:      action,
 		IntentTitle: title,
 		Description: description,
-	})
+	}
+	go runAutoCommitIntent(ctx, opts)
 }

--- a/internal/intent/tui/explorer/audit.go
+++ b/internal/intent/tui/explorer/audit.go
@@ -2,6 +2,8 @@ package explorer
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 	"sync"
@@ -11,7 +13,25 @@ import (
 	"github.com/Obedience-Corp/camp/internal/intent/audit"
 )
 
-var runAutoCommitIntent = func(ctx context.Context, opts commit.IntentOptions) {
+const (
+	quickDrainTimeout      = 300 * time.Millisecond
+	autoCommitDrainTimeout = 15 * time.Second
+)
+
+// autoCommitter runs best-effort intent commits in the background, serialized so
+// they cannot race on the git index lock and tracked so they can be drained
+// before the process exits.
+type autoCommitter struct {
+	mu  sync.Mutex
+	wg  sync.WaitGroup
+	run func(ctx context.Context, opts commit.IntentOptions)
+}
+
+func newAutoCommitter() *autoCommitter {
+	return &autoCommitter{run: runAutoCommitIntent}
+}
+
+func runAutoCommitIntent(ctx context.Context, opts commit.IntentOptions) {
 	if res := commit.Intent(ctx, opts); res.Err != nil {
 		slog.WarnContext(ctx, "intent auto-commit failed",
 			"action", opts.Action,
@@ -21,13 +41,27 @@ var runAutoCommitIntent = func(ctx context.Context, opts commit.IntentOptions) {
 	}
 }
 
-// autoCommitIntentMu serializes background auto-commits so concurrent goroutines
-// cannot race on the git index lock. autoCommitIntentWg tracks in-flight commits
-// so they can be drained before the process exits (see WaitForAutoCommits).
-var (
-	autoCommitIntentMu sync.Mutex
-	autoCommitIntentWg sync.WaitGroup
-)
+func (a *autoCommitter) start(ctx context.Context, opts commit.IntentOptions) {
+	a.wg.Go(func() {
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		a.run(ctx, opts)
+	})
+}
+
+func (a *autoCommitter) wait(timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		a.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
 
 func (m *Model) auditActor() string {
 	actor := strings.TrimSpace(m.author)
@@ -62,7 +96,7 @@ func (m *Model) autoCommitIntent(action commit.IntentAction, title, description 
 	} else {
 		ctx = context.WithoutCancel(ctx)
 	}
-	opts := commit.IntentOptions{
+	m.autoCommit.start(ctx, commit.IntentOptions{
 		Options: commit.Options{
 			CampaignRoot:  m.campaignRoot,
 			CampaignID:    m.campaignID,
@@ -72,31 +106,18 @@ func (m *Model) autoCommitIntent(action commit.IntentAction, title, description 
 		Action:      action,
 		IntentTitle: title,
 		Description: description,
-	}
-	autoCommitIntentWg.Go(func() {
-		autoCommitIntentMu.Lock()
-		defer autoCommitIntentMu.Unlock()
-		runAutoCommitIntent(ctx, opts)
 	})
 }
 
-// WaitForAutoCommits blocks until every background intent auto-commit started by
-// autoCommitIntent has finished, or until timeout elapses. The explorer fires
-// commits asynchronously to keep the UI responsive, so the process must drain
-// them on exit; otherwise an intent change already written to disk could be lost
-// without ever being committed. It returns true if all commits drained, or false
-// if the timeout was hit first. The timeout bounds shutdown so a wedged git lock
-// cannot hang the exit indefinitely.
-func WaitForAutoCommits(timeout time.Duration) bool {
-	done := make(chan struct{})
-	go func() {
-		autoCommitIntentWg.Wait()
-		close(done)
-	}()
-	select {
-	case <-done:
-		return true
-	case <-time.After(timeout):
-		return false
+// DrainAutoCommits waits for background intent commits to finish before the
+// process exits, printing a notice to w if the wait is not immediate and a
+// warning if it exceeds the bounded timeout.
+func (m Model) DrainAutoCommits(w io.Writer) {
+	if m.autoCommit.wait(quickDrainTimeout) {
+		return
+	}
+	_, _ = fmt.Fprintln(w, "Finalizing intent commits...")
+	if !m.autoCommit.wait(autoCommitDrainTimeout) {
+		_, _ = fmt.Fprintln(w, "warning: some intent auto-commits did not finish; run 'camp status' to check for uncommitted intent changes")
 	}
 }

--- a/internal/intent/tui/explorer/audit.go
+++ b/internal/intent/tui/explorer/audit.go
@@ -2,18 +2,32 @@ package explorer
 
 import (
 	"context"
+	"log/slog"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Obedience-Corp/camp/internal/git/commit"
 	"github.com/Obedience-Corp/camp/internal/intent/audit"
 )
 
 var runAutoCommitIntent = func(ctx context.Context, opts commit.IntentOptions) {
-	_ = commit.Intent(ctx, opts)
+	if res := commit.Intent(ctx, opts); res.Err != nil {
+		slog.WarnContext(ctx, "intent auto-commit failed",
+			"action", opts.Action,
+			"intent", opts.IntentTitle,
+			"error", res.Err,
+		)
+	}
 }
 
-var autoCommitIntentMu sync.Mutex
+// autoCommitIntentMu serializes background auto-commits so concurrent goroutines
+// cannot race on the git index lock. autoCommitIntentWg tracks in-flight commits
+// so they can be drained before the process exits (see WaitForAutoCommits).
+var (
+	autoCommitIntentMu sync.Mutex
+	autoCommitIntentWg sync.WaitGroup
+)
 
 func (m *Model) auditActor() string {
 	actor := strings.TrimSpace(m.author)
@@ -59,9 +73,30 @@ func (m *Model) autoCommitIntent(action commit.IntentAction, title, description 
 		IntentTitle: title,
 		Description: description,
 	}
-	go func() {
+	autoCommitIntentWg.Go(func() {
 		autoCommitIntentMu.Lock()
 		defer autoCommitIntentMu.Unlock()
 		runAutoCommitIntent(ctx, opts)
+	})
+}
+
+// WaitForAutoCommits blocks until every background intent auto-commit started by
+// autoCommitIntent has finished, or until timeout elapses. The explorer fires
+// commits asynchronously to keep the UI responsive, so the process must drain
+// them on exit; otherwise an intent change already written to disk could be lost
+// without ever being committed. It returns true if all commits drained, or false
+// if the timeout was hit first. The timeout bounds shutdown so a wedged git lock
+// cannot hang the exit indefinitely.
+func WaitForAutoCommits(timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		autoCommitIntentWg.Wait()
+		close(done)
 	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
 }

--- a/internal/intent/tui/explorer/audit.go
+++ b/internal/intent/tui/explorer/audit.go
@@ -3,6 +3,7 @@ package explorer
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/Obedience-Corp/camp/internal/git/commit"
 	"github.com/Obedience-Corp/camp/internal/intent/audit"
@@ -11,6 +12,8 @@ import (
 var runAutoCommitIntent = func(ctx context.Context, opts commit.IntentOptions) {
 	_ = commit.Intent(ctx, opts)
 }
+
+var autoCommitIntentMu sync.Mutex
 
 func (m *Model) auditActor() string {
 	actor := strings.TrimSpace(m.author)
@@ -56,5 +59,9 @@ func (m *Model) autoCommitIntent(action commit.IntentAction, title, description 
 		IntentTitle: title,
 		Description: description,
 	}
-	go runAutoCommitIntent(ctx, opts)
+	go func() {
+		autoCommitIntentMu.Lock()
+		defer autoCommitIntentMu.Unlock()
+		runAutoCommitIntent(ctx, opts)
+	}()
 }

--- a/internal/intent/tui/explorer/audit_test.go
+++ b/internal/intent/tui/explorer/audit_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/Obedience-Corp/camp/internal/git/commit"
 )
 
 func TestAutoCommitFiles_IncludesAuditLog(t *testing.T) {
@@ -34,5 +37,54 @@ func TestAutoCommitFiles_SkipsAuditLogWithoutIntentsDir(t *testing.T) {
 
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("autoCommitFiles() = %#v, want %#v", got, want)
+	}
+}
+
+func TestAutoCommitIntentReturnsBeforeCommitFinishes(t *testing.T) {
+	oldRun := runAutoCommitIntent
+	defer func() { runAutoCommitIntent = oldRun }()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	runAutoCommitIntent = func(ctx context.Context, opts commit.IntentOptions) {
+		close(started)
+		<-release
+		close(done)
+	}
+
+	campaignRoot := filepath.Join(string(filepath.Separator), "tmp", "campaign")
+	intentsDir := filepath.Join(campaignRoot, ".campaign", "intents")
+	m := NewModel(context.Background(), nil, nil, intentsDir, campaignRoot, "test-id", "", nil)
+
+	returned := make(chan struct{})
+	go func() {
+		m.autoCommitIntent(commit.IntentMove, "Fast action", "Moved", filepath.Join(intentsDir, "foo.md"))
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("autoCommitIntent blocked waiting for commit completion")
+	}
+
+	select {
+	case <-started:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("background auto-commit did not start")
+	}
+
+	select {
+	case <-done:
+		t.Fatal("test commit finished before release; blocking stub was not used")
+	default:
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("background auto-commit did not finish after release")
 	}
 }

--- a/internal/intent/tui/explorer/audit_test.go
+++ b/internal/intent/tui/explorer/audit_test.go
@@ -1,6 +1,7 @@
 package explorer
 
 import (
+	"bytes"
 	"context"
 	"path/filepath"
 	"reflect"
@@ -41,21 +42,18 @@ func TestAutoCommitFiles_SkipsAuditLogWithoutIntentsDir(t *testing.T) {
 }
 
 func TestAutoCommitIntentReturnsBeforeCommitFinishes(t *testing.T) {
-	oldRun := runAutoCommitIntent
-	defer func() { runAutoCommitIntent = oldRun }()
-
 	started := make(chan struct{})
 	release := make(chan struct{})
 	done := make(chan struct{})
-	runAutoCommitIntent = func(ctx context.Context, opts commit.IntentOptions) {
-		close(started)
-		<-release
-		close(done)
-	}
 
 	campaignRoot := filepath.Join(string(filepath.Separator), "tmp", "campaign")
 	intentsDir := filepath.Join(campaignRoot, ".campaign", "intents")
 	m := NewModel(context.Background(), nil, nil, intentsDir, campaignRoot, "test-id", "", nil)
+	m.autoCommit.run = func(ctx context.Context, opts commit.IntentOptions) {
+		close(started)
+		<-release
+		close(done)
+	}
 
 	returned := make(chan struct{})
 	go func() {
@@ -90,16 +88,16 @@ func TestAutoCommitIntentReturnsBeforeCommitFinishes(t *testing.T) {
 }
 
 func TestAutoCommitIntentSerializesBackgroundCommits(t *testing.T) {
-	oldRun := runAutoCommitIntent
-	defer func() { runAutoCommitIntent = oldRun }()
-
 	firstStarted := make(chan struct{})
 	releaseFirst := make(chan struct{})
 	secondStarted := make(chan struct{})
 	done := make(chan struct{})
 	calls := 0
 
-	runAutoCommitIntent = func(ctx context.Context, opts commit.IntentOptions) {
+	campaignRoot := filepath.Join(string(filepath.Separator), "tmp", "campaign")
+	intentsDir := filepath.Join(campaignRoot, ".campaign", "intents")
+	m := NewModel(context.Background(), nil, nil, intentsDir, campaignRoot, "test-id", "", nil)
+	m.autoCommit.run = func(ctx context.Context, opts commit.IntentOptions) {
 		calls++
 		switch calls {
 		case 1:
@@ -112,10 +110,6 @@ func TestAutoCommitIntentSerializesBackgroundCommits(t *testing.T) {
 			t.Fatalf("unexpected auto-commit call %d", calls)
 		}
 	}
-
-	campaignRoot := filepath.Join(string(filepath.Separator), "tmp", "campaign")
-	intentsDir := filepath.Join(campaignRoot, ".campaign", "intents")
-	m := NewModel(context.Background(), nil, nil, intentsDir, campaignRoot, "test-id", "", nil)
 
 	m.autoCommitIntent(commit.IntentMove, "First action", "Moved", filepath.Join(intentsDir, "first.md"))
 	select {
@@ -139,39 +133,42 @@ func TestAutoCommitIntentSerializesBackgroundCommits(t *testing.T) {
 	}
 }
 
-func TestWaitForAutoCommitsDrainsInFlightCommit(t *testing.T) {
-	oldRun := runAutoCommitIntent
-	defer func() { runAutoCommitIntent = oldRun }()
-
-	// Absorb any stragglers from prior tests so the count starts clean.
-	WaitForAutoCommits(time.Second)
-
+func TestAutoCommitterDrainsInFlightCommit(t *testing.T) {
 	release := make(chan struct{})
 	committed := make(chan struct{})
-	runAutoCommitIntent = func(ctx context.Context, opts commit.IntentOptions) {
-		<-release
-		close(committed)
-	}
 
 	campaignRoot := filepath.Join(string(filepath.Separator), "tmp", "campaign")
 	intentsDir := filepath.Join(campaignRoot, ".campaign", "intents")
 	m := NewModel(context.Background(), nil, nil, intentsDir, campaignRoot, "test-id", "", nil)
+	m.autoCommit.run = func(ctx context.Context, opts commit.IntentOptions) {
+		<-release
+		close(committed)
+	}
 
 	m.autoCommitIntent(commit.IntentMove, "Pending action", "Moved", filepath.Join(intentsDir, "pending.md"))
 
-	if WaitForAutoCommits(50 * time.Millisecond) {
-		t.Fatal("WaitForAutoCommits reported drained while a commit was still in flight")
+	if m.autoCommit.wait(50 * time.Millisecond) {
+		t.Fatal("wait reported drained while a commit was still in flight")
 	}
 
 	close(release)
 
-	if !WaitForAutoCommits(time.Second) {
-		t.Fatal("WaitForAutoCommits did not drain after the commit finished")
+	if !m.autoCommit.wait(time.Second) {
+		t.Fatal("wait did not drain after the commit finished")
 	}
 
 	select {
 	case <-committed:
 	default:
 		t.Fatal("auto-commit did not run to completion before drain returned")
+	}
+}
+
+func TestDrainAutoCommitsSilentWhenNothingPending(t *testing.T) {
+	m := NewModel(context.Background(), nil, nil, "/tmp/intents", "/tmp/campaign", "test-id", "", nil)
+	var buf bytes.Buffer
+	m.DrainAutoCommits(&buf)
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output when no commits pending, got %q", buf.String())
 	}
 }

--- a/internal/intent/tui/explorer/audit_test.go
+++ b/internal/intent/tui/explorer/audit_test.go
@@ -88,3 +88,53 @@ func TestAutoCommitIntentReturnsBeforeCommitFinishes(t *testing.T) {
 		t.Fatal("background auto-commit did not finish after release")
 	}
 }
+
+func TestAutoCommitIntentSerializesBackgroundCommits(t *testing.T) {
+	oldRun := runAutoCommitIntent
+	defer func() { runAutoCommitIntent = oldRun }()
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondStarted := make(chan struct{})
+	done := make(chan struct{})
+	calls := 0
+
+	runAutoCommitIntent = func(ctx context.Context, opts commit.IntentOptions) {
+		calls++
+		switch calls {
+		case 1:
+			close(firstStarted)
+			<-releaseFirst
+		case 2:
+			close(secondStarted)
+			close(done)
+		default:
+			t.Fatalf("unexpected auto-commit call %d", calls)
+		}
+	}
+
+	campaignRoot := filepath.Join(string(filepath.Separator), "tmp", "campaign")
+	intentsDir := filepath.Join(campaignRoot, ".campaign", "intents")
+	m := NewModel(context.Background(), nil, nil, intentsDir, campaignRoot, "test-id", "", nil)
+
+	m.autoCommitIntent(commit.IntentMove, "First action", "Moved", filepath.Join(intentsDir, "first.md"))
+	select {
+	case <-firstStarted:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("first background auto-commit did not start")
+	}
+
+	m.autoCommitIntent(commit.IntentMove, "Second action", "Moved", filepath.Join(intentsDir, "second.md"))
+	select {
+	case <-secondStarted:
+		t.Fatal("second background auto-commit started while first commit was still running")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("second background auto-commit did not start after first commit released")
+	}
+}

--- a/internal/intent/tui/explorer/audit_test.go
+++ b/internal/intent/tui/explorer/audit_test.go
@@ -138,3 +138,40 @@ func TestAutoCommitIntentSerializesBackgroundCommits(t *testing.T) {
 		t.Fatal("second background auto-commit did not start after first commit released")
 	}
 }
+
+func TestWaitForAutoCommitsDrainsInFlightCommit(t *testing.T) {
+	oldRun := runAutoCommitIntent
+	defer func() { runAutoCommitIntent = oldRun }()
+
+	// Absorb any stragglers from prior tests so the count starts clean.
+	WaitForAutoCommits(time.Second)
+
+	release := make(chan struct{})
+	committed := make(chan struct{})
+	runAutoCommitIntent = func(ctx context.Context, opts commit.IntentOptions) {
+		<-release
+		close(committed)
+	}
+
+	campaignRoot := filepath.Join(string(filepath.Separator), "tmp", "campaign")
+	intentsDir := filepath.Join(campaignRoot, ".campaign", "intents")
+	m := NewModel(context.Background(), nil, nil, intentsDir, campaignRoot, "test-id", "", nil)
+
+	m.autoCommitIntent(commit.IntentMove, "Pending action", "Moved", filepath.Join(intentsDir, "pending.md"))
+
+	if WaitForAutoCommits(50 * time.Millisecond) {
+		t.Fatal("WaitForAutoCommits reported drained while a commit was still in flight")
+	}
+
+	close(release)
+
+	if !WaitForAutoCommits(time.Second) {
+		t.Fatal("WaitForAutoCommits did not drain after the commit finished")
+	}
+
+	select {
+	case <-committed:
+	default:
+		t.Fatal("auto-commit did not run to completion before drain returned")
+	}
+}

--- a/internal/intent/tui/explorer/filtering.go
+++ b/internal/intent/tui/explorer/filtering.go
@@ -13,14 +13,23 @@ var typeFilterItems = []string{"All", "Idea", "Feature", "Bug", "Research", "Cho
 // statusFilterItems are the available status filter options.
 var statusFilterItems = []string{"All", "Notes", "Inbox", "Ready", "Active", "Done", "Killed"}
 
-type explorerItemSource []*intent.Intent
+type explorerSearchCorpus []string
 
-func (s explorerItemSource) String(i int) string {
-	item := s[i]
-	return strings.Join([]string{item.Title, item.ID, item.Content}, " ")
+func (s explorerSearchCorpus) String(i int) string { return s[i] }
+
+func (s explorerSearchCorpus) Len() int { return len(s) }
+
+func buildSearchCorpus(items []*intent.Intent) []string {
+	corpus := make([]string, len(items))
+	for i, item := range items {
+		corpus[i] = strings.Join([]string{item.Title, item.ID, item.Content}, " ")
+	}
+	return corpus
 }
 
-func (s explorerItemSource) Len() int { return len(s) }
+func (m *Model) rebuildSearchCorpus() {
+	m.searchCorpus = buildSearchCorpus(m.intents)
+}
 
 // applyFilters filters intents using search query and type filter.
 func (m *Model) applyFilters() {
@@ -47,7 +56,10 @@ func (m *Model) applyFilters() {
 	if query == "" {
 		filtered = m.intents
 	} else {
-		matches := fuzzy.FindFrom(query, explorerItemSource(m.intents))
+		if len(m.searchCorpus) != len(m.intents) {
+			m.rebuildSearchCorpus()
+		}
+		matches := fuzzy.FindFrom(query, explorerSearchCorpus(m.searchCorpus))
 		filtered = make([]*intent.Intent, len(matches))
 		for i, match := range matches {
 			filtered[i] = m.intents[match.Index]

--- a/internal/intent/tui/explorer/filtering_test.go
+++ b/internal/intent/tui/explorer/filtering_test.go
@@ -96,6 +96,37 @@ func TestApplyFilters_StatusNotes(t *testing.T) {
 	}
 }
 
+func TestApplyFilters_UsesCachedSearchCorpus(t *testing.T) {
+	ctx := context.Background()
+	m := NewModel(ctx, nil, nil, "/tmp/intents", "/tmp/campaign", "test-id", "", nil)
+	m.ready = true
+
+	now := time.Now()
+	m.intents = []*intent.Intent{
+		{ID: "alpha", Title: "Alpha", Content: "cached-match", Status: intent.StatusInbox, Type: intent.TypeFeature, CreatedAt: now},
+		{ID: "beta", Title: "Beta", Content: "other", Status: intent.StatusInbox, Type: intent.TypeFeature, CreatedAt: now},
+	}
+	m.rebuildSearchCorpus()
+	m.filteredIntents = m.intents
+	m.groups = groupIntentsByStatus(m.intents, m.dungeonExpanded)
+
+	m.searchInput.SetValue("cached-match")
+	m.applyFilters()
+
+	if len(m.filteredIntents) != 1 || m.filteredIntents[0].ID != "alpha" {
+		t.Fatalf("cached search returned %+v, want alpha", m.filteredIntents)
+	}
+
+	m.searchCorpus[0] = "stale-only-match"
+	m.intents[0].Content = "content-changed-without-rebuild"
+	m.searchInput.SetValue("stale-only-match")
+	m.applyFilters()
+
+	if len(m.filteredIntents) != 1 || m.filteredIntents[0].ID != "alpha" {
+		t.Fatalf("search did not use cached corpus; got %+v, want alpha from cache", m.filteredIntents)
+	}
+}
+
 func statusFilterIndex(t *testing.T, label string) int {
 	t.Helper()
 	for i, item := range statusFilterItems {

--- a/internal/intent/tui/explorer/model.go
+++ b/internal/intent/tui/explorer/model.go
@@ -54,6 +54,7 @@ type Model struct {
 	searchCorpus    []string
 	groups          []IntentGroup
 	service         *intent.IntentService
+	autoCommit      *autoCommitter
 	ctx             context.Context
 
 	// Cursor position in nested structure
@@ -205,6 +206,7 @@ func NewModel(ctx context.Context, svc *intent.IntentService, conceptSvc concept
 
 	return Model{
 		service:         svc,
+		autoCommit:      newAutoCommitter(),
 		ctx:             ctx,
 		conceptSvc:      conceptSvc,
 		cursorGroup:     0,

--- a/internal/intent/tui/explorer/model.go
+++ b/internal/intent/tui/explorer/model.go
@@ -51,6 +51,7 @@ type Model struct {
 	// Data
 	intents         []*intent.Intent
 	filteredIntents []*intent.Intent
+	searchCorpus    []string
 	groups          []IntentGroup
 	service         *intent.IntentService
 	ctx             context.Context

--- a/internal/intent/tui/explorer/update.go
+++ b/internal/intent/tui/explorer/update.go
@@ -107,6 +107,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.intents = msg.intents
 		m.filteredIntents = msg.intents
+		m.rebuildSearchCorpus()
 		if m.notesMode {
 			m.groups = groupNotes(msg.intents)
 		} else {


### PR DESCRIPTION
## Summary
- Caches intent explorer searchable text so live search avoids rebuilding content on each keypress.
- Moves best-effort TUI auto-commits into a background goroutine after successful intent/audit updates.

## Validation
- go test ./internal/intent/tui/explorer
- just gate-fast
- just test unit
- git diff --check

## Notes
- Non-TUI CLI intent commands still commit synchronously; a durable background worker would be a separate design.
