### PR TITLE
fix(leverage): exclude worktrees from scc scans

### DIFF
--- a/docs/leverage-score.md
+++ b/docs/leverage-score.md
@@ -122,7 +122,9 @@ checkouts that would inflate COCOMO estimates: `node_modules`, `vendor`,
 `dist`, `build`, `target`, `worktrees`, `.worktrees`, `.camp-worktrees`,
 and similar. Project worktrees under `projects/worktrees/` are full source
 trees; counting them would multi-count the same codebase in leverage scores.
-Per-project extras can still be set via config `ExcludeDirs`.
+Monorepo root entries additionally exclude their expanded subproject
+directories via the project list's `ExcludeDirs`, so submodule code is
+not double-counted.
 
 ### From configuration (actual)
 

--- a/docs/leverage-score.md
+++ b/docs/leverage-score.md
@@ -112,8 +112,17 @@ We use it as the baseline because:
 scc is invoked as:
 
 ```bash
-scc --format json2 --cocomo-project-type <type> <directory>
+scc --format json2 --cocomo-project-type <type> \
+  --exclude-dir node_modules --exclude-dir vendor ... \
+  <directory>
 ```
+
+Default `--exclude-dir` values skip dependency/build caches and parallel
+checkouts that would inflate COCOMO estimates: `node_modules`, `vendor`,
+`dist`, `build`, `target`, `worktrees`, `.worktrees`, `.camp-worktrees`,
+and similar. Project worktrees under `projects/worktrees/` are full source
+trees; counting them would multi-count the same codebase in leverage scores.
+Per-project extras can still be set via config `ExcludeDirs`.
 
 ### From configuration (actual)
 

--- a/internal/leverage/scc.go
+++ b/internal/leverage/scc.go
@@ -9,8 +9,12 @@ import (
 )
 
 // DefaultExcludeDirs are directories excluded from scc scans by default.
-// These contain vendored dependencies, build output, or caches that
-// would inflate COCOMO estimates beyond authored code.
+// These contain vendored dependencies, build output, caches, or parallel
+// checkouts that would inflate COCOMO estimates beyond authored code.
+//
+// worktrees / .worktrees / .camp-worktrees must be excluded: camp project
+// worktrees live under projects/worktrees/ and are full source checkouts.
+// Counting them double/triple-counts the same codebase in leverage scores.
 var DefaultExcludeDirs = []string{
 	"node_modules",
 	"vendor",
@@ -29,6 +33,9 @@ var DefaultExcludeDirs = []string{
 	".mypy_cache",
 	".pytest_cache",
 	".cargo",
+	"worktrees",
+	".worktrees",
+	".camp-worktrees",
 }
 
 // SCCRunner implements Runner by shelling out to the scc binary.

--- a/internal/leverage/scc_test.go
+++ b/internal/leverage/scc_test.go
@@ -109,6 +109,21 @@ func TestDefaultExcludeDirs_NotEmpty(t *testing.T) {
 	}
 }
 
+func TestDefaultExcludeDirs_IncludesWorktrees(t *testing.T) {
+	// Project worktrees are full source checkouts. Without excluding them,
+	// camp leverage multiplies LOC by 1+N worktrees (seen as multi-x spikes).
+	required := []string{"worktrees", ".worktrees", ".camp-worktrees"}
+	present := make(map[string]bool, len(DefaultExcludeDirs))
+	for _, d := range DefaultExcludeDirs {
+		present[d] = true
+	}
+	for _, d := range required {
+		if !present[d] {
+			t.Errorf("DefaultExcludeDirs missing %q — worktree checkouts inflate leverage", d)
+		}
+	}
+}
+
 func TestNewSCCRunner(t *testing.T) {
 	// scc is installed on this machine, so this should succeed.
 	runner, err := NewSCCRunner(COCOMOOrganic)


### PR DESCRIPTION
## Summary

- Add `worktrees`, `.worktrees`, and `.camp-worktrees` to leverage `DefaultExcludeDirs` so `scc` does not scan project worktree checkouts
- Document the exclusion in `docs/leverage-score.md`
- Add a unit test that the worktree dirs stay in the default exclude list

Without this, parallel review worktrees under `projects/worktrees/` are full source trees and multi-count LOC in COCOMO estimates (e.g. camp ~101x → ~331x after two review worktrees).

## Test plan

- [x] `go test ./internal/leverage/ -count=1`
- [ ] After merge/install: run `camp leverage --project camp` with local worktrees present and confirm file/LOC counts match non-worktree baseline
- [ ] Optionally `camp leverage reset` / re-snapshot if cached inflated snapshots need clearing