### PR TITLE
camp workitem commits: ledger-backed answering (D007, CA0002)

### DIFF
--- a/internal/commands/workitem/commits.go
+++ b/internal/commands/workitem/commits.go
@@ -152,6 +152,15 @@ func runCommitsQuery(ctx context.Context, cmd *cobra.Command, flags commitsFlags
 			return camperrors.NewValidation("workitem",
 				"workitem has no ref; run `camp workitem doctor --fix` to backfill", nil)
 		}
+	} else {
+		// --ref skips the full resolve for the identity, but still expand D007
+		// aliases (stable id / key / slug) when the ref maps to an on-disk workitem.
+		if res, rerr := resolver.Resolve(ctx, campaignRoot, resolver.Options{Explicit: ref}); rerr == nil && res != nil && res.Workitem != nil {
+			wi = res.Workitem
+			if r := wkitem.RefOf(wi); r != "" {
+				ref = r
+			}
+		}
 	}
 
 	requested := flags.Source
@@ -181,6 +190,9 @@ func runCommitsQuery(ctx context.Context, cmd *cobra.Command, flags commitsFlags
 			records, answered = ledgerRecs, commitsSourceLedger
 		} else if lerr == nil && len(ledgerRecs) > 0 {
 			records, answered = ledgerRecs, commitsSourceLedger
+		} else if lerr != nil {
+			// Empty ledger → silent scan is fine; unreadable/corrupt is loud.
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: campaign ledger unreadable (%v); falling back to scan\n", lerr)
 		}
 	}
 	if answered == commitsSourceScan && requested != commitsSourceLedger {
@@ -205,7 +217,7 @@ func runCommitsQuery(ctx context.Context, cmd *cobra.Command, flags commitsFlags
 	if flags.JSON {
 		return emitCommitsJSON(cmd.OutOrStdout(), source, records, queryErrs)
 	}
-	if err := emitCommitsTable(cmd.OutOrStdout(), records); err != nil {
+	if err := emitCommitsTable(cmd.OutOrStdout(), source, records); err != nil {
 		return err
 	}
 	return emitCommitsQueryWarnings(cmd.ErrOrStderr(), queryErrs)
@@ -277,7 +289,7 @@ func commitsFromLedgerEvents(events []*ledgerkit.Event, aliases map[string]bool)
 			records = append(records, CommitRecord{
 				SHA:      e.SHA,
 				Author:   ledgerCommitAuthor(ev),
-				Date:     parseLedgerTS(ev.TS),
+				Date:     ledgerCommitDate(ev),
 				Subject:  ev.Why,
 				Repo:     e.Repo,
 				TagParts: commitkit.ParseTag(ev.Why),
@@ -294,6 +306,21 @@ func ledgerCommitAuthor(ev *ledgerkit.Event) string {
 		}
 	}
 	return ev.Actor.Name
+}
+
+// ledgerCommitDate prefers payload commit_date/date (live capture + backfill)
+// and falls back to the event timestamp.
+func ledgerCommitDate(ev *ledgerkit.Event) time.Time {
+	if ev.Payload != nil {
+		for _, key := range []string{"commit_date", "date"} {
+			if d, ok := ev.Payload[key].(string); ok && d != "" {
+				if t := parseLedgerTS(d); !t.IsZero() {
+					return t
+				}
+			}
+		}
+	}
+	return parseLedgerTS(ev.TS)
 }
 
 func parseLedgerTS(ts string) time.Time {
@@ -504,7 +531,12 @@ func isGitRepo(ctx context.Context, path string) (bool, error) {
 	return true, nil
 }
 
-func emitCommitsTable(w io.Writer, records []CommitRecord) error {
+func emitCommitsTable(w io.Writer, source string, records []CommitRecord) error {
+	if source != "" {
+		if _, err := fmt.Fprintf(w, "source: %s\n", source); err != nil {
+			return err
+		}
+	}
 	if len(records) == 0 {
 		_, err := fmt.Fprintln(w, "no commits found")
 		return err

--- a/internal/commands/workitem/commits.go
+++ b/internal/commands/workitem/commits.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
 	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
 	"github.com/Obedience-Corp/camp/pkg/commitkit"
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
 )
 
 const (
@@ -61,18 +62,24 @@ func newCommitsCommand() *cobra.Command {
 		flagLimit    int
 		flagOffset   int
 		flagWorkitem string
+		flagSource   string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "commits [selector]",
 		Short: "List commits referencing a workitem across linked repos",
-		Long: `Search the campaign root and every linked project/repo/worktree/festival
-repo for commits whose campaign tag references this workitem's ref.
+		Long: `List commits referencing this workitem, newest first.
 
-Default sort: most recent first across all repos. Use --json for structured
-output. Repos that are not git checkouts or that fail their git log invocation
-are reported under "errors" in JSON mode; table mode warns on stderr when
-repo queries fail.`,
+When the campaign event ledger already holds the workitem's commit evidence,
+the answer comes from a single merged ledger read (fast path). Otherwise it
+falls back to scanning the campaign root and every linked
+project/repo/worktree/festival repo for commits whose campaign tag references
+the workitem's ref (pre-ledger history).
+
+Use --json for structured output; the "source" field reports which path
+answered ("ledger" or "scan"). Repos that are not git checkouts or that fail
+their git log invocation are reported under "errors" in JSON mode; table mode
+warns on stderr when repo queries fail.`,
 		Args: jsoncontract.Args(WorkitemCommitsJSONVersion, func() bool { return flagJSON }, cobra.MaximumNArgs(1)),
 		Annotations: map[string]string{
 			"agent_allowed": "true",
@@ -93,6 +100,7 @@ repo queries fail.`,
 				JSON:     flagJSON,
 				Limit:    flagLimit,
 				Offset:   flagOffset,
+				Source:   flagSource,
 			})
 		}),
 	}
@@ -102,8 +110,15 @@ repo queries fail.`,
 	cmd.Flags().BoolVar(&flagJSON, "json", false, "emit JSON instead of the default table")
 	cmd.Flags().IntVar(&flagLimit, "limit", commitsDefaultLimit, "maximum commits to return")
 	cmd.Flags().IntVar(&flagOffset, "offset", 0, "number of commits to skip (after sorting)")
+	cmd.Flags().StringVar(&flagSource, "source", commitsSourceAuto, "where to read commits from: auto (ledger when present, else scan), ledger, or scan")
 	return cmd
 }
+
+const (
+	commitsSourceAuto   = "auto"
+	commitsSourceLedger = "ledger"
+	commitsSourceScan   = "scan"
+)
 
 type commitsFlags struct {
 	Selector string
@@ -111,6 +126,7 @@ type commitsFlags struct {
 	JSON     bool
 	Limit    int
 	Offset   int
+	Source   string
 }
 
 func runCommitsQuery(ctx context.Context, cmd *cobra.Command, flags commitsFlags) error {
@@ -120,6 +136,7 @@ func runCommitsQuery(ctx context.Context, cmd *cobra.Command, flags commitsFlags
 	}
 
 	ref := flags.Ref
+	var wi *wkitem.WorkItem
 	if ref == "" {
 		res, rerr := resolver.Resolve(ctx, campaignRoot, resolver.Options{Explicit: flags.Selector})
 		if rerr != nil {
@@ -129,19 +146,51 @@ func runCommitsQuery(ctx context.Context, cmd *cobra.Command, flags commitsFlags
 			return camperrors.NewValidation("workitem",
 				"no workitem context resolved; pass <selector> or --ref WI-...", nil)
 		}
-		ref = wkitem.RefOf(res.Workitem)
+		wi = res.Workitem
+		ref = wkitem.RefOf(wi)
 		if ref == "" {
 			return camperrors.NewValidation("workitem",
 				"workitem has no ref; run `camp workitem doctor --fix` to backfill", nil)
 		}
 	}
 
-	repos, err := enumerateQueryRepos(ctx, campaignRoot)
-	if err != nil {
-		return camperrors.Wrap(err, "enumerate query repos")
+	requested := flags.Source
+	if requested == "" {
+		requested = commitsSourceAuto
+	}
+	if requested != commitsSourceAuto && requested != commitsSourceLedger && requested != commitsSourceScan {
+		return camperrors.NewValidation("source",
+			"must be auto, ledger, or scan", nil)
 	}
 
-	records, queryErrs := searchRepos(ctx, campaignRoot, repos, ref)
+	// Ledger-first (D007/A6): when the campaign event ledger holds this
+	// workitem's commit evidence, answer from one merged ledger read instead of a
+	// git-log fan-out across every linked repo. In auto, an empty or unreadable
+	// ledger falls back to the cross-repo tag scan; --source scan forces the scan
+	// (the exhaustive git --all view) and --source ledger forces the ledger.
+	aliases := workitemAliases(ref, wi)
+	var records []CommitRecord
+	var queryErrs []commitsQueryError
+	answered := commitsSourceScan
+	if requested == commitsSourceLedger || requested == commitsSourceAuto {
+		ledgerRecs, lerr := ledgerCommits(ctx, campaignRoot, aliases)
+		if requested == commitsSourceLedger {
+			if lerr != nil {
+				return camperrors.Wrap(lerr, "read campaign ledger")
+			}
+			records, answered = ledgerRecs, commitsSourceLedger
+		} else if lerr == nil && len(ledgerRecs) > 0 {
+			records, answered = ledgerRecs, commitsSourceLedger
+		}
+	}
+	if answered == commitsSourceScan && requested != commitsSourceLedger {
+		repos, rerr := enumerateQueryRepos(ctx, campaignRoot)
+		if rerr != nil {
+			return camperrors.Wrap(rerr, "enumerate query repos")
+		}
+		records, queryErrs = searchRepos(ctx, campaignRoot, repos, ref)
+	}
+	source := answered
 	sort.Slice(records, func(i, j int) bool { return records[i].Date.After(records[j].Date) })
 
 	if flags.Offset > 0 && flags.Offset < len(records) {
@@ -154,12 +203,107 @@ func runCommitsQuery(ctx context.Context, cmd *cobra.Command, flags commitsFlags
 	}
 
 	if flags.JSON {
-		return emitCommitsJSON(cmd.OutOrStdout(), records, queryErrs)
+		return emitCommitsJSON(cmd.OutOrStdout(), source, records, queryErrs)
 	}
 	if err := emitCommitsTable(cmd.OutOrStdout(), records); err != nil {
 		return err
 	}
 	return emitCommitsQueryWarnings(cmd.ErrOrStderr(), queryErrs)
+}
+
+// workitemAliases returns the identifier forms a ledger event's scope.workitem
+// might carry for this workitem (D007 workitem-id normalization): the ref, the
+// stable id, the workitem key, and the on-disk directory slug all name it.
+func workitemAliases(ref string, wi *wkitem.WorkItem) map[string]bool {
+	aliases := map[string]bool{}
+	if ref != "" {
+		aliases[ref] = true
+	}
+	if wi != nil {
+		if wi.StableID != "" {
+			aliases[wi.StableID] = true
+		}
+		if wi.Key != "" {
+			aliases[wi.Key] = true
+		}
+		if slug := filepath.Base(filepath.FromSlash(wi.RelativePath)); slug != "" && slug != "." {
+			aliases[slug] = true
+		}
+	}
+	return aliases
+}
+
+// ledgerCommits answers the query from the campaign event ledger: the commit
+// evidence on every evidence_attached/repaired event whose scope.workitem names
+// this workitem. A missing or empty ledger yields no records so the caller
+// falls back to the cross-repo scan.
+func ledgerCommits(ctx context.Context, campaignRoot string, aliases map[string]bool) ([]CommitRecord, error) {
+	if len(aliases) == 0 {
+		return nil, nil
+	}
+	reader, err := ledgerkit.NewReader(campaignRoot)
+	if err != nil {
+		return nil, err
+	}
+	events, _, err := reader.Query(ctx, ledgerkit.Filter{
+		Kinds: []ledgerkit.Kind{ledgerkit.KindEvidenceAttached, ledgerkit.KindRepaired},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return commitsFromLedgerEvents(events, aliases), nil
+}
+
+// commitsFromLedgerEvents maps commit evidence to CommitRecords, matching the
+// git-log path's record shape exactly (tag parsed from the subject) so the
+// --json commit contract is identical whichever path answered. Pure so the
+// mapping is unit-testable without a ledger on disk.
+func commitsFromLedgerEvents(events []*ledgerkit.Event, aliases map[string]bool) []CommitRecord {
+	var records []CommitRecord
+	seen := map[string]bool{}
+	for _, ev := range events {
+		if !aliases[ev.Scope.Workitem] {
+			continue
+		}
+		for _, e := range ev.Evidence {
+			if e.Type != ledgerkit.EvidenceCommit || e.SHA == "" {
+				continue
+			}
+			key := e.Repo + "\x00" + e.SHA
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			records = append(records, CommitRecord{
+				SHA:      e.SHA,
+				Author:   ledgerCommitAuthor(ev),
+				Date:     parseLedgerTS(ev.TS),
+				Subject:  ev.Why,
+				Repo:     e.Repo,
+				TagParts: commitkit.ParseTag(ev.Why),
+			})
+		}
+	}
+	return records
+}
+
+func ledgerCommitAuthor(ev *ledgerkit.Event) string {
+	if ev.Payload != nil {
+		if a, ok := ev.Payload["author"].(string); ok && a != "" {
+			return a
+		}
+	}
+	return ev.Actor.Name
+}
+
+func parseLedgerTS(ts string) time.Time {
+	if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+		return t.UTC()
+	}
+	if t, err := time.Parse("2006-01-02", ts); err == nil {
+		return t.UTC()
+	}
+	return time.Time{}
 }
 
 // enumerateQueryRepos returns absolute paths of every git repo to search,
@@ -393,16 +537,18 @@ func emitCommitsQueryWarnings(w io.Writer, errs []commitsQueryError) error {
 // WorkitemCommitsJSONVersion is declared in json_contract.go alongside the
 // rest of the agent-facing JSON schema versions.
 
-func emitCommitsJSON(w io.Writer, records []CommitRecord, errs []commitsQueryError) error {
+func emitCommitsJSON(w io.Writer, source string, records []CommitRecord, errs []commitsQueryError) error {
 	if records == nil {
 		records = []CommitRecord{}
 	}
 	payload := struct {
 		SchemaVersion string              `json:"schema_version"`
+		Source        string              `json:"source"`
 		Commits       []CommitRecord      `json:"commits"`
 		Errors        []commitsQueryError `json:"errors,omitempty"`
 	}{
 		SchemaVersion: WorkitemCommitsJSONVersion,
+		Source:        source,
 		Commits:       records,
 		Errors:        errs,
 	}

--- a/internal/commands/workitem/commits_test.go
+++ b/internal/commands/workitem/commits_test.go
@@ -2,7 +2,11 @@ package workitem
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
 )
 
 func TestCommitsWorkerCountCapsFanout(t *testing.T) {
@@ -35,5 +39,118 @@ func TestEmitCommitsQueryWarnings(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("empty errors emitted warning: %q", stderr.String())
+	}
+}
+
+func TestWorkitemAliasesCollectsRefIdKeyAndSlug(t *testing.T) {
+	wi := &wkitem.WorkItem{
+		StableID:     "design-camp-list-tui-2026-06-24",
+		Key:          "design/camp-list-tui",
+		RelativePath: "workflow/design/camp-list-tui",
+	}
+	got := workitemAliases("WI-abc123", wi)
+	for _, want := range []string{"WI-abc123", "design-camp-list-tui-2026-06-24", "design/camp-list-tui", "camp-list-tui"} {
+		if !got[want] {
+			t.Fatalf("aliases missing %q; got %v", want, got)
+		}
+	}
+	if workitemAliases("", nil)["."] {
+		t.Fatal("empty inputs should not alias the current dir")
+	}
+}
+
+func TestCommitsFromLedgerEventsMatchesAliasesAndShapesRecords(t *testing.T) {
+	aliases := map[string]bool{"WI-abc123": true, "design-camp-list-tui-2026-06-24": true}
+	events := []*ledgerkit.Event{
+		{
+			Kind:     ledgerkit.KindEvidenceAttached,
+			TS:       "2026-06-24T10:00:00Z",
+			Scope:    ledgerkit.Scope{Campaign: "c1", Workitem: "WI-abc123"},
+			Why:      "[obey:c1-WI-abc123] feat: add tui",
+			Payload:  map[string]any{"author": "Lance Rogers"},
+			Evidence: []ledgerkit.Evidence{{Type: ledgerkit.EvidenceCommit, Repo: "camp", SHA: "aaa111"}},
+		},
+		{ // a repair attributing a commit under the stable-id form of the same workitem
+			Kind:     ledgerkit.KindRepaired,
+			TS:       "2026-06-25T10:00:00Z",
+			Scope:    ledgerkit.Scope{Campaign: "c1", Workitem: "design-camp-list-tui-2026-06-24"},
+			Evidence: []ledgerkit.Evidence{{Type: ledgerkit.EvidenceCommit, Repo: "camp", SHA: "bbb222"}},
+		},
+		{ // different workitem: must be ignored
+			Kind:     ledgerkit.KindEvidenceAttached,
+			TS:       "2026-06-26T10:00:00Z",
+			Scope:    ledgerkit.Scope{Campaign: "c1", Workitem: "WI-other"},
+			Evidence: []ledgerkit.Evidence{{Type: ledgerkit.EvidenceCommit, Repo: "camp", SHA: "ccc333"}},
+		},
+		{ // duplicate of the first commit: must dedupe by repo+sha
+			Kind:     ledgerkit.KindEvidenceAttached,
+			TS:       "2026-06-27T10:00:00Z",
+			Scope:    ledgerkit.Scope{Campaign: "c1", Workitem: "WI-abc123"},
+			Evidence: []ledgerkit.Evidence{{Type: ledgerkit.EvidenceCommit, Repo: "camp", SHA: "aaa111"}},
+		},
+	}
+	got := commitsFromLedgerEvents(events, aliases)
+	if len(got) != 2 {
+		t.Fatalf("want 2 records (dedupe + alias filter), got %d: %+v", len(got), got)
+	}
+	byShaSet := map[string]bool{}
+	for _, r := range got {
+		byShaSet[r.SHA] = true
+	}
+	if !byShaSet["aaa111"] || !byShaSet["bbb222"] || byShaSet["ccc333"] {
+		t.Fatalf("unexpected sha set: %v", byShaSet)
+	}
+	var first CommitRecord
+	for _, r := range got {
+		if r.SHA == "aaa111" {
+			first = r
+		}
+	}
+	if first.Author != "Lance Rogers" || first.Repo != "camp" || first.Subject != "[obey:c1-WI-abc123] feat: add tui" {
+		t.Fatalf("record not shaped from the event: %+v", first)
+	}
+	if first.TagParts.WorkitemRef != "WI-abc123" {
+		t.Fatalf("tag parsed from subject wrong: %+v", first.TagParts)
+	}
+	if first.Date.IsZero() {
+		t.Fatal("date not parsed from ledger ts")
+	}
+}
+
+func TestCommitsFromLedgerEventsAuthorFallsBackToActor(t *testing.T) {
+	events := []*ledgerkit.Event{{
+		Kind:     ledgerkit.KindEvidenceAttached,
+		TS:       "2026-06-24T10:00:00Z",
+		Scope:    ledgerkit.Scope{Workitem: "WI-x"},
+		Actor:    ledgerkit.Actor{Type: ledgerkit.ActorAgent, Name: "obey-agent"},
+		Evidence: []ledgerkit.Evidence{{Type: ledgerkit.EvidenceCommit, Repo: ".", SHA: "d1"}},
+	}}
+	got := commitsFromLedgerEvents(events, map[string]bool{"WI-x": true})
+	if len(got) != 1 || got[0].Author != "obey-agent" {
+		t.Fatalf("author fallback to actor failed: %+v", got)
+	}
+}
+
+func TestEmitCommitsJSONIncludesSource(t *testing.T) {
+	var out bytes.Buffer
+	if err := emitCommitsJSON(&out, "ledger", nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		Source        string `json:"source"`
+		Commits       []any  `json:"commits"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Source != "ledger" {
+		t.Fatalf("source = %q, want ledger", payload.Source)
+	}
+	if payload.SchemaVersion != WorkitemCommitsJSONVersion {
+		t.Fatalf("schema_version = %q", payload.SchemaVersion)
+	}
+	if payload.Commits == nil {
+		t.Fatal("commits must serialize as [] not null")
 	}
 }

--- a/internal/commands/workitem/commits_test.go
+++ b/internal/commands/workitem/commits_test.go
@@ -154,3 +154,21 @@ func TestEmitCommitsJSONIncludesSource(t *testing.T) {
 		t.Fatal("commits must serialize as [] not null")
 	}
 }
+
+
+func TestLedgerCommitDatePrefersPayload(t *testing.T) {
+	ev := &ledgerkit.Event{
+		TS: "2026-01-01T00:00:00Z",
+		Payload: map[string]any{
+			"commit_date": "2020-06-15T12:00:00Z",
+			"author":      "Ada",
+		},
+	}
+	got := ledgerCommitDate(ev)
+	if got.Year() != 2020 {
+		t.Fatalf("date = %v, want 2020 from payload", got)
+	}
+	if ledgerCommitAuthor(ev) != "Ada" {
+		t.Fatalf("author = %q, want Ada", ledgerCommitAuthor(ev))
+	}
+}

--- a/internal/commands/workitem/json_contract.go
+++ b/internal/commands/workitem/json_contract.go
@@ -14,6 +14,8 @@ const (
 	// WorkitemCommitJSONVersion is the schema version of camp workitem commit --json.
 	WorkitemCommitJSONVersion = "workitem-commit/v1alpha1"
 	// WorkitemCommitsJSONVersion is the schema version of camp workitem commits --json.
+	// v1alpha1 additively gained a top-level "source" field ("ledger"|"scan")
+	// reporting which path answered; the "commits" record shape is unchanged.
 	WorkitemCommitsJSONVersion = "workitem-commits/v1alpha1"
 	// WorkitemDoctorJSONVersion is the schema version of camp workitem doctor --json.
 	WorkitemDoctorJSONVersion = "workitem-doctor/v1alpha1"


### PR DESCRIPTION
## camp workitem commits: ledger-backed answering (D007 / CA0002)

Part of the obey-campaign audit-trail festival (CA0002), sequence 05. `camp workitem commits` currently fans `git log --grep` across the campaign root and every linked repo. With the campaign event ledger in place it can answer the same query from one merged ledger read.

**Stacked on Obedience-Corp/camp#402** (base branch `campaign-audit-trail`): it imports `pkg/ledgerkit` to read the ledger, so it should merge after #402.

### What this PR does

- Adds a ledger-backed path to `camp workitem commits`. When the ledger holds a workitem's commit evidence (`evidence_attached` / `repaired` events whose `scope.workitem` names the workitem), the answer comes from a single merged `ledgerkit` read instead of a per-repo git fan-out.
- `--source auto|ledger|scan` (default `auto`): `auto` uses the ledger when it has evidence for the workitem and otherwise falls back to the existing scan (pre-ledger history); `scan` forces the exhaustive `git log --all` scan; `ledger` forces the ledger read.
- `scope.workitem` is matched against the workitem's ref, stable id, key, and directory slug, so the three identifier forms all resolve to the one workitem (D007 workitem-id normalization).

### Contract

The `commits` record shape is unchanged: ledger records are built exactly like the scan path (SHA from commit evidence, subject from the event `why`, tag via `commitkit.ParseTag(subject)`), so existing `--json` consumers are unaffected. A top-level `"source"` field (`"ledger"` | `"scan"`) is added additively to report which path answered; the `workitem-commits/v1alpha1` version is unchanged (additive field, alpha contract). jsoncontract does not enforce an output-field allowlist.

### Measurement (real backfilled ledger of the obey-campaign)

Same workitem (`WI-25121c`), same live campaign, warm caches, best of 3:

| path | commits | time |
|------|---------|------|
| `--source ledger` | 13 | 42.5 ms |
| `--source scan` | 20 | 50.8 ms |

The ledger read is faster (one merged read vs a fan-out), and the advantage grows with the number of linked repos. The `commits` count differs because the two views differ, which is a data/backfill characteristic, not a query-design issue (see below).

### Known limitation (follow-up, not a query bug)

The ledger view (13) and the scan view (20) diverge here because:
- `camp audit backfill` derives commit facts with `git log --no-merges` on the default branch, while the scan uses `git log --all` (merge commits and non-default branches included).
- Historical commit subjects carry a doubled workitem tag (`-WI-WI-25121c`); the scan filters on the parsed tag while the ledger matches `scope.workitem`, so a few campaign-root commits appear on one side only.

So `--source auto` (ledger-first) can return a different set than the scan while the ledger is only backfill-populated. For current users no live ledger exists, so `auto` behaves exactly like today (scan). Reaching parity is a backfill concern (scan `--all`, normalize doubled tags) tracked as a follow-up; `--source scan` is the escape hatch to force the exhaustive view meanwhile.

### Tests / gates

`internal/commands/workitem/commits_test.go`: alias collection (ref/id/key/slug), ledger-event -> record mapping (alias filter, repo+sha dedupe, subject/author/date/tag shaping, actor-name author fallback), and the additive `source` field. `just gate-push` green (build, lint ratchets, full test suite).
