### PR TITLE
feat(fresh): add --list to cycle a set of projects in one run

### DIFF
--- a/internal/commands/fresh/all.go
+++ b/internal/commands/fresh/all.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
@@ -51,63 +50,17 @@ Examples:
 			}
 
 			// Read persistent flags from parent (freshCmd)
-			freshBranch, freshNoBranch, freshNoPush, freshNoPrune, freshDryRun := getFreshFlags(freshCmd)
+			flags := getFreshFlagSet(freshCmd)
 
-			green := lipgloss.NewStyle().Foreground(ui.SuccessColor)
-			red := lipgloss.NewStyle().Foreground(ui.ErrorColor)
-
-			fmt.Println(ui.Info("Running fresh across all projects..."))
-			fmt.Println()
-
-			var succeeded, failed int
-			var failedNames []string
-
+			targets := make([]freshTarget, 0, len(paths))
 			for _, p := range paths {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-
-				fullPath := filepath.Join(campRoot, p)
-				name := git.SubmoduleDisplayName(p)
-
-				// Resolve per-project settings
-				branch := cfg.ResolveFreshBranch(freshBranch, freshNoBranch, name)
-				doPrune := !freshNoPrune && cfg.ResolveFreshPrune()
-				doPush := !freshNoPush && cfg.ResolveFreshPushUpstream(name)
-
-				err := executeFresh(ctx, name, fullPath, freshOptions{
-					branch:      branch,
-					prune:       doPrune,
-					pruneRemote: cfg.ResolveFreshPruneRemote(),
-					push:        doPush,
-					dryRun:      freshDryRun,
+				targets = append(targets, freshTarget{
+					name: git.SubmoduleDisplayName(p),
+					path: filepath.Join(campRoot, p),
 				})
-				if err != nil {
-					fmt.Printf("  %s %s: %s\n", red.Render("FAILED"), name, err)
-					failed++
-					failedNames = append(failedNames, name)
-				} else {
-					succeeded++
-				}
 			}
 
-			// Summary
-			fmt.Println()
-			fmt.Println(ui.Separator(50))
-			if failed == 0 {
-				fmt.Printf("%s Fresh completed for %d project(s)\n", green.Render("All done!"), succeeded)
-			} else {
-				fmt.Printf("%s %d succeeded, %d failed\n",
-					ui.Warning("Fresh completed with errors:"), succeeded, failed)
-				for _, name := range failedNames {
-					fmt.Printf("  %s %s\n", red.Render("-"), name)
-				}
-			}
-
-			if failed > 0 {
-				return camperrors.Newf("%d project(s) failed", failed)
-			}
-			return nil
+			return runFreshBatch(ctx, cfg, targets, flags, "Running fresh across all projects...")
 		},
 	}
 }

