### PR TITLE
feat: filter camp list TUI by positional org

### DIFF
--- a/cmd/camp/list.go
+++ b/cmd/camp/list.go
@@ -34,7 +34,7 @@ type campaignEntry struct {
 }
 
 var listCmd = &cobra.Command{
-	Use:   "list",
+	Use:   "list [org]",
 	Short: "List all registered campaigns",
 	Long: `List all campaigns registered in the global registry.
 
@@ -43,8 +43,9 @@ with 'camp register'. The registry lives at ~/.obey/campaign/registry.json.
 
 In a terminal, 'camp list' (with no flags) opens an interactive browser where you
 can deactivate/reactivate campaigns (cycle lifecycle status), reassign their org,
-and copy paths. Piped, with --json/--count, or with any filter/sort flag it
-prints the table instead. Home paths display as '~'.
+and copy paths. Pass an org as a positional argument to open the browser filtered
+to that org. Piped, with --json/--count, or with any filter/sort flag it prints
+the table instead. Home paths display as '~'.
 
 Output formats:
   table   - Aligned columns with headers (default)
@@ -59,6 +60,7 @@ Sorting options:
 
 Examples:
   camp list                  List all campaigns
+  camp list obey             Browse campaigns in the obey org
   camp list --json           Output as JSON
   camp list --format json    Output as JSON
   camp list --sort name      Sort by name
@@ -72,6 +74,7 @@ Examples:
 picked up. If camp still can't be found on a machine, set
 CAMP_REMOTE_CAMP_PATH to its exact path there.`,
 	Aliases: []string{"ls"},
+	Args:    cobra.MaximumNArgs(1),
 	RunE:    runList,
 }
 
