### PR TITLE
Hide dead CLI surface behind deprecation notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ camp pin external-repo
 cgo external-repo
 ```
 
-`camp detach <path>` removes the marker. Linked projects keep using
-`camp project link` / `camp project unlink`.
+To undo an attachment, remove the `.camp` marker by hand. Linked projects
+keep using `camp project link` / `camp project unlink`.
 
 ### Planning
 

--- a/cmd/camp/attach/attach.go
+++ b/cmd/camp/attach/attach.go
@@ -91,9 +91,11 @@ Examples:
 // NewDetachCommand builds the camp detach command.
 func NewDetachCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "detach <path>",
-		Short:   "Remove the attachment marker from a directory",
-		GroupID: "campaign",
+		Use:        "detach <path>",
+		Short:      "Remove the attachment marker from a directory",
+		GroupID:    "campaign",
+		Hidden:     true,
+		Deprecated: "unused; remove the .camp marker by hand, or use 'camp project unlink' for linked projects",
 		Long: `Remove the .camp attachment marker from the target directory.
 
 Refuses on linked-project markers; use 'camp project unlink' for those.

--- a/cmd/camp/attach/attach_test.go
+++ b/cmd/camp/attach/attach_test.go
@@ -1,0 +1,28 @@
+package attach
+
+import (
+	"io"
+	"testing"
+)
+
+func TestDetachCommand_HiddenAndDeprecated(t *testing.T) {
+	cmd := NewDetachCommand()
+	if !cmd.Hidden {
+		t.Error("detach command Hidden = false, want true")
+	}
+	if cmd.Deprecated == "" {
+		t.Error("detach command Deprecated is empty, want a deprecation notice")
+	}
+}
+
+func TestAttachCommand_StaysVisible(t *testing.T) {
+	cmd := NewAttachCommand(func(_ io.Writer, _ string) CampaignResolver {
+		return nil
+	})
+	if cmd.Hidden {
+		t.Error("attach command Hidden = true, want false: camp attach is unaffected by the camp detach deprecation")
+	}
+	if cmd.Deprecated != "" {
+		t.Errorf("attach command Deprecated = %q, want empty", cmd.Deprecated)
+	}
+}

--- a/cmd/camp/copy.go
+++ b/cmd/camp/copy.go
@@ -31,6 +31,8 @@ recursively.`,
   camp cp @f/active/my-fest/OVERVIEW.md @d/
   camp cp @w/design/active/ @w/explore/backup/`,
 	Aliases:           []string{"cp"},
+	Hidden:            true,
+	Deprecated:        "unused; use your shell's cp or 'camp move' instead",
 	Args:              cobra.ExactArgs(2),
 	ValidArgsFunction: completeTransferArgs,
 	RunE:              runCopy,

--- a/cmd/camp/copy_test.go
+++ b/cmd/camp/copy_test.go
@@ -7,6 +7,15 @@ import (
 	"testing"
 )
 