--- a/internal/commands/fresh/batch.go
+++ b/internal/commands/fresh/batch.go
@@ -1,0 +1,152 @@
+package fresh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/project"
+	"github.com/Obedience-Corp/camp/internal/ui"
+)
+
+// freshFlagSet captures the resolved persistent flags shared by every fresh
+// invocation. It is passed to runFreshBatch so per-project settings can be
+// resolved against the fresh config.
+type freshFlagSet struct {
+	branch   string
+	noBranch bool
+	noPush   bool
+	noPrune  bool
+	dryRun   bool
+}
+
+// freshTarget is a resolved project to run the fresh cycle against.
+type freshTarget struct {
+	name string
+	path string
+}
+
+// getFreshFlagSet extracts the fresh persistent flags from the parent command.
+// These are stored on the parent (freshCmd) and inherited by subcommands.
+func getFreshFlagSet(freshCmd *cobra.Command) freshFlagSet {
+	branch, _ := freshCmd.PersistentFlags().GetString("branch")
+	noBranch, _ := freshCmd.PersistentFlags().GetBool("no-branch")
+	noPush, _ := freshCmd.PersistentFlags().GetBool("no-push")
+	noPrune, _ := freshCmd.PersistentFlags().GetBool("no-prune")
+	dryRun, _ := freshCmd.PersistentFlags().GetBool("dry-run")
+	return freshFlagSet{
+		branch:   branch,
+		noBranch: noBranch,
+		noPush:   noPush,
+		noPrune:  noPrune,
+		dryRun:   dryRun,
+	}
+}
+
+// cleanProjectList trims surrounding whitespace from each entry and drops
+// empties, so '--list=camp, fest,' resolves to ["camp", "fest"] rather than
+// failing on a blank or space-padded name.
+func cleanProjectList(list []string) []string {
+	cleaned := make([]string, 0, len(list))
+	for _, name := range list {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			cleaned = append(cleaned, name)
+		}
+	}
+	return cleaned
+}
+
+// resolveFreshTargets resolves a list of project names to fresh targets.
+//
+// All names are resolved up front so an invalid name fails before any project
+// is mutated. Duplicate names collapse to a single target, preserving
+// first-seen order.
+func resolveFreshTargets(ctx context.Context, campRoot string, names []string) ([]freshTarget, error) {
+	seen := make(map[string]struct{}, len(names))
+	targets := make([]freshTarget, 0, len(names))
+	for _, name := range names {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		result, err := project.Resolve(ctx, campRoot, name)
+		if err != nil {
+			var notFound *project.ProjectNotFoundError
+			if errors.As(err, &notFound) {
+				fmt.Println(ui.Dim("\n" + project.FormatProjectList(notFound.AvailableProjects())))
+			}
+			return nil, err
+		}
+
+		if _, ok := seen[result.Name]; ok {
+			continue
+		}
+		seen[result.Name] = struct{}{}
+		targets = append(targets, freshTarget{name: result.Name, path: result.Path})
+	}
+	return targets, nil
+}
+
+// runFreshBatch runs the fresh cycle across multiple targets. It continues on
+// per-project execution errors and reports an aggregate summary, returning an
+// error if any target failed. This backs both `camp fresh <a> <b> ...` and
+// `camp fresh all`.
+func runFreshBatch(ctx context.Context, cfg *config.FreshConfig, targets []freshTarget, flags freshFlagSet, header string) error {
+	green := lipgloss.NewStyle().Foreground(ui.SuccessColor)
+	red := lipgloss.NewStyle().Foreground(ui.ErrorColor)
+
+	fmt.Println(ui.Info(header))
+	fmt.Println()
+
+	var succeeded, failed int
+	var failedNames []string
+
+	for _, t := range targets {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		branch := cfg.ResolveFreshBranch(flags.branch, flags.noBranch, t.name)
+		doPrune := !flags.noPrune && cfg.ResolveFreshPrune()
+		doPush := !flags.noPush && cfg.ResolveFreshPushUpstream(t.name)
+
+		err := executeFresh(ctx, t.name, t.path, freshOptions{
+			branch:      branch,
+			prune:       doPrune,
+			pruneRemote: cfg.ResolveFreshPruneRemote(),
+			push:        doPush,
+			dryRun:      flags.dryRun,
+		})
+		if err != nil {
+			fmt.Printf("  %s %s: %s\n", red.Render("FAILED"), t.name, err)
+			failed++
+			failedNames = append(failedNames, t.name)
+		} else {
+			succeeded++
+		}
+	}
+
+	fmt.Println()
+	fmt.Println(ui.Separator(50))
+	if failed == 0 {
+		fmt.Printf("%s Fresh completed for %d project(s)\n", green.Render("All done!"), succeeded)
+	} else {
+		fmt.Printf("%s %d succeeded, %d failed\n",
+			ui.Warning("Fresh completed with errors:"), succeeded, failed)
+		for _, name := range failedNames {
+			fmt.Printf("  %s %s\n", red.Render("-"), name)
+		}
+	}
+
+	if failed > 0 {
+		return camperrors.Newf("%d project(s) failed", failed)
+	}
+	return nil
+}

