### PR TITLE
fix: apply shared theme to gather design

### DIFF
--- a/internal/commands/workitem/gather.go
+++ b/internal/commands/workitem/gather.go
@@ -1,6 +1,7 @@
 package workitem
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -17,8 +18,11 @@ import (
 	"github.com/Obedience-Corp/camp/internal/jsoncontract"
 	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/internal/ui/theme"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
+
+var gatherFormRunner = theme.RunForm
 
 type gatherOptions struct {
 	Title    string
@@ -160,7 +164,7 @@ func runWorkitemGather(cmd *cobra.Command, wfType string, args []string, opts ga
 			return camperrors.NewValidation("selectors",
 				"pass at least 2 "+wfType+" workitem selectors (list candidates with `camp workitem --json --type "+wfType+"`)", nil)
 		}
-		selected, title, err = promptGatherSelection(typed, wfType, title)
+		selected, title, err = promptGatherSelection(ctx, typed, wfType, title)
 		if err != nil {
 			return err
 		}
@@ -237,7 +241,7 @@ func runWorkitemGather(cmd *cobra.Command, wfType string, args []string, opts ga
 	return emitGatherResult(cmd, plan, execution, opts.JSON)
 }
 
-func promptGatherSelection(typed []wkitem.WorkItem, wfType, preTitle string) ([]wkitem.WorkItem, string, error) {
+func promptGatherSelection(ctx context.Context, typed []wkitem.WorkItem, wfType, preTitle string) ([]wkitem.WorkItem, string, error) {
 	if len(typed) < 2 {
 		return nil, "", camperrors.NewValidation("selectors",
 			fmt.Sprintf("need at least 2 %s workitems to gather, found %d", wfType, len(typed)), nil)
@@ -284,7 +288,7 @@ func promptGatherSelection(typed []wkitem.WorkItem, wfType, preTitle string) ([]
 			Value(&title))
 	}
 
-	if err := huh.NewForm(huh.NewGroup(fields...)).Run(); err != nil {
+	if err := gatherFormRunner(ctx, huh.NewForm(huh.NewGroup(fields...))); err != nil {
 		return nil, "", camperrors.Wrap(err, "gather selection cancelled")
 	}
 

--- a/internal/commands/workitem/gather_theme_test.go
+++ b/internal/commands/workitem/gather_theme_test.go
@@ -1,0 +1,37 @@
+package workitem
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/charmbracelet/huh"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+func TestPromptGatherSelectionUsesSharedThemeRunner(t *testing.T) {
+	wantErr := errors.New("stop before interaction")
+	called := false
+	original := gatherFormRunner
+	gatherFormRunner = func(_ context.Context, form *huh.Form) error {
+		called = true
+		if form == nil {
+			t.Fatal("shared theme runner received nil form")
+		}
+		return wantErr
+	}
+	t.Cleanup(func() { gatherFormRunner = original })
+
+	items := []wkitem.WorkItem{
+		{Title: "One", RelativePath: "workflow/design/one"},
+		{Title: "Two", RelativePath: "workflow/design/two"},
+	}
+	_, _, err := promptGatherSelection(context.Background(), items, "design", "Combined")
+	if !called {
+		t.Fatal("prompt did not use the shared theme runner")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("prompt error = %v, want wrapped runner error", err)
+	}
+}


### PR DESCRIPTION
## Summary

- route the interactive `camp gather design` form through Camp's shared theme runner
- preserve the command context so global and campaign-local theme settings are resolved correctly
- add regression coverage proving the picker uses the shared runner

## Root cause

The gather picker constructed a Huh form and called `Form.Run()` directly. That bypassed `theme.RunForm`, so it used Huh's default palette instead of Camp's adaptive/light/dark/high-contrast theme and its improved help and placeholder contrast.

## User impact

The design gather picker now has the same readable colors and terminal handling as Camp's other themed Huh forms.

## Validation

- focused gather/theme regression test
- `just gate-fast` — stable/dev builds, vet, lint, and 3,301 tests
