### PR TITLE
fix: preserve TUI top rows

### DIFF
--- a/cmd/camp/festivals/tui_responsive_test.go
+++ b/cmd/camp/festivals/tui_responsive_test.go
@@ -41,6 +41,18 @@ func TestBrowser_NoLineExceedsWidth(t *testing.T) {
 	}
 }
 
+func TestBrowser_HasNoPhantomTrailingRow(t *testing.T) {
+	m := makeBrowserWithNFestivals(50)
+	m.width, m.height = 80, 24
+	out := m.View()
+	if strings.HasSuffix(out, "\n") {
+		t.Fatalf("full-screen festivals view ends with a phantom row: %q", out)
+	}
+	if got := len(strings.Split(out, "\n")); got > m.height {
+		t.Fatalf("rendered %d rows for terminal height %d", got, m.height)
+	}
+}
+
 func TestBrowser_ScrollKeepsCursorVisible(t *testing.T) {
 	ui.SetNoColor(true)
 	m := makeBrowserWithNFestivals(50)

--- a/cmd/camp/festivals/tui_view.go
+++ b/cmd/camp/festivals/tui_view.go
@@ -93,9 +93,9 @@ func (m festivalsTUIModel) frame(lines []string, lay festLayout) string {
 	}
 	content := strings.Join(ui.ClampLines(lines, lay.cw), "\n")
 	if lay.boxed {
-		return festBox.Render(content) + "\n"
+		return ui.FitFullscreenView(festBox.Render(content), m.height)
 	}
-	return content + "\n"
+	return ui.FitFullscreenView(content, m.height)
 }
 
 func (m festivalsTUIModel) renderRange(start, end int, headers bool, cw int) []string {

--- a/cmd/camp/list_tui_responsive_test.go
+++ b/cmd/camp/list_tui_responsive_test.go
@@ -59,6 +59,17 @@ func TestListView_BoundedAtEverySize(t *testing.T) {
 	}
 }
 
+func TestListView_HasNoPhantomTrailingRow(t *testing.T) {
+	m := sized(responsiveModel(), 80, 24)
+	out := m.View()
+	if strings.HasSuffix(out, "\n") {
+		t.Fatalf("full-screen list view ends with a phantom row: %q", out)
+	}
+	if got := len(strings.Split(out, "\n")); got > m.height {
+		t.Fatalf("rendered %d rows for terminal height %d", got, m.height)
+	}
+}
+
 func TestListView_SelectionVisibleWhenScrolled(t *testing.T) {
 	m := sized(responsiveModel(), 40, 10)
 	m.cursor = len(m.visible) - 1

--- a/cmd/camp/list_tui_view.go
+++ b/cmd/camp/list_tui_view.go
@@ -133,9 +133,9 @@ func (m listTUIModel) frame(lines []string, lay listLayout) string {
 	}
 	content := strings.Join(ui.ClampLines(lines, lay.cw), "\n")
 	if lay.boxed {
-		return listBox.Render(content) + "\n"
+		return ui.FitFullscreenView(listBox.Render(content), m.height)
 	}
-	return content + "\n"
+	return ui.FitFullscreenView(content, m.height)
 }
 
 // bodyLines renders the campaign rows for the current window. Org headers are

--- a/internal/intent/tui/explorer/model.go
+++ b/internal/intent/tui/explorer/model.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/intent/gather"
 	"github.com/Obedience-Corp/camp/internal/intent/tui"
 	"github.com/Obedience-Corp/camp/internal/intent/tui/filterchip"
+	campui "github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -256,6 +257,10 @@ func (m Model) loadIntents() tea.Cmd {
 
 // View implements tea.Model.
 func (m Model) View() string {
+	return campui.FitFullscreenView(m.view(), m.height)
+}
+
+func (m Model) view() string {
 	if m.quitting {
 		return ""
 	}

--- a/internal/intent/tui/explorer/navigation_test.go
+++ b/internal/intent/tui/explorer/navigation_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Obedience-Corp/camp/internal/intent"
+	"github.com/Obedience-Corp/camp/internal/intent/tui"
 )
 
 // makeTestModel creates a Model with test intents across groups.
