### PR TITLE
feat: first-class orgs (registry, CLI, create/init --org, TUI)

### DIFF
--- a/cmd/camp/create.go
+++ b/cmd/camp/create.go
@@ -88,10 +88,6 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		displayName = name
 	}
 
-	if dryRun && org != "" {
-		_, _ = fmt.Fprintf(w.HumanOut, "would assign org: %s\n", org)
-	}
-
 	p := initcmd.Params{
 		Dir:         target,
 		Name:        displayName,

--- a/cmd/camp/create.go
+++ b/cmd/camp/create.go
@@ -44,12 +44,19 @@ func init() {
 	createCmd.Flags().Bool("no-skills", false, "Skip linking campaign skills into .claude/skills and .agents/skills")
 	createCmd.Flags().Bool("dry-run", false, "Show what would be done without creating anything")
 	createCmd.Flags().String("path", "", "Override the base campaigns directory (campaign created at <path>/<name>/)")
+	createCmd.Flags().String("org", "", "Assign the new campaign to this org (created if new; defaults to the fallback org)")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	if err := validateCampaignName(name); err != nil {
 		return err
+	}
+	org := cmdutil.GetFlagString(cmd, "org")
+	if org != "" {
+		if err := config.ValidateName("org", org); err != nil {
+			return err
+		}
 	}
 	ctx := cmd.Context()
 	dryRun := cmdutil.GetFlagBool(cmd, "dry-run")
@@ -81,6 +88,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		displayName = name
 	}
 
+	if dryRun && org != "" {
+		_, _ = fmt.Fprintf(w.HumanOut, "would assign org: %s\n", org)
+	}
+
 	p := initcmd.Params{
 		Dir:         target,
 		Name:        displayName,
@@ -90,6 +101,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		NoGit:       cmdutil.GetFlagBool(cmd, "no-git"),
 		NoSkills:    cmdutil.GetFlagBool(cmd, "no-skills"),
 		DryRun:      dryRun,
+		Org:         org,
 		// force, noRegister, repair, yes stay zero — create deliberately does not support them.
 	}
 	return initcmd.RunFlow(ctx, p, w, tui.IsTerminal())

--- a/cmd/camp/create_org_flag_test.go
+++ b/cmd/camp/create_org_flag_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func TestCreateOrgFlag_InvalidNameNoRegistryWrite(t *testing.T) {
+	dir := t.TempDir()
+	regPath := filepath.Join(dir, "registry.json")
+	t.Setenv("CAMP_REGISTRY_PATH", regPath)
+	_ = os.WriteFile(regPath, []byte(`{"version":3,"campaigns":{}}`), 0o644)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	cmd := &cobra.Command{Use: "create", RunE: runCreate}
+	cmd.Flags().StringP("name", "n", "", "")
+	cmd.Flags().StringP("type", "t", "product", "")
+	cmd.Flags().StringP("description", "d", "", "")
+	cmd.Flags().StringP("mission", "m", "", "")
+	cmd.Flags().Bool("no-git", false, "")
+	cmd.Flags().Bool("no-skills", false, "")
+	cmd.Flags().Bool("dry-run", false, "")
+	cmd.Flags().String("path", "", "")
+	cmd.Flags().String("org", "", "")
+	cmd.SetContext(context.Background())
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	_ = cmd.Flags().Set("org", "Bad Name")
+	_ = cmd.Flags().Set("path", dir)
+	_ = cmd.Flags().Set("description", "d")
+	_ = cmd.Flags().Set("mission", "m")
+	_ = cmd.Flags().Set("no-git", "true")
+	_ = cmd.Flags().Set("no-skills", "true")
+
+	err := cmd.RunE(cmd, []string{"demo-bad"})
+	if err == nil {
+		t.Fatal("expected validation error for bad org name")
+	}
+	reg, loadErr := config.LoadRegistry(context.Background())
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	if len(reg.Campaigns) != 0 {
+		t.Fatalf("registry should be empty after invalid --org, got %d campaigns", len(reg.Campaigns))
+	}
+}
+
+func TestCreateOrgFlag_DryRunMentionsOrg(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CAMP_REGISTRY_PATH", filepath.Join(dir, "registry.json"))
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	// Capture stdout from dry-run path (create prints to writers using stdout)
+	// Use dry-run with --org; should not write registry.
+	cmd := createCmd
+	// createCmd is shared; set flags carefully
+	_ = cmd.Flags().Set("org", "obey")
+	_ = cmd.Flags().Set("path", dir)
+	_ = cmd.Flags().Set("description", "d")
+	_ = cmd.Flags().Set("mission", "m")
+	_ = cmd.Flags().Set("dry-run", "true")
+	_ = cmd.Flags().Set("no-git", "true")
+	_ = cmd.Flags().Set("no-skills", "true")
+	cmd.SetContext(context.Background())
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := runCreate(cmd, []string{"demo-dry"})
+	_ = w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	out := buf.String()
+	// reset flags for other tests
+	_ = cmd.Flags().Set("org", "")
+	_ = cmd.Flags().Set("dry-run", "false")
+	_ = cmd.Flags().Set("path", "")
+
+	if err != nil {
+		t.Fatalf("dry-run create: %v\nout=%s", err, out)
+	}
+	if !strings.Contains(out, "obey") {
+		t.Fatalf("dry-run output missing org: %s", out)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "registry.json")); !os.IsNotExist(statErr) {
+		// registry may not exist; if it does, campaigns must stay empty
+		reg, _ := config.LoadRegistry(context.Background())
+		if reg != nil && len(reg.Campaigns) != 0 {
+			t.Fatalf("dry-run wrote campaigns: %d", len(reg.Campaigns))
+		}
+	}
+}

--- a/cmd/camp/init/command.go
+++ b/cmd/camp/init/command.go
@@ -85,6 +85,7 @@ func New() *cobra.Command {
 	cmd.Flags().Bool("repair", false, "Add missing files to existing campaign")
 	cmd.Flags().Bool("yes", false, "Skip repair confirmation prompt (for scripting)")
 	cmd.Flags().BoolP("verbose", "v", false, "Show skipped optional setup details")
+	cmd.Flags().String("org", "", "Assign the new campaign to this org (created if new; defaults to the fallback org)")
 
 	return cmd
 }
@@ -105,6 +106,8 @@ type Params struct {
 	Repair        bool
 	Yes           bool
 	VerboseOutput bool
+	// Org assigns the campaign to this org on register (created if new).
+	Org string
 }
 
 // Writers routes init flow output for command callers.
@@ -139,6 +142,12 @@ func runInit(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "failed to resolve directory path")
 	}
 	verboseOutput := cmdutil.GetFlagBool(cmd, "verbose")
+	org := cmdutil.GetFlagString(cmd, "org")
+	if org != "" {
+		if err := config.ValidateName("org", org); err != nil {
+			return err
+		}
+	}
 	p := Params{
 		Dir:           absDir,
 		Name:          cmdutil.GetFlagString(cmd, "name"),
@@ -153,6 +162,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		Repair:        cmdutil.GetFlagBool(cmd, "repair"),
 		Yes:           cmdutil.GetFlagBool(cmd, "yes"),
 		VerboseOutput: verboseOutput,
+		Org:           org,
 	}
 	w := ChooseWriters()
 	return RunFlow(cmd.Context(), p, w, tui.IsTerminal())
@@ -215,6 +225,7 @@ func RunFlow(ctx context.Context, p Params, w Writers, isInteractive bool) error
 		DryRun:      p.DryRun,
 		Repair:      p.Repair,
 		SkipSkills:  p.NoSkills,
+		Org:         p.Org,
 	}
 
 	// Validate options
@@ -309,6 +320,9 @@ func RunFlow(ctx context.Context, p Params, w Writers, isInteractive bool) error
 	// Print results
 	if p.DryRun {
 		writeLine(w.HumanOut, ui.Warning("Dry run - would create:"))
+		if p.Org != "" {
+			writef(w.HumanOut, "  would assign org: %s\n", p.Org)
+		}
 	} else if p.Repair {
 		writeLine(w.HumanOut, ui.Success("✓ Campaign Repaired"))
 	} else {

--- a/cmd/camp/list_org_test.go
+++ b/cmd/camp/list_org_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -248,5 +249,67 @@ func TestList_FilterGroupPerformance(t *testing.T) {
 	_ = sortedGroupOrgs(byOrg, "default")
 	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
 		t.Errorf("filter+group of %d campaigns took %v, want <100ms", n, elapsed)
+	}
+}
+
+func TestList_EmptyOrgDoesNotAppearOrChangeGrouping(t *testing.T) {
+	// Campaigns only in default and obey; empty client-acme must not create a group header
+	// or change auto-group threshold (still 2 member orgs => group).
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+	t.Setenv("CAMP_REGISTRY_PATH", path)
+	fixture := `{
+  "version": 3,
+  "orgs": [{"name":"client-acme"},{"name":"obey"}],
+  "campaigns": {
+    "A-1": {"name":"alpha","path":"/tmp/a","type":"campaign","org":"","status":"active"},
+    "B-2": {"name":"beta","path":"/tmp/b","type":"campaign","org":"obey","status":"active"}
+  }
+}`
+	if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := []campaignEntry{
+		ent("A-1", "alpha", "campaign", "default", "active"),
+		ent("B-2", "beta", "campaign", "obey", "active"),
+	}
+	// Empty orgs are not campaign entries — distinctOrgs remains 2.
+	if distinctOrgs(entries) != 2 {
+		t.Fatalf("distinctOrgs = %d, want 2 (empty orgs must not count)", distinctOrgs(entries))
+	}
+	if !shouldGroupEntries(entries) {
+		t.Fatal("two member-orgs should auto-group")
+	}
+
+	// --org empty returns zero rows, no error.
+	filtered := filterEntries(entries, listFilter{org: "client-acme"})
+	if len(filtered) != 0 {
+		t.Fatalf("--org client-acme = %v, want empty", names(filtered))
+	}
+
+	// Grouped render has only default and obey headers.
+	ui.SetNoColor(true)
+	out := captureListStdout(t, func() error { return outputGrouped(entries, "table", "default") })
+	if strings.Contains(out, "client-acme") {
+		t.Fatalf("empty org leaked into camp list output:\n%s", out)
+	}
+	if !strings.Contains(out, "default") || !strings.Contains(out, "obey") {
+		t.Fatalf("expected default and obey groups:\n%s", out)
+	}
+
+	// JSON field set unchanged.
+	jsonOut := captureListStdout(t, func() error { return outputCampaigns(os.Stdout, entries, "json") })
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(jsonOut), &rows); err != nil {
+		t.Fatalf("json: %v\n%s", err, jsonOut)
+	}
+	wantKeys := map[string]bool{"id": true, "name": true, "type": true, "path": true, "org": true, "status": true, "tags": true}
+	for _, row := range rows {
+		for k := range wantKeys {
+			if _, ok := row[k]; !ok {
+				t.Fatalf("json row missing key %q: %v", k, row)
+			}
+		}
 	}
 }