--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -25,7 +25,6 @@ import (
 var (
 	freshStepDim   = lipgloss.NewStyle().Foreground(ui.DimColor)
 	freshStepGreen = lipgloss.NewStyle().Foreground(ui.SuccessColor)
-	freshStepRed   = lipgloss.NewStyle().Foreground(ui.ErrorColor)
 )
 
 // NewFreshCommand creates and returns the fresh cobra command with all subcommands.
@@ -37,28 +36,31 @@ func NewFreshCommand() *cobra.Command {
 		freshNoPrune     bool
 		freshDryRun      bool
 		freshProjectFlag string
+		freshList        []string
 	)
 
 	freshCmd := &cobra.Command{
 		Use:   "fresh [project-name]",
 		Short: "Post-merge branch cycling: sync to default branch and optionally create a new working branch",
-		Long: `Reset a project to a fresh state after merging a PR.
+		Long: `Reset one or more projects to a fresh state after merging a PR.
 
 Performs the post-merge cycle: checkout default branch, pull latest,
 prune merged branches, and optionally create a new working branch.
 
-Auto-detects the current project from your working directory,
-or accepts a project name as a positional argument.
+Auto-detects the current project from your working directory, or accepts a
+single project name. Use --list to cycle a specific set of projects in one
+run, or 'camp fresh all' to cycle every project submodule in the campaign.
 
 Without configuration, syncs to the default branch and prunes.
 Configure .campaign/settings/fresh.yaml to set a default working branch.
 
 Examples:
-  camp fresh                         # Sync current project (checkout default, pull, prune)
-  camp fresh --branch develop        # Sync and create develop branch
-  camp fresh camp -b feat/new-thing  # Sync camp project, create feature branch
-  camp fresh --no-prune              # Sync without pruning
-  camp fresh --dry-run               # Preview what would happen`,
+  camp fresh                            # Sync current project (checkout default, pull, prune)
+  camp fresh --branch develop           # Sync and create develop branch
+  camp fresh camp -b feat/new-thing     # Sync camp project, create feature branch
+  camp fresh --list camp,fest,festival  # Sync a specific set of projects
+  camp fresh --no-prune                 # Sync without pruning
+  camp fresh --dry-run                  # Preview what would happen`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: completeProjectName,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -69,7 +71,40 @@ Examples:
 				return camperrors.Wrap(err, "not in a campaign")
 			}
 
-			// Resolve project: positional arg > flag > cwd
+			// Load fresh config
+			cfg, err := config.LoadFreshConfig(ctx, campRoot)
+			if err != nil {
+				return camperrors.Wrap(err, "loading fresh config")
+			}
+
+			flags := freshFlagSet{
+				branch:   freshBranch,
+				noBranch: freshNoBranch,
+				noPush:   freshNoPush,
+				noPrune:  freshNoPrune,
+				dryRun:   freshDryRun,
+			}
+
+			// --list runs a batch across an explicit set of projects. It is
+			// mutually exclusive with a positional project name (the -p/--project
+			// flag is guarded by MarkFlagsMutuallyExclusive below).
+			list := cleanProjectList(freshList)
+			if len(list) > 0 {
+				if len(args) > 0 {
+					return camperrors.New("specify a project with a positional name or --list, not both")
+				}
+
+				// Resolve all names up front (fail fast on a bad name), then
+				// run the batch cycle with an aggregate summary.
+				targets, err := resolveFreshTargets(ctx, campRoot, list)
+				if err != nil {
+					return err
+				}
+				header := fmt.Sprintf("Running fresh across %d project(s)...", len(targets))
+				return runFreshBatch(ctx, cfg, targets, flags, header)
+			}
+
+			// Single project: positional name > --project > cwd auto-detect.
 			projectName := freshProjectFlag
 			if len(args) > 0 {
 				projectName = args[0]
@@ -82,12 +117,6 @@ Examples:
 					fmt.Println(ui.Dim("\n" + project.FormatProjectList(notFound.AvailableProjects())))
 				}
 				return err
-			}
-
-			// Load fresh config
-			cfg, err := config.LoadFreshConfig(ctx, campRoot)
-			if err != nil {
-				return camperrors.Wrap(err, "loading fresh config")
 			}
 
 			// Resolve settings
@@ -113,6 +142,9 @@ Examples:
 	freshCmd.PersistentFlags().BoolVarP(&freshDryRun, "dry-run", "n", false, "Preview without making changes")
 	freshCmd.Flags().StringVarP(&freshProjectFlag, "project", "p", "", "Project name (auto-detected from cwd)")
 	freshCmd.RegisterFlagCompletionFunc("project", completeProjectName)
+	freshCmd.Flags().StringSliceVar(&freshList, "list", nil, "Comma-separated set of projects to cycle in one run")
+	_ = freshCmd.RegisterFlagCompletionFunc("list", completeProjectName)
+	freshCmd.MarkFlagsMutuallyExclusive("project", "list")
 
 	// Add subcommand
 	freshCmd.AddCommand(newAllCommand(freshCmd))
@@ -436,15 +468,4 @@ func completeProjectName(cmd *cobra.Command, _ []string, toComplete string) ([]s
 	}
 
 	return names, cobra.ShellCompDirectiveNoFileComp
-}
-
-// getFreshFlags extracts persistent flags from the fresh command.
-// These are stored on the parent command (freshCmd) and accessed here.
-func getFreshFlags(freshCmd *cobra.Command) (branch string, noBranch, noPush, noPrune, dryRun bool) {
-	branch, _ = freshCmd.PersistentFlags().GetString("branch")
-	noBranch, _ = freshCmd.PersistentFlags().GetBool("no-branch")
-	noPush, _ = freshCmd.PersistentFlags().GetBool("no-push")
-	noPrune, _ = freshCmd.PersistentFlags().GetBool("no-prune")
-	dryRun, _ = freshCmd.PersistentFlags().GetBool("dry-run")
-	return
 }