@@ -406,6 +407,24 @@ func TestBuildMainView_DynamicHeight(t *testing.T) {
 
 	if len(lines) != m.height {
 		t.Errorf("buildMainView output = %d lines, want exactly %d", len(lines), m.height)
+	}
+}
+
+func TestView_ProtectsTopRowFromFullscreenOverflow(t *testing.T) {
+	m := makeTestModel(5, 3)
+	m.ready = true
+	m.width = 100
+	m.height = 10
+	m.focus = focusActionMenu
+	m.actionMenu = tui.NewActionMenu(m.filteredIntents[0])
+
+	view := m.View()
+	lines := strings.Split(view, "\n")
+	if len(lines) > m.height {
+		t.Fatalf("View output = %d lines, exceeds terminal height %d", len(lines), m.height)
+	}
+	if !strings.Contains(lines[0], "Intent Explorer") {
+		t.Fatalf("top row was not preserved: %q", lines[0])
 	}
 }
 

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -1,6 +1,10 @@
 package ui
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
 
 func Truncate(s string, n int) string {
 	if n <= 0 {
@@ -32,6 +36,22 @@ func ClampLines(lines []string, w int) []string {
 		out[i] = ClampWidth(l, w)
 	}
 	return out
+}
+
+// FitFullscreenView keeps a Bubble Tea full-screen view within the terminal's
+// row budget. Bubble Tea splits views on newlines and, when there are too many
+// rows, keeps the bottom rows. A trailing newline therefore creates a phantom
+// row that can evict the title or top border. Keep the top of the view instead.
+func FitFullscreenView(view string, height int) string {
+	view = strings.TrimRight(view, "\n")
+	if height <= 0 {
+		return view
+	}
+	lines := strings.Split(view, "\n")
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+	return strings.Join(lines, "\n")
 }
 
 func WindowRange(cursor, total, capacity int) (int, int) {

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -1,6 +1,9 @@
 package ui
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestTruncate(t *testing.T) {
 	cases := []struct {
@@ -42,6 +45,30 @@ func TestClampLines_ZeroWidthIsPassthrough(t *testing.T) {
 		if out[i] != in[i] {
 			t.Errorf("ClampLines width 0 altered line %d: %q -> %q", i, in[i], out[i])
 		}
+	}
+}
+
+func TestFitFullscreenView_RemovesPhantomTrailingRows(t *testing.T) {
+	got := FitFullscreenView("top\nmiddle\nbottom\n", 3)
+	if got != "top\nmiddle\nbottom" {
+		t.Fatalf("FitFullscreenView = %q, want view without trailing row", got)
+	}
+	if strings.HasSuffix(got, "\n") {
+		t.Fatal("fullscreen view must not end with a newline")
+	}
+}
+
+func TestFitFullscreenView_PreservesTopWhenContentOverflows(t *testing.T) {
+	got := FitFullscreenView("top\nsecond\nthird\nbottom", 3)
+	if got != "top\nsecond\nthird" {
+		t.Fatalf("FitFullscreenView = %q, want top three rows", got)
+	}
+}
+
+func TestFitFullscreenView_UnknownHeightOnlyTrimsTrailingRows(t *testing.T) {
+	got := FitFullscreenView("top\nbottom\n\n", 0)
+	if got != "top\nbottom" {
+		t.Fatalf("FitFullscreenView unknown height = %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a shared full-screen view boundary that removes phantom trailing rows and caps overflow while preserving the top of the view
- apply the boundary to `camp list`, `camp festivals`, and every `camp intent explore` view mode
- add raw-render regression coverage for trailing rows, overflow, and top-row preservation

## Root cause

Bubble Tea splits a rendered view on newlines. When the resulting row count exceeds the terminal height, it retains the bottom rows and drops rows from the top. The list and festivals frames appended a trailing newline after already budgeting the full terminal height, which could evict their top border. Intent explorer had no common final row cap across its main view and overlays, allowing the same top-row loss whenever a composed view exceeded the available height.

## User impact

The title or rounded top border now remains visible instead of appearing clipped in all three full-screen TUIs.

## Validation

- focused tests for `internal/ui`, `cmd/camp`, `cmd/camp/festivals`, and `internal/intent/tui/explorer`
- `just gate-fast` (stable/dev builds, vet, lint, and 3,287 tests)
