### PR TITLE
feat(settings): global/local commit ref-sync and tag-tracing prefs

### DIFF
--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -211,10 +211,13 @@ func runCommit(cmd *cobra.Command, args []string) error {
 
 	// Prepend campaign tag (graceful degradation if config unavailable).
 	// Resolves the active workitem (and any captured quest) so the tag
-	// includes WI-<ref> when one is in context.
+	// includes WI-<ref> when one is in context. Skip when commit tracing is
+	// disabled via settings.
 	if cfg, cfgErr := config.LoadCampaignConfig(ctx, campRoot); cfgErr == nil && message != "" {
-		questID, workitemRef := resolveCommitContext(ctx, campRoot, commitWorkitem)
-		message = commitkit.PrependContextTagsFullNamed(cfg.Name, cfg.ID, questID, "", workitemRef, message)
+		if config.EffectiveCommitPrefs(ctx, campRoot).TagCommits() {
+			questID, workitemRef := resolveCommitContext(ctx, campRoot, commitWorkitem)
+			message = commitkit.PrependContextTagsFullNamed(cfg.Name, cfg.ID, questID, "", workitemRef, message)
+		}
 	}
 
 	// Perform commit

--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -46,6 +46,7 @@ var (
 	projectCommitAll       bool
 	projectCommitAmend     bool
 	projectCommitSync      bool
+	projectCommitNoSync    bool
 	projectCommitAutoWrite bool
 	projectCommitWorkitem  string
 )
@@ -55,7 +56,8 @@ func init() {
 	projectCommitCmd.Flags().StringArrayVarP(&projectCommitMessages, "message", "m", nil, "Commit message (repeatable; multiple -m are joined git-style into subject + body; required unless --auto-write)")
 	projectCommitCmd.Flags().BoolVarP(&projectCommitAll, "all", "a", true, "Stage all changes")
 	projectCommitCmd.Flags().BoolVar(&projectCommitAmend, "amend", false, "Amend the previous commit")
-	projectCommitCmd.Flags().BoolVar(&projectCommitSync, "sync", false, "Sync submodule ref at campaign root after commit (opt-in)")
+	projectCommitCmd.Flags().BoolVar(&projectCommitSync, "sync", false, "Sync submodule ref at campaign root after commit (also enabled by commit.sync_project_refs setting)")
+	projectCommitCmd.Flags().BoolVar(&projectCommitNoSync, "no-sync", false, "Do not sync submodule ref even if settings enable it")
 	projectCommitCmd.Flags().BoolVar(&projectCommitAutoWrite, "auto-write", false, "Run configured commit message writer")
 	projectCommitCmd.Flags().StringVar(&projectCommitWorkitem, "workitem", "", "explicit workitem selector for the commit tag (overrides cwd-based resolution)")
 
@@ -176,8 +178,9 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 
 	// Prepend campaign tag (graceful degradation if config unavailable).
 	// Resolves the active workitem so the tag includes WI-<ref> when the
-	// project is linked.
-	if cfg != nil {
+	// project is linked. Skip when commit tracing is disabled in settings.
+	commitPrefs := config.EffectiveCommitPrefs(ctx, campRoot)
+	if cfg != nil && commitPrefs.TagCommits() {
 		questID, workitemRef := resolveProjectCommitContext(ctx, campRoot, resolvedPath, projectCommitWorkitem)
 		message = commitkit.PrependContextTagsFullNamed(cfg.Name, cfg.ID, questID, "", workitemRef, message)
 	}
@@ -205,11 +208,13 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 		emitter.CommitEvidence(ctx, ledgerkit.Scope{}, campRoot, resolvedPath, sha, message)
 	}
 
-	// Auto-sync submodule ref in campaign root. A worktree commit lands on its
-	// own branch under the gitignored worktrees dir, so there is no submodule
-	// ref to sync at the campaign root.
-	if projectCommitSync && !inWorktree && git.HasPathDiff(ctx, campRoot, resolvedPath) {
-		if err := syncParentRef(ctx, campRoot, relPath, cfg, emitter); err != nil {
+	// Sync submodule ref in campaign root when enabled by --sync or by the
+	// commit.sync_project_refs setting (and not disabled by --no-sync). A
+	// worktree commit lands on its own branch under the gitignored worktrees
+	// dir, so there is no submodule ref to sync at the campaign root.
+	doSync := (commitPrefs.SyncProjectRefs || projectCommitSync) && !projectCommitNoSync
+	if doSync && !inWorktree && git.HasPathDiff(ctx, campRoot, resolvedPath) {
+		if err := syncParentRef(ctx, campRoot, relPath, cfg, emitter, commitPrefs); err != nil {
 			fmt.Println()
 			fmt.Println(ui.Warning("Could not auto-sync campaign root: " + err.Error()))
 			fmt.Println(ui.Dim("Run 'camp commit' to update manually."))
@@ -220,7 +225,7 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 }
 
 // syncParentRef stages and commits the submodule ref update in the campaign root.
-func syncParentRef(ctx context.Context, campRoot, relPath string, cfg *config.CampaignConfig, emitter *ledger.Emitter) error {
+func syncParentRef(ctx context.Context, campRoot, relPath string, cfg *config.CampaignConfig, emitter *ledger.Emitter, prefs config.CommitPrefs) error {
 	if err := git.StageFiles(ctx, campRoot, relPath); err != nil {
 		return camperrors.Wrap(err, "staging submodule ref")
 	}
@@ -234,7 +239,7 @@ func syncParentRef(ctx context.Context, campRoot, relPath string, cfg *config.Ca
 
 	projName := filepath.Base(relPath)
 	msg := fmt.Sprintf("update %s submodule ref", projName)
-	if cfg != nil {
+	if cfg != nil && prefs.TagCommits() {
 		msg = git.PrependContextTagsFull(cfg.Name, cfg.ID, "", "", "", msg)
 	}
 

--- a/cmd/camp/refs/commands.go
+++ b/cmd/camp/refs/commands.go
@@ -95,7 +95,7 @@ func runRefsSync(cmd *cobra.Command, args []string) error {
 
 	cfg, _ := config.LoadCampaignConfig(ctx, campRoot)
 	msg := fmt.Sprintf("sync submodule refs: %s", strings.Join(names, ", "))
-	if cfg != nil {
+	if cfg != nil && config.EffectiveCommitPrefs(ctx, campRoot).TagCommits() {
 		msg = git.PrependContextTagsFull(cfg.Name, cfg.ID, "", "", "", msg)
 	}
 	if err := git.CommitScoped(ctx, campRoot, toSync, &git.CommitOptions{Message: msg}); err != nil {

--- a/cmd/camp/settings.go
+++ b/cmd/camp/settings.go
@@ -223,6 +223,8 @@ func editGlobalConfig(ctx context.Context, e settings.SettingEntry, campaignRoot
 			huh.NewOption(fmt.Sprintf("Campaigns Dir  %s", displayStr(cfg.CampaignsDir, "~/campaigns")), "campaigns_dir"),
 			huh.NewOption(fmt.Sprintf("Verbose        %s", boolStr(cfg.Verbose)), "verbose"),
 			huh.NewOption(fmt.Sprintf("No Color       %s", boolStr(cfg.NoColor)), "no_color"),
+			huh.NewOption(fmt.Sprintf("Sync project refs  %s", boolStr(cfg.Commit.SyncProjectRefs)), "commit_sync_refs"),
+			huh.NewOption(fmt.Sprintf("Disable commit tags %s", boolStr(cfg.Commit.DisableCommitTags)), "commit_disable_tags"),
 			huh.NewOption(rowSeparator, valSeparator),
 			huh.NewOption("Back", valBack),
 		}
@@ -270,6 +272,16 @@ func editGlobalConfig(ctx context.Context, e settings.SettingEntry, campaignRoot
 			if err := config.SaveGlobalConfig(ctx, cfg); err != nil {
 				return camperrors.Wrap(err, "saving config")
 			}
+		case "commit_sync_refs":
+			cfg.Commit.SyncProjectRefs = !cfg.Commit.SyncProjectRefs
+			if err := config.SaveGlobalConfig(ctx, cfg); err != nil {
+				return camperrors.Wrap(err, "saving config")
+			}
+		case "commit_disable_tags":
+			cfg.Commit.DisableCommitTags = !cfg.Commit.DisableCommitTags
+			if err := config.SaveGlobalConfig(ctx, cfg); err != nil {
+				return camperrors.Wrap(err, "saving config")
+			}
 		}
 	}
 }
@@ -285,10 +297,19 @@ func editLocalSettingsFile(ctx context.Context, e settings.SettingEntry, campaig
 			return camperrors.Wrap(err, "loading local settings")
 		}
 
+		locSync, locTags := false, false
+		if local.Commit != nil {
+			locSync, locTags = local.Commit.SyncProjectRefs, local.Commit.DisableCommitTags
+		}
+		eff := config.EffectiveCommitPrefs(ctx, campaignRoot)
 		options := []huh.Option[string]{
 			huh.NewOption(fmt.Sprintf("Theme Override  %s (effective: %s)",
 				displayStr(local.ThemeOverride, "inherit global"),
 				config.EffectiveTheme(ctx)), "theme_override"),
+			huh.NewOption(fmt.Sprintf("Sync project refs  %s (effective: %s)",
+				boolStr(locSync), boolStr(eff.SyncProjectRefs)), "commit_sync_refs"),
+			huh.NewOption(fmt.Sprintf("Disable commit tags %s (effective: %s)",
+				boolStr(locTags), boolStr(eff.DisableCommitTags)), "commit_disable_tags"),
 			huh.NewOption(rowSeparator, valSeparator),
 			huh.NewOption("Back", valBack),
 		}
@@ -318,8 +339,36 @@ func editLocalSettingsFile(ctx context.Context, e settings.SettingEntry, campaig
 			if err := editLocalThemeOverride(ctx, campaignRoot, local.ThemeOverride); err != nil {
 				return err
 			}
+		case "commit_sync_refs":
+			if err := toggleLocalCommitPref(ctx, campaignRoot, true); err != nil {
+				return err
+			}
+		case "commit_disable_tags":
+			if err := toggleLocalCommitPref(ctx, campaignRoot, false); err != nil {
+				return err
+			}
 		}
 	}
+}
+
+// toggleLocalCommitPref flips one local commit preference. When local.Commit is
+// nil, seed it from the current effective prefs so the other field keeps its
+// global meaning until explicitly changed.
+func toggleLocalCommitPref(ctx context.Context, campaignRoot string, syncRefs bool) error {
+	return config.WithLocalSettingsLock(ctx, campaignRoot, func(s *config.LocalSettings) error {
+		base := config.EffectiveCommitPrefs(ctx, campaignRoot)
+		if s.Commit != nil {
+			base = *s.Commit
+		}
+		if syncRefs {
+			base.SyncProjectRefs = !base.SyncProjectRefs
+		} else {
+			base.DisableCommitTags = !base.DisableCommitTags
+		}
+		cp := base
+		s.Commit = &cp
+		return nil
+	})
 }
 
 func editLocalThemeOverride(ctx context.Context, campaignRoot, current string) error {

--- a/cmd/camp/settings_cli.go
+++ b/cmd/camp/settings_cli.go
@@ -42,6 +42,14 @@ const (
 	settingsKeyLocalCampaignMission     = "local.campaign.mission"
 	settingsKeyLocalCampaignType        = "local.campaign.type"
 	settingsKeyLocalCampaignCommitHook  = "local.campaign.commit_hook"
+
+	// Commit behavior (global defaults + local overrides + effective view).
+	settingsKeyGlobalCommitSyncRefs       = "global.commit.sync_project_refs"
+	settingsKeyGlobalCommitDisableTags    = "global.commit.disable_commit_tags"
+	settingsKeyLocalCommitSyncRefs        = "local.commit.sync_project_refs"
+	settingsKeyLocalCommitDisableTags     = "local.commit.disable_commit_tags"
+	settingsKeyEffectiveCommitSyncRefs    = "effective.commit.sync_project_refs"
+	settingsKeyEffectiveCommitDisableTags = "effective.commit.disable_commit_tags"
 )
 
 const settingsThemeInherit = "inherit"
@@ -53,7 +61,11 @@ func settingsKeys() []string {
 		settingsKeyGlobalCampaignsDir,
 		settingsKeyGlobalVerbose,
 		settingsKeyGlobalNoColor,
+		settingsKeyGlobalCommitSyncRefs,
+		settingsKeyGlobalCommitDisableTags,
 		settingsKeyLocalThemeOverride,
+		settingsKeyLocalCommitSyncRefs,
+		settingsKeyLocalCommitDisableTags,
 		settingsKeyLocalCampaignName,
 		settingsKeyLocalCampaignDescription,
 		settingsKeyLocalCampaignMission,
@@ -83,19 +95,34 @@ type settingsPayload struct {
 }
 
 type settingsGlobalPayload struct {
-	Theme        string `json:"theme"`
-	Editor       string `json:"editor"`
-	CampaignsDir string `json:"campaigns_dir"`
-	Verbose      bool   `json:"verbose"`
-	NoColor      bool   `json:"no_color"`
+	Theme        string                `json:"theme"`
+	Editor       string                `json:"editor"`
+	CampaignsDir string                `json:"campaigns_dir"`
+	Verbose      bool                  `json:"verbose"`
+	NoColor      bool                  `json:"no_color"`
+	Commit       settingsCommitPayload `json:"commit"`
 }
 
 type settingsLocalPayload struct {
-	ThemeOverride string `json:"theme_override"`
+	ThemeOverride string                 `json:"theme_override"`
+	Commit        *settingsCommitPayload `json:"commit,omitempty"`
 }
 
 type settingsEffectivePayload struct {
-	Theme string `json:"theme"`
+	Theme  string                `json:"theme"`
+	Commit settingsCommitPayload `json:"commit"`
+}
+
+type settingsCommitPayload struct {
+	SyncProjectRefs   bool `json:"sync_project_refs"`
+	DisableCommitTags bool `json:"disable_commit_tags"`
+}
+
+func commitPayload(p config.CommitPrefs) settingsCommitPayload {
+	return settingsCommitPayload{
+		SyncProjectRefs:   p.SyncProjectRefs,
+		DisableCommitTags: p.DisableCommitTags,
+	}
 }
 
 type settingsValuePayload struct {
@@ -121,17 +148,23 @@ Keys:
   global.campaigns_dir       Where camp create places new campaigns
   global.verbose             Verbose output
   global.no_color            Disable colored output
+  global.commit.sync_project_refs   Default: camp p commit updates campaign-root submodule pointer
+  global.commit.disable_commit_tags Default: skip [campaign:…] tags on camp commits
   local.theme_override       Campaign-local theme override (requires a campaign)
+  local.commit.sync_project_refs    Campaign override for project-ref sync after project commits
+  local.commit.disable_commit_tags  Campaign override to skip commit subject tags
   local.campaign.name        Campaign name in .campaign/campaign.yaml
   local.campaign.description Campaign description
   local.campaign.mission     Campaign mission
   local.campaign.type        Campaign type (product, research, tools, personal)
   local.campaign.commit_hook Commit-message hook command
+  effective.commit.*         Resolved commit prefs (get only; local overrides global)
 
 The campaign.yaml list and tree fields (intents.tags, concepts) have no flat
 key and are edited only through the interactive 'camp settings' TUI.`,
 		Example: `  camp settings get
   camp settings get global.theme
+  camp settings get effective.commit.sync_project_refs
   camp settings get --json`,
 		Args:         jsoncontract.Args(SettingsJSONVersion, func() bool { return jsonOut }, cobra.MaximumNArgs(1)),
 		SilenceUsage: true,
@@ -196,10 +229,14 @@ func runSettingsGet(ctx context.Context, cmd *cobra.Command, args []string, json
 	if len(args) == 1 {
 		return printSettingsValue(ctx, cmd, args[0], cfg, local, inCampaign, jsonOut)
 	}
-	if jsonOut {
-		return emitSettingsJSON(cmd.OutOrStdout(), cfg, local, inCampaign, effective)
+	rootForEffective := ""
+	if inCampaign {
+		rootForEffective = root
 	}
-	return printSettingsAll(cmd.OutOrStdout(), cfg, local, inCampaign, effective)
+	if jsonOut {
+		return emitSettingsJSON(cmd.OutOrStdout(), cfg, local, inCampaign, effective, rootForEffective)
+	}
+	return printSettingsAll(cmd.OutOrStdout(), cfg, local, inCampaign, effective, rootForEffective)
 }
 
 // resolveSettingValue returns the value for a key, loading campaign.yaml for the
@@ -208,6 +245,20 @@ func runSettingsGet(ctx context.Context, cmd *cobra.Command, args []string, json
 func resolveSettingValue(ctx context.Context, key string, cfg *config.GlobalConfig, local *config.LocalSettings, inCampaign bool) (any, error) {
 	if isCampaignScalarKey(key) {
 		return campaignScalarGet(ctx, key)
+	}
+	switch key {
+	case settingsKeyEffectiveCommitSyncRefs, settingsKeyEffectiveCommitDisableTags:
+		root := ""
+		if inCampaign {
+			if r, err := campaign.DetectCached(ctx); err == nil {
+				root = r
+			}
+		}
+		prefs := config.EffectiveCommitPrefs(ctx, root)
+		if key == settingsKeyEffectiveCommitSyncRefs {
+			return prefs.SyncProjectRefs, nil
+		}
+		return prefs.DisableCommitTags, nil
 	}
 	return settingsValueFor(key, cfg, local, inCampaign)
 }
@@ -254,6 +305,26 @@ func settingsValueFor(key string, cfg *config.GlobalConfig, local *config.LocalS
 			return nil, errSettingsLocalOutsideCampaign(key)
 		}
 		return local.ThemeOverride, nil
+	case settingsKeyGlobalCommitSyncRefs:
+		return cfg.Commit.SyncProjectRefs, nil
+	case settingsKeyGlobalCommitDisableTags:
+		return cfg.Commit.DisableCommitTags, nil
+	case settingsKeyLocalCommitSyncRefs:
+		if !inCampaign {
+			return nil, errSettingsLocalOutsideCampaign(key)
+		}
+		if local.Commit == nil {
+			return false, nil
+		}
+		return local.Commit.SyncProjectRefs, nil
+	case settingsKeyLocalCommitDisableTags:
+		if !inCampaign {
+			return nil, errSettingsLocalOutsideCampaign(key)
+		}
+		if local.Commit == nil {
+			return false, nil
+		}
+		return local.Commit.DisableCommitTags, nil
 	default:
 		return nil, errSettingsUnknownKey(key)
 	}
@@ -278,7 +349,7 @@ func printSettingsValue(ctx context.Context, cmd *cobra.Command, key string, cfg
 	return err
 }
 
-func printSettingsAll(w io.Writer, cfg *config.GlobalConfig, local *config.LocalSettings, inCampaign bool, effective string) error {
+func printSettingsAll(w io.Writer, cfg *config.GlobalConfig, local *config.LocalSettings, inCampaign bool, effective, campaignRoot string) error {
 	lines := []struct {
 		key   string
 		value any
@@ -288,6 +359,8 @@ func printSettingsAll(w io.Writer, cfg *config.GlobalConfig, local *config.Local
 		{settingsKeyGlobalCampaignsDir, cfg.CampaignsDir},
 		{settingsKeyGlobalVerbose, cfg.Verbose},
 		{settingsKeyGlobalNoColor, cfg.NoColor},
+		{settingsKeyGlobalCommitSyncRefs, cfg.Commit.SyncProjectRefs},
+		{settingsKeyGlobalCommitDisableTags, cfg.Commit.DisableCommitTags},
 	}
 	for _, line := range lines {
 		if _, err := fmt.Fprintf(w, "%s = %v\n", line.key, line.value); err != nil {
@@ -298,12 +371,32 @@ func printSettingsAll(w io.Writer, cfg *config.GlobalConfig, local *config.Local
 		if _, err := fmt.Fprintf(w, "%s = %s\n", settingsKeyLocalThemeOverride, local.ThemeOverride); err != nil {
 			return err
 		}
+		locSync, locTags := false, false
+		if local.Commit != nil {
+			locSync, locTags = local.Commit.SyncProjectRefs, local.Commit.DisableCommitTags
+		}
+		if _, err := fmt.Fprintf(w, "%s = %v\n", settingsKeyLocalCommitSyncRefs, locSync); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "%s = %v\n", settingsKeyLocalCommitDisableTags, locTags); err != nil {
+			return err
+		}
 	}
-	_, err := fmt.Fprintf(w, "%s = %s\n", settingsKeyEffectiveTheme, effective)
+	// printSettingsAll is pure formatting; effective prefs are already merged
+	// via EffectiveCommitPrefs using campaignRoot (empty when outside a campaign).
+	prefs := config.EffectiveCommitPrefs(context.TODO(), campaignRoot)
+	if _, err := fmt.Fprintf(w, "%s = %s\n", settingsKeyEffectiveTheme, effective); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "%s = %v\n", settingsKeyEffectiveCommitSyncRefs, prefs.SyncProjectRefs); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(w, "%s = %v\n", settingsKeyEffectiveCommitDisableTags, prefs.DisableCommitTags)
 	return err
 }
 
-func emitSettingsJSON(w io.Writer, cfg *config.GlobalConfig, local *config.LocalSettings, inCampaign bool, effective string) error {
+func emitSettingsJSON(w io.Writer, cfg *config.GlobalConfig, local *config.LocalSettings, inCampaign bool, effective, campaignRoot string) error {
+	prefs := config.EffectiveCommitPrefs(context.TODO(), campaignRoot)
 	payload := settingsPayload{
 		SchemaVersion: SettingsJSONVersion,
 		GeneratedAt:   time.Now().UTC(),
@@ -314,11 +407,17 @@ func emitSettingsJSON(w io.Writer, cfg *config.GlobalConfig, local *config.Local
 			CampaignsDir: cfg.CampaignsDir,
 			Verbose:      cfg.Verbose,
 			NoColor:      cfg.NoColor,
+			Commit:       commitPayload(cfg.Commit),
 		},
-		Effective: settingsEffectivePayload{Theme: effective},
+		Effective: settingsEffectivePayload{Theme: effective, Commit: commitPayload(prefs)},
 	}
 	if inCampaign {
-		payload.Local = &settingsLocalPayload{ThemeOverride: local.ThemeOverride}
+		lp := &settingsLocalPayload{ThemeOverride: local.ThemeOverride}
+		if local.Commit != nil {
+			cp := commitPayload(*local.Commit)
+			lp.Commit = &cp
+		}
+		payload.Local = lp
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
@@ -328,10 +427,13 @@ func emitSettingsJSON(w io.Writer, cfg *config.GlobalConfig, local *config.Local
 func runSettingsSet(ctx context.Context, cmd *cobra.Command, key, value string) error {
 	switch {
 	case key == settingsKeyGlobalTheme, key == settingsKeyGlobalEditor, key == settingsKeyGlobalCampaignsDir,
-		key == settingsKeyGlobalVerbose, key == settingsKeyGlobalNoColor:
+		key == settingsKeyGlobalVerbose, key == settingsKeyGlobalNoColor,
+		key == settingsKeyGlobalCommitSyncRefs, key == settingsKeyGlobalCommitDisableTags:
 		return setGlobalSetting(ctx, cmd, key, value)
 	case key == settingsKeyLocalThemeOverride:
 		return setLocalThemeOverride(ctx, cmd, value)
+	case key == settingsKeyLocalCommitSyncRefs, key == settingsKeyLocalCommitDisableTags:
+		return setLocalCommitPref(ctx, cmd, key, value)
 	case isCampaignScalarKey(key):
 		return setCampaignScalar(ctx, cmd, key, value)
 	default:
@@ -434,16 +536,22 @@ func applyGlobalSetting(cfg *config.GlobalConfig, key, value string) (string, er
 		}
 		cfg.CampaignsDir = next.CampaignsDir
 		return cfg.CampaignsDir, nil
-	case settingsKeyGlobalVerbose, settingsKeyGlobalNoColor:
+	case settingsKeyGlobalVerbose, settingsKeyGlobalNoColor,
+		settingsKeyGlobalCommitSyncRefs, settingsKeyGlobalCommitDisableTags:
 		parsed, err := strconv.ParseBool(strings.ToLower(strings.TrimSpace(value)))
 		if err != nil {
 			return "", camperrors.NewValidation(key,
 				fmt.Sprintf("invalid boolean %q (valid: true, false)", value), err)
 		}
-		if key == settingsKeyGlobalVerbose {
+		switch key {
+		case settingsKeyGlobalVerbose:
 			cfg.Verbose = parsed
-		} else {
+		case settingsKeyGlobalNoColor:
 			cfg.NoColor = parsed
+		case settingsKeyGlobalCommitSyncRefs:
+			cfg.Commit.SyncProjectRefs = parsed
+		case settingsKeyGlobalCommitDisableTags:
+			cfg.Commit.DisableCommitTags = parsed
 		}
 		return strconv.FormatBool(parsed), nil
 	default:
@@ -479,6 +587,37 @@ func setLocalThemeOverride(ctx context.Context, cmd *cobra.Command, value string
 		return err
 	}
 	_, err = fmt.Fprintf(cmd.OutOrStdout(), "set %s = %s\n", settingsKeyLocalThemeOverride, normalized)
+	return err
+}
+
+func setLocalCommitPref(ctx context.Context, cmd *cobra.Command, key, value string) error {
+	root, err := campaign.DetectCached(ctx)
+	if err != nil || root == "" {
+		return errSettingsLocalOutsideCampaign(key)
+	}
+	parsed, err := strconv.ParseBool(strings.ToLower(strings.TrimSpace(value)))
+	if err != nil {
+		return camperrors.NewValidation(key,
+			fmt.Sprintf("invalid boolean %q (valid: true, false)", value), err)
+	}
+	if err := config.WithLocalSettingsLock(ctx, root, func(s *config.LocalSettings) error {
+		base := config.EffectiveCommitPrefs(ctx, root)
+		if s.Commit != nil {
+			base = *s.Commit
+		}
+		switch key {
+		case settingsKeyLocalCommitSyncRefs:
+			base.SyncProjectRefs = parsed
+		case settingsKeyLocalCommitDisableTags:
+			base.DisableCommitTags = parsed
+		}
+		cp := base
+		s.Commit = &cp
+		return nil
+	}); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "set %s = %s\n", key, strconv.FormatBool(parsed))
 	return err
 }
 

--- a/cmd/camp/worktrees/commit.go
+++ b/cmd/camp/worktrees/commit.go
@@ -143,9 +143,11 @@ func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Prepend campaign/workitem context tag.
-	questID, workitemRef := resolveWorktreeCommitContext(ctx, campRoot, wtCtx.WorktreePath, wtCommitWorkitem)
-	message = commitkit.PrependContextTagsFullNamed(cfg.Name, cfg.ID, questID, "", workitemRef, message)
+	// Prepend campaign/workitem context tag unless tracing is disabled.
+	if config.EffectiveCommitPrefs(ctx, campRoot).TagCommits() {
+		questID, workitemRef := resolveWorktreeCommitContext(ctx, campRoot, wtCtx.WorktreePath, wtCommitWorkitem)
+		message = commitkit.PrependContextTagsFullNamed(cfg.Name, cfg.ID, questID, "", workitemRef, message)
+	}
 
 	// Commit
 	fmt.Println(ui.Info("Committing changes..."))

--- a/docs/campaign-settings-files.md
+++ b/docs/campaign-settings-files.md
@@ -95,7 +95,11 @@ Current fields:
     "theme": "adaptive",
     "vim_mode": false
   },
-  "campaigns_dir": "~/campaigns/"
+  "campaigns_dir": "~/campaigns/",
+  "commit": {
+    "sync_project_refs": false,
+    "disable_commit_tags": false
+  }
 }
 ```
 
@@ -103,6 +107,10 @@ Notes:
 
 - If the file does not exist, camp loads defaults and tries to create it.
 - `editor` is only used if `$EDITOR` and `$VISUAL` are not set.
+- `commit.sync_project_refs` / `commit.disable_commit_tags` are machine-wide
+  defaults for project-ref linking after `camp p commit` and for campaign
+  subject-tag tracing. Per-campaign overrides live in
+  `.campaign/settings/local.json` under the same `commit` object.
 - `camp settings` currently supports the global settings in this file.
 
 #### `campaigns_dir`
@@ -340,7 +348,11 @@ Example:
 
 ```json
 {
-  "theme_override": "dark"
+  "theme_override": "dark",
+  "commit": {
+    "sync_project_refs": false,
+    "disable_commit_tags": false
+  }
 }
 ```
 
@@ -349,9 +361,15 @@ Notes:
 - `theme_override` forces a color theme for this campaign: one of `adaptive`,
   `light`, `dark`, or `high-contrast`. When absent or empty, the campaign
   inherits the global theme from `~/.obey/campaign/config.json`.
+- `commit` (optional) fully overrides machine-global commit prefs for this
+  campaign when present:
+  - `sync_project_refs` — when true, `camp project commit` updates the
+    campaign-root submodule pointer after a project commit (same as `--sync`).
+    Default is false. Use `--no-sync` on a single invocation to force off.
+  - `disable_commit_tags` — when true, skips `[campaign:id-…]` subject prefixes
+    on camp-managed commits. Default is false (tags enabled).
 - The file is created on first save by `camp settings` (Local Settings) or
-  `camp settings set local.theme_override <value>`. Clearing the last setting
-  deletes the file.
+  `camp settings set local.*`. Clearing the last setting deletes the file.
 - Prefer the `camp settings` commands over hand-editing; writes are atomic and
   lock-protected.
 
@@ -392,13 +410,15 @@ Local (under `.campaign/`):
   `intents.tags` list via a one-per-line editor; and the nested `concepts`
   taxonomy via a `$EDITOR` round-trip (the single explicit editor exception,
   validated all-or-nothing so an invalid edit never touches the file).
-- `settings/local.json` - the campaign theme override.
+- `settings/local.json` - the campaign theme override and optional commit
+  behavior overrides (project-ref sync, disable commit tags).
 - `settings/allowlist.json` - toggle `allowed` per command, add, and remove
   commands. `inherit_defaults` is shown but not changed here.
 
 Global (under `~/.obey/campaign/`):
 
-- `config.json` - theme, editor, campaigns dir, verbose, and no-color.
+- `config.json` - theme, editor, campaigns dir, verbose, no-color, and commit
+  defaults (project-ref sync, disable commit tags).
 - `registry.json` - view registered campaigns and make safe per-campaign edits
   (org, display name, and path repair). Path repair only points at an existing
   directory and asks for confirmation. Lifecycle operations (register,
@@ -423,10 +443,14 @@ camp settings set global.theme dark
 camp settings set local.theme_override light
 camp settings set local.theme_override inherit    # Clear the override
 camp settings set local.campaign.type research
+camp settings set global.commit.disable_commit_tags true
+camp settings set local.commit.sync_project_refs true
 ```
 
 Keys: `global.theme`, `global.editor`, `global.campaigns_dir`,
-`global.verbose`, `global.no_color`, `local.theme_override`,
+`global.verbose`, `global.no_color`, `global.commit.sync_project_refs`,
+`global.commit.disable_commit_tags`, `local.theme_override`,
+`local.commit.sync_project_refs`, `local.commit.disable_commit_tags`,
 `local.campaign.name`, `local.campaign.description`, `local.campaign.mission`,
 `local.campaign.type`, and `local.campaign.commit_hook`. The `local.*` keys
 require running inside a campaign. The campaign.yaml list and tree fields

--- a/internal/config/commit_prefs.go
+++ b/internal/config/commit_prefs.go
@@ -1,0 +1,45 @@
+package config
+
+import "context"
+
+// CommitPrefs controls campaign-aware commit behavior for camp commit paths.
+// Stored under global config.json and optionally overridden per campaign in
+// .campaign/settings/local.json.
+type CommitPrefs struct {
+	// SyncProjectRefs when true makes `camp project commit` update the
+	// campaign-root submodule pointer after a project commit (same effect as
+	// passing --sync). Default is false (opt-in).
+	SyncProjectRefs bool `json:"sync_project_refs,omitempty"`
+
+	// DisableCommitTags when true skips [campaign:id-…] subject prefixes on
+	// camp-managed commits (root, project, worktree, refs-sync). Default is
+	// false (tags enabled).
+	DisableCommitTags bool `json:"disable_commit_tags,omitempty"`
+}
+
+// TagCommits reports whether campaign subject tags should be prepended.
+func (p CommitPrefs) TagCommits() bool {
+	return !p.DisableCommitTags
+}
+
+// IsEmpty reports whether all fields are zero (default behavior).
+func (p CommitPrefs) IsEmpty() bool {
+	return !p.SyncProjectRefs && !p.DisableCommitTags
+}
+
+// EffectiveCommitPrefs merges machine-global commit prefs with an optional
+// campaign-local override. When local.Commit is non-nil it fully replaces the
+// global commit block for that campaign.
+func EffectiveCommitPrefs(ctx context.Context, campaignRoot string) CommitPrefs {
+	var prefs CommitPrefs
+	if g, err := LoadGlobalConfig(ctx); err == nil && g != nil {
+		prefs = g.Commit
+	}
+	if campaignRoot == "" {
+		return prefs
+	}
+	if loc, err := LoadLocalSettings(ctx, campaignRoot); err == nil && loc != nil && loc.Commit != nil {
+		return *loc.Commit
+	}
+	return prefs
+}

--- a/internal/config/commit_prefs_test.go
+++ b/internal/config/commit_prefs_test.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCommitPrefs_TagCommitsDefault(t *testing.T) {
+	var p CommitPrefs
+	if !p.TagCommits() {
+		t.Fatal("default CommitPrefs should enable tags")
+	}
+	p.DisableCommitTags = true
+	if p.TagCommits() {
+		t.Fatal("DisableCommitTags should disable tags")
+	}
+}
+
+func TestEffectiveCommitPrefs_GlobalOnly(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+
+	cfg := DefaultGlobalConfig()
+	cfg.Commit = CommitPrefs{SyncProjectRefs: true, DisableCommitTags: true}
+	if err := SaveGlobalConfig(context.Background(), &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	got := EffectiveCommitPrefs(context.Background(), "")
+	if !got.SyncProjectRefs || !got.DisableCommitTags {
+		t.Fatalf("global prefs not applied: %+v", got)
+	}
+}
+
+func TestEffectiveCommitPrefs_LocalOverridesGlobal(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+
+	cfg := DefaultGlobalConfig()
+	cfg.Commit = CommitPrefs{SyncProjectRefs: true, DisableCommitTags: false}
+	if err := SaveGlobalConfig(context.Background(), &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	root := filepath.Join(dir, "campaign")
+	if err := os.MkdirAll(SettingsDirPath(root), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	local := &LocalSettings{Commit: &CommitPrefs{SyncProjectRefs: false, DisableCommitTags: true}}
+	if err := SaveLocalSettings(context.Background(), root, local); err != nil {
+		t.Fatal(err)
+	}
+
+	got := EffectiveCommitPrefs(context.Background(), root)
+	if got.SyncProjectRefs {
+		t.Fatalf("local should override sync to false: %+v", got)
+	}
+	if !got.DisableCommitTags {
+		t.Fatalf("local should override tags off: %+v", got)
+	}
+}
+
+func TestLocalSettings_CommitRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	root := filepath.Join(dir, "c")
+	if err := os.MkdirAll(SettingsDirPath(root), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	in := &LocalSettings{Commit: &CommitPrefs{SyncProjectRefs: true}}
+	if err := SaveLocalSettings(context.Background(), root, in); err != nil {
+		t.Fatal(err)
+	}
+	out, err := LoadLocalSettings(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Commit == nil || !out.Commit.SyncProjectRefs {
+		t.Fatalf("round-trip lost commit prefs: %+v", out)
+	}
+	raw, err := os.ReadFile(LocalSettingsPath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := probe["commit"]; !ok {
+		t.Fatalf("local.json missing commit key: %s", raw)
+	}
+}

--- a/internal/config/localsettings.go
+++ b/internal/config/localsettings.go
@@ -39,10 +39,26 @@ func IsValidThemeName(name string) bool {
 
 type LocalSettings struct {
 	ThemeOverride string `json:"theme_override,omitempty"`
+	// Commit, when non-nil, fully replaces global commit prefs for this campaign.
+	Commit *CommitPrefs `json:"commit,omitempty"`
 }
 
 func (s *LocalSettings) IsEmpty() bool {
-	return s == nil || *s == LocalSettings{}
+	if s == nil {
+		return true
+	}
+	if s.ThemeOverride != "" {
+		return false
+	}
+	if s.Commit != nil && !s.Commit.IsEmpty() {
+		return false
+	}
+	// Explicit empty commit override still counts as non-empty so the file
+	// is kept when the user intentionally cleared both commit flags.
+	if s.Commit != nil {
+		return false
+	}
+	return true
 }
 
 func LocalSettingsPath(campaignRoot string) string {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -322,6 +322,10 @@ type GlobalConfig struct {
 	// keeping the ledger merge-conflict-free. Generated once on first ledger
 	// write via ledgerkit.ResolveWriterID.
 	LedgerWriterID string `json:"ledger_writer_id,omitempty" yaml:"ledger_writer_id,omitempty"`
+	// Commit holds machine-wide defaults for campaign-aware commit behavior
+	// (project ref linking and subject-tag tracing). Per-campaign overrides
+	// live in .campaign/settings/local.json under the same shape.
+	Commit CommitPrefs `json:"commit,omitempty" yaml:"commit,omitempty"`
 }
 
 // RegistryVersion is the current registry format version.


### PR DESCRIPTION
## Summary

Adds the missing **global + per-campaign** settings for two commit behaviors:

1. **Project ↔ campaign ref linking** (`commit.sync_project_refs`)
   - When true, `camp project commit` updates the campaign-root submodule pointer (same as `--sync`)
   - Default remains **false** (opt-in)
   - New **`--no-sync`** forces off even when the setting is enabled

2. **Commit tracing / subject tags** (`commit.disable_commit_tags`)
   - When true, skips `[campaign:id-…]` prefixes on camp-managed commits
   - Default remains **false** (tags on)
   - Applies to `camp commit`, `camp project commit`, worktree commit, and `refs-sync`

### Storage

| Scope | File |
|-------|------|
| Global | `~/.obey/campaign/config.json` → `commit` |
| Local (overrides global when present) | `.campaign/settings/local.json` → `commit` |

### Access

```bash
camp settings get effective.commit.sync_project_refs
camp settings set global.commit.disable_commit_tags true
camp settings set local.commit.sync_project_refs true
```

Also toggles in `camp settings` → Global config / Local settings.

## Test plan

- [x] `go test ./internal/config/ ./cmd/camp/ ./cmd/camp/project/`
- [ ] Manual: set local disable tags, commit, confirm plain subject
- [ ] Manual: set sync_project_refs true, `camp p commit -m "…"` without `--sync`, confirm campaign root updates
- [ ] Manual: `--no-sync` overrides setting

WI-a05044