### PR TITLE
feat: camp gather design — combine design workitems into a gathered package

### DIFF
--- a/cmd/camp/dungeon/move.go
+++ b/cmd/camp/dungeon/move.go
@@ -151,7 +151,7 @@ func StageAndCommitDungeonMove(ctx context.Context, move *DungeonMoveCommit) *Du
 	outcome := &DungeonMoveCommitOutcome{}
 	files := commit.NormalizeFiles(move.CampaignRoot, move.DestinationPaths...)
 	files = append(files, commit.NormalizeFiles(move.CampaignRoot, move.RewrittenFiles...)...)
-	preStaged, err := stageTrackedMoveSourceDeletions(ctx, move.CampaignRoot, move.SourcePaths)
+	preStaged, err := StageTrackedMoveSourceDeletions(ctx, move.CampaignRoot, move.SourcePaths)
 	if err != nil {
 		outcome.StagingErr = err
 		return outcome
@@ -205,7 +205,11 @@ func CommitDungeonMove(ctx context.Context, move *DungeonMoveCommit) error {
 	return outcome.Err()
 }
 
-func stageTrackedMoveSourceDeletions(ctx context.Context, campaignRoot string, sourcePaths []string) ([]string, error) {
+// StageTrackedMoveSourceDeletions pre-stages the deletion of tracked source
+// paths so a selective commit records a directory move as a rename instead of
+// leaving stale deletions unstaged. Returns the campaign-relative paths that
+// were staged; untracked sources are skipped.
+func StageTrackedMoveSourceDeletions(ctx context.Context, campaignRoot string, sourcePaths []string) ([]string, error) {
 	sources := commit.NormalizeFiles(campaignRoot, sourcePaths...)
 	if len(sources) == 0 {
 		return nil, nil

--- a/cmd/camp/gather.go
+++ b/cmd/camp/gather.go
@@ -2,19 +2,21 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+
+	workitemcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 )
 
 var gatherCmd = &cobra.Command{
 	Use:     "gather",
-	Short:   "Import external data into the intent system",
+	Short:   "Gather related work into unified items",
 	GroupID: "planning",
-	Long: `Gather external data sources into trackable intents.
-
-The gather command imports data from various sources into the intent system,
-creating structured intents with checkboxes for tracking progress.
+	Long: `Gather related work into unified items.
 
 Available sources:
-  feedback    Gather feedback observations from festivals`,
+  feedback    Import feedback observations from festivals into intents
+  design      Combine selected design workitems into one gathered package
+
+For gathering intents by tag, hashtag, or similarity, see 'camp intent gather'.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	},
@@ -22,4 +24,5 @@ Available sources:
 
 func init() {
 	rootCmd.AddCommand(gatherCmd)
+	gatherCmd.AddCommand(workitemcmd.NewGatherCommand("design"))
 }

--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -21,6 +21,7 @@ var manifestAgentAllowedReasons = map[string]string{
 	"flow list":           "Read-only flow listing",
 	"flow show":           "Read-only flow structure display",
 	"flow status":         "Read-only flow statistics",
+	"gather design":       "Non-interactive with explicit selectors and --title; interactive picker otherwise",
 	"go":                  "Non-interactive path resolution when used with explicit arguments",
 	"id":                  "Read-only campaign ID output",
 	"intent add":          "Programmatic create path is safe with title/body flags; agents must not use TUI-only flags",
@@ -79,9 +80,10 @@ var manifestAgentAllowedReasons = map[string]string{
 }
 
 var manifestAllowedInteractivePaths = map[string]bool{
-	"create":     true,
-	"intent add": true,
-	"switch":     true,
+	"create":        true,
+	"gather design": true,
+	"intent add":    true,
+	"switch":        true,
 }
 
 var manifestInteractivePaths = map[string]bool{

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -1041,6 +1041,7 @@ camp festivals [flags]
       --all             Include completed/dungeon festivals, passed to fest list
       --all-campaigns   Include inactive/reference campaigns (default: active only)
   -h, --help            help for festivals
+  -i, --interactive     Open the interactive festivals browser
       --json            Output as JSON
       --org string      Only campaigns in this org
       --since string    Festivals created on or after this date, passed to fest list
@@ -1063,23 +1064,25 @@ Post-merge branch cycling: sync to default branch and optionally create a new wo
 
 ### Synopsis
 
-Reset a project to a fresh state after merging a PR.
+Reset one or more projects to a fresh state after merging a PR.
 
 Performs the post-merge cycle: checkout default branch, pull latest,
 prune merged branches, and optionally create a new working branch.
 
-Auto-detects the current project from your working directory,
-or accepts a project name as a positional argument.
+Auto-detects the current project from your working directory, or accepts a
+single project name. Use --list to cycle a specific set of projects in one
+run, or 'camp fresh all' to cycle every project submodule in the campaign.
 
 Without configuration, syncs to the default branch and prunes.
 Configure .campaign/settings/fresh.yaml to set a default working branch.
 
 Examples:
-  camp fresh                         # Sync current project (checkout default, pull, prune)
-  camp fresh --branch develop        # Sync and create develop branch
-  camp fresh camp -b feat/new-thing  # Sync camp project, create feature branch
-  camp fresh --no-prune              # Sync without pruning
-  camp fresh --dry-run               # Preview what would happen
+  camp fresh                            # Sync current project (checkout default, pull, prune)
+  camp fresh --branch develop           # Sync and create develop branch
+  camp fresh camp -b feat/new-thing     # Sync camp project, create feature branch
+  camp fresh --list camp,fest,festival  # Sync a specific set of projects
+  camp fresh --no-prune                 # Sync without pruning
+  camp fresh --dry-run                  # Preview what would happen
 
 ```
 camp fresh [project-name] [flags]
@@ -1091,6 +1094,7 @@ camp fresh [project-name] [flags]
   -b, --branch string    Branch to create after syncing (overrides config)
   -n, --dry-run          Preview without making changes
   -h, --help             help for fresh
+      --list strings     Comma-separated set of projects to cycle in one run
       --no-branch        Skip branch creation even if configured
       --no-prune         Skip pruning merged branches
       --no-push          Skip pushing the new branch upstream
@@ -1143,17 +1147,17 @@ camp fresh all [flags]
 
 ## camp gather
 
-Import external data into the intent system
+Gather related work into unified items
 
 ### Synopsis
 
-Gather external data sources into trackable intents.
-
-The gather command imports data from various sources into the intent system,
-creating structured intents with checkboxes for tracking progress.
+Gather related work into unified items.
 
 Available sources:
-  feedback    Gather feedback observations from festivals
+  feedback    Import feedback observations from festivals into intents
+  design      Combine selected design workitems into one gathered package
+
+For gathering intents by tag, hashtag, or similarity, see 'camp intent gather'.
 
 ```
 camp gather [flags]
@@ -1163,6 +1167,59 @@ camp gather [flags]
 
 ```
   -h, --help   help for gather
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp gather design
+
+Combine selected design workitems into one gathered package
+
+### Synopsis
+
+Combine selected design workitems into one gathered package.
+
+Sources are always chosen explicitly: pass 2 or more selectors (stable id,
+key, path, or directory slug), or run with no arguments in a terminal for an
+interactive picker. There is no automatic discovery mode.
+
+The gather process:
+  1. Create workflow/design/<slug>/ with a fresh .workitem and a
+     generated README.md indexing the gathered packages
+  2. Move each source directory inside the new package (git history follows
+     the rename)
+  3. Stamp gathered_into/gathered_at on each source .workitem
+  4. Migrate manual priority state and re-home workitem links
+  5. Commit the move (unless --no-commit)
+
+Moved sources stop appearing as separate workitems because discovery only
+scans the top level of workflow/design/.
+
+Examples:
+  camp gather design pkg-one pkg-two --title "Unified topic"
+  camp gather design pkg-one pkg-two pkg-three -t "Unified topic" --slug unified-topic
+  camp gather design                # interactive picker (TTY only)
+  camp gather design pkg-one pkg-two -t "Unified topic" --dry-run
+
+```
+camp gather design [selectors...] [flags]
+```
+
+### Options
+
+```
+      --dry-run        Print the planned gather, change nothing
+      --force          Gather sources even when one has an active workflow run
+  -h, --help           help for design
+      --json           Output result as a single JSON object
+      --no-commit      Skip the auto-commit
+      --slug string    Directory slug override (default: derived from title)
+  -t, --title string   Title for the gathered workitem (required unless prompted interactively)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp.md
+++ b/docs/cli-reference/camp.md
@@ -55,7 +55,7 @@ camp [flags]
 * [camp dungeon](camp_dungeon.md)	 - Manage the campaign dungeon
 * [camp festivals](camp_festivals.md)	 - List festivals across campaigns, filtered by org/tag
 * [camp fresh](camp_fresh.md)	 - Post-merge branch cycling: sync to default branch and optionally create a new working branch
-* [camp gather](camp_gather.md)	 - Import external data into the intent system
+* [camp gather](camp_gather.md)	 - Gather related work into unified items
 * [camp go](camp_go.md)	 - Navigate to campaign directories
 * [camp id](camp_id.md)	 - Print the current campaign ID
 * [camp init](camp_init.md)	 - Initialize a new campaign

--- a/docs/cli-reference/camp_festivals.md
+++ b/docs/cli-reference/camp_festivals.md
@@ -33,6 +33,7 @@ camp festivals [flags]
       --all             Include completed/dungeon festivals, passed to fest list
       --all-campaigns   Include inactive/reference campaigns (default: active only)
   -h, --help            help for festivals
+  -i, --interactive     Open the interactive festivals browser
       --json            Output as JSON
       --org string      Only campaigns in this org
       --since string    Festivals created on or after this date, passed to fest list

--- a/docs/cli-reference/camp_fresh.md
+++ b/docs/cli-reference/camp_fresh.md
@@ -4,23 +4,25 @@ Post-merge branch cycling: sync to default branch and optionally create a new wo
 
 ### Synopsis
 
-Reset a project to a fresh state after merging a PR.
+Reset one or more projects to a fresh state after merging a PR.
 
 Performs the post-merge cycle: checkout default branch, pull latest,
 prune merged branches, and optionally create a new working branch.
 
-Auto-detects the current project from your working directory,
-or accepts a project name as a positional argument.
+Auto-detects the current project from your working directory, or accepts a
+single project name. Use --list to cycle a specific set of projects in one
+run, or 'camp fresh all' to cycle every project submodule in the campaign.
 
 Without configuration, syncs to the default branch and prunes.
 Configure .campaign/settings/fresh.yaml to set a default working branch.
 
 Examples:
-  camp fresh                         # Sync current project (checkout default, pull, prune)
-  camp fresh --branch develop        # Sync and create develop branch
-  camp fresh camp -b feat/new-thing  # Sync camp project, create feature branch
-  camp fresh --no-prune              # Sync without pruning
-  camp fresh --dry-run               # Preview what would happen
+  camp fresh                            # Sync current project (checkout default, pull, prune)
+  camp fresh --branch develop           # Sync and create develop branch
+  camp fresh camp -b feat/new-thing     # Sync camp project, create feature branch
+  camp fresh --list camp,fest,festival  # Sync a specific set of projects
+  camp fresh --no-prune                 # Sync without pruning
+  camp fresh --dry-run                  # Preview what would happen
 
 ```
 camp fresh [project-name] [flags]
@@ -32,6 +34,7 @@ camp fresh [project-name] [flags]
   -b, --branch string    Branch to create after syncing (overrides config)
   -n, --dry-run          Preview without making changes
   -h, --help             help for fresh
+      --list strings     Comma-separated set of projects to cycle in one run
       --no-branch        Skip branch creation even if configured
       --no-prune         Skip pruning merged branches
       --no-push          Skip pushing the new branch upstream

--- a/docs/cli-reference/camp_gather.md
+++ b/docs/cli-reference/camp_gather.md
@@ -1,16 +1,16 @@
 ## camp gather
 
-Import external data into the intent system
+Gather related work into unified items
 
 ### Synopsis
 
-Gather external data sources into trackable intents.
-
-The gather command imports data from various sources into the intent system,
-creating structured intents with checkboxes for tracking progress.
+Gather related work into unified items.
 
 Available sources:
-  feedback    Gather feedback observations from festivals
+  feedback    Import feedback observations from festivals into intents
+  design      Combine selected design workitems into one gathered package
+
+For gathering intents by tag, hashtag, or similarity, see 'camp intent gather'.
 
 ```
 camp gather [flags]
@@ -31,4 +31,5 @@ camp gather [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
+* [camp gather design](camp_gather_design.md)	 - Combine selected design workitems into one gathered package
 * [camp gather feedback](camp_gather_feedback.md)	 - Gather feedback observations from festivals into intents

--- a/docs/cli-reference/camp_gather_design.md
+++ b/docs/cli-reference/camp_gather_design.md
@@ -1,0 +1,55 @@
+## camp gather design
+
+Combine selected design workitems into one gathered package
+
+### Synopsis
+
+Combine selected design workitems into one gathered package.
+
+Sources are always chosen explicitly: pass 2 or more selectors (stable id,
+key, path, or directory slug), or run with no arguments in a terminal for an
+interactive picker. There is no automatic discovery mode.
+
+The gather process:
+  1. Create workflow/design/<slug>/ with a fresh .workitem and a
+     generated README.md indexing the gathered packages
+  2. Move each source directory inside the new package (git history follows
+     the rename)
+  3. Stamp gathered_into/gathered_at on each source .workitem
+  4. Migrate manual priority state and re-home workitem links
+  5. Commit the move (unless --no-commit)
+
+Moved sources stop appearing as separate workitems because discovery only
+scans the top level of workflow/design/.
+
+Examples:
+  camp gather design pkg-one pkg-two --title "Unified topic"
+  camp gather design pkg-one pkg-two pkg-three -t "Unified topic" --slug unified-topic
+  camp gather design                # interactive picker (TTY only)
+  camp gather design pkg-one pkg-two -t "Unified topic" --dry-run
+
+```
+camp gather design [selectors...] [flags]
+```
+
+### Options
+
+```
+      --dry-run        Print the planned gather, change nothing
+      --force          Gather sources even when one has an active workflow run
+  -h, --help           help for design
+      --json           Output result as a single JSON object
+      --no-commit      Skip the auto-commit
+      --slug string    Directory slug override (default: derived from title)
+  -t, --title string   Title for the gathered workitem (required unless prompted interactively)
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp gather](camp_gather.md)	 - Gather related work into unified items

--- a/docs/cli-reference/camp_gather_feedback.md
+++ b/docs/cli-reference/camp_gather_feedback.md
@@ -58,4 +58,4 @@ camp gather feedback [flags]
 
 ### SEE ALSO
 
-* [camp gather](camp_gather.md)	 - Import external data into the intent system
+* [camp gather](camp_gather.md)	 - Gather related work into unified items

--- a/internal/commands/workitem/gather.go
+++ b/internal/commands/workitem/gather.go
@@ -1,0 +1,369 @@
+package workitem
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/intent"
+	"github.com/Obedience-Corp/camp/internal/jsoncontract"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+type gatherOptions struct {
+	Title    string
+	Slug     string
+	Force    bool
+	DryRun   bool
+	NoCommit bool
+	JSON     bool
+}
+
+type workitemGatherResult struct {
+	SchemaVersion string                     `json:"schema_version"`
+	GeneratedAt   time.Time                  `json:"generated_at"`
+	DryRun        bool                       `json:"dry_run,omitempty"`
+	Gathered      workitemGatherResultItem   `json:"gathered"`
+	Sources       []workitemGatherResultMove `json:"sources"`
+	Committed     bool                       `json:"committed"`
+	CommitMessage string                     `json:"commit_message,omitempty"`
+	Warnings      []string                   `json:"warnings,omitempty"`
+}
+
+type workitemGatherResultItem struct {
+	ID           string `json:"id,omitempty"`
+	Ref          string `json:"ref,omitempty"`
+	Type         string `json:"type"`
+	Title        string `json:"title"`
+	RelativePath string `json:"relative_path"`
+}
+
+type workitemGatherResultMove struct {
+	ID   string `json:"id,omitempty"`
+	Slug string `json:"slug"`
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// NewGatherCommand creates a `camp gather <type>` subcommand that combines
+// user-selected directory workitems of the given workflow type into one
+// gathered package. Unlike `camp intent gather`, which merges file contents,
+// this moves each source directory inside the new package so nothing is
+// rewritten or lost.
+func NewGatherCommand(workflowType string) *cobra.Command {
+	var (
+		title    string
+		slug     string
+		force    bool
+		dryRun   bool
+		noCommit bool
+		jsonOut  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   workflowType + " [selectors...]",
+		Short: "Combine selected " + workflowType + " workitems into one gathered package",
+		Long: `Combine selected ` + workflowType + ` workitems into one gathered package.
+
+Sources are always chosen explicitly: pass 2 or more selectors (stable id,
+key, path, or directory slug), or run with no arguments in a terminal for an
+interactive picker. There is no automatic discovery mode.
+
+The gather process:
+  1. Create workflow/` + workflowType + `/<slug>/ with a fresh .workitem and a
+     generated README.md indexing the gathered packages
+  2. Move each source directory inside the new package (git history follows
+     the rename)
+  3. Stamp gathered_into/gathered_at on each source .workitem
+  4. Migrate manual priority state and re-home workitem links
+  5. Commit the move (unless --no-commit)
+
+Moved sources stop appearing as separate workitems because discovery only
+scans the top level of workflow/` + workflowType + `/.
+
+Examples:
+  camp gather ` + workflowType + ` pkg-one pkg-two --title "Unified topic"
+  camp gather ` + workflowType + ` pkg-one pkg-two pkg-three -t "Unified topic" --slug unified-topic
+  camp gather ` + workflowType + `                # interactive picker (TTY only)
+  camp gather ` + workflowType + ` pkg-one pkg-two -t "Unified topic" --dry-run`,
+		Args: jsoncontract.Args(WorkitemGatherJSONVersion, func() bool { return jsonOut }, cobra.ArbitraryArgs),
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Fully specified by selectors and flags; only the bare invocation is interactive",
+		},
+		RunE: jsoncontract.RunE(WorkitemGatherJSONVersion, func() bool { return jsonOut }, func(cmd *cobra.Command, args []string) error {
+			return runWorkitemGather(cmd, workflowType, args, gatherOptions{
+				Title: title, Slug: slug, Force: force, DryRun: dryRun, NoCommit: noCommit, JSON: jsonOut,
+			})
+		}),
+	}
+	cmd.SetFlagErrorFunc(jsoncontract.FlagErrorFunc(WorkitemGatherJSONVersion, func() bool { return jsonOut }))
+
+	f := cmd.Flags()
+	f.StringVarP(&title, "title", "t", "", "Title for the gathered workitem (required unless prompted interactively)")
+	f.StringVar(&slug, "slug", "", "Directory slug override (default: derived from title)")
+	f.BoolVar(&force, "force", false, "Gather sources even when one has an active workflow run")
+	f.BoolVar(&dryRun, "dry-run", false, "Print the planned gather, change nothing")
+	f.BoolVar(&noCommit, "no-commit", false, "Skip the auto-commit")
+	f.BoolVar(&jsonOut, "json", false, "Output result as a single JSON object")
+	return cmd
+}
+
+func runWorkitemGather(cmd *cobra.Command, wfType string, args []string, opts gatherOptions) error {
+	ctx := cmd.Context()
+
+	cfg, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	resolver := paths.NewResolverFromConfig(root, cfg)
+	rootDir, err := gatherRootDir(resolver, wfType)
+	if err != nil {
+		return err
+	}
+
+	items, err := wkitem.Discover(ctx, root, resolver)
+	if err != nil {
+		return camperrors.Wrap(err, "discovering work items")
+	}
+	var typed []wkitem.WorkItem
+	for _, item := range items {
+		if item.WorkflowType == wkitem.WorkflowType(wfType) && item.ItemKind == wkitem.ItemKindDirectory {
+			typed = append(typed, item)
+		}
+	}
+
+	title := strings.TrimSpace(opts.Title)
+	var selected []wkitem.WorkItem
+	if len(args) > 0 {
+		for _, arg := range args {
+			match, matchErr := matchGatherSelector(typed, arg)
+			if matchErr != nil {
+				return camperrors.Wrapf(matchErr, "resolving %s workitem", wfType)
+			}
+			selected = append(selected, *match)
+		}
+		selected = dedupeGatherItems(selected)
+	} else {
+		if opts.JSON || !isInteractive() {
+			return camperrors.NewValidation("selectors",
+				"pass at least 2 "+wfType+" workitem selectors (list candidates with `camp workitem --json --type "+wfType+"`)", nil)
+		}
+		selected, title, err = promptGatherSelection(typed, wfType, title)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(selected) < 2 {
+		return camperrors.NewValidation("selectors",
+			fmt.Sprintf("need at least 2 %s workitems to gather, got %d", wfType, len(selected)), nil)
+	}
+	if title == "" {
+		return camperrors.NewValidation("title", "--title is required", nil)
+	}
+
+	slugValue := opts.Slug
+	if slugValue == "" {
+		slugValue = intent.SlugFromTitle(title)
+	}
+	if err := validateSlug(slugValue); err != nil {
+		return camperrors.NewValidation("slug", "invalid slug "+slugValue+": "+err.Error(), nil)
+	}
+
+	targetAbs := filepath.Join(rootDir, slugValue)
+	if _, statErr := os.Stat(targetAbs); statErr == nil {
+		return camperrors.NewValidation("slug",
+			"target directory already exists: "+targetAbs+" (pass --slug to choose another)", nil)
+	} else if !os.IsNotExist(statErr) {
+		return camperrors.Wrapf(statErr, "stat %s", targetAbs)
+	}
+	targetRel, err := filepath.Rel(root, targetAbs)
+	if err != nil {
+		return camperrors.Wrapf(err, "resolving target path %s", targetAbs)
+	}
+
+	var warnings []string
+	var blocked []string
+	sources := make([]gatherSource, 0, len(selected))
+	for _, item := range selected {
+		abs := item.AbsPath(root)
+		run, runErr := wkitem.LoadLocalRun(ctx, abs)
+		if runErr != nil {
+			warnings = append(warnings, fmt.Sprintf("workflow runtime unreadable for %s: %v", filepath.Base(item.RelativePath), runErr))
+		} else if gatherBlockedByRun(run) {
+			blocked = append(blocked, filepath.Base(item.RelativePath))
+		}
+		meta, metaErr := wkitem.LoadMetadata(ctx, abs)
+		if metaErr != nil {
+			warnings = append(warnings, fmt.Sprintf(".workitem unreadable for %s: %v", filepath.Base(item.RelativePath), metaErr))
+			meta = nil
+		}
+		sources = append(sources, gatherSource{Item: item, Meta: meta})
+	}
+	if len(blocked) > 0 && !opts.Force {
+		return camperrors.NewValidation("sources",
+			"active workflow run in: "+strings.Join(blocked, ", ")+" (finish or abandon the run, or pass --force)", nil)
+	}
+
+	plan := gatherPlan{
+		WorkflowType: wfType,
+		Title:        title,
+		Slug:         slugValue,
+		TargetAbs:    targetAbs,
+		TargetRel:    filepath.ToSlash(targetRel),
+		Sources:      sources,
+	}
+
+	if opts.DryRun {
+		return emitGatherDryRun(cmd, plan, opts.JSON)
+	}
+
+	execution, err := executeGather(ctx, cmd, cfg, root, plan, opts, warnings)
+	if err != nil {
+		return err
+	}
+	return emitGatherResult(cmd, plan, execution, opts.JSON)
+}
+
+func promptGatherSelection(typed []wkitem.WorkItem, wfType, preTitle string) ([]wkitem.WorkItem, string, error) {
+	if len(typed) < 2 {
+		return nil, "", camperrors.NewValidation("selectors",
+			fmt.Sprintf("need at least 2 %s workitems to gather, found %d", wfType, len(typed)), nil)
+	}
+
+	byPath := make(map[string]wkitem.WorkItem, len(typed))
+	options := make([]huh.Option[string], 0, len(typed))
+	for _, item := range typed {
+		byPath[item.RelativePath] = item
+		base := filepath.Base(item.RelativePath)
+		label := strings.TrimSpace(item.Title)
+		if label == "" || strings.EqualFold(label, base) {
+			label = base
+		} else {
+			label = label + " (" + base + ")"
+		}
+		options = append(options, huh.NewOption(label, item.RelativePath))
+	}
+
+	var selectedPaths []string
+	title := preTitle
+	fields := []huh.Field{
+		huh.NewMultiSelect[string]().
+			Title("Select " + wfType + " workitems to gather").
+			Description("Space toggles, enter confirms; pick at least 2").
+			Options(options...).
+			Validate(func(v []string) error {
+				if len(v) < 2 {
+					return camperrors.NewValidation("selectors", "select at least 2 workitems", nil)
+				}
+				return nil
+			}).
+			Value(&selectedPaths),
+	}
+	if strings.TrimSpace(title) == "" {
+		fields = append(fields, huh.NewInput().
+			Title("Title for the gathered workitem").
+			Validate(func(s string) error {
+				if strings.TrimSpace(s) == "" {
+					return camperrors.NewValidation("title", "title is required", nil)
+				}
+				return nil
+			}).
+			Value(&title))
+	}
+
+	if err := huh.NewForm(huh.NewGroup(fields...)).Run(); err != nil {
+		return nil, "", camperrors.Wrap(err, "gather selection cancelled")
+	}
+
+	selected := make([]wkitem.WorkItem, 0, len(selectedPaths))
+	for _, p := range selectedPaths {
+		selected = append(selected, byPath[p])
+	}
+	return dedupeGatherItems(selected), strings.TrimSpace(title), nil
+}
+
+func newGatherResult(plan gatherPlan) workitemGatherResult {
+	result := workitemGatherResult{
+		SchemaVersion: WorkitemGatherJSONVersion,
+		GeneratedAt:   time.Now().UTC(),
+	}
+	result.Gathered = workitemGatherResultItem{
+		Type:         plan.WorkflowType,
+		Title:        plan.Title,
+		RelativePath: plan.TargetRel,
+	}
+	for _, src := range plan.Sources {
+		base := filepath.Base(src.Item.RelativePath)
+		move := workitemGatherResultMove{
+			Slug: base,
+			From: filepath.ToSlash(src.Item.RelativePath),
+			To:   plan.TargetRel + "/" + base,
+		}
+		if src.Meta != nil {
+			move.ID = src.Meta.ID
+		}
+		result.Sources = append(result.Sources, move)
+	}
+	return result
+}
+
+func emitGatherJSON(cmd *cobra.Command, result workitemGatherResult) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(result); err != nil {
+		return camperrors.Wrap(err, "encoding JSON output")
+	}
+	return nil
+}
+
+func emitGatherDryRun(cmd *cobra.Command, plan gatherPlan, jsonOut bool) error {
+	if jsonOut {
+		result := newGatherResult(plan)
+		result.DryRun = true
+		return emitGatherJSON(cmd, result)
+	}
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "dry-run: would gather %d %s workitems into %s\n", len(plan.Sources), plan.WorkflowType, plan.TargetRel)
+	for _, src := range plan.Sources {
+		base := filepath.Base(src.Item.RelativePath)
+		_, _ = fmt.Fprintf(out, "  %s → %s/%s\n", filepath.ToSlash(src.Item.RelativePath), plan.TargetRel, base)
+	}
+	return nil
+}
+
+func emitGatherResult(cmd *cobra.Command, plan gatherPlan, execution *gatherExecution, jsonOut bool) error {
+	if jsonOut {
+		result := newGatherResult(plan)
+		result.Gathered.ID = execution.ID
+		result.Gathered.Ref = execution.Ref
+		result.Sources = execution.Moves
+		result.Committed = execution.Committed
+		result.CommitMessage = execution.CommitMessage
+		result.Warnings = execution.Warnings
+		return emitGatherJSON(cmd, result)
+	}
+
+	for _, w := range execution.Warnings {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s %s\n", ui.WarningIcon(), w)
+	}
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "%s Gathered %d %s workitems into %s\n", ui.SuccessIcon(), len(execution.Moves), plan.WorkflowType, plan.TargetRel)
+	for _, move := range execution.Moves {
+		_, _ = fmt.Fprintf(out, "  %s → %s\n", move.From, move.To)
+	}
+	_, err := fmt.Fprintf(out, "  id: %s\n  ref: %s\n", execution.ID, execution.Ref)
+	return err
+}

--- a/internal/commands/workitem/gather_exec.go
+++ b/internal/commands/workitem/gather_exec.go
@@ -179,7 +179,7 @@ func executeGather(ctx context.Context, cmd *cobra.Command, cfg *config.Campaign
 			To:           move.To,
 			GatheredInto: id,
 		}); err != nil {
-			return nil, camperrors.Wrap(err, "writing workitem audit event")
+			execution.Warnings = append(execution.Warnings, fmt.Sprintf("write gather audit event for %s: %v", eventID, err))
 		}
 	}
 	if err := wkaudit.AppendEvent(ctx, root, wkaudit.Event{
@@ -188,7 +188,7 @@ func executeGather(ctx context.Context, cmd *cobra.Command, cfg *config.Campaign
 		Type:  plan.WorkflowType,
 		To:    plan.TargetRel,
 	}); err != nil {
-		return nil, camperrors.Wrap(err, "writing workitem audit event")
+		execution.Warnings = append(execution.Warnings, fmt.Sprintf("write gather audit event for %s: %v", id, err))
 	}
 
 	if navErr := navindex.Delete(root); navErr != nil {

--- a/internal/commands/workitem/gather_exec.go
+++ b/internal/commands/workitem/gather_exec.go
@@ -1,0 +1,242 @@
+package workitem
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	dungeoncmd "github.com/Obedience-Corp/camp/cmd/camp/dungeon"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+	"github.com/Obedience-Corp/camp/internal/git/commit"
+	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	wkaudit "github.com/Obedience-Corp/camp/internal/workitem/audit"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
+)
+
+type gatherExecution struct {
+	ID            string
+	Ref           string
+	Moves         []workitemGatherResultMove
+	Warnings      []string
+	Committed     bool
+	CommitMessage string
+}
+
+// executeGather applies a validated gather plan: it creates the gathered
+// package, moves each source directory inside it, stamps gather lineage,
+// migrates priority and link state, appends audit events, and commits.
+// Bookkeeping failures after the moves are reported as warnings rather than
+// errors so a partial failure never strands the filesystem mid-operation.
+func executeGather(ctx context.Context, cmd *cobra.Command, cfg *config.CampaignConfig, root string, plan gatherPlan, opts gatherOptions, warnings []string) (*gatherExecution, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	execution := &gatherExecution{Warnings: warnings}
+
+	id, err := generateID(ctx, plan.WorkflowType, plan.Slug, "", root)
+	if err != nil {
+		return nil, err
+	}
+	ref, err := deriveUniqueRef(ctx, root, cfg, id)
+	if err != nil {
+		return nil, err
+	}
+	execution.ID, execution.Ref = id, ref
+
+	if err := os.MkdirAll(plan.TargetAbs, 0o755); err != nil {
+		return nil, camperrors.Wrap(err, "create gathered directory")
+	}
+	created := false
+	defer func() {
+		// Only remove the target while it holds nothing but our own files;
+		// once created flips true the source moves may have started.
+		if !created {
+			_ = os.RemoveAll(plan.TargetAbs)
+		}
+	}()
+
+	meta := wkitem.Metadata{
+		Version: wkitem.WorkitemSchemaVersion,
+		Kind:    wkitem.MetadataKind,
+		ID:      id,
+		Type:    plan.WorkflowType,
+		Title:   plan.Title,
+		Ref:     ref,
+	}
+	buf, err := yaml.Marshal(&meta)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "marshal metadata")
+	}
+	if err := fsutil.WriteFileAtomically(filepath.Join(plan.TargetAbs, wkitem.MetadataFilename), buf, 0o644); err != nil {
+		return nil, err
+	}
+
+	sourceItems := make([]wkitem.WorkItem, 0, len(plan.Sources))
+	for _, src := range plan.Sources {
+		sourceItems = append(sourceItems, src.Item)
+	}
+	readme := gatherReadme(plan.Title, plan.WorkflowType, sourceItems)
+	if err := fsutil.WriteFileAtomically(filepath.Join(plan.TargetAbs, "README.md"), []byte(readme), 0o644); err != nil {
+		return nil, err
+	}
+	created = true
+
+	now := time.Now().UTC()
+	idMap := make(map[string]string)
+	sourceAbs := make([]string, 0, len(plan.Sources))
+	sourceKeys := make([]string, 0, len(plan.Sources))
+	for _, src := range plan.Sources {
+		base := filepath.Base(src.Item.RelativePath)
+		fromAbs := src.Item.AbsPath(root)
+		toAbs := filepath.Join(plan.TargetAbs, base)
+		if err := os.Rename(fromAbs, toAbs); err != nil {
+			moved := make([]string, 0, len(execution.Moves))
+			for _, m := range execution.Moves {
+				moved = append(moved, m.Slug)
+			}
+			detail := "none"
+			if len(moved) > 0 {
+				detail = strings.Join(moved, ", ")
+			}
+			return nil, camperrors.Wrapf(err, "moving %s into %s (already moved: %s; recover with git status)", base, plan.TargetRel, detail)
+		}
+
+		toRel := plan.TargetRel + "/" + base
+		move := workitemGatherResultMove{
+			Slug: base,
+			From: filepath.ToSlash(src.Item.RelativePath),
+			To:   toRel,
+		}
+		if src.Meta != nil && src.Meta.ID != "" {
+			move.ID = src.Meta.ID
+			idMap[src.Meta.ID] = id
+		}
+		execution.Moves = append(execution.Moves, move)
+		sourceAbs = append(sourceAbs, fromAbs)
+		sourceKeys = append(sourceKeys, src.Item.Key)
+
+		if src.Meta != nil {
+			if err := wkitem.RecordGather(ctx, root, toRel, id, now); err != nil {
+				execution.Warnings = append(execution.Warnings, fmt.Sprintf("stamp gathered_into on %s: %v", base, err))
+			}
+		}
+	}
+
+	targetKey := plan.WorkflowType + ":" + plan.TargetRel
+	if err := priority.WithLock(ctx, priority.StorePath(root), func(store *priority.Store) error {
+		migrateGatherPriorities(store, sourceKeys, targetKey)
+		return nil
+	}); err != nil {
+		execution.Warnings = append(execution.Warnings, fmt.Sprintf("migrate priority entries: %v", err))
+	}
+
+	linksChanged := false
+	if len(idMap) > 0 {
+		if err := links.WithLock(ctx, root, func(reg *links.Links) error {
+			if !rehomeGatherLinks(reg, idMap) {
+				return links.ErrSkipSave
+			}
+			linksChanged = true
+			return nil
+		}); err != nil {
+			execution.Warnings = append(execution.Warnings, fmt.Sprintf("re-home workitem links: %v", err))
+		}
+
+		cur, curErr := links.LoadCurrent(ctx, root)
+		switch {
+		case curErr != nil:
+			execution.Warnings = append(execution.Warnings, fmt.Sprintf("read current workitem selection: %v", curErr))
+		case cur != nil:
+			if _, ok := idMap[cur.WorkitemID]; ok {
+				cur.WorkitemID = id
+				if err := links.SaveCurrent(ctx, root, cur); err != nil {
+					execution.Warnings = append(execution.Warnings, fmt.Sprintf("update current workitem selection: %v", err))
+				}
+			}
+		}
+	}
+
+	for _, move := range execution.Moves {
+		eventID := move.ID
+		if eventID == "" {
+			eventID = move.Slug
+		}
+		if err := wkaudit.AppendEvent(ctx, root, wkaudit.Event{
+			Event:        wkaudit.EventGather,
+			ID:           eventID,
+			Type:         plan.WorkflowType,
+			From:         move.From,
+			To:           move.To,
+			GatheredInto: id,
+		}); err != nil {
+			return nil, camperrors.Wrap(err, "writing workitem audit event")
+		}
+	}
+	if err := wkaudit.AppendEvent(ctx, root, wkaudit.Event{
+		Event: wkaudit.EventGather,
+		ID:    id,
+		Type:  plan.WorkflowType,
+		To:    plan.TargetRel,
+	}); err != nil {
+		return nil, camperrors.Wrap(err, "writing workitem audit event")
+	}
+
+	if navErr := navindex.Delete(root); navErr != nil {
+		execution.Warnings = append(execution.Warnings, fmt.Sprintf("failed to invalidate navigation cache: %v", navErr))
+	}
+
+	if !opts.NoCommit {
+		// The priority store and current.yaml are gitignored per-machine
+		// state, so only the gathered package, audit log, and (when changed)
+		// the shared links registry are staged.
+		dest := []string{
+			plan.TargetAbs,
+			filepath.Join(root, ".campaign", "workitems", wkaudit.AuditFile),
+		}
+		if linksChanged {
+			dest = append(dest, links.LinksPath(root))
+		}
+		preStaged, stageErr := dungeoncmd.StageTrackedMoveSourceDeletions(ctx, root, sourceAbs)
+		if stageErr != nil {
+			return nil, camperrors.Wrap(stageErr, "staging move source deletions (gather was applied on disk; recover with git status)")
+		}
+		sourceSlugs := make([]string, 0, len(execution.Moves))
+		for _, move := range execution.Moves {
+			sourceSlugs = append(sourceSlugs, move.Slug)
+		}
+		result := commit.Workitem(ctx, commit.WorkitemOptions{
+			Options: commit.Options{
+				CampaignRoot:  root,
+				CampaignID:    cfg.ID,
+				Files:         commit.NormalizeFiles(root, dest...),
+				PreStaged:     preStaged,
+				SelectiveOnly: true,
+			},
+			Action:      commit.WorkitemGather,
+			WorkitemID:  id,
+			WorkitemRef: ref,
+			Title:       fmt.Sprintf("Gather %d %s workitems into %s", len(plan.Sources), plan.WorkflowType, plan.TargetRel),
+			Detail:      "Sources: " + strings.Join(sourceSlugs, ", "),
+		})
+		if !opts.JSON && result.Message != "" {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", result.Message)
+		}
+		execution.Committed = result.Committed
+		execution.CommitMessage = result.Message
+		if result.Err != nil {
+			return nil, camperrors.Wrap(result.Err, "auto-committing gather (gather was applied on disk)")
+		}
+	}
+
+	return execution, nil
+}