--- a/tests/integration/fresh_test.go
+++ b/tests/integration/fresh_test.go
@@ -104,6 +104,49 @@ GIT_ALLOW_PROTOCOL=file git -C %[1]s/projects/test-project submodule update --in
 	return campaignPath, campaignPath + "/projects/test-project", campaignPath + "/projects/test-project/vendor/tool"
 }
 
+// setupFreshCampaignWithTwoSubmodules creates a campaign with two independent
+// submodule projects (test-a, test-b), each with its own bare origin on main.
+// Used to exercise the multi-project `camp fresh <a> <b>` batch path.
+func setupFreshCampaignWithTwoSubmodules(t *testing.T, tc *TestContainer, name string) (string, string, string) {
+	t.Helper()
+
+	campaignPath := "/campaigns/" + name
+	bareA := "/test/" + name + "-a-origin.git"
+	seedA := "/test/" + name + "-a-seed"
+	bareB := "/test/" + name + "-b-origin.git"
+	seedB := "/test/" + name + "-b-seed"
+
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+for spec in "%[1]s %[2]s" "%[3]s %[4]s"; do
+  set -- $spec
+  git init --bare "$1"
+  git clone "$1" "$2"
+  git -C "$2" config user.email test@test.com
+  git -C "$2" config user.name Test
+  printf '# Test Project\n' > "$2"/README.md
+  git -C "$2" add .
+  git -C "$2" commit -m 'Initial commit'
+  git -C "$2" branch -M main
+  git -C "$2" push origin main
+  git --git-dir "$1" symbolic-ref HEAD refs/heads/main
+done
+`, bareA, seedA, bareB, seedB))
+
+	_, err := tc.InitCampaign(campaignPath, name, "product")
+	require.NoError(t, err)
+
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+cd %[1]s
+GIT_ALLOW_PROTOCOL=file git submodule add %[2]s projects/test-a
+GIT_ALLOW_PROTOCOL=file git submodule add %[3]s projects/test-b
+git commit -m 'Add submodules'
+`, campaignPath, bareA, bareB))
+
+	return campaignPath, campaignPath + "/projects/test-a", campaignPath + "/projects/test-b"
+}
+
 // skipIfShort skips container-backed tests under `go test -short`. Each test
 // calls Reset() which wipes + reinitializes the full container fixture, so the
 // suite is not cheap enough for short-mode runs.
@@ -369,6 +412,62 @@ git -C %[1]s commit -m 'Nested drift'
 
 	current := tc.GitOutput(t, projectDir, "rev-parse", "--abbrev-ref", "HEAD")
 	assert.Equal(t, "develop", current)
