### PR TITLE
feat(worktree): link design workitems on create for WI commit tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ __debug_bin*
 CLAUDE.md
 .claude/
 dist/
+projects/worktrees/

--- a/cmd/camp/project/worktree/add.go
+++ b/cmd/camp/project/worktree/add.go
@@ -1,8 +1,10 @@
 package worktree
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
 	"github.com/Obedience-Corp/camp/internal/campaign"
@@ -11,6 +13,8 @@ import (
 	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/selector"
 	intworktree "github.com/Obedience-Corp/camp/internal/worktree"
 	"github.com/spf13/cobra"
 )
@@ -20,6 +24,7 @@ var (
 	wtAddBranch     string
 	wtAddStartPoint string
 	wtAddTrack      string
+	wtAddWorkitem   string
 )
 
 var projectWorktreeAddCmd = &cobra.Command{
@@ -49,7 +54,11 @@ Examples:
   camp project worktree add pr-review --track origin/feature-xyz
 
   # Explicit project
-  camp project worktree add feature --project my-api`,
+  camp project worktree add feature --project my-api
+
+  # Link a design/explore workitem so camp p commit in the worktree tags WI-*
+  camp project worktree add fest-list-watch --project fest --workitem WI-2a7950
+  camp project worktree add settings-tui --project camp --workitem workflow/design/camp-settings-tui`,
 	Args: cobra.ExactArgs(1),
 	RunE: runProjectWorktreeAdd,
 }
