### PR TITLE
feat(workitem): camp workitem worktree - create a worktree from a workitem

### DIFF
--- a/cmd/camp/project/worktree/add.go
+++ b/cmd/camp/project/worktree/add.go
@@ -149,7 +149,7 @@ func runProjectWorktreeAdd(cmd *cobra.Command, args []string) error {
 			return camperrors.Wrap(lerr, "worktree created but workitem link failed")
 		}
 		fmt.Printf("  Workitem: %s (%s)\n", ui.Value(link.WorkitemID), ui.Dim(link.WorkitemKey))
-		fmt.Println(ui.Dim("  camp p commit in this worktree will include WI-* in the campaign tag"))
+		fmt.Println(ui.Dim("  camp worktrees commit in this worktree will include WI-* in the campaign tag"))
 	}
 
 	fmt.Println()

--- a/docs/cli-reference/camp_workitem.md
+++ b/docs/cli-reference/camp_workitem.md
@@ -61,3 +61,4 @@ camp workitem [flags]
 * [camp workitem resolve](camp_workitem_resolve.md)	 - Print the workitem the current context resolves to (read-only)
 * [camp workitem stage](camp_workitem_stage.md)	 - Set or clear the attention stage of a workitem
 * [camp workitem unlink](camp_workitem_unlink.md)	 - Remove one or more workitem links
+* [camp workitem worktree](camp_workitem_worktree.md)	 - Create a project worktree from a workitem