+}
+
+// TestFresh_ListCyclesEachProject verifies `camp fresh --list a,b` runs the
+// fresh cycle against each named project in a single invocation.
+func TestFresh_ListCyclesEachProject(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-list-cycle"
+	campaignPath, projectDirA, projectDirB := setupFreshCampaignWithTwoSubmodules(t, tc, name)
+
+	output, err := tc.RunCampInDir(campaignPath, "fresh", "--list", "test-a,test-b", "--branch", "develop", "--no-push")
+	require.NoError(t, err, "camp fresh --list should cycle each named project:\n%s", output)
+
+	assert.Contains(t, output, "Running fresh across 2 project(s)",
+		"batch run should announce the number of projects")
+
+	currentA := tc.GitOutput(t, projectDirA, "rev-parse", "--abbrev-ref", "HEAD")
+	assert.Equal(t, "develop", currentA, "test-a should be cycled onto the new branch")
+
+	currentB := tc.GitOutput(t, projectDirB, "rev-parse", "--abbrev-ref", "HEAD")
+	assert.Equal(t, "develop", currentB, "test-b should be cycled onto the new branch")
+}
+
+// TestFresh_ListFailFastOnUnknownName verifies that an unknown project name
+// anywhere in --list aborts the batch before mutating any project, since all
+// names are resolved up front.
+func TestFresh_ListFailFastOnUnknownName(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-list-badname"
+	campaignPath, projectDirA, _ := setupFreshCampaignWithTwoSubmodules(t, tc, name)
+
+	output, err := tc.RunCampInDir(campaignPath, "fresh", "--list", "test-a,does-not-exist", "--branch", "develop", "--no-push")
+	require.Error(t, err, "camp fresh --list should fail when a project name is unknown:\n%s", output)
+
+	currentA := tc.GitOutput(t, projectDirA, "rev-parse", "--abbrev-ref", "HEAD")
+	assert.Equal(t, "main", currentA, "test-a must not be mutated when the batch fails name validation")
+
+	_, exitCode, err := tc.ExecCommand("git", "-C", projectDirA, "rev-parse", "--verify", "--quiet", "refs/heads/develop")
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, exitCode, "develop branch should not be created when the batch aborts on validation")
+}
+
+// TestFresh_ListRejectsPositionalArg verifies that combining --list with a
+// positional project name is rejected rather than silently ignoring one.
+func TestFresh_ListRejectsPositionalArg(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-list-conflict"
+	campaignPath, projectDirA, _ := setupFreshCampaignWithTwoSubmodules(t, tc, name)
+
+	output, err := tc.RunCampInDir(campaignPath, "fresh", "test-a", "--list", "test-b", "--no-push")
+	require.Error(t, err, "camp fresh should reject a positional name combined with --list:\n%s", output)
+
+	currentA := tc.GitOutput(t, projectDirA, "rev-parse", "--abbrev-ref", "HEAD")
+	assert.Equal(t, "main", currentA, "no project should be mutated when the invocation is rejected")
 }
 
 func TestFresh_DoesNotDeleteRemoteBranches(t *testing.T) {


### PR DESCRIPTION
## Summary

`camp fresh` previously offered only two granularities: one project at a time (positional arg, `--project`, or cwd auto-detect) or **every** submodule via `camp fresh all`. This PR adds the middle ground via an explicit `--list` flag:

```bash
camp fresh --list camp,fest,festival    # cycle just these three
```

An explicit flag (rather than variadic positional args) keeps the single-project positional form unambiguous — a stray shell token or typo can't silently become a project target.

## Behavior

- **`--list a,b,c`** runs the full fresh cycle (checkout default, pull, prune, optional branch/push) against each named project, honoring all existing flags (`--branch`, `--no-prune`, `--no-push`, `--dry-run`) and per-project `fresh.yaml` overrides.
- **Mutually exclusive**: `--list` cannot be combined with a positional project name or with `--project` (both rejected with a clear error rather than silently ignoring one).
- **Fail-fast validation**: every name is resolved up front, so an unknown project name aborts the batch *before* any project is mutated. Per-project *execution* errors (e.g. uncommitted changes in one repo) are collected and reported in an aggregate summary, matching `camp fresh all`.
- **Robust parsing**: entries are trimmed and empties dropped (`--list=camp, fest,` → `camp`, `fest`); duplicates collapse to a single target, preserving first-seen order.
- Single-project and `camp fresh all` behavior is unchanged. The batch runner is now shared: `all` delegates to it, so its output is identical.

## Implementation

- New `internal/commands/fresh/batch.go` holds the shared `runFreshBatch` runner, `freshTarget`/`freshFlagSet`, target resolution, and list sanitization.
- `fresh.go` adds the `--list` `StringSlice` flag (mutually exclusive with `--project`), routes a non-empty list through the batch path, and keeps `Args: MaximumNArgs(1)` so a stray extra positional still errors.
- `all.go` is reduced to building the target list and delegating to `runFreshBatch` (removes duplicated loop/summary code).
- Dropped a pre-existing unused `freshStepRed` style variable while touching the file.

## Testing

Three container-backed integration tests in `tests/integration/fresh_test.go`:

- `TestFresh_ListCyclesEachProject` — `camp fresh --list test-a,test-b --branch develop` cycles both onto the new branch and announces the project count.
- `TestFresh_ListFailFastOnUnknownName` — an unknown name in the list aborts before mutating any project (asserts `test-a` stays on `main`, no `develop` branch created).
- `TestFresh_ListRejectsPositionalArg` — combining a positional name with `--list` is rejected and mutates nothing.

All 11 `TestFresh_*` integration tests pass (including the pre-existing single-project and worktree suites). `just lint` reports `0 issues`; `just vet` and both lint ratchets (`no-fmt-errorf`, `no-host-fs-tests`) are clean.

### Real CLI output (dry-run)

```
$ camp fresh --list camp,fest --dry-run
Running fresh across 2 project(s)...

  camp (dry-run)
  ...
  fest (dry-run)
  ...

──────────────────────────────────────────────────
All done! Fresh completed for 2 project(s)
```