### PR TITLE
fix(settings): ESC back-nav, in-TUI concepts, clarify daemon allowlist

### DIFF
--- a/cmd/camp/settings.go
+++ b/cmd/camp/settings.go
@@ -133,7 +133,9 @@ func runScopeMenu(ctx context.Context, cat []settings.SettingEntry, scope settin
 		}
 
 		switch choice {
-		case valBack:
+		case valBack, "":
+			// Empty choice is how some terminals surface ESC on Select
+			// without ErrUserAborted — treat it as Back.
 			return nil
 		case valSeparator:
 			continue
@@ -244,7 +246,7 @@ func editGlobalConfig(ctx context.Context, e settings.SettingEntry, campaignRoot
 		}
 
 		switch choice {
-		case valBack:
+		case valBack, "":
 			return nil
 		case valSeparator:
 			continue
@@ -310,7 +312,7 @@ func editLocalSettingsFile(ctx context.Context, e settings.SettingEntry, campaig
 		}
 
 		switch choice {
-		case valBack:
+		case valBack, "":
 			return nil
 		case valSeparator:
 			continue

--- a/cmd/camp/settings_allowlist.go
+++ b/cmd/camp/settings_allowlist.go
@@ -32,7 +32,9 @@ func editAllowlist(ctx context.Context, e settings.SettingEntry, campaignRoot st
 			return camperrors.Wrap(err, "loading allowlist")
 		}
 
-		desc := fmt.Sprintf("File: %s (inherit_defaults: %v)", settings.CatalogPath(e, campaignRoot), al.InheritDefaults)
+		desc := fmt.Sprintf(
+			"File: %s (inherit_defaults: %v)\nDaemon/agent tool permissions — not camp CLI gates. Edit for obey-daemon consumers.",
+			settings.CatalogPath(e, campaignRoot), al.InheritDefaults)
 		var choice string
 		form := huh.NewForm(huh.NewGroup(
 			huh.NewSelect[string]().

--- a/cmd/camp/settings_campaign.go
+++ b/cmd/camp/settings_campaign.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -11,7 +10,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/Obedience-Corp/camp/internal/config"
-	"github.com/Obedience-Corp/camp/internal/editor"
 	"github.com/Obedience-Corp/camp/internal/settings"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/Obedience-Corp/camp/internal/ui/theme"
@@ -26,7 +24,7 @@ func editCampaignManifest(ctx context.Context, e settings.SettingEntry, campaign
 		options := []huh.Option[string]{
 			huh.NewOption("Identity, mission, and type", "scalars"),
 			huh.NewOption("Intent tags", "tags"),
-			huh.NewOption("Concepts taxonomy (opens editor)", "concepts"),
+			huh.NewOption("Concepts taxonomy", "concepts"),
 			huh.NewOption(rowSeparator, valSeparator),
 			huh.NewOption("Back", valBack),
 		}
@@ -48,7 +46,7 @@ func editCampaignManifest(ctx context.Context, e settings.SettingEntry, campaign
 		}
 
 		switch choice {
-		case valBack:
+		case valBack, "":
 			return nil
 		case valSeparator:
 			continue
@@ -61,7 +59,7 @@ func editCampaignManifest(ctx context.Context, e settings.SettingEntry, campaign
 				return err
 			}
 		case "concepts":
-			if err := editConceptsViaEditor(ctx, e, campaignRoot); err != nil {
+			if err := editConceptsInTUI(ctx, e, campaignRoot); err != nil {
 				return err
 			}
 		}
@@ -173,11 +171,7 @@ func editIntentTags(ctx context.Context, e settings.SettingEntry, campaignRoot s
 	return saveCampaignManifest(ctx, campaignRoot, cfg)
 }
 
-const conceptsEditorHeader = `# Edit the campaign concept taxonomy below (YAML list of concepts).
-# Each concept needs a name. A group-only parent may omit path but must have
-# children. Invalid YAML or a missing name is rejected and campaign.yaml is
-# left unchanged.
-`
+const conceptsEditorHelp = `YAML list of concepts. Each needs a name. A group-only parent may omit path but must have children. Invalid YAML or a missing name is rejected and campaign.yaml is left unchanged.`
 
 // validateConcepts checks an edited concept tree before it is written. Each
 // entry needs a name, and needs either a path or children (a pure-parent node
@@ -202,10 +196,11 @@ func validateConceptEntries(entries []config.ConceptEntry, loc string) error {
 	return nil
 }
 
-// editConceptsViaEditor round-trips the concepts subtree through $EDITOR. It is
-// the single explicit editor exception (DP2): the edit is all-or-nothing, so an
-// invalid or unparseable result never touches campaign.yaml.
-func editConceptsViaEditor(ctx context.Context, e settings.SettingEntry, campaignRoot string) error {
+// editConceptsInTUI edits the concepts subtree as YAML inside the settings TUI.
+// External $EDITOR was unreliable here (GUI editors without --wait hang; nested
+// TUI + editor leaves the terminal wedged). The edit is all-or-nothing: invalid
+// YAML or validation failure never touches campaign.yaml.
+func editConceptsInTUI(ctx context.Context, e settings.SettingEntry, campaignRoot string) error {
 	if !ui.IsTerminal() {
 		return camperrors.Wrap(camperrors.ErrInvalidInput, "editing concepts requires an interactive terminal")
 	}
@@ -219,24 +214,27 @@ func editConceptsViaEditor(ctx context.Context, e settings.SettingEntry, campaig
 	if err != nil {
 		return camperrors.Wrap(err, "serializing concepts")
 	}
+	body := strings.TrimSpace(string(data))
+	if body == "null" || body == "" {
+		body = "[]"
+	}
 
-	tmpPath, err := writeConceptsTempFile(data)
-	if err != nil {
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewText().
+			Title("Concepts taxonomy (YAML)").
+			Description("File: " + settings.CatalogPath(e, campaignRoot) + "\n" + conceptsEditorHelp).
+			Value(&body),
+	))
+
+	if err := theme.RunForm(ctx, form); err != nil {
+		if theme.IsCancelled(err) {
+			return nil
+		}
 		return err
-	}
-	defer func() { _ = os.Remove(tmpPath) }()
-
-	if err := editor.Edit(ctx, tmpPath); err != nil {
-		return camperrors.Wrap(err, "running editor")
-	}
-
-	raw, err := os.ReadFile(tmpPath)
-	if err != nil {
-		return camperrors.Wrap(err, "reading edited concepts")
 	}
 
 	var edited []config.ConceptEntry
-	if err := yaml.Unmarshal(raw, &edited); err != nil {
+	if err := yaml.Unmarshal([]byte(body), &edited); err != nil {
 		fmt.Println(ui.Warning(fmt.Sprintf("Concepts not saved: invalid YAML: %v", err)))
 		return nil
 	}
@@ -247,28 +245,6 @@ func editConceptsViaEditor(ctx context.Context, e settings.SettingEntry, campaig
 
 	cfg.ConceptList = edited
 	return saveCampaignManifest(ctx, campaignRoot, cfg)
-}
-
-func writeConceptsTempFile(data []byte) (string, error) {
-	tmp, err := os.CreateTemp("", "camp-concepts-*.yaml")
-	if err != nil {
-		return "", camperrors.Wrap(err, "creating temp file")
-	}
-	if _, err := tmp.WriteString(conceptsEditorHeader); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmp.Name())
-		return "", camperrors.Wrap(err, "writing temp file")
-	}
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmp.Name())
-		return "", camperrors.Wrap(err, "writing temp file")
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmp.Name())
-		return "", camperrors.Wrap(err, "closing temp file")
-	}
-	return tmp.Name(), nil
 }
 
 // saveCampaignManifest persists campaign.yaml edits through SaveCampaignConfig,

--- a/docs/campaign-settings-files.md
+++ b/docs/campaign-settings-files.md
@@ -298,7 +298,9 @@ Notes:
 
 ### `.campaign/settings/allowlist.json`
 
-Optional daemon command allowlist overrides for a specific campaign.
+Optional **daemon/agent** command allowlist overrides for a specific campaign.
+This is not a camp CLI gate — `camp` itself never consults this file. It is for
+obey-daemon / agent runners that honor campaign tool permissions.
 
 Example:
 
@@ -328,9 +330,9 @@ Notes:
 - `inherit_defaults: true` means the campaign file extends the daemon defaults.
 - `inherit_defaults: false` means only commands listed in this file are
   explicitly allowed.
-- `camp settings` (Local Settings, then Command allowlist) edits this file:
-  toggle `allowed` per command, add, and remove commands. `inherit_defaults` is
-  shown there but only changed by hand-editing.
+- `camp settings` (Local Settings, then Daemon command allowlist) edits this
+  file: toggle `allowed` per command, add, and remove commands.
+  `inherit_defaults` is shown there but only changed by hand-editing.
 
 ### `.campaign/settings/local.json`
 
@@ -390,11 +392,12 @@ Local (under `.campaign/`):
 
 - `campaign.yaml` - identity, mission, and type via a structured form; the
   `intents.tags` list via a one-per-line editor; and the nested `concepts`
-  taxonomy via a `$EDITOR` round-trip (the single explicit editor exception,
-  validated all-or-nothing so an invalid edit never touches the file).
+  taxonomy via an in-TUI YAML editor (validated all-or-nothing so an invalid
+  edit never touches the file).
 - `settings/local.json` - the campaign theme override.
-- `settings/allowlist.json` - toggle `allowed` per command, add, and remove
-  commands. `inherit_defaults` is shown but not changed here.
+- `settings/allowlist.json` - daemon/agent tool allowlist (not camp CLI):
+  toggle `allowed` per command, add, and remove commands. `inherit_defaults` is
+  shown but not changed here.
 
 Global (under `~/.obey/campaign/`):
 

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -161,12 +161,20 @@ func MoveFile(src, dst string) error {
 //   - macOS/Linux: nano
 
 // guiEditors contains editor names that require --wait flag to block.
+// Without --wait these fork and return immediately, which looks like a hang
+// to callers that expect the editor session to finish (or worse, a no-op save).
 var guiEditors = map[string]bool{
 	"code":          true,
 	"code-insiders": true,
 	"subl":          true,
 	"sublime_text":  true,
 	"atom":          true,
+	"cursor":        true,
+	"zed":           true,
+	"zeditor":       true,
+	"windsurf":      true,
+	"codium":        true,
+	"code-oss":      true,
 }
 
 // BuildEditorCommand constructs an exec.Cmd for launching the specified editor.

--- a/internal/settings/builder.go
+++ b/internal/settings/builder.go
@@ -67,9 +67,10 @@ func staticEntries() []SettingEntry {
 			Owner:  "camp",
 		},
 		{
-			ID:     "allowlist",
-			Title:  "Command allowlist",
-			Desc:   "Tools this campaign permits agents to run.",
+			ID:    "allowlist",
+			Title: "Daemon command allowlist",
+			Desc: "Agent/daemon tool permissions for this campaign (not camp CLI itself). " +
+				"Consumers: obey-daemon / agent runners that honor .campaign/settings/allowlist.json.",
 			Scope:  ScopeLocal,
 			Path:   ".campaign/settings/allowlist.json",
 			Format: FormatJSON,

--- a/tests/integration/settings_campaign_test.go
+++ b/tests/integration/settings_campaign_test.go
@@ -4,7 +4,6 @@
 package integration
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,11 +11,9 @@ import (
 )
 
 // TestIntegration_SettingsConceptsEditorRoundTrip drives `camp settings` through
-// a real TTY to the campaign-manifest concepts editor, hands off to a scripted
-// $EDITOR that rewrites the concepts temp file, and verifies the edit is
-// persisted to .campaign/campaign.yaml while the rest of the manifest is left
-// intact. Runs entirely inside the shared container so it never touches the host
-// filesystem.
+// a real TTY to the campaign-manifest concepts editor (in-TUI YAML text field),
+// pastes a known-valid concept list, and verifies the edit is persisted to
+// .campaign/campaign.yaml while the rest of the manifest is left intact.
 func TestIntegration_SettingsConceptsEditorRoundTrip(t *testing.T) {
 	skipUnlessSettingsTTYTests(t)
 	tc := GetSharedContainer(t)
@@ -24,7 +21,6 @@ func TestIntegration_SettingsConceptsEditorRoundTrip(t *testing.T) {
 	const (
 		campaignDir = "/test/settings-concepts"
 		campaignYML = campaignDir + "/.campaign/campaign.yaml"
-		editorPath  = "/test/concepts-editor.sh"
 	)
 
 	_, err := tc.RunCamp(
@@ -39,36 +35,21 @@ func TestIntegration_SettingsConceptsEditorRoundTrip(t *testing.T) {
 	)
 	require.NoError(t, err, "camp init should succeed")
 
-	// The scripted editor overwrites the concepts temp file with a known-valid
-	// concept list, so the outcome is deterministic regardless of the seeded
-	// concepts.
-	editorScript := `#!/bin/sh
-set -eu
-printf 'EDITOR_START\n'
-cat > "$1" <<'YAML'
-- name: integration-concept
-  path: some/integration/path/
-  description: added by the integration editor
-YAML
-printf 'EDITOR_DONE\n'
-`
-	require.NoError(t, tc.WriteFile(editorPath, editorScript))
-	tc.Shell(t, fmt.Sprintf("chmod +x %s", editorPath))
-
-	// huh aborts a form on Ctrl+C (\x03); each abort backs out one menu level,
-	// so three unwind manifest -> local -> top and exit camp settings cleanly.
+	// huh Text: type replacement YAML, then Ctrl+D / submit per form binding.
+	// Interactive harness uses Enter to submit multi-line when WaitFor matches
+	// the text field title, then aborts menus with Ctrl+C.
+	conceptYAML := "- name: integration-concept\n  path: some/integration/path/\n  description: added by integration test\n"
 	steps := []InteractiveStep{
-		{WaitFor: "Select configuration scope", Input: "\x1b[B\r"}, // top menu: down to Local, enter
-		{WaitFor: "Files under .campaign/", Input: "\r"},           // local menu: Campaign manifest (first row), enter
-		{WaitFor: "Concepts taxonomy", Input: "\x1b[B\x1b[B\r"},    // manifest menu: down to Concepts, enter
-		{WaitFor: "EDITOR_DONE"},                                   // scripted editor rewrote the temp file
-		{WaitFor: "Concepts taxonomy", Input: "\x03"},              // back at manifest menu, abort
-		{WaitFor: "Files under .campaign/", Input: "\x03"},         // back at local menu, abort
-		{WaitFor: "Select configuration scope", Input: "\x03"},     // back at top menu, abort -> exit
+		{WaitFor: "Select configuration scope", Input: "\x1b[B\r"}, // top: Local
+		{WaitFor: "Files under .campaign/", Input: "\r"},           // Campaign manifest
+		{WaitFor: "Concepts taxonomy", Input: "\x1b[B\x1b[B\r"},    // Concepts row
+		{WaitFor: "Concepts taxonomy (YAML)", Input: "\x01\x0b" + conceptYAML + "\r"}, // clear-ish + paste + submit
+		{WaitFor: "Concepts taxonomy", Input: "\x03"},              // back at manifest
+		{WaitFor: "Files under .campaign/", Input: "\x03"},         // local
+		{WaitFor: "Select configuration scope", Input: "\x03"},     // top exit
 	}
-	output, err := tc.RunCampInteractiveStepsInDirWithEnv(
+	output, err := tc.RunCampInteractiveStepsInDir(
 		campaignDir,
-		map[string]string{"EDITOR": editorPath},
 		steps,
 		"--no-color", "settings",
 	)


### PR DESCRIPTION
## Summary

Fixes several `camp settings` TUI pain points:

1. **ESC / back navigation** — nested Select menus now treat empty choice as Back (same as the allowlist/registry screens), so ESC leaves one menu level instead of no-op looping.
2. **Concepts taxonomy hang** — stop shelling out to `$EDITOR` for concepts. Edit as YAML inside the TUI; invalid YAML still never writes `campaign.yaml`. (External GUI editors without proper wait were hanging the session.)
3. **Command allowlist confusion** — rename/describe it as **Daemon command allowlist**. Camp CLI does not enforce this file; it is for obey-daemon/agent tool permissions.
4. **Editor wait list** — add `cursor`, `zed`, `zeditor`, `windsurf`, `codium`, `code-oss` so other call sites that still use `$EDITOR` block correctly.

## Test plan

- [x] `go test ./cmd/camp/ ./internal/settings/ ./internal/editor/`
- [ ] Manual: `camp settings` → Local → Campaign manifest → ESC should return one level at a time
- [ ] Manual: Concepts taxonomy edits YAML in-TUI and saves/rejects invalid input
- [ ] Manual: Allowlist row shows daemon-oriented description

WI-333b2e