### PR TITLE
fix(manifest): allowlist camp workitem worktree as agent-allowed

### DIFF
--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -95,6 +95,7 @@ var manifestAgentAllowedReasons = map[string]string{
 	"workitem stage":             "Non-interactive attention-stage update with explicit selector",
 	"workitem unlink":            "Non-interactive workitem unlink operation",
 	"workitem validate":          "Read-only structural validator with --json output",
+	"workitem worktree":          "Creates an isolated worktree for a workitem with an explicit selector; --print yields a cd-able path",
 	"worktrees info":             "Read-only worktree metadata",
 	"worktrees list":             "Read-only worktree listing",
 }


### PR DESCRIPTION
The `workitem worktree` command (added in #408) is annotated `agent_allowed=true` but was missing from `manifestAgentAllowedReasons`, so `TestManifestCommand_AllCommandsHaveAnnotations` fails the release gate (`just gate`). This adds its allowlist entry so the gate passes; unblocks cutting the v0.3.0-rc.2 tag. Verified: the manifest test passes in both stable and dev profiles.