### PR TITLE
fix(startup): add bginit dependency-graph guard and document ANSI 8 seed

### DIFF
--- a/internal/bginit/bginit.go
+++ b/internal/bginit/bginit.go
@@ -15,7 +15,11 @@
 //
 // The seed mirrors termenv's non-query fallback: the last field of COLORFGBG
 // is the background ANSI color, and a missing or unparsable value means dark.
-// An explicit theme choice refines this later through the theme package.
+// Values 0..6 and 8 count as dark, 7 and 9..15 as light. ANSI 8 (bright black)
+// intentionally diverges from termenv's luminance math and is treated as dark,
+// because dark is the safer readability default when the terminal cannot be
+// queried. An explicit theme choice refines this later through the theme
+// package.
 package bginit
 
 import (

--- a/internal/bginit/bginit_deps_test.go
+++ b/internal/bginit/bginit_deps_test.go
@@ -1,0 +1,60 @@
+package bginit
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoHeavyCharmDeps guards the invariant that makes the startup seed work:
+// internal/bginit must initialize before the bubbletea subtree, so its import
+// closure may never pull in bubbletea, huh, or glamour, directly or
+// transitively. If one of those crept in, its package init could run first and
+// re-issue the OSC 11 / DSR terminal query this package exists to prevent.
+func TestNoHeavyCharmDeps(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain unavailable")
+	}
+
+	cmd := exec.Command("go", "list", "-deps", "./internal/bginit")
+	cmd.Dir = moduleRoot(t)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("go list -deps ./internal/bginit: %v", err)
+	}
+
+	forbidden := []string{
+		"github.com/charmbracelet/bubbletea",
+		"github.com/charmbracelet/huh",
+		"github.com/charmbracelet/glamour",
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		pkg := strings.TrimSpace(line)
+		for _, bad := range forbidden {
+			if pkg == bad || strings.HasPrefix(pkg, bad+"/") {
+				t.Errorf("internal/bginit must not depend on %s (found %s); "+
+					"it must initialize before the bubbletea subtree", bad, pkg)
+			}
+		}
+	}
+}
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("go.mod not found above %s", dir)
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
## Problem

camp links bubbletea v1.3.10. bubbletea v1's `tea_init.go` calls `lipgloss.HasDarkBackground()` at package init. Without a cached value, lipgloss asks termenv, which writes OSC 11 plus DSR queries to the tty and blocks up to termenv's 5s timeout waiting for a reply. Interactive terminals answer instantly, but recorder, CI, and agent ptys that never answer freeze every camp command (even `camp --version`) for the full timeout before the first byte of output.

## Context: the seed already landed in #391

The core fix (seed `lipgloss.SetHasDarkBackground(...)` from `COLORFGBG` in an `internal/bginit` package that initializes before the bubbletea subtree, plus theme refinements) was merged in #391. This PR completes the port with the two pieces #391 omitted:

1. **Dependency-graph guard test** (`internal/bginit/bginit_deps_test.go`). Runs `go list -deps ./internal/bginit` from the module root and fails if the closure ever contains `charmbracelet/bubbletea`, `charmbracelet/huh`, or `charmbracelet/glamour`. If one of those crept into bginit's imports, its package init could run first and re-issue the exact terminal query the seed exists to prevent, silently regressing the fix. The test skips when the go toolchain is unavailable. It is pure logic plus a read-only `go list` exec, so it stays a unit test.

2. **Doc clarification** in `bginit.go`: documents that ANSI 8 (bright black) is intentionally treated as dark, diverging from termenv's luminance math, because dark is the safer readability default when the terminal cannot be queried.

No CLI surface changes: no new flags, no output changes beyond eliminating the stall.

## Placement note

camp ships a single binary (`cmd/camp`); the other `package main` files are build tools (`internal/buildutil`, `tools/release-notes`) that do not link the TUI stack. The blank import sits in `cmd/camp/main.go`, whose sorted import block keeps `internal/bginit` first, and the harness below confirms bginit's init runs ahead of the bubbletea subtree (zero queries). The new guard test locks in the closure invariant that makes that ordering safe.

## Before / after (mute pty that never answers terminal queries)

Measured with a forkpty harness that counts OSC 11 (`ESC]11;?`) and DSR (`ESC[6n`) bytes and kills the child after N seconds. Pre-fix binary built from `58711a0` (the merge parent before #391); post-fix binary built from this branch.

| command | before (pre-fix) | after (this branch) |
| --- | --- | --- |
| `camp --version` | wall 5.367s, osc11=1, dsr6n=1 | wall 0.352s, osc11=0, dsr6n=0 |
| `camp --help` | wall 5.028s, osc11=1, dsr6n=1 | wall 0.016s, osc11=0, dsr6n=0 |

The residual ~0.35s on the `--version` path is pre-existing non-query startup work (zero terminal queries are emitted); the 5s tty stall is gone.

## Gates

- `just build dev`: successful (113 packages)
- `just test unit`: 3083/3083 passed (includes the new guard test and the existing bginit table test)
- `just lint`: 0 issues; no-host-fs-tests and no-fmt.Errorf ratchets clean
- `go vet ./internal/bginit/`: clean

## Reference

Reference implementation: fest #254 (merged as fbf13c8), which diagnosed and fixed the same stall in the fest CLI.
