### PR TITLE
fix(remote): resolve remote camp over a login shell PATH

### DIFF
--- a/cmd/camp/list.go
+++ b/cmd/camp/list.go
@@ -64,7 +64,13 @@ Examples:
   camp list --sort name      Sort by name
   camp list --sort org       Sort by org, then name
   camp list --format simple  Names only for scripting
-  camp list --count          Print only the total number of campaigns`,
+  camp list --count          Print only the total number of campaigns
+  camp list --remote         Also list campaigns on machines in ~/.obey/machines.yaml
+
+--remote runs each machine's own 'camp list --json' through a login shell
+(sh -lc) so PATH entries a login profile exports (~/.profile, etc.) are
+picked up. If camp still can't be found on a machine, set
+CAMP_REMOTE_CAMP_PATH to its exact path there.`,
 	Aliases: []string{"ls"},
 	RunE:    runList,
 }

--- a/cmd/camp/list_remote.go
+++ b/cmd/camp/list_remote.go
@@ -47,14 +47,15 @@ func fanOutRemote(ctx context.Context, ms []machines.Machine, enumerate enumerat
 }
 
 // remoteListArgs re-expresses the local list filter as flags on the remote
-// `camp list --json`. Passing --all/--status is a correctness requirement, not
-// just payload reduction: the remote default emits active campaigns only, so any
+// `list --json` (the args RunCampCommand appends after the resolved camp
+// binary). Passing --all/--status is a correctness requirement, not just
+// payload reduction: the remote default emits active campaigns only, so any
 // row outside the active set must be explicitly requested or it is never fetched
 // (a local re-filter cannot recover rows the remote never sent). --org/--tag also
 // shrink the ssh payload. renderListTable still re-filters the combined set as the
 // authoritative backstop against a version-skewed or looser remote.
 func remoteListArgs(f listFilter) string {
-	cmd := "camp list --json"
+	cmd := "list --json"
 	if f.org != "" {
 		cmd += " --org " + remote.ShellQuote(f.org)
 	}
@@ -76,12 +77,9 @@ func remoteListArgs(f listFilter) string {
 // each row with the machine id. Remote paths are left verbatim (meaningful only on
 // the far machine).
 func enumerateRemoteFor(f listFilter) enumerateFunc {
-	remoteCmd := remoteListArgs(f)
+	args := remoteListArgs(f)
 	return func(ctx context.Context, m *machines.Machine) ([]campaignEntry, error) {
-		if err := remote.EnsureKeyAuth(m); err != nil {
-			return nil, err
-		}
-		out, err := remote.Run(ctx, remote.Target(m), remote.Opts(m), remoteCmd)
+		out, err := remote.RunCampCommand(ctx, m, args)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/camp/list_remote_test.go
+++ b/cmd/camp/list_remote_test.go
@@ -16,12 +16,12 @@ func TestRemoteListArgs(t *testing.T) {
 		f    listFilter
 		want string
 	}{
-		{"empty", listFilter{}, "camp list --json"},
-		{"org", listFilter{org: "obey"}, "camp list --json --org 'obey'"},
-		{"tags repeat", listFilter{tags: []string{"a", "b"}}, "camp list --json --tag 'a' --tag 'b'"},
-		{"status", listFilter{status: "inactive"}, "camp list --json --status 'inactive'"},
-		{"all", listFilter{all: true}, "camp list --json --all"},
-		{"combined", listFilter{org: "obey", tags: []string{"x"}, all: true}, "camp list --json --org 'obey' --tag 'x' --all"},
+		{"empty", listFilter{}, "list --json"},
+		{"org", listFilter{org: "obey"}, "list --json --org 'obey'"},
+		{"tags repeat", listFilter{tags: []string{"a", "b"}}, "list --json --tag 'a' --tag 'b'"},
+		{"status", listFilter{status: "inactive"}, "list --json --status 'inactive'"},
+		{"all", listFilter{all: true}, "list --json --all"},
+		{"combined", listFilter{org: "obey", tags: []string{"x"}, all: true}, "list --json --org 'obey' --tag 'x' --all"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/camp/switch.go
+++ b/cmd/camp/switch.go
@@ -41,7 +41,16 @@ The --print flag outputs just the path for shell integration:
 
 Use campaign@tab to navigate to a specific location in the target campaign:
   camp switch obey-campaign@p    # Switch and navigate to projects/
-  camp switch obey/platform@f    # Switch inside org and navigate to festivals/`,
+  camp switch obey/platform@f    # Switch inside org and navigate to festivals/
+
+Use machine:campaign to resolve a campaign on a machine registered in
+~/.obey/machines.yaml (via the csw shell wrapper, which hops there over ssh):
+  csw devbox:obey-campaign       # Resolve and hop to obey-campaign on devbox
+
+Remote resolution runs the far machine's own 'camp switch' through a login
+shell (sh -lc) so PATH entries a login profile exports (~/.profile, etc.) are
+picked up. If camp still can't be found there, set CAMP_REMOTE_CAMP_PATH to
+its exact path on that machine.`,
 	Example: `  camp switch                        # Interactive picker
   camp switch obey-campaign          # Switch by name
   camp switch --org obey platform    # Switch by name within an org

--- a/internal/remote/ssh.go
+++ b/internal/remote/ssh.go
@@ -8,6 +8,7 @@ package remote
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -199,8 +200,11 @@ func ShellQuote(s string) string {
 }
 
 // Run execs `ssh <opts> <target> <remoteCmd>` and returns stdout. The call is
-// bounded by ctx (and DefaultTimeout if ctx has no earlier deadline). A non-zero
-// exit or timeout is a wrapped error carrying the remote stderr.
+// bounded by ctx (and DefaultTimeout if ctx has no earlier deadline). A
+// timeout is a wrapped context error; a non-zero exit is a *camperrors.
+// CommandError carrying the exit code and trimmed remote stderr, so callers
+// can distinguish failure shapes (e.g. RunCampCommand's "binary not found"
+// detection) without re-parsing the error string.
 func Run(ctx context.Context, target string, opts []string, remoteCmd string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, DefaultTimeout)
 	defer cancel()
@@ -214,9 +218,93 @@ func Run(ctx context.Context, target string, opts []string, remoteCmd string) ([
 		if ctx.Err() != nil {
 			return nil, camperrors.Wrapf(ctx.Err(), "ssh to %s timed out", target)
 		}
-		return nil, camperrors.Wrapf(err, "ssh to %s: %s", target, strings.TrimSpace(stderr.String()))
+		exitCode := 0
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		}
+		return nil, camperrors.NewCommand("ssh "+target, exitCode, strings.TrimSpace(stderr.String()), err)
 	}
 	return stdout.Bytes(), nil
+}
+
+// RemoteCampPathEnv, when set, is the exact camp invocation used on the far
+// machine in place of the bare name "camp" resolved off the login shell's
+// PATH. It is the escape hatch for a machine where camp is installed
+// somewhere no profile script exports onto PATH, and is documented on
+// `camp switch --help` and `camp list --help`.
+const RemoteCampPathEnv = "CAMP_REMOTE_CAMP_PATH"
+
+// remoteCampBinary returns the argv[0] token for a remote camp invocation:
+// CAMP_REMOTE_CAMP_PATH, shell-quoted, when set; otherwise the bare name
+// "camp" for the remote login shell to resolve off its own PATH.
+func remoteCampBinary() string {
+	if p := os.Getenv(RemoteCampPathEnv); p != "" {
+		return ShellQuote(p)
+	}
+	return "camp"
+}
+
+// RunCampCommand execs the remote machine's OWN camp binary over ssh, through
+// a POSIX login shell (`sh -lc`), and returns stdout. args is everything
+// after the binary name, e.g. `switch 'foo' --print` or `list --json`.
+//
+// A bare non-interactive `ssh host 'camp ...'` runs under ssh's own
+// non-login shell, which never sources a login profile (~/.profile,
+// ~/.bash_profile, etc.) — so a camp installed via a PATH addition that only
+// a login shell picks up (~/.local/bin, asdf, a shell-managed version
+// manager) was invisible to it. `sh -lc` forces the remote's POSIX shell to
+// run as a login shell first, then execute the command, so it sees the same
+// PATH an interactive ssh session would. sh is used rather than assuming
+// bash/zsh because POSIX guarantees /bin/sh exists; the user's actual login
+// shell is whatever their own account is configured to run.
+func RunCampCommand(ctx context.Context, m *machines.Machine, args string) ([]byte, error) {
+	if err := EnsureKeyAuth(m); err != nil {
+		return nil, err
+	}
+	binary := remoteCampBinary()
+	out, err := Run(ctx, Target(m), Opts(m), campRemoteCommandLine(binary, args))
+	if err != nil {
+		return nil, campNotFoundHint(err, m, binary)
+	}
+	return out, nil
+}
+
+// campRemoteCommandLine builds the single token handed to ssh as the remote
+// command for a camp invocation: binary+args wrapped in a POSIX login shell
+// (`sh -lc '<binary> <args>'`). Kept as a pure function of its inputs (no ssh,
+// no machine lookup) so the exact wrapping and quoting is unit-testable
+// without a live ssh connection.
+func campRemoteCommandLine(binary, args string) string {
+	return "sh -lc " + ShellQuote(binary+" "+args)
+}
+
+// campNotFoundHint appends the login-shell context and the
+// CAMP_REMOTE_CAMP_PATH escape hatch to err, but only when the failure
+// carries exit code 127 — the POSIX convention every common shell (sh, bash,
+// dash, ash/busybox, zsh) uses exclusively for "command not found". That
+// narrow, explicit signal (rather than matching stderr text) matters here:
+// camp's own domain errors can legitimately contain the words "not found"
+// too (e.g. ErrCampaignNotFound, when the campaign name just does not
+// resolve on a far machine whose camp binary ran fine), and mislabeling
+// those as a missing binary would send the user chasing PATH for nothing.
+// Any exit code other than 127 is returned unchanged.
+func campNotFoundHint(err error, m *machines.Machine, binary string) error {
+	var cmdErr *camperrors.CommandError
+	if !errors.As(err, &cmdErr) || cmdErr.ExitCode != 127 {
+		return err
+	}
+	return camperrors.Wrapf(err,
+		"remote camp not found on %s (tried %q via sh -lc, i.e. the machine's login-shell PATH); "+
+			"if camp lives outside that PATH, set %s to its exact path on that machine",
+		m.ID, binary, RemoteCampPathEnv)
+}
+
+// resolveRootArgs builds the `switch` args RunCampCommand appends after the
+// resolved camp binary. remainder is single-quoted for injection safety.
+// Split out from ResolveRoot so it is unit-testable without ssh.
+func resolveRootArgs(remainder string) string {
+	return "switch " + ShellQuote(remainder) + " --print"
 }
 
 // ResolveRoot runs the remote's OWN `camp switch <remainder> --print` so the
@@ -224,11 +312,7 @@ func Run(ctx context.Context, target string, opts []string, remoteCmd string) ([
 // never the local filesystem. The remainder is single-quoted for injection
 // safety. The returned path is meaningful only on the far machine.
 func ResolveRoot(ctx context.Context, m *machines.Machine, remainder string) (string, error) {
-	if err := EnsureKeyAuth(m); err != nil {
-		return "", err
-	}
-	remoteCmd := "camp switch " + ShellQuote(remainder) + " --print"
-	out, err := Run(ctx, Target(m), Opts(m), remoteCmd)
+	out, err := RunCampCommand(ctx, m, resolveRootArgs(remainder))
 	if err != nil {
 		return "", camperrors.Wrapf(err, "could not resolve %q on %s", remainder, m.ID)
 	}

--- a/internal/remote/ssh_test.go
+++ b/internal/remote/ssh_test.go
@@ -3,11 +3,13 @@ package remote
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/machines"
 )
 
@@ -157,5 +159,186 @@ func TestShellQuote(t *testing.T) {
 		if got := ShellQuote(in); got != want {
 			t.Errorf("ShellQuote(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+func TestCampRemoteCommandLineWrapsLoginShell(t *testing.T) {
+	cases := []struct {
+		name   string
+		binary string
+		args   string
+		want   string
+	}{
+		{
+			name:   "simple switch",
+			binary: "camp",
+			args:   "switch 'my-campaign' --print",
+			want:   `sh -lc 'camp switch '\''my-campaign'\'' --print'`,
+		},
+		{
+			name:   "list json",
+			binary: "camp",
+			args:   "list --json",
+			want:   `sh -lc 'camp list --json'`,
+		},
+		{
+			name:   "explicit binary path with a space",
+			binary: `'/opt/my camp/camp'`,
+			args:   "list --json",
+			want:   `sh -lc ''\''/opt/my camp/camp'\'' list --json'`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := campRemoteCommandLine(tc.binary, tc.args); got != tc.want {
+				t.Errorf("campRemoteCommandLine(%q, %q) = %q, want %q", tc.binary, tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInnerCommandRoundTripsThroughPosixShell proves the quoting
+// campRemoteCommandLine relies on actually survives being parsed by a real
+// POSIX shell, the way the remote's login shell (`sh -lc '<inner>'`) parses
+// <inner> a second time on the far machine: it hands `binary+" "+args`
+// (the exact string ShellQuote wraps as <inner>) to a plain, non-login
+// `sh -c`, using an absolute-path probe script as the binary so the test
+// depends on neither PATH nor any login-shell profile file — only on the
+// shell's ordinary command-line parsing, which is what both the remote's
+// non-login default shell and its login shell use for this. This is
+// local-only shell parsing, not a live ssh connection.
+func TestInnerCommandRoundTripsThroughPosixShell(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("no sh on PATH")
+	}
+	dir := t.TempDir()
+	probePath := filepath.Join(dir, "probe.sh")
+	if err := os.WriteFile(probePath, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\"\n"), 0o700); err != nil {
+		t.Fatalf("write probe script: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		remainder string
+	}{
+		{"plain", "my-campaign"},
+		{"spaces", "my campaign name"},
+		{"single quote", "o'brien's-campaign"},
+		{"glob chars", "campaign-*[1]?"},
+		{"org scoped", "obey/platform@f"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := resolveRootArgs(tc.remainder)
+			inner := ShellQuote(probePath) + " " + args
+
+			out, err := exec.Command("sh", "-c", inner).CombinedOutput()
+			if err != nil {
+				t.Fatalf("round-trip parse failed: %v\noutput: %s", err, out)
+			}
+			got := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
+			want := []string{"switch", tc.remainder, "--print"}
+			if len(got) != len(want) {
+				t.Fatalf("round-trip argv = %q, want %q", got, want)
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Errorf("round-trip argv[%d] = %q, want %q", i, got[i], want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestResolveRootArgs(t *testing.T) {
+	cases := map[string]string{
+		"my-campaign":       `switch 'my-campaign' --print`,
+		"org/campaign":      `switch 'org/campaign' --print`,
+		"has 'quote":        `switch 'has '\''quote' --print`,
+		"campaign-*[glob]?": `switch 'campaign-*[glob]?' --print`,
+	}
+	for in, want := range cases {
+		if got := resolveRootArgs(in); got != want {
+			t.Errorf("resolveRootArgs(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRemoteCampBinaryDefault(t *testing.T) {
+	t.Setenv(RemoteCampPathEnv, "")
+	if got := remoteCampBinary(); got != "camp" {
+		t.Errorf("remoteCampBinary() with no override = %q, want %q", got, "camp")
+	}
+}
+
+func TestRemoteCampBinaryOverride(t *testing.T) {
+	t.Setenv(RemoteCampPathEnv, "/opt/camp/bin/camp")
+	want := `'/opt/camp/bin/camp'`
+	if got := remoteCampBinary(); got != want {
+		t.Errorf("remoteCampBinary() with override = %q, want %q", got, want)
+	}
+}
+
+func TestRemoteCampBinaryOverrideWithSpace(t *testing.T) {
+	t.Setenv(RemoteCampPathEnv, "/opt/my camp/camp")
+	want := `'/opt/my camp/camp'`
+	if got := remoteCampBinary(); got != want {
+		t.Errorf("remoteCampBinary() with spaced override = %q, want %q", got, want)
+	}
+}
+
+func TestCampNotFoundHintDetectsExit127(t *testing.T) {
+	m := &machines.Machine{ID: "devbox"}
+	err := camperrors.NewCommand("ssh devbox", 127, "sh: line 1: camp: command not found", nil)
+	got := campNotFoundHint(err, m, "camp")
+	if got == nil {
+		t.Fatal("expected a non-nil error")
+	}
+	if !strings.Contains(got.Error(), RemoteCampPathEnv) {
+		t.Errorf("not-found hint missing %s mention: %v", RemoteCampPathEnv, got)
+	}
+	if !strings.Contains(got.Error(), "devbox") {
+		t.Errorf("not-found hint missing machine id: %v", got)
+	}
+}
+
+// TestCampNotFoundHintIgnoresNotFoundTextAtOtherExitCodes guards the false
+// positive that motivated using exit code 127 alone: camp's own
+// ErrCampaignNotFound ("campaign not found: ...") can legitimately appear in
+// stderr when the far machine's camp ran fine but the campaign name just
+// does not resolve there. That must never be relabeled as a missing binary.
+func TestCampNotFoundHintIgnoresNotFoundTextAtOtherExitCodes(t *testing.T) {
+	m := &machines.Machine{ID: "devbox"}
+	original := camperrors.NewCommand("ssh devbox", 1, `campaign not found: "nope"`, nil)
+	got := campNotFoundHint(original, m, "camp")
+	if got != original {
+		t.Errorf("campNotFoundHint relabeled a domain 'not found' error as a missing binary: got %v, want unchanged %v", got, original)
+	}
+}
+
+func TestCampNotFoundHintIgnoresPermissionDenied(t *testing.T) {
+	m := &machines.Machine{ID: "devbox"}
+	original := camperrors.NewCommand("ssh devbox", 126, "sh: camp: Permission denied", nil)
+	got := campNotFoundHint(original, m, "camp")
+	if got != original {
+		t.Errorf("campNotFoundHint should leave a permission-denied (126, not 127) failure unchanged: got %v, want unchanged %v", got, original)
+	}
+}
+
+func TestCampNotFoundHintLeavesUnrelatedErrorsUnchanged(t *testing.T) {
+	m := &machines.Machine{ID: "devbox"}
+	original := camperrors.NewCommand("ssh devbox", 1, "campaign \"nope\" not registered", nil)
+	got := campNotFoundHint(original, m, "camp")
+	if got != original {
+		t.Errorf("campNotFoundHint changed an unrelated command failure: got %v, want unchanged %v", got, original)
+	}
+}
+
+func TestCampNotFoundHintPassesThroughNonCommandErrors(t *testing.T) {
+	m := &machines.Machine{ID: "devbox"}
+	original := camperrors.New("ssh to devbox timed out")
+	got := campNotFoundHint(original, m, "camp")
+	if got != original {
+		t.Errorf("campNotFoundHint changed a non-CommandError: got %v, want unchanged %v", got, original)
 	}
 }


### PR DESCRIPTION
## Summary

- `camp switch <machine>:<campaign>` and `camp list --remote` invoked the remote camp binary via a bare, non-interactive `ssh host 'camp ...'`, which runs under ssh's own non-login shell. That shell never sources a login profile (`~/.profile`, `~/.bash_profile`, etc.), so a camp installed via a PATH addition only a login shell picks up (`~/.local/bin`, asdf, etc.) was invisible to `ResolveRoot` and the remote list fan-out.
- Every remote camp invocation now runs through `sh -lc '<camp command>'`, so the remote's POSIX login shell resolves PATH the way an interactive ssh session would.
- Added `CAMP_REMOTE_CAMP_PATH` as an explicit-path escape hatch for machines where camp still isn't reachable via the login shell's PATH, documented in `camp switch --help` and `camp list --help`.
- `internal/remote.Run` now returns a `*camperrors.CommandError` (exit code + stderr) instead of an opaque wrapped string, so a missing-binary failure (exit 127) gets an actionable hint pointing at the override, instead of a bare exit status. The detection is scoped to exit code 127 specifically (not stderr text matching) so it never mislabels camp's own domain errors (e.g. `ErrCampaignNotFound` for an unregistered campaign on an otherwise-working remote) as a missing binary.

## Command shape before/after

Before (`internal/remote.ResolveRoot`):
```
ssh <opts> <target> "camp switch 'foo' --print"
```

After:
```
ssh <opts> <target> "sh -lc 'camp switch '\''foo'\'' --print'"
```

With `CAMP_REMOTE_CAMP_PATH=/opt/camp/bin/camp` set:
```
ssh <opts> <target> "sh -lc ''\''/opt/camp/bin/camp'\'' switch '\''foo'\'' --print'"
```

Same wrapping applies to `camp list --remote`'s per-machine `camp list --json` fan-out (`cmd/camp/list_remote.go`).

## Where the override lives

`CAMP_REMOTE_CAMP_PATH` (`internal/remote/ssh.go`): a process environment variable, not `~/.obey/machines.yaml`. The `machines.Machine` struct is an intentionally shared cross-tool contract with the festival app's `RemoteMachine` (mirrored field-for-field per the doc comment on `internal/machines/machines.go`), which explicitly says camp-only fields do not belong there. There is also no existing per-remote settings surface documented in `docs/campaign-settings-files.md` that fits a remote camp binary path. Given that, this ships as a system-level env var per the task's fallback guidance; a proper per-machine config field (e.g. on `Machine`, coordinated with the festival-app schema) is a reasonable follow-up if machines end up needing different explicit paths.

## Gate results

Ran the full local gate from the worktree:
- `just build-camp`: build successful
- `just test unit`: 95 packages, 3093/3093 tests passed
- `just lint`: 0 issues, no new fmt.Errorf/host-fs-test regressions
- `just gate`: `gate-fast` (vet stable/dev/integration, lint stable/dev, unit tests dev profile: 97 packages, 3122/3122 passed) and `gate` (unit tests stable profile: 95 packages, 3093/3093 passed) both `PASSED`

New unit tests added in `internal/remote/ssh_test.go` cover: the `sh -lc` wrapping and quoting (table-driven, plus a POSIX-shell round-trip using an absolute-path probe script: no live ssh, no login-shell profile sourcing), the `CAMP_REMOTE_CAMP_PATH` override (default and with spaces), `resolveRootArgs` quoting (spaces, single quotes, globs), and the not-found hint's exit-code-127 detection including two explicit false-positive guards (permission-denied at 126, and camp's own "not found" domain error at exit 1).

## Deviations from the original ask

- Did not regenerate `docs/cli-reference/*.md`. Running `just docs` pulled in unrelated drift from an already-merged, unrelated feature (org commands: new `camp_org_delete.md`, changes to `camp_create.md`, `camp_init.md`, `camp_org.md`, `camp_org_create.md`). Per established convention, doc regen drift should not be folded into a feature commit, so those are left for a separate docs-only commit. The help text itself (which satisfies "document in command help") is live in the Go source and covered by `--help` output.
- `CAMP_REMOTE_CAMP_PATH` is a single global override, not per-machine. `~/.obey/machines.yaml`'s `Machine` struct explicitly forbids camp-only fields (it mirrors the festival app's schema), and there's no other per-remote config surface today, so a system-level env var is what the task's own fallback guidance calls for. Noted above as a follow-up if per-machine paths turn out to be needed.

Ref intent: `camp-switch-remote-resolve-needs-20260708-234643`
