### PR TITLE
MM0001 follow-ups: identity ~ expansion + camp machine diagnose (stale ControlMaster)

### DIFF
--- a/cmd/camp/machine.go
+++ b/cmd/camp/machine.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/machines"
+	"github.com/Obedience-Corp/camp/internal/remote"
 	"github.com/Obedience-Corp/camp/internal/ui"
 )
 
@@ -58,11 +59,17 @@ var machineCmd = &cobra.Command{
 and 'camp list --remote'.
 
 Machines are stored in ~/.obey/machines.yaml. The current machine is always
-implicitly available as "local" and is never written to that file.`,
+implicitly available as "local" and is never written to that file.
+
+'camp machine diagnose' inspects the per-machine ssh ControlMaster sockets and
+can clear a stale one (the state a sleep or network flap can leave behind, which
+would otherwise hang the next hop until ControlPersist expires).`,
 	Example: `  camp machine list
   camp machine add devbox --host devbox.tailnet.ts.net --auth tailscale-ssh
   camp machine add --discover
-  camp machine remove devbox`,
+  camp machine remove devbox
+  camp machine diagnose
+  camp machine diagnose devbox --reset`,
 }
 
 var machineListCmd = &cobra.Command{
@@ -104,15 +111,40 @@ var machineRemoveCmd = &cobra.Command{
 	RunE:    runMachineRemove,
 }
 
+var machineDiagnoseCmd = &cobra.Command{
+	Use:   "diagnose [id]",
+	Short: "Inspect (and optionally clear) ssh ControlMaster sockets",
+	Long: `Report the ssh ControlMaster multiplex socket state for each configured machine
+(or one machine if an id is given):
+
+  none   no socket — the next hop opens a fresh master
+  live   socket present and the master answers 'ssh -O check'
+  stale  socket present but the master no longer answers
+
+A stale socket is what a sleep or network flap can leave behind; until it is
+removed (or ControlPersist expires) the next 'camp switch machine:...' or
+'camp list --remote' hop to that machine can hang. Pass --reset to tear down
+stale sockets so the next hop reconnects cleanly. Live and absent sockets are
+left untouched.`,
+	Example: `  camp machine diagnose
+  camp machine diagnose devbox
+  camp machine diagnose --reset
+  camp machine diagnose devbox --reset --json`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runMachineDiagnose,
+}
+
 var (
-	machineListJSON    bool
-	machineAddHost     string
-	machineAddLabel    string
-	machineAddAuth     string
-	machineAddUser     string
-	machineAddIdentity string
-	machineAddDiscover bool
-	machineAddYes      bool
+	machineListJSON      bool
+	machineAddHost       string
+	machineAddLabel      string
+	machineAddAuth       string
+	machineAddUser       string
+	machineAddIdentity   string
+	machineAddDiscover   bool
+	machineAddYes        bool
+	machineDiagnoseReset bool
+	machineDiagnoseJSON  bool
 )
 
 func init() {
@@ -121,8 +153,12 @@ func init() {
 	machineCmd.AddCommand(machineListCmd)
 	machineCmd.AddCommand(machineAddCmd)
 	machineCmd.AddCommand(machineRemoveCmd)
+	machineCmd.AddCommand(machineDiagnoseCmd)
 
 	machineListCmd.Flags().BoolVar(&machineListJSON, "json", false, "Output as JSON")
+
+	machineDiagnoseCmd.Flags().BoolVar(&machineDiagnoseReset, "reset", false, "Tear down stale ControlMaster sockets so the next hop reconnects")
+	machineDiagnoseCmd.Flags().BoolVar(&machineDiagnoseJSON, "json", false, "Output as JSON")
 
 	machineAddCmd.Flags().StringVar(&machineAddHost, "host", "", "SSH host or Tailscale MagicDNS name (required unless --discover)")
 	machineAddCmd.Flags().StringVar(&machineAddLabel, "label", "", "Human-readable label")
@@ -248,6 +284,113 @@ func runMachineRemove(cmd *cobra.Command, args []string) error {
 	}
 	_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s machine %q removed\n", ui.SuccessIcon(), id)
 	return err
+}
+
+// machineDiagnoseRow is one machine's ControlMaster status in
+// `camp machine diagnose --json`. Reset is true when --reset cleared a stale
+// socket for this machine on this run.
+type machineDiagnoseRow struct {
+	ID     string `json:"id"`
+	Socket string `json:"socket"`
+	State  string `json:"state"`
+	Reset  bool   `json:"reset"`
+}
+
+func runMachineDiagnose(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	mf, err := machines.Load()
+	if err != nil {
+		return err
+	}
+
+	targets := mf.Machines
+	if len(args) == 1 {
+		id := args[0]
+		if id == machines.LocalMachineID {
+			return camperrors.New(`"local" is this machine and has no ControlMaster socket`)
+		}
+		found := false
+		for _, m := range mf.Machines {
+			if m.ID == id {
+				targets = []machines.Machine{m}
+				found = true
+				break
+			}
+		}
+		if !found {
+			return camperrors.New(fmt.Sprintf("unknown machine %q", id))
+		}
+	}
+
+	rows := make([]machineDiagnoseRow, 0, len(targets))
+	for i := range targets {
+		m := &targets[i]
+		d := remote.CheckControlMaster(ctx, m)
+		row := machineDiagnoseRow{ID: m.ID, Socket: d.Socket, State: string(d.State)}
+		if machineDiagnoseReset && d.State == remote.ControlStale {
+			if err := remote.ResetControlMaster(ctx, m); err != nil {
+				return err
+			}
+			row.State = string(remote.ControlNone)
+			row.Reset = true
+		}
+		rows = append(rows, row)
+	}
+
+	if machineDiagnoseJSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(struct {
+			Machines []machineDiagnoseRow `json:"machines"`
+		}{Machines: rows})
+	}
+	return renderMachineDiagnoseTable(cmd.OutOrStdout(), rows)
+}
+
+func renderMachineDiagnoseTable(w io.Writer, rows []machineDiagnoseRow) error {
+	if len(rows) == 0 {
+		_, err := fmt.Fprintln(w, ui.Dim("No machines configured; nothing to diagnose."))
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", ui.Label("ID"), ui.Label("STATE"), ui.Label("SOCKET")); err != nil {
+		return err
+	}
+	reset := 0
+	for _, r := range rows {
+		state := r.State
+		if r.Reset {
+			state = r.State + " (was stale, cleared)"
+			reset++
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", ui.Label(r.ID), state, ui.Dim(r.Socket)); err != nil {
+			return err
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	if !machineDiagnoseReset && machineDiagnoseHasStale(rows) {
+		if _, err := fmt.Fprintln(w, ui.Dim("Stale socket(s) found. Run 'camp machine diagnose --reset' to clear them.")); err != nil {
+			return err
+		}
+	}
+	if machineDiagnoseReset {
+		if _, err := fmt.Fprintln(w, ui.Dim(ui.CountLabel(reset, "stale socket cleared", "stale sockets cleared"))); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func machineDiagnoseHasStale(rows []machineDiagnoseRow) bool {
+	for _, r := range rows {
+		if r.State == string(remote.ControlStale) {
+			return true
+		}
+	}
+	return false
 }
 
 // validateMachineID rejects the reserved "local" id and enforces the same

--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -30,6 +30,7 @@ var manifestAgentAllowedReasons = map[string]string{
 	"intent show":         "Read-only intent detail",
 	"log":                 "Read-only git log",
 	"machine add":         "Explicit id/host/auth args (or --discover with --yes/an id) are non-interactive",
+	"machine diagnose":    "Read path (socket status) is safe; never pass --reset from an agent",
 	"machine list":        "Read-only listing of ~/.obey/machines.yaml",
 	"machine remove":      "Non-interactive removal with explicit id argument",
 	"project list":        "Read-only project listing",

--- a/docs/cli-reference/camp.md
+++ b/docs/cli-reference/camp.md
@@ -64,6 +64,7 @@ camp [flags]
 * [camp lifecycle](camp_lifecycle.md)	 - Manage campaign lifecycle status
 * [camp list](camp_list.md)	 - List all registered campaigns
 * [camp log](camp_log.md)	 - Show git log of the campaign
+* [camp machine](camp_machine.md)	 - Manage remote machines (~/.obey/machines.yaml)
 * [camp move](camp_move.md)	 - Move a file or directory within the campaign
 * [camp org](camp_org.md)	 - Group campaigns into orgs
 * [camp pin](camp_pin.md)	 - Pin a directory

--- a/docs/cli-reference/camp_list.md
+++ b/docs/cli-reference/camp_list.md
@@ -50,6 +50,7 @@ camp list [flags]
       --json             Output as JSON (shorthand for --format json)
       --no-group         Suppress org grouping
       --org string       Only campaigns in this org
+      --remote           Also list campaigns on machines in ~/.obey/machines.yaml (ssh)
   -s, --sort string      Sort by (name, accessed, type, org) (default "accessed")
       --status string    Only campaigns in this status (active, inactive, reference)
       --tag strings      Only campaigns carrying this tag (repeat for AND)

--- a/docs/cli-reference/camp_machine.md
+++ b/docs/cli-reference/camp_machine.md
@@ -1,0 +1,46 @@
+## camp machine
+
+Manage remote machines (~/.obey/machines.yaml)
+
+### Synopsis
+
+Manage the fleet of remote machines camp can reach for 'camp switch machine:campaign'
+and 'camp list --remote'.
+
+Machines are stored in ~/.obey/machines.yaml. The current machine is always
+implicitly available as "local" and is never written to that file.
+
+'camp machine diagnose' inspects the per-machine ssh ControlMaster sockets and
+can clear a stale one (the state a sleep or network flap can leave behind, which
+would otherwise hang the next hop until ControlPersist expires).
+
+### Examples
+
+```
+  camp machine list
+  camp machine add devbox --host devbox.tailnet.ts.net --auth tailscale-ssh
+  camp machine add --discover
+  camp machine remove devbox
+  camp machine diagnose
+  camp machine diagnose devbox --reset
+```
+
+### Options
+
+```
+  -h, --help   help for machine
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
+* [camp machine add](camp_machine_add.md)	 - Add or update a machine
+* [camp machine diagnose](camp_machine_diagnose.md)	 - Inspect (and optionally clear) ssh ControlMaster sockets
+* [camp machine list](camp_machine_list.md)	 - List configured machines
+* [camp machine remove](camp_machine_remove.md)	 - Remove a machine

--- a/docs/cli-reference/camp_machine_add.md
+++ b/docs/cli-reference/camp_machine_add.md
@@ -1,0 +1,52 @@
+## camp machine add
+
+Add or update a machine
+
+### Synopsis
+
+Add a machine to ~/.obey/machines.yaml, or update it if the id already exists
+(idempotent on id: a second 'add' with the same id replaces the entry rather
+than duplicating it).
+
+With --discover, camp runs 'tailscale status --json' and lets you pick a
+tailnet device instead of specifying --host/--auth by hand; the chosen device
+is saved with auth_method=tailscale-ssh. Pass an id positionally with
+--discover to select that device by its derived id non-interactively (skips
+the picker), or use --yes to take the first discovered device.
+
+```
+camp machine add [id] [flags]
+```
+
+### Examples
+
+```
+  camp machine add devbox --host devbox.tailnet.ts.net --auth tailscale-ssh
+  camp machine add buildbox --host 10.0.0.12 --auth ssh-agent --user ci
+  camp machine add --discover
+  camp machine add devbox --discover
+  camp machine add --discover --yes
+```
+
+### Options
+
+```
+      --auth string       Auth method: tailscale-ssh, ssh-agent, ssh-password (default "ssh-agent")
+      --discover          Discover devices via 'tailscale status --json' and pick one
+  -h, --help              help for add
+      --host string       SSH host or Tailscale MagicDNS name (required unless --discover)
+      --identity string   Path to SSH identity file
+      --label string      Human-readable label
+      --user string       SSH user
+      --yes               With --discover, take the first discovered device non-interactively
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp machine](camp_machine.md)	 - Manage remote machines (~/.obey/machines.yaml)

--- a/docs/cli-reference/camp_machine_diagnose.md
+++ b/docs/cli-reference/camp_machine_diagnose.md
@@ -1,0 +1,49 @@
+## camp machine diagnose
+
+Inspect (and optionally clear) ssh ControlMaster sockets
+
+### Synopsis
+
+Report the ssh ControlMaster multiplex socket state for each configured machine
+(or one machine if an id is given):
+
+  none   no socket — the next hop opens a fresh master
+  live   socket present and the master answers 'ssh -O check'
+  stale  socket present but the master no longer answers
+
+A stale socket is what a sleep or network flap can leave behind; until it is
+removed (or ControlPersist expires) the next 'camp switch machine:...' or
+'camp list --remote' hop to that machine can hang. Pass --reset to tear down
+stale sockets so the next hop reconnects cleanly. Live and absent sockets are
+left untouched.
+
+```
+camp machine diagnose [id] [flags]
+```
+
+### Examples
+
+```
+  camp machine diagnose
+  camp machine diagnose devbox
+  camp machine diagnose --reset
+  camp machine diagnose devbox --reset --json
+```
+
+### Options
+
+```
+  -h, --help    help for diagnose
+      --json    Output as JSON
+      --reset   Tear down stale ControlMaster sockets so the next hop reconnects
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp machine](camp_machine.md)	 - Manage remote machines (~/.obey/machines.yaml)