--- a/internal/commands/workitem/gather_plan.go
+++ b/internal/commands/workitem/gather_plan.go
@@ -1,0 +1,236 @@
+package workitem
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
+)
+
+// gatherSource pairs a discovered workitem with its loaded .workitem
+// metadata. Meta is nil when the directory has no marker file.
+type gatherSource struct {
+	Item wkitem.WorkItem
+	Meta *wkitem.Metadata
+}
+
+// gatherPlan is the fully validated input to executeGather.
+type gatherPlan struct {
+	WorkflowType string
+	Title        string
+	Slug         string
+	TargetAbs    string
+	TargetRel    string
+	Sources      []gatherSource
+}
+
+// gatherRootDir maps a gatherable workflow type to its campaign directory.
+// Only directory-based builtin types can be gathered; intents have their own
+// content-merge gather and festivals have lifecycle state that a directory
+// move would corrupt.
+func gatherRootDir(resolver *paths.Resolver, wfType string) (string, error) {
+	switch wfType {
+	case string(wkitem.WorkflowTypeDesign):
+		return resolver.Design(), nil
+	case string(wkitem.WorkflowTypeExplore):
+		return resolver.Explore(), nil
+	}
+	return "", camperrors.NewValidation("type", "gather does not support workflow type "+wfType, nil)
+}
+
+// matchGatherSelector resolves one user-supplied selector against the typed
+// candidate set, using the same precedence as the workitem selector package:
+// exact stable id, exact key, exact relative path, exact directory slug.
+func matchGatherSelector(items []wkitem.WorkItem, query string) (*wkitem.WorkItem, error) {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, camperrors.NewValidation("selector", "selector must not be empty", nil)
+	}
+
+	type matcher struct {
+		name string
+		eq   func(wkitem.WorkItem) bool
+	}
+	matchers := []matcher{
+		{"id", func(w wkitem.WorkItem) bool { return w.StableID != "" && w.StableID == q }},
+		{"key", func(w wkitem.WorkItem) bool { return strings.EqualFold(w.Key, q) }},
+		{"path", func(w wkitem.WorkItem) bool { return w.RelativePath == strings.TrimRight(q, "/") }},
+		{"slug", func(w wkitem.WorkItem) bool { return strings.EqualFold(filepath.Base(w.RelativePath), q) }},
+	}
+	for _, m := range matchers {
+		var matched []wkitem.WorkItem
+		for _, item := range items {
+			if m.eq(item) {
+				matched = append(matched, item)
+			}
+		}
+		if len(matched) == 1 {
+			return &matched[0], nil
+		}
+		if len(matched) > 1 {
+			keys := make([]string, 0, len(matched))
+			for _, w := range matched {
+				keys = append(keys, w.Key)
+			}
+			sort.Strings(keys)
+			return nil, camperrors.NewValidation("selector",
+				"selector "+q+" matched "+m.name+" against multiple workitems: "+strings.Join(keys, ", "), nil)
+		}
+	}
+	return nil, camperrors.NewValidation("selector", "no workitem matched selector "+q, nil)
+}
+
+// dedupeGatherItems removes duplicate selections while preserving order.
+func dedupeGatherItems(items []wkitem.WorkItem) []wkitem.WorkItem {
+	seen := make(map[string]bool, len(items))
+	out := make([]wkitem.WorkItem, 0, len(items))
+	for _, item := range items {
+		if seen[item.RelativePath] {
+			continue
+		}
+		seen[item.RelativePath] = true
+		out = append(out, item)
+	}
+	return out
+}
+
+// gatherBlockedByRun reports whether a source has a live fest workflow run
+// that gathering would orphan mid-execution.
+func gatherBlockedByRun(run *wkitem.LocalRunProgress) bool {
+	if run == nil || run.ActiveRunID == "" {
+		return false
+	}
+	switch run.RunStatus {
+	case "completed", "abandoned":
+		return false
+	}
+	return true
+}
+
+// gatherReadme renders the generated primary doc for the gathered package.
+// It indexes each moved source so the new directory has a navigable entry
+// point for both humans and workitem discovery.
+func gatherReadme(title, wfType string, sources []wkitem.WorkItem) string {
+	var b strings.Builder
+	b.WriteString("# " + title + "\n\n")
+	fmt.Fprintf(&b,
+		"Gathered %s package combining %d workitems. Each source package was moved here unchanged and keeps its documents in the subdirectory listed below.\n\n",
+		wfType, len(sources))
+	b.WriteString("## Gathered packages\n\n")
+	for _, item := range sources {
+		b.WriteString(gatherReadmeEntry(item) + "\n")
+	}
+	return b.String()
+}
+
+func gatherReadmeEntry(item wkitem.WorkItem) string {
+	base := filepath.Base(item.RelativePath)
+	label := strings.TrimSpace(item.Title)
+	if label == "" {
+		label = base
+	}
+	entry := "- "
+	if doc := gatherPrimaryDocRel(item); doc != "" {
+		entry += "[" + label + "](" + doc + ")"
+	} else {
+		entry += label + " (" + base + "/)"
+	}
+	if summary := gatherSummaryLine(item.Summary); summary != "" {
+		entry += ": " + summary
+	}
+	return entry
+}
+
+// gatherPrimaryDocRel returns the source's primary doc path relative to the
+// gathered package root, or "" when the source has no primary doc inside its
+// own directory.
+func gatherPrimaryDocRel(item wkitem.WorkItem) string {
+	if item.PrimaryDoc == "" {
+		return ""
+	}
+	prefix := filepath.ToSlash(item.RelativePath) + "/"
+	doc := filepath.ToSlash(item.PrimaryDoc)
+	if !strings.HasPrefix(doc, prefix) {
+		return ""
+	}
+	return filepath.Base(item.RelativePath) + "/" + strings.TrimPrefix(doc, prefix)
+}
+
+func gatherSummaryLine(summary string) string {
+	return strings.Join(strings.Fields(summary), " ")
+}
+
+// migrateGatherPriorities moves manual priority state from the gathered
+// sources onto the target key. The highest source priority wins; attention
+// stages are dropped because a stage describes one item's position, which is
+// not meaningful for the combined package. A group carries over only when
+// every grouped source agrees on the same group. Returns true when the store
+// changed.
+func migrateGatherPriorities(store *priority.Store, sourceKeys []string, targetKey string) bool {
+	changed := false
+	best := priority.None
+	groups := make(map[string]bool)
+	for _, key := range sourceKeys {
+		if entry, ok := store.ManualPriorities[key]; ok {
+			if entry.Priority.Rank() < best.Rank() {
+				best = entry.Priority
+			}
+			priority.Clear(store, key)
+			changed = true
+		}
+		if entry, ok := store.Attention[key]; ok {
+			if entry.Group != "" {
+				groups[entry.Group] = true
+			}
+			priority.ClearAttentionStage(store, key)
+			priority.ClearGroup(store, key)
+			changed = true
+		}
+	}
+	if best.Valid() {
+		priority.Set(store, targetKey, best)
+		changed = true
+	}
+	if len(groups) == 1 {
+		for group := range groups {
+			priority.SetGroup(store, targetKey, group)
+		}
+		changed = true
+	}
+	return changed
+}
+
+// rehomeGatherLinks re-points registry links from gathered source workitem
+// ids to the gathered workitem id, then drops links that became exact
+// duplicates (same workitem, scope, and role). Returns true when the
+// registry changed.
+func rehomeGatherLinks(reg *links.Links, idMap map[string]string) bool {
+	changed := false
+	for i := range reg.Links {
+		if newID, ok := idMap[reg.Links[i].WorkitemID]; ok && newID != reg.Links[i].WorkitemID {
+			reg.Links[i].WorkitemID = newID
+			changed = true
+		}
+	}
+	if !changed {
+		return false
+	}
+	seen := make(map[string]bool, len(reg.Links))
+	deduped := make([]links.Link, 0, len(reg.Links))
+	for _, link := range reg.Links {
+		key := link.WorkitemID + "|" + string(link.Scope.Kind) + "|" + link.Scope.Path + "|" + string(link.Role)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		deduped = append(deduped, link)
+	}
+	reg.Links = deduped
+	return true
+}

