### PR TITLE
fix: eliminate terminal background query stall at startup

### DIFF
--- a/cmd/camp/main.go
+++ b/cmd/camp/main.go
@@ -8,6 +8,9 @@ import (
 	"os/signal"
 	"syscall"
 
+	// bginit must initialize before the bubbletea subtree under the command
+	// packages; its path keeps it first under gofmt.
+	_ "github.com/Obedience-Corp/camp/internal/bginit"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 

--- a/internal/bginit/bginit.go
+++ b/internal/bginit/bginit.go
@@ -1,0 +1,43 @@
+// Package bginit seeds lipgloss's background-color cache before any
+// charmbracelet package init can query the terminal.
+//
+// bubbletea v1 calls lipgloss.HasDarkBackground() from a package init
+// (tea_init.go). Without a cached value, lipgloss asks termenv, which writes
+// OSC 11 / DSR queries to the tty and blocks up to termenv.OSCTimeout (5s)
+// waiting for a reply. Interactive terminals answer instantly, but recorder,
+// CI, and agent ptys that never answer freeze every camp command for the full
+// timeout before a single byte of output appears.
+//
+// Seeding an explicit value makes lipgloss skip the terminal query entirely.
+// This package must initialize before bubbletea, so it may only import
+// lipgloss (never bubbletea or huh, directly or transitively), and cmd/camp
+// must import it alongside the command subtree.
+//
+// The seed mirrors termenv's non-query fallback: the last field of COLORFGBG
+// is the background ANSI color, and a missing or unparsable value means dark.
+// An explicit theme choice refines this later through the theme package.
+package bginit
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func init() {
+	lipgloss.SetHasDarkBackground(backgroundIsDark(os.Getenv("COLORFGBG")))
+}
+
+func backgroundIsDark(colorFGBG string) bool {
+	if !strings.Contains(colorFGBG, ";") {
+		return true
+	}
+	fields := strings.Split(colorFGBG, ";")
+	bg, err := strconv.Atoi(fields[len(fields)-1])
+	if err != nil {
+		return true
+	}
+	return bg >= 0 && bg <= 8 && bg != 7
+}

--- a/internal/bginit/bginit_test.go
+++ b/internal/bginit/bginit_test.go
@@ -1,0 +1,29 @@
+package bginit
+
+import "testing"
+
+func TestBackgroundIsDark(t *testing.T) {
+	tests := []struct {
+		name      string
+		colorFGBG string
+		want      bool
+	}{
+		{"unset defaults dark", "", true},
+		{"no separator defaults dark", "15", true},
+		{"unparsable background defaults dark", "15;default", true},
+		{"black background", "15;0", true},
+		{"blue background", "15;4", true},
+		{"bright black background", "15;8", true},
+		{"light grey background", "0;7", false},
+		{"white background", "0;15", false},
+		{"bright yellow background", "0;11", false},
+		{"three fields uses last", "15;default;0", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := backgroundIsDark(tt.colorFGBG); got != tt.want {
+				t.Errorf("backgroundIsDark(%q) = %v, want %v", tt.colorFGBG, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/intent/tui/styles.go
+++ b/internal/intent/tui/styles.go
@@ -1,14 +1,12 @@
 package tui
 
 import (
-	"os"
 	"strings"
 	"sync"
 
 	"github.com/Obedience-Corp/camp/internal/ui/theme"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/termenv"
 )
 
 var (
@@ -29,9 +27,9 @@ func InitGlamourStyle(themeName string) {
 		case "high-contrast":
 			glamourStyle = "dark" // high-contrast uses dark base
 		default: // "adaptive" or empty
-			// Detect once - this is the slow operation
-			output := termenv.NewOutput(os.Stdout)
-			if output.HasDarkBackground() {
+			// bginit seeded this cache before bubbletea initialization, so this
+			// resolves adaptive styling without issuing an OSC terminal query.
+			if lipgloss.HasDarkBackground() {
 				glamourStyle = "dark"
 			} else {
 				glamourStyle = "light"

--- a/internal/ui/theme/theme.go
+++ b/internal/ui/theme/theme.go
@@ -51,13 +51,17 @@ type palette struct {
 func GetTheme(name ThemeName) *huh.Theme {
 	switch name {
 	case ThemeLight:
+		lipgloss.SetHasDarkBackground(false)
 		return buildTheme(lightPalette())
 	case ThemeDark:
+		lipgloss.SetHasDarkBackground(true)
 		return buildTheme(darkPalette())
 	case ThemeHighContrast:
+		lipgloss.SetHasDarkBackground(true)
 		return buildTheme(highContrastPalette())
 	default:
-		// Adaptive: ThemeCharm with only Help style fixes
+		// Adaptive keeps the background seeded by bginit (COLORFGBG or dark)
+		// so ThemeCharm resolves adaptive colors without querying the terminal.
 		return buildAdaptiveTheme()
 	}
 }


### PR DESCRIPTION
## Summary
- seed Lipgloss background detection from `COLORFGBG` before Bubble Tea initializes
- make explicit light/dark/high-contrast themes refine the cached background without terminal queries
- route adaptive Glamour selection through the seeded Lipgloss cache instead of calling termenv directly

This ports the startup portion of fest #254 to camp and closes the fresh campaign intent for mute PTYs used by recorders, CI, and agent sessions.

## Reproduction and verification
Controlled PTY that advertises `TERM=xterm-256color` but never answers OSC 11/DSR:

```text
Before: OSC 11 + DSR emitted; camp version output after 5.03s
After:  no terminal query bytes; output after 0.40s
```

## Gates
- focused `go test` for bginit, theme, intent TUI, and cmd/camp
- `just build dev`
- `just test unit`
- `just lint` (0 issues; no new host-filesystem or fmt.Errorf ratchet violations)
- `just gate`