--- a/docs/cli-reference/camp_machine_list.md
+++ b/docs/cli-reference/camp_machine_list.md
@@ -1,0 +1,29 @@
+## camp machine list
+
+List configured machines
+
+### Synopsis
+
+List every machine in ~/.obey/machines.yaml, plus the implicit "local" machine
+(this machine, never persisted to the file).
+
+```
+camp machine list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+      --json   Output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp machine](camp_machine.md)	 - Manage remote machines (~/.obey/machines.yaml)

--- a/docs/cli-reference/camp_machine_remove.md
+++ b/docs/cli-reference/camp_machine_remove.md
@@ -1,0 +1,27 @@
+## camp machine remove
+
+Remove a machine
+
+### Synopsis
+
+Remove a machine from ~/.obey/machines.yaml. Removing "local" or an unknown id is an error.
+
+```
+camp machine remove <id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for remove
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp machine](camp_machine.md)	 - Manage remote machines (~/.obey/machines.yaml)

--- a/internal/remote/ssh.go
+++ b/internal/remote/ssh.go
@@ -35,12 +35,39 @@ func Target(m *machines.Machine) string {
 // agent/key case: BatchMode=yes (never prompt), plus IdentitiesOnly and -i when
 // an identity file is configured. Password auth is rejected upstream by
 // EnsureKeyAuth, so its interactive-prompt args are never emitted.
+//
+// The identity path is tilde-expanded here: OpenSSH's IdentityFile config
+// directive expands a leading ~, but whether ssh expands ~ in a -i argument is
+// client- and platform-dependent, so camp resolves it to an absolute path
+// itself. That makes `camp machine add --identity '~/.ssh/id'` behave the way
+// users expect from ssh_config regardless of the ssh build, and keeps the path
+// camp hands off unambiguous.
 func authArgs(m *machines.Machine) []string {
 	args := []string{"-o", "BatchMode=yes"}
 	if m.IdentityFile != "" {
-		args = append(args, "-o", "IdentitiesOnly=yes", "-i", m.IdentityFile)
+		args = append(args, "-o", "IdentitiesOnly=yes", "-i", expandTilde(m.IdentityFile))
 	}
 	return args
+}
+
+// expandTilde resolves a leading ~ or ~/ to the current user's home directory,
+// matching OpenSSH's IdentityFile expansion. A ~otheruser/ prefix is left
+// untouched for ssh to resolve, and a path with no leading tilde (including one
+// where ~ appears mid-path) is returned unchanged. If the home directory cannot
+// be determined, the original path is returned so ssh still sees something.
+func expandTilde(path string) string {
+	if path == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+		return path
+	}
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, path[len("~/"):])
+		}
+	}
+	return path
 }
 
 // Opts returns the ssh option args (excluding the target) for a command on m.
