### PR TITLE
camp project run: cr -p shorthand, tab completion, refreshed help

### DIFF
--- a/cmd/camp/project/root.go
+++ b/cmd/camp/project/root.go
@@ -21,12 +21,17 @@ A project can be:
   - a machine-local linked workspace attached via symlink under projects/
 
 Use 'camp project add' for submodules and 'camp project link' / 'camp project unlink'
-for linked workspaces.
+for linked workspaces. Use 'camp project run' (or the 'cr -p' shell shorthand)
+to run a command inside a project from anywhere in the campaign.
 
 Examples:
   camp project list                    List all projects
   camp project add git@github.com:org/repo.git  Add a new project
   camp project link ~/code/my-project  Link an existing local workspace
+  camp project run -p fest -- just build  Run a command inside a project
+  camp project commit -p fest -m "fix"  Commit changes in a project submodule
+  camp project prune                   Delete merged branches in the cwd's project
+  camp project worktree add my-branch --project fest  Create a worktree for a project
   camp project remove api-service      Remove a project`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cmd.Help()

--- a/cmd/camp/project/run.go
+++ b/cmd/camp/project/run.go
@@ -17,11 +17,14 @@ import (
 
 var projectRunCmd = &cobra.Command{
 	Use:   "run [--project <name>] [--] <command> [args...]",
-	Short: "Run a command inside a project directory",
+	Short: "Run a command inside a project directory, like cr but project-scoped",
 	Long: `Run any shell command inside a project directory from anywhere in the campaign.
 
+This is the project-scoped counterpart to 'camp run' (cr): cr runs from the
+campaign root, camp project run (cr -p) runs inside a project.
+
 The project is resolved in this order:
-  1. --project / -p flag (explicit project name)
+  1. --project / -p flag (explicit project name, tab-completes registered projects)
   2. Auto-detect from current working directory
   3. Interactive fuzzy picker (if neither above applies)
 
@@ -39,12 +42,25 @@ Examples:
   camp project run -- just test all
 
   # Simple commands (no -- needed when no flags)
-  camp project run make build`,
+  camp project run make build
+
+  # Shell shorthand (after 'eval "$(camp shell-init <shell>)"')
+  cr -p fest -- just build
+  cr -p camp go test ./...`,
 	DisableFlagParsing: true,
 	RunE:               runProjectRun,
+	ValidArgsFunction:  completeProjectRunArgs,
 }
 
 func init() {
+	// Registered only so cobra's completion machinery advertises --project/-p
+	// as known flag names (see completeRequireFlags/doCompleteFlags in
+	// cobra's completions.go, which walk NonInheritedFlags() even when
+	// DisableFlagParsing is set). DisableFlagParsing means cobra never
+	// parses or binds this flag at runtime; parseProjectRunArgs below does
+	// that manually, and completeProjectRunArgs handles its value completion.
+	projectRunCmd.Flags().StringP("project", "p", "", "Project name (auto-detected from cwd, or interactive picker if omitted)")
+
 	Cmd.AddCommand(projectRunCmd)
 }
 
@@ -152,6 +168,68 @@ func parseProjectRunArgs(args []string) (projectName string, command []string) {
 	}
 
 	return projectName, nil
+}
+
+// completeProjectRunArgs provides --project/-p value completion for a
+// DisableFlagParsing command. Cobra skips its own flag-value detection in
+// this mode (checkIfFlagCompletion short-circuits when DisableFlagParsing is
+// set), so ValidArgsFunction receives the raw, unparsed args and must decide
+// for itself whether toComplete is a flag value. args mirrors what
+// parseProjectRunArgs would have already consumed.
+func completeProjectRunArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	inZone, awaitingValue := projectRunFlagZone(args)
+	if awaitingValue {
+		return cmdutil.CompleteProjectName(cmd, args, toComplete)
+	}
+
+	if inZone {
+		for _, prefix := range []string{"--project=", "-p="} {
+			if strings.HasPrefix(toComplete, prefix) {
+				names, directive := cmdutil.CompleteProjectName(cmd, args, strings.TrimPrefix(toComplete, prefix))
+				return prefixCompletions(names, prefix), directive
+			}
+		}
+	}
+
+	return nil, cobra.ShellCompDirectiveDefault
+}
+
+// projectRunFlagZone walks already-typed args the same way parseProjectRunArgs
+// does, reporting whether a fresh --project/-p is still eligible (inZone,
+// i.e. no "--" or command word seen yet) and whether the word currently being
+// completed is the value for a trailing, unconsumed --project/-p.
+func projectRunFlagZone(args []string) (inZone, awaitingValue bool) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		if arg == "--" {
+			return false, false
+		}
+		if strings.HasPrefix(arg, "--project=") || strings.HasPrefix(arg, "-p=") {
+			continue
+		}
+		if arg == "--project" || arg == "-p" {
+			if i+1 < len(args) {
+				i++
+				continue
+			}
+			return true, true
+		}
+
+		return false, false
+	}
+
+	return true, false
+}
+
+// prefixCompletions re-applies prefix to each completion so a "--project="
+// or "-p=" style value completes back into the same flag=value form.
+func prefixCompletions(names []string, prefix string) []string {
+	out := make([]string, len(names))
+	for i, n := range names {
+		out[i] = prefix + n
+	}
+	return out
 }
 
 // pickProject launches an interactive fuzzy finder for project selection.

