### PR TITLE
fix(commit): concatenate repeated -m flags git-style instead of dropping all but the last

### DIFF
--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -43,7 +43,7 @@ Examples:
 }
 
 var (
-	commitMessage     string
+	commitMessages    []string
 	commitAll         bool
 	commitAmend       bool
 	commitSub         bool
@@ -55,7 +55,7 @@ var (
 )
 
 func init() {
-	commitCmd.Flags().StringVarP(&commitMessage, "message", "m", "", "Commit message (required unless --auto-write)")
+	commitCmd.Flags().StringArrayVarP(&commitMessages, "message", "m", nil, "Commit message (repeatable; multiple -m are joined git-style into subject + body; required unless --auto-write)")
 	commitCmd.Flags().BoolVarP(&commitAll, "all", "a", true, "Stage all changes before committing")
 	commitCmd.Flags().BoolVar(&commitAmend, "amend", false, "Amend the previous commit")
 	commitCmd.Flags().BoolVar(&commitNoEdit, "no-edit", false, "Amend without editing the commit message (requires --amend)")
@@ -91,6 +91,10 @@ func completeProjectFlag(cmd *cobra.Command, args []string, toComplete string) (
 
 func runCommit(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+
+	// Join repeated -m values git-style before any tag prepending so the tag
+	// lands on the subject line.
+	commitMessage := commitkit.JoinMessages(commitMessages)
 
 	// Find campaign root
 	campRoot, err := campaign.DetectCached(ctx)

--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -38,7 +38,7 @@ Examples:
 
 var (
 	projectCommitProject   string
-	projectCommitMessage   string
+	projectCommitMessages  []string
 	projectCommitAll       bool
 	projectCommitAmend     bool
 	projectCommitSync      bool
@@ -48,7 +48,7 @@ var (
 
 func init() {
 	projectCommitCmd.Flags().StringVarP(&projectCommitProject, "project", "p", "", "Project name (auto-detected from cwd if not specified)")
-	projectCommitCmd.Flags().StringVarP(&projectCommitMessage, "message", "m", "", "Commit message (required unless --auto-write)")
+	projectCommitCmd.Flags().StringArrayVarP(&projectCommitMessages, "message", "m", nil, "Commit message (repeatable; multiple -m are joined git-style into subject + body; required unless --auto-write)")
 	projectCommitCmd.Flags().BoolVarP(&projectCommitAll, "all", "a", true, "Stage all changes")
 	projectCommitCmd.Flags().BoolVar(&projectCommitAmend, "amend", false, "Amend the previous commit")
 	projectCommitCmd.Flags().BoolVar(&projectCommitSync, "sync", false, "Sync submodule ref at campaign root after commit (opt-in)")
@@ -64,6 +64,10 @@ func init() {
 
 func runProjectCommit(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+
+	// Join repeated -m values git-style before any tag prepending so the tag
+	// lands on the subject line.
+	projectCommitMessage := commitkit.JoinMessages(projectCommitMessages)
 
 	// Find campaign root
 	campRoot, err := campaign.DetectCached(ctx)

--- a/cmd/camp/worktrees/commit.go
+++ b/cmd/camp/worktrees/commit.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	wtCommitMessage   string
+	wtCommitMessages  []string
 	wtCommitAll       bool
 	wtCommitAmend     bool
 	wtCommitAutoWrite bool
@@ -48,8 +48,8 @@ Examples:
 func init() {
 	Cmd.AddCommand(worktreesCommitCmd)
 
-	worktreesCommitCmd.Flags().StringVarP(&wtCommitMessage, "message", "m", "",
-		"Commit message (required unless --auto-write)")
+	worktreesCommitCmd.Flags().StringArrayVarP(&wtCommitMessages, "message", "m", nil,
+		"Commit message (repeatable; multiple -m are joined git-style into subject + body; required unless --auto-write)")
 	worktreesCommitCmd.Flags().BoolVarP(&wtCommitAll, "all", "a", true,
 		"Stage all changes before committing")
 	worktreesCommitCmd.Flags().BoolVar(&wtCommitAmend, "amend", false,
@@ -62,6 +62,10 @@ func init() {
 
 func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+
+	// Join repeated -m values git-style before any tag prepending so the tag
+	// lands on the subject line.
+	wtCommitMessage := commitkit.JoinMessages(wtCommitMessages)
 
 	campRoot, err := campaign.DetectCached(ctx)
 	if err != nil {

--- a/internal/commands/workitem/commit.go
+++ b/internal/commands/workitem/commit.go
@@ -14,6 +14,7 @@ import (
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/git/commit"
 	"github.com/Obedience-Corp/camp/internal/jsoncontract"
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
 )
 
 // noContextHint is the multi-line refusal message printed when the resolver
@@ -27,7 +28,7 @@ Try one of:
 
 func newCommitCommand() *cobra.Command {
 	var (
-		flagMessage                 string
+		flagMessage                 []string
 		flagWorkitem                string
 		flagProject                 string
 		flagFestival                string
@@ -63,7 +64,7 @@ precedence.`,
 				selector = args[0]
 			}
 			return runCommit(ctx, cmd, commitFlags{
-				Message:                 flagMessage,
+				Message:                 commitkit.JoinMessages(flagMessage),
 				Workitem:                selector,
 				Project:                 flagProject,
 				Festival:                flagFestival,
@@ -77,7 +78,7 @@ precedence.`,
 		}),
 	}
 	cmd.SetFlagErrorFunc(jsoncontract.FlagErrorFunc(WorkitemCommitJSONVersion, func() bool { return flagJSON }))
-	cmd.Flags().StringVarP(&flagMessage, "message", "m", "", "commit message (required unless --dry-run)")
+	cmd.Flags().StringArrayVarP(&flagMessage, "message", "m", nil, "commit message (repeatable; multiple -m are joined git-style into subject + body; required unless --dry-run)")
 	cmd.Flags().StringVar(&flagWorkitem, "workitem", "", "explicit workitem selector (overrides cwd-based resolution)")
 	cmd.Flags().StringVar(&flagProject, "project", "", "force project-repo context by name (skips resolver)")
 	cmd.Flags().StringVar(&flagFestival, "festival", "", "festival id for the festival resolver tier")

--- a/pkg/commitkit/commitkit.go
+++ b/pkg/commitkit/commitkit.go
@@ -13,6 +13,7 @@ package commitkit
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
@@ -22,6 +23,25 @@ import (
 
 // ErrNoChanges is returned when there are no changes to commit.
 var ErrNoChanges = git.ErrNoChanges
+
+// JoinMessages assembles repeated -m/--message flag values using git's exact
+// multi -m semantics: empty values are dropped and the remaining values are
+// joined with a blank line, so each becomes its own paragraph and the first is
+// the commit subject. A single non-empty value is returned unchanged (embedded
+// newlines preserved). Zero values, or an all-empty input, yield "" so callers
+// keep their existing "no message" path (prompt, editor, or error) intact.
+//
+// This must run before the campaign tag is prepended so the tag lands on the
+// real subject line rather than a body paragraph.
+func JoinMessages(messages []string) string {
+	nonEmpty := make([]string, 0, len(messages))
+	for _, m := range messages {
+		if m != "" {
+			nonEmpty = append(nonEmpty, m)
+		}
+	}
+	return strings.Join(nonEmpty, "\n\n")
+}
 
 // CommitOptions configures a commit operation.
 type CommitOptions struct {

--- a/pkg/commitkit/join_messages_test.go
+++ b/pkg/commitkit/join_messages_test.go
@@ -1,0 +1,79 @@
+package commitkit_test
+
+import (
+	"testing"
+
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
+)
+
+func TestJoinMessages(t *testing.T) {
+	cases := []struct {
+		name     string
+		messages []string
+		want     string
+	}{
+		{
+			name:     "nil is empty",
+			messages: nil,
+			want:     "",
+		},
+		{
+			name:     "single value unchanged",
+			messages: []string{"subject only"},
+			want:     "subject only",
+		},
+		{
+			name:     "single value with embedded newlines preserved",
+			messages: []string{"subject\n\nauthored body\nsecond line"},
+			want:     "subject\n\nauthored body\nsecond line",
+		},
+		{
+			name:     "two values join with blank line",
+			messages: []string{"subject", "body paragraph"},
+			want:     "subject\n\nbody paragraph",
+		},
+		{
+			name:     "three values each their own paragraph",
+			messages: []string{"subject", "para one", "para two"},
+			want:     "subject\n\npara one\n\npara two",
+		},
+		{
+			name:     "empty string value alone yields empty",
+			messages: []string{""},
+			want:     "",
+		},
+		{
+			name:     "leading empty dropped git-style",
+			messages: []string{"", "body after empty"},
+			want:     "body after empty",
+		},
+		{
+			name:     "trailing empty dropped git-style",
+			messages: []string{"real subject", ""},
+			want:     "real subject",
+		},
+		{
+			name:     "interior empty collapses without double blank",
+			messages: []string{"subject", "", "body"},
+			want:     "subject\n\nbody",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := commitkit.JoinMessages(tc.messages); got != tc.want {
+				t.Fatalf("JoinMessages(%q) = %q, want %q", tc.messages, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestJoinMessages_TagLandsOnSubject proves the join runs before tag prepend so
+// the campaign tag lands on the subject line, not a body paragraph.
+func TestJoinMessages_TagLandsOnSubject(t *testing.T) {
+	joined := commitkit.JoinMessages([]string{"test: subject", "body paragraph"})
+	tagged := commitkit.PrependContextTagsFullNamed("obey-campaign", "8deed8b4", "", "", "", joined)
+	want := "[obey-campaign:8deed8b4] test: subject\n\nbody paragraph"
+	if tagged != want {
+		t.Fatalf("tagged = %q, want %q", tagged, want)
+	}
+}


### PR DESCRIPTION
## The bug

`camp p commit -m "subject" -m "body paragraph"` (and the other camp commit commands) silently DROPPED the first `-m` and used the second as the commit subject. The message flag was a single cobra `StringVarP`, where repeated flags overwrite (last wins). Plain git concatenates multiple `-m` values into subject + blank line + body paragraphs, so anyone with git muscle memory got a body-length subject with no title, no error, and no warning. Observed today while committing camp PR #406.

Reproduced with the current released binary in a throwaway campaign:

```
$ camp commit -m "test: subject" -m "body paragraph"
$ git log -1 --format=%B
[e2e-camp:bb90cd01] body paragraph
```

The `test: subject` value is gone.

## The fix

Every commit-message flag now uses `StringArrayVarP` (not `StringSliceVarP`, which would split on commas), and the repeated values are joined with git's exact multi `-m` semantics via a new pure helper `commitkit.JoinMessages`:

- Empty values are dropped (git aborts on all-empty; a lone `-m ""` still yields no message, preserving the existing prompt/editor/error path).
- Remaining values are joined by a blank line, so each is its own paragraph and the first is the subject.
- A single non-empty value is returned unchanged, including any embedded newlines (byte-for-byte).
- The join runs BEFORE the campaign traceability tag is prepended, so the tag lands on the real subject line, not a body paragraph.

Fixed at every registration site (no single shared flag layer existed, but all four now route through the one shared `commitkit.JoinMessages`):

- `cmd/camp/commit.go` (`camp commit`)
- `cmd/camp/project/commit.go` (`camp project commit` / `camp p commit`)
- `cmd/camp/worktrees/commit.go` (`camp worktrees commit`)
- `internal/commands/workitem/commit.go` (`camp workitem commit`)

## Behavior change callout (public CLI contract)

This is the fix itself: repeated `-m/--message` goes from "last wins, silently" to git-style concatenation. Users who previously (accidentally) relied on last-wins will now get all their `-m` values in the message. Flag names, defaults, and `--json` output are unchanged. `camp workitem commit --json` does not surface the message, so its schema is untouched.

## Tests

Added table-driven unit coverage in `pkg/commitkit/join_messages_test.go` for the pure join: nil/zero, single value, single value with embedded newlines, two values, three values, lone empty string, leading empty, trailing empty, and interior empty (git-style collapse). Plus a test proving the join runs before tag prepend so the tag lands on the subject.

Filesystem-mutating git-commit tests stay out of host unit tests per camp convention (`lint-no-host-fs-tests`); the pure join is covered as a unit test and the full path is verified end-to-end below.

## Gates (from the worktree, all pass)

- `just build dev`: BUILD SUCCESSFUL (vet clean)
- `just test unit`: 3097/3097 tests passed, 95 packages
- `just lint`: 0 issues; `lint-no-host-fs-tests` clean (no new violators); `lint-no-fmt-errorf` clean

## End-to-end proof (built worktree binary, throwaway campaign)

Multiple `-m` (the exact bug-report command), now correct:

```
$ camp p commit --project myproj -m "test: subject" -m "body paragraph"
$ git log -1 --format=%B
[e2e-camp:bb90cd01] test: subject

body paragraph
```

Root `camp commit` multi `-m`:

```
$ camp commit -m "test: subject" -m "body paragraph"
$ git log -1 --format=%B
[e2e-camp:bb90cd01] test: subject

body paragraph
```

Single `-m` unchanged:

```
$ camp commit -m "fix: single message subject"
$ git log -1 --format=%B
[e2e-camp:bb90cd01] fix: single message subject
```

Single `-m` with embedded newlines preserved byte-for-byte (no injected blank line):

```
$ camp commit -m "feat: subject
already embedded body line one
line two"
$ git log -1 --format=%B
[e2e-camp:bb90cd01] feat: subject
already embedded body line one
line two
```

Three `-m` (git-style paragraphs):

```
$ camp commit -m "chore: subject" -m "para one" -m "para two"
$ git log -1 --format=%B
[e2e-camp:bb90cd01] chore: subject

para one

para two
```