@@ -60,15 +87,99 @@ func Opts(m *machines.Machine) []string {
 	return append(opts, authArgs(m)...)
 }
 
-// controlPath returns the per-machine ssh ControlMaster socket path under
-// ~/.obey/ssh-ctl and best-effort-creates the directory so ControlMaster=auto can
-// bind the socket. A short, per-id name keeps the path under the OS socket-length
-// limit for typical home directories.
-func controlPath(m *machines.Machine) string {
+// controlDir is ~/.obey/ssh-ctl, the directory holding one ControlMaster socket
+// per machine.
+func controlDir() string {
 	home, _ := os.UserHomeDir()
-	dir := filepath.Join(home, ".obey", "ssh-ctl")
-	_ = os.MkdirAll(dir, 0o700)
-	return filepath.Join(dir, m.ID+".sock")
+	return filepath.Join(home, ".obey", "ssh-ctl")
+}
+
+// ControlSocketPath returns the per-machine ssh ControlMaster socket path under
+// ~/.obey/ssh-ctl without creating anything. A short, per-id name keeps the path
+// under the OS socket-length limit for typical home directories. Exposed so
+// diagnostics can inspect and clear a machine's multiplex socket.
+func ControlSocketPath(m *machines.Machine) string {
+	return filepath.Join(controlDir(), m.ID+".sock")
+}
+
+// controlPath returns the machine's ControlMaster socket path and
+// best-effort-creates ~/.obey/ssh-ctl so ControlMaster=auto can bind the socket.
+func controlPath(m *machines.Machine) string {
+	_ = os.MkdirAll(controlDir(), 0o700)
+	return ControlSocketPath(m)
+}
+
+// ControlMasterState describes a machine's ssh ControlMaster multiplex socket.
+type ControlMasterState string
+
+const (
+	// ControlNone means no socket file exists — the next hop opens a fresh master.
+	ControlNone ControlMasterState = "none"
+	// ControlLive means the socket exists and its master answers `ssh -O check`.
+	ControlLive ControlMasterState = "live"
+	// ControlStale means the socket exists but the master no longer answers —
+	// the state a sleep/network flap leaves behind, which can hang later hops
+	// until ControlPersist expires or the socket is removed.
+	ControlStale ControlMasterState = "stale"
+)
+
+// SocketDiagnosis is one machine's ControlMaster socket status.
+type SocketDiagnosis struct {
+	MachineID string             `json:"machine_id"`
+	Socket    string             `json:"socket"`
+	State     ControlMasterState `json:"state"`
+}
+
+// controlProbeTimeout bounds the local `ssh -O check`/`-O exit` control
+// operations. They talk only to the local multiplex socket, so they are fast or
+// they are hung; either way we do not wait long.
+const controlProbeTimeout = 3 * time.Second
+
+// CheckControlMaster reports the state of m's ControlMaster socket. A missing
+// socket is ControlNone; a present socket is probed with `ssh -O check` and
+// classified ControlLive or ControlStale. It never opens a new connection.
+func CheckControlMaster(ctx context.Context, m *machines.Machine) SocketDiagnosis {
+	d := SocketDiagnosis{MachineID: m.ID, Socket: ControlSocketPath(m), State: ControlNone}
+	fi, err := os.Stat(d.Socket)
+	if err != nil || fi.Mode()&os.ModeSocket == 0 {
+		return d
+	}
+	if controlMasterAlive(ctx, m) {
+		d.State = ControlLive
+	} else {
+		d.State = ControlStale
+	}
+	return d
+}
+
+// controlMasterAlive returns true when `ssh -O check` reports a running master
+// for m. It uses the same per-machine opts (and thus ControlPath) as a real hop,
+// and does not fall back to opening a connection.
+func controlMasterAlive(ctx context.Context, m *machines.Machine) bool {
+	ctx, cancel := context.WithTimeout(ctx, controlProbeTimeout)
+	defer cancel()
+	args := append(append([]string{}, Opts(m)...), "-O", "check", Target(m))
+	return exec.CommandContext(ctx, "ssh", args...).Run() == nil
+}
+
+// ResetControlMaster tears down m's ControlMaster socket: it asks the master to
+// exit (`ssh -O exit`, best effort — a stale master will not answer) and then
+// removes the socket file so a stuck socket cannot hang the next hop. A machine
+// with no socket is a no-op. It returns an error only if the socket file is
+// present and cannot be removed.
+func ResetControlMaster(ctx context.Context, m *machines.Machine) error {
+	socket := ControlSocketPath(m)
+	if _, err := os.Stat(socket); err != nil {
+		return nil
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, controlProbeTimeout)
+	defer cancel()
+	args := append(append([]string{}, Opts(m)...), "-O", "exit", Target(m))
+	_ = exec.CommandContext(probeCtx, "ssh", args...).Run()
+	if err := os.Remove(socket); err != nil && !os.IsNotExist(err) {
+		return camperrors.Wrapf(err, "remove control socket %s", socket)
+	}
+	return nil
 }
 
 // EnsureKeyAuth rejects password-auth machines: v1 terminal switch/list is

--- a/internal/remote/ssh_test.go
+++ b/internal/remote/ssh_test.go
@@ -1,6 +1,9 @@
 package remote
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -32,6 +35,77 @@ func TestOptsAuthArgs(t *testing.T) {
 	withKey := Opts(&machines.Machine{AuthMethod: machines.AuthSSHAgent, IdentityFile: "/home/lance/.ssh/id_ed25519"})
 	if !slices.Contains(withKey, "IdentitiesOnly=yes") || !slices.Contains(withKey, "/home/lance/.ssh/id_ed25519") {
 		t.Errorf("identity-file opts missing IdentitiesOnly/-i: %v", withKey)
+	}
+}
+
+func TestAuthArgsExpandsIdentityTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	withKey := Opts(&machines.Machine{AuthMethod: machines.AuthSSHAgent, IdentityFile: "~/.ssh/id_ed25519"})
+	want := filepath.Join(home, ".ssh", "id_ed25519")
+	if !slices.Contains(withKey, want) {
+		t.Errorf("identity ~ not expanded to %q: %v", want, withKey)
+	}
+	if slices.ContainsFunc(withKey, func(s string) bool { return strings.HasPrefix(s, "~") }) {
+		t.Errorf("opts still carry an unexpanded tilde: %v", withKey)
+	}
+}
+
+func TestExpandTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cases := map[string]string{
+		"~":                  home,
+		"~/.ssh/id":          filepath.Join(home, ".ssh", "id"),
+		"/abs/path/id":       "/abs/path/id",       // absolute untouched
+		"relative/id":        "relative/id",        // relative untouched
+		"~otheruser/.ssh/id": "~otheruser/.ssh/id", // other-user tilde left for ssh
+		"/has/~/mid/path":    "/has/~/mid/path",    // mid-path tilde untouched
+	}
+	for in, want := range cases {
+		if got := expandTilde(in); got != want {
+			t.Errorf("expandTilde(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestControlSocketPathNoSideEffect(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got := ControlSocketPath(&machines.Machine{ID: "devbox"})
+	want := filepath.Join(home, ".obey", "ssh-ctl", "devbox.sock")
+	if got != want {
+		t.Errorf("ControlSocketPath = %q, want %q", got, want)
+	}
+	// Purely computing the path must not create the ssh-ctl directory.
+	if _, err := os.Stat(filepath.Join(home, ".obey", "ssh-ctl")); !os.IsNotExist(err) {
+		t.Errorf("ControlSocketPath created the socket dir (stat err = %v); it must be side-effect free", err)
+	}
+}
+
+func TestCheckControlMasterNoSocket(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	d := CheckControlMaster(context.Background(), &machines.Machine{ID: "devbox", Host: "devbox.ts.net", AuthMethod: machines.AuthSSHAgent})
+	if d.State != ControlNone {
+		t.Errorf("no socket file should be ControlNone, got %q", d.State)
+	}
+	if d.MachineID != "devbox" {
+		t.Errorf("diagnosis machine id = %q, want devbox", d.MachineID)
+	}
+}
+
+func TestResetControlMasterNoSocket(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// No socket file present: reset is a no-op and must not error or shell out.
+	if err := ResetControlMaster(context.Background(), &machines.Machine{ID: "devbox", Host: "devbox.ts.net", AuthMethod: machines.AuthSSHAgent}); err != nil {
+		t.Errorf("reset with no socket should be a no-op, got %v", err)
 	}
 }
 

--- a/tests/integration/machine_diagnose_test.go
+++ b/tests/integration/machine_diagnose_test.go
@@ -1,0 +1,122 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// machineDiagnoseRow mirrors `camp machine diagnose --json`'s per-machine shape
+// (cmd/camp/machine.go's machineDiagnoseRow).
+type machineDiagnoseRow struct {
+	ID     string `json:"id"`
+	Socket string `json:"socket"`
+	State  string `json:"state"`
+	Reset  bool   `json:"reset"`
+}
+
+func diagnoseJSON(t *testing.T, tc *TestContainer, args ...string) []machineDiagnoseRow {
+	t.Helper()
+	out, err := tc.RunCamp(append([]string{"machine", "diagnose", "--json"}, args...)...)
+	require.NoError(t, err, "camp machine diagnose --json failed: %s", out)
+	var payload struct {
+		Machines []machineDiagnoseRow `json:"machines"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &payload), "output not JSON: %s", out)
+	return payload.Machines
+}
+
+func diagnoseRow(rows []machineDiagnoseRow, id string) (machineDiagnoseRow, bool) {
+	for _, r := range rows {
+		if r.ID == id {
+			return r, true
+		}
+	}
+	return machineDiagnoseRow{}, false
+}
+
+// TestMachineDiagnoseControlMasterLifecycle proves `camp machine diagnose` over a
+// real loopback ssh ControlMaster: a warmed master reads back "live", --reset
+// tears it down (socket file removed), and a re-diagnose reads "none". This is
+// the operator recovery path for a stale multiplex socket flagged in the MM0001
+// review (a socket left behind by a sleep/network flap would otherwise hang the
+// next hop until ControlPersist expires).
+func TestMachineDiagnoseControlMasterLifecycle(t *testing.T) {
+	tc := GetSharedContainer(t)
+	provisionLoopbackSSH(t, tc)
+
+	const base = "/campaigns"
+	_, err := tc.RunCamp("create", "diagnose-campaign",
+		"-d", "diagnose control master", "-m", "warm a master", "--no-git", "--path", base)
+	require.NoError(t, err)
+
+	machinesYAML := `version: 1
+machines:
+  - id: self
+    label: Self (loopback)
+    host: localhost
+    auth_method: ssh-agent
+    ssh_user: root
+    identity_file: /root/.ssh/id_ed25519
+`
+	require.NoError(t, tc.WriteFile("/root/.obey/machines.yaml", machinesYAML))
+
+	// Before any hop there is no socket: the machine reads "none".
+	before, ok := diagnoseRow(diagnoseJSON(t, tc), "self")
+	require.True(t, ok, "self should appear in diagnose output")
+	require.Equal(t, "none", before.State, "no hop yet, expected none")
+
+	// Warm a ControlMaster over real ssh: the resolve step of a remote switch
+	// opens the per-machine master (ControlPersist keeps it alive briefly).
+	shellConnect, err := tc.RunCamp("switch", "self:diagnose-campaign", "--shell-connect")
+	require.NoError(t, err, "warming switch failed: %s", shellConnect)
+
+	const socketPath = "/root/.obey/ssh-ctl/self.sock"
+	_, code, err := tc.ExecCommand("test", "-S", socketPath)
+	require.NoError(t, err)
+	require.Equal(t, 0, code, "resolve should have created the ControlMaster socket %s", socketPath)
+
+	// diagnose now sees a live master (the socket answers `ssh -O check`).
+	live, ok := diagnoseRow(diagnoseJSON(t, tc, "self"), "self")
+	require.True(t, ok)
+	require.Equal(t, "live", live.State, "warmed master should read live")
+	require.False(t, live.Reset, "read-only diagnose must not clear anything")
+
+	// --reset only clears STALE sockets, so a live socket survives a plain reset.
+	liveAfterReset, ok := diagnoseRow(diagnoseJSON(t, tc, "self", "--reset"), "self")
+	require.True(t, ok)
+	require.Equal(t, "live", liveAfterReset.State, "--reset must not tear down a live master")
+	require.False(t, liveAfterReset.Reset)
+
+	// Simulate the stuck-socket case: SIGKILL the master out from under its
+	// socket so the file is left behind (no unlink on -9) but `ssh -O check` no
+	// longer answers. The pid comes from -O check itself, so the kill is exact.
+	tc.Shell(t, `
+pid=$(ssh -o ControlPath=`+socketPath+` -O check root@localhost 2>&1 | sed -n 's/.*pid=\([0-9][0-9]*\).*/\1/p')
+[ -n "$pid" ] && kill -9 "$pid" 2>/dev/null || true
+test -S `+socketPath+` || { echo "socket vanished before stale check" >&2; exit 1; }
+`)
+
+	stale, ok := diagnoseRow(diagnoseJSON(t, tc, "self"), "self")
+	require.True(t, ok)
+	require.Equal(t, "stale", stale.State, "socket present but master gone should read stale")
+
+	// --reset clears the stale socket: it reports reset and removes the file.
+	cleared, ok := diagnoseRow(diagnoseJSON(t, tc, "self", "--reset"), "self")
+	require.True(t, ok)
+	require.True(t, cleared.Reset, "stale socket should be reported as reset")
+	require.Equal(t, "none", cleared.State, "after reset the state is none")
+
+	_, code, err = tc.ExecCommand("test", "-e", socketPath)
+	require.NoError(t, err)
+	require.NotEqual(t, 0, code, "reset should have removed the stale socket file %s", socketPath)
+
+	// A final diagnose confirms the machine is back to none.
+	final, ok := diagnoseRow(diagnoseJSON(t, tc), "self")
+	require.True(t, ok)
+	require.Equal(t, "none", final.State)
+}


### PR DESCRIPTION
## Summary

Follow-ups from the MM0001 review on #384 (multi-machine campaign navigation), which merged with two non-blocking inline notes on `internal/remote/ssh.go`. Both are addressed here.

### 1. Tilde expansion for `-i` identity files
`authArgs` now resolves a leading `~`/`~/` in a machine's `identity_file` to the current user's home before handing it to `ssh -i`.

OpenSSH's `IdentityFile` config directive expands `~`, but whether `ssh -i` expands it is client- and platform-dependent (OpenSSH 10.2 here does; not guaranteed elsewhere). Expanding in camp makes `camp machine add --identity '~/.ssh/id'` behave the way users expect from `ssh_config` regardless of the ssh build, and keeps the path camp hands off unambiguous. `~otheruser/` and mid-path `~` are left untouched for ssh to resolve. This is hardening, not a fix for a guaranteed break.

### 2. `camp machine diagnose` for stale ControlMaster sockets
The review flagged that a stuck ControlMaster socket (left behind by a sleep or network flap) can hang the next `camp switch machine:…` / `camp list --remote` hop until `ControlPersist` expires. New subcommand:

```
camp machine diagnose [id]          # report socket state: none | live | stale
camp machine diagnose [id] --reset  # tear down STALE sockets (live/absent left alone)
camp machine diagnose --json        # scriptable output
```

`live`/`stale` are distinguished with `ssh -O check`; `--reset` runs `ssh -O exit` then removes the socket file so a truly stuck socket cannot survive. Read path is agent-allowed; `--reset` is not (mirrors `camp doctor --fix`).

`camp doctor` was intentionally not used: it is campaign/submodule-scoped and requires a campaign root, whereas machines are a global `~/.obey/machines.yaml` concern — `camp machine` is the right home.

## Tests
- **Unit** (`internal/remote/ssh_test.go`): tilde expansion table (incl. `~user`/mid-path untouched), `authArgs` end-to-end expansion, side-effect-free `ControlSocketPath`, and the no-socket `none`/no-op reset paths.
- **Container integration** (`tests/integration/machine_diagnose_test.go`): real loopback ssh lifecycle — warm→`live`, `--reset` preserves a live master, SIGKILL the master→`stale`, `--reset` clears→`none` and removes the socket file.
- `just gate-fast` green (3064/3064 dev tests, lint clean); full multi-machine container integration suite passes.

## Docs
CLI reference regenerated for the `camp machine` family (add/list/remove/diagnose) and `list --remote` — surface that #384 introduced but did not regenerate. Kept scoped; the combined `camp-reference.md` full sweep (which also picks up unrelated `fresh`/`festivals` doc debt on main) is left for a dedicated docs pass.