--- a/cmd/camp/project/run.go
+++ b/cmd/camp/project/run.go
@@ -179,6 +179,10 @@ func parseProjectRunArgs(args []string) (projectName string, command []string) {
 func completeProjectRunArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	inZone, awaitingValue := projectRunFlagZone(args)
 	if awaitingValue {
+		// Deliberately offer a value after a trailing bare -p/--project even
+		// though runtime parsing treats that token as the command when no value
+		// follows. Completion runs before the value exists and should help the
+		// user finish the intended project flag.
 		return cmdutil.CompleteProjectName(cmd, args, toComplete)
 	}
 

--- a/cmd/camp/project/run_test.go
+++ b/cmd/camp/project/run_test.go
@@ -1,0 +1,177 @@
+package project
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestParseProjectRunArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantProject string
+		wantCommand []string
+	}{
+		{"no flags", []string{"ls", "-la"}, "", []string{"ls", "-la"}},
+		{"empty args", nil, "", nil},
+		{"-p value", []string{"-p", "fest", "just", "build"}, "fest", []string{"just", "build"}},
+		{"--project value", []string{"--project", "camp", "go", "test"}, "camp", []string{"go", "test"}},
+		{"--project= inline", []string{"--project=fest", "just", "build"}, "fest", []string{"just", "build"}},
+		{"-p= inline", []string{"-p=fest", "just", "build"}, "fest", []string{"just", "build"}},
+		{"-- separator with no flags", []string{"--", "ls", "-la"}, "", []string{"ls", "-la"}},
+		{"-p then --", []string{"-p", "fest", "--", "just", "build"}, "fest", []string{"just", "build"}},
+		{"flag after command word is not a camp flag", []string{"ls", "-p", "fest"}, "", []string{"ls", "-p", "fest"}},
+		{"-p with no following arg falls through as a command", []string{"-p"}, "", []string{"-p"}},
+		{"only --", []string{"--"}, "", []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotProject, gotCommand := parseProjectRunArgs(tt.args)
+			if gotProject != tt.wantProject {
+				t.Errorf("project = %q, want %q", gotProject, tt.wantProject)
+			}
+			if !reflect.DeepEqual(gotCommand, tt.wantCommand) {
+				t.Errorf("command = %v, want %v", gotCommand, tt.wantCommand)
+			}
+		})
+	}
+}
+
+func TestProjectRunFlagZone(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		wantInZone      bool
+		wantAwaitsValue bool
+	}{
+		{"no args yet", nil, true, false},
+		{"trailing -p awaits value", []string{"-p"}, true, true},
+		{"trailing --project awaits value", []string{"--project"}, true, true},
+		{"-p already has a value", []string{"-p", "fest"}, true, false},
+		{"--project= inline consumed", []string{"--project=fest"}, true, false},
+		{"-p= inline consumed", []string{"-p=fest"}, true, false},
+		{"-- ends the zone", []string{"--"}, false, false},
+		{"-p then -- ends the zone", []string{"-p", "--"}, true, false},
+		{"command word ends the zone", []string{"ls"}, false, false},
+		{"command word then -p is not a flag", []string{"ls", "-p"}, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotInZone, gotAwaits := projectRunFlagZone(tt.args)
+			if gotInZone != tt.wantInZone || gotAwaits != tt.wantAwaitsValue {
+				t.Errorf("projectRunFlagZone(%v) = (%v, %v), want (%v, %v)",
+					tt.args, gotInZone, gotAwaits, tt.wantInZone, tt.wantAwaitsValue)
+			}
+		})
+	}
+}
+
+// setupRunTestCampaign creates a temporary campaign root with a projects
+// directory and one project per name. projectsvc.List only checks for a
+// .git path's existence (internal/project/list.go), so a marker directory
+// is enough here; no real git repo (and no host-side git exec.Command) is
+// needed for name-only completion coverage.
+func setupRunTestCampaign(t *testing.T, projectNames ...string) string {
+	t.Helper()
+
+	campRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(campRoot, ".campaign"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	projectsDir := filepath.Join(campRoot, "projects")
+	for _, name := range projectNames {
+		if err := os.MkdirAll(filepath.Join(projectsDir, name, ".git"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return campRoot
+}
+
+func newProjectRunTestCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{Use: "run", RunE: runProjectRun}
+	cmd.SetContext(context.Background())
+	return cmd
+}
+
+func TestCompleteProjectRunArgs(t *testing.T) {
+	campRoot := setupRunTestCampaign(t, "camp", "fest", "festival")
+	t.Chdir(campRoot)
+
+	cmd := newProjectRunTestCmd(t)
+
+	t.Run("bare -p offers every project", func(t *testing.T) {
+		got, directive := completeProjectRunArgs(cmd, []string{"-p"}, "")
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Fatalf("directive = %v, want NoFileComp", directive)
+		}
+		want := []string{"camp", "fest", "festival"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("completions = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("bare --project offers every project", func(t *testing.T) {
+		got, _ := completeProjectRunArgs(cmd, []string{"--project"}, "")
+		want := []string{"camp", "fest", "festival"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("completions = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("-p with prefix filters", func(t *testing.T) {
+		got, _ := completeProjectRunArgs(cmd, []string{"-p"}, "fe")
+		want := []string{"fest", "festival"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("completions = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("--project= inline form re-prefixes results", func(t *testing.T) {
+		got, directive := completeProjectRunArgs(cmd, nil, "--project=fe")
+		if directive != cobra.ShellCompDirectiveNoFileComp {
+			t.Fatalf("directive = %v, want NoFileComp", directive)
+		}
+		want := []string{"--project=fest", "--project=festival"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("completions = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("-p= inline form re-prefixes results", func(t *testing.T) {
+		got, _ := completeProjectRunArgs(cmd, nil, "-p=fe")
+		want := []string{"-p=fest", "-p=festival"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("completions = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("past the -- separator falls back to default completion", func(t *testing.T) {
+		got, directive := completeProjectRunArgs(cmd, []string{"-p", "--"}, "")
+		if directive != cobra.ShellCompDirectiveDefault {
+			t.Fatalf("directive = %v, want Default", directive)
+		}
+		if len(got) != 0 {
+			t.Fatalf("completions = %v, want none", got)
+		}
+	})
+
+	t.Run("after a command word falls back to default completion", func(t *testing.T) {
+		got, directive := completeProjectRunArgs(cmd, []string{"ls"}, "-p")
+		if directive != cobra.ShellCompDirectiveDefault {
+			t.Fatalf("directive = %v, want Default", directive)
+		}
+		if len(got) != 0 {
+			t.Fatalf("completions = %v, want none", got)
+		}
+	})
+}

--- a/internal/shell/bash_test.go
+++ b/internal/shell/bash_test.go
@@ -58,6 +58,27 @@ func TestGenerateBash(t *testing.T) {
 	}
 }
 
+func TestGenerateBash_CrProjectShorthand(t *testing.T) {
+	output := generateBash()
+
+	checks := []struct {
+		name    string
+		content string
+	}{
+		{"cr recognizes -p", `"$1" = "-p"`},
+		{"cr dispatches to project run", `camp project run -p "$cr_project" -- "$@"`},
+		{"project subcommand list includes run", "add commit link list new prune remote remove run stage unlink worktree"},
+	}
+
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if !strings.Contains(output, check.content) {
+				t.Errorf("bash init missing %s: %q", check.name, check.content)
+			}
+		})
+	}
+}
+
 func TestGenerateBash_FestivalsArm(t *testing.T) {
 	output := generateBash()
 	section := shellWrapperSection(t, output, "    festivals)", "    *)")

--- a/internal/shell/bash_test.go
+++ b/internal/shell/bash_test.go
@@ -65,7 +65,9 @@ func TestGenerateBash_CrProjectShorthand(t *testing.T) {
 		name    string
 		content string
 	}{
-		{"cr recognizes -p", `"$1" = "-p"`},
+		{"cr recognizes -p", `-p|--project)`},
+		{"cr recognizes equals form", `-p=*|--project=*)`},
+		{"cr rejects missing project", `usage: cr -p <project>`},
 		{"cr dispatches to project run", `camp project run -p "$cr_project" -- "$@"`},
 		{"project subcommand list includes run", "add commit link list new prune remote remove run stage unlink worktree"},
 	}

--- a/internal/shell/fish_test.go
+++ b/internal/shell/fish_test.go
@@ -55,6 +55,27 @@ func TestGenerateFish(t *testing.T) {
 	}
 }
 
+func TestGenerateFish_CrProjectShorthand(t *testing.T) {
+	output := generateFish()
+
+	checks := []struct {
+		name    string
+		content string
+	}{
+		{"cr recognizes -p", `"$argv[1]" = "-p"`},
+		{"cr dispatches to project run", `camp project run -p "$cr_project" -- $rest`},
+		{"project subcommand list includes run", `-a "run" -d "Run a command inside a project directory"`},
+	}
+
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if !strings.Contains(output, check.content) {
+				t.Errorf("fish init missing %s: %q", check.name, check.content)
+			}
+		})
+	}
+}
+
 func TestGenerateFish_FestivalsArm(t *testing.T) {
 	output := generateFish()
 	section := shellWrapperSection(t, output, "        case festivals", "        case '*'")

--- a/internal/shell/fish_test.go
+++ b/internal/shell/fish_test.go
@@ -63,6 +63,8 @@ func TestGenerateFish_CrProjectShorthand(t *testing.T) {
 		content string
 	}{
 		{"cr recognizes -p", `"$argv[1]" = "-p"`},
+		{"cr recognizes equals form", `string match -q -- '-p=*'`},
+		{"cr rejects missing project", `usage: cr -p <project>`},
 		{"cr dispatches to project run", `camp project run -p "$cr_project" -- $rest`},
 		{"project subcommand list includes run", `-a "run" -d "Run a command inside a project directory"`},
 	}

--- a/internal/shell/templates/bash.sh.tmpl
+++ b/internal/shell/templates/bash.sh.tmpl
@@ -241,10 +241,19 @@ _cgo_complete() {
 }
 complete -o nospace -F _cgo_complete cgo
 
-# Run command from campaign root
+# Run command from campaign root, or in a project with -p
 # Usage: cr <command> [args...]
+#        cr -p <project> [--] <command> [args...]
 cr() {
-  camp run "$@"
+  if [ "$1" = "-p" ] || [ "$1" = "--project" ]; then
+    shift
+    local cr_project="$1"
+    [ $# -gt 0 ] && shift
+    [ "$1" = "--" ] && shift
+    camp project run -p "$cr_project" -- "$@"
+  else
+    camp run "$@"
+  fi
 }
 
 # Switch campaigns
@@ -291,7 +300,7 @@ _camp_complete() {
       ;;
     project)
       if [ "$COMP_CWORD" -eq 2 ]; then
-        COMPREPLY=($(compgen -W "add list remove" -- "$cur"))
+        COMPREPLY=($(compgen -W "add commit link list new prune remote remove run stage unlink worktree" -- "$cur"))
       fi
       ;;
     shell-init)

--- a/internal/shell/templates/bash.sh.tmpl
+++ b/internal/shell/templates/bash.sh.tmpl
@@ -245,10 +245,26 @@ complete -o nospace -F _cgo_complete cgo
 # Usage: cr <command> [args...]
 #        cr -p <project> [--] <command> [args...]
 cr() {
-  if [ "$1" = "-p" ] || [ "$1" = "--project" ]; then
-    shift
-    local cr_project="$1"
-    [ $# -gt 0 ] && shift
+  local cr_project=""
+  case "${1:-}" in
+    -p|--project)
+      if [ $# -lt 2 ] || [ -z "$2" ]; then
+        echo "usage: cr -p <project> [--] <command> [args...]" >&2
+        return 2
+      fi
+      cr_project="$2"
+      shift 2
+      ;;
+    -p=*|--project=*)
+      cr_project="${1#*=}"
+      if [ -z "$cr_project" ]; then
+        echo "usage: cr -p <project> [--] <command> [args...]" >&2
+        return 2
+      fi
+      shift
+      ;;
+  esac
+  if [ -n "$cr_project" ]; then
     [ "$1" = "--" ] && shift
     camp project run -p "$cr_project" -- "$@"
   else

--- a/internal/shell/templates/fish.sh.tmpl
+++ b/internal/shell/templates/fish.sh.tmpl
@@ -252,15 +252,31 @@ complete -c cgo -n "not __camp_is_first_arg; and not __camp_is_first_arg_drill" 
 # Usage: cr <command> [args...]
 #        cr -p <project> [--] <command> [args...]
 function cr --description "Run command from campaign root, or in a project with -p"
+    set -l cr_project
+    set -l rest
     if test "$argv[1]" = "-p" -o "$argv[1]" = "--project"
-        set -l cr_project $argv[2]
-        set -l rest
+		if test (count $argv) -lt 2 -o -z "$argv[2]"
+			echo "usage: cr -p <project> [--] <command> [args...]" >&2
+			return 2
+		end
+		set cr_project $argv[2]
         if test (count $argv) -gt 2
             set rest $argv[3..-1]
         end
-        if test (count $rest) -gt 0 -a "$rest[1]" = "--"
-            set rest $rest[2..-1]
-        end
+    else if string match -q -- '-p=*' "$argv[1]"; or string match -q -- '--project=*' "$argv[1]"
+		set cr_project (string replace -r '^[^=]*=' '' -- "$argv[1]")
+		if test -z "$cr_project"
+			echo "usage: cr -p <project> [--] <command> [args...]" >&2
+			return 2
+		end
+		if test (count $argv) -gt 1
+			set rest $argv[2..-1]
+		end
+    end
+    if test -n "$cr_project"
+		if test (count $rest) -gt 0 -a "$rest[1]" = "--"
+			set rest $rest[2..-1]
+		end
         camp project run -p "$cr_project" -- $rest
     else
         camp run $argv

--- a/internal/shell/templates/fish.sh.tmpl
+++ b/internal/shell/templates/fish.sh.tmpl
@@ -248,10 +248,23 @@ complete -c cgo -f  # no file completion
 complete -c cgo -n "__camp_is_first_arg_drill" -a "(NO_COLOR=1 command camp complete --described (commandline -ct) 2>/dev/null)"
 complete -c cgo -n "not __camp_is_first_arg; and not __camp_is_first_arg_drill" -a "(NO_COLOR=1 command camp complete --described (commandline -opc)[2..-1] 2>/dev/null)"
 
-# Run command from campaign root
+# Run command from campaign root, or in a project with -p
 # Usage: cr <command> [args...]
-function cr --description "Run command from campaign root"
-    camp run $argv
+#        cr -p <project> [--] <command> [args...]
+function cr --description "Run command from campaign root, or in a project with -p"
+    if test "$argv[1]" = "-p" -o "$argv[1]" = "--project"
+        set -l cr_project $argv[2]
+        set -l rest
+        if test (count $argv) -gt 2
+            set rest $argv[3..-1]
+        end
+        if test (count $rest) -gt 0 -a "$rest[1]" = "--"
+            set rest $rest[2..-1]
+        end
+        camp project run -p "$cr_project" -- $rest
+    else
+        camp run $argv
+    end
 end
 
 # Switch campaigns
@@ -300,9 +313,18 @@ complete -c camp -n "__fish_seen_subcommand_from shell-init" -a "bash" -d "Bash 
 complete -c camp -n "__fish_seen_subcommand_from shell-init" -a "fish" -d "Fish shell"
 
 # Project subcommands
-complete -c camp -n "__fish_seen_subcommand_from project" -a "add" -d "Add a project"
-complete -c camp -n "__fish_seen_subcommand_from project" -a "list" -d "List projects"
-complete -c camp -n "__fish_seen_subcommand_from project" -a "remove" -d "Remove a project"
+complete -c camp -n "__fish_seen_subcommand_from project" -a "add" -d "Add a project (submodule)"
+complete -c camp -n "__fish_seen_subcommand_from project" -a "commit" -d "Commit changes in a project submodule"
+complete -c camp -n "__fish_seen_subcommand_from project" -a "link" -d "Link an existing local project into the campaign"
+complete -c camp -n "__fish_seen_subcommand_from project" -a "list" -d "List projects in campaign"
+complete -c camp -n "__fish_seen_subcommand_from project" -a "new" -d "Create a new project in campaign"
+complete -c camp -n "__fish_seen_subcommand_from project" -a "prune" -d "Delete merged branches in a project"
+complete -c camp -n "__fish_seen_subcommand_from project" -a "remote" -d "Manage remotes for a project"
+complete -c camp -n "__fish_seen_subcommand_from project" -a "remove" -d "Remove a project from campaign"
+complete -c camp -n "__fish_seen_subcommand_from project" -a "run" -d "Run a command inside a project directory"
+complete -c camp -n "__fish_seen_subcommand_from project" -a "stage" -d "Stage changes in a project submodule"
+complete -c camp -n "__fish_seen_subcommand_from project" -a "unlink" -d "Unlink a linked project from the campaign"
+complete -c camp -n "__fish_seen_subcommand_from project" -a "worktree" -d "Manage worktrees for a project"
 
 # Global flags
 complete -c camp -l help -s h -d "Show help"

--- a/internal/shell/templates/zsh.sh.tmpl
+++ b/internal/shell/templates/zsh.sh.tmpl
@@ -268,10 +268,26 @@ _cgo() {
 # Usage: cr <command> [args...]
 #        cr -p <project> [--] <command> [args...]
 cr() {
-  if [[ "$1" == "-p" || "$1" == "--project" ]]; then
-    shift
-    local cr_project="$1"
-    [[ $# -gt 0 ]] && shift
+  local cr_project=""
+  case "${1:-}" in
+    -p|--project)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "usage: cr -p <project> [--] <command> [args...]" >&2
+        return 2
+      fi
+      cr_project="$2"
+      shift 2
+      ;;
+    -p=*|--project=*)
+      cr_project="${1#*=}"
+      if [[ -z "$cr_project" ]]; then
+        echo "usage: cr -p <project> [--] <command> [args...]" >&2
+        return 2
+      fi
+      shift
+      ;;
+  esac
+  if [[ -n "$cr_project" ]]; then
     [[ "$1" == "--" ]] && shift
     camp project run -p "$cr_project" -- "$@"
   else

--- a/internal/shell/templates/zsh.sh.tmpl
+++ b/internal/shell/templates/zsh.sh.tmpl
@@ -264,10 +264,66 @@ _cgo() {
     fi
   fi
 }
-# Run command from campaign root
+# Run command from campaign root, or in a project with -p
 # Usage: cr <command> [args...]
+#        cr -p <project> [--] <command> [args...]
 cr() {
-  camp run "$@"
+  if [[ "$1" == "-p" || "$1" == "--project" ]]; then
+    shift
+    local cr_project="$1"
+    [[ $# -gt 0 ]] && shift
+    [[ "$1" == "--" ]] && shift
+    camp project run -p "$cr_project" -- "$@"
+  else
+    camp run "$@"
+  fi
+}
+
+# Tab completion for cr / cr -p <project>.
+# Delegates to _normal (the same technique zsh's own _precommand uses for
+# nohup/time/env-style wrappers) so the wrapped command completes exactly
+# as it would at the top level, once cr's own leading words are consumed.
+_cr() {
+  if [[ "${words[2]}" == "-p" || "${words[2]}" == "--project" ]]; then
+    if (( CURRENT == 3 )); then
+      local -a projects
+      local output line
+      output=$(command camp __complete project run -p "${words[3]:-}" 2>/dev/null)
+      for line in ${(f)output}; do
+        [[ "$line" == :* ]] && continue
+        [[ -n "$line" ]] && projects+=("$line")
+      done
+      (( ${#projects} )) && compadd -a projects
+      return
+    fi
+
+    shift 3 words
+    (( CURRENT -= 3 ))
+    [[ "${words[1]}" == "--" ]] && { shift words; (( CURRENT-- )) }
+    _normal
+    return
+  fi
+
+  shift words
+  (( CURRENT-- ))
+  _normal
+}
+
+# Tab completion for 'camp project run -p <project>' (called from _camp
+# with the previous word and the word being completed, taken from _camp's
+# pre-_arguments snapshot rather than the live, rebased $words/$CURRENT).
+_camp_project_run() {
+  local prev="$1" cur="$2"
+  if [[ "$prev" == "-p" || "$prev" == "--project" ]]; then
+    local -a projects
+    local output line
+    output=$(command camp __complete project run -p "$cur" 2>/dev/null)
+    for line in ${(f)output}; do
+      [[ "$line" == :* ]] && continue
+      [[ -n "$line" ]] && projects+=("$line")
+    done
+    (( ${#projects} )) && compadd -a projects
+  fi
 }
 
 # Switch campaigns
@@ -311,6 +367,14 @@ cie() {
 
 # Camp command completion
 _camp() {
+  # _arguments -C rebases (and may re-invoke with alternate splits of)
+  # $words/$CURRENT/$line while it resolves the '*::arg:->args' spec below,
+  # so a snapshot taken before calling it is the only reliable way to see
+  # the original, full command line inside the nested 'args' dispatch.
+  local -a orig_words
+  orig_words=("${words[@]}")
+  local orig_current="$CURRENT"
+
   local curcontext="$curcontext" state line
   typeset -A opt_args
 
@@ -351,13 +415,26 @@ _camp() {
             '1:directory:_directories'
           ;;
         project)
-          local -a project_cmds
-          project_cmds=(
-            'add:Add a project'
-            'list:List projects'
-            'remove:Remove a project'
-          )
-          _describe 'project command' project_cmds
+          if (( orig_current == 3 )); then
+            local -a project_cmds
+            project_cmds=(
+              'add:Add a project (submodule)'
+              'commit:Commit changes in a project submodule'
+              'link:Link an existing local project into the campaign'
+              'list:List projects in campaign'
+              'new:Create a new project in campaign'
+              'prune:Delete merged branches in a project'
+              'remote:Manage remotes for a project'
+              'remove:Remove a project from campaign'
+              'run:Run a command inside a project directory'
+              'stage:Stage changes in a project submodule'
+              'unlink:Unlink a linked project from the campaign'
+              'worktree:Manage worktrees for a project'
+            )
+            _describe 'project command' project_cmds
+          elif [[ "${orig_words[3]}" == "run" ]]; then
+            _camp_project_run "${orig_words[orig_current-1]}" "${orig_words[orig_current]:-}"
+          fi
           ;;
         shell-init)
           local -a shells
@@ -384,6 +461,7 @@ _camp() {
 # user's own compinit runs, without erroring when it never does.
 _camp_register_completions() {
   compdef _cgo cgo
+  compdef _cr cr
   compdef _csw csw
   compdef _camp camp
 }

--- a/internal/shell/zsh_test.go
+++ b/internal/shell/zsh_test.go
@@ -88,6 +88,31 @@ func TestGenerateZsh_FestivalsArm(t *testing.T) {
 	}
 }
 
+func TestGenerateZsh_CrProjectShorthand(t *testing.T) {
+	output := generateZsh()
+
+	checks := []struct {
+		name    string
+		content string
+	}{
+		{"cr recognizes -p", `"$1" == "-p"`},
+		{"cr dispatches to project run", `camp project run -p "$cr_project" -- "$@"`},
+		{"cr registered for completion", "compdef _cr cr"},
+		{"cr completion calls __complete", "command camp __complete project run -p"},
+		{"cr completion delegates to _normal", "_normal"},
+		{"project run wired into project dispatch", "_camp_project_run"},
+		{"project subcommand list includes run", "'run:Run a command inside a project directory'"},
+	}
+
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if !strings.Contains(output, check.content) {
+				t.Errorf("zsh init missing %s: %q", check.name, check.content)
+			}
+		})
+	}
+}
+
 func TestGenerateZsh_ValidSyntax(t *testing.T) {
 	output := generateZsh()
 

--- a/internal/shell/zsh_test.go
+++ b/internal/shell/zsh_test.go
@@ -95,7 +95,9 @@ func TestGenerateZsh_CrProjectShorthand(t *testing.T) {
 		name    string
 		content string
 	}{
-		{"cr recognizes -p", `"$1" == "-p"`},
+		{"cr recognizes -p", `-p|--project)`},
+		{"cr recognizes equals form", `-p=*|--project=*)`},
+		{"cr rejects missing project", `usage: cr -p <project>`},
 		{"cr dispatches to project run", `camp project run -p "$cr_project" -- "$@"`},
 		{"cr registered for completion", "compdef _cr cr"},
 		{"cr completion calls __complete", "command camp __complete project run -p"},


### PR DESCRIPTION
## Summary

- Wires `-p`/`--project` tab completion onto `camp project run` despite `DisableFlagParsing`. Cobra never calls its own flag-value completion machinery in that mode (`checkIfFlagCompletion` short-circuits on `DisableFlagParsing`), so `ValidArgsFunction` now inspects the raw args itself to detect flag context, matching `parseProjectRunArgs`'s own resolution order exactly (including edge cases like a trailing bare `-p` or a `-p` that appears after the command has already started).
- Adds a `cr -p <project> [--] <command...>` shell shorthand for `camp project run -p <project> -- <command...>` in the zsh, bash, and fish shell-init templates, alongside the existing root-level `cr <command...>` (unchanged).
- zsh gets full dynamic completion: `cr -p <TAB>` and `camp project run -p <TAB>` both list registered project names via `camp __complete`, and `camp project <TAB>` now lists the real subcommand set (it was hardcoded to `add|list|remove` and didn't even include `run`). Plain `cr <command> [args...]` completion is preserved exactly via zsh's own `_normal` delegation technique (the same one `_precommand` uses for `nohup`/`time`/`env`-style wrappers).
- bash and fish get the `cr -p` shorthand and the corrected static `project` subcommand list, but not dynamic project-name completion for `-p`: neither template has any existing `__complete`-driven dynamic completion precedent to extend (zsh's `_csw` is the only prior art), so this keeps parity with each shell's current completion tier rather than introducing a new pattern in one PR.
- Refreshes `camp project run --help` (documents the `cr -p` shorthand and completion) and `camp project --help` (the parent listing was missing `run`, `commit`, `prune`, and `worktree` entirely).

Ref: intent `camp-project-run-command-needs-20260708-011321`.

## How completion works under DisableFlagParsing (and how I verified it)

Cobra's completion path (`completions.go`) special-cases `DisableFlagParsing`: `checkIfFlagCompletion` returns immediately with a nil flag, so `RegisterFlagCompletionFunc` never fires for this command (it's dead code if added): `ValidArgsFunction` is the *only* mechanism that runs, and it receives the raw, unparsed args plus the word being completed. `completeProjectRunArgs` in `cmd/camp/project/run.go` walks those args the same way `parseProjectRunArgs` does (via a new `projectRunFlagZone` helper) to decide whether the current word is a `-p`/`--project` value, an inline `--project=`/`-p=` form, or neither.

Verified by driving the hidden `__complete` command directly against the built binary:

```
$ camp __complete project run -p ""
camp
fest
festival
...
:4
Completion ended with directive: ShellCompDirectiveNoFileComp

$ camp __complete project run "--project=fe"
--project=fest
--project=festival
:4
```

and confirmed the negative cases (flag-name completion for `-`/`--pro`, no completion past `--`, no completion once a command word has started) all match `parseProjectRunArgs`'s actual runtime behavior. Added `TestParseProjectRunArgs`, `TestProjectRunFlagZone`, and `TestCompleteProjectRunArgs` (`cmd/camp/project/run_test.go`) covering all of this at the Go level.

For the zsh shell glue specifically, I additionally drove a real interactive zsh session non-interactively via `zsh/zpty`, sourcing the rendered `camp shell-init zsh` output against a fixture campaign, and confirmed `cr -p f<TAB>`, `camp project run -p <TAB>`, and `camp project r<TAB>` all produce the right candidates, while `cr ls -<TAB>` still gets normal top-level completion (not project names) via `_normal`. That surfaced a real bug along the way: `_arguments -C`'s `->args` state handler rebases (and can re-invoke with alternate splits of) `$words`/`$CURRENT`/`$line`, so a two-level nested dispatch (project → run → -p-value) can never see a stable view of the original command line from inside that handler. Fixed by snapshotting `$words`/`$CURRENT` in `_camp` *before* calling `_arguments -C`, and passing that snapshot down explicitly instead of reading the live (rebased) globals.

## Deviations from the docs regen convention

`docs/cli-reference` is generated by `just docs` and already has unrelated drift from the orgs merge (PR #387). Per campaign convention, regen is kept out of feature PRs: not run here.

## Test plan

- [x] `just build-camp` (stable and dev profiles)
- [x] `go vet ./...` (stable, dev, integration tags)
- [x] `just lint` (stable and dev; `lint-no-host-fs-tests` clean, `lint-no-fmt-errorf` clean)
- [x] `just test unit`: 3117/3117 (dev profile) and 3088/3088 (stable profile) passing
- [x] `just gate`: full gate passed end-to-end
- [x] Manual `camp __complete project run ...` verification of every branch (bare `-p`, prefix filter, `--project=`/`-p=` inline forms, flag-name completion, past-`--` fallback, past-a-command-word fallback)
- [x] Real interactive zsh session via `zsh/zpty` confirming `cr -p <TAB>`, `camp project run -p <TAB>`, `camp project r<TAB>`, and plain `cr <command> -<TAB>` all behave correctly
