### PR TITLE
fix(intent): let notes be archived/restored in the explorer

### DIFF
--- a/internal/intent/notes.go
+++ b/internal/intent/notes.go
@@ -194,6 +194,49 @@ func (s *IntentService) ArchiveNote(ctx context.Context, id string) (*Intent, er
 	return note, nil
 }
 
+// RestoreNote moves a note back from notes/archived/ into the active notes/
+// store, reversing ArchiveNote so an archived note is never a dead end.
+func (s *IntentService) RestoreNote(ctx context.Context, id string) (*Intent, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, camperrors.Wrap(err, "context cancelled")
+	}
+
+	note, err := s.GetNote(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if note.Status == StatusNote {
+		return note, nil
+	}
+
+	oldPath := note.Path
+	note.Status = StatusNote
+	note.UpdatedAt = time.Now()
+
+	newPath := s.getIntentPath(StatusNote, note.ID)
+	if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
+		return nil, camperrors.Wrap(err, "creating directory")
+	}
+
+	data, err := SerializeIntent(note)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "serializing note")
+	}
+	if err := fsutil.WriteFileAtomically(newPath, data, 0644); err != nil {
+		return nil, camperrors.Wrap(err, "writing note file")
+	}
+
+	if err := os.Remove(oldPath); err != nil {
+		_ = os.Remove(newPath)
+		return nil, camperrors.Wrap(err, "removing old note file")
+	}
+
+	note.Path = newPath
+	s.invalidateIDIndex()
+	return note, nil
+}
+
 // MoveIntentToNote moves a lifecycle intent into the active notes/ store. The
 // file keeps its title, body, author, tags, and timestamps, but drops lifecycle
 // metadata that notes do not carry.