--- a/docs/cli-reference/camp_workitem_worktree.md
+++ b/docs/cli-reference/camp_workitem_worktree.md
@@ -1,0 +1,58 @@
+## camp workitem worktree
+
+Create a project worktree from a workitem
+
+### Synopsis
+
+Create a git worktree for a workitem and primary-link it, so commits in
+that worktree carry the workitem's WI-* tag.
+
+This is the workitem-first counterpart to 'camp project worktree add': instead
+of naming a worktree and optionally tagging a workitem, you name a workitem and
+the worktree name, branch, and link are derived from it.
+
+Project resolution:
+  The target project is taken from the workitem's linked project (see
+  'camp workitem link --project'). When the workitem has no project link, or
+  is linked to more than one, pass --project explicitly.
+
+Re-entry:
+  If the workitem already has a primary worktree link, the existing path is
+  printed and no new worktree is created.
+
+Examples:
+  # Festival workitem already linked to a project
+  camp workitem worktree WI-2a7950
+
+  # Design/explore/intent workitem: name the project
+  camp workitem worktree workflow/design/camp-settings-tui --project camp
+
+  # Override the derived worktree name
+  camp workitem worktree WI-2a7950 --name grok-list-fix
+
+  # Print only the path (for shell integration)
+  cd "$(camp workitem worktree WI-2a7950 --print)"
+
+```
+camp workitem worktree <selector> [flags]
+```
+
+### Options
+
+```
+  -h, --help                 help for worktree
+      --name string          Worktree/branch name (derived from the workitem if omitted)
+      --print                Print only the worktree path
+  -p, --project string       Project name (inferred from the workitem's project link if omitted)
+  -s, --start-point string   Base branch/commit for the new branch (default: current branch)
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -157,6 +157,7 @@ Examples:
 	cmd.AddCommand(newLinkCommand())
 	cmd.AddCommand(newUnlinkCommand())
 	cmd.AddCommand(newLinksCommand())
+	cmd.AddCommand(newWorktreeCommand())
 	cmd.AddCommand(newCurrentCommand())
 	cmd.AddCommand(newResolveCommand())
 	cmd.AddCommand(newPriorityCommand())

--- a/internal/commands/workitem/worktree.go
+++ b/internal/commands/workitem/worktree.go
@@ -1,0 +1,347 @@
+package workitem
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	"github.com/Obedience-Corp/camp/internal/project"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/selector"
+	intworktree "github.com/Obedience-Corp/camp/internal/worktree"
+)
+
+func newWorktreeCommand() *cobra.Command {
+	var (
+		projectName string
+		name        string
+		startPoint  string
+		printPath   bool
+	)
+	cmd := &cobra.Command{
+		Use:     "worktree <selector>",
+		Aliases: []string{"wt"},
+		Short:   "Create a project worktree from a workitem",
+		Long: `Create a git worktree for a workitem and primary-link it, so commits in
+that worktree carry the workitem's WI-* tag.
+
+This is the workitem-first counterpart to 'camp project worktree add': instead
+of naming a worktree and optionally tagging a workitem, you name a workitem and
+the worktree name, branch, and link are derived from it.
+
+Project resolution:
+  The target project is taken from the workitem's linked project (see
+  'camp workitem link --project'). When the workitem has no project link, or
+  is linked to more than one, pass --project explicitly.
+
+Re-entry:
+  If the workitem already has a primary worktree link, the existing path is
+  printed and no new worktree is created.
+
+Examples:
+  # Festival workitem already linked to a project
+  camp workitem worktree WI-2a7950
+
+  # Design/explore/intent workitem: name the project
+  camp workitem worktree workflow/design/camp-settings-tui --project camp
+
+  # Override the derived worktree name
+  camp workitem worktree WI-2a7950 --name grok-list-fix
+
+  # Print only the path (for shell integration)
+  cd "$(camp workitem worktree WI-2a7950 --print)"`,
+		Args: cobra.ExactArgs(1),
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Creates an isolated worktree for a workitem; --print yields a cd-able path",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runWorktree(cmd, worktreeOptions{
+				Selector:   args[0],
+				Project:    projectName,
+				Name:       name,
+				StartPoint: startPoint,
+				Print:      printPath,
+			})
+		},
+	}
+	cmd.Flags().StringVarP(&projectName, "project", "p", "", "Project name (inferred from the workitem's project link if omitted)")
+	cmd.Flags().StringVar(&name, "name", "", "Worktree/branch name (derived from the workitem if omitted)")
+	cmd.Flags().StringVarP(&startPoint, "start-point", "s", "", "Base branch/commit for the new branch (default: current branch)")
+	cmd.Flags().BoolVar(&printPath, "print", false, "Print only the worktree path")
+	return cmd
+}
+
+type worktreeOptions struct {
+	Selector   string
+	Project    string
+	Name       string
+	StartPoint string
+	Print      bool
+}
+
+func runWorktree(cmd *cobra.Command, opts worktreeOptions) error {
+	ctx := cmd.Context()
+
+	cfg, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	wi, err := selector.Resolve(ctx, root, opts.Selector, selector.ResolveOptions{})
+	if err != nil {
+		return camperrors.Wrap(err, "resolve workitem "+opts.Selector)
+	}
+
+	registry, err := links.Load(ctx, root)
+	if err != nil {
+		return camperrors.Wrap(err, "load workitem links")
+	}
+
+	// Idempotent re-entry: the workitem already owns a worktree.
+	if existing, ok := existingWorktreeLink(registry, wi); ok {
+		return emitWorktree(cmd, opts.Print, existing, "", wi, true)
+	}
+
+	projectName, err := resolveWorktreeProject(ctx, root, registry, wi, opts.Project)
+	if err != nil {
+		return err
+	}
+	resolved, err := project.Resolve(ctx, root, projectName)
+	if err != nil {
+		var notFound *project.ProjectNotFoundError
+		if errors.As(err, &notFound) {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), ui.Dim("\n"+project.FormatProjectList(notFound.AvailableProjects())))
+		}
+		return err
+	}
+	if err := resolved.RequireGit("git worktrees"); err != nil {
+		return err
+	}
+
+	worktreeName := opts.Name
+	if worktreeName == "" {
+		worktreeName = deriveWorktreeName(wi)
+	}
+	if err := intworktree.ValidateName(worktreeName); err != nil {
+		return camperrors.Wrap(err, "derived worktree name invalid; pass --name")
+	}
+
+	result, err := createWorktree(ctx, root, cfg, resolved, worktreeName, opts.StartPoint)
+	if err != nil {
+		return err
+	}
+
+	link, err := attachWorktreeLink(ctx, root, wi, filepath.ToSlash(result.RelativePath))
+	if err != nil {
+		return camperrors.Wrap(err, "worktree created but workitem link failed")
+	}
+	_ = link
+	return emitWorktree(cmd, opts.Print, filepath.ToSlash(result.RelativePath), result.Branch, wi, false)
+}
+
+// createWorktree builds the worktree via the shared creator, mirroring
+// 'camp project worktree add': a new branch named after the worktree, based on
+// --start-point or the project's current branch.
+func createWorktree(
+	ctx context.Context,
+	root string,
+	cfg *config.CampaignConfig,
+	resolved *project.ResolveResult,
+	name, startPoint string,
+) (*intworktree.CreateResult, error) {
+	resolver := paths.NewResolver(root, cfg.Paths())
+	creator := intworktree.NewCreator(resolver, cfg)
+	opts := &intworktree.CreateOptions{
+		Project:     resolved.Name,
+		ProjectPath: resolved.Path,
+		Name:        name,
+		NewBranch:   true,
+		Branch:      name,
+		StartPoint:  startPoint,
+	}
+	if opts.StartPoint == "" {
+		git := intworktree.NewGitWorktree(resolved.Path)
+		current, err := git.CurrentBranch(ctx)
+		if err != nil {
+			return nil, camperrors.Wrap(err, "failed to detect current branch")
+		}
+		opts.StartPoint = current
+	}
+
+	result, err := creator.Create(ctx, opts)
+	if err != nil {
+		if errors.Is(err, intworktree.ErrWorktreeExists) {
+			return nil, camperrors.Wrap(err,
+				fmt.Sprintf("link it with 'camp workitem link %s --worktree %s/%s' or choose another --name",
+					name, resolved.Name, name))
+		}
+		return nil, err
+	}
+	return result, nil
+}
+
+// resolveWorktreeProject returns the project to create the worktree in: the
+// explicit flag when set, otherwise the workitem's single linked project.
+func resolveWorktreeProject(ctx context.Context, root string, registry *links.Links, wi *wkitem.WorkItem, flag string) (string, error) {
+	if flag != "" {
+		return flag, nil
+	}
+	projects := linkedProjects(registry, wi)
+	switch len(projects) {
+	case 1:
+		return projects[0], nil
+	case 0:
+		return "", camperrors.NewValidation("project",
+			fmt.Sprintf("workitem %s has no linked project; pass --project <name>", identityOf(wi)), nil)
+	default:
+		return "", camperrors.NewValidation("project",
+			fmt.Sprintf("workitem %s is linked to multiple projects (%s); pass --project <name>",
+				identityOf(wi), strings.Join(projects, ", ")), nil)
+	}
+}
+
+// linkedProjects returns the distinct project names the workitem is linked to,
+// derived from project-scope links (whose path is projects/<name>).
+func linkedProjects(registry *links.Links, wi *wkitem.WorkItem) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, link := range registry.Links {
+		if link.Scope.Kind != links.ScopeProject || !linkMatchesWorkitem(link, wi) {
+			continue
+		}
+		name := strings.Trim(strings.TrimPrefix(filepath.ToSlash(link.Scope.Path), "projects/"), "/")
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; !ok {
+			seen[name] = struct{}{}
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// existingWorktreeLink returns the relative path of the primary worktree already
+// linked to the workitem, if any.
+func existingWorktreeLink(registry *links.Links, wi *wkitem.WorkItem) (string, bool) {
+	for _, link := range registry.Links {
+		if link.Role == links.RolePrimary && link.Scope.Kind == links.ScopeWorktree && linkMatchesWorkitem(link, wi) {
+			return link.Scope.Path, true
+		}
+	}
+	return "", false
+}
+
+func linkMatchesWorkitem(link links.Link, wi *wkitem.WorkItem) bool {
+	if wi.StableID != "" && link.WorkitemID == wi.StableID {
+		return true
+	}
+	return wi.Key != "" && link.WorkitemKey == wi.Key
+}
+
+// attachWorktreeLink primary-links the worktree so the resolver (and therefore
+// camp p commit) picks up the workitem ref inside that tree.
+func attachWorktreeLink(ctx context.Context, root string, wi *wkitem.WorkItem, relativeWorktreePath string) (links.Link, error) {
+	if relativeWorktreePath == "" {
+		return links.Link{}, camperrors.NewValidation("worktree", "missing worktree relative path", nil)
+	}
+	workitemID := wi.StableID
+	if workitemID == "" {
+		workitemID = wi.Key
+	}
+	return links.AttachPrimary(ctx, root, links.AttachOptions{
+		WorkitemID:  workitemID,
+		WorkitemKey: wi.Key,
+		Scope: links.LinkScope{
+			Kind: links.ScopeWorktree,
+			Path: relativeWorktreePath,
+		},
+		CreatedBy: "camp_workitem_worktree",
+		Replace:   true,
+	})
+}
+
+// deriveWorktreeName builds a branch-safe worktree name from the workitem,
+// preferring the last path segment of its location (already slug-like).
+func deriveWorktreeName(wi *wkitem.WorkItem) string {
+	candidate := ""
+	if wi.RelativePath != "" {
+		candidate = path.Base(filepath.ToSlash(wi.RelativePath))
+	}
+	if candidate == "" || candidate == "." || candidate == "/" {
+		candidate = wi.Key
+	}
+	if candidate == "" {
+		candidate = wi.Title
+	}
+	return sanitizeWorktreeName(candidate)
+}
+
+// sanitizeWorktreeName coerces an arbitrary string into a name accepted by
+// worktree.ValidateName: lowercase alphanumerics, hyphens, and underscores,
+// starting on an alphanumeric.
+func sanitizeWorktreeName(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	out := b.String()
+	for strings.Contains(out, "--") {
+		out = strings.ReplaceAll(out, "--", "-")
+	}
+	out = strings.Trim(out, "-_")
+	if len(out) > 64 {
+		out = strings.Trim(out[:64], "-_")
+	}
+	return out
+}
+
+func emitWorktree(cmd *cobra.Command, printOnly bool, relPath, branch string, wi *wkitem.WorkItem, reused bool) error {
+	out := cmd.OutOrStdout()
+	if printOnly {
+		_, err := fmt.Fprintln(out, relPath)
+		return err
+	}
+
+	var lines []string
+	if reused {
+		lines = []string{
+			ui.Success(fmt.Sprintf("Worktree already linked for workitem %s", identityOf(wi))),
+			fmt.Sprintf("  Path: %s", ui.Value(relPath)),
+		}
+	} else {
+		lines = []string{
+			ui.Success("Created worktree from workitem " + identityOf(wi)),
+			fmt.Sprintf("  Path:     %s", ui.Value(relPath)),
+		}
+		if branch != "" {
+			lines = append(lines, fmt.Sprintf("  Branch:   %s", ui.Value(branch)))
+		}
+		lines = append(lines, ui.Dim("  camp worktrees commit in this worktree will include WI-* in the campaign tag"))
+	}
+	lines = append(lines, ui.Dim(fmt.Sprintf("To navigate: cd %s", relPath)))
+
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(out, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/commands/workitem/worktree_test.go
+++ b/internal/commands/workitem/worktree_test.go
@@ -1,0 +1,111 @@
+package workitem
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+func TestSanitizeWorktreeName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"camp-settings-tui", "camp-settings-tui"},
+		{"Fest List Watch", "fest-list-watch"},
+		{"  spaced  ", "spaced"},
+		{"weird/slashes:and.dots", "weird-slashes-and-dots"},
+		{"--leading-and-trailing--", "leading-and-trailing"},
+		{"multiple___under", "multiple___under"},
+		{"UPPER_case-42", "upper_case-42"},
+		{"", ""},
+		{"///", ""},
+	}
+	for _, tc := range cases {
+		if got := sanitizeWorktreeName(tc.in); got != tc.want {
+			t.Errorf("sanitizeWorktreeName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDeriveWorktreeName(t *testing.T) {
+	cases := []struct {
+		name string
+		wi   *wkitem.WorkItem
+		want string
+	}{
+		{"from relative path", &wkitem.WorkItem{RelativePath: "workflow/design/camp-settings-tui"}, "camp-settings-tui"},
+		{"festival path", &wkitem.WorkItem{RelativePath: "festivals/active/fest-list-watch"}, "fest-list-watch"},
+		{"falls back to key", &wkitem.WorkItem{Key: "design:grok-fix"}, "design-grok-fix"},
+		{"falls back to title", &wkitem.WorkItem{Title: "My Big Feature"}, "my-big-feature"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := deriveWorktreeName(tc.wi); got != tc.want {
+				t.Errorf("deriveWorktreeName() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLinkedProjects(t *testing.T) {
+	wi := &wkitem.WorkItem{StableID: "wi-1", Key: "design:foo"}
+	registry := &links.Links{Links: []links.Link{
+		{WorkitemID: "wi-1", Scope: links.LinkScope{Kind: links.ScopeProject, Path: "projects/camp"}},
+		{WorkitemID: "wi-1", Scope: links.LinkScope{Kind: links.ScopeProject, Path: "projects/camp"}},
+		{WorkitemID: "wi-1", Scope: links.LinkScope{Kind: links.ScopeWorktree, Path: "projects/worktrees/camp/x"}},
+		{WorkitemID: "other", Scope: links.LinkScope{Kind: links.ScopeProject, Path: "projects/fest"}},
+	}}
+	got := linkedProjects(registry, wi)
+	if len(got) != 1 || got[0] != "camp" {
+		t.Fatalf("linkedProjects = %v, want [camp]", got)
+	}
+}
+
+func TestExistingWorktreeLink(t *testing.T) {
+	wi := &wkitem.WorkItem{StableID: "wi-1", Key: "design:foo"}
+	registry := &links.Links{Links: []links.Link{
+		{WorkitemKey: "design:foo", Role: links.RolePrimary, Scope: links.LinkScope{Kind: links.ScopeWorktree, Path: "projects/worktrees/camp/foo"}},
+	}}
+	path, ok := existingWorktreeLink(registry, wi)
+	if !ok || path != "projects/worktrees/camp/foo" {
+		t.Fatalf("existingWorktreeLink = %q, %v; want the primary worktree path", path, ok)
+	}
+
+	none := &links.Links{Links: []links.Link{
+		{WorkitemID: "wi-1", Role: links.RoleRelated, Scope: links.LinkScope{Kind: links.ScopeWorktree, Path: "x"}},
+	}}
+	if _, ok := existingWorktreeLink(none, wi); ok {
+		t.Fatal("related (non-primary) worktree link must not count as existing")
+	}
+}
+
+func TestResolveWorktreeProject(t *testing.T) {
+	wi := &wkitem.WorkItem{StableID: "wi-1"}
+	ctx := context.Background()
+
+	if got, err := resolveWorktreeProject(ctx, "", &links.Links{}, wi, "explicit"); err != nil || got != "explicit" {
+		t.Fatalf("flag should win: got %q, err %v", got, err)
+	}
+
+	single := &links.Links{Links: []links.Link{
+		{WorkitemID: "wi-1", Scope: links.LinkScope{Kind: links.ScopeProject, Path: "projects/fest"}},
+	}}
+	if got, err := resolveWorktreeProject(ctx, "", single, wi, ""); err != nil || got != "fest" {
+		t.Fatalf("single linked project: got %q, err %v", got, err)
+	}
+
+	if _, err := resolveWorktreeProject(ctx, "", &links.Links{}, wi, ""); err == nil {
+		t.Fatal("no linked project must error asking for --project")
+	}
+
+	multi := &links.Links{Links: []links.Link{
+		{WorkitemID: "wi-1", Scope: links.LinkScope{Kind: links.ScopeProject, Path: "projects/fest"}},
+		{WorkitemID: "wi-1", Scope: links.LinkScope{Kind: links.ScopeProject, Path: "projects/camp"}},
+	}}
+	if _, err := resolveWorktreeProject(ctx, "", multi, wi, ""); err == nil {
+		t.Fatal("multiple linked projects must error asking for --project")
+	}
+}

--- a/tests/integration/workitem_worktree_test.go
+++ b/tests/integration/workitem_worktree_test.go
@@ -1,0 +1,61 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_WorkitemWorktree_InfersProjectAndLinks(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/workitem-worktree"
+	initCommitTagsCampaign(t, tc, dir)
+	ref := seedDesignWorkitemWithRef(t, tc, dir, "settings-tui")
+
+	_, err := tc.RunCampInDir(dir, "project", "new", "camp-app")
+	require.NoError(t, err, "camp project new")
+	_, err = tc.RunCampInDir(dir, "workitem", "link", "settings-tui", "--project", "camp-app")
+	require.NoError(t, err, "workitem link --project")
+
+	out, err := tc.RunCampInDir(dir, "workitem", "worktree", "settings-tui")
+	require.NoError(t, err, "camp workitem worktree: %s", out)
+
+	wtRel := "projects/worktrees/camp-app/settings-tui"
+	exists, err := tc.CheckDirExists(dir + "/" + wtRel)
+	require.NoError(t, err)
+	require.True(t, exists, "worktree dir should exist at %s; output:\n%s", wtRel, out)
+
+	resolveOut, err := tc.RunCampInDir(dir+"/"+wtRel, "workitem", "resolve")
+	require.NoError(t, err, "resolve from worktree: %s", resolveOut)
+	assert.Contains(t, resolveOut, "settings-tui",
+		"resolving from inside the worktree should surface the linked workitem: %s", resolveOut)
+
+	require.NoError(t, tc.WriteFile(dir+"/"+wtRel+"/foo.go", "package x\n"))
+	commitOut, err := tc.RunCampInDir(dir+"/"+wtRel, "worktrees", "commit", "-m", "feat: stub")
+	require.NoError(t, err, "camp worktrees commit in worktree: %s", commitOut)
+	subject := lastCommitSubject(t, tc, dir+"/"+wtRel)
+	assert.Contains(t, subject, ref,
+		"commit made inside the linked worktree should carry the WI-<ref> tag: %s", subject)
+
+	printOut, err := tc.RunCampInDir(dir, "workitem", "worktree", "settings-tui", "--print")
+	require.NoError(t, err, "re-entry --print: %s", printOut)
+	assert.Equal(t, wtRel, strings.TrimSpace(printOut),
+		"re-entry must return the existing worktree path without creating a new one")
+}
+
+func TestIntegration_WorkitemWorktree_RequiresProjectWhenUnlinked(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/workitem-worktree-unlinked"
+	initCommitTagsCampaign(t, tc, dir)
+	seedDesignWorkitemWithRef(t, tc, dir, "orphan")
+
+	out, err := tc.RunCampInDir(dir, "workitem", "worktree", "orphan")
+	require.Error(t, err, "must require --project when the workitem has no linked project; output:\n%s", out)
+	assert.Contains(t, out, "no linked project",
+		"error should name the missing-project cause: %s", out)
+}


### PR DESCRIPTION
## Summary

Adds `camp workitem worktree <selector>` (alias `camp wi wt`) - the
workitem-first counterpart to `camp project worktree add`. Instead of naming a
worktree and optionally tagging a workitem (as `--workitem` on `add` does since
#405), you name a **workitem** and the worktree name, branch, project, and
primary link are all derived from it. The result: `camp worktrees commit` in
that tree carries the workitem's `WI-*` tag with zero manual naming - the exact
flow an agent wants when it picks up a workitem to execute.

It composes the existing machinery (`intworktree.Creator` + `links.AttachPrimary`) -
no parallel worktree-creation path.

## Design decisions

- **Project inference is explicit, not heuristic.** The target project comes
  from the workitem's linked project (`camp workitem link --project`, stored as
  a `projects/<name>` project-scope link). When the workitem has no project
  link, or is linked to more than one, the command errors and asks for
  `--project` rather than guessing.
- **Idempotent re-entry.** If the workitem already owns a primary worktree link,
  the command prints that path and creates nothing new ("get me to this
  workitem's worktree, creating if needed").
- **Name derivation** comes from the workitem's location slug (last path
  segment), sanitized to a branch-safe name; `--name` overrides.
- **`--print`** emits just the path for `cd "$(camp wi worktree <sel> --print)"`,
  mirroring `camp workitem --print` / `camp go --print`.

## Commit-verb correction

While testing I found the "worktree created" hint printed `camp p commit ...`,
but `camp p commit` resolves a *submodule project dir* and cannot map a worktree
path back to its project (it errors "project not found"). The verb that works is
`camp worktrees commit`, which detects the worktree from cwd and resolves the
`WI-*` tag from the primary link. Corrected the hint in this command **and** in
`camp project worktree add` (the latter's hint was inherited from #405).

## Tests

- **Unit** (`internal/commands/workitem/worktree_test.go`): name sanitization,
  derivation, project inference (0 / 1 / ambiguous), idempotency link lookup,
  and `--project` precedence. All pure-logic, no FS.
- **Integration** (`tests/integration/workitem_worktree_test.go`, containerized
  per the host-fs-test rule): creates a worktree from a linked workitem with the
  project **inferred**, asserts the worktree exists, that `camp workitem resolve`
  from inside the tree surfaces the workitem, that `camp worktrees commit` there
  carries the `WI-<ref>` tag, that `--print` re-entry returns the same path, and
  that an unlinked workitem errors for `--project`. Both pass in the container.

Verified end-to-end on a real campaign: commit subject came out
`[wt-smoke:6ade284a-WI-0b5ae9] feat: stub`.

## Gates

- `go build ./...`, `go vet ./...` - clean
- `golangci-lint` on changed packages - clean
- `just test integration-run TestIntegration_WorkitemWorktree` - 2/2 pass

## Note on generated docs

`just docs` currently pulls broad unrelated drift (stale `camp_audit_*`,
`camp_event_*`, `camp_org_*`, `camp_commit`, `camp_init`, ... docs on `main`).
To keep this PR honest I included only the two doc files that are actually this
feature's (`camp_workitem_worktree.md` new, `camp_workitem.md` subcommand list)
and reverted the rest. A full CLI-reference regen is a separate maintenance pass.