@@ -61,6 +70,7 @@ func init() {
 	projectWorktreeAddCmd.Flags().StringVarP(&wtAddBranch, "branch", "b", "", "Checkout existing branch instead of creating new one")
 	projectWorktreeAddCmd.Flags().StringVarP(&wtAddStartPoint, "start-point", "s", "", "Base branch/commit for new branch (default: current branch)")
 	projectWorktreeAddCmd.Flags().StringVarP(&wtAddTrack, "track", "t", "", "Remote branch to track (creates new local tracking branch)")
+	projectWorktreeAddCmd.Flags().StringVar(&wtAddWorkitem, "workitem", "", "workitem selector (ref, path, or id) to primary-link to this worktree for camp p commit tags")
 
 	if err := projectWorktreeAddCmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjectName); err != nil {
 		panic(err)
@@ -132,8 +142,45 @@ func runProjectWorktreeAdd(cmd *cobra.Command, args []string) error {
 	fmt.Println(ui.Success(fmt.Sprintf("Created worktree: %s/%s", result.Project, result.Name)))
 	fmt.Printf("  Path:   %s\n", ui.Value(result.Path))
 	fmt.Printf("  Branch: %s\n", ui.Value(result.Branch))
+
+	if wtAddWorkitem != "" {
+		link, lerr := linkWorktreeToWorkitem(ctx, campRoot, wtAddWorkitem, filepath.ToSlash(result.RelativePath))
+		if lerr != nil {
+			return camperrors.Wrap(lerr, "worktree created but workitem link failed")
+		}
+		fmt.Printf("  Workitem: %s (%s)\n", ui.Value(link.WorkitemID), ui.Dim(link.WorkitemKey))
+		fmt.Println(ui.Dim("  camp p commit in this worktree will include WI-* in the campaign tag"))
+	}
+
 	fmt.Println()
 	fmt.Println(ui.Dim(fmt.Sprintf("To navigate: cd %s", result.RelativePath)))
 
 	return nil
+}
+
+// linkWorktreeToWorkitem attaches a primary worktree link so the resolver
+// (and therefore camp p commit) picks up the workitem ref inside that tree.
+func linkWorktreeToWorkitem(ctx context.Context, campRoot, selectorQuery, relativeWorktreePath string) (links.Link, error) {
+	wi, err := selector.Resolve(ctx, campRoot, selectorQuery, selector.ResolveOptions{})
+	if err != nil {
+		return links.Link{}, camperrors.Wrap(err, "resolve workitem "+selectorQuery)
+	}
+	workitemID := wi.StableID
+	if workitemID == "" {
+		workitemID = wi.Key
+	}
+	scopePath := relativeWorktreePath
+	if scopePath == "" {
+		return links.Link{}, camperrors.NewValidation("worktree", "missing worktree relative path", nil)
+	}
+	return links.AttachPrimary(ctx, campRoot, links.AttachOptions{
+		WorkitemID:  workitemID,
+		WorkitemKey: wi.Key,
+		Scope: links.LinkScope{
+			Kind: links.ScopeWorktree,
+			Path: scopePath,
+		},
+		CreatedBy: "camp_project_worktree_add",
+		Replace:   true,
+	})
 }

--- a/cmd/camp/worktrees/create.go
+++ b/cmd/camp/worktrees/create.go
@@ -1,7 +1,10 @@
 package worktrees
 
 import (
+	"context"
 	"fmt"
+	"path/filepath"
+
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
@@ -9,6 +12,8 @@ import (
 	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/selector"
 	"github.com/Obedience-Corp/camp/internal/worktree"
 	"github.com/spf13/cobra"
 )
@@ -17,6 +22,7 @@ var (
 	createBranch     string
 	createStartPoint string
 	createTrack      string
+	createWorkitem   string
 )
 
 var worktreesCreateCmd = &cobra.Command{
@@ -40,7 +46,10 @@ Examples:
   camp worktrees create my-api hotfix --branch hotfix-123
 
   # Create worktree tracking remote branch
-  camp worktrees create web pr-review --track origin/feature-xyz`,
+  camp worktrees create web pr-review --track origin/feature-xyz
+
+  # Link a design workitem so camp p commit tags WI-*
+  camp worktrees create fest fest-list-watch --workitem WI-2a7950`,
 	Args: cobra.ExactArgs(2),
 	RunE: runWorktreesCreate,
 }
@@ -54,6 +63,8 @@ func init() {
 		"Base branch/commit for new branch (default: current branch)")
 	worktreesCreateCmd.Flags().StringVarP(&createTrack, "track", "t", "",
 		"Remote branch to track (creates new local tracking branch)")
+	worktreesCreateCmd.Flags().StringVar(&createWorkitem, "workitem", "",
+		"workitem selector (ref, path, or id) to primary-link to this worktree for camp p commit tags")
 }
 
 func runWorktreesCreate(cmd *cobra.Command, args []string) error {
@@ -134,8 +145,39 @@ func runWorktreesCreate(cmd *cobra.Command, args []string) error {
 	fmt.Println(ui.Success(fmt.Sprintf("Created worktree: %s/%s", result.Project, result.Name)))
 	fmt.Printf("  Path:   %s\n", ui.Value(result.Path))
 	fmt.Printf("  Branch: %s\n", ui.Value(result.Branch))
+
+	if createWorkitem != "" {
+		link, lerr := linkWorktreeToWorkitem(ctx, campRoot, createWorkitem, filepath.ToSlash(result.RelativePath))
+		if lerr != nil {
+			return camperrors.Wrap(lerr, "worktree created but workitem link failed")
+		}
+		fmt.Printf("  Workitem: %s (%s)\n", ui.Value(link.WorkitemID), ui.Dim(link.WorkitemKey))
+		fmt.Println(ui.Dim("  camp p commit in this worktree will include WI-* in the campaign tag"))
+	}
+
 	fmt.Println()
 	fmt.Println(ui.Dim(fmt.Sprintf("To navigate: cd %s", result.RelativePath)))
 
 	return nil
+}
+
+func linkWorktreeToWorkitem(ctx context.Context, campRoot, selectorQuery, relativeWorktreePath string) (links.Link, error) {
+	wi, err := selector.Resolve(ctx, campRoot, selectorQuery, selector.ResolveOptions{})
+	if err != nil {
+		return links.Link{}, camperrors.Wrap(err, "resolve workitem "+selectorQuery)
+	}
+	workitemID := wi.StableID
+	if workitemID == "" {
+		workitemID = wi.Key
+	}
+	return links.AttachPrimary(ctx, campRoot, links.AttachOptions{
+		WorkitemID:  workitemID,
+		WorkitemKey: wi.Key,
+		Scope: links.LinkScope{
+			Kind: links.ScopeWorktree,
+			Path: relativeWorktreePath,
+		},
+		CreatedBy: "camp_worktrees_create",
+		Replace:   true,
+	})
 }

--- a/internal/commands/workitem/link.go
+++ b/internal/commands/workitem/link.go
@@ -38,7 +38,18 @@ func newLinkCommand() *cobra.Command {
 Links are stored in .campaign/workitems/links.yaml and connect a .workitem
 identity to an explicit scope for planning, execution, and lookup. Pass a
 workitem selector plus a path, or use --project, --festival, --worktree, or
---cwd to derive the scope. Use --json for machine-readable link output.`,
+--cwd to derive the scope. Use --json for machine-readable link output.
+
+A primary worktree link is how design/explore workitems under workflow/ get
+into camp p commit tags: when you commit from that worktree, the resolver
+matches the link and stamps WI-<ref> on the subject.
+
+Examples:
+  camp workitem link WI-2a7950 --worktree fest/fest-list-watch
+  camp workitem link workflow/design/fest-list-watch --worktree projects/worktrees/fest/fest-list-watch
+  camp workitem link WI-2a7950 projects/worktrees/fest/fest-list-watch
+  # Or at create time:
+  camp project worktree add fest-list-watch --project fest --workitem WI-2a7950`,
 		Args: jsoncontract.Args(links.LinksSchemaVersion, func() bool { return jsonOut }, cobra.RangeArgs(1, 2)),
 		Annotations: map[string]string{
 			"agent_allowed": "true",
@@ -66,7 +77,7 @@ workitem selector plus a path, or use --project, --festival, --worktree, or
 	cmd.SetFlagErrorFunc(jsoncontract.FlagErrorFunc(links.LinksSchemaVersion, func() bool { return jsonOut }))
 	cmd.Flags().StringVar(&project, "project", "", "project name (matches projects/<name>)")
 	cmd.Flags().StringVar(&festival, "festival", "", "festival id or relative path under festivals/")
-	cmd.Flags().StringVar(&worktree, "worktree", "", "worktree relative path under projects/worktrees/")
+	cmd.Flags().StringVar(&worktree, "worktree", "", "worktree path under projects/worktrees/ (project/name or full projects/worktrees/project/name)")
 	cmd.Flags().BoolVar(&useCwd, "cwd", false, "use current working directory as the scope")
 	cmd.Flags().StringVar(&role, "role", string(links.RolePrimary), "primary | related | blocked_by | supersedes")
 	cmd.Flags().BoolVar(&replace, "replace", false, "replace an existing primary link on the same scope")

--- a/internal/workitem/links/attach.go
+++ b/internal/workitem/links/attach.go
@@ -1,0 +1,110 @@
+package links
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/quest"
+)
+
+// AttachOptions configures AttachPrimary.
+type AttachOptions struct {
+	// WorkitemID is the stable workitem identity stored on the link
+	// (prefer StableID / .workitem id).
+	WorkitemID string
+	// WorkitemKey is the discoverable key (e.g. design:workflow/design/foo).
+	WorkitemKey string
+	// Scope is the target (worktree, project, festival, …).
+	Scope LinkScope
+	// CreatedBy stamps the link; empty defaults to "camp".
+	CreatedBy string
+	// Replace replaces an existing primary on the same scope.
+	Replace bool
+	// AllowMissing skips ValidateLinkPath existence checks (migrations).
+	AllowMissing bool
+}
+
+// AttachPrimary records a primary workitem→scope link in links.yaml.
+// This is the shared writer used by `camp workitem link` and by
+// `camp project worktree add --workitem` so worktree creation can attach a
+// design/explore/… workitem and `camp p commit` in that worktree inherits WI-*.
+func AttachPrimary(ctx context.Context, campaignRoot string, opts AttachOptions) (Link, error) {
+	if opts.WorkitemID == "" {
+		return Link{}, camperrors.NewValidation("workitem_id", "workitem id is required", nil)
+	}
+	if opts.Scope.Kind == "" || opts.Scope.Path == "" {
+		return Link{}, camperrors.NewValidation("scope", "scope kind and path are required", nil)
+	}
+	if !opts.AllowMissing {
+		if err := quest.ValidateLinkPath(campaignRoot, opts.Scope.Path); err != nil {
+			return Link{}, camperrors.Wrap(err, "scope path")
+		}
+	}
+	createdBy := opts.CreatedBy
+	if createdBy == "" {
+		createdBy = "camp"
+	}
+
+	var out Link
+	err := WithLock(ctx, campaignRoot, func(registry *Links) error {
+		id, idErr := NewLinkID(registry)
+		if idErr != nil {
+			return idErr
+		}
+		out = Link{
+			ID:          id,
+			WorkitemID:  opts.WorkitemID,
+			WorkitemKey: opts.WorkitemKey,
+			Scope:       opts.Scope,
+			Role:        RolePrimary,
+			CreatedAt:   time.Now().UTC().Truncate(time.Second),
+			CreatedBy:   createdBy,
+		}
+		if err := registry.AddLink(out, opts.Replace); err != nil {
+			return err
+		}
+		if errs := Validate(ctx, registry, ValidateOptions{
+			CampaignRoot: campaignRoot,
+			AllowMissing: opts.AllowMissing,
+			Now:          out.CreatedAt,
+		}); len(errs) > 0 {
+			return camperrors.NewValidation(errs[0].Field, errs[0].Message, nil)
+		}
+		return nil
+	})
+	if err != nil {
+		return Link{}, err
+	}
+	return out, nil
+}
+
+// WorktreeScopePath returns the campaign-relative path for a project worktree
+// at projects/worktrees/<project>/<name>.
+func WorktreeScopePath(project, name string) string {
+	return "projects/worktrees/" + project + "/" + name
+}
+
+// NewLinkID returns a fresh lnk_YYYYMMDD_<6 hex> ID that does not collide with
+// any existing entry in registry.
+func NewLinkID(registry *Links) (string, error) {
+	existing := make(map[string]struct{}, len(registry.Links))
+	for _, l := range registry.Links {
+		existing[l.ID] = struct{}{}
+	}
+	const maxAttempts = 32
+	for i := 0; i < maxAttempts; i++ {
+		var b [3]byte
+		if _, err := rand.Read(b[:]); err != nil {
+			return "", camperrors.Wrap(err, "generate link id: read random bytes")
+		}
+		candidate := fmt.Sprintf("lnk_%s_%02x%02x%02x",
+			time.Now().UTC().Format("20060102"), b[0], b[1], b[2])
+		if _, clash := existing[candidate]; !clash {
+			return candidate, nil
+		}
+	}
+	return "", camperrors.New(fmt.Sprintf("generate link id: %d-attempt collision retry exhausted", maxAttempts))
+}

--- a/internal/workitem/links/attach_test.go
+++ b/internal/workitem/links/attach_test.go
@@ -1,0 +1,55 @@
+package links
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAttachPrimaryWorktree(t *testing.T) {
+	root := t.TempDir()
+	// Worktree path must exist for ValidateLinkPath.
+	wtRel := "projects/worktrees/fest/demo"
+	if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(wtRel)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Seed empty registry.
+	if err := os.MkdirAll(filepath.Join(root, ".campaign", "workitems"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	link, err := AttachPrimary(context.Background(), root, AttachOptions{
+		WorkitemID:  "design-fest-list-watch-2026-07-12",
+		WorkitemKey: "design:workflow/design/fest-list-watch",
+		Scope:       LinkScope{Kind: ScopeWorktree, Path: wtRel},
+		CreatedBy:   "test",
+		// Workitem may not exist on disk in this unit test.
+		AllowMissing: true,
+	})
+	if err != nil {
+		t.Fatalf("AttachPrimary: %v", err)
+	}
+	if link.ID == "" || link.Role != RolePrimary {
+		t.Fatalf("unexpected link: %+v", link)
+	}
+	if link.Scope.Path != wtRel {
+		t.Fatalf("scope path = %q, want %q", link.Scope.Path, wtRel)
+	}
+
+	// Reload and confirm primary covers the worktree path.
+	reg, err := Load(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	primary, ok := reg.PrimaryForScope(ScopeWorktree, wtRel)
+	if !ok || primary.WorkitemID != "design-fest-list-watch-2026-07-12" {
+		t.Fatalf("primary after reload = %+v ok=%v", primary, ok)
+	}
+}
+
+func TestWorktreeScopePath(t *testing.T) {
+	if got := WorktreeScopePath("fest", "list-watch"); got != "projects/worktrees/fest/list-watch" {
+		t.Fatalf("WorktreeScopePath = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Workitem directories under `workflow/design/`, `workflow/explore/`, etc. can already be linked to project worktrees via `camp workitem link`, and `camp p commit` already stamps `WI-*` when the resolver finds a primary worktree link (as with fest-list-watch → WI-2a7950).

What was missing was a **create-time** path: worktrees were made with `camp project worktree add` without attaching a workitem, so later commits only got the bare campaign id.

### Changes

- `camp project worktree add --workitem <selector>` — after create, attaches a **primary** worktree link
- `camp worktrees create --workitem <selector>` — same
- `links.AttachPrimary` — shared writer for the registry
- Docs/examples on `camp workitem link` for the design→worktree→commit flow

### Usage

```bash
# At create time
camp project worktree add fest-list-watch --project fest --workitem WI-2a7950
# or existing worktree
camp workitem link WI-2a7950 --worktree fest/fest-list-watch

cd projects/worktrees/fest/fest-list-watch
camp p commit -m "fix: …"   # subject includes WI-2a7950
```

### Test plan

- [x] `go test ./internal/workitem/links/ ./internal/commands/workitem/ ./cmd/camp/worktrees/`
- [ ] Manual: create worktree with `--workitem`, `camp workitem resolve` from that tree shows the design, commit subject includes WI