--- a/internal/intent/notes.go
+++ b/internal/intent/notes.go
@@ -180,6 +180,11 @@ func (s *IntentService) ArchiveNote(ctx context.Context, id string) (*Intent, er
 	if err != nil {
 		return nil, camperrors.Wrap(err, "serializing note")
 	}
+	if _, statErr := os.Stat(newPath); statErr == nil {
+		return nil, camperrors.Wrap(ErrFileExists, newPath)
+	} else if !os.IsNotExist(statErr) {
+		return nil, camperrors.Wrap(statErr, "checking destination note file")
+	}
 	if err := fsutil.WriteFileAtomically(newPath, data, 0644); err != nil {
 		return nil, camperrors.Wrap(err, "writing note file")
 	}
@@ -222,6 +227,11 @@ func (s *IntentService) RestoreNote(ctx context.Context, id string) (*Intent, er
 	data, err := SerializeIntent(note)
 	if err != nil {
 		return nil, camperrors.Wrap(err, "serializing note")
+	}
+	if _, statErr := os.Stat(newPath); statErr == nil {
+		return nil, camperrors.Wrap(ErrFileExists, newPath)
+	} else if !os.IsNotExist(statErr) {
+		return nil, camperrors.Wrap(statErr, "checking destination note file")
 	}
 	if err := fsutil.WriteFileAtomically(newPath, data, 0644); err != nil {
 		return nil, camperrors.Wrap(err, "writing note file")

--- a/internal/intent/notes_test.go
+++ b/internal/intent/notes_test.go
@@ -224,6 +224,67 @@ func TestArchiveNote_MovesToArchived(t *testing.T) {
 	}
 }
 
+func TestRestoreNote_MovesArchivedBackToActive(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	note, err := svc.CreateNote(ctx, CreateOptions{
+		Title:     "note to archive then restore",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	archived, err := svc.ArchiveNote(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("ArchiveNote: %v", err)
+	}
+	archivedPath := archived.Path
+
+	restored, err := svc.RestoreNote(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("RestoreNote: %v", err)
+	}
+	if restored.Status != StatusNote {
+		t.Errorf("Status = %q, want %q", restored.Status, StatusNote)
+	}
+	wantDir := filepath.Join(svc.intentsDir, "notes")
+	if filepath.Dir(restored.Path) != wantDir {
+		t.Errorf("restored dir = %q, want %q", filepath.Dir(restored.Path), wantDir)
+	}
+	if _, err := os.Stat(archivedPath); !os.IsNotExist(err) {
+		t.Errorf("archived note file still present at %q", archivedPath)
+	}
+
+	active, err := svc.ListNotes(ctx, false)
+	if err != nil {
+		t.Fatalf("ListNotes(active): %v", err)
+	}
+	if len(active) != 1 {
+		t.Errorf("active notes = %d, want 1 after restore", len(active))
+	}
+}
+
+func TestRestoreNote_ActiveNoteIsNoOp(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	note, err := svc.CreateNote(ctx, CreateOptions{
+		Title:     "already active note",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	restored, err := svc.RestoreNote(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("RestoreNote: %v", err)
+	}
+	if restored.Status != StatusNote {
+		t.Errorf("Status = %q, want %q", restored.Status, StatusNote)
+	}
+}
+
 func TestConvert_NoteBecomesIntent(t *testing.T) {
 	svc, ctx := newNotesTestService(t)
 

--- a/internal/intent/notes_test.go
+++ b/internal/intent/notes_test.go
@@ -285,6 +285,52 @@ func TestRestoreNote_ActiveNoteIsNoOp(t *testing.T) {
 	}
 }
 
+func TestRestoreNote_RefusesToClobberExistingActiveFile(t *testing.T) {
+	svc, ctx := newNotesTestService(t)
+
+	note, err := svc.CreateNote(ctx, CreateOptions{
+		Title:     "archived note that races a restore",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	archived, err := svc.ArchiveNote(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("ArchiveNote: %v", err)
+	}
+
+	// Simulate a corrupt double-presence (or a lost restore race): an unrelated
+	// file already occupies the active destination for this id. GetNote still
+	// resolves the archived copy, so RestoreNote reaches the write. It must fail
+	// loudly instead of overwriting the occupant and then deleting the archived
+	// source when the follow-up remove races.
+	activePath := svc.getIntentPath(StatusNote, note.ID)
+	if err := os.MkdirAll(filepath.Dir(activePath), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	occupant := "---\nid: unrelated-active-note\n---\nnot the archived note\n"
+	if err := os.WriteFile(activePath, []byte(occupant), 0644); err != nil {
+		t.Fatalf("seed occupant: %v", err)
+	}
+
+	if _, err := svc.RestoreNote(ctx, note.ID); !errors.Is(err, ErrFileExists) {
+		t.Fatalf("RestoreNote over an occupied destination err = %v, want ErrFileExists", err)
+	}
+
+	// The occupant is untouched and the archived source is preserved.
+	got, err := os.ReadFile(activePath)
+	if err != nil {
+		t.Fatalf("read occupant: %v", err)
+	}
+	if string(got) != occupant {
+		t.Error("RestoreNote clobbered the existing active file")
+	}
+	if _, err := os.Stat(archived.Path); err != nil {
+		t.Errorf("archived source removed after refused restore: %v", err)
+	}
+}
+
 func TestConvert_NoteBecomesIntent(t *testing.T) {
 	svc, ctx := newNotesTestService(t)
 

--- a/internal/intent/tui/action_menu.go
+++ b/internal/intent/tui/action_menu.go
@@ -12,7 +12,7 @@ import (
 // ActionMenuItem represents an item in the action menu.
 type ActionMenuItem struct {
 	Label   string
-	Action  string // "view", "edit", "convert", "move", "promote", "archive", "gather", "delete", "open", "reveal"
+	Action  string // "view", "edit", "convert", "move", "promote", "archive", "restore", "gather", "delete", "open", "reveal"
 	Enabled bool
 }
 
@@ -35,11 +35,14 @@ type ActionMenuCancelledMsg struct{}
 // NewActionMenu creates a new action menu for the given intent.
 func NewActionMenu(i *intent.Intent) ActionMenu {
 	if i.Status.IsNote() {
+		active := i.Status == intent.StatusNote
 		return newActionMenu([]ActionMenuItem{
 			{Label: "View full screen", Action: "view", Enabled: true},
 			{Label: "Edit in editor", Action: "edit", Enabled: true},
-			{Label: "Move to status", Action: "move", Enabled: i.Status == intent.StatusNote},
-			{Label: "Convert to intent", Action: "convert", Enabled: i.Status == intent.StatusNote},
+			{Label: "Move to status", Action: "move", Enabled: active},
+			{Label: "Convert to intent", Action: "convert", Enabled: active},
+			{Label: "Archive", Action: "archive", Enabled: active},
+			{Label: "Restore", Action: "restore", Enabled: !active},
 		})
 	}
 

--- a/internal/intent/tui/action_menu_test.go
+++ b/internal/intent/tui/action_menu_test.go
@@ -1,0 +1,57 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/intent"
+)
+
+// itemEnabled reports whether the menu offers action with Enabled=true.
+func itemEnabled(m ActionMenu, action string) bool {
+	for _, item := range m.items {
+		if item.Action == action {
+			return item.Enabled
+		}
+	}
+	return false
+}
+
+func hasAction(m ActionMenu, action string) bool {
+	for _, item := range m.items {
+		if item.Action == action {
+			return true
+		}
+	}
+	return false
+}
+
+func TestNewActionMenu_ActiveNoteOffersArchiveNotRestore(t *testing.T) {
+	m := NewActionMenu(&intent.Intent{ID: "a", Status: intent.StatusNote})
+
+	if !itemEnabled(m, "archive") {
+		t.Error("active note menu should enable Archive")
+	}
+	if !hasAction(m, "restore") {
+		t.Fatal("note menu missing Restore item")
+	}
+	if itemEnabled(m, "restore") {
+		t.Error("active note menu should not enable Restore")
+	}
+	if !itemEnabled(m, "convert") {
+		t.Error("active note menu should enable Convert")
+	}
+}
+
+func TestNewActionMenu_ArchivedNoteOffersRestoreNotArchive(t *testing.T) {
+	m := NewActionMenu(&intent.Intent{ID: "b", Status: intent.StatusNoteArchived})
+
+	if itemEnabled(m, "archive") {
+		t.Error("archived note menu should not enable Archive")
+	}
+	if !itemEnabled(m, "restore") {
+		t.Error("archived note menu should enable Restore")
+	}
+	if itemEnabled(m, "convert") {
+		t.Error("archived note menu should not enable Convert")
+	}
+}

--- a/internal/intent/tui/explorer/notes_view.go
+++ b/internal/intent/tui/explorer/notes_view.go
@@ -131,6 +131,51 @@ func (m *Model) convertNote(note *intent.Intent, newType intent.Type, targetStat
 	}
 }
 
+// archiveNote moves the note into notes/archived/ and emits an
+// archiveFinishedMsg so the list reloads. Notes carry no lifecycle metadata or
+// decision records, so archiving is reason-free, unlike dungeoning an intent.
+func (m *Model) archiveNote(note *intent.Intent) tea.Cmd {
+	return func() tea.Msg {
+		sourcePath := note.Path
+		archived, err := m.service.ArchiveNote(m.ctx, note.ID)
+		if err == nil {
+			err = m.appendAuditEvent(audit.Event{
+				Type:  audit.EventArchive,
+				ID:    note.ID,
+				Title: note.Title,
+				From:  string(intent.StatusNote),
+				To:    string(intent.StatusNoteArchived),
+			})
+		}
+		if err == nil {
+			m.autoCommitIntent(commit.IntentArchive, note.Title, "Archived note", sourcePath, archived.Path)
+		}
+		return archiveFinishedMsg{err: err, intentID: note.ID}
+	}
+}
+
+// restoreNote moves an archived note back into the active notes/ store and emits
+// a moveFinishedMsg so the list reloads.
+func (m *Model) restoreNote(note *intent.Intent) tea.Cmd {
+	return func() tea.Msg {
+		sourcePath := note.Path
+		restored, err := m.service.RestoreNote(m.ctx, note.ID)
+		if err == nil {
+			err = m.appendAuditEvent(audit.Event{
+				Type:  audit.EventMove,
+				ID:    note.ID,
+				Title: note.Title,
+				From:  string(intent.StatusNoteArchived),
+				To:    string(intent.StatusNote),
+			})
+		}
+		if err == nil {
+			m.autoCommitIntent(commit.IntentMove, note.Title, "Restored note", sourcePath, restored.Path)
+		}
+		return moveFinishedMsg{err: err, intentID: note.ID, newStatus: intent.StatusNote}
+	}
+}
+
 // viewConvert renders the convert type picker.
 func (m *Model) viewConvert() string {
 	var b strings.Builder

--- a/internal/intent/tui/explorer/notes_view_test.go
+++ b/internal/intent/tui/explorer/notes_view_test.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/Obedience-Corp/camp/internal/intent"
+	"github.com/Obedience-Corp/camp/internal/intent/tui"
 )
 
 func TestGroupNotes_SplitsActiveAndArchived(t *testing.T) {
@@ -227,6 +228,93 @@ func TestMove_TUIFlow_NoteBecomesReadyIntent(t *testing.T) {
 	}
 	if converted.Type != intent.TypeFeature {
 		t.Errorf("Type = %q, want feature", converted.Type)
+	}
+}
+
+func TestArchive_TUIFlow_NoteMovesToArchived(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := intent.NewIntentService(tmp, intentsDir)
+
+	note, err := svc.CreateNote(ctx, intent.CreateOptions{
+		Title:     "note to dungeon",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	m := NewModel(ctx, svc, nil, intentsDir, "", "", "", nil)
+	m.ready = true
+	m.notesMode = true
+	m.groups = groupNotes([]*intent.Intent{note})
+	m.cursorGroup = 0
+	m.cursorItem = 0
+
+	// Dispatch the Archive action the note action menu now offers.
+	_, cmd := m.handleActionMenuSelection(tui.ActionMenuSelectedMsg{Action: "archive"})
+	if cmd == nil {
+		t.Fatal("archive action produced no command")
+	}
+	msg := cmd()
+	if fin, ok := msg.(archiveFinishedMsg); !ok {
+		t.Fatalf("expected archiveFinishedMsg, got %T", msg)
+	} else if fin.err != nil {
+		t.Fatalf("archive failed: %v", fin.err)
+	}
+
+	archived, err := svc.GetNote(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("GetNote after archive: %v", err)
+	}
+	if archived.Status != intent.StatusNoteArchived {
+		t.Errorf("Status = %q, want %q", archived.Status, intent.StatusNoteArchived)
+	}
+}
+
+func TestRestore_TUIFlow_ArchivedNoteBecomesActive(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := intent.NewIntentService(tmp, intentsDir)
+
+	note, err := svc.CreateNote(ctx, intent.CreateOptions{
+		Title:     "archived note to restore",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+	archived, err := svc.ArchiveNote(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("ArchiveNote: %v", err)
+	}
+
+	m := NewModel(ctx, svc, nil, intentsDir, "", "", "", nil)
+	m.ready = true
+	m.notesMode = true
+	m.groups = groupNotes([]*intent.Intent{archived})
+	m.cursorGroup = 1 // Archived group
+	m.cursorItem = 0
+
+	_, cmd := m.handleActionMenuSelection(tui.ActionMenuSelectedMsg{Action: "restore"})
+	if cmd == nil {
+		t.Fatal("restore action produced no command")
+	}
+	msg := cmd()
+	if fin, ok := msg.(moveFinishedMsg); !ok {
+		t.Fatalf("expected moveFinishedMsg, got %T", msg)
+	} else if fin.err != nil {
+		t.Fatalf("restore failed: %v", fin.err)
+	}
+
+	restored, err := svc.GetNote(ctx, note.ID)
+	if err != nil {
+		t.Fatalf("GetNote after restore: %v", err)
+	}
+	if restored.Status != intent.StatusNote {
+		t.Errorf("Status = %q, want %q", restored.Status, intent.StatusNote)
 	}
 }
 

--- a/internal/intent/tui/explorer/notes_view_test.go
+++ b/internal/intent/tui/explorer/notes_view_test.go
@@ -318,6 +318,49 @@ func TestRestore_TUIFlow_ArchivedNoteBecomesActive(t *testing.T) {
 	}
 }
 
+// TestRestore_TUIFlow_NonArchivedNoOp pins that dispatching "restore" on a note
+// that is not archived is an inert no-op: Go switch cases do not fall through,
+// so it never reaches the "delete" case. The action menu already disables
+// Restore for active notes; this guards the dispatch layer directly.
+func TestRestore_TUIFlow_NonArchivedNoOp(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := intent.NewIntentService(tmp, intentsDir)
+
+	note, err := svc.CreateNote(ctx, intent.CreateOptions{
+		Title:     "active note, restore should no-op",
+		Timestamp: time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CreateNote: %v", err)
+	}
+
+	m := NewModel(ctx, svc, nil, intentsDir, "", "", "", nil)
+	m.ready = true
+	m.notesMode = true
+	m.groups = groupNotes([]*intent.Intent{note})
+	m.cursorGroup = 0
+	m.cursorItem = 0
+
+	updated, cmd := m.handleActionMenuSelection(tui.ActionMenuSelectedMsg{Action: "restore"})
+	if cmd != nil {
+		t.Fatalf("restore on active note produced a command: %T", cmd())
+	}
+	got := updated.(Model)
+	if got.focus == focusConfirm {
+		t.Error("restore on active note fell through into delete confirmation")
+	}
+	if got.pendingAction == "delete" {
+		t.Errorf("pendingAction = %q, restore must not reach the delete path", got.pendingAction)
+	}
+
+	// The note still exists and is unchanged.
+	if _, err := svc.GetNote(ctx, note.ID); err != nil {
+		t.Fatalf("note missing after restore no-op: %v", err)
+	}
+}
+
 func TestUpdateNormal_COnSelectedNoteStartsConvert(t *testing.T) {
 	ctx := context.Background()
 	note := &intent.Intent{ID: "n", Title: "note", Status: intent.StatusNote}

--- a/internal/intent/tui/explorer/notes_view_test.go
+++ b/internal/intent/tui/explorer/notes_view_test.go
@@ -354,6 +354,9 @@ func TestRestore_TUIFlow_NonArchivedNoOp(t *testing.T) {
 	if got.pendingAction == "delete" {
 		t.Errorf("pendingAction = %q, restore must not reach the delete path", got.pendingAction)
 	}
+	if got.statusMessage == "" {
+		t.Error("restore on a non-archived note should surface a status message, not silently no-op")
+	}
 
 	// The note still exists and is unchanged.
 	if _, err := svc.GetNote(ctx, note.ID); err != nil {

--- a/internal/intent/tui/explorer/update.go
+++ b/internal/intent/tui/explorer/update.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Obedience-Corp/camp/internal/intent"
 	"github.com/Obedience-Corp/camp/internal/intent/tui"
 	"github.com/Obedience-Corp/camp/internal/intent/tui/filterchip"
 	tea "github.com/charmbracelet/bubbletea"
@@ -336,10 +337,19 @@ func (m Model) handleActionMenuSelection(msg tui.ActionMenuSelectedMsg) (tea.Mod
 		return m.handlePromoteAction()
 	case "archive":
 		if selected.Status.IsNote() {
-			m.statusMessage = "Note archiving is not available in the explorer yet"
-			return m, nil
+			if selected.Status != intent.StatusNote {
+				m.statusMessage = "Note is already archived"
+				return m, nil
+			}
+			m.statusMessage = "Archiving note..."
+			return m, m.archiveNote(selected)
 		}
 		return m.handleArchiveAction()
+	case "restore":
+		if selected.Status == intent.StatusNoteArchived {
+			m.statusMessage = "Restoring note..."
+			return m, m.restoreNote(selected)
+		}
 	case "delete":
 		if selected.Status.IsNote() {
 			m.statusMessage = "Note deletion is not available in the explorer yet"

--- a/internal/intent/tui/explorer/update.go
+++ b/internal/intent/tui/explorer/update.go
@@ -350,6 +350,8 @@ func (m Model) handleActionMenuSelection(msg tui.ActionMenuSelectedMsg) (tea.Mod
 			m.statusMessage = "Restoring note..."
 			return m, m.restoreNote(selected)
 		}
+		m.statusMessage = "Note is not archived"
+		return m, nil
 	case "delete":
 		if selected.Status.IsNote() {
 			m.statusMessage = "Note deletion is not available in the explorer yet"

--- a/internal/intent/tui/explorer/update_keys.go
+++ b/internal/intent/tui/explorer/update_keys.go
@@ -1,6 +1,7 @@
 package explorer
 
 import (
+	"github.com/Obedience-Corp/camp/internal/intent"
 	"github.com/Obedience-Corp/camp/internal/intent/tui"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -144,10 +145,15 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m.handlePromoteAction()
 	case "a":
-		// Archive (move to dungeon/archived) - requires reason
+		// Archive (move to dungeon/archived). Notes archive into notes/archived/
+		// reason-free; lifecycle intents require a dungeon reason.
 		if selected := m.SelectedIntent(); selected != nil && selected.Status.IsNote() {
-			m.statusMessage = "Note archiving is not available in the explorer yet"
-			return m, nil
+			if selected.Status != intent.StatusNote {
+				m.statusMessage = "Note is already archived"
+				return m, nil
+			}
+			m.statusMessage = "Archiving note..."
+			return m, m.archiveNote(selected)
 		}
 		return m.handleArchiveAction()
 	case "d":


### PR DESCRIPTION
## Problem

In the intent explorer's **notes view**, a note could not be dungeoned. Both the action menu and the `a` key stubbed note archiving with the message _"Note archiving is not available in the explorer yet"_, so the only lifecycle action available on a note was converting/promoting it into an intent. There was no way to shelve a note you were done with.

## Change

Wire note archiving through the existing `IntentService.ArchiveNote` path (`notes/` → `notes/archived/`) and add a symmetric `RestoreNote` so an archived note is never a dead end.

- **Action menu** (`Enter` → Actions) on a note now offers:
  - **Archive** — enabled for active notes
  - **Restore** — enabled for archived notes
- **`a` key** archives the selected active note directly.
- Archiving a note is **reason-free**, matching the lightweight note model (notes carry no lifecycle metadata or decision records), unlike dungeoning a lifecycle intent which still requires a reason.

Archive emits an `EventArchive` audit event and an `IntentArchive` auto-commit; restore emits an `EventMove` audit event and an `IntentMove` auto-commit — consistent with the existing intent flows.

## Tests

- `RestoreNote` service tests: archived→active restore, and active-note no-op.
- TUI dispatch tests exercising the real `handleActionMenuSelection` path for both `archive` and `restore`.
- Action-menu enablement test: active notes offer Archive (not Restore); archived notes offer Restore (not Archive).

Full local gate passes (`just gate-fast`): build, vet, lint (no new host-fs or `fmt.Errorf` violators), and all 2983 unit tests.

## Notes / tradeoffs

- Note archive is intentionally reason-free to stay consistent with the note model. If reasons are wanted for note dungeoning later, that would be a follow-up.
- Restore is exposed via the action menu only (no dedicated key), since it is a rarer operation than archive.
