### PR TITLE
Campaign audit trail: bypass doctor + backfill (CA0002 part 2, stacked on #402)

### DIFF
--- a/cmd/camp/audit/audit.go
+++ b/cmd/camp/audit/audit.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Obedience-Corp/camp/internal/audit"
-	"github.com/Obedience-Corp/camp/internal/campaign"
+	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/git"
 	"github.com/Obedience-Corp/camp/internal/ledger"
@@ -65,7 +65,7 @@ most recent N commits (default: full history).`,
 
 func runDoctor(cmd *cobra.Command, window int, jsonOut bool) error {
 	ctx := cmd.Context()
-	campRoot, err := campaign.DetectCached(ctx)
+	cfg, campRoot, err := config.LoadCampaignConfigFromCwd(ctx)
 	if err != nil {
 		return camperrors.Wrap(err, "not in a campaign")
 	}
@@ -90,19 +90,28 @@ func runDoctor(cmd *cobra.Command, window int, jsonOut bool) error {
 		totalCommits += scan.Total
 	}
 
+	// Second pass (D004): reconciliation gaps, read-only. The doctor surfaces
+	// how many state-file facts the ledger does not capture; the actual write is
+	// opt-in via `camp audit reconcile --apply`.
+	gaps, err := audit.Reconcile(ctx, campRoot, cfg.ID)
+	if err != nil {
+		return err
+	}
+
 	if jsonOut {
 		return json.NewEncoder(cmd.OutOrStdout()).Encode(struct {
 			SchemaVersion string           `json:"schema_version"`
 			TotalCommits  int              `json:"total_commits"`
 			TotalUntagged int              `json:"total_untagged"`
+			ReconcileGaps int              `json:"reconcile_gaps"`
 			Repos         []audit.RepoScan `json:"repos"`
-		}{"camp-audit-doctor/v1", totalCommits, totalUntagged, scans})
+		}{"camp-audit-doctor/v1", totalCommits, totalUntagged, len(gaps), scans})
 	}
 
-	return printReport(cmd, scans, totalCommits, totalUntagged)
+	return printReport(cmd, scans, totalCommits, totalUntagged, len(gaps))
 }
 
-func printReport(cmd *cobra.Command, scans []audit.RepoScan, totalCommits, totalUntagged int) error {
+func printReport(cmd *cobra.Command, scans []audit.RepoScan, totalCommits, totalUntagged, reconcileGaps int) error {
 	w := cmd.OutOrStdout()
 	if _, err := fmt.Fprintln(w, ui.Subheader("Campaign audit trail: commit attribution")); err != nil {
 		return err
@@ -124,6 +133,12 @@ func printReport(cmd *cobra.Command, scans []audit.RepoScan, totalCommits, total
 	if _, err := fmt.Fprintf(w, "\n%s %d of %d commits (%.0f%%) have no captured intent linkage.\n",
 		ui.InfoIcon(), totalUntagged, totalCommits, overall); err != nil {
 		return err
+	}
+	if reconcileGaps > 0 {
+		if _, err := fmt.Fprintf(w, "%s %d state-file fact(s) are not in the ledger. Run 'camp audit reconcile --apply' to record them.\n",
+			ui.InfoIcon(), reconcileGaps); err != nil {
+			return err
+		}
 	}
 	_, err := fmt.Fprintln(w, ui.Dim("  This is informational. Capture in state-changing commands (not commit discipline) is the trail; reconciliation and opt-in repair attribute the rest."))
 	return err

--- a/cmd/camp/audit/audit.go
+++ b/cmd/camp/audit/audit.go
@@ -1,0 +1,153 @@
+// Package audit implements the `camp audit` command group: the bypass-tolerance
+// doctor (D004). `camp audit doctor` scans linked repos for commits with no
+// captured intent linkage and reports them informationally (untagged commits
+// are a normal mode, never a violation; exit 0 on findings).
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/audit"
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git"
+	"github.com/Obedience-Corp/camp/internal/ledger"
+	"github.com/Obedience-Corp/camp/internal/ui"
+)
+
+// Cmd is the `camp audit` command group.
+var Cmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Inspect the campaign audit trail",
+	Long: `Inspect the campaign audit trail.
+
+'camp audit doctor' scans linked repos for commits with no captured intent
+linkage and reports them informationally. Untagged commits are a normal mode
+for wrapper-opt-out workflows, not a violation.`,
+}
+
+func init() {
+	Cmd.AddCommand(newDoctorCommand())
+}
+
+func newDoctorCommand() *cobra.Command {
+	var (
+		window  int
+		jsonOut bool
+	)
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Scan linked repos for unattributed commits (informational)",
+		Long: `Scan the campaign root and every linked project repo, classifying each
+commit as tagged, degraded, or untagged (no captured intent linkage).
+
+Output is informational: untagged commits are surfaced, never scolded, and the
+command exits 0 even when findings exist. Use --window to bound each repo to its
+most recent N commits (default: full history).`,
+		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Read-only scan with --json output for automation",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDoctor(cmd, window, jsonOut)
+		},
+	}
+	cmd.Flags().IntVar(&window, "window", 0, "scan only the most recent N commits per repo (0 = full history)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a structured JSON report")
+	return cmd
+}
+
+func runDoctor(cmd *cobra.Command, window int, jsonOut bool) error {
+	ctx := cmd.Context()
+	campRoot, err := campaign.DetectCached(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign")
+	}
+
+	repos, err := scanTargets(ctx, campRoot)
+	if err != nil {
+		return err
+	}
+
+	scans := make([]audit.RepoScan, 0, len(repos))
+	var totalUntagged, totalCommits int
+	for _, r := range repos {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		scan, scanErr := audit.ScanRepo(ctx, r.label, r.path, window)
+		if scanErr != nil {
+			return scanErr
+		}
+		scans = append(scans, scan)
+		totalUntagged += scan.Untagged
+		totalCommits += scan.Total
+	}
+
+	if jsonOut {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(struct {
+			SchemaVersion string           `json:"schema_version"`
+			TotalCommits  int              `json:"total_commits"`
+			TotalUntagged int              `json:"total_untagged"`
+			Repos         []audit.RepoScan `json:"repos"`
+		}{"camp-audit-doctor/v1", totalCommits, totalUntagged, scans})
+	}
+
+	return printReport(cmd, scans, totalCommits, totalUntagged)
+}
+
+func printReport(cmd *cobra.Command, scans []audit.RepoScan, totalCommits, totalUntagged int) error {
+	w := cmd.OutOrStdout()
+	if _, err := fmt.Fprintln(w, ui.Subheader("Campaign audit trail: commit attribution")); err != nil {
+		return err
+	}
+	for _, s := range scans {
+		pct := 0.0
+		if s.Total > 0 {
+			pct = 100 * float64(s.Untagged) / float64(s.Total)
+		}
+		if _, err := fmt.Fprintf(w, "  %-16s tagged %-5d degraded %-3d untagged %-5d / %-5d (%.0f%% unattributed)\n",
+			s.Repo, s.Tagged, s.Degraded, s.Untagged, s.Total, pct); err != nil {
+			return err
+		}
+	}
+	overall := 0.0
+	if totalCommits > 0 {
+		overall = 100 * float64(totalUntagged) / float64(totalCommits)
+	}
+	if _, err := fmt.Fprintf(w, "\n%s %d of %d commits (%.0f%%) have no captured intent linkage.\n",
+		ui.InfoIcon(), totalUntagged, totalCommits, overall); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintln(w, ui.Dim("  This is informational. Capture in state-changing commands (not commit discipline) is the trail; reconciliation and opt-in repair attribute the rest."))
+	return err
+}
+
+type scanTarget struct {
+	label string
+	path  string
+}
+
+// scanTargets returns the campaign root plus every linked submodule repo,
+// each with its campaign-relative label.
+func scanTargets(ctx context.Context, campRoot string) ([]scanTarget, error) {
+	targets := []scanTarget{{label: "campaign-root", path: campRoot}}
+	subs, err := git.ListSubmodulePaths(ctx, campRoot)
+	if err != nil {
+		// No .gitmodules or no submodules is fine: scan the root only.
+		return targets, nil
+	}
+	for _, rel := range subs {
+		targets = append(targets, scanTarget{
+			label: ledger.RepoLabel(campRoot, filepath.Join(campRoot, rel)),
+			path:  filepath.Join(campRoot, rel),
+		})
+	}
+	return targets, nil
+}

--- a/cmd/camp/audit/backfill.go
+++ b/cmd/camp/audit/backfill.go
@@ -1,0 +1,88 @@
+package audit
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/audit"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/ui"
+)
+
+func init() {
+	Cmd.AddCommand(newBackfillCommand())
+}
+
+func newBackfillCommand() *cobra.Command {
+	var (
+		apply   bool
+		jsonOut bool
+	)
+	cmd := &cobra.Command{
+		Use:   "backfill",
+		Short: "Derive a source:backfill event stream from history (opt-in write)",
+		Long: `Derive ledger events from a campaign's existing history - tagged commits across
+linked repos, intent frontmatter, and festival status histories - so a pre-ledger
+campaign (or the pre-ledger history of this one) renders on the same timeline as
+new activity.
+
+Backfill is optional and never required. It is idempotent and live-wins: a fact
+already captured live or by a prior backfill is skipped, so consecutive runs
+produce zero new events. Dry-run by default; --apply writes the source:backfill
+events into the standard shard layout.`,
+		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Dry-run backfill is read-only; --apply is an explicit opt-in write",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			cfg, campRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+			if err != nil {
+				return camperrors.Wrap(err, "not in a campaign directory")
+			}
+			targets, err := scanTargets(ctx, campRoot)
+			if err != nil {
+				return err
+			}
+			repos := make([]audit.RepoTarget, 0, len(targets))
+			for _, t := range targets {
+				repos = append(repos, audit.RepoTarget{Label: t.label, Path: t.path})
+			}
+			res, err := audit.Backfill(ctx, campRoot, cfg.ID, repos)
+			if err != nil {
+				return err
+			}
+			written := 0
+			if apply && len(res.Events) > 0 {
+				if written, err = audit.Apply(ctx, campRoot, res.Events); err != nil {
+					return err
+				}
+			}
+			if jsonOut {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(struct {
+					SchemaVersion string `json:"schema_version"`
+					Derived       int    `json:"derived"`
+					Skipped       int    `json:"already_captured"`
+					New           int    `json:"new"`
+					Applied       int    `json:"applied"`
+				}{"camp-audit-backfill/v1", res.Derived, res.Skipped, len(res.Events), written})
+			}
+			w := cmd.OutOrStdout()
+			if apply {
+				_, err := fmt.Fprintf(w, "%s Backfilled %d event(s) (%d derived, %d already captured).\n",
+					ui.SuccessIcon(), written, res.Derived, res.Skipped)
+				return err
+			}
+			_, err = fmt.Fprintf(w, "%s %d event(s) would be backfilled (%d derived, %d already captured). Re-run with --apply to write them.\n",
+				ui.InfoIcon(), len(res.Events), res.Derived, res.Skipped)
+			return err
+		},
+	}
+	cmd.Flags().BoolVar(&apply, "apply", false, "write the derived source:backfill events into the ledger")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a structured JSON result")
+	return cmd
+}

--- a/cmd/camp/audit/reconcile_repair.go
+++ b/cmd/camp/audit/reconcile_repair.go
@@ -92,7 +92,7 @@ in the ledger (D004). Use it to claim an untagged commit surfaced by
 		Args: cobra.NoArgs,
 		Annotations: map[string]string{
 			"agent_allowed": "true",
-			"agent_reason":  "Appends an attribution event from explicit flags",
+			"agent_reason":  "Appends attribution; requires --why and is write-idempotent on re-run",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, campRoot, err := config.LoadCampaignConfigFromCwd(cmd.Context())
@@ -108,6 +108,16 @@ in the ledger (D004). Use it to claim an untagged commit surfaced by
 			if err != nil {
 				return err
 			}
+			// Write-idempotent: content-derived rp_ ids skip when already present.
+			present, perr := audit.EventIDPresent(cmd.Context(), campRoot, ev.ID)
+			if perr != nil {
+				return camperrors.Wrap(perr, "check existing repair")
+			}
+			if present {
+				_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s Already repaired: %s@%s → %s (no new event)\n",
+					ui.InfoIcon(), in.Repo, shortSHA(in.SHA), scopeLabel(in))
+				return err
+			}
 			if _, err := audit.Apply(cmd.Context(), campRoot, []*ledgerkit.Event{ev}); err != nil {
 				return err
 			}
@@ -121,7 +131,8 @@ in the ledger (D004). Use it to claim an untagged commit surfaced by
 	f.StringVar(&in.Repo, "repo", "", "evidence repo label (default: campaign-root)")
 	f.StringVar(&in.Workitem, "workitem", "", "workitem to attribute the commit to")
 	f.StringVar(&in.Festival, "festival", "", "festival to attribute the commit to")
-	f.StringVar(&in.Why, "why", "", "the reason / context for the attribution")
+	f.StringVar(&in.Why, "why", "", "reason for the attribution (required)")
+	_ = cmd.MarkFlagRequired("why")
 	return cmd
 }
 

--- a/cmd/camp/audit/reconcile_repair.go
+++ b/cmd/camp/audit/reconcile_repair.go
@@ -1,0 +1,140 @@
+package audit
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/audit"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
+)
+
+func init() {
+	Cmd.AddCommand(newReconcileCommand())
+	Cmd.AddCommand(newRepairCommand())
+}
+
+func newReconcileCommand() *cobra.Command {
+	var (
+		apply   bool
+		jsonOut bool
+	)
+	cmd := &cobra.Command{
+		Use:   "reconcile",
+		Short: "Fill ledger gaps from state files (opt-in write)",
+		Long: `Derive the events implied by campaign state files (intent statuses and
+festival status histories), diff them against the ledger, and report the gaps -
+facts the ledger does not yet capture. This covers users who never commit at all.
+
+By default this is a dry run. Pass --apply to append the missing facts as
+reconciled events (idempotent: reconciled ids are content-derived, so re-running
+does not duplicate).`,
+		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Dry-run reconciliation is read-only; --apply is an explicit opt-in write",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, campRoot, err := config.LoadCampaignConfigFromCwd(cmd.Context())
+			if err != nil {
+				return camperrors.Wrap(err, "not in a campaign directory")
+			}
+			gaps, err := audit.Reconcile(cmd.Context(), campRoot, cfg.ID)
+			if err != nil {
+				return err
+			}
+			written := 0
+			if apply && len(gaps) > 0 {
+				if written, err = audit.Apply(cmd.Context(), campRoot, gaps); err != nil {
+					return err
+				}
+			}
+			if jsonOut {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(struct {
+					SchemaVersion string `json:"schema_version"`
+					Gaps          int    `json:"gaps"`
+					Applied       int    `json:"applied"`
+				}{"camp-audit-reconcile/v1", len(gaps), written})
+			}
+			w := cmd.OutOrStdout()
+			if len(gaps) == 0 {
+				_, err := fmt.Fprintln(w, ui.Success("Ledger is consistent with state files: no gaps."))
+				return err
+			}
+			if apply {
+				_, err := fmt.Fprintf(w, "%s Reconciled %d gap(s) into the ledger.\n", ui.SuccessIcon(), written)
+				return err
+			}
+			_, err = fmt.Fprintf(w, "%s %d state-file fact(s) are not yet in the ledger. Re-run with --apply to record them as reconciled events.\n",
+				ui.InfoIcon(), len(gaps))
+			return err
+		},
+	}
+	cmd.Flags().BoolVar(&apply, "apply", false, "append the missing facts as reconciled events")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a structured JSON result")
+	return cmd
+}
+
+func newRepairCommand() *cobra.Command {
+	in := audit.RepairInput{}
+	cmd := &cobra.Command{
+		Use:   "repair --sha <sha> (--workitem <id> | --festival <id>) --why <reason>",
+		Short: "Attribute a commit to a workitem or festival after the fact",
+		Long: `Attribute an already-landed commit to a workitem or festival by appending a
+repaired event. This never rewrites git history; it only records the attribution
+in the ledger (D004). Use it to claim an untagged commit surfaced by
+'camp audit doctor' for a piece of work.`,
+		Args: cobra.NoArgs,
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Appends an attribution event from explicit flags",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, campRoot, err := config.LoadCampaignConfigFromCwd(cmd.Context())
+			if err != nil {
+				return camperrors.Wrap(err, "not in a campaign directory")
+			}
+			in.CampaignID = cfg.ID
+			if in.Repo == "" {
+				in.Repo = "campaign-root"
+			}
+			in.Actor = ledgerkit.Actor{Type: ledgerkit.ActorHuman, Name: git.GetUserName(cmd.Context())}
+			ev, err := audit.BuildRepair(in)
+			if err != nil {
+				return err
+			}
+			if _, err := audit.Apply(cmd.Context(), campRoot, []*ledgerkit.Event{ev}); err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s Repaired: attributed %s@%s to %s\n",
+				ui.SuccessIcon(), in.Repo, shortSHA(in.SHA), scopeLabel(in))
+			return err
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&in.SHA, "sha", "", "commit sha to attribute (required)")
+	f.StringVar(&in.Repo, "repo", "", "evidence repo label (default: campaign-root)")
+	f.StringVar(&in.Workitem, "workitem", "", "workitem to attribute the commit to")
+	f.StringVar(&in.Festival, "festival", "", "festival to attribute the commit to")
+	f.StringVar(&in.Why, "why", "", "the reason / context for the attribution")
+	return cmd
+}
+
+func scopeLabel(in audit.RepairInput) string {
+	if in.Workitem != "" {
+		return "workitem " + in.Workitem
+	}
+	return "festival " + in.Festival
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}

--- a/cmd/camp/root.go
+++ b/cmd/camp/root.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	attachpkg "github.com/Obedience-Corp/camp/cmd/camp/attach"
+	auditpkg "github.com/Obedience-Corp/camp/cmd/camp/audit"
 	cachepkg "github.com/Obedience-Corp/camp/cmd/camp/cache"
 	dungeonpkg "github.com/Obedience-Corp/camp/cmd/camp/dungeon"
 	eventpkg "github.com/Obedience-Corp/camp/cmd/camp/event"
@@ -220,6 +221,7 @@ func init() {
 
 	rootCmd.AddCommand(skillspkg.Cmd)
 	rootCmd.AddCommand(eventpkg.Cmd)
+	rootCmd.AddCommand(auditpkg.Cmd)
 	rootCmd.AddCommand(cachepkg.Cmd)
 	rootCmd.AddCommand(navigationpkg.Cmd)
 	rootCmd.AddCommand(initcmd.New())

--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -9,6 +9,7 @@ const (
 )
 
 var manifestAgentAllowedReasons = map[string]string{
+	"audit doctor":               "Read-only bypass scan; --json output for automation",
 	"cache info":                 "Read-only cache metadata",
 	"concepts":                   "Read-only concept listing",
 	"create":                     "Non-interactive with -d and -m; interactive fallback otherwise",

--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -9,6 +9,7 @@ const (
 )
 
 var manifestAgentAllowedReasons = map[string]string{
+	"audit backfill":             "Dry-run backfill is read-only; --apply is an explicit opt-in write",
 	"audit doctor":               "Read-only bypass scan; --json output for automation",
 	"audit reconcile":            "Dry-run reconciliation is read-only; --apply is an explicit opt-in write",
 	"audit repair":               "Appends a commit-attribution event from explicit flags",

--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -10,6 +10,8 @@ const (
 
 var manifestAgentAllowedReasons = map[string]string{
 	"audit doctor":               "Read-only bypass scan; --json output for automation",
+	"audit reconcile":            "Dry-run reconciliation is read-only; --apply is an explicit opt-in write",
+	"audit repair":               "Appends a commit-attribution event from explicit flags",
 	"cache info":                 "Read-only cache metadata",
 	"concepts":                   "Read-only concept listing",
 	"create":                     "Non-interactive with -d and -m; interactive fallback otherwise",

--- a/docs/audit-trail-rollout.md
+++ b/docs/audit-trail-rollout.md
@@ -52,4 +52,3 @@ The writer slug in each shard filename is machine-local, so two machines never
 write the same shard and the ledger merges without conflict. Running backfill on
 two machines derives the same content-addressed ids, so the streams dedupe on
 read.
-</content>

--- a/docs/audit-trail-rollout.md
+++ b/docs/audit-trail-rollout.md
@@ -1,0 +1,55 @@
+# Campaign audit trail: rollout for existing campaigns
+
+The campaign event ledger (`.campaign/events/<YYYY-MM>/<writer>.jsonl`) is
+additive and optional. New campaigns capture events automatically as you run
+state-changing camp commands. Existing campaigns with history predating the
+ledger can derive a trail on demand. Nothing here is required, and none of it
+touches git history.
+
+## Recommended run order
+
+1. `camp audit backfill` (dry run) - shows how many events would be derived from
+   your history (tagged commits across linked repos, intent frontmatter, and
+   festival status histories) and how many are already captured.
+2. `camp audit backfill --apply` - writes the derived `source: backfill` events
+   into the standard shard layout.
+3. `camp audit reconcile` then `camp audit reconcile --apply` - fills any state
+   file facts (intents, festival transitions) that neither live capture nor
+   backfill covered. This matters for work that never produced a commit.
+4. `camp audit doctor` - the informational bypass report: per-repo
+   tagged/degraded/untagged commit counts. Untagged commits are a normal mode
+   (wrapper-opt-out), never a violation; the command exits 0 on findings.
+
+Backfill first, then reconcile, then doctor. Backfill covers the commit-derived
+facts; reconcile covers the commit-less remainder; doctor reports what remains
+unattributed and is the input to opt-in repair.
+
+## What to expect
+
+- Backfill and reconcile are dry runs by default. They only write with `--apply`.
+- `source: backfill` and `source: reconciled` events render identically to live
+  events in the timeline and graph; only their provenance differs.
+- The doctor's numbers are a baseline. As you keep working through camp/fest
+  commands, new activity is captured at the state-change boundary regardless of
+  commit habits, so the unattributed population stops growing as a blind spot.
+
+## How re-runs behave
+
+- All three write commands are idempotent. Backfill and reconcile derive stable,
+  content-derived ids and skip any fact the ledger already captures (live events
+  win; a prior backfill or reconcile is recognized), so a second run reports zero
+  new events.
+- Commit shas are matched on a short prefix, so a commit captured live (short
+  sha) and the same commit derived by backfill (full sha) are recognized as one
+  fact and never duplicated.
+- Repair (`camp audit repair --sha ... --workitem|--festival ... --why ...`)
+  appends an attribution event for an already-landed commit. It also uses a
+  content-derived id, so repairing the same commit twice converges.
+
+## Multi-machine note
+
+The writer slug in each shard filename is machine-local, so two machines never
+write the same shard and the ledger merges without conflict. Running backfill on
+two machines derives the same content-addressed ids, so the streams dedupe on
+read.
+</content>

--- a/internal/audit/apply.go
+++ b/internal/audit/apply.go
@@ -2,6 +2,7 @@ package audit
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -52,13 +53,16 @@ type RepairInput struct {
 // BuildRepair constructs a repaired event attributing the evidence to a
 // workitem/festival. It never rewrites git history; it only appends an
 // attribution event (D004). The id is content-derived so re-running the same
-// repair converges.
+// repair converges (callers must skip when the id is already on disk).
 func BuildRepair(in RepairInput) (*ledgerkit.Event, error) {
 	if in.SHA == "" {
 		return nil, camperrors.NewValidation("sha", "a commit sha is required to repair", nil)
 	}
 	if in.Workitem == "" && in.Festival == "" {
 		return nil, camperrors.NewValidation("scope", "repair needs a --workitem or --festival to attribute the commit to", nil)
+	}
+	if strings.TrimSpace(in.Why) == "" {
+		return nil, camperrors.NewValidation("why", "a non-empty --why reason is required for repair", nil)
 	}
 	scope := ledgerkit.Scope{Campaign: in.CampaignID, Workitem: in.Workitem, Festival: in.Festival}
 	evidence := []ledgerkit.Evidence{{Type: ledgerkit.EvidenceCommit, Repo: in.Repo, SHA: in.SHA}}
@@ -69,8 +73,30 @@ func BuildRepair(in RepairInput) (*ledgerkit.Event, error) {
 		Kind:     ledgerkit.KindRepaired,
 		Scope:    scope,
 		Actor:    in.Actor,
-		Why:      in.Why,
+		Why:      strings.TrimSpace(in.Why),
 		Evidence: evidence,
 		Source:   ledgerkit.SourceReconciled,
 	}, nil
+}
+
+// EventIDPresent reports whether the campaign ledger already holds an event
+// with the given id (used so repair skips instead of re-appending).
+func EventIDPresent(ctx context.Context, campaignRoot, eventID string) (bool, error) {
+	if eventID == "" {
+		return false, nil
+	}
+	reader, err := ledgerkit.NewReader(campaignRoot)
+	if err != nil {
+		return false, err
+	}
+	events, _, err := reader.Query(ctx, ledgerkit.Filter{})
+	if err != nil {
+		return false, err
+	}
+	for _, ev := range events {
+		if ev.ID == eventID {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/internal/audit/apply.go
+++ b/internal/audit/apply.go
@@ -1,0 +1,76 @@
+package audit
+
+import (
+	"context"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
+)
+
+// Apply appends already-built events (reconciled or repaired) to the campaign
+// ledger. Ids are set by the caller (content-derived for reconciled events), so
+// re-applying is idempotent at the read layer: duplicate ids dedupe on read.
+// It returns the number of events written.
+func Apply(ctx context.Context, campaignRoot string, events []*ledgerkit.Event) (int, error) {
+	if len(events) == 0 {
+		return 0, nil
+	}
+	writerID, err := ledgerkit.ResolveWriterID(ctx)
+	if err != nil {
+		return 0, camperrors.Wrap(err, "audit: resolve writer id")
+	}
+	w, err := ledgerkit.NewWriter(campaignRoot, writerID)
+	if err != nil {
+		return 0, camperrors.Wrap(err, "audit: init writer")
+	}
+	written := 0
+	for _, ev := range events {
+		if err := ctx.Err(); err != nil {
+			return written, err
+		}
+		if err := w.Append(ctx, ev); err != nil {
+			return written, camperrors.Wrapf(err, "audit: append %s", ev.ID)
+		}
+		written++
+	}
+	return written, nil
+}
+
+// RepairInput describes an opt-in repair: attributing a commit (or other
+// evidence) to a workitem or festival after the fact.
+type RepairInput struct {
+	CampaignID string
+	Repo       string // evidence repo label (campaign-relative)
+	SHA        string
+	Workitem   string
+	Festival   string
+	Why        string
+	Actor      ledgerkit.Actor
+}
+
+// BuildRepair constructs a repaired event attributing the evidence to a
+// workitem/festival. It never rewrites git history; it only appends an
+// attribution event (D004). The id is content-derived so re-running the same
+// repair converges.
+func BuildRepair(in RepairInput) (*ledgerkit.Event, error) {
+	if in.SHA == "" {
+		return nil, camperrors.NewValidation("sha", "a commit sha is required to repair", nil)
+	}
+	if in.Workitem == "" && in.Festival == "" {
+		return nil, camperrors.NewValidation("scope", "repair needs a --workitem or --festival to attribute the commit to", nil)
+	}
+	scope := ledgerkit.Scope{Campaign: in.CampaignID, Workitem: in.Workitem, Festival: in.Festival}
+	evidence := []ledgerkit.Evidence{{Type: ledgerkit.EvidenceCommit, Repo: in.Repo, SHA: in.SHA}}
+	return &ledgerkit.Event{
+		V:        ledgerkit.EnvelopeVersion,
+		ID:       ledgerkit.DerivedID("rp", "repair", in.Repo, in.SHA, in.Workitem, in.Festival),
+		TS:       ledgerkit.NowUTC(time.Now()),
+		Kind:     ledgerkit.KindRepaired,
+		Scope:    scope,
+		Actor:    in.Actor,
+		Why:      in.Why,
+		Evidence: evidence,
+		Source:   ledgerkit.SourceReconciled,
+	}, nil
+}

--- a/internal/audit/backfill.go
+++ b/internal/audit/backfill.go
@@ -1,0 +1,146 @@
+package audit
+
+import (
+	"bufio"
+	"context"
+	"os/exec"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
+)
+
+// BackfillResult reports a backfill run.
+type BackfillResult struct {
+	Derived int // facts derived from all source families
+	Skipped int // facts already captured (live or a prior backfill)
+	Events  []*ledgerkit.Event
+}
+
+// Backfill derives events from every source family (commit tags, intent
+// frontmatter, festival status histories) and returns the source:backfill
+// events for facts the ledger does not already capture. It is idempotent and
+// live-wins: a fact captured live (a ULID event) or by a prior backfill (a bf_
+// event) is skipped, so consecutive runs converge and live events are never
+// duplicated. Emitted ids are content-derived (bf_ prefix).
+func Backfill(ctx context.Context, campaignRoot, campaignID string, repos []RepoTarget) (*BackfillResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	facts, err := DeriveFacts(ctx, campaignRoot, campaignID)
+	if err != nil {
+		return nil, err
+	}
+	commitFacts, err := deriveCommitFacts(ctx, campaignRoot, campaignID, repos)
+	if err != nil {
+		return nil, err
+	}
+	facts = append(facts, commitFacts...)
+
+	reader, err := ledgerkit.NewReader(campaignRoot)
+	if err != nil {
+		return nil, err
+	}
+	events, _, err := reader.Read(ctx)
+	if err != nil {
+		return nil, err
+	}
+	captured := capturedIndex(events)
+
+	res := &BackfillResult{Derived: len(facts)}
+	seen := make(map[string]bool)
+	for _, f := range facts {
+		if captured[factCoverageKey(f)] {
+			res.Skipped++
+			continue
+		}
+		id := ledgerkit.DerivedID("bf", f.IdentityKey)
+		if seen[id] {
+			continue // two derived facts with the same identity: keep one
+		}
+		seen[id] = true
+		res.Events = append(res.Events, &ledgerkit.Event{
+			V:        ledgerkit.EnvelopeVersion,
+			ID:       id,
+			TS:       f.TS,
+			Kind:     f.Kind,
+			Scope:    f.Scope,
+			Actor:    ledgerkit.Actor{Type: ledgerkit.ActorUnknown},
+			Why:      f.Why,
+			Payload:  f.Payload,
+			Evidence: f.Evidence,
+			Source:   ledgerkit.SourceBackfill,
+		})
+	}
+	return res, nil
+}
+
+// RepoTarget is a repo to scan for commit-tag facts, with its campaign-relative
+// label.
+type RepoTarget struct {
+	Label string
+	Path  string
+}
+
+// deriveCommitFacts turns tagged/degraded commits into evidence_attached facts,
+// with scope from the tag. Untagged commits produce no fact (they are the
+// bypass population the doctor reports, not backfillable to a scope).
+func deriveCommitFacts(ctx context.Context, campaignRoot, campaignID string, repos []RepoTarget) ([]DerivedFact, error) {
+	var facts []DerivedFact
+	for _, r := range repos {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		lines, err := commitLog(ctx, r.Path)
+		if err != nil {
+			continue // an unreadable/empty repo contributes nothing
+		}
+		for _, ln := range lines {
+			cols := strings.SplitN(ln, "\x1f", 4)
+			if len(cols) != 4 {
+				continue
+			}
+			sha, author, date, subject := cols[0], cols[1], cols[2], cols[3]
+			tc, _ := commitkit.ParseTagDetailed(subject)
+			if tc.CampaignID == "" {
+				continue // untagged: not attributable
+			}
+			facts = append(facts, DerivedFact{
+				Kind: ledgerkit.KindEvidenceAttached,
+				Scope: ledgerkit.Scope{
+					Campaign: campaignID, Festival: tc.FestRef,
+					Workitem: tc.WorkitemRef, Quest: tc.QuestID,
+				},
+				TS:          normalizeTS(date),
+				Why:         firstLineOf(subject),
+				Evidence:    []ledgerkit.Evidence{{Type: ledgerkit.EvidenceCommit, Repo: r.Label, SHA: sha}},
+				Payload:     map[string]any{"author": author},
+				IdentityKey: "commit:" + r.Label + "@" + sha,
+			})
+		}
+	}
+	return facts, nil
+}
+
+func commitLog(ctx context.Context, repoPath string) ([]string, error) {
+	out, err := exec.CommandContext(ctx, "git", "-C", repoPath, "log", "--no-merges", "--format=%H%x1f%an%x1f%aI%x1f%s").Output()
+	if err != nil {
+		return nil, err
+	}
+	var lines []string
+	sc := bufio.NewScanner(strings.NewReader(string(out)))
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		if sc.Text() != "" {
+			lines = append(lines, sc.Text())
+		}
+	}
+	return lines, sc.Err()
+}
+
+func firstLineOf(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/internal/audit/backfill_test.go
+++ b/internal/audit/backfill_test.go
@@ -1,0 +1,39 @@
+package audit
+
+import (
+	"testing"
+
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommitCoverageMatchesShortAndFullSHA(t *testing.T) {
+	// Live capture stores a short sha; backfill derives the full sha for the same
+	// commit. Coverage keys must match so backfill does not re-attach it (the
+	// idempotence-critical case).
+	live := []*ledgerkit.Event{{
+		Kind:     ledgerkit.KindEvidenceAttached,
+		Source:   ledgerkit.SourceCommand,
+		Evidence: []ledgerkit.Evidence{{Type: ledgerkit.EvidenceCommit, Repo: "campaign-root", SHA: "89c5ad1"}},
+	}}
+	captured := capturedIndex(live)
+
+	derived := DerivedFact{
+		Kind:     ledgerkit.KindEvidenceAttached,
+		Evidence: []ledgerkit.Evidence{{Type: ledgerkit.EvidenceCommit, Repo: "campaign-root", SHA: "89c5ad104ff798952e3499f9aab01071288b21b6"}},
+	}
+	assert.True(t, captured[factCoverageKey(derived)],
+		"a full-sha backfill fact is covered by the live short-sha evidence")
+
+	other := DerivedFact{
+		Kind:     ledgerkit.KindEvidenceAttached,
+		Evidence: []ledgerkit.Evidence{{Type: ledgerkit.EvidenceCommit, Repo: "campaign-root", SHA: "ffffffffffffffffffffffffffffffffffffffff"}},
+	}
+	assert.False(t, captured[factCoverageKey(other)], "a different commit is not covered")
+}
+
+func TestNormSHA(t *testing.T) {
+	assert.Equal(t, "89c5ad1", normSHA("89c5ad104ff798952e3499f9aab01071288b21b6"))
+	assert.Equal(t, "89c5ad1", normSHA("89c5ad1"))
+	assert.Equal(t, "abc", normSHA("abc"))
+}

--- a/internal/audit/reconcile.go
+++ b/internal/audit/reconcile.go
@@ -17,11 +17,12 @@ import (
 // checked against the ledger. Backfill emits every fact; reconciliation emits
 // only facts the ledger does not already capture.
 type DerivedFact struct {
-	Kind    ledgerkit.Kind
-	Scope   ledgerkit.Scope
-	TS      string
-	Why     string
-	Payload map[string]any
+	Kind     ledgerkit.Kind
+	Scope    ledgerkit.Scope
+	TS       string
+	Why      string
+	Payload  map[string]any
+	Evidence []ledgerkit.Evidence
 	// IdentityKey is the stable content identity used to derive the event id and
 	// to detect whether the ledger already captures this fact.
 	IdentityKey string
@@ -168,6 +169,15 @@ func capturedIndex(events []*ledgerkit.Event) map[string]bool {
 				idx["fest-transitioned:"+e.Scope.Festival+":"+from+"->"+to] = true
 			}
 		}
+		// Commit evidence (live or backfilled) covers a commit fact regardless of
+		// the event kind, so backfill does not re-attach an already-recorded sha.
+		// Shas are normalized to a short prefix so live short shas and backfill
+		// full shas for the same commit match.
+		for _, ev := range e.Evidence {
+			if ev.Type == ledgerkit.EvidenceCommit && ev.SHA != "" {
+				idx["commit:"+ev.Repo+"@"+normSHA(ev.SHA)] = true
+			}
+		}
 	}
 	return idx
 }
@@ -186,8 +196,22 @@ func factCoverageKey(f DerivedFact) string {
 			to, _ := f.Payload["to"].(string)
 			return "fest-transitioned:" + f.Scope.Festival + ":" + from + "->" + to
 		}
+	case ledgerkit.KindEvidenceAttached:
+		if len(f.Evidence) > 0 && f.Evidence[0].Type == ledgerkit.EvidenceCommit {
+			return "commit:" + f.Evidence[0].Repo + "@" + normSHA(f.Evidence[0].SHA)
+		}
 	}
 	return f.IdentityKey
+}
+
+// normSHA normalizes a commit sha to a short prefix so a short sha stored by
+// live capture and a full sha derived by backfill for the same commit compare
+// equal in coverage keys.
+func normSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
 }
 
 // ---- small helpers ----

--- a/internal/audit/reconcile.go
+++ b/internal/audit/reconcile.go
@@ -166,7 +166,19 @@ func capturedIndex(events []*ledgerkit.Event) map[string]bool {
 			if e.Scope.Festival != "" {
 				from, _ := e.Payload["from"].(string)
 				to, _ := e.Payload["to"].(string)
-				idx["fest-transitioned:"+e.Scope.Festival+":"+from+"->"+to] = true
+				// Occurrence-faithful: each from→to edge keeps a sequential
+				// index so bouncing festivals (ready→active→ready→active) are
+				// not collapsed when any live edge already exists.
+				base := fmtKey("fest-transitioned", e.Scope.Festival, from, to)
+				i := 0
+				for {
+					key := fmtKey(base, itoaSmall(i))
+					if !idx[key] {
+						idx[key] = true
+						break
+					}
+					i++
+				}
 			}
 		}
 		// Commit evidence (live or backfilled) covers a commit fact regardless of
@@ -191,10 +203,14 @@ func factCoverageKey(f DerivedFact) string {
 			return "intent-created:" + f.Scope.Intent
 		}
 	case ledgerkit.KindTransitioned:
+		// Prefer the occurrence-indexed IdentityKey (set by deriveFestivalFacts).
+		if f.IdentityKey != "" {
+			return f.IdentityKey
+		}
 		if f.Scope.Festival != "" {
 			from, _ := f.Payload["from"].(string)
 			to, _ := f.Payload["to"].(string)
-			return "fest-transitioned:" + f.Scope.Festival + ":" + from + "->" + to
+			return fmtKey("fest-transitioned", f.Scope.Festival, from, to, "0")
 		}
 	case ledgerkit.KindEvidenceAttached:
 		if len(f.Evidence) > 0 && f.Evidence[0].Type == ledgerkit.EvidenceCommit {

--- a/internal/audit/reconcile.go
+++ b/internal/audit/reconcile.go
@@ -1,0 +1,306 @@
+package audit
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
+)
+
+// DerivedFact is one event derived from a campaign state file, before it is
+// checked against the ledger. Backfill emits every fact; reconciliation emits
+// only facts the ledger does not already capture.
+type DerivedFact struct {
+	Kind    ledgerkit.Kind
+	Scope   ledgerkit.Scope
+	TS      string
+	Why     string
+	Payload map[string]any
+	// IdentityKey is the stable content identity used to derive the event id and
+	// to detect whether the ledger already captures this fact.
+	IdentityKey string
+}
+
+// DeriveFacts reads the campaign's state files (intent frontmatter and festival
+// status histories) and returns the events they imply. It is the shared
+// derivation used by both reconciliation and backfill; it is deterministic
+// (same disk state yields the same facts in the same order).
+func DeriveFacts(ctx context.Context, campaignRoot, campaignID string) ([]DerivedFact, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	var facts []DerivedFact
+	facts = append(facts, deriveIntentFacts(campaignRoot, campaignID)...)
+	festFacts, err := deriveFestivalFacts(ctx, campaignRoot, campaignID)
+	if err != nil {
+		return nil, err
+	}
+	facts = append(facts, festFacts...)
+	return facts, nil
+}
+
+// deriveIntentFacts derives a created fact per intent on disk.
+func deriveIntentFacts(campaignRoot, campaignID string) []DerivedFact {
+	root := filepath.Join(campaignRoot, ".campaign", "intents")
+	var facts []DerivedFact
+	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Ext(p) != ".md" || strings.HasSuffix(p, "OBEY.md") {
+			return nil
+		}
+		fm := parseFrontmatter(p)
+		if fm["id"] == "" {
+			return nil
+		}
+		facts = append(facts, DerivedFact{
+			Kind:        ledgerkit.KindCreated,
+			Scope:       ledgerkit.Scope{Campaign: campaignID, Intent: fm["id"]},
+			TS:          normalizeTS(firstNonEmpty(fm["created_at"], fm["updated_at"])),
+			Why:         fm["title"],
+			Payload:     map[string]any{"status": fm["status"], "type": fm["type"]},
+			IdentityKey: "intent-created:" + fm["id"],
+		})
+		return nil
+	})
+	return facts
+}
+
+// deriveFestivalFacts derives a transitioned fact per festival status-history
+// entry.
+func deriveFestivalFacts(ctx context.Context, campaignRoot, campaignID string) ([]DerivedFact, error) {
+	festRoot := filepath.Join(campaignRoot, "festivals")
+	var facts []DerivedFact
+	err := filepath.WalkDir(festRoot, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if d.IsDir() || filepath.Base(p) != "status_history.json" {
+			return nil
+		}
+		fest := festivalID(campaignRoot, p)
+		var hist []struct {
+			Timestamp  string `json:"timestamp"`
+			FromStatus string `json:"from_status"`
+			ToStatus   string `json:"to_status"`
+		}
+		if b, readErr := os.ReadFile(p); readErr == nil {
+			_ = json.Unmarshal(b, &hist)
+		}
+		for i, h := range hist {
+			facts = append(facts, DerivedFact{
+				Kind:        ledgerkit.KindTransitioned,
+				Scope:       ledgerkit.Scope{Campaign: campaignID, Festival: fest},
+				TS:          normalizeTS(h.Timestamp),
+				Payload:     map[string]any{"from": h.FromStatus, "to": h.ToStatus},
+				IdentityKey: fmtKey("fest-transitioned", fest, h.FromStatus, h.ToStatus, itoaSmall(i)),
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, camperrors.Wrap(err, "audit: walk festival histories")
+	}
+	return facts, nil
+}
+
+// Reconcile derives expected events from state files, diffs them against the
+// current ledger, and returns reconciled events for facts the ledger does not
+// already capture. It is idempotent: reconciled event ids are content-derived
+// (rc_ prefix), so once emitted they are captured and skipped on the next run.
+func Reconcile(ctx context.Context, campaignRoot, campaignID string) ([]*ledgerkit.Event, error) {
+	facts, err := DeriveFacts(ctx, campaignRoot, campaignID)
+	if err != nil {
+		return nil, err
+	}
+	reader, err := ledgerkit.NewReader(campaignRoot)
+	if err != nil {
+		return nil, err
+	}
+	events, _, err := reader.Read(ctx)
+	if err != nil {
+		return nil, err
+	}
+	captured := capturedIndex(events)
+
+	var reconciled []*ledgerkit.Event
+	for _, f := range facts {
+		if captured[factCoverageKey(f)] {
+			continue // the ledger already captures this fact (live or backfilled)
+		}
+		reconciled = append(reconciled, &ledgerkit.Event{
+			V:       ledgerkit.EnvelopeVersion,
+			ID:      ledgerkit.DerivedID("rc", f.IdentityKey),
+			TS:      f.TS,
+			Kind:    f.Kind,
+			Scope:   f.Scope,
+			Actor:   ledgerkit.Actor{Type: ledgerkit.ActorUnknown},
+			Why:     f.Why,
+			Payload: f.Payload,
+			Source:  ledgerkit.SourceReconciled,
+		})
+	}
+	return reconciled, nil
+}
+
+// capturedIndex builds the set of coverage keys already present in the ledger.
+// A created event covers its scope entity; a transitioned event covers its
+// scope entity's from/to move.
+func capturedIndex(events []*ledgerkit.Event) map[string]bool {
+	idx := make(map[string]bool, len(events))
+	for _, e := range events {
+		switch e.Kind {
+		case ledgerkit.KindCreated:
+			if e.Scope.Intent != "" {
+				idx["intent-created:"+e.Scope.Intent] = true
+			}
+		case ledgerkit.KindTransitioned:
+			if e.Scope.Festival != "" {
+				from, _ := e.Payload["from"].(string)
+				to, _ := e.Payload["to"].(string)
+				idx["fest-transitioned:"+e.Scope.Festival+":"+from+"->"+to] = true
+			}
+		}
+	}
+	return idx
+}
+
+// factCoverageKey is the key a fact would occupy in capturedIndex, so a derived
+// fact can be matched against events regardless of their id scheme.
+func factCoverageKey(f DerivedFact) string {
+	switch f.Kind {
+	case ledgerkit.KindCreated:
+		if f.Scope.Intent != "" {
+			return "intent-created:" + f.Scope.Intent
+		}
+	case ledgerkit.KindTransitioned:
+		if f.Scope.Festival != "" {
+			from, _ := f.Payload["from"].(string)
+			to, _ := f.Payload["to"].(string)
+			return "fest-transitioned:" + f.Scope.Festival + ":" + from + "->" + to
+		}
+	}
+	return f.IdentityKey
+}
+
+// ---- small helpers ----
+
+func parseFrontmatter(path string) map[string]string {
+	out := map[string]string{}
+	f, err := os.Open(path)
+	if err != nil {
+		return out
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	first := true
+	inFM := false
+	for sc.Scan() {
+		line := sc.Text()
+		if first {
+			first = false
+			if strings.TrimSpace(line) == "---" {
+				inFM = true
+				continue
+			}
+			return out
+		}
+		if !inFM {
+			break
+		}
+		if strings.TrimSpace(line) == "---" {
+			break
+		}
+		k, v, ok := strings.Cut(line, ":")
+		if ok {
+			out[strings.TrimSpace(k)] = strings.TrimSpace(v)
+		}
+	}
+	return out
+}
+
+func normalizeTS(s string) string {
+	if s == "" {
+		return "1970-01-01T00:00:00Z"
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02T15:04:05Z07:00"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC().Format(time.RFC3339Nano)
+		}
+	}
+	return s
+}
+
+func festivalID(campaignRoot, historyPath string) string {
+	rel, _ := filepath.Rel(campaignRoot, historyPath)
+	parts := strings.Split(rel, string(os.PathSeparator))
+	for i, seg := range parts {
+		if seg == ".fest" && i > 0 {
+			return canonicalFestivalID(parts[i-1])
+		}
+	}
+	return rel
+}
+
+// canonicalFestivalID parses the trailing id token (e.g. CA0002) from a festival
+// directory name, per D001's canonical-festival-id rule; falls back to the dir
+// name when no id token is present.
+func canonicalFestivalID(dirName string) string {
+	if i := strings.LastIndex(dirName, "-"); i >= 0 && i < len(dirName)-1 {
+		tail := dirName[i+1:]
+		if looksLikeFestID(tail) {
+			return tail
+		}
+	}
+	return dirName
+}
+
+func looksLikeFestID(s string) bool {
+	if len(s) < 3 {
+		return false
+	}
+	hasAlpha, hasDigit := false, false
+	for _, r := range s {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			hasAlpha = true
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		default:
+			return false
+		}
+	}
+	return hasAlpha && hasDigit
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func fmtKey(parts ...string) string { return strings.Join(parts, ":") }
+
+func itoaSmall(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [12]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/internal/audit/reconcile_test.go
+++ b/internal/audit/reconcile_test.go
@@ -24,8 +24,15 @@ func TestCoverageMatchingAcrossIdSchemes(t *testing.T) {
 	assert.True(t, captured[factCoverageKey(coveredIntent)], "intent already captured live is covered")
 
 	coveredTransition := DerivedFact{Kind: ledgerkit.KindTransitioned, Scope: ledgerkit.Scope{Festival: "CA0002"},
-		Payload: map[string]any{"from": "ready", "to": "active"}}
+		Payload:     map[string]any{"from": "ready", "to": "active"},
+		IdentityKey: "fest-transitioned:CA0002:ready:active:0"}
 	assert.True(t, captured[factCoverageKey(coveredTransition)], "festival transition already backfilled is covered")
+
+	// A second ready→active occurrence is a gap under occurrence-faithful coverage.
+	secondBounce := DerivedFact{Kind: ledgerkit.KindTransitioned, Scope: ledgerkit.Scope{Festival: "CA0002"},
+		Payload:     map[string]any{"from": "ready", "to": "active"},
+		IdentityKey: "fest-transitioned:CA0002:ready:active:1"}
+	assert.False(t, captured[factCoverageKey(secondBounce)], "second bounce of the same edge remains a gap")
 
 	// A gap: an intent with no event in the ledger.
 	gap := DerivedFact{Kind: ledgerkit.KindCreated, Scope: ledgerkit.Scope{Intent: "i2"}, IdentityKey: "intent-created:i2"}

--- a/internal/audit/reconcile_test.go
+++ b/internal/audit/reconcile_test.go
@@ -1,0 +1,50 @@
+package audit
+
+import (
+	"testing"
+
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoverageMatchingAcrossIdSchemes(t *testing.T) {
+	// The ledger already captures intent i1 (a live ULID event) and a festival
+	// transition (a backfill bf_ event). Reconciliation must recognize both as
+	// covered even though neither id matches a derived rc_ id - coverage is by
+	// content (scope + kind), not id.
+	events := []*ledgerkit.Event{
+		{ID: "01ARZ...ulid", Kind: ledgerkit.KindCreated, Scope: ledgerkit.Scope{Intent: "i1"}},
+		{ID: "bf_deadbeef", Kind: ledgerkit.KindTransitioned, Scope: ledgerkit.Scope{Festival: "CA0002"},
+			Payload: map[string]any{"from": "ready", "to": "active"}},
+	}
+	captured := capturedIndex(events)
+
+	coveredIntent := DerivedFact{Kind: ledgerkit.KindCreated, Scope: ledgerkit.Scope{Intent: "i1"}, IdentityKey: "intent-created:i1"}
+	assert.True(t, captured[factCoverageKey(coveredIntent)], "intent already captured live is covered")
+
+	coveredTransition := DerivedFact{Kind: ledgerkit.KindTransitioned, Scope: ledgerkit.Scope{Festival: "CA0002"},
+		Payload: map[string]any{"from": "ready", "to": "active"}}
+	assert.True(t, captured[factCoverageKey(coveredTransition)], "festival transition already backfilled is covered")
+
+	// A gap: an intent with no event in the ledger.
+	gap := DerivedFact{Kind: ledgerkit.KindCreated, Scope: ledgerkit.Scope{Intent: "i2"}, IdentityKey: "intent-created:i2"}
+	assert.False(t, captured[factCoverageKey(gap)], "an unrepresented intent is a reconciliation gap")
+}
+
+func TestReconciledIdIsDeterministicAndPrefixed(t *testing.T) {
+	// The same gap always derives the same rc_ id, so re-running reconciliation
+	// converges (idempotence): once emitted, the event is in the ledger and
+	// covered on the next pass.
+	a := ledgerkit.DerivedID("rc", "intent-created:i2")
+	b := ledgerkit.DerivedID("rc", "intent-created:i2")
+	require.Equal(t, a, b)
+	assert.Contains(t, a, "rc_")
+}
+
+func TestCanonicalFestivalID(t *testing.T) {
+	assert.Equal(t, "CA0002", canonicalFestivalID("campaign-audit-trail-CA0002"))
+	assert.Equal(t, "RI0002", canonicalFestivalID("remaining-intent-followups-RI0002"))
+	// No trailing id token: fall back to the directory name.
+	assert.Equal(t, "just-a-name", canonicalFestivalID("just-a-name"))
+}

--- a/internal/audit/scan.go
+++ b/internal/audit/scan.go
@@ -1,0 +1,140 @@
+// Package audit implements the campaign audit doctor (D004): a scan that
+// classifies commits across linked repos as tagged/degraded/untagged, a
+// reconciliation pass that derives events from state files and fills ledger
+// gaps, and opt-in repair. It is informational by design: untagged commits are
+// a normal mode for wrapper-opt-out users, not a violation. No git hooks.
+package audit
+
+import (
+	"bufio"
+	"context"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
+)
+
+// CommitClass is how a commit's subject classifies against the campaign tag
+// grammar.
+type CommitClass string
+
+const (
+	// ClassTagged is a recognized leading campaign tag with no shape warnings.
+	ClassTagged CommitClass = "tagged"
+	// ClassDegraded is a recognized leading tag with >=1 shape-check warning.
+	ClassDegraded CommitClass = "degraded"
+	// ClassUntagged is a commit with no recognized leading campaign tag: the
+	// bypass hole this doctor surfaces informationally.
+	ClassUntagged CommitClass = "untagged"
+)
+
+// ClassifyCommit classifies a commit subject using the same parser the ledger
+// uses (commitkit.ParseTagDetailed). It is pure and unit-testable.
+func ClassifyCommit(subject string) CommitClass {
+	tc, warnings := commitkit.ParseTagDetailed(subject)
+	switch {
+	case tc.CampaignID == "":
+		return ClassUntagged
+	case len(warnings) > 0:
+		return ClassDegraded
+	default:
+		return ClassTagged
+	}
+}
+
+// UntaggedCommit is one commit with no captured intent linkage.
+type UntaggedCommit struct {
+	SHA     string
+	Author  string
+	Subject string
+}
+
+// RepoScan is the classification result for one repo.
+type RepoScan struct {
+	Repo     string // campaign-relative label
+	Tagged   int
+	Degraded int
+	Untagged int
+	Total    int
+	// Sample holds up to SampleLimit untagged commits so the report can show the
+	// bypass population without dumping thousands of lines.
+	Sample []UntaggedCommit
+}
+
+// SampleLimit bounds the untagged sample per repo in a scan report.
+const SampleLimit = 20
+
+// gitLogLine is the record separator layout used by ScanRepo.
+const gitLogFormat = "%H%x1f%an%x1f%s"
+
+// ScanRepo walks a repo's history (optionally bounded to the most recent
+// maxCommits, 0 = all) and classifies every non-merge commit. It shells out to
+// git read-only; a repo with no commits yields a zero scan, not an error.
+func ScanRepo(ctx context.Context, repoLabel, repoPath string, maxCommits int) (RepoScan, error) {
+	if err := ctx.Err(); err != nil {
+		return RepoScan{}, err
+	}
+	args := []string{"-C", repoPath, "log", "--no-merges", "--format=" + gitLogFormat}
+	if maxCommits > 0 {
+		args = append(args, "-n", strconv.Itoa(maxCommits))
+	}
+	out, err := exec.CommandContext(ctx, "git", args...).Output()
+	if err != nil {
+		// An empty/uninitialized repo (no HEAD) is not a scan error.
+		if isNoHeadErr(err) {
+			return RepoScan{Repo: repoLabel}, nil
+		}
+		return RepoScan{}, camperrors.Wrapf(err, "audit: git log in %s", repoPath)
+	}
+	scan := RepoScan{Repo: repoLabel}
+	sc := bufio.NewScanner(strings.NewReader(string(out)))
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := sc.Text()
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\x1f", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		sha, author, subject := parts[0], parts[1], parts[2]
+		scan.Total++
+		switch ClassifyCommit(subject) {
+		case ClassTagged:
+			scan.Tagged++
+		case ClassDegraded:
+			scan.Degraded++
+		case ClassUntagged:
+			scan.Untagged++
+			if len(scan.Sample) < SampleLimit {
+				scan.Sample = append(scan.Sample, UntaggedCommit{SHA: sha, Author: author, Subject: subject})
+			}
+		}
+	}
+	return scan, sc.Err()
+}
+
+func isNoHeadErr(err error) bool {
+	var exitErr *exec.ExitError
+	if strings.Contains(err.Error(), "does not have any commits") {
+		return true
+	}
+	// git log on an unborn branch exits 128 with a stderr message; Output()
+	// discards stderr, so fall back to the exit code plus a best-effort check.
+	if e, ok := asExit(err, &exitErr); ok && e == 128 {
+		return true
+	}
+	return false
+}
+
+// asExit extracts the exit code from an error if it is an *exec.ExitError.
+func asExit(err error, target **exec.ExitError) (int, bool) {
+	if ee, ok := err.(*exec.ExitError); ok {
+		*target = ee
+		return ee.ExitCode(), true
+	}
+	return 0, false
+}

--- a/internal/audit/scan_test.go
+++ b/internal/audit/scan_test.go
@@ -1,0 +1,36 @@
+package audit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyCommit(t *testing.T) {
+	tests := []struct {
+		name    string
+		subject string
+		want    CommitClass
+	}{
+		{"name-style tag clean", "[obey-campaign:8deed8b4] docs: update", ClassTagged},
+		{"legacy id tag clean", "[OBEY-CAMPAIGN-8deed8b4] Create: thing", ClassTagged},
+		{"tag with fest ref clean", "[obey-campaign:8deed8b4-FE-CA0002] verify: shipped", ClassTagged},
+		{"degraded duplicate quest segment", "[obey-campaign:8deed8b4-qst_aaa-qst_bbb] chore: dup", ClassDegraded},
+		{"no tag is untagged", "fix: a plain commit with no tag", ClassUntagged},
+		{"non-tag bracket is untagged", "[WIP] scratch work", ClassUntagged},
+		{"empty subject is untagged", "", ClassUntagged},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ClassifyCommit(tt.subject))
+		})
+	}
+}
+
+func TestRepoScanSampleBounded(t *testing.T) {
+	// A pure check that the sample cap constant is sane and the struct math is
+	// consistent (tagged+degraded+untagged == total is enforced by ScanRepo).
+	assert.Positive(t, SampleLimit)
+	s := RepoScan{Tagged: 3, Degraded: 1, Untagged: 6, Total: 10}
+	assert.Equal(t, s.Total, s.Tagged+s.Degraded+s.Untagged)
+}


### PR DESCRIPTION
## Campaign audit trail: bypass doctor + backfill (festival CA0002, part 2)

Stacked on #402 (base branch `campaign-audit-trail`). This PR depends on #402 and should merge after it; it adds the D004 bypass-tolerance surface and the D006/A10 backfill tool on top of the ledger core and capture.

Review #402 first. The diff here is only the doctor/backfill work.

### What is in this PR

New `internal/audit` package and `camp audit` command group:

- `camp audit doctor` - informational bypass report. Scans the campaign root and every linked submodule repo, classifying each commit as tagged/degraded/untagged via the same parser the ledger uses (commitkit.ParseTagDetailed), and runs a read-only reconciliation pass to also report state-file facts not yet in the ledger (D004's two passes in one command). Untagged commits are a normal wrapper-opt-out mode, never scolded; exit 0 on findings. `--window`, `--json`.
- `camp audit reconcile [--apply]` - derives the events state files imply (intent frontmatter, festival status histories), diffs against the ledger by content (not id, so it recognizes live ULID and backfill events as coverage), and appends `source: reconciled` events for gaps. This covers users who never commit at all. Idempotent.
- `camp audit backfill [--apply]` - derives a `source: backfill` event stream from history (tagged commits across linked repos, intent frontmatter, festival status histories) so a pre-ledger campaign renders on the same timeline as new activity. Idempotent and live-wins.
- `camp audit repair --sha ... (--workitem | --festival) --why ...` - attributes an already-landed commit to a workitem or festival via a `repaired` event. Never rewrites git history.

### Design (D004 / D006)

- Informational, never scolding; exit 0 on findings; opt-in writes; no git hooks; no history rewrite.
- Idempotence: reconciled/backfill ids are content-derived (rc_/bf_ prefixes), so re-runs converge. Live-wins: a fact already captured live (a ULID event) or by a prior backfill is skipped, so live events are never duplicated. Commit coverage matches on a normalized short sha prefix, so a commit captured live (short sha) and derived by backfill (full sha) dedupe as one fact.
- Reconciliation and backfill share one derivation (internal/audit DeriveFacts), so the two stay consistent.

### Verification

- `just gate-push` green. Unit tests cover the idempotence-critical logic (commit-coverage matching across id and sha-length schemes, reconciled-id determinism, canonical festival id parsing, commit classification). Every command verified end to end on real and throwaway campaigns, including reconcile and backfill re-running to zero new events, and repair attribution.
- Real-campaign run (F6): `camp audit doctor` reproduces the dated bypass baseline from #402 (fest 71 percent, camp 42, campaign-root 22 percent untagged). `camp audit backfill` dry-run derives 9314 events, a superset of the sequence-01 prototype's 6266; the difference is scanning all linked submodule repos versus the prototype's hardcoded five.
- Rollout notes for existing campaigns: docs/audit-trail-rollout.md (run order backfill, then reconcile, then doctor; expectations; re-run behavior).

### Follow-on work (same festival)

fest-side capture and timeline/graph ingestion remain separate PRs (see #402's follow-on section).
</content>
