### PR TITLE
feat(git): add NT-<ref> note commit tag segment

### DIFF
--- a/cmd/camp/intent/note.go
+++ b/cmd/camp/intent/note.go
@@ -19,7 +19,19 @@ import (
 	"github.com/Obedience-Corp/camp/internal/intent/tui"
 	navtui "github.com/Obedience-Corp/camp/internal/nav/tui"
 	"github.com/Obedience-Corp/camp/internal/paths"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
+
+// noteRefPrefix is the NT- tag prefix for note commits, mirroring
+// wkitem.RefPrefix ("WI-") for workitems.
+const noteRefPrefix = "NT-"
+
+// noteRef derives the NT-<6 hex> commit tag ref for a note from its
+// frontmatter id, reusing the same sha256-prefix scheme workitem refs use
+// (internal/workitem/ref.go) via wkitem.DeriveWithPrefix.
+func noteRef(id string) string {
+	return wkitem.DeriveWithPrefix(noteRefPrefix, id)
+}
 
 var intentNoteCmd = &cobra.Command{
 	Use:   "note [text]",
@@ -191,6 +203,7 @@ func finalizeCreatedNote(ctx context.Context, result *intent.Intent, intentsDir 
 
 	if !noCommit {
 		opts := wkcmd.AmbientCommitOptions(ctx, campaignRoot, cfg.ID, os.Stderr)
+		opts.NoteRef = noteRef(result.ID)
 		opts.Files = commit.NormalizeFiles(campaignRoot, result.Path, audit.FilePath(intentsDir))
 		opts.SelectiveOnly = true
 		commitResult := commit.Intent(ctx, commit.IntentOptions{

--- a/internal/git/campaign_tag.go
+++ b/internal/git/campaign_tag.go
@@ -17,9 +17,13 @@ const legacyTagMarker = "OBEY-CAMPAIGN"
 // FormatContextTagsFull builds the campaign tag. The leading token is the
 // slugified campaign name plus the short id ("[obey-campaign:8deed8b4]"),
 // falling back to "[OBEY-CAMPAIGN-<id>]" when campaignName has no slug. The
-// remaining components follow in fixed order: quest, festival, workitem.
+// remaining components follow in fixed order: quest, festival, workitem,
+// note. noteRef is optional (mirroring FormatCampaignTag's questID) so
+// existing callers are unaffected; only the note commit path passes one, and
+// it may co-occur with workitemRef since they describe different things (the
+// ambient context a note was captured in vs. the note itself).
 // Returns "" when campaignID is empty.
-func FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef string) string {
+func FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemRef string, noteRef ...string) string {
 	if campaignID == "" {
 		return ""
 	}
@@ -50,6 +54,16 @@ func FormatContextTagsFull(campaignName, campaignID, questID, festRef, workitemR
 		// The ref already carries WI-, so it is self-identifying and embedded
 		// verbatim (no extra marker).
 		parts = append(parts, workitemRef)
+	}
+	nr := ""
+	if len(noteRef) > 0 {
+		nr = noteRef[0]
+	}
+	if nr != "" {
+		if !strings.HasPrefix(nr, "NT-") {
+			nr = "NT-" + nr
+		}
+		parts = append(parts, nr)
 	}
 	return "[" + strings.Join(parts, "-") + "]"
 }
@@ -96,6 +110,7 @@ type TagComponents struct {
 	QuestID      string `json:"quest_id"`
 	FestRef      string `json:"fest_ref"`
 	WorkitemRef  string `json:"workitem_ref"` // carries the WI- prefix
+	NoteRef      string `json:"note_ref"`     // carries the NT- prefix
 }
 
 // leadingTagRegex captures the leading bracket content; tags are only honored
@@ -108,6 +123,7 @@ var tagBodyScanRegex = regexp.MustCompile(`\[(?:` + legacyTagMarker + `-[^\]]+|[
 
 var (
 	tagWorkitemRefRe = regexp.MustCompile(`^WI-[0-9a-f]{6}$`)
+	tagNoteRefRe     = regexp.MustCompile(`^NT-[0-9a-f]{6}$`)
 	tagQuestIDRe     = regexp.MustCompile(`^qst_[A-Za-z0-9_]{1,40}$`)
 	tagFestRefRe     = regexp.MustCompile(`^[A-Za-z0-9]{1,32}$`)
 	// Real campaign ids are UUID-derived hex; gating on it rejects ordinary
@@ -199,24 +215,40 @@ func ParseTagDetailed(subject string) (TagComponents, []TagParseWarning) {
 			}
 			rest = after
 		case strings.HasPrefix(rest, "WI-"):
-			// WI- is the last segment. Accept the single-prefix ref (WI-abcdef)
-			// and the historical doubled form (WI-WI-abcdef).
-			ref := rest
-			if strings.HasPrefix(ref, "WI-WI-") {
-				ref = ref[len("WI-"):]
-			}
-			if !tagWorkitemRefRe.MatchString(ref) {
+			// WI- used to be the last segment; it no longer is (NT- may follow,
+			// since a note captured inside an active workitem carries both).
+			// splitWorkitemSegment bounds the match at the fixed ref length so
+			// any trailing "-NT-..." is left for the next loop iteration.
+			seg, after := splitWorkitemSegment(rest)
+			if !tagWorkitemRefRe.MatchString(seg) {
 				warnings = append(warnings, TagParseWarning{
-					Field: "workitem_ref", Value: ref,
+					Field: "workitem_ref", Value: seg,
 					Reason: "shape check failed (want WI-<6 hex>)",
 				})
 			} else if out.WorkitemRef != "" {
 				warnings = append(warnings, TagParseWarning{
-					Field: "workitem_ref", Value: ref,
+					Field: "workitem_ref", Value: seg,
 					Reason: "duplicate workitem_ref segment",
 				})
 			} else {
-				out.WorkitemRef = ref
+				out.WorkitemRef = seg
+			}
+			rest = after
+		case strings.HasPrefix(rest, "NT-"):
+			// NT- is always the last segment in the fixed order.
+			seg := rest
+			if !tagNoteRefRe.MatchString(seg) {
+				warnings = append(warnings, TagParseWarning{
+					Field: "note_ref", Value: seg,
+					Reason: "shape check failed (want NT-<6 hex>)",
+				})
+			} else if out.NoteRef != "" {
+				warnings = append(warnings, TagParseWarning{
+					Field: "note_ref", Value: seg,
+					Reason: "duplicate note_ref segment",
+				})
+			} else {
+				out.NoteRef = seg
 			}
 			rest = ""
 		default:
@@ -250,4 +282,42 @@ func splitAtDash(s string) (string, string) {
 		return s[:i], s[i+1:]
 	}
 	return s, ""
+}
+
+// splitWorkitemSegment extracts a WI- segment from the front of rest,
+// returning the remainder that follows it. splitAtDash cannot be used here:
+// the historical doubled form (WI-WI-abcdef) has an internal dash that is
+// not a segment boundary. On a shape match (single or doubled prefix plus
+// exactly 6 lowercase hex chars) it returns the normalized single-prefix
+// ref and the trailing remainder (leading "-" stripped) so a following
+// segment such as NT- is left for the next parse iteration. On a shape
+// mismatch it falls back to the legacy behavior of treating the entire
+// remainder as the malformed value (doubled-prefix stripped once, mirroring
+// the historical ref-detection step) so existing malformed-tag warnings are
+// unchanged.
+func splitWorkitemSegment(rest string) (seg, after string) {
+	doubled := strings.HasPrefix(rest, "WI-WI-")
+	prefixLen := len("WI-")
+	if doubled {
+		prefixLen = len("WI-WI-")
+	}
+	if len(rest) >= prefixLen+6 && isLowerHex(rest[prefixLen:prefixLen+6]) {
+		end := prefixLen + 6
+		return "WI-" + rest[prefixLen:end], strings.TrimPrefix(rest[end:], "-")
+	}
+	seg = rest
+	if doubled {
+		seg = rest[len("WI-"):]
+	}
+	return seg, ""
+}
+
+// isLowerHex reports whether s consists solely of lowercase hex digits.
+func isLowerHex(s string) bool {
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/git/campaign_tag_full_test.go
+++ b/internal/git/campaign_tag_full_test.go
@@ -102,6 +102,62 @@ func TestFormatContextTagsFull_AllCombinations(t *testing.T) {
 	}
 }
 
+func TestFormatContextTagsFull_NoteRef(t *testing.T) {
+	cases := []struct {
+		name                                               string
+		cname, campaign, quest, fest, workitem, note, want string
+	}{
+		{
+			name:     "note only",
+			campaign: "8deed8b4", note: "NT-abcdef",
+			want: "[OBEY-CAMPAIGN-8deed8b4-NT-abcdef]",
+		},
+		{
+			name:     "note ref normalized",
+			campaign: "8deed8b4", note: "abcdef",
+			want: "[OBEY-CAMPAIGN-8deed8b4-NT-abcdef]",
+		},
+		{
+			name:     "note co-occurs with workitem, note goes last",
+			campaign: "8deed8b4", workitem: "WI-abcdef", note: "NT-123456",
+			want: "[OBEY-CAMPAIGN-8deed8b4-WI-abcdef-NT-123456]",
+		},
+		{
+			name:     "note co-occurs with quest, festival, and workitem",
+			campaign: "8deed8b4", quest: "qst_abc", fest: "CW0003", workitem: "WI-abcdef", note: "NT-123456",
+			want: "[OBEY-CAMPAIGN-8deed8b4-qst_abc-FE-CW0003-WI-abcdef-NT-123456]",
+		},
+		{
+			name:  "name-style head with note ref",
+			cname: "obey-campaign", campaign: "8deed8b4", note: "NT-abcdef",
+			want: "[obey-campaign:8deed8b4-NT-abcdef]",
+		},
+		{
+			name:     "no note ref omits the segment",
+			campaign: "8deed8b4", workitem: "WI-abcdef",
+			want: "[OBEY-CAMPAIGN-8deed8b4-WI-abcdef]",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatContextTagsFull(tc.cname, tc.campaign, tc.quest, tc.fest, tc.workitem, tc.note)
+			if got != tc.want {
+				t.Fatalf("FormatContextTagsFull = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatContextTagsFull_NoteRefOmittedWhenNotPassed(t *testing.T) {
+	// Existing 5-arg callers (no noteRef argument at all) must be unaffected
+	// by the new variadic trailing parameter.
+	got := FormatContextTagsFull("", "8deed8b4", "", "", "WI-abcdef")
+	want := "[OBEY-CAMPAIGN-8deed8b4-WI-abcdef]"
+	if got != want {
+		t.Fatalf("FormatContextTagsFull (5-arg call) = %q, want %q", got, want)
+	}
+}
+
 func TestFormatCampaignTag_BackwardCompat(t *testing.T) {
 	cases := []struct {
 		campaign, quest, want string
@@ -257,6 +313,140 @@ func TestParseTag_RoundTripProperty(t *testing.T) {
 		if got.WorkitemRef != workitem {
 			t.Fatalf("iter %d: workitem round-trip broke: %q -> %q (tag %q)", i, workitem, got.WorkitemRef, tag)
 		}
+	}
+}
+
+func TestParseTag_NoteRefRoundTripProperty(t *testing.T) {
+	const iterations = 100
+	for i := 0; i < iterations; i++ {
+		cname := "c" + randHex(t, 2)
+		campaign := randHex(t, 4)
+		quest := ""
+		fest := ""
+		workitem := ""
+		note := ""
+		if i%2 == 0 {
+			quest = "qst_" + randHex(t, 3)
+		}
+		if i%3 == 0 {
+			fest = "CW" + randHex(t, 2)
+		}
+		if i%5 == 0 {
+			workitem = "WI-" + randHex(t, 3)
+		}
+		if i%7 == 0 {
+			note = "NT-" + randHex(t, 3)
+		}
+
+		tag := FormatContextTagsFull(cname, campaign, quest, fest, workitem, note)
+		got := ParseTag(tag)
+		if got.WorkitemRef != workitem {
+			t.Fatalf("iter %d: workitem round-trip broke: %q -> %q (tag %q)", i, workitem, got.WorkitemRef, tag)
+		}
+		if got.NoteRef != note {
+			t.Fatalf("iter %d: note round-trip broke: %q -> %q (tag %q)", i, note, got.NoteRef, tag)
+		}
+	}
+}
+
+func TestFormatAndParse_NoteRefWithWorkitem_RoundTrip(t *testing.T) {
+	tag := FormatContextTagsFull("obey-campaign", "8deed8b4", "qst_abc", "CW0003", "WI-abcdef", "NT-123456")
+	got := ParseTag(tag)
+	if got.WorkitemRef != "WI-abcdef" {
+		t.Fatalf("WorkitemRef = %q, want WI-abcdef (tag %q)", got.WorkitemRef, tag)
+	}
+	if got.NoteRef != "NT-123456" {
+		t.Fatalf("NoteRef = %q, want NT-123456 (tag %q)", got.NoteRef, tag)
+	}
+	if got.FestRef != "CW0003" {
+		t.Fatalf("FestRef = %q, want CW0003 (tag %q)", got.FestRef, tag)
+	}
+	if got.QuestID != "qst_abc" {
+		t.Fatalf("QuestID = %q, want qst_abc (tag %q)", got.QuestID, tag)
+	}
+}
+
+func TestFormatAndParse_NoteRefWithoutWorkitem_RoundTrip(t *testing.T) {
+	tag := FormatContextTagsFull("obey-campaign", "8deed8b4", "", "", "", "NT-123456")
+	got := ParseTag(tag)
+	if got.WorkitemRef != "" {
+		t.Fatalf("WorkitemRef = %q, want empty (tag %q)", got.WorkitemRef, tag)
+	}
+	if got.NoteRef != "NT-123456" {
+		t.Fatalf("NoteRef = %q, want NT-123456 (tag %q)", got.NoteRef, tag)
+	}
+}
+
+func TestParseTagDetailed_NoteRefShapeChecks(t *testing.T) {
+	cases := []struct {
+		name             string
+		subject          string
+		wantNoteRef      string
+		wantWarningField []string
+	}{
+		{
+			name:        "valid note ref, no workitem",
+			subject:     "[OBEY-CAMPAIGN-abc-NT-abcdef] x",
+			wantNoteRef: "NT-abcdef",
+		},
+		{
+			name:        "valid note ref co-occurring with workitem",
+			subject:     "[OBEY-CAMPAIGN-abc-WI-WI-deadbe-NT-abcdef] x",
+			wantNoteRef: "NT-abcdef",
+		},
+		{
+			name:             "malformed note ref (bad hex) zeroes ref",
+			subject:          "[OBEY-CAMPAIGN-abc-NT-ZZZZZZ] x",
+			wantWarningField: []string{"note_ref"},
+		},
+		{
+			name:             "malformed note ref (wrong length) zeroes ref",
+			subject:          "[OBEY-CAMPAIGN-abc-NT-abcd] x",
+			wantWarningField: []string{"note_ref"},
+		},
+		{
+			// NT- is terminal (unlike WI-, it never has a following segment), so
+			// once the "NT-" prefix is seen the whole remainder is the shape-check
+			// candidate; a second "-NT-..." here is just more malformed content,
+			// not a separate duplicate segment.
+			name:             "trailing junk after note ref fails shape as one segment",
+			subject:          "[OBEY-CAMPAIGN-abc-NT-aaaaaa-NT-bbbbbb] x",
+			wantWarningField: []string{"note_ref"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, warnings := ParseTagDetailed(tc.subject)
+			if got.NoteRef != tc.wantNoteRef {
+				t.Errorf("NoteRef = %q, want %q", got.NoteRef, tc.wantNoteRef)
+			}
+			if len(warnings) != len(tc.wantWarningField) {
+				t.Fatalf("warnings count = %d, want %d: %+v", len(warnings), len(tc.wantWarningField), warnings)
+			}
+			for i, want := range tc.wantWarningField {
+				if warnings[i].Field != want {
+					t.Errorf("warning[%d].Field = %q, want %q", i, warnings[i].Field, want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseTagDetailed_UnrecognizedNotePrefixIsUnknownSegment(t *testing.T) {
+	// "NTX-..." does not match the "NT-" prefix boundary, so it falls to the
+	// generic unknown-segment path (split at each dash) instead of the
+	// dedicated note_ref check, the same way "WIX-..." would miss the WI- case.
+	got, warnings := ParseTagDetailed("[OBEY-CAMPAIGN-abc-NTX-abcdef] x")
+	if got.NoteRef != "" {
+		t.Fatalf("NoteRef = %q, want empty", got.NoteRef)
+	}
+	for i, w := range warnings {
+		if w.Field != "unknown" {
+			t.Errorf("warning[%d].Field = %q, want unknown", i, w.Field)
+		}
+	}
+	if len(warnings) != 2 {
+		t.Fatalf("warnings = %+v, want two unknown-segment warnings (NTX, abcdef)", warnings)
 	}
 }
 

--- a/internal/git/commit/commit.go
+++ b/internal/git/commit/commit.go
@@ -50,6 +50,7 @@ type Options struct {
 	QuestID       string   // Optional quest ID for additive commit context
 	FestivalRef   string   // Optional festival ref for additive commit context
 	WorkitemRef   string   // Optional workitem ref (WI-<6 hex>) for additive commit context
+	NoteRef       string   // Optional note ref (NT-<6 hex>); set only by the note commit path
 	Files         []string // If set, stage only these paths instead of everything
 	PreStaged     []string // Paths already staged; copied from the real index into the temp-index commit scope
 	SelectiveOnly bool     // When true, never fall back to CommitAll; no-op if Files is empty
@@ -96,7 +97,7 @@ func doCommit(ctx context.Context, opts Options, action, subject, description st
 	}
 
 	commitMsg := fmt.Sprintf("%s %s: %s",
-		git.FormatContextTagsFull(resolveCampaignName(ctx, opts), opts.CampaignID, opts.QuestID, opts.FestivalRef, opts.WorkitemRef),
+		git.FormatContextTagsFull(resolveCampaignName(ctx, opts), opts.CampaignID, opts.QuestID, opts.FestivalRef, opts.WorkitemRef, opts.NoteRef),
 		action,
 		subject,
 	)

--- a/internal/git/commit/commit_test.go
+++ b/internal/git/commit/commit_test.go
@@ -328,6 +328,97 @@ func TestIntent_WithQuestTag(t *testing.T) {
 	}
 }
 
+func TestIntent_WithNoteRefTag(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := exec.Command("git", "-C", tmpDir, "init").Run(); err != nil {
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+	if err := exec.Command("git", "-C", tmpDir, "config", "user.email", "test@test.com").Run(); err != nil {
+		t.Fatalf("failed to configure git email: %v", err)
+	}
+	if err := exec.Command("git", "-C", tmpDir, "config", "user.name", "Test").Run(); err != nil {
+		t.Fatalf("failed to configure git name: %v", err)
+	}
+
+	testFile := filepath.Join(tmpDir, "note.txt")
+	if err := os.WriteFile(testFile, []byte("note content"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	result := Intent(context.Background(), IntentOptions{
+		Options: Options{
+			CampaignRoot: tmpDir,
+			CampaignID:   "abcdef12",
+			WorkitemRef:  "WI-deadbe",
+			NoteRef:      "NT-abcdef",
+		},
+		Action:      IntentCreate,
+		IntentTitle: "Note-tagged intent",
+	})
+
+	if !result.Committed {
+		t.Fatalf("expected commit to succeed, got %s", result.Message)
+	}
+
+	out, err := exec.Command("git", "-C", tmpDir, "log", "-1", "--format=%B").Output()
+	if err != nil {
+		t.Fatalf("failed to get git log: %v", err)
+	}
+	commitMsg := string(out)
+	if !strings.Contains(commitMsg, "[OBEY-CAMPAIGN-abcdef12-WI-deadbe-NT-abcdef]") {
+		t.Fatalf("commit message missing note tag co-occurring with workitem: %s", commitMsg)
+	}
+}
+
+func TestIntent_NoteRefUnsetOmitsNoteSegment(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	if err := exec.Command("git", "-C", tmpDir, "init").Run(); err != nil {
+		t.Fatalf("failed to init git repo: %v", err)
+	}
+	if err := exec.Command("git", "-C", tmpDir, "config", "user.email", "test@test.com").Run(); err != nil {
+		t.Fatalf("failed to configure git email: %v", err)
+	}
+	if err := exec.Command("git", "-C", tmpDir, "config", "user.name", "Test").Run(); err != nil {
+		t.Fatalf("failed to configure git name: %v", err)
+	}
+
+	testFile := filepath.Join(tmpDir, "move.txt")
+	if err := os.WriteFile(testFile, []byte("move content"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	// A non-note action (e.g. IntentMove) with an active workitem in scope
+	// but NoteRef left unset (as every non-note call site does) must never
+	// emit an NT- segment.
+	result := Intent(context.Background(), IntentOptions{
+		Options: Options{
+			CampaignRoot: tmpDir,
+			CampaignID:   "abcdef12",
+			WorkitemRef:  "WI-deadbe",
+		},
+		Action:      IntentMove,
+		IntentTitle: "Moved intent",
+	})
+
+	if !result.Committed {
+		t.Fatalf("expected commit to succeed, got %s", result.Message)
+	}
+
+	out, err := exec.Command("git", "-C", tmpDir, "log", "-1", "--format=%B").Output()
+	if err != nil {
+		t.Fatalf("failed to get git log: %v", err)
+	}
+	commitMsg := string(out)
+	if strings.Contains(commitMsg, "-NT-") {
+		t.Fatalf("non-note commit must never carry an NT- segment: %s", commitMsg)
+	}
+	if !strings.Contains(commitMsg, "[OBEY-CAMPAIGN-abcdef12-WI-deadbe]") {
+		t.Fatalf("commit message missing expected workitem tag: %s", commitMsg)
+	}
+}
+
 func TestIntent_SelectiveStaging(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/workitem/ref.go
+++ b/internal/workitem/ref.go
@@ -14,13 +14,20 @@ const RefPrefix = "WI-"
 
 const maxRefCollisionRetries = 1 << 24
 
-// Derive returns the canonical ref for a workitem id. The shape is stable:
-// "WI-" plus the first 6 lowercase hex chars of sha256(id). Same id always
-// yields the same ref; this is the reason the field is safe to recompute
-// during migrations and doctor backfills.
+// Derive returns the canonical ref for a workitem id via DeriveWithPrefix.
+// Same id always yields the same ref; this is the reason the field is safe
+// to recompute during migrations and doctor backfills.
 func Derive(id string) string {
+	return DeriveWithPrefix(RefPrefix, id)
+}
+
+// DeriveWithPrefix returns "<prefix>" plus the first 6 lowercase hex chars
+// of sha256(id). Derive is DeriveWithPrefix(RefPrefix, id); other ref
+// families that share this scheme but are not workitems (e.g. note refs)
+// call it directly instead of duplicating the hashing logic.
+func DeriveWithPrefix(prefix, id string) string {
 	sum := sha256.Sum256([]byte(id))
-	return RefPrefix + hex.EncodeToString(sum[:])[:6]
+	return prefix + hex.EncodeToString(sum[:])[:6]
 }
 
 // DeriveUnique returns a ref guaranteed not to collide with the keys of

--- a/internal/workitem/ref_test.go
+++ b/internal/workitem/ref_test.go
@@ -25,6 +25,38 @@ func TestDerive_Deterministic(t *testing.T) {
 	}
 }
 
+func TestDerive_MatchesDeriveWithPrefix(t *testing.T) {
+	id := "design-foo-2026-05-24"
+	if got, want := Derive(id), DeriveWithPrefix(RefPrefix, id); got != want {
+		t.Fatalf("Derive(%q) = %q, want DeriveWithPrefix(RefPrefix, id) = %q", id, got, want)
+	}
+}
+
+func TestDeriveWithPrefix_Deterministic(t *testing.T) {
+	id := "give-notes-their-own-nt-20260623-221250"
+	first := DeriveWithPrefix("NT-", id)
+	second := DeriveWithPrefix("NT-", id)
+	if first != second {
+		t.Fatalf("DeriveWithPrefix(%q) is non-deterministic: %q vs %q", id, first, second)
+	}
+	notePattern := regexp.MustCompile(`^NT-[0-9a-f]{6}$`)
+	if !notePattern.MatchString(first) {
+		t.Fatalf("DeriveWithPrefix(%q) = %q does not match %s", id, first, notePattern)
+	}
+}
+
+func TestDeriveWithPrefix_DifferentPrefixesDifferentRefs(t *testing.T) {
+	id := "design-foo-2026-05-24"
+	wi := DeriveWithPrefix("WI-", id)
+	nt := DeriveWithPrefix("NT-", id)
+	if wi == nt {
+		t.Fatalf("DeriveWithPrefix with different prefixes collided: %q == %q", wi, nt)
+	}
+	if wi[len("WI-"):] != nt[len("NT-"):] {
+		t.Fatalf("expected same hash suffix across prefixes: WI %q, NT %q", wi, nt)
+	}
+}
+
 func TestDerive_DifferentIDsDifferentRefs(t *testing.T) {
 	a := Derive("design-foo-2026-05-24")
 	b := Derive("design-bar-2026-05-24")

--- a/tests/integration/commit_tags_test.go
+++ b/tests/integration/commit_tags_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -233,6 +234,58 @@ func TestIntegration_CommitTags_NoteNoContext(t *testing.T) {
 	assert.NotContains(t, subject, "FE-", "no-context note must not include FE-: %s", subject)
 	assert.Regexp(t, `^\[commit-tags:[0-9a-f]{1,8}\]`, subject,
 		"note should still carry the campaign tag: %s", subject)
+}
+
+func TestIntegration_CommitTags_NoteRefSegment(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/commit-tags-note-ref"
+	initCommitTagsCampaign(t, tc, dir)
+
+	// No workitem context: the note still gets its own NT-<ref> segment even
+	// though there is no WI- to sit alongside.
+	out, err := tc.RunCampInDir(dir, "intent", "note", "loose note for NT ref")
+	require.NoError(t, err, "camp intent note: %s", out)
+
+	subject := lastCommitSubject(t, tc, dir)
+	assert.Regexp(t, `-NT-[0-9a-f]{6}\]`, subject,
+		"note commit should carry its own NT-<ref> segment: %s", subject)
+}
+
+func TestIntegration_CommitTags_NoteRefCoOccursWithWorkitem(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/commit-tags-note-ref-wi"
+	initCommitTagsCampaign(t, tc, dir)
+	ref := seedDesignWorkitemWithRef(t, tc, dir, "noteref")
+
+	// A note captured inside an active workitem carries both: WI- (the ambient
+	// context it was captured in) and NT- (the note itself), in that order.
+	wiDir := dir + "/workflow/design/noteref"
+	out, err := tc.RunCampInDir(wiDir, "intent", "note", "note inside a workitem")
+	require.NoError(t, err, "camp intent note: %s", out)
+
+	subject := lastCommitSubject(t, tc, dir)
+	assert.Contains(t, subject, ref, "note commit should still inherit the ambient WI-<ref>: %s", subject)
+	assert.Regexp(t, regexp.QuoteMeta(ref)+`-NT-[0-9a-f]{6}\]`, subject,
+		"NT- should follow WI- in the fixed tag order: %s", subject)
+}
+
+func TestIntegration_CommitTags_NonNoteActionNeverEmitsNoteRef(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/commit-tags-no-note-leak"
+	initCommitTagsCampaign(t, tc, dir)
+	ref := seedDesignWorkitemWithRef(t, tc, dir, "noleak")
+
+	// A non-note intent action from inside the same workitem context: it must
+	// still carry WI- but never NT-, since only the note commit path derives
+	// a note ref (guards against AmbientCommitOptions accidentally leaking one
+	// into every other intent auto-commit call site).
+	wiDir := dir + "/workflow/design/noleak"
+	out, err := tc.RunCampInDir(wiDir, "intent", "add", "regular intent, not a note")
+	require.NoError(t, err, "camp intent add: %s", out)
+
+	subject := lastCommitSubject(t, tc, dir)
+	assert.Contains(t, subject, ref, "intent add should still inherit ambient WI-<ref>: %s", subject)
+	assert.NotContains(t, subject, "-NT-", "non-note commit must never carry an NT- segment: %s", subject)
 }
 
 func TestIntegration_AutoWriteEnv(t *testing.T) {


### PR DESCRIPTION
## Summary

Notes are a separate non-lifecycle category (`internal/intent/notes.go:18`) and are not workitems, so today a note commit can only ever carry the campaign/ambient tags, never an identifier for the note itself. This gives notes their own `NT-<ref>` commit tag segment.

Addresses intent `give-notes-their-own-nt-20260623-221250`.

**Stacked on #394 (`intent-commit-context`). This PR targets `intent-commit-context`, not `main`, and must merge after it.** It builds on the `wkcmd.AmbientCommitOptions` / `commit.Options` seam that #394 introduced for note auto-commits.

## Design decisions

- **Position and co-occurrence**: fixed tag order is now `head, qst_, FE-, WI-, NT-`. `NT-` may co-occur with `WI-`: with #394, a note captured while a festival/workitem is active inherits that ambient context (`FE-`/`WI-` describe *where* the note was captured), while `NT-` identifies *the note itself*. These are different dimensions, so mutual exclusion would discard real information.
- **Ref derivation**: `NT-<6 hex>` is derived from the note's frontmatter id using the same sha256-prefix scheme `WI-` uses. `internal/workitem/ref.go`'s `Derive` is now `DeriveWithPrefix(RefPrefix, id)`; the note commit path calls `DeriveWithPrefix("NT-", id)` directly, so the hashing logic isn't duplicated and `Derive`'s output stays byte-identical.
- **Blast radius**: `FormatContextTagsFull` gains `noteRef` as a variadic trailing param (mirroring the existing `FormatCampaignTag(campaignID string, questID ...string)` pattern in the same file), not a new positional arg. That means the five other call sites of `FormatContextTagsFull`/`PrependContextTagsFull` (`cmd/camp/commit.go`, `cmd/camp/project/commit.go`, `cmd/camp/worktrees/commit.go`, `cmd/camp/refs/commands.go`, `internal/commands/workitem/staging.go`, `pkg/commitkit`) don't need to change at all: only the note commit path (`cmd/camp/intent/note.go` → `commit.Options.NoteRef` → `doCommit`) ever sets one.
- **Parser**: `WI-` used to be the terminal segment in `ParseTagDetailed`; it no longer is. `splitWorkitemSegment` now bounds the match at the fixed 6-hex-char ref length (handling the historical doubled `WI-WI-` form) so a following `-NT-...` is left for the next parse iteration instead of being swallowed. Malformed-shape behavior for `WI-` itself is unchanged (verified via the existing `TestParseTagDetailed_RejectsSilentMerge` cases, which still pass).

## Scope

- `internal/git/campaign_tag.go`: `FormatContextTagsFull` NT- segment, `TagComponents.NoteRef`, `tagNoteRefRe`, `ParseTagDetailed` WI-/NT- parsing.
- `internal/workitem/ref.go`: generalized `Derive` → `DeriveWithPrefix`.
- `internal/git/commit/commit.go`: `Options.NoteRef`, threaded into `doCommit`'s tag formatting.
- `cmd/camp/intent/note.go`: derives and sets `NoteRef` on the note commit path only.

## Test plan

- [x] `internal/git`: format round-trip (with/without co-occurring WI-), parser shape checks (valid NT-, malformed NT- shape-check-failure, non-`NT-`-prefixed content still falls to unknown-segment), randomized round-trip property test extended with note refs, all pre-existing WI-/FE-/quest tests still green.
- [x] `internal/workitem`: `DeriveWithPrefix` determinism, prefix independence, `Derive` byte-identical to `DeriveWithPrefix(RefPrefix, id)`.
- [x] `internal/git/commit`: unit tests confirming `NoteRef` reaches the commit message and co-occurs with `WorkitemRef`, plus a guard test that a non-note action (`IntentMove`) with `WorkitemRef` set but `NoteRef` unset never emits `-NT-`.
- [x] `tests/integration/commit_tags_test.go` (containerized, real `camp` binary): note commit gets its own `NT-<ref>`, a note captured inside an active workitem carries `WI-...-NT-...` in that order, and `camp intent add` from the same workitem context never leaks an `NT-` segment (guards `AmbientCommitOptions` isn't accidentally shared into non-note call sites).
- [x] `just build`, `just test unit` (3101/3101 passed), `just lint` (0 issues, no new host-FS test violators, no fmt.Errorf regressions) all green on the worktree.
