### PR TITLE
fix(project): make camp p commit work from inside a worktree

### DIFF
--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -13,8 +13,10 @@ import (
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/git"
 	"github.com/Obedience-Corp/camp/internal/ledger"
+	"github.com/Obedience-Corp/camp/internal/paths"
 	projectsvc "github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/internal/worktree"
 	"github.com/Obedience-Corp/camp/pkg/commitkit"
 	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
 	"github.com/spf13/cobra"
@@ -77,28 +79,46 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "not in a campaign")
 	}
 
-	// Resolve project
-	result, err := projectsvc.Resolve(ctx, campRoot, projectCommitProject)
-	if err != nil {
-		var notFound *projectsvc.ProjectNotFoundError
-		if errors.As(err, &notFound) {
-			fmt.Println(ui.Dim("\n" + projectsvc.FormatProjectList(notFound.AvailableProjects())))
+	// Load campaign config once (used for worktree detection, the commit tag,
+	// and the optional parent-ref sync).
+	cfg, _ := config.LoadCampaignConfig(ctx, campRoot)
+
+	// Resolve the working directory to commit in. With no explicit --project and
+	// a cwd inside a worktree, commit in the worktree itself: the generic project
+	// resolver only understands projects/<name> and submodule roots, so a commit
+	// from projects/worktrees/<project>/<name> would otherwise fail to resolve.
+	var (
+		resolvedPath string
+		relPath      string
+		inWorktree   bool
+	)
+	if projectCommitProject == "" && cfg != nil {
+		if wtCtx, derr := worktree.NewDetector(paths.NewResolver(campRoot, cfg.Paths())).DetectFromCwd(); derr == nil {
+			resolvedPath = wtCtx.WorktreePath
+			relPath, _ = filepath.Rel(campRoot, resolvedPath)
+			inWorktree = true
+			fmt.Printf("Worktree: %s\n", ui.Value(wtCtx.Project+"/"+wtCtx.WorktreeName))
 		}
-		return err
 	}
-
-	resolvedPath := result.Path
-
-	if err := result.RequireGit("git commits"); err != nil {
-		return err
+	if !inWorktree {
+		result, rerr := projectsvc.Resolve(ctx, campRoot, projectCommitProject)
+		if rerr != nil {
+			var notFound *projectsvc.ProjectNotFoundError
+			if errors.As(rerr, &notFound) {
+				fmt.Println(ui.Dim("\n" + projectsvc.FormatProjectList(notFound.AvailableProjects())))
+			}
+			return rerr
+		}
+		if rgErr := result.RequireGit("git commits"); rgErr != nil {
+			return rgErr
+		}
+		resolvedPath = result.Path
+		relPath = result.LogicalPath
+		if relPath == "" {
+			relPath, _ = filepath.Rel(campRoot, resolvedPath)
+		}
+		fmt.Printf("Project: %s\n", ui.Value(relPath))
 	}
-
-	// Display which project
-	relPath := result.LogicalPath
-	if relPath == "" {
-		relPath, _ = filepath.Rel(campRoot, resolvedPath)
-	}
-	fmt.Printf("Project: %s\n", ui.Value(relPath))
 
 	// Create executor for the submodule
 	executor, err := git.NewExecutor(resolvedPath)
@@ -144,9 +164,6 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 	// Show what's staged
 	cmdutil.ShowStagedSummary(ctx, resolvedPath)
 
-	// Load campaign config (used for tag and parent sync)
-	cfg, _ := config.LoadCampaignConfig(ctx, campRoot)
-
 	if projectCommitAutoWrite {
 		fmt.Println(ui.Info("Writing commit message..."))
 		var hookErr error
@@ -188,8 +205,10 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 		emitter.CommitEvidence(ctx, ledgerkit.Scope{}, campRoot, resolvedPath, sha, message)
 	}
 
-	// Auto-sync submodule ref in campaign root
-	if projectCommitSync && git.HasPathDiff(ctx, campRoot, resolvedPath) {
+	// Auto-sync submodule ref in campaign root. A worktree commit lands on its
+	// own branch under the gitignored worktrees dir, so there is no submodule
+	// ref to sync at the campaign root.
+	if projectCommitSync && !inWorktree && git.HasPathDiff(ctx, campRoot, resolvedPath) {
 		if err := syncParentRef(ctx, campRoot, relPath, cfg, emitter); err != nil {
 			fmt.Println()
 			fmt.Println(ui.Warning("Could not auto-sync campaign root: " + err.Error()))

--- a/cmd/camp/project/worktree/add.go
+++ b/cmd/camp/project/worktree/add.go
@@ -149,7 +149,7 @@ func runProjectWorktreeAdd(cmd *cobra.Command, args []string) error {
 			return camperrors.Wrap(lerr, "worktree created but workitem link failed")
 		}
 		fmt.Printf("  Workitem: %s (%s)\n", ui.Value(link.WorkitemID), ui.Dim(link.WorkitemKey))
-		fmt.Println(ui.Dim("  camp worktrees commit in this worktree will include WI-* in the campaign tag"))
+		fmt.Println(ui.Dim("  camp p commit in this worktree will include WI-* in the campaign tag"))
 	}
 
 	fmt.Println()

--- a/internal/commands/workitem/worktree.go
+++ b/internal/commands/workitem/worktree.go
@@ -334,7 +334,7 @@ func emitWorktree(cmd *cobra.Command, printOnly bool, relPath, branch string, wi
 		if branch != "" {
 			lines = append(lines, fmt.Sprintf("  Branch:   %s", ui.Value(branch)))
 		}
-		lines = append(lines, ui.Dim("  camp worktrees commit in this worktree will include WI-* in the campaign tag"))
+		lines = append(lines, ui.Dim("  camp p commit in this worktree will include WI-* in the campaign tag"))
 	}
 	lines = append(lines, ui.Dim(fmt.Sprintf("To navigate: cd %s", relPath)))
 

--- a/tests/integration/project_commit_worktree_test.go
+++ b/tests/integration/project_commit_worktree_test.go
@@ -1,0 +1,63 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// camp p commit run from inside a worktree used to fail ("project not found")
+// because the generic project resolver only understands projects/<name> and
+// submodule roots, not the projects/worktrees/<project>/<name> layout. It should
+// now detect the worktree, commit there, and carry the workitem's WI-<ref> tag.
+func TestIntegration_ProjectCommit_InWorktreeTagsWI(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/pcommit-worktree"
+	initCommitTagsCampaign(t, tc, dir)
+	ref := seedDesignWorkitemWithRef(t, tc, dir, "wt-fix")
+
+	_, err := tc.RunCampInDir(dir, "project", "new", "demo-app")
+	require.NoError(t, err, "camp project new")
+
+	out, err := tc.RunCampInDir(dir, "project", "worktree", "add", "wt-fix",
+		"--project", "demo-app", "--workitem", "wt-fix")
+	require.NoError(t, err, "worktree add: %s", out)
+
+	wtRel := "projects/worktrees/demo-app/wt-fix"
+	require.NoError(t, tc.WriteFile(dir+"/"+wtRel+"/foo.go", "package x\n"))
+
+	commitOut, err := tc.RunCampInDir(dir+"/"+wtRel, "p", "commit", "-m", "feat: stub")
+	require.NoError(t, err, "camp p commit inside worktree: %s", commitOut)
+
+	subject := lastCommitSubject(t, tc, dir+"/"+wtRel)
+	assert.Contains(t, subject, ref,
+		"camp p commit from inside the worktree should carry the WI-<ref> tag: %s", subject)
+}
+
+// An explicit --project from inside a worktree must still target the named
+// project's main checkout, not the worktree (the escape hatch is preserved).
+func TestIntegration_ProjectCommit_ExplicitProjectFromWorktree(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/pcommit-worktree-explicit"
+	initCommitTagsCampaign(t, tc, dir)
+	seedDesignWorkitemWithRef(t, tc, dir, "wt-explicit")
+
+	_, err := tc.RunCampInDir(dir, "project", "new", "demo-app")
+	require.NoError(t, err, "camp project new")
+	out, err := tc.RunCampInDir(dir, "project", "worktree", "add", "wt-explicit",
+		"--project", "demo-app", "--workitem", "wt-explicit")
+	require.NoError(t, err, "worktree add: %s", out)
+
+	require.NoError(t, tc.WriteFile(dir+"/projects/demo-app/bar.go", "package y\n"))
+	wtRel := "projects/worktrees/demo-app/wt-explicit"
+	commitOut, err := tc.RunCampInDir(dir+"/"+wtRel, "p", "commit", "--project", "demo-app", "-m", "chore: bar")
+	require.NoError(t, err, "camp p commit --project from worktree: %s", commitOut)
+
+	subject := lastCommitSubject(t, tc, dir+"/projects/demo-app")
+	assert.Contains(t, subject, "chore: bar",
+		"explicit --project should commit in the project main checkout: %s", subject)
+}


### PR DESCRIPTION
## Summary

`camp p commit` run from **inside a worktree** (`projects/worktrees/<project>/<name>/`)
failed with `project "...worktrees/<project>/<name>" not found`. This makes it
work: it now detects the worktree, commits there, and carries the workitem's
`WI-*` tag - so `camp p commit` is the single commit verb for both a project dir
and its worktrees.

Follow-up to #408 (which added `camp workitem worktree`); the "why" that
prompted it: `camp p commit` couldn't resolve a worktree, so worktree commits
had to go through `camp worktrees commit`.

## Root cause

`project.ResolveFromCwd` maps a cwd to a project only when it is inside a
registered `projects/<name>` dir or a recognized git **submodule** root. A
worktree is a **sibling** of its project under the gitignored `worktrees/` dir,
and its `.git` is a gitdir-pointer file that isn't classified as a submodule, so
all three resolution tiers miss and it falls through to `ProjectNotFoundError`
with the full worktree path as the name.

## Fix

`runProjectCommit`, when given no explicit `--project`, first detects a worktree
cwd via `worktree.Detector` and commits in the worktree working dir. The WI-tag
comes from the existing resolver against that cwd - no new tag logic, because
the workitem resolver is already worktree-aware and the project/worktree
commit-context resolvers were byte-for-byte identical.

- Purely additive: from a project dir, behavior is unchanged; from a worktree,
  what used to error now works.
- Explicit `--project` from a worktree still targets the project's main checkout
  (escape hatch preserved).
- The parent submodule-ref `--sync` is skipped in a worktree (a worktree branch
  has no campaign-root ref to sync; the worktrees dir is gitignored anyway).
- The worktree-created hints (in `camp workitem worktree` and `camp project
  worktree add`) are updated back to `camp p commit`, now that it is the
  universal verb.

## Tests

Containerized integration tests:
- `TestIntegration_ProjectCommit_InWorktreeTagsWI` - commit from inside a linked
  worktree carries `WI-<ref>`.
- `TestIntegration_ProjectCommit_ExplicitProjectFromWorktree` - `--project` from
  a worktree commits in the project main checkout.

Both pass. Verified on a real campaign: subject came out
`[pc-smoke:d006a4be-WI-966439] feat: stub` from inside the worktree, and a
project-dir commit still works unchanged.

## Gates

- `go build ./...`, `go vet ./...`, `go vet -tags integration ./...` - clean
- `golangci-lint --new-from-merge-base origin/main` - 0 new issues
- `lint-no-fmt-errorf` - clean
- `just test integration-run TestIntegration_ProjectCommit_` - 2/2 pass