--- a/cmd/camp/org/create.go
+++ b/cmd/camp/org/create.go
@@ -74,27 +74,29 @@ type orgCreateEmptyResult struct {
 
 func createEmptyOrg(cmd *cobra.Command, org string, asJSON bool) error {
 	created := false
+	members := 0
 	err := config.UpdateRegistry(cmd.Context(), func(reg *config.Registry) error {
 		if !orgExists(reg, org) {
 			created = true
 		}
 		ensureOrg(reg, org)
+		members = len(membersOf(reg, org))
 		return nil
 	})
 	if err != nil {
 		return err
 	}
-	result := orgCreateEmptyResult{Org: org, Created: created, Members: 0}
+	result := orgCreateEmptyResult{Org: org, Created: created, Members: members}
 	if asJSON {
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
 		return enc.Encode(result)
 	}
 	if created {
-		_, err := fmt.Fprintf(cmd.OutOrStdout(), "created org %q (0 members)\n", org)
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "created org %q (%d members)\n", org, members)
 		return err
 	}
-	_, err = fmt.Fprintf(cmd.OutOrStdout(), "org %q already exists (0 members added)\n", org)
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "org %q already exists (%d members)\n", org, members)
 	return err
 }
 

--- a/cmd/camp/org/create.go
+++ b/cmd/camp/org/create.go
@@ -2,6 +2,8 @@ package org
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
@@ -11,8 +13,8 @@ import (
 
 var orgCreateCmd = &cobra.Command{
 	Use:   "create <org> [campaign...]",
-	Short: "Create an org by joining campaigns (the current campaign if none named)",
-	Long: `Create an org by joining campaigns to it.
+	Short: "Create an org (optionally empty) and join campaigns",
+	Long: `Create a first-class org, optionally joining campaigns to it.
 
 Run inside a campaign with no campaign arguments to add the current campaign:
   camp org create obey
@@ -20,10 +22,14 @@ Run inside a campaign with no campaign arguments to add the current campaign:
 Or name the campaigns explicitly:
   camp org create obey obey-campaign obey-content
 
-Orgs remain derived: "create" assigns membership and never makes an empty org.
+Create an empty org with no members (works outside a campaign):
+  camp org create obey --empty
+
+Orgs are first-class: they persist in the registry even with zero members.
 Joining an org that already has members is allowed; there is no "already exists"
 error, and a campaign already in the org is reported as unchanged.`,
 	Example: `  camp org create obey
+  camp org create obey --empty
   camp org create client-acme acme-site other-site`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runOrgCreate,
@@ -32,6 +38,7 @@ error, and a campaign already in the org is reported as unchanged.`,
 func init() {
 	Cmd.AddCommand(orgCreateCmd)
 	orgCreateCmd.Flags().Bool("json", false, "Output as JSON")
+	orgCreateCmd.Flags().Bool("empty", false, "Create the org with no members (do not join any campaign)")
 }
 
 func runOrgCreate(cmd *cobra.Command, args []string) error {
@@ -40,6 +47,13 @@ func runOrgCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	asJSON, _ := cmd.Flags().GetBool("json")
+	empty, _ := cmd.Flags().GetBool("empty")
+	if empty {
+		if len(args) > 1 {
+			return camperrors.NewValidation("empty", "--empty takes no campaign arguments", nil)
+		}
+		return createEmptyOrg(cmd, org, asJSON)
+	}
 
 	campaignArgs := args[1:]
 	if len(campaignArgs) == 0 {
@@ -50,6 +64,38 @@ func runOrgCreate(cmd *cobra.Command, args []string) error {
 		campaignArgs = []string{id}
 	}
 	return reassignOrg(cmd, func(*config.Registry) string { return org }, campaignArgs, asJSON)
+}
+
+type orgCreateEmptyResult struct {
+	Org     string `json:"org"`
+	Created bool   `json:"created"`
+	Members int    `json:"members"`
+}
+
+func createEmptyOrg(cmd *cobra.Command, org string, asJSON bool) error {
+	created := false
+	err := config.UpdateRegistry(cmd.Context(), func(reg *config.Registry) error {
+		if !orgExists(reg, org) {
+			created = true
+		}
+		ensureOrg(reg, org)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	result := orgCreateEmptyResult{Org: org, Created: created, Members: 0}
+	if asJSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+	if created {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "created org %q (0 members)\n", org)
+		return err
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "org %q already exists (0 members added)\n", org)
+	return err
 }
 
 func currentCampaignID(ctx context.Context) (string, error) {

--- a/cmd/camp/org/create_test.go
+++ b/cmd/camp/org/create_test.go
@@ -180,3 +180,23 @@ func TestOrgCreate_JoinPersistsOrgAfterLastMemberRemoved(t *testing.T) {
 		t.Fatalf("alpha org = %q, want default", got)
 	}
 }
+
+func TestOrgCreate_Empty_PopulatedOrg_ReportsActualCount(t *testing.T) {
+	// create --empty on an org that already has members must report the actual
+	// current membership count, not a hardcoded 0 (PR #387 review cleanup).
+	setOrgRegistry(t, orgFixture) // org "obey" already has 2 members (beta, gamma)
+	out, err := execOrgWithFlags(t, runOrgCreate, map[string]bool{"empty": true, "json": true}, "obey")
+	if err != nil {
+		t.Fatalf("create --empty on existing org: %v", err)
+	}
+	var result orgCreateEmptyResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("unmarshal: %v\nout=%s", err, out)
+	}
+	if result.Created {
+		t.Fatalf("Created = true, want false for an existing org")
+	}
+	if result.Members != 2 {
+		t.Fatalf("Members = %d, want 2 (actual current membership, not hardcoded 0)", result.Members)
+	}
+}

--- a/cmd/camp/org/create_test.go
+++ b/cmd/camp/org/create_test.go
@@ -2,11 +2,14 @@ package org
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
+	"github.com/Obedience-Corp/camp/internal/config"
 )
 
 func TestOrgCreate_WithCampaignArgs(t *testing.T) {
@@ -83,5 +86,97 @@ func TestOrgCreate_UnregisteredCurrent_Errors(t *testing.T) {
 	setOrgRegistry(t, orgFixture)
 	if _, err := execOrg(t, runOrgCreate, false, "obey"); err == nil {
 		t.Error("expected error: current campaign not registered")
+	}
+}
+
+func TestOrgCreate_Empty(t *testing.T) {
+	// Error path first: --empty rejects campaign args.
+	setOrgRegistry(t, orgFixture)
+	_, err := execOrgWithFlags(t, runOrgCreate, map[string]bool{"empty": true}, "newco", "alpha")
+	if err == nil {
+		t.Fatal("expected error when --empty is combined with campaign args")
+	}
+	if !strings.Contains(err.Error(), "--empty") {
+		t.Fatalf("error = %v, want --empty mention", err)
+	}
+
+	// Happy path outside any campaign.
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv(campaign.EnvCacheDisable, "1")
+	setOrgRegistry(t, `{"version":3,"campaigns":{}}`)
+
+	out, err := execOrgWithFlags(t, runOrgCreate, map[string]bool{"empty": true}, "empty-co")
+	if err != nil {
+		t.Fatalf("create --empty: %v", err)
+	}
+	if !strings.Contains(out, "created org") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+	reg, err := config.LoadRegistry(context.Background())
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	if !orgExists(reg, "empty-co") {
+		t.Fatal("empty-co missing from reg.Orgs")
+	}
+	if len(membersOf(reg, "empty-co")) != 0 {
+		t.Fatalf("empty-co has members: %v", membersOf(reg, "empty-co"))
+	}
+
+	// Idempotent second create.
+	out, err = execOrgWithFlags(t, runOrgCreate, map[string]bool{"empty": true}, "empty-co")
+	if err != nil {
+		t.Fatalf("second create --empty: %v", err)
+	}
+	if !strings.Contains(out, "already exists") {
+		t.Fatalf("expected already-exists message, got %s", out)
+	}
+}
+
+func TestOrgCreate_Empty_JSONShape(t *testing.T) {
+	setOrgRegistry(t, `{"version":3,"campaigns":{}}`)
+	out, err := execOrgWithFlags(t, runOrgCreate, map[string]bool{"empty": true, "json": true}, "json-org")
+	if err != nil {
+		t.Fatalf("create --empty --json: %v", err)
+	}
+	if strings.Contains(out, "null") {
+		t.Fatalf("JSON contains null: %s", out)
+	}
+	var result orgCreateEmptyResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("unmarshal: %v\nout=%s", err, out)
+	}
+	if !result.Created || result.Org != "json-org" || result.Members != 0 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestOrgCreate_JoinPersistsOrgAfterLastMemberRemoved(t *testing.T) {
+	setOrgRegistry(t, orgFixture)
+	if _, err := execOrg(t, runOrgCreate, false, "newco", "alpha"); err != nil {
+		t.Fatalf("create join: %v", err)
+	}
+	reg, err := config.LoadRegistry(context.Background())
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !orgExists(reg, "newco") {
+		t.Fatal("newco not in reg.Orgs after join create")
+	}
+
+	// Remove the only member (return alpha to default).
+	if _, err := execOrg(t, runOrgRemove, false, "alpha"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	reg, err = config.LoadRegistry(context.Background())
+	if err != nil {
+		t.Fatalf("load after remove: %v", err)
+	}
+	if !orgExists(reg, "newco") {
+		t.Fatal("newco vanished after last member left; first-class persistence broken")
+	}
+	if got := orgOf(t, "A-1"); got != "default" {
+		t.Fatalf("alpha org = %q, want default", got)
 	}
 }

--- a/cmd/camp/org/delete.go
+++ b/cmd/camp/org/delete.go
@@ -1,0 +1,95 @@
+package org
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/spf13/cobra"
+)
+
+type orgDeleteResult struct {
+	Org        string   `json:"org"`
+	Deleted    bool     `json:"deleted"`
+	Force      bool     `json:"force"`
+	Reassigned []string `json:"reassigned,omitempty"`
+}
+
+var orgDeleteCmd = &cobra.Command{
+	Use:   "delete <name>",
+	Short: "Delete an org (empty only unless --force)",
+	Long: `Delete a first-class org from the registry.
+
+Empty orgs delete without flags. Orgs with members require --force, which
+reassigns every member to the fallback org and then deletes the org.
+
+The fallback org cannot be deleted.`,
+	Example: `  camp org delete empty-org
+  camp org delete obey --force
+  camp org delete empty-org --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runOrgDelete,
+}
+
+func init() {
+	Cmd.AddCommand(orgDeleteCmd)
+	orgDeleteCmd.Flags().Bool("force", false, "Reassign members to the fallback org, then delete")
+	orgDeleteCmd.Flags().Bool("json", false, "Output as JSON")
+}
+
+func runOrgDelete(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	if err := validateOrgName(name); err != nil {
+		return err
+	}
+	force, _ := cmd.Flags().GetBool("force")
+	asJSON, _ := cmd.Flags().GetBool("json")
+
+	result := orgDeleteResult{Org: name, Force: force, Reassigned: []string{}}
+	err := config.UpdateRegistry(cmd.Context(), func(reg *config.Registry) error {
+		if name == reg.FallbackOrg() {
+			return camperrors.NewValidation("org", "cannot delete the fallback org", nil)
+		}
+		if !orgExists(reg, name) {
+			return camperrors.NewNotFound("org", name, nil)
+		}
+		members := membersOf(reg, name)
+		if len(members) > 0 {
+			if !force {
+				return camperrors.NewValidation("org",
+					fmt.Sprintf("org %q has %d member(s); pass --force to reassign them to %q and delete",
+						name, len(members), reg.FallbackOrg()), nil)
+			}
+			fallback := reg.FallbackOrg()
+			for _, c := range members {
+				entry := reg.Campaigns[c.ID]
+				entry.Org = fallback
+				reg.Campaigns[c.ID] = entry
+				result.Reassigned = append(result.Reassigned, c.Name)
+			}
+		}
+		removeOrg(reg, name)
+		result.Deleted = true
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return renderOrgDeleteResult(cmd, result, asJSON)
+}
+
+func renderOrgDeleteResult(cmd *cobra.Command, r orgDeleteResult, asJSON bool) error {
+	if asJSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(r)
+	}
+	if len(r.Reassigned) > 0 {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(),
+			"deleted org %q (reassigned %d member(s) to fallback)\n", r.Org, len(r.Reassigned))
+		return err
+	}
+	_, err := fmt.Fprintf(cmd.OutOrStdout(), "deleted org %q\n", r.Org)
+	return err
+}

--- a/cmd/camp/org/delete_test.go
+++ b/cmd/camp/org/delete_test.go
@@ -1,0 +1,190 @@
+package org
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func execOrgWithFlags(t *testing.T, run func(*cobra.Command, []string) error, flags map[string]bool, args ...string) (string, error) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	for name, val := range flags {
+		cmd.Flags().Bool(name, val, "")
+	}
+	if cmd.Flags().Lookup("json") == nil {
+		cmd.Flags().Bool("json", false, "")
+	}
+	err := run(cmd, args)
+	return buf.String(), err
+}
+
+func TestOrgDelete(t *testing.T) {
+	cases := []struct {
+		name         string
+		fixture      string
+		arg          string
+		force        bool
+		wantErrSub   string // "" = success
+		wantDeleted  bool
+		wantMemberAt string // campaign id -> expected org after ("" = skip)
+		wantMemberID string
+	}{
+		{
+			name:        "empty org deletes",
+			fixture:     `{"version":3,"orgs":[{"name":"empty-co"}],"campaigns":{}}`,
+			arg:         "empty-co",
+			wantDeleted: true,
+		},
+		{
+			name:       "non-empty needs force",
+			fixture:    orgFixture,
+			arg:        "obey",
+			wantErrSub: "has 2 member",
+		},
+		{
+			name:         "force reassigns and deletes",
+			fixture:      orgFixture,
+			arg:          "obey",
+			force:        true,
+			wantDeleted:  true,
+			wantMemberID: "B-2",
+			wantMemberAt: "default",
+		},
+		{
+			name:       "fallback refused",
+			fixture:    orgFixture,
+			arg:        "default",
+			wantErrSub: "cannot delete the fallback",
+		},
+		{
+			name:       "unknown not found",
+			fixture:    orgFixture,
+			arg:        "ghost",
+			wantErrSub: "not found",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setOrgRegistry(t, tc.fixture)
+			// Ensure load reconciliation has run so reg.Orgs is populated from v2 fixtures.
+			if _, err := config.LoadRegistry(context.Background()); err != nil {
+				t.Fatalf("preload: %v", err)
+			}
+			// For empty fixture, orgs are already on disk; for v2-style, seed via UpdateRegistry
+			// so delete can find them after load reconcile.
+			if tc.arg != "default" && tc.arg != "ghost" {
+				_ = config.UpdateRegistry(context.Background(), func(reg *config.Registry) error {
+					ensureOrg(reg, tc.arg)
+					return nil
+				})
+			}
+
+			out, err := execOrgWithFlags(t, runOrgDelete, map[string]bool{
+				"force": tc.force,
+				"json":  false,
+			}, tc.arg)
+
+			if tc.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil (out=%q)", tc.wantErrSub, out)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			reg, loadErr := config.LoadRegistry(context.Background())
+			if loadErr != nil {
+				t.Fatalf("LoadRegistry: %v", loadErr)
+			}
+			if tc.wantDeleted && orgExists(reg, tc.arg) {
+				t.Fatalf("org %q still present after delete", tc.arg)
+			}
+			if tc.wantMemberID != "" {
+				c, ok := reg.Campaigns[tc.wantMemberID]
+				if !ok {
+					t.Fatalf("campaign %s missing", tc.wantMemberID)
+				}
+				if c.Org != tc.wantMemberAt {
+					t.Fatalf("campaign %s org = %q, want %q", tc.wantMemberID, c.Org, tc.wantMemberAt)
+				}
+			}
+		})
+	}
+}
+
+func TestOrgDelete_JSONShape(t *testing.T) {
+	setOrgRegistry(t, `{"version":3,"orgs":[{"name":"empty-co"}],"campaigns":{}}`)
+	out, err := execOrgWithFlags(t, runOrgDelete, map[string]bool{"json": true, "force": false}, "empty-co")
+	if err != nil {
+		t.Fatalf("delete --json: %v", err)
+	}
+	var result orgDeleteResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("unmarshal: %v\nout=%s", err, out)
+	}
+	if !result.Deleted || result.Org != "empty-co" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	// reassigned must be [] not null in raw JSON
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(out), &raw); err != nil {
+		t.Fatal(err)
+	}
+	if string(raw["reassigned"]) != "[]" && string(raw["reassigned"]) != "" {
+		// omitempty may drop empty slice; either [] or absent is OK, never null
+		if string(raw["reassigned"]) == "null" {
+			t.Fatal("reassigned marshaled as null")
+		}
+	}
+}
+
+func TestOrgDelete_ForceJSONReassignedSlice(t *testing.T) {
+	setOrgRegistry(t, orgFixture)
+	_ = config.UpdateRegistry(context.Background(), func(reg *config.Registry) error {
+		ensureOrg(reg, "obey")
+		return nil
+	})
+	out, err := execOrgWithFlags(t, runOrgDelete, map[string]bool{"json": true, "force": true}, "obey")
+	if err != nil {
+		t.Fatalf("delete --force --json: %v", err)
+	}
+	if strings.Contains(out, `"reassigned": null`) {
+		t.Fatalf("reassigned is null: %s", out)
+	}
+	var result orgDeleteResult
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(result.Reassigned) == 0 {
+		t.Fatalf("expected reassigned members, got %+v / %s", result, out)
+	}
+}
+
+func TestOrgDelete_DoesNotWriteOnError(t *testing.T) {
+	path := setOrgRegistry(t, orgFixture)
+	before, _ := os.ReadFile(path)
+	_, err := execOrgWithFlags(t, runOrgDelete, map[string]bool{"force": false}, "obey")
+	if err == nil {
+		t.Fatal("expected error for non-empty delete without force")
+	}
+	after, _ := os.ReadFile(path)
+	if !bytes.Equal(before, after) {
+		t.Error("registry modified after failed delete")
+	}
+}

--- a/cmd/camp/org/list_semantics_test.go
+++ b/cmd/camp/org/list_semantics_test.go
@@ -1,0 +1,169 @@
+package org
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+)
+
+// fixtureWithEmptyOrg: alpha in default, beta+gamma in obey, plus empty client-acme.
+const fixtureWithEmptyOrg = `{
+  "version": 3,
+  "orgs": [{"name":"client-acme"},{"name":"obey"}],
+  "campaigns": {
+    "A-1": {"name":"alpha","path":"/tmp/a","type":"campaign","last_access":"2026-06-16T10:00:00Z"},
+    "B-2": {"name":"beta","path":"/tmp/b","type":"campaign","last_access":"2026-06-16T10:00:00Z","org":"obey"},
+    "C-3": {"name":"gamma","path":"/tmp/c","type":"campaign","last_access":"2026-06-16T10:00:00Z","org":"obey","status":"inactive","tags":["x"]}
+  }
+}`
+
+func TestOrgList_IncludesEmptyOrgs(t *testing.T) {
+	setOrgRegistry(t, fixtureWithEmptyOrg)
+	out, err := execOrg(t, runOrgList, true)
+	if err != nil {
+		t.Fatalf("org list --json: %v", err)
+	}
+	var counts []orgCount
+	if err := json.Unmarshal([]byte(out), &counts); err != nil {
+		t.Fatalf("parse: %v\n%s", err, out)
+	}
+	if len(counts) == 0 || counts[0].Org != "default" {
+		t.Fatalf("expected fallback-first order, got %+v", counts)
+	}
+	got := map[string]orgCount{}
+	for _, c := range counts {
+		got[c.Org] = c
+	}
+	if got["client-acme"].Campaigns != 0 || got["client-acme"].Active != 0 {
+		t.Fatalf("empty org counts = %+v, want 0/0", got["client-acme"])
+	}
+	if got["obey"].Campaigns != 2 {
+		t.Fatalf("obey campaigns = %d, want 2", got["obey"].Campaigns)
+	}
+	if _, ok := got["client-acme"]; !ok {
+		t.Fatal("client-acme missing from org list")
+	}
+}
+
+func TestOrgShow_EmptyAndAbsent(t *testing.T) {
+	setOrgRegistry(t, fixtureWithEmptyOrg)
+
+	out, err := execOrg(t, runOrgShow, false, "client-acme")
+	if err != nil {
+		t.Fatalf("show empty: %v", err)
+	}
+	if !strings.Contains(out, "0 campaigns") {
+		t.Fatalf("expected 0-member header, got:\n%s", out)
+	}
+
+	jsonOut, err := execOrg(t, runOrgShow, true, "client-acme")
+	if err != nil {
+		t.Fatalf("show empty --json: %v", err)
+	}
+	if strings.Contains(jsonOut, `"members": null`) {
+		t.Fatalf("members is null: %s", jsonOut)
+	}
+	var result orgShowResult
+	if err := json.Unmarshal([]byte(jsonOut), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if result.Members == nil || len(result.Members) != 0 {
+		t.Fatalf("members = %#v, want empty non-nil slice", result.Members)
+	}
+
+	if _, err := execOrg(t, runOrgShow, false, "ghost"); err == nil {
+		t.Fatal("expected NotFound for absent org")
+	} else if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error = %v, want not found", err)
+	}
+}
+
+func TestOrgRename_EmptySourceAndTargetBlock(t *testing.T) {
+	cases := []struct {
+		name      string
+		setup     func(t *testing.T)
+		from, to  string
+		wantErr   string
+		check     func(t *testing.T)
+	}{
+		{
+			name: "empty source renames",
+			setup: func(t *testing.T) {
+				setOrgRegistry(t, fixtureWithEmptyOrg)
+			},
+			from: "client-acme",
+			to:   "acme",
+			check: func(t *testing.T) {
+				reg, err := config.LoadRegistry(context.Background())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if orgExists(reg, "client-acme") {
+					t.Fatal("old name still present")
+				}
+				if !orgExists(reg, "acme") {
+					t.Fatal("new name missing")
+				}
+			},
+		},
+		{
+			name: "existing empty target blocks",
+			setup: func(t *testing.T) {
+				setOrgRegistry(t, fixtureWithEmptyOrg)
+				// acme empty after first rename in isolation: seed both
+				_ = config.UpdateRegistry(context.Background(), func(reg *config.Registry) error {
+					ensureOrg(reg, "acme")
+					return nil
+				})
+			},
+			from:    "obey",
+			to:      "acme",
+			wantErr: "already exists",
+		},
+		{
+			name: "fallback rename moves DefaultOrg",
+			setup: func(t *testing.T) {
+				setOrgRegistry(t, fixtureWithEmptyOrg)
+			},
+			from: "default",
+			to:   "personal",
+			check: func(t *testing.T) {
+				reg, err := config.LoadRegistry(context.Background())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if reg.FallbackOrg() != "personal" {
+					t.Fatalf("FallbackOrg = %q, want personal", reg.FallbackOrg())
+				}
+				if reg.DefaultOrg != "personal" {
+					t.Fatalf("DefaultOrg = %q, want personal", reg.DefaultOrg)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup(t)
+			_, err := execOrg(t, runOrgRename, false, tc.from, tc.to)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q missing %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("rename: %v", err)
+			}
+			if tc.check != nil {
+				tc.check(t)
+			}
+		})
+	}
+}

--- a/cmd/camp/org/membership.go
+++ b/cmd/camp/org/membership.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/Obedience-Corp/camp/internal/config"
@@ -141,7 +142,8 @@ func renameOrgEntry(reg *config.Registry, oldName, newName string) {
 	}
 }
 
-// membersOf returns campaigns whose Org equals name.
+// membersOf returns campaigns whose Org equals name, ordered by name then ID so
+// callers (e.g. --force delete reassignment) produce stable, deterministic output.
 func membersOf(reg *config.Registry, name string) []config.RegisteredCampaign {
 	var members []config.RegisteredCampaign
 	for _, c := range reg.Campaigns {
@@ -149,6 +151,12 @@ func membersOf(reg *config.Registry, name string) []config.RegisteredCampaign {
 			members = append(members, c)
 		}
 	}
+	sort.Slice(members, func(i, j int) bool {
+		if members[i].Name != members[j].Name {
+			return members[i].Name < members[j].Name
+		}
+		return members[i].ID < members[j].ID
+	})
 	return members
 }
 

--- a/cmd/camp/org/membership.go
+++ b/cmd/camp/org/membership.go
@@ -134,6 +134,16 @@ func removeOrg(reg *config.Registry, name string) {
 	reg.Orgs = out
 }
 
+// renameOrgEntry renames an OrgEntry in reg.Orgs. No-op if oldName is absent.
+func renameOrgEntry(reg *config.Registry, oldName, newName string) {
+	for i, o := range reg.Orgs {
+		if o.Name == oldName {
+			reg.Orgs[i].Name = newName
+			return
+		}
+	}
+}
+
 // membersOf returns campaigns whose Org equals name.
 func membersOf(reg *config.Registry, name string) []config.RegisteredCampaign {
 	var members []config.RegisteredCampaign

--- a/cmd/camp/org/membership.go
+++ b/cmd/camp/org/membership.go
@@ -108,10 +108,7 @@ func reassignOrg(cmd *cobra.Command, target func(*config.Registry) string, campa
 
 // ensureOrg appends name to reg.Orgs if it is not already present. Idempotent.
 func ensureOrg(reg *config.Registry, name string) {
-	if name == "" || orgExists(reg, name) {
-		return
-	}
-	reg.Orgs = append(reg.Orgs, config.OrgEntry{Name: name})
+	reg.EnsureOrg(name)
 }
 
 func orgExists(reg *config.Registry, name string) bool {

--- a/cmd/camp/org/membership.go
+++ b/cmd/camp/org/membership.go
@@ -83,6 +83,7 @@ func reassignOrg(cmd *cobra.Command, target func(*config.Registry) string, campa
 	err := config.UpdateRegistry(cmd.Context(), func(reg *config.Registry) error {
 		targetOrg := target(reg)
 		result.Org = targetOrg
+		ensureOrg(reg, targetOrg)
 		resolved, err := resolveUnique(reg, campaignArgs)
 		if err != nil {
 			return err
@@ -103,6 +104,45 @@ func reassignOrg(cmd *cobra.Command, target func(*config.Registry) string, campa
 		return err
 	}
 	return renderOrgMoveResult(cmd.OutOrStdout(), result, asJSON)
+}
+
+// ensureOrg appends name to reg.Orgs if it is not already present. Idempotent.
+func ensureOrg(reg *config.Registry, name string) {
+	if name == "" || orgExists(reg, name) {
+		return
+	}
+	reg.Orgs = append(reg.Orgs, config.OrgEntry{Name: name})
+}
+
+func orgExists(reg *config.Registry, name string) bool {
+	for _, o := range reg.Orgs {
+		if o.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func removeOrg(reg *config.Registry, name string) {
+	out := make([]config.OrgEntry, 0, len(reg.Orgs))
+	for _, o := range reg.Orgs {
+		if o.Name == name {
+			continue
+		}
+		out = append(out, o)
+	}
+	reg.Orgs = out
+}
+
+// membersOf returns campaigns whose Org equals name.
+func membersOf(reg *config.Registry, name string) []config.RegisteredCampaign {
+	var members []config.RegisteredCampaign
+	for _, c := range reg.Campaigns {
+		if c.Org == name {
+			members = append(members, c)
+		}
+	}
+	return members
 }
 
 func resolveUnique(reg *config.Registry, queries []string) ([]config.RegisteredCampaign, error) {

--- a/cmd/camp/org/root.go
+++ b/cmd/camp/org/root.go
@@ -6,11 +6,11 @@ var Cmd = &cobra.Command{
 	Use:     "org",
 	Short:   "Group campaigns into orgs",
 	GroupID: "registry",
-	Long: `Group related campaigns into orgs.
+	Long: `Group related campaigns into first-class orgs.
 
-Every campaign belongs to exactly one org (default "default"). Orgs are derived:
-an org exists because a campaign names it, and disappears when its last member
-leaves.
+Every campaign belongs to exactly one org (default "default"). Orgs are first-class:
+they persist in the machine-wide registry, can hold zero members, and are deleted
+explicitly with 'camp org delete'.
 
 In a terminal, 'camp org' (no arguments) opens an interactive browser of orgs
 and their members where you can move, create, rename, and return campaigns. When
@@ -19,14 +19,17 @@ piped or with --json it prints the current campaign's org instead; use
 
 Commands:
   which   Print the current campaign's org
-  create  Create an org by joining campaigns (the current campaign if none named)
+  create  Create an org (optionally --empty) and optionally join campaigns
   add     Assign campaigns to an org (also reassigns; single-membership)
-  remove  Return campaigns to the default org`,
+  remove  Return campaigns to the default org
+  delete  Delete an org (empty only unless --force)`,
 	Example: `  camp org                                       Browse and manage orgs interactively (TTY)
   camp org which                                 Print the current campaign's org
   camp org create obey                           Add the current campaign to "obey"
+  camp org create empty-org --empty              Create an org with no members
   camp org add obey obey-campaign obey-content   Move campaigns into "obey"
-  camp org remove obey-content                   Return a campaign to "default"`,
+  camp org remove obey-content                   Return a campaign to "default"
+  camp org delete empty-org                      Delete an empty org`,
 	Args: cobra.NoArgs,
 	RunE: runOrgBare,
 }

--- a/cmd/camp/org/tui.go
+++ b/cmd/camp/org/tui.go
@@ -31,7 +31,10 @@ const (
 	overlayNone orgOverlay = iota
 	overlayMove
 	overlayRename
-	overlayCreate
+	overlayCreate      // create org and add focused member (members pane, "c")
+	overlayCreateEmpty // create empty org (orgs pane, "n")
+	overlayConfirmDelete
+	overlayNewCampaign
 )
 
 type orgTUIModel struct {
@@ -49,8 +52,10 @@ type orgTUIModel struct {
 	orgCursor int
 	memCursor int
 
-	overlay orgOverlay
-	input   textinput.Model
+	overlay       orgOverlay
+	input         textinput.Model
+	pendingDelete string
+	pendingOrg    string // focused org for new-campaign action
 
 	status    string
 	statusErr bool
@@ -59,6 +64,9 @@ type orgTUIModel struct {
 	height   int
 	quitting bool
 }
+
+// createCampaignInOrg is the seam for TUI "N new campaign". Tests stub it.
+var createCampaignInOrg = defaultCreateCampaignInOrg
 
 func newOrgTUIModel(ctx context.Context, reg *config.Registry) orgTUIModel {
 	ti := textinput.New()
@@ -144,7 +152,48 @@ func (m *orgTUIModel) assignOrg(campaignID, targetOrg string) error {
 		}
 		entry.Org = targetOrg
 		reg.Campaigns[campaignID] = entry
+		ensureOrg(reg, targetOrg)
 		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return m.reload()
+}
+
+// createEmptyOrg persists name in reg.Orgs (idempotent) and reloads.
+func (m *orgTUIModel) createEmptyOrg(name string) error {
+	if err := validateOrgName(name); err != nil {
+		return err
+	}
+	err := config.UpdateRegistry(m.ctx, func(reg *config.Registry) error {
+		ensureOrg(reg, name)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return m.reload()
+}
+
+// deleteOrgIfEmpty removes name when it is empty and not the fallback.
+func deleteOrgIfEmpty(reg *config.Registry, name string) error {
+	if name == reg.FallbackOrg() {
+		return camperrors.NewValidation("org", "cannot delete the fallback org", nil)
+	}
+	if !orgExists(reg, name) {
+		return camperrors.NewNotFound("org", name, nil)
+	}
+	if len(membersOf(reg, name)) > 0 {
+		return camperrors.NewValidation("org", "cannot delete: org has members", nil)
+	}
+	removeOrg(reg, name)
+	return nil
+}
+
+func (m *orgTUIModel) deleteEmptyOrg(name string) error {
+	err := config.UpdateRegistry(m.ctx, func(reg *config.Registry) error {
+		return deleteOrgIfEmpty(reg, name)
 	})
 	if err != nil {
 		return err

--- a/cmd/camp/org/tui_create.go
+++ b/cmd/camp/org/tui_create.go
@@ -1,0 +1,60 @@
+package org
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	initcmd "github.com/Obedience-Corp/camp/cmd/camp/init"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// defaultCreateCampaignInOrg calls the shared camp create/init registration path
+// with --org, non-interactively. Used by the org TUI "N" action.
+func defaultCreateCampaignInOrg(ctx context.Context, name, org string) error {
+	if name == "" {
+		return camperrors.New("campaign name is empty")
+	}
+	if err := config.ValidateName("org", org); err != nil {
+		return err
+	}
+	cfg, err := config.LoadGlobalConfig(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "loading global config")
+	}
+	base, err := cfg.ResolvedCampaignsDir(ctx)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		return camperrors.Wrapf(err, "ensure campaigns dir %s", base)
+	}
+	target := filepath.Join(base, name)
+	// Prefer empty-or-missing target; refuse non-empty without repair.
+	if info, statErr := os.Stat(target); statErr == nil {
+		if !info.IsDir() {
+			return camperrors.New(fmt.Sprintf("target exists and is not a directory: %s", target))
+		}
+		entries, readErr := os.ReadDir(target)
+		if readErr != nil {
+			return camperrors.Wrap(readErr, "reading target")
+		}
+		if len(entries) > 0 {
+			return camperrors.New(fmt.Sprintf("target %s exists and is not empty", target))
+		}
+	}
+	p := initcmd.Params{
+		Dir:         target,
+		Name:        name,
+		TypeStr:     string(config.CampaignTypeProduct),
+		Description: "Created from camp org browser",
+		Mission:     "Created from camp org browser",
+		NoGit:       true,
+		NoSkills:    true,
+		Org:         org,
+	}
+	// Non-interactive: description/mission already set, no forms.
+	return initcmd.RunFlow(ctx, p, initcmd.Writers{HumanOut: os.Stderr}, false)
+}

--- a/cmd/camp/org/tui_create.go
+++ b/cmd/camp/org/tui_create.go
@@ -52,9 +52,11 @@ func defaultCreateCampaignInOrg(ctx context.Context, name, org string) error {
 		TypeStr:     string(config.CampaignTypeProduct),
 		Description: "Created from camp org browser",
 		Mission:     "Created from camp org browser",
-		NoGit:       true,
-		NoSkills:    true,
-		Org:         org,
+		// Match `camp create` defaults (git init + skills linking) so a campaign
+		// made from the org browser is not a silent subset of `camp create`.
+		NoGit:    false,
+		NoSkills: false,
+		Org:      org,
 	}
 	// Non-interactive: description/mission already set, no forms.
 	return initcmd.RunFlow(ctx, p, initcmd.Writers{HumanOut: os.Stderr}, false)

--- a/cmd/camp/org/tui_create.go
+++ b/cmd/camp/org/tui_create.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	initcmd "github.com/Obedience-Corp/camp/cmd/camp/init"
 	"github.com/Obedience-Corp/camp/internal/config"
@@ -14,8 +15,8 @@ import (
 // defaultCreateCampaignInOrg calls the shared camp create/init registration path
 // with --org, non-interactively. Used by the org TUI "N" action.
 func defaultCreateCampaignInOrg(ctx context.Context, name, org string) error {
-	if name == "" {
-		return camperrors.New("campaign name is empty")
+	if err := validateTUICampaignName(name); err != nil {
+		return err
 	}
 	if err := config.ValidateName("org", org); err != nil {
 		return err
@@ -57,4 +58,24 @@ func defaultCreateCampaignInOrg(ctx context.Context, name, org string) error {
 	}
 	// Non-interactive: description/mission already set, no forms.
 	return initcmd.RunFlow(ctx, p, initcmd.Writers{HumanOut: os.Stderr}, false)
+}
+
+// validateTUICampaignName mirrors `camp create`'s single path-segment guard for
+// the org TUI's new-campaign action. This function intentionally allows display
+// names broader than config.ValidateName while rejecting path traversal.
+func validateTUICampaignName(name string) error {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return camperrors.New("campaign name is empty")
+	}
+	if trimmed == "." || trimmed == ".." {
+		return camperrors.New(fmt.Sprintf("invalid campaign name: %q", trimmed))
+	}
+	if strings.HasPrefix(trimmed, ".") {
+		return camperrors.New(fmt.Sprintf("campaign name cannot start with '.': %q", trimmed))
+	}
+	if strings.ContainsAny(trimmed, "/\\") {
+		return camperrors.New(fmt.Sprintf("campaign name cannot contain path separators: %q", trimmed))
+	}
+	return nil
 }

--- a/cmd/camp/org/tui_test.go
+++ b/cmd/camp/org/tui_test.go
@@ -2,6 +2,8 @@ package org
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -330,6 +332,45 @@ func TestOrgTUI_NewCampaign_CallsSeam(t *testing.T) {
 	}
 	if m.statusErr {
 		t.Fatalf("status error: %s", m.status)
+	}
+}
+
+func TestDefaultCreateCampaignInOrgRejectsPathLikeNames(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "campaigns")
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+	t.Setenv("CAMP_REGISTRY_PATH", filepath.Join(dir, "registry.json"))
+
+	cases := []struct {
+		name       string
+		shouldMiss string
+	}{
+		{name: "../outside", shouldMiss: filepath.Join(dir, "outside")},
+		{name: "nested/name", shouldMiss: filepath.Join(base, "nested")},
+		{name: `nested\name`, shouldMiss: filepath.Join(base, `nested\name`)},
+		{name: ".hidden", shouldMiss: filepath.Join(base, ".hidden")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := defaultCreateCampaignInOrg(context.Background(), tc.name, "obey")
+			if err == nil {
+				t.Fatalf("defaultCreateCampaignInOrg(%q) = nil, want validation error", tc.name)
+			}
+			if _, statErr := os.Stat(tc.shouldMiss); !os.IsNotExist(statErr) {
+				t.Fatalf("invalid name %q created %s (stat err=%v)", tc.name, tc.shouldMiss, statErr)
+			}
+		})
+	}
+	if _, statErr := os.Stat(base); !os.IsNotExist(statErr) {
+		t.Fatalf("invalid names should not create campaigns base %s (stat err=%v)", base, statErr)
+	}
+	reg, err := config.LoadRegistry(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reg.Campaigns) != 0 {
+		t.Fatalf("invalid names wrote registry campaigns: %d", len(reg.Campaigns))
 	}
 }
 

--- a/cmd/camp/org/tui_test.go
+++ b/cmd/camp/org/tui_test.go
@@ -195,3 +195,151 @@ func TestOrgTUI_ViewSmoke(t *testing.T) {
 		t.Error("narrow view should not be empty")
 	}
 }
+
+func TestOrgTUI_CreateEmptyOrg(t *testing.T) {
+	// 08-T1
+	m := newTestOrgModel(t)
+	m = key(m, "n")
+	if m.overlay != overlayCreateEmpty {
+		t.Fatalf("overlay = %v, want create empty", m.overlay)
+	}
+	m = key(m, "client-acme")
+	m = key(m, "enter")
+	if m.statusErr {
+		t.Fatalf("error: %s", m.status)
+	}
+	if m.overlay != overlayNone {
+		t.Fatal("overlay should close")
+	}
+	found := false
+	for _, o := range m.orgs {
+		if o.Org == "client-acme" && o.Campaigns == 0 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("empty org not listed: %v", m.orgs)
+	}
+}
+
+func TestOrgTUI_CreateEmptyOrg_InvalidKeepsOverlay(t *testing.T) {
+	m := newTestOrgModel(t)
+	m = key(m, "n")
+	m = key(m, "Bad Name")
+	m = key(m, "enter")
+	if !m.statusErr {
+		t.Fatal("expected error for invalid name")
+	}
+	if m.overlay != overlayCreateEmpty {
+		t.Fatalf("overlay should stay open, got %v", m.overlay)
+	}
+	m = key(m, "esc")
+	if m.overlay != overlayNone {
+		t.Fatal("esc should cancel")
+	}
+}
+
+func TestOrgTUI_DeleteEmptyOrg_Confirm(t *testing.T) {
+	// seed empty org
+	setOrgRegistry(t, fixtureWithEmptyOrg)
+	reg, err := config.LoadRegistry(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := newOrgTUIModel(context.Background(), reg)
+
+	// find client-acme cursor
+	for i, o := range m.orgs {
+		if o.Org == "client-acme" {
+			m.orgCursor = i
+			m.syncFocusedOrg()
+			break
+		}
+	}
+	m = key(m, "x")
+	if m.overlay != overlayConfirmDelete {
+		t.Fatalf("overlay = %v, want confirm delete", m.overlay)
+	}
+	// before confirm, org still present
+	regMid, _ := config.LoadRegistry(context.Background())
+	if !orgExists(regMid, "client-acme") {
+		t.Fatal("org deleted before confirm")
+	}
+	m = key(m, "y")
+	if m.statusErr {
+		t.Fatalf("delete error: %s", m.status)
+	}
+	regAfter, _ := config.LoadRegistry(context.Background())
+	if orgExists(regAfter, "client-acme") {
+		t.Fatal("org still present after confirm")
+	}
+}
+
+func TestOrgTUI_DeleteGuards(t *testing.T) {
+	// 08-T3
+	m := newTestOrgModel(t)
+	// fallback first
+	m = key(m, "x")
+	if !m.statusErr || !strings.Contains(m.status, "fallback") {
+		t.Fatalf("expected fallback guard, status=%q", m.status)
+	}
+	// non-empty obey
+	m = key(m, "j") // obey
+	before, _ := config.LoadRegistry(context.Background())
+	m = key(m, "x")
+	if !m.statusErr || !strings.Contains(m.status, "member") {
+		t.Fatalf("expected members guard, status=%q", m.status)
+	}
+	after, _ := config.LoadRegistry(context.Background())
+	if len(before.Orgs) != len(after.Orgs) {
+		t.Fatal("registry mutated on guarded delete")
+	}
+}
+
+func TestOrgTUI_NewCampaign_CallsSeam(t *testing.T) {
+	// 08-T4
+	var gotName, gotOrg string
+	prev := createCampaignInOrg
+	createCampaignInOrg = func(ctx context.Context, name, org string) error {
+		gotName, gotOrg = name, org
+		return nil
+	}
+	t.Cleanup(func() { createCampaignInOrg = prev })
+
+	m := newTestOrgModel(t)
+	m = key(m, "j") // obey
+	m = key(m, "N")
+	if m.overlay != overlayNewCampaign {
+		t.Fatalf("overlay = %v", m.overlay)
+	}
+	if m.pendingOrg != "obey" {
+		t.Fatalf("pendingOrg = %q", m.pendingOrg)
+	}
+	m = key(m, "new-demo")
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(orgTUIModel)
+	if cmd == nil {
+		t.Fatal("expected async create cmd")
+	}
+	// Run the cmd synchronously
+	msg := cmd()
+	next, _ = m.Update(msg)
+	m = next.(orgTUIModel)
+	if gotName != "new-demo" || gotOrg != "obey" {
+		t.Fatalf("seam called with name=%q org=%q", gotName, gotOrg)
+	}
+	if m.statusErr {
+		t.Fatalf("status error: %s", m.status)
+	}
+}
+
+func TestOrgTUI_HelpAdvertisesNewKeys(t *testing.T) {
+	m := newTestOrgModel(t)
+	m.width = 120
+	out := m.View()
+	for _, want := range []string{"n: new org", "N: new campaign", "x: delete"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("help missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/cmd/camp/org/tui_update.go
+++ b/cmd/camp/org/tui_update.go
@@ -1,17 +1,28 @@
 package org
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+type createCampaignDoneMsg struct {
+	name string
+	org  string
+	err  error
+}
 
 func (m orgTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 		return m, nil
+	case createCampaignDoneMsg:
+		return m.handleCreateCampaignDone(msg)
 	case tea.KeyMsg:
 		if m.overlay != overlayNone {
 			return m.updateOverlay(msg)
@@ -56,6 +67,24 @@ func (m orgTUIModel) updateBrowse(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.openOverlay(overlayRename, "new org name")
 		}
 		return m, nil
+	case "n":
+		if m.pane == paneOrgs {
+			m.openOverlay(overlayCreateEmpty, "new org name")
+			return m, textinput.Blink
+		}
+		return m, nil
+	case "N":
+		if m.pane == paneOrgs && len(m.orgs) > 0 {
+			m.pendingOrg = m.orgs[m.orgCursor].Org
+			m.openOverlay(overlayNewCampaign, "new campaign name")
+			return m, textinput.Blink
+		}
+		return m, nil
+	case "x", "D":
+		if m.pane == paneOrgs && len(m.orgs) > 0 {
+			return m.beginDeleteFocused()
+		}
+		return m, nil
 	case "m":
 		if m.pane == paneMembers && len(m.members) > 0 {
 			m.openOverlay(overlayMove, "target org")
@@ -77,6 +106,22 @@ func (m orgTUIModel) updateBrowse(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	}
+	return m, nil
+}
+
+func (m orgTUIModel) beginDeleteFocused() (tea.Model, tea.Cmd) {
+	row := m.orgs[m.orgCursor]
+	if row.Org == m.fallback {
+		m.setError(camperrors.NewValidation("org", "cannot delete the fallback org", nil))
+		return m, nil
+	}
+	if row.Campaigns > 0 {
+		m.setError(camperrors.NewValidation("org",
+			fmt.Sprintf("cannot delete: %q has %d member(s)", row.Org, row.Campaigns), nil))
+		return m, nil
+	}
+	m.pendingDelete = row.Org
+	m.overlay = overlayConfirmDelete
 	return m, nil
 }
 
@@ -120,13 +165,15 @@ func (m *orgTUIModel) openOverlay(kind orgOverlay, placeholder string) {
 }
 
 func (m orgTUIModel) updateOverlay(key tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.overlay == overlayConfirmDelete {
+		return m.updateConfirmDelete(key)
+	}
 	switch key.String() {
 	case "ctrl+c":
 		m.quitting = true
 		return m, tea.Quit
 	case "esc":
-		m.overlay = overlayNone
-		m.input.Blur()
+		m.closeOverlay()
 		return m, nil
 	case "enter":
 		return m.commitOverlay()
@@ -134,6 +181,34 @@ func (m orgTUIModel) updateOverlay(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	m.input, cmd = m.input.Update(key)
 	return m, cmd
+}
+
+func (m orgTUIModel) updateConfirmDelete(key tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch key.String() {
+	case "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "esc", "n":
+		m.pendingDelete = ""
+		m.closeOverlay()
+		return m, nil
+	case "y", "enter":
+		name := m.pendingDelete
+		m.pendingDelete = ""
+		m.closeOverlay()
+		if err := m.deleteEmptyOrg(name); err != nil {
+			m.setError(err)
+		} else {
+			m.setStatus(fmt.Sprintf("deleted org %q", name))
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m *orgTUIModel) closeOverlay() {
+	m.overlay = overlayNone
+	m.input.Blur()
 }
 
 func (m orgTUIModel) commitOverlay() (tea.Model, tea.Cmd) {
@@ -163,8 +238,70 @@ func (m orgTUIModel) commitOverlay() (tea.Model, tea.Cmd) {
 		} else {
 			m.setStatus(fmt.Sprintf("created org %q with %q", value, member.Name))
 		}
+	case overlayCreateEmpty:
+		if value == "" {
+			m.setError(camperrors.NewValidation("org", "org name is required", nil))
+			return m, nil // keep overlay open
+		}
+		if err := validateOrgName(value); err != nil {
+			m.setError(err)
+			return m, nil // keep overlay open
+		}
+		existed := m.orgExists(value)
+		if err := m.createEmptyOrg(value); err != nil {
+			m.setError(err)
+			return m, nil
+		}
+		if existed {
+			m.setStatus(fmt.Sprintf("org %q already exists", value))
+		} else {
+			m.setStatus(fmt.Sprintf("created org %q", value))
+		}
+		// focus the new org if present
+		for i, o := range m.orgs {
+			if o.Org == value {
+				m.orgCursor = i
+				m.syncFocusedOrg()
+				break
+			}
+		}
+	case overlayNewCampaign:
+		if value == "" {
+			m.setError(camperrors.NewValidation("campaign", "campaign name is required", nil))
+			return m, nil
+		}
+		org := m.pendingOrg
+		m.closeOverlay()
+		m.setStatus(fmt.Sprintf("creating %q in %q...", value, org))
+		return m, createCampaignCmd(m.ctx, value, org)
 	}
-	m.overlay = overlayNone
-	m.input.Blur()
+	m.closeOverlay()
 	return m, nil
+}
+
+func (m orgTUIModel) handleCreateCampaignDone(msg createCampaignDoneMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		m.setError(msg.err)
+		return m, nil
+	}
+	if err := m.reload(); err != nil {
+		m.setError(err)
+		return m, nil
+	}
+	m.setStatus(fmt.Sprintf("created %q in %q", msg.name, msg.org))
+	// Focus the org the campaign was created into.
+	for i, o := range m.orgs {
+		if o.Org == msg.org {
+			m.orgCursor = i
+			m.syncFocusedOrg()
+			break
+		}
+	}
+	return m, nil
+}
+
+func createCampaignCmd(ctx context.Context, name, org string) tea.Cmd {
+	return func() tea.Msg {
+		return createCampaignDoneMsg{name: name, org: org, err: createCampaignInOrg(ctx, name, org)}
+	}
 }

--- a/cmd/camp/org/tui_view.go
+++ b/cmd/camp/org/tui_view.go
@@ -153,7 +153,7 @@ func (m orgTUIModel) paneStyle(p orgPane) lipgloss.Style {
 
 func (m orgTUIModel) footer() string {
 	if m.pane == paneOrgs {
-		return orgHelpStyle.Render("j/k: orgs . l: members . r: rename . q: quit")
+		return orgHelpStyle.Render("j/k: orgs . l: members . n: new org . N: new campaign . x: delete (empty) . r: rename . q: quit")
 	}
 	return orgHelpStyle.Render("j/k: members . h: orgs . m: move . c: create . d: default . q: quit")
 }
@@ -169,18 +169,34 @@ func (m orgTUIModel) statusLine() string {
 }
 
 func (m orgTUIModel) overlayView() string {
+	if m.overlay == overlayConfirmDelete {
+		prompt := fmt.Sprintf("Delete empty org %q?", m.pendingDelete)
+		box := orgTitleStyle.Render(prompt) + "\n\n" +
+			orgHelpStyle.Render("y/enter: delete . n/esc: cancel")
+		return orgPaneFocused.Render(box) + "\n"
+	}
 	var prompt string
+	var help string
 	switch m.overlay {
 	case overlayRename:
 		prompt = fmt.Sprintf("Rename org %q to:", m.orgs[m.orgCursor].Org)
+		help = "enter: confirm . esc: cancel"
 	case overlayMove:
 		prompt = fmt.Sprintf("Move %q to org:", m.members[m.memCursor].Name)
+		help = "enter: confirm . esc: cancel"
 	case overlayCreate:
 		prompt = fmt.Sprintf("Create org and add %q:", m.members[m.memCursor].Name)
+		help = "enter: confirm . esc: cancel"
+	case overlayCreateEmpty:
+		prompt = "New org name:"
+		help = "enter: create . esc: cancel"
+	case overlayNewCampaign:
+		prompt = fmt.Sprintf("New campaign in org %q:", m.pendingOrg)
+		help = "enter: create . esc: cancel"
 	}
 	box := orgTitleStyle.Render(prompt) + "\n\n" +
 		m.input.View() + "\n\n" +
 		orgMutedStyle.Render("existing orgs: "+m.orgNamesCSV()) + "\n\n" +
-		orgHelpStyle.Render("enter: confirm . esc: cancel")
+		orgHelpStyle.Render(help)
 	return orgPaneFocused.Render(box) + "\n"
 }

--- a/cmd/camp/org/views.go
+++ b/cmd/camp/org/views.go
@@ -177,9 +177,14 @@ func runOrgList(cmd *cobra.Command, _ []string) error {
 
 func computeOrgCounts(reg *config.Registry) []orgCount {
 	byOrg := make(map[string]*orgCount)
+	// Seed every persisted first-class org at zero so empty orgs appear in list.
+	for _, o := range reg.Orgs {
+		byOrg[o.Name] = &orgCount{Org: o.Name}
+	}
 	for _, c := range reg.ListAll() {
 		oc := byOrg[c.Org]
 		if oc == nil {
+			// Defensive: reconcileOrgs should prevent missing membership orgs.
 			oc = &orgCount{Org: c.Org}
 			byOrg[c.Org] = oc
 		}
@@ -240,10 +245,10 @@ func runOrgShow(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return camperrors.Wrap(err, "failed to load registry")
 	}
-	result := buildOrgShow(reg, org)
-	if result.Campaigns == 0 {
+	if !orgExists(reg, org) {
 		return camperrors.NewNotFound("org", org, nil)
 	}
+	result := buildOrgShow(reg, org)
 	if asJSON {
 		return encodeJSON(cmd.OutOrStdout(), result)
 	}

--- a/cmd/camp/org/views.go
+++ b/cmd/camp/org/views.go
@@ -129,29 +129,26 @@ func renameOrgInRegistry(reg *config.Registry, oldOrg, newOrg string) (int, erro
 	if oldOrg == newOrg {
 		return 0, camperrors.NewValidation("org", "old and new org are the same: \""+oldOrg+"\"", nil)
 	}
-	fallback := reg.FallbackOrg()
-	isFallback := oldOrg == fallback
-
-	var memberIDs []string
-	for _, c := range reg.ListAll() {
-		switch c.Org {
-		case newOrg:
-			if newOrg != oldOrg {
-				return 0, camperrors.NewValidation("org",
-					"org \""+newOrg+"\" already exists; no implicit merge", nil)
-			}
-		case oldOrg:
-			memberIDs = append(memberIDs, c.ID)
-		}
-	}
-	if len(memberIDs) == 0 && !isFallback {
+	if !orgExists(reg, oldOrg) {
 		return 0, camperrors.NewNotFound("org", oldOrg, nil)
 	}
-	for _, id := range memberIDs {
-		e := reg.Campaigns[id]
-		e.Org = newOrg
-		reg.Campaigns[id] = e
+	if orgExists(reg, newOrg) {
+		return 0, camperrors.NewValidation("org",
+			fmt.Sprintf("target org %q already exists; no implicit merge", newOrg), nil)
 	}
+
+	fallback := reg.FallbackOrg()
+	isFallback := oldOrg == fallback
+	n := 0
+	for id, c := range reg.Campaigns {
+		if c.Org != oldOrg {
+			continue
+		}
+		c.Org = newOrg
+		reg.Campaigns[id] = c
+		n++
+	}
+	renameOrgEntry(reg, oldOrg, newOrg)
 	if isFallback {
 		if newOrg == config.DefaultOrg {
 			reg.DefaultOrg = ""
@@ -159,7 +156,7 @@ func renameOrgInRegistry(reg *config.Registry, oldOrg, newOrg string) (int, erro
 			reg.DefaultOrg = newOrg
 		}
 	}
-	return len(memberIDs), nil
+	return n, nil
 }
 
 func runOrgList(cmd *cobra.Command, _ []string) error {

--- a/internal/config/register_org_test.go
+++ b/internal/config/register_org_test.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRegisterWithOrg_Table(t *testing.T) {
+	cases := []struct {
+		name     string
+		org      string
+		preSeed  []string
+		wantOrg  string // in-memory after register ("" means fallback not stored)
+		wantInOrgs string
+		wantErr  string
+	}{
+		{name: "new org", org: "obey", wantOrg: "obey", wantInOrgs: "obey"},
+		{name: "existing org", org: "obey", preSeed: []string{"obey"}, wantOrg: "obey", wantInOrgs: "obey"},
+		{name: "no flag empty org", org: "", wantOrg: "", wantInOrgs: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := NewRegistry()
+			for _, o := range tc.preSeed {
+				reg.EnsureOrg(o)
+			}
+			before := len(reg.Orgs)
+			if err := reg.RegisterWithOrg("id-1", "demo", "/tmp/demo-"+tc.name, CampaignTypeProduct, tc.org); err != nil {
+				t.Fatalf("RegisterWithOrg: %v", err)
+			}
+			got := reg.Campaigns["id-1"]
+			if got.Org != tc.wantOrg {
+				t.Fatalf("entry.Org = %q, want %q", got.Org, tc.wantOrg)
+			}
+			if tc.wantInOrgs != "" {
+				count := 0
+				for _, o := range reg.Orgs {
+					if o.Name == tc.wantInOrgs {
+						count++
+					}
+				}
+				if count != 1 {
+					t.Fatalf("Orgs entries for %q = %d, want 1 (no dups); Orgs=%v", tc.wantInOrgs, count, reg.Orgs)
+				}
+			}
+			if tc.org == "" && len(reg.Orgs) != before {
+				t.Fatalf("no-flag Register should not grow Orgs; before=%d after=%d", before, len(reg.Orgs))
+			}
+		})
+	}
+}
+
+func TestRegisterWithOrg_PersistsThroughSaveLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+	t.Setenv("CAMP_REGISTRY_PATH", path)
+
+	ctx := context.Background()
+	if err := UpdateRegistry(ctx, func(r *Registry) error {
+		return r.RegisterWithOrg("id-1", "demo", "/tmp/demo", CampaignTypeProduct, "obey")
+	}); err != nil {
+		t.Fatalf("UpdateRegistry: %v", err)
+	}
+
+	reg, err := LoadRegistry(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, ok := reg.Campaigns["id-1"]
+	if !ok {
+		t.Fatal("campaign missing")
+	}
+	if c.Org != "obey" {
+		t.Fatalf("Org = %q, want obey", c.Org)
+	}
+	if !orgPresent(reg, "obey") {
+		t.Fatal("obey missing from reg.Orgs after load")
+	}
+}
+
+func TestValidateOrgName_ForCreateFlag(t *testing.T) {
+	// Mirrors the create/init early validation gate.
+	if err := ValidateName("org", "Bad Name"); err == nil {
+		t.Fatal("expected invalid name error")
+	} else if !strings.Contains(strings.ToLower(err.Error()), "invalid") &&
+		!strings.Contains(err.Error(), "org") {
+		// ValidateName error should be actionable; just ensure non-nil.
+		t.Logf("validation error: %v", err)
+	}
+	if err := ValidateName("org", "obey"); err != nil {
+		t.Fatalf("valid name rejected: %v", err)
+	}
+}
+
+func TestRegisterWithOrg_InvalidDoesNotWriteWhenCreateValidates(t *testing.T) {
+	// Simulate create early-exit: bad name never reaches Register.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+	t.Setenv("CAMP_REGISTRY_PATH", path)
+	_ = os.WriteFile(path, []byte(`{"version":3,"campaigns":{}}`), 0o644)
+
+	if err := ValidateName("org", "Bad Name"); err == nil {
+		t.Fatal("expected validation error")
+	}
+	reg, err := LoadRegistry(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reg.Campaigns) != 0 {
+		t.Fatalf("expected no campaigns, got %d", len(reg.Campaigns))
+	}
+}

--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -37,6 +37,10 @@ func LoadRegistry(ctx context.Context) (*Registry, error) {
 	reg := NewRegistry()
 	reg.Version = file.Version
 	reg.DefaultOrg = file.DefaultOrg
+	reg.Orgs = make([]OrgEntry, 0, len(file.Orgs))
+	for _, o := range file.Orgs {
+		reg.Orgs = append(reg.Orgs, OrgEntry{Name: o.Name})
+	}
 	fallback := reg.FallbackOrg()
 	for id, entry := range file.Campaigns {
 		c := RegisteredCampaign{
@@ -58,9 +62,33 @@ func LoadRegistry(ctx context.Context) (*Registry, error) {
 		reg.Version = RegistryVersion
 	}
 
+	reg.reconcileOrgs()
 	reg.rebuildPathIndex()
 
 	return reg, nil
+}
+
+// reconcileOrgs ensures reg.Orgs contains every persisted org, every org named
+// by a campaign, and the fallback org, deduped by name. Idempotent.
+func (r *Registry) reconcileOrgs() {
+	seen := make(map[string]bool)
+	ordered := make([]OrgEntry, 0, len(r.Orgs)+len(r.Campaigns)+1)
+	add := func(name string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		ordered = append(ordered, OrgEntry{Name: name})
+	}
+	add(r.FallbackOrg()) // fallback always present (synthesized, Q12)
+	for _, o := range r.Orgs {
+		add(o.Name)
+	}
+	for _, c := range r.Campaigns {
+		// c.Org is already normalized to the fallback if empty.
+		add(c.Org)
+	}
+	r.Orgs = ordered
 }
 
 // SaveRegistry saves the campaign registry to ~/.obey/campaign/registry.json.

--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -188,6 +188,12 @@ var ErrEmptyID = errors.New("campaign ID cannot be empty")
 // The campaign is keyed by its ID for uniqueness.
 // Returns an error if the path is already registered to a different campaign.
 func (r *Registry) Register(id, name, path string, campaignType CampaignType) error {
+	return r.RegisterWithOrg(id, name, path, campaignType, "")
+}
+
+// RegisterWithOrg registers a campaign and assigns it to org when non-empty.
+// The org is ensured in r.Orgs in the same mutation (created if new).
+func (r *Registry) RegisterWithOrg(id, name, path string, campaignType CampaignType, org string) error {
 	// Validate: ID must not be empty
 	if id == "" {
 		return ErrEmptyID
@@ -220,12 +226,37 @@ func (r *Registry) Register(id, name, path string, campaignType CampaignType) er
 		entry.Org = existing.Org
 		entry.Tags = existing.Tags
 		entry.Status = existing.Status
+		// Explicit org on re-register overrides prior membership.
+		if org != "" {
+			entry.Org = org
+		}
+	} else if org != "" {
+		entry.Org = org
+	}
+
+	// Persist the org in the first-class set when membership is explicit.
+	// Empty Org still normalizes to the fallback on load (not stored).
+	if entry.Org != "" {
+		r.EnsureOrg(entry.Org)
 	}
 
 	r.Campaigns[id] = entry
 	r.pathIndex[path] = id
 
 	return nil
+}
+
+// EnsureOrg appends name to r.Orgs if absent. Idempotent.
+func (r *Registry) EnsureOrg(name string) {
+	if name == "" {
+		return
+	}
+	for _, o := range r.Orgs {
+		if o.Name == name {
+			return
+		}
+	}
+	r.Orgs = append(r.Orgs, OrgEntry{Name: name})
 }
 
 // UnregisterByID removes a campaign from the registry by ID.

--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -95,6 +95,14 @@ func SaveRegistry(ctx context.Context, reg *Registry) error {
 func denormalizeForPersist(reg *Registry) *Registry {
 	fallback := reg.FallbackOrg()
 	out := *reg
+	// Fallback is synthesized on load, not persisted (Q12).
+	out.Orgs = make([]OrgEntry, 0, len(reg.Orgs))
+	for _, o := range reg.Orgs {
+		if o.Name == fallback {
+			continue
+		}
+		out.Orgs = append(out.Orgs, o)
+	}
 	out.Campaigns = make(map[string]RegisteredCampaign, len(reg.Campaigns))
 	for id, c := range reg.Campaigns {
 		if c.Org == fallback {

--- a/internal/config/registry_orgs_test.go
+++ b/internal/config/registry_orgs_test.go
@@ -1,0 +1,240 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func withTempRegistryPath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+	t.Setenv("CAMP_REGISTRY_PATH", path)
+	return path
+}
+
+func orgNamesSorted(reg *Registry) []string {
+	names := make([]string, 0, len(reg.Orgs))
+	for _, o := range reg.Orgs {
+		names = append(names, o.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func orgPresent(reg *Registry, name string) bool {
+	for _, o := range reg.Orgs {
+		if o.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRegistryPersistsEmptyOrg(t *testing.T) {
+	withTempRegistryPath(t)
+	ctx := context.Background()
+
+	if err := UpdateRegistry(ctx, func(r *Registry) error {
+		if err := r.Register("camp-1", "alpha", "/tmp/alpha", CampaignTypeProduct); err != nil {
+			return err
+		}
+		// Zero-member non-fallback org must survive the read/write asymmetry trap.
+		r.Orgs = append(r.Orgs, OrgEntry{Name: "obey"})
+		return nil
+	}); err != nil {
+		t.Fatalf("UpdateRegistry: %v", err)
+	}
+
+	reg, err := LoadRegistry(ctx)
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	if !orgPresent(reg, "obey") {
+		t.Fatalf("empty org %q missing after round-trip; Orgs=%v", "obey", orgNamesSorted(reg))
+	}
+}
+
+func TestRegistryFallbackNotPersistedButPresentOnLoad(t *testing.T) {
+	path := withTempRegistryPath(t)
+	ctx := context.Background()
+
+	reg := NewRegistry()
+	if err := reg.Register("camp-1", "alpha", "/tmp/alpha", CampaignTypeProduct); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	// Include fallback and a real org in memory before save.
+	reg.Orgs = []OrgEntry{{Name: reg.FallbackOrg()}, {Name: "obey"}}
+	if err := SaveRegistry(ctx, reg); err != nil {
+		t.Fatalf("SaveRegistry: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read disk: %v", err)
+	}
+	var disk struct {
+		Orgs []OrgEntry `json:"orgs"`
+	}
+	if err := json.Unmarshal(raw, &disk); err != nil {
+		t.Fatalf("unmarshal disk: %v", err)
+	}
+	for _, o := range disk.Orgs {
+		if o.Name == DefaultOrg {
+			t.Fatalf("fallback %q must not appear in on-disk orgs: %v", DefaultOrg, disk.Orgs)
+		}
+	}
+	if !orgPresentOnDisk(disk.Orgs, "obey") {
+		t.Fatalf("expected obey on disk, got %v", disk.Orgs)
+	}
+
+	loaded, err := LoadRegistry(ctx)
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	if !orgPresent(loaded, DefaultOrg) {
+		t.Fatalf("fallback missing after load: %v", orgNamesSorted(loaded))
+	}
+	if !orgPresent(loaded, "obey") {
+		t.Fatalf("obey missing after load: %v", orgNamesSorted(loaded))
+	}
+}
+
+func orgPresentOnDisk(orgs []OrgEntry, name string) bool {
+	for _, o := range orgs {
+		if o.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRegistryOrgsLoadSaveIdempotent(t *testing.T) {
+	withTempRegistryPath(t)
+	ctx := context.Background()
+
+	if err := UpdateRegistry(ctx, func(r *Registry) error {
+		if err := r.Register("camp-1", "alpha", "/tmp/alpha", CampaignTypeProduct); err != nil {
+			return err
+		}
+		entry := r.Campaigns["camp-1"]
+		entry.Org = "obey"
+		r.Campaigns["camp-1"] = entry
+		r.Orgs = []OrgEntry{{Name: "obey"}, {Name: "empty-co"}}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	first, err := LoadRegistry(ctx)
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	firstNames := orgNamesSorted(first)
+
+	if err := SaveRegistry(ctx, first); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	second, err := LoadRegistry(ctx)
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	if !reflect.DeepEqual(firstNames, orgNamesSorted(second)) {
+		t.Fatalf("orgs not idempotent: first=%v second=%v", firstNames, orgNamesSorted(second))
+	}
+
+	if err := SaveRegistry(ctx, second); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+	third, err := LoadRegistry(ctx)
+	if err != nil {
+		t.Fatalf("third load: %v", err)
+	}
+	if !reflect.DeepEqual(firstNames, orgNamesSorted(third)) {
+		t.Fatalf("orgs grew/changed on third cycle: first=%v third=%v", firstNames, orgNamesSorted(third))
+	}
+}
+
+func TestRegistryV2BackfillOrgs(t *testing.T) {
+	path := withTempRegistryPath(t)
+	ctx := context.Background()
+
+	// Bypass SaveRegistry: legacy v2 file with no top-level orgs key.
+	v2 := []byte(`{
+  "version": 2,
+  "campaigns": {
+    "aaaa": {"name": "one", "path": "/tmp/one", "org": "obey"},
+    "bbbb": {"name": "two", "path": "/tmp/two"},
+    "cccc": {"name": "three", "path": "/tmp/three", "org": "client-acme"}
+  }
+}`)
+	if err := os.WriteFile(path, v2, 0o644); err != nil {
+		t.Fatalf("write v2 fixture: %v", err)
+	}
+
+	reg, err := LoadRegistry(ctx)
+	if err != nil {
+		t.Fatalf("LoadRegistry v2: %v", err)
+	}
+	got := orgNamesSorted(reg)
+	want := []string{"client-acme", DefaultOrg, "obey"}
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("v2 backfill Orgs = %v, want %v", got, want)
+	}
+
+	if err := SaveRegistry(ctx, reg); err != nil {
+		t.Fatalf("SaveRegistry: %v", err)
+	}
+	// Save stamps current version.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after save: %v", err)
+	}
+	var disk struct {
+		Version int `json:"version"`
+	}
+	if err := json.Unmarshal(raw, &disk); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if disk.Version != RegistryVersion {
+		t.Fatalf("version after save = %d, want %d", disk.Version, RegistryVersion)
+	}
+	if RegistryVersion != 3 {
+		t.Fatalf("RegistryVersion = %d, want 3", RegistryVersion)
+	}
+
+	reloaded, err := LoadRegistry(ctx)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !reflect.DeepEqual(got, orgNamesSorted(reloaded)) {
+		t.Fatalf("after v2 save reload Orgs = %v, want %v", orgNamesSorted(reloaded), got)
+	}
+}
+
+func TestRegistryOrgsRoundTripFailsWithoutFileField(t *testing.T) {
+	// Documents the asymmetry trap: marshaling config.Registry includes Orgs,
+	// but LoadRegistry reads through registryfile.File. This test exercises the
+	// real Load path and asserts empty orgs survive — which requires Orgs on both.
+	withTempRegistryPath(t)
+	ctx := context.Background()
+
+	reg := NewRegistry()
+	reg.Orgs = []OrgEntry{{Name: "lonely"}}
+	if err := SaveRegistry(ctx, reg); err != nil {
+		t.Fatalf("SaveRegistry: %v", err)
+	}
+	loaded, err := LoadRegistry(ctx)
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	if !orgPresent(loaded, "lonely") {
+		t.Fatal("empty org lost on load — Orgs missing from read or write path")
+	}
+}

--- a/internal/config/registryfile/registryfile.go
+++ b/internal/config/registryfile/registryfile.go
@@ -11,7 +11,14 @@ import (
 type File struct {
 	Version    int                 `json:"version"`
 	DefaultOrg string              `json:"default_org,omitempty"`
+	Orgs       []OrgEntry          `json:"orgs,omitempty"`
 	Campaigns  map[string]Campaign `json:"campaigns"`
+}
+
+// OrgEntry is a persisted org in the registry file. Mirrors config.OrgEntry
+// so Load can deserialize orgs without importing config (import cycle).
+type OrgEntry struct {
+	Name string `json:"name"`
 }
 
 // Campaign is the minimal persisted registry campaign shape.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -319,7 +319,7 @@ type GlobalConfig struct {
 }
 
 // RegistryVersion is the current registry format version.
-const RegistryVersion = 2
+const RegistryVersion = 3
 
 // Registry represents ~/.obey/campaign/registry.json for tracking campaigns.
 type Registry struct {
@@ -327,6 +327,10 @@ type Registry struct {
 	Version int `json:"version" yaml:"version,omitempty"`
 
 	DefaultOrg string `json:"default_org,omitempty" yaml:"default_org,omitempty"`
+
+	// Orgs is the persisted set of orgs. The fallback org is synthesized on load,
+	// not stored here (see LoadRegistry reconciliation).
+	Orgs []OrgEntry `json:"orgs,omitempty" yaml:"orgs,omitempty"`
 
 	// Campaigns maps campaign IDs to their registration info.
 	Campaigns map[string]RegisteredCampaign `json:"campaigns" yaml:"campaigns,omitempty"`
@@ -340,6 +344,12 @@ func (r *Registry) FallbackOrg() string {
 		return DefaultOrg
 	}
 	return r.DefaultOrg
+}
+
+// OrgEntry is a persisted org. Membership stays a field on each campaign; this
+// records the org's existence so an org with zero members survives a round-trip.
+type OrgEntry struct {
+	Name string `json:"name" yaml:"name"`
 }
 
 // RegisteredCampaign holds information about a registered campaign.

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -50,6 +50,9 @@ type InitOptions struct {
 	Repair bool
 	// SkipSkills disables projecting campaign skills into tool directories.
 	SkipSkills bool
+	// Org assigns the new campaign to this org on register (created if new).
+	// Empty leaves the campaign in the fallback org.
+	Org string
 	// RepairPlan is the pre-computed repair plan (set by the caller after preview).
 	// When set, Init uses the merged jumps config from the plan instead of defaults.
 	RepairPlan *RepairPlan
@@ -435,7 +438,7 @@ workitems/current.yaml
 	// Register in global registry
 	if !opts.NoRegister && !opts.DryRun {
 		if err := config.UpdateRegistry(ctx, func(reg *config.Registry) error {
-			return reg.Register(campaignID, name, absDir, opts.Type)
+			return reg.RegisterWithOrg(campaignID, name, absDir, opts.Type, opts.Org)
 		}); err != nil {
 			return nil, camperrors.Wrap(err, "failed to register campaign")
 		}


### PR DESCRIPTION
## Summary

Make orgs a first-class, machine-wide concept in camp (festival CF0002).

- **Registry v3:** persist `orgs` on both `config.Registry` and `registryfile.File`, with load-time reconcile/v2 backfill and fallback synthesis (not written to disk).
- **CLI:** `camp org create --empty`, `camp org delete` (empty-only / `--force` reassign), empty-aware `list` / `show` / `rename`.
- **Create/init:** `--org` on `camp create` and `camp init` via atomic `RegisterWithOrg` + `EnsureOrg`.
- **TUI:** `n` create empty org, `x`/`D` confirm-delete empty org, `N` new campaign into focused org (async create seam).

## Test plan

- [x] `just build-camp` green
- [x] Unit tests for registry round-trip, v2 backfill, create/delete, list/show/rename, create `--org` validation
- [x] Org TUI model tests for empty create, delete guards/confirm, new-campaign seam
- [ ] CI green on this PR
- [ ] Manual smoke: `camp org create foo --empty` → `list`/`show`/`rename`/`delete`
- [ ] Manual smoke: `camp create demo --org obey` (or dry-run) assigns org
- [ ] Optional: TUI theme screenshots for experience bar (PR attach)

Festival: `camp-first-class-orgs-CF0002` (`projects/worktrees/camp/first-class-orgs`)