### PR TITLE
Inherit ambient commit context on all intent auto-commit paths, make silent skips loud

### DIFF
--- a/cmd/camp/gather_feedback.go
+++ b/cmd/camp/gather_feedback.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	workitemcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/git/commit"
 	"github.com/Obedience-Corp/camp/internal/intent/feedback"
@@ -241,13 +243,11 @@ func commitGatherFeedback(ctx context.Context, campaignRoot, campaignID string, 
 	description := fmt.Sprintf("Gathered %d observations from %d festivals: %s",
 		result.NewObservations, len(ids), strings.Join(ids, ", "))
 
+	opts := workitemcmd.AmbientCommitOptions(ctx, campaignRoot, campaignID, os.Stderr)
+	opts.Files = commit.NormalizeFiles(campaignRoot, files...)
+	opts.SelectiveOnly = true
 	commitResult := commit.Intent(ctx, commit.IntentOptions{
-		Options: commit.Options{
-			CampaignRoot:  campaignRoot,
-			CampaignID:    campaignID,
-			Files:         commit.NormalizeFiles(campaignRoot, files...),
-			SelectiveOnly: true,
-		},
+		Options:     opts,
 		Action:      commit.IntentGather,
 		IntentTitle: "Gather festival feedback",
 		Description: description,
@@ -255,4 +255,5 @@ func commitGatherFeedback(ctx context.Context, campaignRoot, campaignID string, 
 	if commitResult.Message != "" {
 		fmt.Printf("  %s\n", commitResult.Message)
 	}
+	commit.WarnIfSkipped(os.Stderr, commitResult)
 }

--- a/cmd/camp/intent/add.go
+++ b/cmd/camp/intent/add.go
@@ -496,19 +496,11 @@ func finalizeCreatedIntentWithOutput(ctx context.Context, result *intent.Intent,
 
 	// Auto-commit (unless --no-commit)
 	if !noCommit {
-		files := commit.NormalizeFiles(campaignRoot, result.Path, audit.FilePath(intentsDir))
-		cwd, _ := os.Getwd()
-		cc := wkcmd.ResolveCommitContext(ctx, campaignRoot, cwd, os.Stderr)
+		opts := wkcmd.AmbientCommitOptions(ctx, campaignRoot, cfg.ID, os.Stderr)
+		opts.Files = commit.NormalizeFiles(campaignRoot, result.Path, audit.FilePath(intentsDir))
+		opts.SelectiveOnly = true
 		commitResult := commit.Intent(ctx, commit.IntentOptions{
-			Options: commit.Options{
-				CampaignRoot:  campaignRoot,
-				CampaignID:    cfg.ID,
-				QuestID:       cc.QuestID,
-				FestivalRef:   cc.FestivalRef,
-				WorkitemRef:   cc.WorkitemRef,
-				Files:         files,
-				SelectiveOnly: true,
-			},
+			Options:     opts,
 			Action:      commit.IntentCreate,
 			IntentTitle: result.Title,
 		})
@@ -517,6 +509,7 @@ func finalizeCreatedIntentWithOutput(ctx context.Context, result *intent.Intent,
 				return err
 			}
 		}
+		commit.WarnIfSkipped(os.Stderr, commitResult)
 	}
 
 	return nil

--- a/cmd/camp/intent/archive.go
+++ b/cmd/camp/intent/archive.go
@@ -2,12 +2,14 @@ package intent
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/spf13/cobra"
 
+	wkcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/git/commit"
 	"github.com/Obedience-Corp/camp/internal/intent"
@@ -105,14 +107,11 @@ func runIntentArchive(cmd *cobra.Command, args []string) error {
 
 	// Auto-commit (unless --no-commit)
 	if !noCommit {
-		files := commit.NormalizeFiles(campaignRoot, sourcePath, result.Path, audit.FilePath(resolver.Intents()))
+		opts := wkcmd.AmbientCommitOptions(ctx, campaignRoot, cfg.ID, os.Stderr)
+		opts.Files = commit.NormalizeFiles(campaignRoot, sourcePath, result.Path, audit.FilePath(resolver.Intents()))
+		opts.SelectiveOnly = true
 		commitResult := commit.Intent(ctx, commit.IntentOptions{
-			Options: commit.Options{
-				CampaignRoot:  campaignRoot,
-				CampaignID:    cfg.ID,
-				Files:         files,
-				SelectiveOnly: true,
-			},
+			Options:     opts,
 			Action:      commit.IntentArchive,
 			IntentTitle: intentTitle,
 			Description: fmt.Sprintf("Moved to %s status", intent.StatusArchived),
@@ -120,6 +119,7 @@ func runIntentArchive(cmd *cobra.Command, args []string) error {
 		if commitResult.Message != "" {
 			fmt.Printf("  %s\n", commitResult.Message)
 		}
+		commit.WarnIfSkipped(os.Stderr, commitResult)
 	}
 
 	return nil

--- a/cmd/camp/intent/convert.go
+++ b/cmd/camp/intent/convert.go
@@ -2,9 +2,11 @@ package intent
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
+	wkcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/git/commit"
@@ -78,14 +80,11 @@ func runIntentConvert(cmd *cobra.Command, args []string) error {
 	}
 
 	if !noCommit {
-		files := commit.NormalizeFiles(campaignRoot, sourcePath, result.Path, audit.FilePath(resolver.Intents()))
+		opts := wkcmd.AmbientCommitOptions(ctx, campaignRoot, cfg.ID, os.Stderr)
+		opts.Files = commit.NormalizeFiles(campaignRoot, sourcePath, result.Path, audit.FilePath(resolver.Intents()))
+		opts.SelectiveOnly = true
 		commitResult := commit.Intent(ctx, commit.IntentOptions{
-			Options: commit.Options{
-				CampaignRoot:  campaignRoot,
-				CampaignID:    cfg.ID,
-				Files:         files,
-				SelectiveOnly: true,
-			},
+			Options:     opts,
 			Action:      commit.IntentMove,
 			IntentTitle: result.Title,
 			Description: "Converted note to " + typeFlag + " intent",
@@ -93,6 +92,7 @@ func runIntentConvert(cmd *cobra.Command, args []string) error {
 		if commitResult.Message != "" {
 			fmt.Printf("  %s\n", commitResult.Message)
 		}
+		commit.WarnIfSkipped(os.Stderr, commitResult)
 	}
 
 	return nil

--- a/cmd/camp/intent/crawl.go
+++ b/cmd/camp/intent/crawl.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/spf13/cobra"
 
+	wkcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/config"
 	sharedcrawl "github.com/Obedience-Corp/camp/internal/crawl"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -193,18 +195,17 @@ func commitIntentCrawl(ctx context.Context, campaignRoot, campaignID string, res
 		crawlID = ""
 	}
 
+	opts := wkcmd.AmbientCommitOptions(ctx, campaignRoot, campaignID, os.Stderr)
+	opts.Files = files
+	opts.PreStaged = preStaged
+	opts.SelectiveOnly = true
 	res := commit.Intent(ctx, commit.IntentOptions{
-		Options: commit.Options{
-			CampaignRoot:  campaignRoot,
-			CampaignID:    campaignID,
-			Files:         files,
-			PreStaged:     preStaged,
-			SelectiveOnly: true,
-		},
+		Options:     opts,
 		Action:      commit.IntentCrawl,
 		IntentTitle: commit.IntentCrawlSubject(crawlID),
 		Description: buildIntentCrawlCommitDescription(result),
 	})
+	commit.WarnIfSkipped(os.Stderr, res)
 
 	if res.Committed {
 		fmt.Printf("\n%s %s\n", ui.SuccessIcon(), res.Message)

--- a/cmd/camp/intent/edit.go
+++ b/cmd/camp/intent/edit.go
@@ -3,10 +3,12 @@ package intent
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/ktr0731/go-fuzzyfinder"
 	"github.com/spf13/cobra"
 
+	wkcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/editor"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -228,20 +230,18 @@ func runProgrammaticEdit(
 		if target.Path != updated.Path {
 			filesToCommit = append(filesToCommit, target.Path)
 		}
-		files := commit.NormalizeFiles(campaignRoot, filesToCommit...)
+		opts := wkcmd.AmbientCommitOptions(ctx, campaignRoot, cfg.ID, os.Stderr)
+		opts.Files = commit.NormalizeFiles(campaignRoot, filesToCommit...)
+		opts.SelectiveOnly = true
 		commitResult := commit.Intent(ctx, commit.IntentOptions{
-			Options: commit.Options{
-				CampaignRoot:  campaignRoot,
-				CampaignID:    cfg.ID,
-				Files:         files,
-				SelectiveOnly: true,
-			},
+			Options:     opts,
 			Action:      commit.IntentEdit,
 			IntentTitle: updated.Title,
 		})
 		if commitResult.Message != "" {
 			fmt.Printf("  %s\n", commitResult.Message)
 		}
+		commit.WarnIfSkipped(os.Stderr, commitResult)
 	}
 
 	return nil

--- a/cmd/camp/intent/gather.go
+++ b/cmd/camp/intent/gather.go
@@ -3,12 +3,14 @@ package intent
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/spf13/cobra"
 
+	wkcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/git/commit"
 	"github.com/Obedience-Corp/camp/internal/intent"
@@ -242,13 +244,11 @@ func runIntentGather(cmd *cobra.Command, args []string) error {
 		files = append(files, result.ArchivedPaths...)
 		files = append(files, audit.FilePath(resolver.Intents()))
 
+		opts := wkcmd.AmbientCommitOptions(ctx, campaignRoot, cfg.ID, os.Stderr)
+		opts.Files = commit.NormalizeFiles(campaignRoot, files...)
+		opts.SelectiveOnly = true
 		commitResult := commit.Intent(ctx, commit.IntentOptions{
-			Options: commit.Options{
-				CampaignRoot:  campaignRoot,
-				CampaignID:    cfg.ID,
-				Files:         commit.NormalizeFiles(campaignRoot, files...),
-				SelectiveOnly: true,
-			},
+			Options:     opts,
 			Action:      commit.IntentGather,
 			IntentTitle: gatherTitle,
 			Description: description,
@@ -256,6 +256,7 @@ func runIntentGather(cmd *cobra.Command, args []string) error {
 		if commitResult.Message != "" {
 			fmt.Printf("  %s\n", commitResult.Message)
 		}
+		commit.WarnIfSkipped(os.Stderr, commitResult)
 	}
 
 	return nil

--- a/cmd/camp/intent/move.go
+++ b/cmd/camp/intent/move.go
@@ -2,12 +2,14 @@ package intent
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
+	wkcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/git/commit"
 	"github.com/Obedience-Corp/camp/internal/intent"
@@ -131,14 +133,11 @@ func runIntentMove(cmd *cobra.Command, args []string) error {
 
 	// Auto-commit (unless --no-commit)
 	if !noCommit {
-		files := commit.NormalizeFiles(campaignRoot, sourcePath, result.Path, audit.FilePath(resolver.Intents()))
+		opts := wkcmd.AmbientCommitOptions(ctx, campaignRoot, cfg.ID, os.Stderr)
+		opts.Files = commit.NormalizeFiles(campaignRoot, sourcePath, result.Path, audit.FilePath(resolver.Intents()))
+		opts.SelectiveOnly = true
 		commitResult := commit.Intent(ctx, commit.IntentOptions{
-			Options: commit.Options{
-				CampaignRoot:  campaignRoot,
-				CampaignID:    cfg.ID,
-				Files:         files,
-				SelectiveOnly: true,
-			},
+			Options:     opts,
 			Action:      commit.IntentMove,
 			IntentTitle: intentTitle,
 			Description: fmt.Sprintf("Moved to %s status", status),
@@ -146,6 +145,7 @@ func runIntentMove(cmd *cobra.Command, args []string) error {
 		if commitResult.Message != "" {
 			fmt.Printf("  %s\n", commitResult.Message)
 		}
+		commit.WarnIfSkipped(os.Stderr, commitResult)
 	}
 
 	return nil

--- a/cmd/camp/intent/note.go
+++ b/cmd/camp/intent/note.go
@@ -19,7 +19,19 @@ import (
 	"github.com/Obedience-Corp/camp/internal/intent/tui"
 	navtui "github.com/Obedience-Corp/camp/internal/nav/tui"
 	"github.com/Obedience-Corp/camp/internal/paths"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
+
+// noteRefPrefix is the NT- tag prefix for note commits, mirroring
+// wkitem.RefPrefix ("WI-") for workitems.
+const noteRefPrefix = "NT-"
+
+// noteRef derives the NT-<6 hex> commit tag ref for a note from its
+// frontmatter id, reusing the same sha256-prefix scheme workitem refs use
+// (internal/workitem/ref.go) via wkitem.DeriveWithPrefix.
+func noteRef(id string) string {
+	return wkitem.DeriveWithPrefix(noteRefPrefix, id)
+}
 
 var intentNoteCmd = &cobra.Command{
 	Use:   "note [text]",
@@ -191,6 +203,7 @@ func finalizeCreatedNote(ctx context.Context, result *intent.Intent, intentsDir 
 
 	if !noCommit {
 		opts := wkcmd.AmbientCommitOptions(ctx, campaignRoot, cfg.ID, os.Stderr)
+		opts.NoteRef = noteRef(result.ID)
 		opts.Files = commit.NormalizeFiles(campaignRoot, result.Path, audit.FilePath(intentsDir))
 		opts.SelectiveOnly = true
 		commitResult := commit.Intent(ctx, commit.IntentOptions{

--- a/cmd/camp/intent/note.go
+++ b/cmd/camp/intent/note.go
@@ -190,25 +190,18 @@ func finalizeCreatedNote(ctx context.Context, result *intent.Intent, intentsDir 
 	fmt.Printf("✓ Note created: %s\n", result.Path)
 
 	if !noCommit {
-		files := commit.NormalizeFiles(campaignRoot, result.Path, audit.FilePath(intentsDir))
-		cwd, _ := os.Getwd()
-		cc := wkcmd.ResolveCommitContext(ctx, campaignRoot, cwd, os.Stderr)
+		opts := wkcmd.AmbientCommitOptions(ctx, campaignRoot, cfg.ID, os.Stderr)
+		opts.Files = commit.NormalizeFiles(campaignRoot, result.Path, audit.FilePath(intentsDir))
+		opts.SelectiveOnly = true
 		commitResult := commit.Intent(ctx, commit.IntentOptions{
-			Options: commit.Options{
-				CampaignRoot:  campaignRoot,
-				CampaignID:    cfg.ID,
-				QuestID:       cc.QuestID,
-				FestivalRef:   cc.FestivalRef,
-				WorkitemRef:   cc.WorkitemRef,
-				Files:         files,
-				SelectiveOnly: true,
-			},
+			Options:     opts,
 			Action:      commit.IntentCreate,
 			IntentTitle: result.Title,
 		})
 		if commitResult.Message != "" {
 			fmt.Printf("  %s\n", commitResult.Message)
 		}
+		commit.WarnIfSkipped(os.Stderr, commitResult)
 	}
 
 	return nil

--- a/cmd/camp/intent/promote.go
+++ b/cmd/camp/intent/promote.go
@@ -9,6 +9,7 @@ import (
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
+	wkcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/git/commit"
 	"github.com/Obedience-Corp/camp/internal/intent"
@@ -150,13 +151,11 @@ func runIntentPromote(cmd *cobra.Command, args []string) error {
 		}
 
 		files = append(files, audit.FilePath(resolver.Intents()))
+		opts := wkcmd.AmbientCommitOptions(ctx, campaignRoot, cfg.ID, os.Stderr)
+		opts.Files = commit.NormalizeFiles(campaignRoot, files...)
+		opts.SelectiveOnly = true
 		commitResult := commit.Intent(ctx, commit.IntentOptions{
-			Options: commit.Options{
-				CampaignRoot:  campaignRoot,
-				CampaignID:    cfg.ID,
-				Files:         commit.NormalizeFiles(campaignRoot, files...),
-				SelectiveOnly: true,
-			},
+			Options:     opts,
 			Action:      commit.IntentPromote,
 			IntentTitle: i.Title,
 			Description: fmt.Sprintf("Promoted from %s to %s", prevStatus, result.NewStatus),
@@ -164,6 +163,7 @@ func runIntentPromote(cmd *cobra.Command, args []string) error {
 		if commitResult.Message != "" {
 			fmt.Printf("  %s\n", commitResult.Message)
 		}
+		commit.WarnIfSkipped(os.Stderr, commitResult)
 	}
 
 	// Report outcome based on target.

--- a/cmd/camp/intent/rename.go
+++ b/cmd/camp/intent/rename.go
@@ -2,10 +2,12 @@ package intent
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
 
+	wkcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/git/commit"
@@ -83,14 +85,11 @@ func runIntentRename(cmd *cobra.Command, args []string) error {
 	}
 
 	if !noCommit {
-		files := commit.NormalizeFiles(campaignRoot, oldPath, renamed.Path, audit.FilePath(resolver.Intents()))
+		opts := wkcmd.AmbientCommitOptions(ctx, campaignRoot, cfg.ID, os.Stderr)
+		opts.Files = commit.NormalizeFiles(campaignRoot, oldPath, renamed.Path, audit.FilePath(resolver.Intents()))
+		opts.SelectiveOnly = true
 		commitResult := commit.Intent(ctx, commit.IntentOptions{
-			Options: commit.Options{
-				CampaignRoot:  campaignRoot,
-				CampaignID:    cfg.ID,
-				Files:         files,
-				SelectiveOnly: true,
-			},
+			Options:     opts,
 			Action:      commit.IntentRename,
 			IntentTitle: renamed.Title,
 			Description: "Renamed from " + oldTitle,
@@ -98,6 +97,7 @@ func runIntentRename(cmd *cobra.Command, args []string) error {
 		if commitResult.Message != "" {
 			fmt.Printf("  %s\n", commitResult.Message)
 		}
+		commit.WarnIfSkipped(os.Stderr, commitResult)
 	}
 
 	return nil

--- a/internal/commands/workitem/commit_context.go
+++ b/internal/commands/workitem/commit_context.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/Obedience-Corp/camp/internal/git/commit"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
 )
@@ -56,5 +57,31 @@ func ResolveCommitContext(ctx context.Context, campaignRoot, cwd string, errw io
 		QuestID:     res.QuestID,
 		FestivalRef: festivalRef,
 		WorkitemRef: ref,
+	}
+}
+
+// AmbientCommitOptions resolves the ambient commit context via
+// ResolveCommitContext against the process working directory and returns a
+// commit.Options seeded with CampaignRoot, CampaignID, and the resolved
+// QuestID/FestivalRef/WorkitemRef. It is the shared entry point for every
+// intent/note auto-commit call site so they inherit ambient context the
+// same way `camp commit` does, instead of each re-implementing the
+// resolve-and-populate step. Callers still set Files/PreStaged/
+// SelectiveOnly themselves before passing the result into commit.Intent.
+//
+// errw receives ref-backfill warnings from the underlying resolver; pass
+// os.Stderr for CLI callers, or nil to default to it. A TUI or other
+// screen-owning caller should pass a writer that does not touch the raw
+// terminal (see internal/intent/tui/explorer for the pattern that routes
+// this through slog instead).
+func AmbientCommitOptions(ctx context.Context, campaignRoot, campaignID string, errw io.Writer) commit.Options {
+	cwd, _ := os.Getwd()
+	cc := ResolveCommitContext(ctx, campaignRoot, cwd, errw)
+	return commit.Options{
+		CampaignRoot: campaignRoot,
+		CampaignID:   campaignID,
+		QuestID:      cc.QuestID,
+		FestivalRef:  cc.FestivalRef,
+		WorkitemRef:  cc.WorkitemRef,
 	}
 }

--- a/internal/commands/workitem/commit_context_test.go
+++ b/internal/commands/workitem/commit_context_test.go
@@ -76,3 +76,45 @@ func TestResolveCommitContext_CancelledContextIsZero(t *testing.T) {
 		t.Errorf("expected zero CommitContext on cancelled context, got %+v", cc)
 	}
 }
+
+func TestAmbientCommitOptions_ContextPresent(t *testing.T) {
+	const ref = "WI-abc123"
+	root := writeCommitContextCampaign(t)
+	wiDir := seedDesignWorkitemMarker(t, root, ref)
+	restore := chdir(t, wiDir)
+	t.Cleanup(restore)
+
+	var errw bytes.Buffer
+	opts := AmbientCommitOptions(context.Background(), root, "campaign-id", &errw)
+
+	if opts.CampaignRoot != root {
+		t.Errorf("CampaignRoot = %q, want %q", opts.CampaignRoot, root)
+	}
+	if opts.CampaignID != "campaign-id" {
+		t.Errorf("CampaignID = %q, want %q", opts.CampaignID, "campaign-id")
+	}
+	if opts.WorkitemRef != ref {
+		t.Errorf("WorkitemRef = %q, want %q (errw=%q)", opts.WorkitemRef, ref, errw.String())
+	}
+	if opts.FestivalRef != "" {
+		t.Errorf("FestivalRef = %q, want empty for a non-festival source", opts.FestivalRef)
+	}
+}
+
+func TestAmbientCommitOptions_ContextAbsent(t *testing.T) {
+	root := writeCommitContextCampaign(t)
+	restore := chdir(t, root)
+	t.Cleanup(restore)
+
+	opts := AmbientCommitOptions(context.Background(), root, "campaign-id", nil)
+
+	if opts.CampaignRoot != root {
+		t.Errorf("CampaignRoot = %q, want %q", opts.CampaignRoot, root)
+	}
+	if opts.CampaignID != "campaign-id" {
+		t.Errorf("CampaignID = %q, want %q", opts.CampaignID, "campaign-id")
+	}
+	if opts.QuestID != "" || opts.FestivalRef != "" || opts.WorkitemRef != "" {
+		t.Errorf("expected zero ambient context, got QuestID=%q FestivalRef=%q WorkitemRef=%q", opts.QuestID, opts.FestivalRef, opts.WorkitemRef)
+	}
+}

--- a/internal/git/campaign_tag.go
+++ b/internal/git/campaign_tag.go
@@ -17,9 +17,13 @@ const legacyTagMarker = "OBEY-CAMPAIGN"
 // FormatContextTagsFull builds the campaign tag. The leading token is the
 // slugified campaign name plus the short id ("[obey-campaign:8deed8b4]"),
 // falling back to "[OBEY-CAMPAIGN-<id>]" when campaignName has no slug. The
-// remaining components follow in fixed order: quest, festival, workitem.
+// remaining components follow in fixed order: quest, festival, workitem,
+// note. noteRef is optional (mirroring FormatCampaignTag's questID) so
+// existing callers are unaffected; only the note commit path passes one, and
+// it may co-occur with workitemRef since they describe different things (the
+// ambient context a note was captured in vs. the note itself).
 // Returns "" when campaignID is empty.
-func FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef string) string {
+func FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef string, noteRef ...string) string {
 	if campaignID == "" {
 		return ""
 	}
@@ -50,6 +54,16 @@ func FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemR
 		// The ref already carries WI-, so it is self-identifying and embedded
 		// verbatim (no extra marker).
 		parts = append(parts, workitemRef)
+	}
+	nr := ""
+	if len(noteRef) > 0 {
+		nr = noteRef[0]
+	}
+	if nr != "" {
+		if !strings.HasPrefix(nr, "NT-") {
+			nr = "NT-" + nr
+		}
+		parts = append(parts, nr)
 	}
 	return "[" + strings.Join(parts, "-") + "]"
 }
@@ -96,6 +110,7 @@ type TagComponents struct {
 	QuestID      string `json:"quest_id"`
 	FestRef      string `json:"fest_ref"`
 	WorkitemRef  string `json:"workitem_ref"` // carries the WI- prefix
+	NoteRef      string `json:"note_ref"`     // carries the NT- prefix
 }
 
 // leadingTagRegex captures the leading bracket content; tags are only honored
@@ -108,6 +123,7 @@ var tagBodyScanRegex = regexp.MustCompile(`\[(?:` + legacyTagMarker + `-[^\]]+|[
 
 var (
 	tagWorkitemRefRe = regexp.MustCompile(`^WI-[0-9a-f]{6}$`)
+	tagNoteRefRe     = regexp.MustCompile(`^NT-[0-9a-f]{6}$`)
 	tagQuestIDRe     = regexp.MustCompile(`^qst_[A-Za-z0-9_]{1,40}$`)
 	tagFestRefRe     = regexp.MustCompile(`^[A-Za-z0-9]{1,32}$`)
 	// Real campaign ids are UUID-derived hex; gating on it rejects ordinary
@@ -199,24 +215,40 @@ func ParseTagDetailed(subject string) (TagComponents, []TagParseWarning) {
 			}
 			rest = after
 		case strings.HasPrefix(rest, "WI-"):
-			// WI- is the last segment. Accept the single-prefix ref (WI-abcdef)
-			// and the historical doubled form (WI-WI-abcdef).
-			ref := rest
-			if strings.HasPrefix(ref, "WI-WI-") {
-				ref = ref[len("WI-"):]
-			}
-			if !tagWorkitemRefRe.MatchString(ref) {
+			// WI- used to be the last segment; it no longer is (NT- may follow,
+			// since a note captured inside an active workitem carries both).
+			// splitWorkitemSegment bounds the match at the fixed ref length so
+			// any trailing "-NT-..." is left for the next loop iteration.
+			seg, after := splitWorkitemSegment(rest)
+			if !tagWorkitemRefRe.MatchString(seg) {
 				warnings = append(warnings, TagParseWarning{
-					Field: "workitem_ref", Value: ref,
+					Field: "workitem_ref", Value: seg,
 					Reason: "shape check failed (want WI-<6 hex>)",
 				})
 			} else if out.WorkitemRef != "" {
 				warnings = append(warnings, TagParseWarning{
-					Field: "workitem_ref", Value: ref,
+					Field: "workitem_ref", Value: seg,
 					Reason: "duplicate workitem_ref segment",
 				})
 			} else {
-				out.WorkitemRef = ref
+				out.WorkitemRef = seg
+			}
+			rest = after
+		case strings.HasPrefix(rest, "NT-"):
+			// NT- is always the last segment in the fixed order.
+			seg := rest
+			if !tagNoteRefRe.MatchString(seg) {
+				warnings = append(warnings, TagParseWarning{
+					Field: "note_ref", Value: seg,
+					Reason: "shape check failed (want NT-<6 hex>)",
+				})
+			} else if out.NoteRef != "" {
+				warnings = append(warnings, TagParseWarning{
+					Field: "note_ref", Value: seg,
+					Reason: "duplicate note_ref segment",
+				})
+			} else {
+				out.NoteRef = seg
 			}
 			rest = ""
 		default:
@@ -250,4 +282,42 @@ func splitAtDash(s string) (string, string) {
 		return s[:i], s[i+1:]
 	}
 	return s, ""
+}
+
+// splitWorkitemSegment extracts a WI- segment from the front of rest,
+// returning the remainder that follows it. splitAtDash cannot be used here:
+// the historical doubled form (WI-WI-abcdef) has an internal dash that is
+// not a segment boundary. On a shape match (single or doubled prefix plus
+// exactly 6 lowercase hex chars) it returns the normalized single-prefix
+// ref and the trailing remainder (leading "-" stripped) so a following
+// segment such as NT- is left for the next parse iteration. On a shape
+// mismatch it falls back to the legacy behavior of treating the entire
+// remainder as the malformed value (doubled-prefix stripped once, mirroring
+// the historical ref-detection step) so existing malformed-tag warnings are
+// unchanged.
+func splitWorkitemSegment(rest string) (seg, after string) {
+	doubled := strings.HasPrefix(rest, "WI-WI-")
+	prefixLen := len("WI-")
+	if doubled {
+		prefixLen = len("WI-WI-")
+	}
+	if len(rest) >= prefixLen+6 && isLowerHex(rest[prefixLen:prefixLen+6]) {
+		end := prefixLen + 6
+		return "WI-" + rest[prefixLen:end], strings.TrimPrefix(rest[end:], "-")
+	}
+	seg = rest
+	if doubled {
+		seg = rest[len("WI-"):]
+	}
+	return seg, ""
+}
+
+// isLowerHex reports whether s consists solely of lowercase hex digits.
+func isLowerHex(s string) bool {
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/git/campaign_tag_full_test.go
+++ b/internal/git/campaign_tag_full_test.go
@@ -102,6 +102,62 @@ func TestFormatContextTagsFull_AllCombinations(t *testing.T) {
 	}
 }
 
+func TestFormatContextTagsFull_NoteRef(t *testing.T) {
+	cases := []struct {
+		name                                               string
+		cname, campaign, quest, fest, workitem, note, want string
+	}{
+		{
+			name:     "note only",
+			campaign: "8deed8b4", note: "NT-abcdef",
+			want: "[OBEY-CAMPAIGN-8deed8b4-NT-abcdef]",
+		},
+		{
+			name:     "note ref normalized",
+			campaign: "8deed8b4", note: "abcdef",
+			want: "[OBEY-CAMPAIGN-8deed8b4-NT-abcdef]",
+		},
+		{
+			name:     "note co-occurs with workitem, note goes last",
+			campaign: "8deed8b4", workitem: "WI-abcdef", note: "NT-123456",
+			want: "[OBEY-CAMPAIGN-8deed8b4-WI-abcdef-NT-123456]",
+		},
+		{
+			name:     "note co-occurs with quest, festival, and workitem",
+			campaign: "8deed8b4", quest: "qst_abc", fest: "CW0003", workitem: "WI-abcdef", note: "NT-123456",
+			want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc-FE-CW0003-WI-abcdef-NT-123456]",
+		},
+		{
+			name:  "name-style head with note ref",
+			cname: "obey-campaign", campaign: "8deed8b4", note: "NT-abcdef",
+			want: "[obey-campaign:8deed8b4-NT-abcdef]",
+		},
+		{
+			name:     "no note ref omits the segment",
+			campaign: "8deed8b4", workitem: "WI-abcdef",
+			want: "[OBEY-CAMPAIGN-8deed8b4-WI-abcdef]",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatContextTagsFull(tc.cname, tc.campaign, tc.quest, tc.fest, tc.workitem, tc.note)
+			if got != tc.want {
+				t.Fatalf("FormatContextTagsFull = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatContextTagsFull_NoteRefOmittedWhenNotPassed(t *testing.T) {
+	// Existing 5-arg callers (no noteRef argument at all) must be unaffected
+	// by the new variadic trailing parameter.
+	got := FormatContextTagsFull("", "8deed8b4", "", "", "WI-abcdef")
+	want := "[OBEY-CAMPAIGN-8deed8b4-WI-abcdef]"
+	if got != want {
+		t.Fatalf("FormatContextTagsFull (5-arg call) = %q, want %q", got, want)
+	}
+}
+
 func TestFormatCampaignTag_BackwardCompat(t *testing.T) {
 	cases := []struct {
 		campaign, quest, want string
@@ -257,6 +313,140 @@ func TestParseTag_RoundTripProperty(t *testing.T) {
 		if got.WorkitemRef != workitem {
 			t.Fatalf("iter %d: workitem round-trip broke: %q -> %q (tag %q)", i, workitem, got.WorkitemRef, tag)
 		}
+	}
+}
+
+func TestParseTag_NoteRefRoundTripProperty(t *testing.T) {
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		cname := "c" + randHex(t, 2)
+		campaign := randHex(t, 4)
+		quest := ""
+		fest := ""
+		workitem := ""
+		note := ""
+		if i%2 == 0 {
+			quest = "qst_" + randHex(t, 3)
+		}
+		if i%3 == 0 {
+			fest = "CW" + randHex(t, 2)
+		}
+		if i%5 == 0 {
+			workitem = "WI-" + randHex(t, 3)
+		}
+		if i%7 == 0 {
+			note = "NT-" + randHex(t, 3)
+		}
+
+		tag := FormatContextTagsFull(cname, campaign, quest, fest, workitem, note)
+		got := ParseTag(tag)
+		if got.WorkitemRef != workitem {
+			t.Fatalf("iter %d: workitem round-trip broke: %q -> %q (tag %q)", i, workitem, got.WorkitemRef, tag)
+		}
+		if got.NoteRef != note {
+			t.Fatalf("iter %d: note round-trip broke: %q -> %q (tag %q)", i, note, got.NoteRef, tag)
+		}
+	}
+}
+
+func TestFormatAndParse_NoteRefWithWorkitem_RoundTrip(t *testing.T) {
+	tag := FormatContextTagsFull("obey-campaign", "8deed8b4", "qst_abc", "CW0003", "WI-abcdef", "NT-123456")
+	got := ParseTag(tag)
+	if got.WorkitemRef != "WI-abcdef" {
+		t.Fatalf("WorkitemRef = %q, want WI-abcdef (tag %q)", got.WorkitemRef, tag)
+	}
+	if got.NoteRef != "NT-123456" {
+		t.Fatalf("NoteRef = %q, want NT-123456 (tag %q)", got.NoteRef, tag)
+	}
+	if got.FestRef != "CW0003" {
+		t.Fatalf("FestRef = %q, want CW0003 (tag %q)", got.FestRef, tag)
+	}
+	if got.QuestID != "qst_abc" {
+		t.Fatalf("QuestID = %q, want qst_abc (tag %q)", got.QuestID, tag)
+	}
+}
+
+func TestFormatAndParse_NoteRefWithoutWorkitem_RoundTrip(t *testing.T) {
+	tag := FormatContextTagsFull("obey-campaign", "8deed8b4", "", "", "", "NT-123456")
+	got := ParseTag(tag)
+	if got.WorkitemRef != "" {
+		t.Fatalf("WorkitemRef = %q, want empty (tag %q)", got.WorkitemRef, tag)
+	}
+	if got.NoteRef != "NT-123456" {
+		t.Fatalf("NoteRef = %q, want NT-123456 (tag %q)", got.NoteRef, tag)
+	}
+}
+
+func TestParseTagDetailed_NoteRefShapeChecks(t *testing.T) {
+	cases := []struct {
+		name             string
+		subject          string
+		wantNoteRef      string
+		wantWarningField []string
+	}{
+		{
+			name:        "valid note ref, no workitem",
+			subject:     "[OBEY-CAMPAIGN-abc-NT-abcdef] x",
+			wantNoteRef: "NT-abcdef",
+		},
+		{
+			name:        "valid note ref co-occurring with workitem",
+			subject:     "[OBEY-CAMPAIGN-abc-WI-WI-deadbe-NT-abcdef] x",
+			wantNoteRef: "NT-abcdef",
+		},
+		{
+			name:             "malformed note ref (bad hex) zeroes ref",
+			subject:          "[OBEY-CAMPAIGN-abc-NT-ZZZZZZ] x",
+			wantWarningField: []string{"note_ref"},
+		},
+		{
+			name:             "malformed note ref (wrong length) zeroes ref",
+			subject:          "[OBEY-CAMPAIGN-abc-NT-abcd] x",
+			wantWarningField: []string{"note_ref"},
+		},
+		{
+			// NT- is terminal (unlike WI-, it never has a following segment), so
+			// once the "NT-" prefix is seen the whole remainder is the shape-check
+			// candidate; a second "-NT-..." here is just more malformed content,
+			// not a separate duplicate segment.
+			name:             "trailing junk after note ref fails shape as one segment",
+			subject:          "[OBEY-CAMPAIGN-abc-NT-aaaaaa-NT-bbbbbb] x",
+			wantWarningField: []string{"note_ref"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, warnings := ParseTagDetailed(tc.subject)
+			if got.NoteRef != tc.wantNoteRef {
+				t.Errorf("NoteRef = %q, want %q", got.NoteRef, tc.wantNoteRef)
+			}
+			if len(warnings) != len(tc.wantWarningField) {
+				t.Fatalf("warnings count = %d, want %d: %+v", len(warnings), len(tc.wantWarningField), warnings)
+			}
+			for i, want := range tc.wantWarningField {
+				if warnings[i].Field != want {
+					t.Errorf("warning[%d].Field = %q, want %q", i, warnings[i].Field, want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseTagDetailed_UnrecognizedNotePrefixIsUnknownSegment(t *testing.T) {
+	// "NTX-..." does not match the "NT-" prefix boundary, so it falls to the
+	// generic unknown-segment path (split at each dash) instead of the
+	// dedicated note_ref check, the same way "WIX-..." would miss the WI- case.
+	got, warnings := ParseTagDetailed("[OBEY-CAMPAIGN-abc-NTX-abcdef] x")
+	if got.NoteRef != "" {
+		t.Fatalf("NoteRef = %q, want empty", got.NoteRef)
+	}
+	for i, w := range warnings {
+		if w.Field != "unknown" {
+			t.Errorf("warning[%d].Field = %q, want unknown", i, w.Field)
+		}
+	}
+	if len(warnings) != 2 {
+		t.Fatalf("warnings = %+v, want two unknown-segment warnings (NTX, abcdef)", warnings)
 	}
 }
 

--- a/internal/git/commit/commit.go
+++ b/internal/git/commit/commit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/git"
@@ -15,6 +16,30 @@ type Result struct {
 	NoChanges bool   // True if there was nothing to commit
 	Err       error  // Set when a commit attempt failed
 	Message   string // User-facing message
+
+	// Skipped is true when the commit was never attempted because of a
+	// caller-detectable precondition (missing campaign context, or a
+	// selective commit that resolved to zero files to stage) rather than
+	// git genuinely finding nothing changed. SkipReason explains why.
+	// Both preconditions would otherwise look identical to a legitimate
+	// "nothing to commit" outcome, so callers that want to surface a
+	// symptom like "my capture didn't commit" should check Skipped via
+	// WarnIfSkipped instead of relying on Message alone.
+	Skipped    bool
+	SkipReason string
+}
+
+// WarnIfSkipped writes a warning line to w when res reports a guaranteed
+// commit skip (see Result.Skipped). It is a no-op otherwise. Committed,
+// NoChanges, Message, and Err are unaffected by a skip, so existing
+// Message-based output at call sites is unchanged; this only adds an
+// explicit, greppable signal for the skip causes that would otherwise be
+// silent or indistinguishable from a normal no-op commit.
+func WarnIfSkipped(w io.Writer, res Result) {
+	if !res.Skipped {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "warning: %s\n", res.SkipReason)
 }
 
 // Options configures common commit parameters.
@@ -54,8 +79,19 @@ func resolveCampaignName(ctx context.Context, opts Options) string {
 func doCommit(ctx context.Context, opts Options, action, subject, description string) Result {
 	if opts.CampaignRoot == "" || opts.CampaignID == "" {
 		return Result{
-			Committed: false,
-			Message:   "", // Silent failure - campaign info not available
+			Committed:  false,
+			Skipped:    true,
+			SkipReason: fmt.Sprintf("%s: missing campaign context (CampaignRoot or CampaignID is empty)", action),
+		}
+	}
+
+	if opts.SelectiveOnly && len(opts.Files) == 0 && len(opts.PreStaged) == 0 {
+		return Result{
+			Committed:  false,
+			NoChanges:  true,
+			Skipped:    true,
+			SkipReason: fmt.Sprintf("%s: selective commit requested but no files resolved to stage", action),
+			Message:    "(no changes to commit)",
 		}
 	}
 

--- a/internal/git/commit/commit.go
+++ b/internal/git/commit/commit.go
@@ -50,6 +50,7 @@ type Options struct {
 	QuestID       string   // Optional quest ID for additive commit context
 	FestivalRef   string   // Optional festival ref for additive commit context
 	WorkitemRef   string   // Optional workitem ref (WI-<6 hex>) for additive commit context
+	NoteRef       string   // Optional note ref (NT-<6 hex>); set only by the note commit path
 	Files         []string // If set, stage only these paths instead of everything
 	PreStaged     []string // Paths already staged; copied from the real index into the temp-index commit scope
 	SelectiveOnly bool     // When true, never fall back to CommitAll; no-op if Files is empty
@@ -96,7 +97,7 @@ func doCommit(ctx context.Context, opts Options, action, subject, description st
 	}
 
 	commitMsg := fmt.Sprintf("%s %s: %s",
-		git.FormatContextTagsFull(resolveCampaignName(ctx, opts), opts.CampaignID, opts.QuestID, opts.FestivalRef, opts.WorkitemRef),
+		git.FormatContextTagsFull(resolveCampaignName(ctx, opts), opts.CampaignID, opts.QuestID, opts.FestivalRef, opts.WorkitemRef, opts.NoteRef),
 		action,
 		subject,
 	)

--- a/internal/git/commit/commit_test.go
+++ b/internal/git/commit/commit_test.go
@@ -1,6 +1,7 @@
 package commit
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"os/exec"
@@ -41,6 +42,108 @@ func TestIntent_MissingCampaignInfo(t *testing.T) {
 
 	if result.Committed {
 		t.Error("expected Committed to be false when CampaignID is empty")
+	}
+}
+
+func TestDoCommit_SkippedReasons(t *testing.T) {
+	tests := []struct {
+		name           string
+		opts           Options
+		wantSkipped    bool
+		wantNoChanges  bool
+		wantMessage    string
+		wantReasonPart string
+	}{
+		{
+			name:           "missing campaign root",
+			opts:           Options{CampaignRoot: "", CampaignID: "test-id"},
+			wantSkipped:    true,
+			wantNoChanges:  false,
+			wantMessage:    "",
+			wantReasonPart: "missing campaign context",
+		},
+		{
+			name:           "missing campaign id",
+			opts:           Options{CampaignRoot: "/some/path", CampaignID: ""},
+			wantSkipped:    true,
+			wantNoChanges:  false,
+			wantMessage:    "",
+			wantReasonPart: "missing campaign context",
+		},
+		{
+			name:           "selective commit with zero resolved files",
+			opts:           Options{CampaignRoot: "/some/path", CampaignID: "test-id", SelectiveOnly: true},
+			wantSkipped:    true,
+			wantNoChanges:  true,
+			wantMessage:    "(no changes to commit)",
+			wantReasonPart: "no files resolved to stage",
+		},
+		{
+			name:        "selective commit with pre-staged files is not a skip precondition",
+			opts:        Options{CampaignRoot: "/nonexistent-repo-for-test", CampaignID: "test-id", SelectiveOnly: true, PreStaged: []string{"a.txt"}},
+			wantSkipped: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "selective commit with pre-staged files is not a skip precondition" {
+				// This case is expected to attempt a real commit and fail
+				// because the campaign root does not exist; we only care
+				// that it was not classified as a guaranteed Skip.
+				result := doCommit(context.Background(), tt.opts, "Test", "subject", "")
+				if result.Skipped != tt.wantSkipped {
+					t.Errorf("Skipped = %v, want %v (result=%+v)", result.Skipped, tt.wantSkipped, result)
+				}
+				return
+			}
+
+			result := doCommit(context.Background(), tt.opts, "Test", "subject", "")
+			if result.Skipped != tt.wantSkipped {
+				t.Errorf("Skipped = %v, want %v", result.Skipped, tt.wantSkipped)
+			}
+			if result.NoChanges != tt.wantNoChanges {
+				t.Errorf("NoChanges = %v, want %v", result.NoChanges, tt.wantNoChanges)
+			}
+			if result.Message != tt.wantMessage {
+				t.Errorf("Message = %q, want %q", result.Message, tt.wantMessage)
+			}
+			if result.Committed {
+				t.Error("Committed = true, want false for a skip precondition")
+			}
+			if tt.wantReasonPart != "" && !strings.Contains(result.SkipReason, tt.wantReasonPart) {
+				t.Errorf("SkipReason = %q, want it to contain %q", result.SkipReason, tt.wantReasonPart)
+			}
+		})
+	}
+}
+
+func TestWarnIfSkipped(t *testing.T) {
+	tests := []struct {
+		name string
+		res  Result
+		want string
+	}{
+		{
+			name: "skipped writes a warning",
+			res:  Result{Skipped: true, SkipReason: "missing campaign context"},
+			want: "warning: missing campaign context\n",
+		},
+		{
+			name: "not skipped writes nothing",
+			res:  Result{Skipped: false, Message: "(no changes to commit)"},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			WarnIfSkipped(&buf, tt.res)
+			if got := buf.String(); got != tt.want {
+				t.Errorf("WarnIfSkipped() wrote %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/git/commit/commit_test.go
+++ b/internal/git/commit/commit_test.go
@@ -328,6 +328,97 @@ func TestIntent_WithQuestTag(t *testing.T) {
 	}
 }
 
+func TestIntent_WithNoteRefTag(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := exec.Command("git", "-C", tmpDir, "init").Run(); err != nil {
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+	if err := exec.Command("git", "-C", tmpDir, "config", "user.email", "test@test.com").Run(); err != nil {
+		t.Fatalf("failed to configure git email: %v", err)
+	}
+	if err := exec.Command("git", "-C", tmpDir, "config", "user.name", "Test").Run(); err != nil {
+		t.Fatalf("failed to configure git name: %v", err)
+	}
+
+	testFile := filepath.Join(tmpDir, "note.txt")
+	if err := os.WriteFile(testFile, []byte("note content"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	result := Intent(context.Background(), IntentOptions{
+		Options: Options{
+			CampaignRoot: tmpDir,
+			CampaignID:   "abcdef12",
+			WorkitemRef:  "WI-deadbe",
+			NoteRef:      "NT-abcdef",
+		},
+		Action:      IntentCreate,
+		IntentTitle: "Note-tagged intent",
+	})
+
+	if !result.Committed {
+		t.Fatalf("expected commit to succeed, got %s", result.Message)
+	}
+
+	out, err := exec.Command("git", "-C", tmpDir, "log", "-1", "--format=%B").Output()
+	if err != nil {
+		t.Fatalf("failed to get git log: %v", err)
+	}
+	commitMsg := string(out)
+	if !strings.Contains(commitMsg, "[OBEY-CAMPAIGN-abcdef12-WI-deadbe-NT-abcdef]") {
+		t.Fatalf("commit message missing note tag co-occurring with workitem: %s", commitMsg)
+	}
+}
+
+func TestIntent_NoteRefUnsetOmitsNoteSegment(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := exec.Command("git", "-C", tmpDir, "init").Run(); err != nil {
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+	if err := exec.Command("git", "-C", tmpDir, "config", "user.email", "test@test.com").Run(); err != nil {
+		t.Fatalf("failed to configure git email: %v", err)
+	}
+	if err := exec.Command("git", "-C", tmpDir, "config", "user.name", "Test").Run(); err != nil {
+		t.Fatalf("failed to configure git name: %v", err)
+	}
+
+	testFile := filepath.Join(tmpDir, "move.txt")
+	if err := os.WriteFile(testFile, []byte("move content"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	// A non-note action (e.g. IntentMove) with an active workitem in scope
+	// but NoteRef left unset (as every non-note call site does) must never
+	// emit an NT- segment.
+	result := Intent(context.Background(), IntentOptions{
+		Options: Options{
+			CampaignRoot: tmpDir,
+			CampaignID:   "abcdef12",
+			WorkitemRef:  "WI-deadbe",
+		},
+		Action:      IntentMove,
+		IntentTitle: "Moved intent",
+	})
+
+	if !result.Committed {
+		t.Fatalf("expected commit to succeed, got %s", result.Message)
+	}
+
+	out, err := exec.Command("git", "-C", tmpDir, "log", "-1", "--format=%B").Output()
+	if err != nil {
+		t.Fatalf("failed to get git log: %v", err)
+	}
+	commitMsg := string(out)
+	if strings.Contains(commitMsg, "-NT-") {
+		t.Fatalf("non-note commit must never carry an NT- segment: %s", commitMsg)
+	}
+	if !strings.Contains(commitMsg, "[OBEY-CAMPAIGN-abcdef12-WI-deadbe]") {
+		t.Fatalf("commit message missing expected workitem tag: %s", commitMsg)
+	}
+}
+
 func TestIntent_SelectiveStaging(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/intent/tui/explorer/audit.go
+++ b/internal/intent/tui/explorer/audit.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	wkcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/git/commit"
 	"github.com/Obedience-Corp/camp/internal/intent/audit"
 )
@@ -32,13 +33,37 @@ func newAutoCommitter() *autoCommitter {
 }
 
 func runAutoCommitIntent(ctx context.Context, opts commit.IntentOptions) {
-	if res := commit.Intent(ctx, opts); res.Err != nil {
+	res := commit.Intent(ctx, opts)
+	if res.Err != nil {
 		slog.WarnContext(ctx, "intent auto-commit failed",
 			"action", opts.Action,
 			"intent", opts.IntentTitle,
 			"error", res.Err,
 		)
+		return
 	}
+	if res.Skipped {
+		slog.WarnContext(ctx, "intent auto-commit skipped",
+			"action", opts.Action,
+			"intent", opts.IntentTitle,
+			"reason", res.SkipReason,
+		)
+	}
+}
+
+// slogWarnWriter adapts an io.Writer to slog.WarnContext so best-effort
+// ambient-context resolution warnings (ref backfill, etc.) reach the TUI's
+// redirected log file instead of the live terminal. Writing raw text to
+// stderr here would corrupt the bubbletea alt-screen; quietSlogDuringTUI
+// already routes the default slog handler to a log file for the same
+// reason, so this keeps warnings on that same path.
+type slogWarnWriter struct {
+	ctx context.Context
+}
+
+func (w slogWarnWriter) Write(p []byte) (int, error) {
+	slog.WarnContext(w.ctx, "intent auto-commit context resolution warning", "message", strings.TrimSpace(string(p)))
+	return len(p), nil
 }
 
 func (a *autoCommitter) start(ctx context.Context, opts commit.IntentOptions) {
@@ -87,22 +112,25 @@ func (m *Model) autoCommitFiles(files ...string) []string {
 
 // autoCommitIntent starts a best-effort intent commit if campaign context is available.
 func (m *Model) autoCommitIntent(action commit.IntentAction, title, description string, files ...string) {
-	if m.campaignRoot == "" || m.campaignID == "" {
-		return
-	}
 	ctx := m.ctx
 	if ctx == nil {
 		ctx = context.Background()
 	} else {
 		ctx = context.WithoutCancel(ctx)
 	}
+	if m.campaignRoot == "" || m.campaignID == "" {
+		slog.WarnContext(ctx, "intent auto-commit skipped",
+			"action", action,
+			"intent", title,
+			"reason", "missing campaign context: campaignRoot or campaignID is empty",
+		)
+		return
+	}
+	opts := wkcmd.AmbientCommitOptions(ctx, m.campaignRoot, m.campaignID, slogWarnWriter{ctx: ctx})
+	opts.Files = m.autoCommitFiles(files...)
+	opts.SelectiveOnly = true
 	m.autoCommit.start(ctx, commit.IntentOptions{
-		Options: commit.Options{
-			CampaignRoot:  m.campaignRoot,
-			CampaignID:    m.campaignID,
-			Files:         m.autoCommitFiles(files...),
-			SelectiveOnly: true,
-		},
+		Options:     opts,
 		Action:      action,
 		IntentTitle: title,
 		Description: description,

--- a/internal/intent/tui/explorer/audit_test.go
+++ b/internal/intent/tui/explorer/audit_test.go
@@ -3,13 +3,62 @@ package explorer
 import (
 	"bytes"
 	"context"
+	"log/slog"
+	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Obedience-Corp/camp/internal/git/commit"
 )
+
+func captureSlogWarnings(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+func seedExplorerAmbientCampaign(t *testing.T, withWorkitem bool) (root, wiDir string) {
+	t.Helper()
+	root = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".campaign"), 0o755); err != nil {
+		t.Fatalf("MkdirAll(.campaign): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".campaign", "campaign.yaml"),
+		[]byte("id: test-campaign\nname: Test\ntype: product\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(campaign.yaml): %v", err)
+	}
+
+	wiDir = filepath.Join(root, "workflow", "design", "example")
+	if err := os.MkdirAll(wiDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(wiDir): %v", err)
+	}
+	if !withWorkitem {
+		return root, wiDir
+	}
+	marker := "version: v1alpha6\nkind: workitem\nid: design-example-2026-05-24\ntype: design\ntitle: Example\nref: WI-abc123\n"
+	if err := os.WriteFile(filepath.Join(wiDir, ".workitem"), []byte(marker), 0o644); err != nil {
+		t.Fatalf("WriteFile(.workitem): %v", err)
+	}
+	return root, wiDir
+}
+
+func chdirForTest(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd(): %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir(%s): %v", dir, err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}
 
 func TestAutoCommitFiles_IncludesAuditLog(t *testing.T) {
 	campaignRoot := filepath.Join(string(filepath.Separator), "tmp", "campaign")
@@ -170,5 +219,101 @@ func TestDrainAutoCommitsSilentWhenNothingPending(t *testing.T) {
 	m.DrainAutoCommits(&buf)
 	if buf.Len() != 0 {
 		t.Fatalf("expected no output when no commits pending, got %q", buf.String())
+	}
+}
+
+func TestAutoCommitIntent_AmbientContext(t *testing.T) {
+	tests := []struct {
+		name            string
+		withWorkitem    bool
+		wantWorkitemRef string
+	}{
+		{
+			name:            "context present inherits workitem ref",
+			withWorkitem:    true,
+			wantWorkitemRef: "WI-abc123",
+		},
+		{
+			name:            "context absent falls back to bare tag",
+			withWorkitem:    false,
+			wantWorkitemRef: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root, wiDir := seedExplorerAmbientCampaign(t, tt.withWorkitem)
+			chdirForTest(t, wiDir)
+
+			intentsDir := filepath.Join(root, ".campaign", "intents")
+			m := NewModel(context.Background(), nil, nil, intentsDir, root, "campaign-id", "", nil)
+
+			captured := make(chan commit.IntentOptions, 1)
+			m.autoCommit.run = func(ctx context.Context, opts commit.IntentOptions) {
+				captured <- opts
+			}
+
+			m.autoCommitIntent(commit.IntentMove, "Test Intent", "desc", filepath.Join(intentsDir, "foo.md"))
+
+			select {
+			case opts := <-captured:
+				if opts.WorkitemRef != tt.wantWorkitemRef {
+					t.Errorf("WorkitemRef = %q, want %q", opts.WorkitemRef, tt.wantWorkitemRef)
+				}
+				if opts.CampaignRoot != root {
+					t.Errorf("CampaignRoot = %q, want %q", opts.CampaignRoot, root)
+				}
+				if opts.CampaignID != "campaign-id" {
+					t.Errorf("CampaignID = %q, want %q", opts.CampaignID, "campaign-id")
+				}
+			case <-time.After(time.Second):
+				t.Fatal("background auto-commit did not run")
+			}
+		})
+	}
+}
+
+func TestAutoCommitIntent_SkipsMissingCampaignContext(t *testing.T) {
+	buf := captureSlogWarnings(t)
+
+	m := NewModel(context.Background(), nil, nil, "", "", "", "", nil)
+	ran := false
+	m.autoCommit.run = func(ctx context.Context, opts commit.IntentOptions) {
+		ran = true
+	}
+
+	m.autoCommitIntent(commit.IntentMove, "Test Intent", "desc", "some/file.md")
+
+	if ran {
+		t.Fatal("expected auto-commit to be skipped when campaign context is missing, but run was invoked")
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "intent auto-commit skipped") {
+		t.Fatalf("expected skip warning logged, got: %s", logged)
+	}
+	if !strings.Contains(logged, "missing campaign context") {
+		t.Fatalf("expected missing-campaign-context reason logged, got: %s", logged)
+	}
+}
+
+func TestRunAutoCommitIntent_LogsSkipWarningForEmptySelectiveScope(t *testing.T) {
+	buf := captureSlogWarnings(t)
+
+	runAutoCommitIntent(context.Background(), commit.IntentOptions{
+		Options: commit.Options{
+			CampaignRoot:  "/some/campaign",
+			CampaignID:    "campaign-id",
+			SelectiveOnly: true,
+		},
+		Action:      commit.IntentMove,
+		IntentTitle: "Test Intent",
+	})
+
+	logged := buf.String()
+	if !strings.Contains(logged, "intent auto-commit skipped") {
+		t.Fatalf("expected skip warning logged, got: %s", logged)
+	}
+	if !strings.Contains(logged, "no files resolved to stage") {
+		t.Fatalf("expected skip reason logged, got: %s", logged)
 	}
 }

--- a/internal/workitem/ref.go
+++ b/internal/workitem/ref.go
@@ -14,13 +14,20 @@ const RefPrefix = "WI-"
 
 const maxRefCollisionRetries = 1 << 24
 
-// Derive returns the canonical ref for a workitem id. The shape is stable:
-// "WI-" plus the first 6 lowercase hex chars of sha256(id). Same id always
-// yields the same ref; this is the reason the field is safe to recompute
-// during migrations and doctor backfills.
+// Derive returns the canonical ref for a workitem id via DeriveWithPrefix.
+// Same id always yields the same ref; this is the reason the field is safe
+// to recompute during migrations and doctor backfills.
 func Derive(id string) string {
+	return DeriveWithPrefix(RefPrefix, id)
+}
+
+// DeriveWithPrefix returns "<prefix>" plus the first 6 lowercase hex chars
+// of sha256(id). Derive is DeriveWithPrefix(RefPrefix, id); other ref
+// families that share this scheme but are not workitems (e.g. note refs)
+// call it directly instead of duplicating the hashing logic.
+func DeriveWithPrefix(prefix, id string) string {
 	sum := sha256.Sum256([]byte(id))
-	return RefPrefix + hex.EncodeToString(sum[:])[:6]
+	return prefix + hex.EncodeToString(sum[:])[:6]
 }
 
 // DeriveUnique returns a ref guaranteed not to collide with the keys of

--- a/internal/workitem/ref_test.go
+++ b/internal/workitem/ref_test.go
@@ -25,6 +25,38 @@ func TestDerive_Deterministic(t *testing.T) {
 	}
 }
 
+func TestDerive_MatchesDeriveWithPrefix(t *testing.T) {
+	id := "design-foo-2026-05-24"
+	if got, want := Derive(id), DeriveWithPrefix(RefPrefix, id); got != want {
+		t.Fatalf("Derive(%q) = %q, want DeriveWithPrefix(RefPrefix, id) = %q", id, got, want)
+	}
+}
+
+func TestDeriveWithPrefix_Deterministic(t *testing.T) {
+	id := "give-notes-their-own-nt-20260623-221250"
+	first := DeriveWithPrefix("NT-", id)
+	second := DeriveWithPrefix("NT-", id)
+	if first != second {
+		t.Fatalf("DeriveWithPrefix(%q) is non-deterministic: %q vs %q", id, first, second)
+	}
+	notePattern := regexp.MustCompile(`^NT-[0-9a-f]{6}$`)
+	if !notePattern.MatchString(first) {
+		t.Fatalf("DeriveWithPrefix(%q) = %q does not match %s", id, first, notePattern)
+	}
+}
+
+func TestDeriveWithPrefix_DifferentPrefixesDifferentRefs(t *testing.T) {
+	id := "design-foo-2026-05-24"
+	wi := DeriveWithPrefix("WI-", id)
+	nt := DeriveWithPrefix("NT-", id)
+	if wi == nt {
+		t.Fatalf("DeriveWithPrefix with different prefixes collided: %q == %q", wi, nt)
+	}
+	if wi[len("WI-"):] != nt[len("NT-"):] {
+		t.Fatalf("expected same hash suffix across prefixes: WI %q, NT %q", wi, nt)
+	}
+}
+
 func TestDerive_DifferentIDsDifferentRefs(t *testing.T) {
 	a := Derive("design-foo-2026-05-24")
 	b := Derive("design-bar-2026-05-24")

--- a/tests/integration/commit_tags_test.go
+++ b/tests/integration/commit_tags_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -233,6 +234,58 @@ func TestIntegration_CommitTags_NoteNoContext(t *testing.T) {
 	assert.NotContains(t, subject, "FE-", "no-context note must not include FE-: %s", subject)
 	assert.Regexp(t, `^\[commit-tags:[0-9a-f]{1,8}\]`, subject,
 		"note should still carry the campaign tag: %s", subject)
+}
+
+func TestIntegration_CommitTags_NoteRefSegment(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/commit-tags-note-ref"
+	initCommitTagsCampaign(t, tc, dir)
+
+	// No workitem context: the note still gets its own NT-<ref> segment even
+	// though there is no WI- to sit alongside.
+	out, err := tc.RunCampInDir(dir, "intent", "note", "loose note for NT ref")
+	require.NoError(t, err, "camp intent note: %s", out)
+
+	subject := lastCommitSubject(t, tc, dir)
+	assert.Regexp(t, `-NT-[0-9a-f]{6}\]`, subject,
+		"note commit should carry its own NT-<ref> segment: %s", subject)
+}
+
+func TestIntegration_CommitTags_NoteRefCoOccursWithWorkitem(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/commit-tags-note-ref-wi"
+	initCommitTagsCampaign(t, tc, dir)
+	ref := seedDesignWorkitemWithRef(t, tc, dir, "noteref")
+
+	// A note captured inside an active workitem carries both: WI- (the ambient
+	// context it was captured in) and NT- (the note itself), in that order.
+	wiDir := dir + "/workflow/design/noteref"
+	out, err := tc.RunCampInDir(wiDir, "intent", "note", "note inside a workitem")
+	require.NoError(t, err, "camp intent note: %s", out)
+
+	subject := lastCommitSubject(t, tc, dir)
+	assert.Contains(t, subject, ref, "note commit should still inherit the ambient WI-<ref>: %s", subject)
+	assert.Regexp(t, regexp.QuoteMeta(ref)+`-NT-[0-9a-f]{6}\]`, subject,
+		"NT- should follow WI- in the fixed tag order: %s", subject)
+}
+
+func TestIntegration_CommitTags_NonNoteActionNeverEmitsNoteRef(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/commit-tags-no-note-leak"
+	initCommitTagsCampaign(t, tc, dir)
+	ref := seedDesignWorkitemWithRef(t, tc, dir, "noleak")
+
+	// A non-note intent action from inside the same workitem context: it must
+	// still carry WI- but never NT-, since only the note commit path derives
+	// a note ref (guards against AmbientCommitOptions accidentally leaking one
+	// into every other intent auto-commit call site).
+	wiDir := dir + "/workflow/design/noleak"
+	out, err := tc.RunCampInDir(wiDir, "intent", "add", "regular intent, not a note")
+	require.NoError(t, err, "camp intent add: %s", out)
+
+	subject := lastCommitSubject(t, tc, dir)
+	assert.Contains(t, subject, ref, "intent add should still inherit ambient WI-<ref>: %s", subject)
+	assert.NotContains(t, subject, "-NT-", "non-note commit must never carry an NT- segment: %s", subject)
 }
 
 func TestIntegration_AutoWriteEnv(t *testing.T) {


### PR DESCRIPTION
## Summary

Covers two related intents about intent/note auto-commits:

- `inherit-ambient-questfestivalworkitem-context-on-20260623-221208`: intent/note auto-commits should inherit ambient quest/festival/workitem context in their commit tags, the same way `camp commit` does.
- `intents-not-auto-committing-20260628-225225`: Lance reported intents not auto-committing from festival-app adds and TUI moves.

### Intent A: ambient context on every remaining call site

`add.go`/`note.go` already resolved ambient context via `wkcmd.ResolveCommitContext` and populated `commit.Options.QuestID/FestivalRef/WorkitemRef` by hand. Every other intent mutation caller emitted only a bare `[OBEY-CAMPAIGN-<id>]` tag. This PR extends the same behavior to all of them: `move`, `archive`, `edit`, `promote`, `convert`, `rename`, `gather`, `crawl`, `camp gather feedback`, and the TUI explorer's background auto-commit.

Instead of repeating the resolve-and-populate block at eleven call sites, it is factored into one shared helper:

```go
// internal/commands/workitem/commit_context.go
func AmbientCommitOptions(ctx context.Context, campaignRoot, campaignID string, errw io.Writer) commit.Options
```

Every CLI call site now does:

```go
opts := wkcmd.AmbientCommitOptions(ctx, campaignRoot, cfg.ID, os.Stderr)
opts.Files = commit.NormalizeFiles(...)
opts.SelectiveOnly = true
commitResult := commit.Intent(ctx, commit.IntentOptions{Options: opts, Action: ..., IntentTitle: ...})
```

`add.go`/`note.go` were refactored onto the same helper for consistency. Resolution failures stay non-fatal (empty fields, bare tag), matching current behavior.

For the TUI (`internal/intent/tui/explorer/audit.go`), the helper's `errw` parameter is routed through a small `slogWarnWriter` adapter instead of `os.Stderr`, so ref-backfill warnings land in the TUI's redirected log file (`quietSlogDuringTUI`) instead of corrupting the bubbletea alt-screen.

### Intent B: silent auto-commit skips are now loud

Investigated the reported symptom against current code: it does not reproduce. The TUI move path already commits via `autoCommitIntent` (`internal/intent/tui/explorer/actions.go:136`), and there is no config gate that disables auto-commit. However, two `commit.Options` preconditions were verified that would look exactly like this bug if they ever trigger, because both currently look identical to a legitimate no-op commit:

1. `doCommit` returns silently when `CampaignRoot` or `CampaignID` is empty.
2. A `SelectiveOnly` commit that resolves to zero files (`Files` and `PreStaged` both empty) hits `git.ErrNoChanges` without ever attempting anything.

`commit.Result` now carries `Skipped bool` / `SkipReason string`, populated for exactly these two preconditions (existing `Committed`/`NoChanges`/`Message`/`Err` values are unchanged, so this is additive). A new `commit.WarnIfSkipped(w io.Writer, res Result)` writes a stderr warning; every CLI call site invokes it after building the commit result. The TUI's `runAutoCommitIntent` and `autoCommitIntent` log through the existing `slog.WarnContext` mechanism instead, keeping the terminal clean.

Net effect: both skip paths are non-fatal exactly as before, but now surface a clear, greppable signal instead of nothing, so a recurrence of Lance's symptom is diagnosable.

## Test plan

- [x] `just build` (stable and dev profiles)
- [x] `go vet ./...`, `go vet -tags dev ./...`, `go vet -tags=integration ./...`
- [x] `just lint` (stable and dev profiles): 0 issues, no new host-FS-test violators, no fmt.Errorf regressions
- [x] `just test unit` (stable profile): 3089/3089 passed
- [x] `BUILD_TAGS=dev just test unit`: 3118/3118 passed
- [x] New table-driven tests: `internal/git/commit/commit_test.go` (`Skipped`/`SkipReason` for both trigger conditions, `WarnIfSkipped`), `internal/commands/workitem/commit_context_test.go` (`AmbientCommitOptions` context-present/context-absent), `internal/intent/tui/explorer/audit_test.go` (ambient context threading, both loud-skip paths, via the existing `m.autoCommit.run` stub seam - no host git mutation)
- [x] Pure-logic/unit only; no new host-FS-mutating tests added (existing `internal/git/commit` suite already used t.TempDir + real git, extended in place)