### PR TITLE
feat: add filtered workitem list command

### DIFF
--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -87,6 +87,7 @@ var manifestAgentAllowedReasons = map[string]string{
 	"workitem doctor":            "Read path (--json) is safe; never pass --fix from an agent",
 	"workitem link":              "Non-interactive workitem link operation",
 	"workitem links":             "Read-only workitem link listing",
+	"workitem list":              "Read-only filtered listing with non-interactive compact and JSON output",
 	"workitem group":             "Non-interactive group update with explicit selector",
 	"workitem priority":          "Non-interactive priority update with explicit selector",
 	"workitem promote":           "Non-interactive promote fully specified by --target and flags",

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -6010,6 +6010,7 @@ camp workitem [flags]
       --query string                  Search query to filter items
       --show-parked                   include parked attention-stage workitems in default output
       --stage stringArray             Filter by lifecycle stage (none, inbox, active, ready, planning, ritual, chains)
+      --status stringArray            Filter by displayed status (current, next, active, parked, inbox, ready, plan, ritual, chains, none)
       --type stringArray              Filter by workflow type (builtin: intent, design, explore, festival; or any slug-safe custom type produced by 'camp workitem create --type <name>')
 ```
 
@@ -6317,6 +6318,55 @@ camp workitem links [selector] [flags]
 ```
   -h, --help   help for links
       --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp workitem list
+
+List or browse filtered workitems
+
+### Synopsis
+
+List campaign workitems with the same filters used by the dashboard.
+
+In a terminal, this opens the TUI with visible, editable prefilters. When
+stdout is not a terminal, it prints a compact grouped list. Use --json for the
+stable machine-readable contract in either environment.
+
+The optional positional filter resolves as a workflow type, displayed status,
+or configured category. Ambiguous values must use an explicit flag.
+
+Examples:
+  camp workitem list intent
+  camp workitem list active
+  camp workitem list --category research --query auth
+  camp workitem list festival --status ready --json
+
+```
+camp workitem list [type|status|category] [flags]
+```
+
+### Options
+
+```
+      --attention-stage stringArray   Filter by attention stage (repeat for OR)
+      --category stringArray          Filter by workflow category (repeat for OR)
+      --group stringArray             Filter by workitem group (repeat for OR)
+      --group-by string               Group output sections by attention_stage, group, type, or category
+  -h, --help                          help for list
+      --json                          Output as JSON
+      --limit int                     Maximum number of items to return
+      --query string                  Search query to filter items
+      --show-parked                   Include parked attention-stage workitems
+      --stage stringArray             Filter by lifecycle stage (repeat for OR)
+      --status stringArray            Filter by displayed status (repeat for OR)
+      --type stringArray              Filter by workflow type (repeat for OR)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_workitem.md
+++ b/docs/cli-reference/camp_workitem.md
@@ -35,6 +35,7 @@ camp workitem [flags]
       --query string                  Search query to filter items
       --show-parked                   include parked attention-stage workitems in default output
       --stage stringArray             Filter by lifecycle stage (none, inbox, active, ready, planning, ritual, chains)
+      --status stringArray            Filter by displayed status (current, next, active, parked, inbox, ready, plan, ritual, chains, none)
       --type stringArray              Filter by workflow type (builtin: intent, design, explore, festival; or any slug-safe custom type produced by 'camp workitem create --type <name>')
 ```
 
@@ -56,6 +57,7 @@ camp workitem [flags]
 * [camp workitem group](camp_workitem_group.md)	 - Set or clear the group of a workitem
 * [camp workitem link](camp_workitem_link.md)	 - Attach a workitem to a project, festival, worktree, or campaign path
 * [camp workitem links](camp_workitem_links.md)	 - List workitem links
+* [camp workitem list](camp_workitem_list.md)	 - List or browse filtered workitems
 * [camp workitem priority](camp_workitem_priority.md)	 - Set or clear the manual priority of a workitem
 * [camp workitem promote](camp_workitem_promote.md)	 - Promote a workitem to a festival, doc, or dungeon status
 * [camp workitem resolve](camp_workitem_resolve.md)	 - Print the workitem the current context resolves to (read-only)

--- a/docs/cli-reference/camp_workitem_list.md
+++ b/docs/cli-reference/camp_workitem_list.md
@@ -1,0 +1,51 @@
+## camp workitem list
+
+List or browse filtered workitems
+
+### Synopsis
+
+List campaign workitems with the same filters used by the dashboard.
+
+In a terminal, this opens the TUI with visible, editable prefilters. When
+stdout is not a terminal, it prints a compact grouped list. Use --json for the
+stable machine-readable contract in either environment.
+
+The optional positional filter resolves as a workflow type, displayed status,
+or configured category. Ambiguous values must use an explicit flag.
+
+Examples:
+  camp workitem list intent
+  camp workitem list active
+  camp workitem list --category research --query auth
+  camp workitem list festival --status ready --json
+
+```
+camp workitem list [type|status|category] [flags]
+```
+
+### Options
+
+```
+      --attention-stage stringArray   Filter by attention stage (repeat for OR)
+      --category stringArray          Filter by workflow category (repeat for OR)
+      --group stringArray             Filter by workitem group (repeat for OR)
+      --group-by string               Group output sections by attention_stage, group, type, or category
+  -h, --help                          help for list
+      --json                          Output as JSON
+      --limit int                     Maximum number of items to return
+      --query string                  Search query to filter items
+      --show-parked                   Include parked attention-stage workitems
+      --stage stringArray             Filter by lifecycle stage (repeat for OR)
+      --status stringArray            Filter by displayed status (repeat for OR)
+      --type stringArray              Filter by workflow type (repeat for OR)
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/internal/commands/workitem/list.go
+++ b/internal/commands/workitem/list.go
@@ -1,0 +1,170 @@
+package workitem
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/jsoncontract"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+type listOptions struct {
+	json            bool
+	types           []string
+	categories      []string
+	statuses        []string
+	stages          []string
+	attentionStages []string
+	groups          []string
+	groupBy         string
+	showParked      bool
+	limit           int
+	query           string
+}
+
+func (o listOptions) filterOptions() wkitem.FilterOptions {
+	return wkitem.FilterOptions{
+		Types:           o.types,
+		Categories:      o.categories,
+		Statuses:        o.statuses,
+		LifecycleStages: o.stages,
+		AttentionStages: o.attentionStages,
+		Groups:          o.groups,
+		Query:           o.query,
+		ShowParked:      o.showParked,
+	}
+}
+
+func newListCommand() *cobra.Command {
+	var opts listOptions
+	cmd := &cobra.Command{
+		Use:   "list [type|status|category]",
+		Short: "List or browse filtered workitems",
+		Long: `List campaign workitems with the same filters used by the dashboard.
+
+In a terminal, this opens the TUI with visible, editable prefilters. When
+stdout is not a terminal, it prints a compact grouped list. Use --json for the
+stable machine-readable contract in either environment.
+
+The optional positional filter resolves as a workflow type, displayed status,
+or configured category. Ambiguous values must use an explicit flag.
+
+Examples:
+  camp workitem list intent
+  camp workitem list active
+  camp workitem list --category research --query auth
+  camp workitem list festival --status ready --json`,
+		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Non-TTY compact output and --json are safe for scripts and agents",
+		},
+		RunE: jsoncontract.RunE(wkitem.SchemaVersion, func() bool { return opts.json }, func(cmd *cobra.Command, args []string) error {
+			state, err := discoverWorkitems(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if len(args) == 1 {
+				if err := applyPositionalFilter(args[0], state, &opts); err != nil {
+					return err
+				}
+			}
+			if err := validateFlags(opts.json, false, false, "", opts.types, opts.categories, opts.stages, opts.attentionStages, opts.groups, opts.groupBy); err != nil {
+				return err
+			}
+			if err := validateDisplayStatuses(opts.statuses); err != nil {
+				return err
+			}
+			filters := opts.filterOptions()
+			if isInteractive() && !opts.json {
+				return runTUIWithFilters(cmd.Context(), state, filters, opts.limit)
+			}
+
+			items := wkitem.FilterAdvanced(state.items, filters)
+			if opts.limit > 0 && len(items) > opts.limit {
+				items = items[:opts.limit]
+			}
+			groupBy := opts.groupBy
+			if groupBy == "" {
+				if opts.json {
+					groupBy = "attention_stage"
+				} else {
+					groupBy = "group"
+				}
+			}
+			if opts.json {
+				return outputJSON(state.campaignRoot, state.cfg, items, groupBy)
+			}
+			return outputList(cmd.OutOrStdout(), items, groupBy)
+		}),
+	}
+	cmd.SetFlagErrorFunc(jsoncontract.FlagErrorFunc(wkitem.SchemaVersion, func() bool { return opts.json }))
+
+	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
+	cmd.Flags().StringArrayVar(&opts.types, "type", nil, "Filter by workflow type (repeat for OR)")
+	cmd.Flags().StringArrayVar(&opts.categories, "category", nil, "Filter by workflow category (repeat for OR)")
+	cmd.Flags().StringArrayVar(&opts.statuses, "status", nil, "Filter by displayed status (repeat for OR)")
+	cmd.Flags().StringArrayVar(&opts.stages, "stage", nil, "Filter by lifecycle stage (repeat for OR)")
+	cmd.Flags().StringArrayVar(&opts.attentionStages, "attention-stage", nil, "Filter by attention stage (repeat for OR)")
+	cmd.Flags().StringArrayVar(&opts.groups, "group", nil, "Filter by workitem group (repeat for OR)")
+	cmd.Flags().StringVar(&opts.groupBy, "group-by", "", "Group output sections by attention_stage, group, type, or category")
+	cmd.Flags().BoolVar(&opts.showParked, "show-parked", false, "Include parked attention-stage workitems")
+	cmd.Flags().IntVar(&opts.limit, "limit", 0, "Maximum number of items to return")
+	cmd.Flags().StringVar(&opts.query, "query", "", "Search query to filter items")
+	return cmd
+}
+
+func applyPositionalFilter(raw string, state *discoveredWorkitems, opts *listOptions) error {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	types := map[string]bool{
+		string(wkitem.WorkflowTypeIntent): true, string(wkitem.WorkflowTypeDesign): true,
+		string(wkitem.WorkflowTypeExplore): true, string(wkitem.WorkflowTypeFestival): true,
+	}
+	for _, item := range state.items {
+		types[string(item.WorkflowType)] = true
+	}
+	categories := map[string]bool{
+		config.WorkflowCategoryPlan: true, config.WorkflowCategoryResearch: true,
+		config.WorkflowCategoryPipeline: true, config.WorkflowCategoryReview: true,
+		"uncategorized": true,
+	}
+	for _, category := range categoryVocabulary(state.cfg) {
+		categories[category.Key] = true
+	}
+	for _, item := range state.items {
+		if item.WorkflowCategory != "" {
+			categories[item.WorkflowCategory] = true
+		}
+	}
+
+	status := wkitem.NormalizeDisplayStatus(value)
+	var dimensions []string
+	if types[value] {
+		dimensions = append(dimensions, "type")
+	}
+	if categories[value] {
+		dimensions = append(dimensions, "category")
+	}
+	if wkitem.IsDisplayStatus(status) {
+		dimensions = append(dimensions, "status")
+	}
+	if len(dimensions) == 0 {
+		return camperrors.NewValidation("filter", fmt.Sprintf("unknown workitem filter %q; use --type, --status, or --category", raw), nil)
+	}
+	if len(dimensions) > 1 {
+		return camperrors.NewValidation("filter", fmt.Sprintf("ambiguous workitem filter %q matches %s; use an explicit flag", raw, strings.Join(dimensions, " and ")), nil)
+	}
+	switch dimensions[0] {
+	case "type":
+		opts.types = append(opts.types, value)
+	case "category":
+		opts.categories = append(opts.categories, value)
+	case "status":
+		opts.statuses = append(opts.statuses, status)
+	}
+	return nil
+}

--- a/internal/commands/workitem/list.go
+++ b/internal/commands/workitem/list.go
@@ -119,34 +119,36 @@ Examples:
 }
 
 func applyPositionalFilter(raw string, state *discoveredWorkitems, opts *listOptions) error {
-	value := strings.ToLower(strings.TrimSpace(raw))
-	types := map[string]bool{
-		string(wkitem.WorkflowTypeIntent): true, string(wkitem.WorkflowTypeDesign): true,
-		string(wkitem.WorkflowTypeExplore): true, string(wkitem.WorkflowTypeFestival): true,
+	value := strings.TrimSpace(raw)
+	normalized := strings.ToLower(value)
+	types := map[string]string{
+		string(wkitem.WorkflowTypeIntent): string(wkitem.WorkflowTypeIntent), string(wkitem.WorkflowTypeDesign): string(wkitem.WorkflowTypeDesign),
+		string(wkitem.WorkflowTypeExplore): string(wkitem.WorkflowTypeExplore), string(wkitem.WorkflowTypeFestival): string(wkitem.WorkflowTypeFestival),
 	}
 	for _, item := range state.items {
-		types[string(item.WorkflowType)] = true
+		workflowType := string(item.WorkflowType)
+		types[strings.ToLower(workflowType)] = workflowType
 	}
-	categories := map[string]bool{
-		config.WorkflowCategoryPlan: true, config.WorkflowCategoryResearch: true,
-		config.WorkflowCategoryPipeline: true, config.WorkflowCategoryReview: true,
-		"uncategorized": true,
+	categories := map[string]string{
+		config.WorkflowCategoryPlan: config.WorkflowCategoryPlan, config.WorkflowCategoryResearch: config.WorkflowCategoryResearch,
+		config.WorkflowCategoryPipeline: config.WorkflowCategoryPipeline, config.WorkflowCategoryReview: config.WorkflowCategoryReview,
+		"uncategorized": "uncategorized",
 	}
 	for _, category := range categoryVocabulary(state.cfg) {
-		categories[category.Key] = true
+		categories[strings.ToLower(category.Key)] = category.Key
 	}
 	for _, item := range state.items {
 		if item.WorkflowCategory != "" {
-			categories[item.WorkflowCategory] = true
+			categories[strings.ToLower(item.WorkflowCategory)] = item.WorkflowCategory
 		}
 	}
 
-	status := wkitem.NormalizeDisplayStatus(value)
+	status := wkitem.NormalizeDisplayStatus(normalized)
 	var dimensions []string
-	if types[value] {
+	if _, ok := types[normalized]; ok {
 		dimensions = append(dimensions, "type")
 	}
-	if categories[value] {
+	if _, ok := categories[normalized]; ok {
 		dimensions = append(dimensions, "category")
 	}
 	if wkitem.IsDisplayStatus(status) {
@@ -160,9 +162,9 @@ func applyPositionalFilter(raw string, state *discoveredWorkitems, opts *listOpt
 	}
 	switch dimensions[0] {
 	case "type":
-		opts.types = append(opts.types, value)
+		opts.types = append(opts.types, types[normalized])
 	case "category":
-		opts.categories = append(opts.categories, value)
+		opts.categories = append(opts.categories, categories[normalized])
 	case "status":
 		opts.statuses = append(opts.statuses, status)
 	}

--- a/internal/commands/workitem/list.go
+++ b/internal/commands/workitem/list.go
@@ -81,7 +81,8 @@ Examples:
 			}
 			filters := opts.filterOptions()
 			if isInteractive() && !opts.json {
-				return runTUIWithFilters(cmd.Context(), state, filters, opts.limit)
+				// --limit applies only to non-TTY / --json result size, not the TUI.
+				return runTUIWithFilters(cmd.Context(), state, filters, false, "")
 			}
 
 			items := wkitem.FilterAdvanced(state.items, filters)
@@ -107,13 +108,13 @@ Examples:
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
 	cmd.Flags().StringArrayVar(&opts.types, "type", nil, "Filter by workflow type (repeat for OR)")
 	cmd.Flags().StringArrayVar(&opts.categories, "category", nil, "Filter by workflow category (repeat for OR)")
-	cmd.Flags().StringArrayVar(&opts.statuses, "status", nil, "Filter by displayed status (repeat for OR)")
+	cmd.Flags().StringArrayVar(&opts.statuses, "status", nil, "Filter by displayed status: current, next, active, parked, inbox, ready, plan, ritual, chains, none (repeat for OR)")
 	cmd.Flags().StringArrayVar(&opts.stages, "stage", nil, "Filter by lifecycle stage (repeat for OR)")
 	cmd.Flags().StringArrayVar(&opts.attentionStages, "attention-stage", nil, "Filter by attention stage (repeat for OR)")
 	cmd.Flags().StringArrayVar(&opts.groups, "group", nil, "Filter by workitem group (repeat for OR)")
 	cmd.Flags().StringVar(&opts.groupBy, "group-by", "", "Group output sections by attention_stage, group, type, or category")
 	cmd.Flags().BoolVar(&opts.showParked, "show-parked", false, "Include parked attention-stage workitems")
-	cmd.Flags().IntVar(&opts.limit, "limit", 0, "Maximum number of items to return")
+	cmd.Flags().IntVar(&opts.limit, "limit", 0, "Maximum number of items to return (non-interactive / --json only)")
 	cmd.Flags().StringVar(&opts.query, "query", "", "Search query to filter items")
 	return cmd
 }
@@ -158,7 +159,15 @@ func applyPositionalFilter(raw string, state *discoveredWorkitems, opts *listOpt
 		return camperrors.NewValidation("filter", fmt.Sprintf("unknown workitem filter %q; use --type, --status, or --category", raw), nil)
 	}
 	if len(dimensions) > 1 {
-		return camperrors.NewValidation("filter", fmt.Sprintf("ambiguous workitem filter %q matches %s; use an explicit flag", raw, strings.Join(dimensions, " and ")), nil)
+		// Name the flags so callers (especially always-ambiguous "plan") know
+		// which dimension to pin without re-reading the help text.
+		flagHints := make([]string, 0, len(dimensions))
+		for _, d := range dimensions {
+			flagHints = append(flagHints, "--"+d+" "+value)
+		}
+		return camperrors.NewValidation("filter", fmt.Sprintf(
+			"ambiguous workitem filter %q matches %s; use %s",
+			raw, strings.Join(dimensions, " and "), strings.Join(flagHints, " or ")), nil)
 	}
 	switch dimensions[0] {
 	case "type":

--- a/internal/commands/workitem/list_output.go
+++ b/internal/commands/workitem/list_output.go
@@ -109,7 +109,8 @@ func listLifecycleLabel(stage wkitem.LifecycleStage) string {
 	case wkitem.LifecycleStageChains:
 		return "chains"
 	case wkitem.LifecycleStageNone, "":
-		return "-"
+		// Match DisplayStatus / --status none filter token.
+		return "none"
 	default:
 		return string(stage)
 	}

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -79,9 +79,7 @@ Examples:
 			if err != nil {
 				return err
 			}
-			items := state.items
-
-			items = wkitem.FilterAdvanced(items, wkitem.FilterOptions{
+			filters := wkitem.FilterOptions{
 				Types:           flagTypes,
 				Categories:      flagCategories,
 				Statuses:        flagStatuses,
@@ -90,9 +88,6 @@ Examples:
 				Groups:          flagGroups,
 				Query:           flagQuery,
 				ShowParked:      flagShowParked,
-			})
-			if flagLimit > 0 && flagLimit < len(items) {
-				items = items[:flagLimit]
 			}
 
 			displayGroupBy := flagGroupBy
@@ -100,23 +95,28 @@ Examples:
 				displayGroupBy = "group"
 			}
 
+			// Interactive TUI: pass the full discovery set + editable prefilters
+			// (same contract as `camp workitem list`). Do not pre-slice allItems.
+			if interactive && !flagList && !flagJSON {
+				return runTUIWithFilters(ctx, state, filters, flagPrint, flagPathOutput)
+			}
+
+			items := wkitem.FilterAdvanced(state.items, filters)
+			if flagLimit > 0 && flagLimit < len(items) {
+				items = items[:flagLimit]
+			}
+
 			switch {
 			case flagList:
 				return outputList(cmd.OutOrStdout(), items, displayGroupBy)
 			case flagJSON:
 				return outputJSON(state.campaignRoot, state.cfg, items, displayGroupBy)
-			case !interactive:
+			default:
 				// Non-interactive --print/--path-output: output first item path directly.
 				if len(items) == 0 {
 					return camperrors.Newf("no work items found")
 				}
 				return outputSelectedPath(items[0], flagPrint, flagPathOutput)
-			case flagPathOutput != "":
-				return runTUI(ctx, items, false, flagPathOutput, state.campaignRoot, state.resolver, state.store, state.storePath, flagShowParked, state.cfg.WorkflowCategoryForType)
-			case flagPrint:
-				return runTUI(ctx, items, true, "", state.campaignRoot, state.resolver, state.store, state.storePath, flagShowParked, state.cfg.WorkflowCategoryForType)
-			default:
-				return runTUI(ctx, items, false, "", state.campaignRoot, state.resolver, state.store, state.storePath, flagShowParked, state.cfg.WorkflowCategoryForType)
 			}
 		}),
 	}
@@ -359,29 +359,13 @@ func categoryVocabulary(cfg *config.CampaignConfig) []wkitem.CategoryVocabEntry 
 	return out
 }
 
-func runTUI(ctx context.Context, items []wkitem.WorkItem, printOnly bool, pathOutput string, campaignRoot string, resolver *paths.Resolver, store *priority.Store, storePath string, showParked bool, categoryForType func(string) string) error {
-	if len(items) == 0 {
+func runTUIWithFilters(ctx context.Context, state *discoveredWorkitems, filters wkitem.FilterOptions, printOnly bool, pathOutput string) error {
+	if len(state.items) == 0 {
 		return camperrors.Newf("no work items found")
 	}
-
-	model := wktui.New(ctx, items, campaignRoot, resolver, store, storePath, showParked)
-	model.SetCategoryResolver(categoryForType)
-	p := tea.NewProgram(model, tea.WithAltScreen())
-	result, err := p.Run()
-	if err != nil {
-		return camperrors.Wrap(err, "TUI error")
-	}
-	m, ok := result.(wktui.Model)
-	if !ok || m.Selected == nil {
-		return nil
-	}
-	return runSelectedAction(ctx, *m.Selected, printOnly, pathOutput, campaignRoot)
-}
-
-func runTUIWithFilters(ctx context.Context, state *discoveredWorkitems, filters wkitem.FilterOptions, limit int) error {
 	model := wktui.New(ctx, state.items, state.campaignRoot, state.resolver, state.store, state.storePath, filters.ShowParked)
 	model.SetCategoryResolver(state.cfg.WorkflowCategoryForType)
-	model.SetInitialFilters(filters, limit)
+	model.SetInitialFilters(filters)
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	result, err := p.Run()
 	if err != nil {
@@ -391,5 +375,5 @@ func runTUIWithFilters(ctx context.Context, state *discoveredWorkitems, filters 
 	if !ok || m.Selected == nil {
 		return nil
 	}
-	return runSelectedAction(ctx, *m.Selected, false, "", state.campaignRoot)
+	return runSelectedAction(ctx, *m.Selected, printOnly, pathOutput, state.campaignRoot)
 }

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
@@ -30,6 +31,7 @@ func NewWorkitemCommand() *cobra.Command {
 		flagPathOutput      string
 		flagTypes           []string
 		flagCategories      []string
+		flagStatuses        []string
 		flagStages          []string
 		flagAttentionStages []string
 		flagGroups          []string
@@ -64,42 +66,25 @@ Examples:
 			if err := validateFlags(flagJSON, flagList, flagPrint, flagPathOutput, flagTypes, flagCategories, flagStages, flagAttentionStages, flagGroups, flagGroupBy); err != nil {
 				return err
 			}
+			if err := validateDisplayStatuses(flagStatuses); err != nil {
+				return err
+			}
 
 			interactive := isInteractive()
 			if !interactive && !flagJSON && !flagList && !flagPrint && flagPathOutput == "" {
 				return camperrors.New("non-interactive use requires --json, --list, or --print flag")
 			}
 
-			cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+			state, err := discoverWorkitems(ctx)
 			if err != nil {
-				return camperrors.Wrap(err, "not in a campaign directory")
+				return err
 			}
-			campaignRoot, err = pathutil.ResolveRoot(campaignRoot)
-			if err != nil {
-				return camperrors.Wrap(err, "resolving campaign root")
-			}
-			resolver := paths.NewResolverFromConfig(campaignRoot, cfg)
-
-			items, err := wkitem.Discover(ctx, campaignRoot, resolver)
-			if err != nil {
-				return camperrors.Wrap(err, "discovering work items")
-			}
-			items = wkitem.ApplyWorkflowCategories(items, cfg.WorkflowCategoryForType)
-
-			// Load priority store read-only; pruning happens only in explicit write paths.
-			storePath := priority.StorePath(campaignRoot)
-			store, err := priority.Load(storePath)
-			if err != nil {
-				return camperrors.Wrap(err, "loading priority store")
-			}
-
-			// Apply priority overlay and re-sort with priority buckets.
-			items = priority.Apply(store, items)
-			wkitem.Sort(items)
+			items := state.items
 
 			items = wkitem.FilterAdvanced(items, wkitem.FilterOptions{
 				Types:           flagTypes,
 				Categories:      flagCategories,
+				Statuses:        flagStatuses,
 				LifecycleStages: flagStages,
 				AttentionStages: flagAttentionStages,
 				Groups:          flagGroups,
@@ -119,7 +104,7 @@ Examples:
 			case flagList:
 				return outputList(cmd.OutOrStdout(), items, displayGroupBy)
 			case flagJSON:
-				return outputJSON(campaignRoot, cfg, items, displayGroupBy)
+				return outputJSON(state.campaignRoot, state.cfg, items, displayGroupBy)
 			case !interactive:
 				// Non-interactive --print/--path-output: output first item path directly.
 				if len(items) == 0 {
@@ -127,11 +112,11 @@ Examples:
 				}
 				return outputSelectedPath(items[0], flagPrint, flagPathOutput)
 			case flagPathOutput != "":
-				return runTUI(ctx, items, false, flagPathOutput, campaignRoot, resolver, store, storePath, flagShowParked, cfg.WorkflowCategoryForType)
+				return runTUI(ctx, items, false, flagPathOutput, state.campaignRoot, state.resolver, state.store, state.storePath, flagShowParked, state.cfg.WorkflowCategoryForType)
 			case flagPrint:
-				return runTUI(ctx, items, true, "", campaignRoot, resolver, store, storePath, flagShowParked, cfg.WorkflowCategoryForType)
+				return runTUI(ctx, items, true, "", state.campaignRoot, state.resolver, state.store, state.storePath, flagShowParked, state.cfg.WorkflowCategoryForType)
 			default:
-				return runTUI(ctx, items, false, "", campaignRoot, resolver, store, storePath, flagShowParked, cfg.WorkflowCategoryForType)
+				return runTUI(ctx, items, false, "", state.campaignRoot, state.resolver, state.store, state.storePath, flagShowParked, state.cfg.WorkflowCategoryForType)
 			}
 		}),
 	}
@@ -144,6 +129,7 @@ Examples:
 	_ = cmd.Flags().MarkHidden("path-output")
 	cmd.Flags().StringArrayVar(&flagTypes, "type", nil, "Filter by workflow type (builtin: intent, design, explore, festival; or any slug-safe custom type produced by 'camp workitem create --type <name>')")
 	cmd.Flags().StringArrayVar(&flagCategories, "category", nil, "Filter by workflow category (builtin: plan, research, pipeline, review, uncategorized; or any category defined under workflows in campaign.yaml)")
+	cmd.Flags().StringArrayVar(&flagStatuses, "status", nil, "Filter by displayed status (current, next, active, parked, inbox, ready, plan, ritual, chains, none)")
 	cmd.Flags().StringArrayVar(&flagStages, "stage", nil, "Filter by lifecycle stage (none, inbox, active, ready, planning, ritual, chains)")
 	cmd.Flags().StringArrayVar(&flagAttentionStages, "attention-stage", nil, "Filter by attention stage (current, next, active, parked)")
 	cmd.Flags().StringArrayVar(&flagGroups, "group", nil, "Filter by workitem group")
@@ -169,8 +155,43 @@ Examples:
 	cmd.AddCommand(newRepairCommand())
 	cmd.AddCommand(newCommitCommand())
 	cmd.AddCommand(newCommitsCommand())
+	cmd.AddCommand(newListCommand())
 
 	return cmd
+}
+
+type discoveredWorkitems struct {
+	cfg          *config.CampaignConfig
+	campaignRoot string
+	resolver     *paths.Resolver
+	items        []wkitem.WorkItem
+	store        *priority.Store
+	storePath    string
+}
+
+func discoverWorkitems(ctx context.Context) (*discoveredWorkitems, error) {
+	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "not in a campaign directory")
+	}
+	campaignRoot, err = pathutil.ResolveRoot(campaignRoot)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "resolving campaign root")
+	}
+	resolver := paths.NewResolverFromConfig(campaignRoot, cfg)
+	items, err := wkitem.Discover(ctx, campaignRoot, resolver)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "discovering work items")
+	}
+	items = wkitem.ApplyWorkflowCategories(items, cfg.WorkflowCategoryForType)
+	storePath := priority.StorePath(campaignRoot)
+	store, err := priority.Load(storePath)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "loading priority store")
+	}
+	items = priority.Apply(store, items)
+	wkitem.Sort(items)
+	return &discoveredWorkitems{cfg: cfg, campaignRoot: campaignRoot, resolver: resolver, items: items, store: store, storePath: storePath}, nil
 }
 
 func outputSelectedPath(item wkitem.WorkItem, printOnly bool, pathOutput string) error {
@@ -309,6 +330,16 @@ func validateFlags(jsonMode, listMode, printMode bool, pathOutput string, types,
 	return nil
 }
 
+func validateDisplayStatuses(statuses []string) error {
+	for _, status := range statuses {
+		if !wkitem.IsDisplayStatus(status) {
+			return camperrors.NewValidation("status",
+				fmt.Sprintf("unknown --status value %q (valid: %s)", status, strings.Join(wkitem.DisplayStatusVocabulary(), ", ")), nil)
+		}
+	}
+	return nil
+}
+
 func outputJSON(campaignRoot string, cfg *config.CampaignConfig, items []wkitem.WorkItem, groupBy string) error {
 	payload := wkitem.NewPayloadWithGrouping(campaignRoot, items, groupBy)
 	payload.CategoryVocabulary = categoryVocabulary(cfg)
@@ -345,4 +376,20 @@ func runTUI(ctx context.Context, items []wkitem.WorkItem, printOnly bool, pathOu
 		return nil
 	}
 	return runSelectedAction(ctx, *m.Selected, printOnly, pathOutput, campaignRoot)
+}
+
+func runTUIWithFilters(ctx context.Context, state *discoveredWorkitems, filters wkitem.FilterOptions, limit int) error {
+	model := wktui.New(ctx, state.items, state.campaignRoot, state.resolver, state.store, state.storePath, filters.ShowParked)
+	model.SetCategoryResolver(state.cfg.WorkflowCategoryForType)
+	model.SetInitialFilters(filters, limit)
+	p := tea.NewProgram(model, tea.WithAltScreen())
+	result, err := p.Run()
+	if err != nil {
+		return camperrors.Wrap(err, "TUI error")
+	}
+	m, ok := result.(wktui.Model)
+	if !ok || m.Selected == nil {
+		return nil
+	}
+	return runSelectedAction(ctx, *m.Selected, false, "", state.campaignRoot)
 }

--- a/internal/commands/workitem/workitem_test.go
+++ b/internal/commands/workitem/workitem_test.go
@@ -95,6 +95,7 @@ func TestApplyPositionalFilter(t *testing.T) {
 		items: []wkitem.WorkItem{
 			{WorkflowType: wkitem.WorkflowTypeDesign, WorkflowCategory: "plan"},
 			{WorkflowType: wkitem.WorkflowType("bug"), WorkflowCategory: "review"},
+			{WorkflowType: wkitem.WorkflowType("PascalCase"), WorkflowCategory: "CamelCase"},
 		},
 	}
 	tests := []struct {
@@ -108,6 +109,8 @@ func TestApplyPositionalFilter(t *testing.T) {
 		{value: "research", wantCat: "research"},
 		{value: "active", wantState: "active"},
 		{value: "planning", wantState: "plan"},
+		{value: "PascalCase", wantType: "PascalCase"},
+		{value: "CamelCase", wantCat: "CamelCase"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.value, func(t *testing.T) {

--- a/internal/commands/workitem/workitem_test.go
+++ b/internal/commands/workitem/workitem_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Obedience-Corp/camp/internal/config"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/priority"
 )
@@ -85,6 +86,65 @@ func TestValidateFlagsAcceptsStageNoneForNoStageTypes(t *testing.T) {
 	}
 	if err := validateFlags(true, false, false, "", []string{"explore"}, nil, []string{"none"}, nil, nil, "attention_stage"); err != nil {
 		t.Fatalf("validateFlags(explore, none) error = %v", err)
+	}
+}
+
+func TestApplyPositionalFilter(t *testing.T) {
+	state := &discoveredWorkitems{
+		cfg: &config.CampaignConfig{},
+		items: []wkitem.WorkItem{
+			{WorkflowType: wkitem.WorkflowTypeDesign, WorkflowCategory: "plan"},
+			{WorkflowType: wkitem.WorkflowType("bug"), WorkflowCategory: "review"},
+		},
+	}
+	tests := []struct {
+		value     string
+		wantType  string
+		wantCat   string
+		wantState string
+	}{
+		{value: "intent", wantType: "intent"},
+		{value: "bug", wantType: "bug"},
+		{value: "research", wantCat: "research"},
+		{value: "active", wantState: "active"},
+		{value: "planning", wantState: "plan"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.value, func(t *testing.T) {
+			var opts listOptions
+			if err := applyPositionalFilter(tc.value, state, &opts); err != nil {
+				t.Fatalf("applyPositionalFilter: %v", err)
+			}
+			if tc.wantType != "" && (len(opts.types) != 1 || opts.types[0] != tc.wantType) {
+				t.Fatalf("types = %v, want %q", opts.types, tc.wantType)
+			}
+			if tc.wantCat != "" && (len(opts.categories) != 1 || opts.categories[0] != tc.wantCat) {
+				t.Fatalf("categories = %v, want %q", opts.categories, tc.wantCat)
+			}
+			if tc.wantState != "" && (len(opts.statuses) != 1 || opts.statuses[0] != tc.wantState) {
+				t.Fatalf("statuses = %v, want %q", opts.statuses, tc.wantState)
+			}
+		})
+	}
+}
+
+func TestApplyPositionalFilterRejectsAmbiguousAndUnknown(t *testing.T) {
+	state := &discoveredWorkitems{
+		cfg:   &config.CampaignConfig{},
+		items: []wkitem.WorkItem{{WorkflowType: wkitem.WorkflowType("plan"), WorkflowCategory: "plan"}},
+	}
+	for _, value := range []string{"plan", "does-not-exist"} {
+		if err := applyPositionalFilter(value, state, &listOptions{}); err == nil {
+			t.Fatalf("applyPositionalFilter(%q) error = nil", value)
+		}
+	}
+}
+
+func TestWorkitemCommandIncludesListSubcommand(t *testing.T) {
+	cmd := NewWorkitemCommand()
+	child, _, err := cmd.Find([]string{"list"})
+	if err != nil || child == cmd || child.Name() != "list" {
+		t.Fatalf("list subcommand not registered: child=%v err=%v", child, err)
 	}
 }
 

--- a/internal/workitem/filter.go
+++ b/internal/workitem/filter.go
@@ -11,6 +11,7 @@ func Filter(items []WorkItem, types, stages []string, query string) []WorkItem {
 type FilterOptions struct {
 	Types           []string
 	Categories      []string
+	Statuses        []string
 	LifecycleStages []string
 	AttentionStages []string
 	Groups          []string
@@ -19,12 +20,13 @@ type FilterOptions struct {
 }
 
 func FilterAdvanced(items []WorkItem, opts FilterOptions) []WorkItem {
-	if len(opts.Types) == 0 && len(opts.Categories) == 0 && len(opts.LifecycleStages) == 0 && len(opts.AttentionStages) == 0 && len(opts.Groups) == 0 && opts.Query == "" && opts.ShowParked {
+	if len(opts.Types) == 0 && len(opts.Categories) == 0 && len(opts.Statuses) == 0 && len(opts.LifecycleStages) == 0 && len(opts.AttentionStages) == 0 && len(opts.Groups) == 0 && opts.Query == "" && opts.ShowParked {
 		return items
 	}
 
 	typeSet := toSet(opts.Types)
 	categorySet := toSet(opts.Categories)
+	statusSet := normalizedStatusSet(opts.Statuses)
 	stageSet := toSet(opts.LifecycleStages)
 	attentionSet := toSet(opts.AttentionStages)
 	groupSet := toSet(opts.Groups)
@@ -35,7 +37,14 @@ func FilterAdvanced(items []WorkItem, opts FilterOptions) []WorkItem {
 		if len(typeSet) > 0 && !typeSet[string(item.WorkflowType)] {
 			continue
 		}
-		if len(categorySet) > 0 && !categorySet[item.WorkflowCategory] {
+		category := item.WorkflowCategory
+		if category == "" {
+			category = "uncategorized"
+		}
+		if len(categorySet) > 0 && !categorySet[category] {
+			continue
+		}
+		if len(statusSet) > 0 && !statusSet[DisplayStatus(item)] {
 			continue
 		}
 		if len(stageSet) > 0 && !stageSet[string(item.LifecycleStage)] {
@@ -47,7 +56,7 @@ func FilterAdvanced(items []WorkItem, opts FilterOptions) []WorkItem {
 		if len(groupSet) > 0 && !groupSet[item.Group] {
 			continue
 		}
-		if !opts.ShowParked && len(attentionSet) == 0 && item.AttentionStage == "parked" {
+		if !opts.ShowParked && len(attentionSet) == 0 && len(statusSet) == 0 && item.AttentionStage == "parked" {
 			continue
 		}
 		if query != "" && !matchesQuery(item, query) {
@@ -56,6 +65,17 @@ func FilterAdvanced(items []WorkItem, opts FilterOptions) []WorkItem {
 		result = append(result, item)
 	}
 	return result
+}
+
+func normalizedStatusSet(vals []string) map[string]bool {
+	set := make(map[string]bool, len(vals))
+	for _, value := range vals {
+		set[NormalizeDisplayStatus(value)] = true
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return set
 }
 
 func toSet(vals []string) map[string]bool {

--- a/internal/workitem/filter_test.go
+++ b/internal/workitem/filter_test.go
@@ -112,6 +112,14 @@ func TestFilter_ByCategory(t *testing.T) {
 	}
 }
 
+func TestFilter_UncategorizedMatchesEmptyCategory(t *testing.T) {
+	items := []WorkItem{{Title: "uncategorized"}, {Title: "plan", WorkflowCategory: "plan"}}
+	got := FilterAdvanced(items, FilterOptions{Categories: []string{"uncategorized"}, ShowParked: true})
+	if len(got) != 1 || got[0].Title != "uncategorized" {
+		t.Fatalf("uncategorized filter = %v", got)
+	}
+}
+
 func TestFilter_CategoryCombinesWithType(t *testing.T) {
 	items := []WorkItem{
 		{WorkflowType: WorkflowTypeDesign, WorkflowCategory: "plan", Title: "d"},
@@ -121,6 +129,32 @@ func TestFilter_CategoryCombinesWithType(t *testing.T) {
 	got := FilterAdvanced(items, FilterOptions{Types: []string{"festival"}, Categories: []string{"plan"}, ShowParked: true})
 	if len(got) != 1 || got[0].Title != "f" {
 		t.Fatalf("type+category filter = %v, want festival plan item", got)
+	}
+}
+
+func TestFilter_ByDisplayedStatus(t *testing.T) {
+	items := []WorkItem{
+		{Title: "intent active", LifecycleStage: LifecycleStageActive},
+		{Title: "design active", LifecycleStage: LifecycleStageNone, AttentionStage: "active"},
+		{Title: "current", LifecycleStage: LifecycleStageNone, AttentionStage: "current"},
+		{Title: "planning", LifecycleStage: LifecycleStagePlanning},
+	}
+
+	got := FilterAdvanced(items, FilterOptions{Statuses: []string{"active"}})
+	if len(got) != 2 || got[0].Title != "intent active" || got[1].Title != "design active" {
+		t.Fatalf("display status active = %v", got)
+	}
+	got = FilterAdvanced(items, FilterOptions{Statuses: []string{"planning"}})
+	if len(got) != 1 || got[0].Title != "planning" {
+		t.Fatalf("planning alias = %v", got)
+	}
+}
+
+func TestFilter_StatusParkedOverridesDefaultHiding(t *testing.T) {
+	items := []WorkItem{{Title: "parked", AttentionStage: "parked"}, {Title: "active", AttentionStage: "active"}}
+	got := FilterAdvanced(items, FilterOptions{Statuses: []string{"parked"}, ShowParked: false})
+	if len(got) != 1 || got[0].Title != "parked" {
+		t.Fatalf("status parked = %v", got)
 	}
 }
 

--- a/internal/workitem/status.go
+++ b/internal/workitem/status.go
@@ -1,0 +1,46 @@
+package workitem
+
+import "strings"
+
+var displayStatusVocabulary = []string{
+	"current", "next", "active", "parked",
+	"inbox", "ready", "plan", "ritual", "chains", "none",
+}
+
+// DisplayStatus returns the status shown for a workitem row. Directory-backed
+// attention work uses its attention stage; other work uses lifecycle stage.
+func DisplayStatus(item WorkItem) string {
+	if item.AttentionStage != "" {
+		return item.AttentionStage
+	}
+	switch item.LifecycleStage {
+	case LifecycleStagePlanning:
+		return "plan"
+	case LifecycleStageNone, "":
+		return "none"
+	default:
+		return string(item.LifecycleStage)
+	}
+}
+
+func NormalizeDisplayStatus(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "planning" {
+		return "plan"
+	}
+	return value
+}
+
+func IsDisplayStatus(value string) bool {
+	value = NormalizeDisplayStatus(value)
+	for _, status := range displayStatusVocabulary {
+		if value == status {
+			return true
+		}
+	}
+	return false
+}
+
+func DisplayStatusVocabulary() []string {
+	return append([]string(nil), displayStatusVocabulary...)
+}

--- a/internal/workitem/tui/model.go
+++ b/internal/workitem/tui/model.go
@@ -121,14 +121,25 @@ type Model struct {
 	savedSearchQuery string // snapshot of committed query when search mode starts
 
 	// Filters
-	typeFilter      string // empty = all, or any workflow type
-	categoryFilter  string // empty = all, or any workflow category
+	typeFilter      string // interactive single-type override
+	categoryFilter  string // interactive single-category override
+	statusFilter    string // interactive displayed-status override
+	initialFilters  workitem.FilterOptions
+	limit           int
 	categoryForType func(string) string
 	showParked      bool
 	filterMode      bool
 	filterOptions   []string // chip values while filter mode is active; "" = all
 	filterIndex     int
 	savedTypeFilter string // snapshot of typeFilter when filter mode starts
+	savedTypes      []string
+	statusMode      bool
+	statusOptions   []string
+	statusIndex     int
+	savedStatus     string
+	savedStatuses   []string
+	savedStages     []string
+	savedAttention  []string
 
 	// Preview
 	showPreview    bool
@@ -187,6 +198,28 @@ func (m *Model) SetCategoryResolver(fn func(string) string) {
 	m.categoryForType = fn
 }
 
+// SetInitialFilters seeds visible, editable filters supplied by the command.
+func (m *Model) SetInitialFilters(opts workitem.FilterOptions, limit int) {
+	m.initialFilters = opts
+	m.limit = limit
+	m.showParked = opts.ShowParked
+	m.searchQuery = opts.Query
+	m.searchInput.SetValue(opts.Query)
+	if len(opts.Types) == 1 {
+		m.typeFilter = opts.Types[0]
+		m.initialFilters.Types = nil
+	}
+	if len(opts.Categories) == 1 {
+		m.categoryFilter = opts.Categories[0]
+		m.initialFilters.Categories = nil
+	}
+	if len(opts.Statuses) == 1 {
+		m.statusFilter = workitem.NormalizeDisplayStatus(opts.Statuses[0])
+		m.initialFilters.Statuses = nil
+	}
+	m.refilter()
+}
+
 // typeFilterFor resolves a pressed key to a type filter value.
 // "0" clears the filter; 1-4 are the builtin types.
 func (m Model) typeFilterFor(key string) (string, bool) {
@@ -204,6 +237,7 @@ func (m Model) typeFilterFor(key string) (string, bool) {
 func (m *Model) enterFilterMode() {
 	m.rebuildFilterOptions()
 	m.savedTypeFilter = m.typeFilter
+	m.savedTypes = append([]string(nil), m.initialFilters.Types...)
 	m.filterMode = true
 }
 
@@ -229,13 +263,41 @@ func (m *Model) rebuildFilterOptions() {
 	}
 }
 
-// visibleBaseItems returns allItems narrowed by the committed search and
-// parked visibility: exactly what the list shows before any type filter.
+// visibleBaseItems returns the rows visible before applying the type dimension,
+// so type chips and counts still reflect every other active filter.
 func (m Model) visibleBaseItems() []workitem.WorkItem {
-	return workitem.FilterAdvanced(m.allItems, workitem.FilterOptions{
-		Query:      m.searchQuery,
-		ShowParked: m.showParked,
-	})
+	opts := m.filterOptionsForState(m.searchQuery)
+	opts.Types = nil
+	return workitem.FilterAdvanced(m.allItems, opts)
+}
+
+func (m Model) categoryBaseItems() []workitem.WorkItem {
+	opts := m.filterOptionsForState(m.searchQuery)
+	opts.Categories = nil
+	return workitem.FilterAdvanced(m.allItems, opts)
+}
+
+func (m *Model) enterStatusMode() {
+	m.statusOptions = deriveStatusOptions(m.visibleBaseItems(), m.statusFilter)
+	m.statusIndex = 0
+	for i, status := range m.statusOptions {
+		if status == m.statusFilter {
+			m.statusIndex = i
+			break
+		}
+	}
+	m.savedStatus = m.statusFilter
+	m.savedStatuses = append([]string(nil), m.initialFilters.Statuses...)
+	m.savedStages = append([]string(nil), m.initialFilters.LifecycleStages...)
+	m.savedAttention = append([]string(nil), m.initialFilters.AttentionStages...)
+	m.statusMode = true
+}
+
+func (m Model) isStatusMode() bool { return m.statusMode }
+
+func deriveStatusOptions(_ []workitem.WorkItem, _ string) []string {
+	opts := []string{""}
+	return append(opts, workitem.DisplayStatusVocabulary()...)
 }
 
 // visibleTypeCounts tallies visible items per workflow type, returning the
@@ -275,6 +337,9 @@ func (m Model) currentItem() workitem.WorkItem {
 // then clamps cursor and scrollOffset to stay within bounds.
 func (m *Model) refilter() {
 	m.filteredItems = workitem.FilterAdvanced(m.allItems, m.filterOptionsForState(m.searchQuery))
+	if m.limit > 0 && len(m.filteredItems) > m.limit {
+		m.filteredItems = m.filteredItems[:m.limit]
+	}
 	if m.cursor >= len(m.filteredItems) {
 		m.cursor = max(0, len(m.filteredItems)-1)
 	}
@@ -282,24 +347,23 @@ func (m *Model) refilter() {
 }
 
 func (m Model) filterOptionsForState(query string) workitem.FilterOptions {
-	var types []string
+	opts := m.initialFilters
 	if m.typeFilter != "" {
-		types = []string{m.typeFilter}
+		opts.Types = []string{m.typeFilter}
 	}
-	var categories []string
 	if m.categoryFilter != "" {
-		categories = []string{m.categoryFilter}
+		opts.Categories = []string{m.categoryFilter}
 	}
-	return workitem.FilterOptions{
-		Types:      types,
-		Categories: categories,
-		Query:      query,
-		ShowParked: m.showParked,
+	if m.statusFilter != "" {
+		opts.Statuses = []string{m.statusFilter}
 	}
+	opts.Query = query
+	opts.ShowParked = m.showParked
+	return opts
 }
 
 func (m *Model) cycleCategory() {
-	opts := deriveCategoryOptions(m.visibleBaseItems(), m.categoryFilter)
+	opts := deriveCategoryOptions(m.categoryBaseItems(), m.categoryFilter)
 	if len(opts) <= 1 {
 		return
 	}
@@ -311,6 +375,7 @@ func (m *Model) cycleCategory() {
 		}
 	}
 	m.categoryFilter = opts[(idx+1)%len(opts)]
+	m.initialFilters.Categories = nil
 	m.refilter()
 }
 

--- a/internal/workitem/tui/model.go
+++ b/internal/workitem/tui/model.go
@@ -199,9 +199,11 @@ func (m *Model) SetCategoryResolver(fn func(string) string) {
 }
 
 // SetInitialFilters seeds visible, editable filters supplied by the command.
-func (m *Model) SetInitialFilters(opts workitem.FilterOptions, limit int) {
+// Result-size limits (--limit) are intentionally not applied here: limit is a
+// non-interactive result control, not a browsable TUI prefilter.
+func (m *Model) SetInitialFilters(opts workitem.FilterOptions) {
 	m.initialFilters = opts
-	m.limit = limit
+	m.limit = 0
 	m.showParked = opts.ShowParked
 	m.searchQuery = opts.Query
 	m.searchInput.SetValue(opts.Query)

--- a/internal/workitem/tui/model_test.go
+++ b/internal/workitem/tui/model_test.go
@@ -601,7 +601,7 @@ func TestModel_InitialFiltersAreVisibleAndEditable(t *testing.T) {
 		Statuses:   []string{"active"},
 		Query:      "auth",
 		ShowParked: false,
-	}, 0)
+	})
 	if len(m.filteredItems) != 1 || m.filteredItems[0].Key != "design" {
 		t.Fatalf("initial filters = %v, want design", m.filteredItems)
 	}
@@ -636,7 +636,7 @@ func TestModel_ZeroClearsSeededSelectionFilters(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := New(context.Background(), items, "/campaign", nil, nil, "")
-			m.SetInitialFilters(tt.filters, 0)
+			m.SetInitialFilters(tt.filters)
 			if len(m.filteredItems) != 1 {
 				t.Fatalf("seeded filter returned %d items, want 1", len(m.filteredItems))
 			}
@@ -666,7 +666,7 @@ func TestModel_StatusFilterModeClearsSeededStatus(t *testing.T) {
 		{Key: "active", AttentionStage: "active"},
 	}
 	m := New(context.Background(), items, "/campaign", nil, nil, "")
-	m.SetInitialFilters(workitem.FilterOptions{Statuses: []string{"current"}}, 0)
+	m.SetInitialFilters(workitem.FilterOptions{Statuses: []string{"current"}})
 	if len(m.filteredItems) != 1 {
 		t.Fatalf("seeded status returned %d items", len(m.filteredItems))
 	}
@@ -675,6 +675,60 @@ func TestModel_StatusFilterModeClearsSeededStatus(t *testing.T) {
 	m = updated.(Model)
 	if m.statusFilter != "" || len(m.initialFilters.Statuses) != 0 || len(m.filteredItems) != 2 {
 		t.Fatalf("status clear failed: filter=%q seed=%v items=%d", m.statusFilter, m.initialFilters.Statuses, len(m.filteredItems))
+	}
+}
+
+// Stage seeds must survive live navigation back to "all" in status mode; only
+// a concrete status (or explicit 0) clears lifecycle/attention prefilters.
+func TestModel_StatusModePreservesStageSeedsOnAll(t *testing.T) {
+	items := []workitem.WorkItem{
+		{Key: "active", LifecycleStage: workitem.LifecycleStageActive, Title: "active"},
+		{Key: "ready", LifecycleStage: workitem.LifecycleStageReady, Title: "ready"},
+	}
+	m := New(context.Background(), items, "/campaign", nil, nil, "")
+	m.SetInitialFilters(workitem.FilterOptions{LifecycleStages: []string{"active"}})
+	if len(m.filteredItems) != 1 {
+		t.Fatalf("seeded stage returned %d items", len(m.filteredItems))
+	}
+	m.enterStatusMode()
+	// Navigate to a concrete status then back to "all" (index 0).
+	m.statusIndex = 1
+	m.applyStatusFilter(m.statusOptions[1])
+	if len(m.initialFilters.LifecycleStages) != 0 {
+		t.Fatalf("concrete status should clear lifecycle seeds, got %v", m.initialFilters.LifecycleStages)
+	}
+	m.statusIndex = 0
+	m.applyStatusFilter("")
+	// "all" does not restore seeds (they were cleared by concrete status), but
+	// also must not panic; re-seed and verify empty apply leaves stages alone.
+	m.initialFilters.LifecycleStages = []string{"active"}
+	m.applyStatusFilter("")
+	if got := m.initialFilters.LifecycleStages; len(got) != 1 || got[0] != "active" {
+		t.Fatalf("applyStatusFilter(\"\") clobbered lifecycle seeds: %v", got)
+	}
+	if len(m.filteredItems) != 1 {
+		t.Fatalf("stage seed after all: %d items, want 1", len(m.filteredItems))
+	}
+}
+
+func TestModel_LimitNotAppliedInTUI(t *testing.T) {
+	items := makeTestItems(3)
+	m := New(context.Background(), items, "/campaign", nil, nil, "")
+	// Even if a caller left limit set, SetInitialFilters clears it.
+	m.limit = 1
+	m.SetInitialFilters(workitem.FilterOptions{})
+	if m.limit != 0 {
+		t.Fatalf("limit after SetInitialFilters = %d, want 0", m.limit)
+	}
+	if len(m.filteredItems) != 3 {
+		t.Fatalf("filtered = %d, want full set 3", len(m.filteredItems))
+	}
+	m.limit = 1
+	m.refilter()
+	// refilter still honors an explicit internal limit if set, but clear-all drops it.
+	m.clearAllFilters()
+	if m.limit != 0 || len(m.filteredItems) != 3 {
+		t.Fatalf("after clearAll: limit=%d items=%d", m.limit, len(m.filteredItems))
 	}
 }
 

--- a/internal/workitem/tui/model_test.go
+++ b/internal/workitem/tui/model_test.go
@@ -619,6 +619,47 @@ func TestModel_InitialFiltersAreVisibleAndEditable(t *testing.T) {
 	}
 }
 
+func TestModel_ZeroClearsSeededSelectionFilters(t *testing.T) {
+	items := []workitem.WorkItem{
+		{Key: "one", Title: "one", WorkflowType: workitem.WorkflowTypeDesign, WorkflowCategory: "plan", AttentionStage: "active", Group: "alpha"},
+		{Key: "two", Title: "two", WorkflowType: workitem.WorkflowTypeIntent, WorkflowCategory: "research", AttentionStage: "ready", Group: "beta"},
+	}
+	tests := []struct {
+		name    string
+		filters workitem.FilterOptions
+	}{
+		{name: "category", filters: workitem.FilterOptions{Categories: []string{"plan"}}},
+		{name: "status", filters: workitem.FilterOptions{Statuses: []string{"active"}}},
+		{name: "group", filters: workitem.FilterOptions{Groups: []string{"alpha"}}},
+		{name: "query", filters: workitem.FilterOptions{Query: "one"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := New(context.Background(), items, "/campaign", nil, nil, "")
+			m.SetInitialFilters(tt.filters, 0)
+			if len(m.filteredItems) != 1 {
+				t.Fatalf("seeded filter returned %d items, want 1", len(m.filteredItems))
+			}
+
+			updated, _ := m.handleNormalKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'0'}})
+			m = updated.(Model)
+			if len(m.filteredItems) != len(items) {
+				t.Fatalf("after '0': %d items, want %d", len(m.filteredItems), len(items))
+			}
+			if m.typeFilter != "" || m.categoryFilter != "" || m.statusFilter != "" {
+				t.Fatalf("interactive filters remain: type=%q category=%q status=%q", m.typeFilter, m.categoryFilter, m.statusFilter)
+			}
+			if m.searchQuery != "" || m.searchInput.Value() != "" {
+				t.Fatalf("search filter remains: query=%q input=%q", m.searchQuery, m.searchInput.Value())
+			}
+			if len(m.initialFilters.Types) != 0 || len(m.initialFilters.Categories) != 0 || len(m.initialFilters.Statuses) != 0 ||
+				len(m.initialFilters.LifecycleStages) != 0 || len(m.initialFilters.AttentionStages) != 0 || len(m.initialFilters.Groups) != 0 {
+				t.Fatalf("seeded filters remain: %+v", m.initialFilters)
+			}
+		})
+	}
+}
+
 func TestModel_StatusFilterModeClearsSeededStatus(t *testing.T) {
 	items := []workitem.WorkItem{
 		{Key: "current", AttentionStage: "current"},

--- a/internal/workitem/tui/model_test.go
+++ b/internal/workitem/tui/model_test.go
@@ -588,6 +588,55 @@ func TestModel_FooterRendersFilterChips(t *testing.T) {
 	}
 }
 
+func TestModel_InitialFiltersAreVisibleAndEditable(t *testing.T) {
+	items := []workitem.WorkItem{
+		{Key: "design", WorkflowType: workitem.WorkflowTypeDesign, WorkflowCategory: "plan", AttentionStage: "active", Title: "auth design"},
+		{Key: "intent", WorkflowType: workitem.WorkflowTypeIntent, WorkflowCategory: "plan", LifecycleStage: workitem.LifecycleStageActive, Title: "auth intent"},
+		{Key: "other", WorkflowType: workitem.WorkflowTypeExplore, WorkflowCategory: "research", AttentionStage: "active", Title: "other"},
+	}
+	m := New(context.Background(), items, "/campaign", nil, nil, "")
+	m.SetInitialFilters(workitem.FilterOptions{
+		Types:      []string{"design"},
+		Categories: []string{"plan"},
+		Statuses:   []string{"active"},
+		Query:      "auth",
+		ShowParked: false,
+	}, 0)
+	if len(m.filteredItems) != 1 || m.filteredItems[0].Key != "design" {
+		t.Fatalf("initial filters = %v, want design", m.filteredItems)
+	}
+	header := m.renderHeader()
+	for _, want := range []string{"type:design", "category:plan", "status:active", "search:auth"} {
+		if !strings.Contains(header, want) {
+			t.Fatalf("header missing %q: %s", want, header)
+		}
+	}
+
+	updated, _ := m.handleNormalKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'0'}})
+	m = updated.(Model)
+	if m.typeFilter != "" || len(m.initialFilters.Types) != 0 {
+		t.Fatalf("type filter not cleared: %q / %v", m.typeFilter, m.initialFilters.Types)
+	}
+}
+
+func TestModel_StatusFilterModeClearsSeededStatus(t *testing.T) {
+	items := []workitem.WorkItem{
+		{Key: "current", AttentionStage: "current"},
+		{Key: "active", AttentionStage: "active"},
+	}
+	m := New(context.Background(), items, "/campaign", nil, nil, "")
+	m.SetInitialFilters(workitem.FilterOptions{Statuses: []string{"current"}}, 0)
+	if len(m.filteredItems) != 1 {
+		t.Fatalf("seeded status returned %d items", len(m.filteredItems))
+	}
+	m.enterStatusMode()
+	updated, _ := m.handleStatusFilterKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'0'}})
+	m = updated.(Model)
+	if m.statusFilter != "" || len(m.initialFilters.Statuses) != 0 || len(m.filteredItems) != 2 {
+		t.Fatalf("status clear failed: filter=%q seed=%v items=%d", m.statusFilter, m.initialFilters.Statuses, len(m.filteredItems))
+	}
+}
+
 func TestChipWindow(t *testing.T) {
 	labels := []string{"all 40", "intent 10", "design 10", "bug 10", "feature 10"}
 	tests := []struct {

--- a/internal/workitem/tui/update.go
+++ b/internal/workitem/tui/update.go
@@ -60,6 +60,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.isFilterMode() {
 			return m.handleFilterKey(msg)
 		}
+		if m.isStatusMode() {
+			return m.handleStatusFilterKey(msg)
+		}
 		if m.searchMode {
 			return m.handleSearchKey(msg)
 		}
@@ -74,17 +77,20 @@ func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.filterIndex < len(m.filterOptions)-1 {
 			m.filterIndex++
 			m.typeFilter = m.filterOptions[m.filterIndex]
+			m.initialFilters.Types = nil
 			m.refilter()
 		}
 	case "k", "up", "h", "left":
 		if m.filterIndex > 0 {
 			m.filterIndex--
 			m.typeFilter = m.filterOptions[m.filterIndex]
+			m.initialFilters.Types = nil
 			m.refilter()
 		}
 	case "0":
 		m.filterIndex = 0
 		m.typeFilter = ""
+		m.initialFilters.Types = nil
 		m.refilter()
 	case "1", "2", "3", "4":
 		t, _ := m.typeFilterFor(msg.String())
@@ -92,6 +98,7 @@ func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if opt == t {
 				m.filterIndex = i
 				m.typeFilter = t
+				m.initialFilters.Types = nil
 				m.refilter()
 				break
 			}
@@ -100,10 +107,47 @@ func (m Model) handleFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.exitFilterMode()
 	case "esc":
 		m.typeFilter = m.savedTypeFilter
+		m.initialFilters.Types = append([]string(nil), m.savedTypes...)
 		m.refilter()
 		m.exitFilterMode()
 	}
 	return m, nil
+}
+
+func (m Model) handleStatusFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "j", "down", "l", "right":
+		if m.statusIndex < len(m.statusOptions)-1 {
+			m.statusIndex++
+			m.applyStatusFilter(m.statusOptions[m.statusIndex])
+		}
+	case "k", "up", "h", "left":
+		if m.statusIndex > 0 {
+			m.statusIndex--
+			m.applyStatusFilter(m.statusOptions[m.statusIndex])
+		}
+	case "0":
+		m.statusIndex = 0
+		m.applyStatusFilter("")
+	case "enter", "s":
+		m.statusMode = false
+	case "esc":
+		m.statusFilter = m.savedStatus
+		m.initialFilters.Statuses = append([]string(nil), m.savedStatuses...)
+		m.initialFilters.LifecycleStages = append([]string(nil), m.savedStages...)
+		m.initialFilters.AttentionStages = append([]string(nil), m.savedAttention...)
+		m.refilter()
+		m.statusMode = false
+	}
+	return m, nil
+}
+
+func (m *Model) applyStatusFilter(status string) {
+	m.statusFilter = status
+	m.initialFilters.Statuses = nil
+	m.initialFilters.LifecycleStages = nil
+	m.initialFilters.AttentionStages = nil
+	m.refilter()
 }
 
 func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -125,6 +169,7 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// Type filter accelerators — 0 for all, 1-4 for the builtin types
 	if filter, ok := m.typeFilterFor(key); ok {
 		m.typeFilter = filter
+		m.initialFilters.Types = nil
 		m.refilter()
 		return m, nil
 	}
@@ -181,6 +226,8 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.enterPriorityMode()
 	case "S":
 		m.enterStageMode()
+	case "s":
+		m.enterStatusMode()
 
 	// Type filter mode
 	case "f":
@@ -212,8 +259,14 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.searchQuery = ""
 			m.searchInput.SetValue("")
 			m.refilter()
-		} else if m.categoryFilter != "" {
+		} else if m.categoryFilter != "" || len(m.initialFilters.Categories) > 0 {
 			m.categoryFilter = ""
+			m.initialFilters.Categories = nil
+			m.refilter()
+		} else if m.statusFilter != "" || len(m.initialFilters.Statuses) > 0 || len(m.initialFilters.LifecycleStages) > 0 || len(m.initialFilters.AttentionStages) > 0 {
+			m.applyStatusFilter("")
+		} else if len(m.initialFilters.Groups) > 0 {
+			m.initialFilters.Groups = nil
 			m.refilter()
 		}
 	}

--- a/internal/workitem/tui/update.go
+++ b/internal/workitem/tui/update.go
@@ -150,6 +150,22 @@ func (m *Model) applyStatusFilter(status string) {
 	m.refilter()
 }
 
+func (m *Model) clearAllFilters() {
+	m.typeFilter = ""
+	m.categoryFilter = ""
+	m.statusFilter = ""
+	m.searchQuery = ""
+	m.searchInput.SetValue("")
+	m.initialFilters.Types = nil
+	m.initialFilters.Categories = nil
+	m.initialFilters.Statuses = nil
+	m.initialFilters.LifecycleStages = nil
+	m.initialFilters.AttentionStages = nil
+	m.initialFilters.Groups = nil
+	m.initialFilters.Query = ""
+	m.refilter()
+}
+
 func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
@@ -166,7 +182,15 @@ func (m Model) handleNormalKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	m.lastKeyWasG = false
 
-	// Type filter accelerators — 0 for all, 1-4 for the builtin types
+	// Clear every selection filter before handling the type accelerators so
+	// command-seeded category, status, stage, and group filters do not survive
+	// the footer-advertised "0 all" action.
+	if key == "0" {
+		m.clearAllFilters()
+		return m, nil
+	}
+
+	// Type filter accelerators — 1-4 for the builtin types.
 	if filter, ok := m.typeFilterFor(key); ok {
 		m.typeFilter = filter
 		m.initialFilters.Types = nil

--- a/internal/workitem/tui/update.go
+++ b/internal/workitem/tui/update.go
@@ -127,8 +127,9 @@ func (m Model) handleStatusFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.applyStatusFilter(m.statusOptions[m.statusIndex])
 		}
 	case "0":
+		// Explicit clear of the whole status dimension (display + stage/attention).
 		m.statusIndex = 0
-		m.applyStatusFilter("")
+		m.clearStatusDimension()
 	case "enter", "s":
 		m.statusMode = false
 	case "esc":
@@ -142,8 +143,22 @@ func (m Model) handleStatusFilterKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// applyStatusFilter sets the interactive displayed-status chip. A concrete
+// status supersedes lifecycle/attention seeds; empty ("all") only clears the
+// chip and multi-status seeds so stage/attention prefilters survive live
+// navigation back to "all" (explicit full clear is clearStatusDimension / 0).
 func (m *Model) applyStatusFilter(status string) {
 	m.statusFilter = status
+	m.initialFilters.Statuses = nil
+	if status != "" {
+		m.initialFilters.LifecycleStages = nil
+		m.initialFilters.AttentionStages = nil
+	}
+	m.refilter()
+}
+
+func (m *Model) clearStatusDimension() {
+	m.statusFilter = ""
 	m.initialFilters.Statuses = nil
 	m.initialFilters.LifecycleStages = nil
 	m.initialFilters.AttentionStages = nil
@@ -156,6 +171,7 @@ func (m *Model) clearAllFilters() {
 	m.statusFilter = ""
 	m.searchQuery = ""
 	m.searchInput.SetValue("")
+	m.limit = 0
 	m.initialFilters.Types = nil
 	m.initialFilters.Categories = nil
 	m.initialFilters.Statuses = nil

--- a/internal/workitem/tui/view.go
+++ b/internal/workitem/tui/view.go
@@ -439,7 +439,8 @@ func shortLifecycle(stage workitem.LifecycleStage) string {
 	case workitem.LifecycleStageChains:
 		return "chains"
 	case workitem.LifecycleStageNone, "":
-		return "-"
+		// Match DisplayStatus / --status none filter token.
+		return "none"
 	default:
 		return string(stage)
 	}

--- a/internal/workitem/tui/view.go
+++ b/internal/workitem/tui/view.go
@@ -608,7 +608,7 @@ func (m Model) renderHelp() string {
 			{"/", "Start search"},
 			{"Esc", "Clear search / close overlay"},
 			{"f", "Filter by type (j/k or arrows step, Enter apply, Esc cancel)"},
-			{"0", "Show all types"},
+			{"0", "Clear all filters"},
 			{"1", "Filter: intent"},
 			{"2", "Filter: design"},
 			{"3", "Filter: explore"},

--- a/internal/workitem/tui/view.go
+++ b/internal/workitem/tui/view.go
@@ -67,11 +67,17 @@ func (m Model) renderPreviewOverlay() string {
 func (m Model) renderHeader() string {
 	title := headerStyle.Render("camp workitem")
 	var filters []string
-	if m.typeFilter != "" {
-		filters = append(filters, filterActiveStyle.Render("type:"+m.typeFilter))
+	if values := m.activeTypes(); len(values) > 0 {
+		filters = append(filters, filterActiveStyle.Render("type:"+strings.Join(values, ",")))
 	}
-	if m.categoryFilter != "" {
-		filters = append(filters, filterActiveStyle.Render("category:"+m.categoryFilter))
+	if values := m.activeCategories(); len(values) > 0 {
+		filters = append(filters, filterActiveStyle.Render("category:"+strings.Join(values, ",")))
+	}
+	if values := m.activeStatuses(); len(values) > 0 {
+		filters = append(filters, filterActiveStyle.Render("status:"+strings.Join(values, ",")))
+	}
+	if len(m.initialFilters.Groups) > 0 {
+		filters = append(filters, filterActiveStyle.Render("group:"+strings.Join(m.initialFilters.Groups, ",")))
 	}
 	if m.searchQuery != "" {
 		filters = append(filters, filterActiveStyle.Render("search:"+m.searchQuery))
@@ -83,6 +89,34 @@ func (m Model) renderHeader() string {
 		title += "  " + footerStyle.Render("/"+m.searchInput.Value())
 	}
 	return title
+}
+
+func (m Model) activeTypes() []string {
+	if m.typeFilter != "" {
+		return []string{m.typeFilter}
+	}
+	return m.initialFilters.Types
+}
+
+func (m Model) activeCategories() []string {
+	if m.categoryFilter != "" {
+		return []string{m.categoryFilter}
+	}
+	return m.initialFilters.Categories
+}
+
+func (m Model) activeStatuses() []string {
+	if m.statusFilter != "" {
+		return []string{m.statusFilter}
+	}
+	values := append([]string(nil), m.initialFilters.Statuses...)
+	for _, stage := range m.initialFilters.LifecycleStages {
+		values = append(values, "lifecycle="+stage)
+	}
+	for _, stage := range m.initialFilters.AttentionStages {
+		values = append(values, "attention="+stage)
+	}
+	return values
 }
 
 func (m Model) renderFooter() string {
@@ -104,12 +138,36 @@ func (m Model) renderFooter() string {
 	if m.isFilterMode() {
 		return m.renderFilterChips()
 	}
+	if m.isStatusMode() {
+		return m.renderStatusFilter()
+	}
 	count := fmt.Sprintf("%d items", len(m.filteredItems))
-	keys := "j/k move  / search  f filter  c category  0 all  S stage  P priority  tab preview  r refresh  ? help  q quit"
+	keys := "j/k move  / search  f type  s status  c category  0 all  S set-stage  P priority  tab preview  r refresh  ? help  q quit"
 	if len(keys)+len(count)+2 > m.width {
-		keys = "j/k / f c P tab r ? q"
+		keys = "j/k / f filter s status c category P tab r ? q"
 	}
 	return footerStyle.Render(fmt.Sprintf("%s  %s", count, keys))
+}
+
+func (m Model) renderStatusFilter() string {
+	labels := make([]string, len(m.statusOptions))
+	for i, status := range m.statusOptions {
+		if status == "" {
+			labels[i] = "all"
+		} else {
+			labels[i] = status
+		}
+	}
+	parts := make([]string, len(labels))
+	for i, label := range labels {
+		if i == m.statusIndex {
+			parts[i] = "[" + label + "]"
+		} else {
+			parts[i] = label
+		}
+	}
+	row := "status: " + strings.Join(parts, "  ")
+	return footerStyle.Render(truncate(row, max(m.width, 1)))
 }
 
 const (

--- a/tests/integration/workitem_list_filter_test.go
+++ b/tests/integration/workitem_list_filter_test.go
@@ -1,0 +1,52 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_WorkitemListFiltersNonTTYAndJSON(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/workitem-list-filters"
+	_, err := tc.InitCampaign(dir, "workitem-list-filters", "product")
+	require.NoError(t, err)
+
+	_, err = tc.RunCampInDir(dir, "workitem", "create", "auth-design", "--type", "design", "--title", "Auth Design")
+	require.NoError(t, err)
+	_, err = tc.RunCampInDir(dir, "workitem", "create", "search-notes", "--type", "explore", "--title", "Search Notes")
+	require.NoError(t, err)
+
+	text, err := tc.RunCampInDir(dir, "workitem", "list", "design")
+	require.NoError(t, err, "compact list: %s", text)
+	assert.Contains(t, text, "Auth Design")
+	assert.NotContains(t, text, "Search Notes")
+
+	raw, err := tc.RunCampInDir(dir, "workitem", "list", "active", "--json")
+	require.NoError(t, err, "JSON list: %s", raw)
+	start := strings.Index(raw, "{")
+	require.GreaterOrEqual(t, start, 0, "missing JSON: %s", raw)
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		Items         []struct {
+			AttentionStage string `json:"attention_stage"`
+			LifecycleStage string `json:"lifecycle_stage"`
+		} `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(raw[start:]), &payload))
+	assert.Equal(t, "workitems/v1alpha8", payload.SchemaVersion)
+	require.NotEmpty(t, payload.Items)
+	for _, item := range payload.Items {
+		assert.True(t, item.AttentionStage == "active" || item.LifecycleStage == "active")
+	}
+
+	legacy, err := tc.RunCampInDir(dir, "workitem", "--list", "--type", "design")
+	require.NoError(t, err, "legacy --list: %s", legacy)
+	assert.Contains(t, legacy, "Auth Design")
+}


