### PR TITLE
refactor(ui): extract shared TUI canvas helpers

### DIFF
--- a/cmd/camp/festivals/tui_responsive_test.go
+++ b/cmd/camp/festivals/tui_responsive_test.go
@@ -6,9 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/charmbracelet/lipgloss"
-
 	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/internal/ui/uitest"
 )
 
 func makeBrowserWithNFestivals(n int) festivalsTUIModel {
@@ -33,11 +32,7 @@ func TestBrowser_NoLineExceedsWidth(t *testing.T) {
 	m := makeBrowserWithNFestivals(50)
 	for _, w := range []int{20, 30, 40, 60, 80, 120} {
 		m.width, m.height = w, 24
-		for _, line := range strings.Split(m.View(), "\n") {
-			if lipgloss.Width(line) > w {
-				t.Errorf("width %d: line exceeds cw: %q (%d)", w, line, lipgloss.Width(line))
-			}
-		}
+		uitest.AssertBounded(t, m.View(), w, 24)
 	}
 }
 

--- a/cmd/camp/festivals/tui_view.go
+++ b/cmd/camp/festivals/tui_view.go
@@ -81,17 +81,14 @@ func (m festivalsTUIModel) View() string {
 }
 
 func (m festivalsTUIModel) frame(lines []string, lay festLayout) string {
+	budget := 0
 	if m.height > 0 {
-		budget := m.height
+		budget = m.height
 		if lay.boxed {
-			budget -= 2
-		}
-		budget = max(budget, 1)
-		if len(lines) > budget {
-			lines = lines[:budget]
+			budget = max(budget-2, 1)
 		}
 	}
-	content := strings.Join(ui.ClampLines(lines, lay.cw), "\n")
+	content := strings.Join(ui.CapFrame(lines, lay.cw, budget), "\n")
 	if lay.boxed {
 		return ui.FitFullscreenView(festBox.Render(content), m.height)
 	}
@@ -140,13 +137,11 @@ func (m festivalsTUIModel) topBar() string {
 }
 
 func (m festivalsTUIModel) footer(cw int) string {
-	help := "g/enter: go . j/k: move . f: active-only . y: copy . q: quit"
-	if cw > 0 && lipgloss.Width(help) > cw {
-		help = "j/k move . g go . f filter . q quit"
-	}
-	if cw > 0 && lipgloss.Width(help) > cw {
-		help = "q quit"
-	}
+	help := ui.CollapseHelp(cw,
+		"g/enter: go . j/k: move . f: active-only . y: copy . q: quit",
+		"j/k move . g go . f filter . q quit",
+		"q quit",
+	)
 	return festHelpStyle.Render(help)
 }
 

--- a/cmd/camp/list_tui_responsive_test.go
+++ b/cmd/camp/list_tui_responsive_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/Obedience-Corp/camp/internal/ui/uitest"
 )
 
 func responsiveModel() listTUIModel {
@@ -31,23 +32,6 @@ func sized(m listTUIModel, w, h int) listTUIModel {
 	return next.(listTUIModel)
 }
 
-func viewLines(s string) []string {
-	return strings.Split(strings.TrimRight(s, "\n"), "\n")
-}
-
-func assertBounded(t *testing.T, out string, w, h int) {
-	t.Helper()
-	lines := viewLines(out)
-	if len(lines) > h {
-		t.Fatalf("%dx%d: rendered %d lines, exceeds height %d:\n%s", w, h, len(lines), h, out)
-	}
-	for i, ln := range lines {
-		if got := lipgloss.Width(ln); got > w {
-			t.Fatalf("%dx%d: line %d width %d exceeds terminal width %d: %q", w, h, i, got, w, ln)
-		}
-	}
-}
-
 func TestListView_BoundedAtEverySize(t *testing.T) {
 	sizes := []struct{ w, h int }{
 		{120, 40}, {80, 24}, {60, 20}, {40, 10}, {30, 8}, {24, 6}, {20, 5}, {15, 6},
@@ -55,7 +39,7 @@ func TestListView_BoundedAtEverySize(t *testing.T) {
 	for _, s := range sizes {
 		m := sized(responsiveModel(), s.w, s.h)
 		m.cursor = 3
-		assertBounded(t, m.View(), s.w, s.h)
+		uitest.AssertBounded(t, m.View(), s.w, s.h)
 	}
 }
 
@@ -74,7 +58,7 @@ func TestListView_SelectionVisibleWhenScrolled(t *testing.T) {
 	m := sized(responsiveModel(), 40, 10)
 	m.cursor = len(m.visible) - 1
 	out := m.View()
-	assertBounded(t, out, 40, 10)
+	uitest.AssertBounded(t, out, 40, 10)
 	if !strings.Contains(out, "> ") {
 		t.Fatalf("selected row cursor not rendered at 40x10:\n%s", out)
 	}
@@ -92,7 +76,7 @@ func TestListView_NoPanicAtAbsurdSizes(t *testing.T) {
 			t.Fatalf("%dx%d produced empty view", s.w, s.h)
 		}
 		if s.w > 0 && s.h > 0 {
-			assertBounded(t, out, s.w, s.h)
+			uitest.AssertBounded(t, out, s.w, s.h)
 		}
 	}
 }
@@ -108,7 +92,7 @@ func TestListView_EmptyListBounded(t *testing.T) {
 			t.Fatalf("%dx%d empty view missing placeholder:\n%s", s.w, s.h, out)
 		}
 		if s.w > 0 && s.h > 0 {
-			assertBounded(t, out, s.w, s.h)
+			uitest.AssertBounded(t, out, s.w, s.h)
 		}
 	}
 }
@@ -123,7 +107,7 @@ func TestListView_OverlayBounded(t *testing.T) {
 			t.Fatalf("%dx%d overlay empty", s.w, s.h)
 		}
 		if s.w > 0 && s.h > 0 {
-			assertBounded(t, out, s.w, s.h)
+			uitest.AssertBounded(t, out, s.w, s.h)
 		}
 	}
 }