@@ -103,13 +106,48 @@ func init() {
 }
 
 func runList(cmd *cobra.Command, args []string) error {
-	if listTUIRequested(cmd, stdoutIsTTY()) {
-		return runListTUI(cmd)
+	positionalOrg, err := parseListPositionalOrg(cmd, args)
+	if err != nil {
+		return err
 	}
-	return renderListTable(cmd)
+	openTUI := listTUIRequested(cmd, stdoutIsTTY())
+	if positionalOrg != "" {
+		if err := cmd.Flags().Set("org", positionalOrg); err != nil {
+			return camperrors.Wrap(err, "setting positional org filter")
+		}
+	}
+	if openTUI {
+		return runListTUI(cmd, positionalOrg)
+	}
+	return renderListTable(cmd, positionalOrg)
 }
 
-func renderListTable(cmd *cobra.Command) error {
+func parseListPositionalOrg(cmd *cobra.Command, args []string) (string, error) {
+	if len(args) == 0 {
+		return "", nil
+	}
+	if cmd.Flags().Changed("org") {
+		return "", camperrors.NewValidation("org", "provide an org either positionally or with --org, not both", nil)
+	}
+	if err := config.ValidateName("org", args[0]); err != nil {
+		return "", err
+	}
+	return args[0], nil
+}
+
+func requireListOrg(reg *config.Registry, org string) error {
+	if org == "" {
+		return nil
+	}
+	for _, entry := range reg.Orgs {
+		if entry.Name == org {
+			return nil
+		}
+	}
+	return camperrors.NewNotFound("org", org, nil)
+}
+
+func renderListTable(cmd *cobra.Command, positionalOrg string) error {
 	ctx := cmd.Context()
 	formatStr, _ := cmd.Flags().GetString("format")
 	if listJSON {
@@ -123,6 +161,9 @@ func renderListTable(cmd *cobra.Command) error {
 
 	reg, report, err := loadVerifiedListRegistry(ctx)
 	if err != nil {
+		return err
+	}
+	if err := requireListOrg(reg, positionalOrg); err != nil {
 		return err
 	}
 

--- a/cmd/camp/list_org_test.go
+++ b/cmd/camp/list_org_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -82,6 +84,40 @@ func TestFilterEntries(t *testing.T) {
 				t.Errorf("filter = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestParseListPositionalOrg(t *testing.T) {
+	cmd := listTestCmd()
+	got, err := parseListPositionalOrg(cmd, []string{"obey"})
+	if err != nil {
+		t.Fatalf("parse positional org: %v", err)
+	}
+	if got != "obey" {
+		t.Fatalf("org = %q, want obey", got)
+	}
+
+	if err := cmd.Flags().Set("org", "default"); err != nil {
+		t.Fatalf("set --org: %v", err)
+	}
+	if _, err := parseListPositionalOrg(cmd, []string{"obey"}); err == nil {
+		t.Fatal("expected positional org and --org conflict")
+	}
+}
+
+func TestRequireListOrg(t *testing.T) {
+	reg := config.NewRegistry()
+	reg.Orgs = append(reg.Orgs, config.OrgEntry{Name: "obey"}, config.OrgEntry{Name: "empty-co"})
+	for _, org := range []string{"obey", "empty-co"} {
+		if err := requireListOrg(reg, org); err != nil {
+			t.Fatalf("require existing org %q: %v", org, err)
+		}
+	}
+
+	err := requireListOrg(reg, "missing")
+	var notFound *camperrors.NotFoundError
+	if !errors.As(err, &notFound) || notFound.Resource != "org" || notFound.ID != "missing" {
+		t.Fatalf("missing org error = %v, want typed org not-found", err)
 	}
 }
 

--- a/cmd/camp/list_tui.go
+++ b/cmd/camp/list_tui.go
@@ -31,6 +31,7 @@ type listTUIModel struct {
 	ctx context.Context
 
 	fallback   string
+	orgFilter  string
 	all        []campaignEntry
 	visible    []campaignEntry
 	cursor     int
@@ -71,17 +72,21 @@ func listTUIRequested(cmd *cobra.Command, isTTY bool) bool {
 	return isTTY
 }
 
-func runListTUI(cmd *cobra.Command) error {
+func runListTUI(cmd *cobra.Command, positionalOrg string) error {
 	ctx := cmd.Context()
 	if !term.IsTerminal(int(os.Stdout.Fd())) {
-		return renderListTable(cmd)
+		return renderListTable(cmd, positionalOrg)
 	}
 	pathOutput, _ := cmd.Flags().GetString("path-output")
 	reg, report, err := loadVerifiedListRegistry(ctx)
 	if err != nil {
 		return camperrors.Wrap(err, "failed to load registry")
 	}
-	model := newListTUIModel(ctx, reg)
+	orgFilter, _ := cmd.Flags().GetString("org")
+	if err := requireListOrg(reg, orgFilter); err != nil {
+		return err
+	}
+	model := newListTUIModel(ctx, reg, orgFilter)
 	model.gotoEnabled = pathOutput != ""
 	if report.HasChanges() {
 		model.setStatus("registry cleaned: "+verificationSummaryText(report), false)
@@ -105,10 +110,10 @@ func writeGotoSelection(final tea.Model, pathOutput string) error {
 	return os.WriteFile(pathOutput, []byte(m.gotoPath), 0o600)
 }
 
-func newListTUIModel(ctx context.Context, reg *config.Registry) listTUIModel {
+func newListTUIModel(ctx context.Context, reg *config.Registry, orgFilter string) listTUIModel {
 	ti := textinput.New()
 	ti.Prompt = "> "
-	m := listTUIModel{ctx: ctx, input: ti}
+	m := listTUIModel{ctx: ctx, input: ti, orgFilter: orgFilter}
 	m.loadFromRegistry(reg)
 	return m
 }
@@ -120,17 +125,17 @@ func (m *listTUIModel) loadFromRegistry(reg *config.Registry) {
 }
 
 func (m *listTUIModel) rebuildVisible() {
-	if !m.activeOnly {
-		m.visible = m.all
-	} else {
-		out := make([]campaignEntry, 0, len(m.all))
-		for _, e := range m.all {
-			if e.Status == config.StatusActive {
-				out = append(out, e)
-			}
+	out := make([]campaignEntry, 0, len(m.all))
+	for _, e := range m.all {
+		if m.orgFilter != "" && e.Org != m.orgFilter {
+			continue
 		}
-		m.visible = out
+		if m.activeOnly && e.Status != config.StatusActive {
+			continue
+		}
+		out = append(out, e)
 	}
+	m.visible = out
 	m.cursor = ui.ClampIdx(m.cursor, len(m.visible))
 }
 

--- a/cmd/camp/list_tui_test.go
+++ b/cmd/camp/list_tui_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -40,7 +41,7 @@ func newTestListModel(t *testing.T) listTUIModel {
 	if err != nil {
 		t.Fatalf("load registry: %v", err)
 	}
-	return newListTUIModel(context.Background(), reg)
+	return newListTUIModel(context.Background(), reg, "")
 }
 
 func lkey(m listTUIModel, s string) listTUIModel {
@@ -205,6 +206,25 @@ func TestListTUI_OpensOrgMajorAllStatuses(t *testing.T) {
 	}
 	if m.visible[0].Name != "alpha" {
 		t.Errorf("first row = %q, want alpha (default org first)", m.visible[0].Name)
+	}
+}
+
+func TestListTUI_PositionalOrgFilterIncludesAllStatuses(t *testing.T) {
+	reg := config.NewRegistry()
+	reg.Campaigns = map[string]config.RegisteredCampaign{
+		"A-1": {Name: "alpha", Org: "default", Status: config.StatusActive},
+		"B-2": {Name: "beta", Org: "obey", Status: config.StatusActive},
+		"C-3": {Name: "gamma", Org: "obey", Status: config.StatusInactive},
+	}
+	m := newListTUIModel(context.Background(), reg, "obey")
+	if got := names(m.visible); !reflect.DeepEqual(got, []string{"beta", "gamma"}) {
+		t.Fatalf("visible = %v, want obey campaigns across all statuses", got)
+	}
+
+	m.activeOnly = true
+	m.rebuildVisible()
+	if got := names(m.visible); !reflect.DeepEqual(got, []string{"beta"}) {
+		t.Fatalf("active visible = %v, want only active obey campaign", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- accept an optional org in `camp list [org]`
- open the interactive campaign browser filtered to that org when attached to a terminal
- return a typed `org not found` error when the positional org is not registered
- preserve existing `--org` text-output behavior and support first-class empty orgs

## Why

The positional argument was previously accepted by Cobra but ignored, so `camp list obey` opened the unfiltered browser. This makes the positional form an explicit org-scoped navigation path while retaining machine-readable and piped output behavior.

## Validation

- `go test ./cmd/camp`
- `just gate-fast` (stable/dev builds, vet, lint, and 3,284 dev-profile tests)