+func TestCopyCommand_HiddenAndDeprecated(t *testing.T) {
+	if !copyCmd.Hidden {
+		t.Error("copyCmd.Hidden = false, want true")
+	}
+	if copyCmd.Deprecated == "" {
+		t.Error("copyCmd.Deprecated is empty, want a deprecation notice")
+	}
+}
+
 func TestResolvePathThroughExistingAncestorResolvesSymlinkAncestor(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink behavior is platform dependent on Windows")

--- a/cmd/camp/intent/convert.go
+++ b/cmd/camp/intent/convert.go
@@ -14,8 +14,10 @@ import (
 )
 
 var intentConvertCmd = &cobra.Command{
-	Use:   "convert <id>",
-	Short: "Convert a note into an intent",
+	Use:        "convert <id>",
+	Short:      "Convert a note into an intent",
+	Hidden:     true,
+	Deprecated: "unused; edit the note's frontmatter type and move it into inbox/ by hand",
 	Long: `Promote a note into the intent lifecycle.
 
 A note lives outside the inbox → ready → active lifecycle. Converting it moves

--- a/cmd/camp/intent/deprecated_surface_test.go
+++ b/cmd/camp/intent/deprecated_surface_test.go
@@ -1,0 +1,36 @@
+package intent
+
+import "testing"
+
+// TestDeprecatedIntentSubcommands_HiddenAndDeprecated asserts convert, find,
+// and rename are hidden from help with a deprecation notice while remaining
+// invocable, per the 2026-07-09 CLI usage audit
+// (decommission-dead-cli-surface-per-20260709-234257).
+func TestDeprecatedIntentSubcommands_HiddenAndDeprecated(t *testing.T) {
+	for _, name := range []string{"convert", "find", "rename"} {
+		cmd := findIntentSubcommand(name)
+		if cmd == nil {
+			t.Fatalf("camp intent %s is not registered under camp intent", name)
+		}
+		if !cmd.Hidden {
+			t.Errorf("camp intent %s: Hidden = false, want true", name)
+		}
+		if cmd.Deprecated == "" {
+			t.Errorf("camp intent %s: Deprecated is empty, want a deprecation notice", name)
+		}
+	}
+}
+
+// TestActiveIntentSubcommands_StayVisible guards against accidentally hiding
+// the intent verbs that carry the product (add/list/move/promote and friends).
+func TestActiveIntentSubcommands_StayVisible(t *testing.T) {
+	for _, name := range []string{"add", "list", "move", "promote", "show", "edit", "archive"} {
+		cmd := findIntentSubcommand(name)
+		if cmd == nil {
+			t.Fatalf("camp intent %s is not registered under camp intent", name)
+		}
+		if cmd.Hidden {
+			t.Errorf("camp intent %s: Hidden = true, want false", name)
+		}
+	}
+}

--- a/cmd/camp/intent/find.go
+++ b/cmd/camp/intent/find.go
@@ -21,8 +21,10 @@ var intentFindCmd = newIntentFindCommand()
 func newIntentFindCommand() *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
-		Use:   "find [query]",
-		Short: "Search for intents by title or content",
+		Use:        "find [query]",
+		Short:      "Search for intents by title or content",
+		Hidden:     true,
+		Deprecated: "unused; use 'camp intent list' or 'camp workitem' instead",
 		Long: `Search for intents across all statuses by title, content, or ID.
 
 The search is case-insensitive and matches partial strings.

--- a/cmd/camp/intent/json_contract_test.go
+++ b/cmd/camp/intent/json_contract_test.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -314,7 +316,23 @@ func executeIntentJSONTestCommand(t *testing.T, cmd *cobra.Command, args ...stri
 	cmd.SilenceUsage = true
 	cmd.SilenceErrors = true
 	err := cmd.ExecuteContext(context.Background())
-	return stdout.String(), stderr.String(), err
+
+	// Cobra prints the deprecation notice (when cmd.Deprecated is set) through
+	// OutOrStderr, which resolves to the captured stdout buffer here because
+	// SetOut was called above; it never reaches the stderr buffer in this
+	// harness. In production nothing calls SetOut on rootCmd, so the same
+	// notice lands on the real stderr instead, never mixing into stdout or
+	// into a JSON error envelope (which uses ErrOrStderr and so already
+	// lands cleanly in the stderr buffer here). Strip the notice from stdout
+	// so JSON contract assertions see the same clean stdout production
+	// emits; deprecation behavior itself is covered by
+	// TestDeprecatedIntentSubcommands_HiddenAndDeprecated.
+	out := stdout.String()
+	if cmd.Deprecated != "" {
+		prefix := fmt.Sprintf("Command %q is deprecated, %s\n", cmd.Name(), cmd.Deprecated)
+		out = strings.TrimPrefix(out, prefix)
+	}
+	return out, stderr.String(), err
 }
 
 func decodeIntentJSONPayload(t *testing.T, raw string) map[string]any {

--- a/cmd/camp/intent/rename.go
+++ b/cmd/camp/intent/rename.go
@@ -15,8 +15,10 @@ import (
 )
 
 var intentRenameCmd = &cobra.Command{
-	Use:   "rename <id> <new title>",
-	Short: "Rename an intent",
+	Use:        "rename <id> <new title>",
+	Short:      "Rename an intent",
+	Hidden:     true,
+	Deprecated: "unused; use 'camp intent edit' to update the title instead",
 	Long: `Rename an intent: update its title and regenerate its human-readable
 filename. The intent's stable id is preserved, so references and lookups survive
 the rename.

--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -26,7 +26,6 @@ var manifestAgentAllowedReasons = map[string]string{
 	"id":                  "Read-only campaign ID output",
 	"intent add":          "Programmatic create path is safe with title/body flags; agents must not use TUI-only flags",
 	"intent count":        "Read-only intent count",
-	"intent find":         "Read-only intent search",
 	"intent list":         "Read-only intent listing",
 	"intent show":         "Read-only intent detail",
 	"log":                 "Read-only git log",


### PR DESCRIPTION
## Summary

Executes Step 2 of the camp side of the CLI usage audit (`workflow/audits/cli-usage-2026-07-09/RECOMMENDATIONS.md`, corrected by `FABLE-REVIEW.md`), per intent `decommission-dead-cli-surface-per-20260709-234257`. Companion to fest PR #255 (Obedience-Corp/fest#255), which applied the same mechanism to fest's dead surface.

camp has real users, so this is **help-hiding plus a deprecation notice only. No code is deleted.** Every affected command keeps its implementation; it only gets `Hidden: true` and a `Deprecated` string on the `cobra.Command`, exactly matching fest PR #255's pattern (also camp's own existing precedent: `cmd/camp/worktrees/root.go`'s `Deprecated` field and `internal/commands/flow/flow.go`'s `Hidden: true`). Cobra prints `Command "X" is deprecated, <reason>` on every invocation of a hidden command, so callers still working get a warning instead of silent removal.

### Hidden + deprecated

- `camp copy` (alias `cp`), unused; use your shell's `cp` or `camp move` instead
- `camp detach`, unused; remove the `.camp` marker by hand, or use `camp project unlink` for linked projects
- `camp intent convert`, unused; edit the note's frontmatter type and move it into `inbox/` by hand
- `camp intent find`, unused; use `camp intent list` or `camp workitem` instead
- `camp intent rename`, unused; use `camp intent edit` to update the title instead (verified `camp intent edit --title` exists)

### Left visible (deviation from the audit)

- **`camp attach`**, the paired command to `camp detach`. The audit only flagged `detach` as zero-usage; `attach` is unaffected.
- **`camp workflow`** (entire tree: create/list/show/shortcut/doctor/sync): the audit recommends deprecating this for the `fest workflow` name collision plus near-zero usage. I did not hide it. Evidence against hiding:
  - A dedicated, current reference doc (`docs/workflow-reference.md`), a June 2026 migration guide (`docs/migrations/workflow-subconcepts-2026-06.md`), a `workflow/v1` JSON contract (`docs/json-contracts.md`), onboarding coverage in `docs/OBEY.md`, and config documentation in `docs/campaign-settings-files.md` and `docs/architecture/command-conventions.md`.
  - Three of the most recent feature commits on this branch's history (`8022369 feat(workflow): category on create/list/show`, `2262e36 docs: document workflow categories`, `6f3942c style(workflow-categories): remove over-verbose code comments`) are active development on `camp workflow`, not abandonment.
  - By contrast, `internal/commands/flow/flow.go` (the older `camp flow` system) is *already* `Hidden: true` from an earlier commit (`3cf47b5 feat(flow): hide camp flow from primary help; keep dungeon primitive`): `camp workflow` is its actively-maintained replacement, not a second dead "workflow" product.
  - This reads as a live product surface with a real plan behind it, not dead/forgotten code. The name-collision argument is real but doesn't outweigh this on its own; flagging for a product call rather than hiding unilaterally.

### Why hide, not delete

Consistent with the intent's "hide first, delete only after a referenced-by gate" rule. No removal gate is claimed as passed in this PR; that's future work.

### How I verified no programmatic callers exist

Grepped `camp copy`/`cp`, `camp detach`, `camp intent convert`, `camp intent find`, `camp intent rename` across:
- `projects/festival-app/src-tauri/src/cli/commands.rs` (only `workflow` hits found are `fest workflow` calls via `fest_workflow_*` helpers, unrelated to `camp workflow`)
- `projects/obey-platform-monorepo/obey/internal/executor/allowlist.go`
- campaign root `.campaign/skills/`, `.claude/skills/`, `docs/`
- camp's own shell integration templates (`internal/shell/templates/*.tmpl`)
- camp's own embedded/generated docs (`docs/cli-reference/*.md`, `README.md`)

All clean for the five hidden commands. `README.md` has one-line usage-list mentions of `camp copy` and `camp detach` (lines 196, 259); left as-is since they're plain command listings, not "how to use X" prose advertising the workflow the way fest's embedded docs did. Flagging here in case a docs pass is wanted separately.

### docs/cli-reference regen

`docs/cli-reference/*.md` is auto-generated (`just docs`). Running it against current `main` (before any of my changes) already produces an unrelated diff from the just-merged orgs PR (#387: `camp_org*.md`, `camp_create.md`, `camp_init.md` drift) that hasn't been regenerated yet. Per this campaign's convention (docs regen commits are kept separate from feature commits to avoid folding in unrelated drift), I did not run the full regen here. The five newly-hidden commands' reference pages become stale; a follow-up docs-only PR should regenerate `docs/cli-reference` once the orgs drift is also ready to land.

### Known caveat: JSON contract + deprecation notice interleave

`camp intent find` supports `--json`. Cobra's deprecation notice and this project's JSON error envelope both write to stderr; the deprecation notice always prints first (before flag parsing), so on a *flag-parse error* specifically, real stderr contains the deprecation line followed by the JSON error envelope, not pure JSON. Stdout stays completely clean in all cases (success and error paths), since JSON payloads render to stdout and error envelopes/deprecation both use stderr. This is inherent to cobra's `Deprecated` field mechanism (the same one fest PR #255 uses) applied to a JSON-contract command, not something specific to this change. Since the command is being hidden specifically because it's unused, and only a script that explicitly invokes a hidden command and parses raw stderr as strict JSON on a flag error would notice, I left the mechanism as-is rather than diverging from the shared pattern. A companion test-helper fix (`executeIntentJSONTestCommand` in `cmd/camp/intent/json_contract_test.go`) strips the deprecation prefix from the captured stdout buffer only, since that capture artifact is purely a byproduct of the test's `SetOut`/`SetErr` wiring (cobra's `OutOrStderr()` returns the `SetOut` writer when set, regardless of a separately configured `SetErr` writer) and does not reflect any real stdout contamination in production.

### Manifest cleanup

Removed the now-orphaned `"intent find": "Read-only intent search"` entry from `manifestAgentAllowedReasons` in `cmd/camp/zz_manifest_annotations.go`. Hidden commands are skipped before manifest annotations are applied (`skipManifestCommand` checks `cmd.Hidden` first), so this entry would otherwise silently stop applying while still implying `intent find` is part of the agent-safe, visible manifest surface.

## Test plan

- [x] `go build ./...` clean
- [x] `just test unit`: 96 packages, 3087/3087 tests passed
- [x] `just test integration`: 407/407 tests passed (Docker)
- [x] `just lint`: 0 issues; `lint-no-host-fs-tests` and `lint-no-fmt-errorf` clean
- [x] Manual verification with a built binary: hidden commands no longer appear in `camp --help` / `camp intent --help`; running any hidden command (`camp copy`, `camp detach`, `camp intent convert/find/rename`) prints the cobra deprecation notice on stderr and still executes; `camp attach` and `camp workflow` remain visible in `camp --help`
- [x] New tests added asserting `Hidden`/`Deprecated` per affected command (`cmd/camp/copy_test.go`, `cmd/camp/attach/attach_test.go`, `cmd/camp/intent/deprecated_surface_test.go`), plus a guard that `camp attach` stays visible and that the active intent verbs (add/list/move/promote/show/edit/archive) are not accidentally hidden
- [x] Existing `cmd/camp` manifest/registration test suite (`TestManifestCommand_*`, `TestRootRegisters*`) passes unmodified: those tests derive their expectations from the live command tree, so hiding a command is automatically reflected without hardcoded updates

Ref: intent `decommission-dead-cli-surface-per-20260709-234257`