--- a/cmd/camp/list_tui_view.go
+++ b/cmd/camp/list_tui_view.go
@@ -121,17 +121,14 @@ func (m listTUIModel) View() string {
 // guard so an unexpectedly tall render can never overflow a short window, then
 // wraps it in the border when the size allows.
 func (m listTUIModel) frame(lines []string, lay listLayout) string {
+	budget := 0
 	if m.height > 0 {
-		budget := m.height
+		budget = m.height
 		if lay.boxed {
-			budget -= 2
-		}
-		budget = max(budget, 1)
-		if len(lines) > budget {
-			lines = lines[:budget]
+			budget = max(budget-2, 1)
 		}
 	}
-	content := strings.Join(ui.ClampLines(lines, lay.cw), "\n")
+	content := strings.Join(ui.CapFrame(lines, lay.cw, budget), "\n")
 	if lay.boxed {
 		return ui.FitFullscreenView(listBox.Render(content), m.height)
 	}
@@ -237,13 +234,11 @@ func (m listTUIModel) topBar() string {
 }
 
 func (m listTUIModel) footer(cw int) string {
-	help := "g: go . j/k: move . s: status . m: org . y: copy . f: filter . q: quit"
-	if cw > 0 && lipgloss.Width(help) > cw {
-		help = "j/k move . g go . f filter . q quit"
-	}
-	if cw > 0 && lipgloss.Width(help) > cw {
-		help = "q quit"
-	}
+	help := ui.CollapseHelp(cw,
+		"g: go . j/k: move . s: status . m: org . y: copy . f: filter . q: quit",
+		"j/k move . g go . f filter . q quit",
+		"q quit",
+	)
 	return listHelpStyle.Render(help)
 }
 

--- a/cmd/camp/org/tui_responsive_test.go
+++ b/cmd/camp/org/tui_responsive_test.go
@@ -10,31 +10,12 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/internal/ui/uitest"
 )
 
 func sizedOrg(m orgTUIModel, w, h int) orgTUIModel {
 	next, _ := m.Update(tea.WindowSizeMsg{Width: w, Height: h})
 	return next.(orgTUIModel)
-}
-
-func orgViewLines(s string) []string {
-	return strings.Split(strings.TrimRight(s, "\n"), "\n")
-}
-
-func assertOrgBounded(t *testing.T, out string, w, h int) {
-	t.Helper()
-	lines := orgViewLines(out)
-	if h > 0 && len(lines) > h {
-		t.Fatalf("%dx%d: rendered %d lines, exceeds height %d:\n%s", w, h, len(lines), h, out)
-	}
-	if w <= 0 {
-		return
-	}
-	for i, ln := range lines {
-		if got := lipgloss.Width(ln); got > w {
-			t.Fatalf("%dx%d: line %d width %d exceeds terminal width %d: %q", w, h, i, got, w, ln)
-		}
-	}
 }
 
 func manyOrgsModel(t *testing.T, nOrgs, membersPer int) orgTUIModel {
@@ -71,11 +52,11 @@ func TestOrgView_BoundedAtEverySize(t *testing.T) {
 		m := sizedOrg(manyOrgsModel(t, 20, 15), s.w, s.h)
 		m.orgCursor = 12
 		m.syncFocusedOrg()
-		assertOrgBounded(t, m.View(), s.w, s.h)
+		uitest.AssertBounded(t, m.View(), s.w, s.h)
 
 		m.pane = paneMembers
 		m.memCursor = 10
-		assertOrgBounded(t, m.View(), s.w, s.h)
+		uitest.AssertBounded(t, m.View(), s.w, s.h)
 	}
 }
 
@@ -87,7 +68,7 @@ func TestOrgView_SelectionVisibleWhenScrolled(t *testing.T) {
 	m.orgCursor = len(m.orgs) - 1
 	m.syncFocusedOrg()
 	out := m.View()
-	assertOrgBounded(t, out, 40, 10)
+	uitest.AssertBounded(t, out, 40, 10)
 	want := m.orgs[m.orgCursor].Org
 	// Name may be truncated; require a distinctive prefix.
 	prefix := ui.Truncate(want, 12)
@@ -115,7 +96,7 @@ func TestOrgView_NoPanicAtAbsurdSizes(t *testing.T) {
 			t.Fatalf("%dx%d produced empty view", s.w, s.h)
 		}
 		if s.w > 0 && s.h > 0 {
-			assertOrgBounded(t, out, s.w, s.h)
+			uitest.AssertBounded(t, out, s.w, s.h)
 		}
 	}
 }