--- a/internal/commands/workitem/gather_plan_test.go
+++ b/internal/commands/workitem/gather_plan_test.go
@@ -1,0 +1,257 @@
+package workitem
+
+import (
+	"strings"
+	"testing"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
+)
+
+func designItem(slug, title, id string) wkitem.WorkItem {
+	item := wkitem.WorkItem{
+		Key:          "design:workflow/design/" + slug,
+		WorkflowType: wkitem.WorkflowTypeDesign,
+		Title:        title,
+		RelativePath: "workflow/design/" + slug,
+		ItemKind:     wkitem.ItemKindDirectory,
+		StableID:     id,
+	}
+	return item
+}
+
+func TestMatchGatherSelector(t *testing.T) {
+	items := []wkitem.WorkItem{
+		designItem("auth-flow", "Auth Flow", "design-auth-flow-2026-07-01"),
+		designItem("auth-tokens", "Auth Tokens", "design-auth-tokens-2026-07-02"),
+	}
+
+	cases := []struct {
+		name    string
+		query   string
+		want    string
+		wantErr string
+	}{
+		{"by slug", "auth-flow", "workflow/design/auth-flow", ""},
+		{"by path", "workflow/design/auth-tokens", "workflow/design/auth-tokens", ""},
+		{"by path trailing slash", "workflow/design/auth-tokens/", "workflow/design/auth-tokens", ""},
+		{"by id", "design-auth-flow-2026-07-01", "workflow/design/auth-flow", ""},
+		{"by key", "design:workflow/design/auth-flow", "workflow/design/auth-flow", ""},
+		{"slug case insensitive", "AUTH-FLOW", "workflow/design/auth-flow", ""},
+		{"not found", "missing", "", "no workitem matched selector"},
+		{"empty", "  ", "", "selector must not be empty"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := matchGatherSelector(items, tc.query)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("matchGatherSelector(%q) error = %v, want containing %q", tc.query, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("matchGatherSelector(%q) error = %v", tc.query, err)
+			}
+			if got.RelativePath != tc.want {
+				t.Fatalf("matchGatherSelector(%q) = %s, want %s", tc.query, got.RelativePath, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchGatherSelector_Ambiguous(t *testing.T) {
+	items := []wkitem.WorkItem{
+		designItem("dup", "First", "id-one"),
+		designItem("dup", "Second", "id-two"),
+	}
+	_, err := matchGatherSelector(items, "dup")
+	if err == nil || !strings.Contains(err.Error(), "multiple workitems") {
+		t.Fatalf("expected ambiguity error, got %v", err)
+	}
+}
+
+func TestDedupeGatherItems(t *testing.T) {
+	a := designItem("a", "A", "id-a")
+	b := designItem("b", "B", "id-b")
+	got := dedupeGatherItems([]wkitem.WorkItem{a, b, a})
+	if len(got) != 2 || got[0].RelativePath != a.RelativePath || got[1].RelativePath != b.RelativePath {
+		t.Fatalf("dedupeGatherItems returned %+v", got)
+	}
+}
+
+func TestGatherBlockedByRun(t *testing.T) {
+	cases := []struct {
+		name string
+		run  *wkitem.LocalRunProgress
+		want bool
+	}{
+		{"nil run", nil, false},
+		{"no active run", &wkitem.LocalRunProgress{RunStatus: "running"}, false},
+		{"active running", &wkitem.LocalRunProgress{ActiveRunID: "r1", RunStatus: "running"}, true},
+		{"active created", &wkitem.LocalRunProgress{ActiveRunID: "r1", RunStatus: "created"}, true},
+		{"completed", &wkitem.LocalRunProgress{ActiveRunID: "r1", RunStatus: "completed"}, false},
+		{"abandoned", &wkitem.LocalRunProgress{ActiveRunID: "r1", RunStatus: "abandoned"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := gatherBlockedByRun(tc.run); got != tc.want {
+				t.Fatalf("gatherBlockedByRun() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGatherReadme(t *testing.T) {
+	linked := designItem("auth-flow", "Auth Flow", "id-a")
+	linked.PrimaryDoc = "workflow/design/auth-flow/README.md"
+	linked.Summary = "Login  and\nsession design."
+	bare := designItem("auth-tokens", "", "id-b")
+
+	got := gatherReadme("Unified Auth", "design", []wkitem.WorkItem{linked, bare})
+
+	for _, want := range []string{
+		"# Unified Auth\n",
+		"combining 2 workitems",
+		"- [Auth Flow](auth-flow/README.md): Login and session design.",
+		"- auth-tokens (auth-tokens/)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("gatherReadme missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestGatherPrimaryDocRel(t *testing.T) {
+	item := designItem("pkg", "Pkg", "id")
+	cases := []struct {
+		name string
+		doc  string
+		want string
+	}{
+		{"readme", "workflow/design/pkg/README.md", "pkg/README.md"},
+		{"nested doc", "workflow/design/pkg/docs/01-scope.md", "pkg/docs/01-scope.md"},
+		{"empty", "", ""},
+		{"outside dir", "workflow/design/other/README.md", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			item.PrimaryDoc = tc.doc
+			if got := gatherPrimaryDocRel(item); got != tc.want {
+				t.Fatalf("gatherPrimaryDocRel(%q) = %q, want %q", tc.doc, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMigrateGatherPriorities(t *testing.T) {
+	const (
+		keyA   = "design:workflow/design/a"
+		keyB   = "design:workflow/design/b"
+		target = "design:workflow/design/combined"
+	)
+
+	t.Run("highest priority wins and sources clear", func(t *testing.T) {
+		store := priority.NewStore()
+		priority.Set(store, keyA, priority.Low)
+		priority.Set(store, keyB, priority.High)
+
+		if !migrateGatherPriorities(store, []string{keyA, keyB}, target) {
+			t.Fatal("expected store change")
+		}
+		if _, ok := store.ManualPriorities[keyA]; ok {
+			t.Fatal("source A priority should be cleared")
+		}
+		if _, ok := store.ManualPriorities[keyB]; ok {
+			t.Fatal("source B priority should be cleared")
+		}
+		if got := store.ManualPriorities[target].Priority; got != priority.High {
+			t.Fatalf("target priority = %q, want high", got)
+		}
+	})
+
+	t.Run("attention entries drop and shared group carries", func(t *testing.T) {
+		store := priority.NewStore()
+		priority.SetAttentionStage(store, keyA, priority.AttentionCurrent)
+		priority.SetGroup(store, keyA, "auth")
+		priority.SetGroup(store, keyB, "auth")
+
+		migrateGatherPriorities(store, []string{keyA, keyB}, target)
+
+		if _, ok := store.Attention[keyA]; ok {
+			t.Fatal("source A attention should be cleared")
+		}
+		if _, ok := store.Attention[keyB]; ok {
+			t.Fatal("source B attention should be cleared")
+		}
+		entry, ok := store.Attention[target]
+		if !ok || entry.Group != "auth" {
+			t.Fatalf("target attention = %+v (ok=%v), want group auth", entry, ok)
+		}
+		if entry.Stage != priority.AttentionNone {
+			t.Fatalf("target stage = %q, want none", entry.Stage)
+		}
+	})
+
+	t.Run("conflicting groups drop", func(t *testing.T) {
+		store := priority.NewStore()
+		priority.SetGroup(store, keyA, "auth")
+		priority.SetGroup(store, keyB, "billing")
+
+		migrateGatherPriorities(store, []string{keyA, keyB}, target)
+
+		if _, ok := store.Attention[target]; ok {
+			t.Fatal("target should not inherit a group when sources disagree")
+		}
+	})
+
+	t.Run("no entries no change", func(t *testing.T) {
+		store := priority.NewStore()
+		if migrateGatherPriorities(store, []string{keyA, keyB}, target) {
+			t.Fatal("expected no change for empty store")
+		}
+	})
+}
+
+func TestRehomeGatherLinks(t *testing.T) {
+	link := func(id, wiID, scopePath string, role links.Role) links.Link {
+		return links.Link{
+			ID:         id,
+			WorkitemID: wiID,
+			Scope:      links.LinkScope{Kind: links.ScopeProject, Path: scopePath},
+			Role:       role,
+		}
+	}
+
+	t.Run("repoints and dedupes", func(t *testing.T) {
+		reg := &links.Links{Links: []links.Link{
+			link("lnk_20260701_aaaaaa", "src-a", "projects/camp", links.RolePrimary),
+			link("lnk_20260701_bbbbbb", "src-b", "projects/camp", links.RolePrimary),
+			link("lnk_20260701_cccccc", "other", "projects/fest", links.RolePrimary),
+		}}
+		idMap := map[string]string{"src-a": "combined", "src-b": "combined"}
+
+		if !rehomeGatherLinks(reg, idMap) {
+			t.Fatal("expected registry change")
+		}
+		if len(reg.Links) != 2 {
+			t.Fatalf("links after rehome = %d, want 2 (duplicate dropped)", len(reg.Links))
+		}
+		if reg.Links[0].WorkitemID != "combined" {
+			t.Fatalf("first link workitem = %q, want combined", reg.Links[0].WorkitemID)
+		}
+		if reg.Links[1].WorkitemID != "other" {
+			t.Fatalf("unrelated link workitem = %q, want other", reg.Links[1].WorkitemID)
+		}
+	})
+
+	t.Run("no matching ids no change", func(t *testing.T) {
+		reg := &links.Links{Links: []links.Link{
+			link("lnk_20260701_aaaaaa", "other", "projects/camp", links.RolePrimary),
+		}}
+		if rehomeGatherLinks(reg, map[string]string{"src-a": "combined"}) {
+			t.Fatal("expected no change")
+		}
+	})
+}

--- a/internal/commands/workitem/json_contract.go
+++ b/internal/commands/workitem/json_contract.go
@@ -17,4 +17,6 @@ const (
 	WorkitemCommitsJSONVersion = "workitem-commits/v1alpha1"
 	// WorkitemDoctorJSONVersion is the schema version of camp workitem doctor --json.
 	WorkitemDoctorJSONVersion = "workitem-doctor/v1alpha1"
+	// WorkitemGatherJSONVersion is the schema version of camp gather <type> --json.
+	WorkitemGatherJSONVersion = "workitem-gather/v1alpha1"
 )

--- a/internal/git/commit/workitem.go
+++ b/internal/git/commit/workitem.go
@@ -5,11 +5,13 @@ import "context"
 // WorkitemAction identifies the high-level operation captured by the commit.
 // WorkitemScope is the generic case used by `camp workitem commit`.
 // WorkitemEdit is reserved for flows that mutate workitem metadata.
+// WorkitemGather marks `camp gather <type>` combining workitems into one package.
 type WorkitemAction string
 
 const (
-	WorkitemEdit  WorkitemAction = "WorkitemEdit"
-	WorkitemScope WorkitemAction = "WorkitemScope"
+	WorkitemEdit   WorkitemAction = "WorkitemEdit"
+	WorkitemScope  WorkitemAction = "WorkitemScope"
+	WorkitemGather WorkitemAction = "WorkitemGather"
 )
 
 // WorkitemOptions configures a workitem-scoped commit. The embedded Options

--- a/internal/workitem/audit/audit.go
+++ b/internal/workitem/audit/audit.go
@@ -16,17 +16,21 @@ const AuditFile = ".workitems.jsonl"
 
 type EventType string
 
-const EventPromote EventType = "promote"
+const (
+	EventPromote EventType = "promote"
+	EventGather  EventType = "gather"
+)
 
 type Event struct {
-	Timestamp  time.Time `json:"ts"`
-	Event      EventType `json:"event"`
-	ID         string    `json:"id"`
-	Type       string    `json:"type,omitempty"`
-	From       string    `json:"from,omitempty"`
-	To         string    `json:"to,omitempty"`
-	Target     string    `json:"target,omitempty"`
-	PromotedTo string    `json:"promoted_to,omitempty"`
+	Timestamp    time.Time `json:"ts"`
+	Event        EventType `json:"event"`
+	ID           string    `json:"id"`
+	Type         string    `json:"type,omitempty"`
+	From         string    `json:"from,omitempty"`
+	To           string    `json:"to,omitempty"`
+	Target       string    `json:"target,omitempty"`
+	PromotedTo   string    `json:"promoted_to,omitempty"`
+	GatheredInto string    `json:"gathered_into,omitempty"`
 }
 
 func AppendEvent(ctx context.Context, campaignRoot string, e Event) error {

--- a/internal/workitem/gather.go
+++ b/internal/workitem/gather.go
@@ -1,0 +1,53 @@
+package workitem
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+)
+
+// RecordGather stamps gathered_into and gathered_at on the .workitem file of
+// a gathered source. relPath is the source's campaign-relative location after
+// the move into the gathered package. Existing keys are updated in place so
+// the operation is idempotent.
+func RecordGather(ctx context.Context, root, relPath, gatheredInto string, at time.Time) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	abs := filepath.Join(root, filepath.FromSlash(relPath), MetadataFilename)
+
+	release, err := fsutil.AcquireFileLock(ctx, abs+".lock")
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	raw, err := os.ReadFile(abs)
+	if err != nil {
+		return camperrors.Wrapf(err, "read %s", abs)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return camperrors.Wrapf(err, "parse %s", abs)
+	}
+
+	if err := insertScalarAfter(&doc, "type", "gathered_into", gatheredInto); err != nil {
+		return err
+	}
+	if err := insertScalarAfter(&doc, "gathered_into", "gathered_at", at.UTC().Format(time.RFC3339)); err != nil {
+		return err
+	}
+
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return camperrors.Wrap(err, "marshal updated workitem")
+	}
+	return fsutil.WriteFileAtomically(abs, out, 0o644)
+}

--- a/internal/workitem/metadata.go
+++ b/internal/workitem/metadata.go
@@ -54,6 +54,14 @@ type Metadata struct {
 	PromotedTo string `yaml:"promoted_to,omitempty"`
 	// PromotedAt is the RFC3339 UTC timestamp of the promotion.
 	PromotedAt string `yaml:"promoted_at,omitempty"`
+	// GatheredInto records the id of the combined workitem this workitem was
+	// merged into by `camp gather`. Set on source workitems when their
+	// directories are moved inside the gathered package. Added without a
+	// schema version bump, following the promoted_to precedent; loaders use
+	// non-strict YAML so older binaries ignore the field.
+	GatheredInto string `yaml:"gathered_into,omitempty"`
+	// GatheredAt is the RFC3339 UTC timestamp of the gather.
+	GatheredAt string `yaml:"gathered_at,omitempty"`
 }
 
 // LoadMetadata reads .workitem from dir on the host filesystem.

--- a/tests/integration/gather_workitem_test.go
+++ b/tests/integration/gather_workitem_test.go
@@ -1,0 +1,191 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createDesignWorkitem(t *testing.T, tc *TestContainer, campaign, slug, title, body string) {
+	t.Helper()
+	_, err := tc.RunCampInDir(campaign, "workitem", "create", slug, "--type", "design", "--title", title)
+	require.NoError(t, err, "create design workitem %s", slug)
+	require.NoError(t, tc.WriteFile(campaign+"/workflow/design/"+slug+"/README.md", body))
+}
+
+func TestGatherDesign_MovesSourcesIntoGatheredPackage(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaign := "/campaigns/gather-design"
+
+	_, err := tc.InitCampaign(campaign, "gather-design", "product")
+	require.NoError(t, err)
+
+	createDesignWorkitem(t, tc, campaign, "auth-flow", "Auth Flow", "# Auth Flow\n\nLogin and session design.\n")
+	createDesignWorkitem(t, tc, campaign, "auth-tokens", "Auth Tokens", "# Auth Tokens\n\nToken rotation design.\n")
+	createDesignWorkitem(t, tc, campaign, "billing", "Billing", "# Billing\n\nUnrelated design.\n")
+	tc.GitOutput(t, campaign, "add", "-A")
+	tc.GitOutput(t, campaign, "commit", "-m", "seed design workitems")
+
+	output, err := tc.RunCampInDir(campaign, "gather", "design", "auth-flow", "auth-tokens", "--title", "Unified Auth", "--json")
+	require.NoError(t, err, "gather output: %s", output)
+
+	var result struct {
+		SchemaVersion string `json:"schema_version"`
+		Gathered      struct {
+			ID           string `json:"id"`
+			Ref          string `json:"ref"`
+			Type         string `json:"type"`
+			RelativePath string `json:"relative_path"`
+		} `json:"gathered"`
+		Sources []struct {
+			ID   string `json:"id"`
+			Slug string `json:"slug"`
+			From string `json:"from"`
+			To   string `json:"to"`
+		} `json:"sources"`
+		Committed bool     `json:"committed"`
+		Warnings  []string `json:"warnings"`
+	}
+	jsonStart := strings.Index(output, "{")
+	require.GreaterOrEqual(t, jsonStart, 0, "no JSON in output: %s", output)
+	require.NoError(t, json.Unmarshal([]byte(output[jsonStart:]), &result), "output: %s", output)
+
+	assert.Equal(t, "workitem-gather/v1alpha1", result.SchemaVersion)
+	assert.Equal(t, "design", result.Gathered.Type)
+	assert.Equal(t, "workflow/design/unified-auth", result.Gathered.RelativePath)
+	assert.NotEmpty(t, result.Gathered.ID)
+	assert.Regexp(t, `^WI-[0-9a-f]{6}$`, result.Gathered.Ref)
+	assert.Len(t, result.Sources, 2)
+	assert.True(t, result.Committed, "gather should auto-commit")
+	assert.Empty(t, result.Warnings, "gather should complete without warnings")
+
+	// Source directories moved inside the gathered package.
+	for _, slug := range []string{"auth-flow", "auth-tokens"} {
+		moved, err := tc.CheckDirExists(campaign + "/workflow/design/unified-auth/" + slug)
+		require.NoError(t, err)
+		assert.True(t, moved, "%s should live inside the gathered package", slug)
+
+		old, err := tc.CheckDirExists(campaign + "/workflow/design/" + slug)
+		require.NoError(t, err)
+		assert.False(t, old, "%s should no longer exist at the top level", slug)
+	}
+
+	// Generated README indexes both sources.
+	readme, err := tc.ReadFile(campaign + "/workflow/design/unified-auth/README.md")
+	require.NoError(t, err)
+	assert.Contains(t, readme, "# Unified Auth")
+	assert.Contains(t, readme, "[Auth Flow](auth-flow/README.md)")
+	assert.Contains(t, readme, "[Auth Tokens](auth-tokens/README.md)")
+
+	// Sources are stamped with gather lineage.
+	marker, err := tc.ReadFile(campaign + "/workflow/design/unified-auth/auth-flow/.workitem")
+	require.NoError(t, err)
+	assert.Contains(t, marker, "gathered_into: "+result.Gathered.ID)
+	assert.Contains(t, marker, "gathered_at:")
+
+	// Discovery lists the gathered package but not the moved sources.
+	listOutput, err := tc.RunCampInDir(campaign, "workitem", "--json", "--type", "design")
+	require.NoError(t, err)
+	assert.Contains(t, listOutput, "workflow/design/unified-auth")
+	assert.Contains(t, listOutput, "workflow/design/billing")
+	assert.NotContains(t, listOutput, `"relative_path": "workflow/design/auth-flow"`)
+	assert.NotContains(t, listOutput, `"relative_path": "workflow/design/auth-tokens"`)
+
+	// The move landed in one commit that leaves the tree clean.
+	gitLog := tc.GitOutput(t, campaign, "log", "-1", "--pretty=%s")
+	assert.Contains(t, gitLog, "WorkitemGather: Gather 2 design workitems into workflow/design/unified-auth")
+	gitStatus := tc.GitOutput(t, campaign, "status", "--porcelain")
+	assert.Empty(t, strings.TrimSpace(gitStatus), "working tree should be clean after gather commit")
+
+	// Unchanged source docs are recorded as renames, preserving history.
+	nameStatus := tc.GitOutput(t, campaign, "log", "-1", "-M", "--name-status", "--pretty=format:")
+	assert.Contains(t, nameStatus, "workflow/design/unified-auth/auth-flow/README.md")
+	assert.Regexp(t, `R\d+\s+workflow/design/auth-flow/README.md`, nameStatus)
+
+	// Audit trail records the gather.
+	audit, err := tc.ReadFile(campaign + "/.campaign/workitems/.workitems.jsonl")
+	require.NoError(t, err)
+	assert.Contains(t, audit, `"event":"gather"`)
+	assert.Contains(t, audit, `"gathered_into":"`+result.Gathered.ID+`"`)
+}
+
+func TestGatherDesign_PriorityMigratesToGatheredItem(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaign := "/campaigns/gather-design-priority"
+
+	_, err := tc.InitCampaign(campaign, "gather-design-priority", "product")
+	require.NoError(t, err)
+
+	createDesignWorkitem(t, tc, campaign, "cache-l1", "Cache L1", "# Cache L1\n\nDesign.\n")
+	createDesignWorkitem(t, tc, campaign, "cache-l2", "Cache L2", "# Cache L2\n\nDesign.\n")
+
+	_, err = tc.RunCampInDir(campaign, "workitem", "priority", "cache-l1", "high")
+	require.NoError(t, err)
+	_, err = tc.RunCampInDir(campaign, "workitem", "priority", "cache-l2", "low")
+	require.NoError(t, err)
+
+	output, err := tc.RunCampInDir(campaign, "gather", "design", "cache-l1", "cache-l2", "--title", "Cache Design")
+	require.NoError(t, err, "gather output: %s", output)
+
+	store, err := tc.ReadFile(campaign + "/.campaign/settings/workitems.json")
+	require.NoError(t, err)
+	assert.Contains(t, store, "design:workflow/design/cache-design")
+	assert.Contains(t, store, `"priority": "high"`)
+	assert.NotContains(t, store, "design:workflow/design/cache-l1")
+	assert.NotContains(t, store, "design:workflow/design/cache-l2")
+}
+
+func TestGatherDesign_Guards(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaign := "/campaigns/gather-design-guards"
+
+	_, err := tc.InitCampaign(campaign, "gather-design-guards", "product")
+	require.NoError(t, err)
+
+	createDesignWorkitem(t, tc, campaign, "solo", "Solo", "# Solo\n\nDesign.\n")
+	createDesignWorkitem(t, tc, campaign, "duo", "Duo", "# Duo\n\nDesign.\n")
+
+	// Fewer than 2 sources is rejected.
+	output, err := tc.RunCampInDir(campaign, "gather", "design", "solo", "--title", "Only One")
+	require.Error(t, err)
+	assert.Contains(t, output, "need at least 2")
+
+	// Duplicate selectors collapse and are rejected.
+	output, err = tc.RunCampInDir(campaign, "gather", "design", "solo", "solo", "--title", "Same Twice")
+	require.Error(t, err)
+	assert.Contains(t, output, "need at least 2")
+
+	// Missing title is rejected.
+	output, err = tc.RunCampInDir(campaign, "gather", "design", "solo", "duo")
+	require.Error(t, err)
+	assert.Contains(t, output, "--title is required")
+
+	// Unknown selector is rejected.
+	output, err = tc.RunCampInDir(campaign, "gather", "design", "solo", "missing", "--title", "Nope")
+	require.Error(t, err)
+	assert.Contains(t, output, "no workitem matched selector missing")
+
+	// Existing target directory is rejected.
+	output, err = tc.RunCampInDir(campaign, "gather", "design", "solo", "duo", "--title", "Solo", "--slug", "duo")
+	require.Error(t, err)
+	assert.Contains(t, output, "target directory already exists")
+
+	// Dry run changes nothing.
+	output, err = tc.RunCampInDir(campaign, "gather", "design", "solo", "duo", "--title", "Pair", "--dry-run")
+	require.NoError(t, err)
+	assert.Contains(t, output, "dry-run: would gather 2 design workitems")
+	exists, err := tc.CheckDirExists(campaign + "/workflow/design/pair")
+	require.NoError(t, err)
+	assert.False(t, exists, "dry-run must not create the target")
+
+	// Non-interactive invocation without selectors is rejected.
+	output, err = tc.RunCampInDir(campaign, "gather", "design", "--title", "Bare")
+	require.Error(t, err)
+	assert.Contains(t, output, "pass at least 2 design workitem selectors")
+}

--- a/tests/integration/gather_workitem_test.go
+++ b/tests/integration/gather_workitem_test.go
@@ -141,6 +141,52 @@ func TestGatherDesign_PriorityMigratesToGatheredItem(t *testing.T) {
 	assert.NotContains(t, store, "design:workflow/design/cache-l2")
 }
 
+func TestGatherDesign_AuditFailureIsWarningNotError(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaign := "/campaigns/gather-design-audit-warn"
+
+	_, err := tc.InitCampaign(campaign, "gather-design-audit-warn", "product")
+	require.NoError(t, err)
+
+	createDesignWorkitem(t, tc, campaign, "svc-a", "Service A", "# Service A\n\nDesign.\n")
+	createDesignWorkitem(t, tc, campaign, "svc-b", "Service B", "# Service B\n\nDesign.\n")
+	tc.GitOutput(t, campaign, "add", "-A")
+	tc.GitOutput(t, campaign, "commit", "-m", "seed design workitems")
+
+	// Force the post-move audit append to fail by replacing the audit log with a
+	// directory, so os.OpenFile(..., O_APPEND) errors even as root. Audit runs
+	// only after the sources are already moved, so the command must surface a
+	// warning and still exit zero rather than stranding a mutated filesystem
+	// behind a non-zero exit.
+	auditPath := campaign + "/.campaign/workitems/.workitems.jsonl"
+	tc.Shell(t, "rm -rf "+auditPath+" && mkdir -p "+auditPath)
+
+	output, err := tc.RunCampInDir(campaign, "gather", "design", "svc-a", "svc-b", "--title", "Unified Svc", "--no-commit", "--json")
+	require.NoError(t, err, "audit failure must not fail the command; output: %s", output)
+
+	var result struct {
+		Warnings []string `json:"warnings"`
+	}
+	jsonStart := strings.Index(output, "{")
+	require.GreaterOrEqual(t, jsonStart, 0, "no JSON in output: %s", output)
+	require.NoError(t, json.Unmarshal([]byte(output[jsonStart:]), &result), "output: %s", output)
+
+	// The gather still applied on disk despite the audit failure.
+	moved, err := tc.CheckDirExists(campaign + "/workflow/design/unified-svc/svc-a")
+	require.NoError(t, err)
+	assert.True(t, moved, "sources should be moved despite the audit failure")
+
+	// The audit write failure is reported as a warning, not swallowed or fatal.
+	var auditWarn bool
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "gather audit event") {
+			auditWarn = true
+			break
+		}
+	}
+	assert.True(t, auditWarn, "audit write failure should surface as a warning, got: %v", result.Warnings)
+}
+
 func TestGatherDesign_Guards(t *testing.T) {
 	tc := GetSharedContainer(t)
 	campaign := "/campaigns/gather-design-guards"


### PR DESCRIPTION
## Summary

Adds `camp gather <type>` for directory-based workitems, registered for `design`. Where `camp intent gather` merges file contents, this command **moves** each selected source directory inside a new gathered package, so nothing is rewritten and git history follows the rename.

```
camp gather design pkg-one pkg-two --title "Unified topic"
camp gather design            # interactive multi-select picker (TTY only)
```

## Behavior

- **Explicit selection only**: 2+ selectors (stable id, key, path, or slug), or an interactive huh multi-select picker when run bare on a TTY. No `--tag`/`--similar` auto-discovery.
- Creates `workflow/design/<slug>/` with a fresh `.workitem` (new id + WI- ref) and a generated `README.md` indexing each gathered package (title, link to primary doc, summary).
- Moves each source to `workflow/design/<slug>/<orig-slug>/`. Because workitem discovery of `workflow/design/` is non-recursive, moved sources automatically stop listing as separate workitems; no dungeon/archive step.
- Stamps `gathered_into`/`gathered_at` on each source `.workitem` and appends `gather` events to the workitem audit log.
- Migrates manual priority state (highest source priority wins; a group carries only when all grouped sources agree; attention stages drop) and re-homes links registry entries plus the current selection to the gathered item.
- Refuses to gather a source with an active workflow run unless `--force`.
- Commits via a new `WorkitemGather` commit action with pre-staged source deletions so the move lands as a rename in one commit. Supports `--dry-run`, `--no-commit`, `--slug`, and `--json` (schema `workitem-gather/v1alpha1`).

## Design decisions

- **No .workitem schema version bump** for `gathered_into`/`gathered_at`: follows the `promoted_to` precedent; loaders use non-strict YAML so older binaries ignore the fields. Bumping to v1alpha7 would force a version ripple for two optional fields.
- **Gitignored per-machine state is never staged**: `.campaign/settings/workitems.json` and `workitems/current.yaml` are updated on disk but excluded from the commit (staging them fails on the scaffold .gitignore). The shared `links.yaml` is staged when changed.
- **Generic over directory workitem types**: the implementation takes the workflow type as a parameter, so `camp gather explore` is a one-line registration later. Only `design` is exposed in this PR.
- `gather design` is added to the agent manifest allowlist as non-interactive-with-flags, interactive fallback (same class as `intent add`).

## Testing

- Unit: selector matching, dedupe, README generation, priority migration, link re-homing, active-run guard (pure in-memory, `internal/commands/workitem/gather_plan_test.go`).
- Integration (containerized, `tests/integration/gather_workitem_test.go`): full flow including directory moves, lineage stamping, discovery de-listing, rename-preserving single commit, priority migration, and guard rails (min sources, duplicate selectors, missing title, unknown selector, existing target, dry-run, non-interactive bare invocation).
- `just gate-fast` passes: stable+dev builds, vet (incl. integration tags), lint 0 issues, 3017 unit tests.

Docs regen is a separate commit and includes pending drift from `camp festivals --interactive` and the `camp fresh` synopsis.