### PR DESCRIPTION
## Summary

- add `camp workitem list [type|status|category]`
- open the workitem TUI with visible, editable prefilters when stdout is a terminal
- emit compact grouped text outside a TTY and preserve `workitems/v1alpha8` with `--json`
- add unified displayed-status filtering across lifecycle and attention stages
- retain compatibility with `camp workitem --list`

## Why

Users currently have to reopen the workitem dashboard and reapply common filters. Scripts and agents can use root-level flags, but there is no list-shaped command that gives humans and automation the same filter vocabulary and environment-appropriate output.

The new command supports positional type/status/category shortcuts plus explicit repeatable filters for type, displayed status, category, lifecycle stage, attention stage, and group. Ambiguous positional values return guidance to use an explicit flag.

## User impact

- `camp workitem list intent` opens a prefiltered dashboard in a terminal and produces compact text when piped.
- `camp workitem list active --json` returns lifecycle-active and attention-active work using the existing JSON schema.
- TUI filters can be changed or cleared without rediscovering or permanently narrowing the candidate set.

## Validation

- `just gate-fast` — 3,305 tests
- `go test ./...`
- `go vet -tags=integration ./...`
- containerized `TestIntegration_WorkitemListFiltersNonTTYAndJSON`
- command smokes for compact output, JSON output, and positional ambiguity