@@ -126,7 +107,7 @@ func TestOrgView_DualVsSingleReflow(t *testing.T) {
 
 	m := sizedOrg(newTestOrgModel(t), 100, 24)
 	wide := m.View()
-	assertOrgBounded(t, wide, 100, 24)
+	uitest.AssertBounded(t, wide, 100, 24)
 	// Wide dual should mention both pane titles.
 	if !strings.Contains(wide, "Orgs") || !strings.Contains(wide, "Members") {
 		t.Fatalf("wide view missing pane titles:\n%s", wide)
@@ -134,7 +115,7 @@ func TestOrgView_DualVsSingleReflow(t *testing.T) {
 
 	m = sizedOrg(m, 40, 24)
 	narrow := m.View()
-	assertOrgBounded(t, narrow, 40, 24)
+	uitest.AssertBounded(t, narrow, 40, 24)
 	// Single-pane still usable; focused org list remains.
 	if !strings.Contains(narrow, "default") && !strings.Contains(narrow, "Orgs") {
 		t.Fatalf("narrow view missing org content:\n%s", narrow)
@@ -153,7 +134,7 @@ func TestOrgView_OverlayBounded(t *testing.T) {
 		if out == "" {
 			t.Fatalf("%dx%d overlay empty", s.w, s.h)
 		}
-		assertOrgBounded(t, out, s.w, s.h)
+		uitest.AssertBounded(t, out, s.w, s.h)
 	}
 }
 
@@ -188,6 +169,6 @@ func TestOrgView_EmptyRegistryBounded(t *testing.T) {
 		if !strings.Contains(out, "No campaigns") && !strings.Contains(out, "Orgs") {
 			t.Fatalf("%dx%d empty view missing placeholder:\n%s", s.w, s.h, out)
 		}
-		assertOrgBounded(t, out, s.w, s.h)
+		uitest.AssertBounded(t, out, s.w, s.h)
 	}
 }

--- a/cmd/camp/org/tui_view.go
+++ b/cmd/camp/org/tui_view.go
@@ -160,19 +160,15 @@ func (m orgTUIModel) emptyView() string {
 // frame hard-caps line count and width so a short/narrow split can never be
 // overpainted. Dual-pane body lines are pre-joined; this is the final guard.
 func (m orgTUIModel) frame(lines []string, lay orgLayout) string {
-	if m.height > 0 {
-		budget := max(m.height, 1)
-		if len(lines) > budget {
-			lines = lines[:budget]
-		}
-	}
-	// Body lines from dual panes may already span full terminal width; clamp
-	// everything to the outer canvas when known.
 	cw := lay.cw
 	if cw <= 0 && m.width > 0 {
 		cw = m.width
 	}
-	return strings.Join(ui.ClampLines(lines, cw), "\n") + "\n"
+	budget := 0
+	if m.height > 0 {
+		budget = max(m.height, 1)
+	}
+	return ui.FitFullscreenView(strings.Join(ui.CapFrame(lines, cw, budget), "\n"), m.height)
 }
 
 func (m orgTUIModel) bodyLines(lay orgLayout) []string {
@@ -411,17 +407,7 @@ func (m orgTUIModel) footer(cw int) string {
 		mid = "j/k members . h orgs . m move . c create . q"
 		short = "j/k . h . q"
 	}
-	help := full
-	if cw > 0 && lipgloss.Width(help) > cw {
-		help = mid
-	}
-	if cw > 0 && lipgloss.Width(help) > cw {
-		help = short
-	}
-	if cw > 0 && lipgloss.Width(help) > cw {
-		help = "q"
-	}
-	return orgHelpStyle.Render(help)
+	return orgHelpStyle.Render(ui.CollapseHelp(cw, full, mid, short, "q"))
 }
 
 func (m orgTUIModel) statusLine() string {

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -38,6 +38,34 @@ func ClampLines(lines []string, w int) []string {
 	return out
 }
 
+// CapFrame is the pure canvas guard used by interactive views: keep at most h
+// rows and clamp each line to width w. h <= 0 skips the height cap; w <= 0
+// skips width clamping (same passthrough contract as ClampLines).
+func CapFrame(lines []string, w, h int) []string {
+	if h > 0 && len(lines) > h {
+		lines = lines[:h]
+	}
+	return ClampLines(lines, w)
+}
+
+// CollapseHelp picks the first help level whose display width fits in cw.
+// When cw <= 0 (size unknown), the first level is returned. If no level fits,
+// the last level is returned so callers can still render a minimal prompt.
+func CollapseHelp(cw int, levels ...string) string {
+	if len(levels) == 0 {
+		return ""
+	}
+	if cw <= 0 {
+		return levels[0]
+	}
+	for _, s := range levels {
+		if lipgloss.Width(s) <= cw {
+			return s
+		}
+	}
+	return levels[len(levels)-1]
+}
+
 // FitFullscreenView keeps a Bubble Tea full-screen view within the terminal's
 // row budget. Bubble Tea splits views on newlines and, when there are too many
 // rows, keeps the bottom rows. A trailing newline therefore creates a phantom

--- a/internal/ui/layout_test.go
+++ b/internal/ui/layout_test.go
@@ -3,6 +3,8 @@ package ui
 import (
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 func TestTruncate(t *testing.T) {
@@ -45,6 +47,48 @@ func TestClampLines_ZeroWidthIsPassthrough(t *testing.T) {
 		if out[i] != in[i] {
 			t.Errorf("ClampLines width 0 altered line %d: %q -> %q", i, in[i], out[i])
 		}
+	}
+}
+
+func TestCapFrame_HeightAndWidth(t *testing.T) {
+	in := []string{"alpha", "bravo-charlie", "delta", "echo"}
+	out := CapFrame(in, 5, 2)
+	if len(out) != 2 {
+		t.Fatalf("CapFrame height: got %d lines, want 2: %v", len(out), out)
+	}
+	for i, line := range out {
+		if got := lipgloss.Width(line); got > 5 {
+			t.Errorf("CapFrame width: line %d width %d > 5 (%q)", i, got, line)
+		}
+	}
+}
+
+func TestCapFrame_ZeroMeansPassthroughLimits(t *testing.T) {
+	in := []string{"one", "two", "three"}
+	out := CapFrame(in, 0, 0)
+	if len(out) != 3 || out[0] != "one" || out[2] != "three" {
+		t.Fatalf("CapFrame(0,0) = %v, want passthrough", out)
+	}
+}
+
+func TestCollapseHelp(t *testing.T) {
+	full := "j/k move . g go . f filter . q quit"
+	mid := "j/k . g . q"
+	short := "q"
+	if got := CollapseHelp(0, full, mid, short); got != full {
+		t.Errorf("unknown width: got %q, want full", got)
+	}
+	if got := CollapseHelp(80, full, mid, short); got != full {
+		t.Errorf("wide: got %q, want full", got)
+	}
+	if got := CollapseHelp(lipgloss.Width(mid), full, mid, short); got != mid {
+		t.Errorf("mid width: got %q, want mid", got)
+	}
+	if got := CollapseHelp(1, full, mid, short); got != short {
+		t.Errorf("tiny: got %q, want short", got)
+	}
+	if got := CollapseHelp(10); got != "" {
+		t.Errorf("no levels: got %q, want empty", got)
 	}
 }
 

--- a/internal/ui/uitest/bounded.go
+++ b/internal/ui/uitest/bounded.go
@@ -1,0 +1,28 @@
+// Package uitest holds shared assertions for camp interactive view tests.
+package uitest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// AssertBounded fails if the rendered view exceeds the terminal canvas.
+// w <= 0 skips width checks; h <= 0 skips height checks. Trailing newlines are
+// ignored when counting rows so FitFullscreenView output compares cleanly.
+func AssertBounded(t testing.TB, out string, w, h int) {
+	t.Helper()
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if h > 0 && len(lines) > h {
+		t.Fatalf("%dx%d: rendered %d lines, exceeds height %d:\n%s", w, h, len(lines), h, out)
+	}
+	if w <= 0 {
+		return
+	}
+	for i, ln := range lines {
+		if got := lipgloss.Width(ln); got > w {
+			t.Fatalf("%dx%d: line %d width %d exceeds terminal width %d: %q", w, h, i, got, w, ln)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Lift pure canvas helpers that list/festivals/org had reinvented into `internal/ui`, without introducing a browser framework.

- **`ui.CapFrame`** — height + width clamp for frame paint
- **`ui.CollapseHelp`** — progressive help levels by terminal width
- **`uitest.AssertBounded`** — shared responsive assertion
- Rewire `camp list`, `camp festivals`, and `camp org` footers/frames/tests
- Org frame now also uses `FitFullscreenView` (no phantom trailing row), matching list/festivals

Domain layout (dual-pane org, row content, chrome math) stays local to each command.

## Test plan

- [x] `go test ./internal/ui/...`
- [x] `go test ./cmd/camp/org/ ./cmd/camp/festivals/`
- [x] `go test ./cmd/camp/ -run 'ListView_|ListColumns_'`
- [ ] Spot-check: `camp list`, `camp festivals`, `camp org` still reflow in narrow splits

WI-93e0fc