### PR TITLE
perf(sync): parallelize submodule update under the --parallel semaphore

### DIFF
--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	gosync "sync"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/git"
@@ -217,9 +218,12 @@ func (s *Syncer) diffURLs(before, after map[string]string) []URLChange {
 	return changes
 }
 
-// updateSubmodules initializes and updates submodules one-by-one with graceful
+// updateSubmodules initializes and updates submodules individually with graceful
 // stale reference handling. This replaces the bulk `git submodule update --init --recursive`
-// which fails entirely if any single submodule has a stale ref.
+// which fails entirely if any single submodule has a stale ref. Submodules are
+// processed concurrently under a semaphore bounded by SyncOptions.Parallel,
+// mirroring the worker pattern clone uses for submodule initialization; results
+// preserve .gitmodules declaration order.
 func (s *Syncer) updateSubmodules(ctx context.Context) ([]SubmoduleResult, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
@@ -229,55 +233,97 @@ func (s *Syncer) updateSubmodules(ctx context.Context) ([]SubmoduleResult, error
 	if err != nil {
 		return nil, err
 	}
+	if len(paths) == 0 {
+		return nil, nil
+	}
 
-	var results []SubmoduleResult
-	for _, path := range paths {
+	parallel := s.options.Parallel
+	if parallel <= 0 {
+		parallel = 4
+	}
+	if parallel > len(paths) {
+		parallel = len(paths)
+	}
+
+	results := make([]SubmoduleResult, len(paths))
+	sem := make(chan struct{}, parallel)
+	var wg gosync.WaitGroup
+
+	for i, path := range paths {
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			break
 		}
 
-		result := SubmoduleResult{
-			Path:    path,
-			Name:    path,
-			Success: true,
-		}
+		wg.Add(1)
+		go func(idx int, path string) {
+			defer wg.Done()
 
-		// Use shared graceful init (handles stale refs with fallback)
-		if err := git.InitSubmoduleGraceful(ctx, s.repoRoot, path); err != nil {
-			result.Success = false
-			result.Error = &SyncError{Op: "init", Submodule: path, Cause: err}
-			results = append(results, result)
-			continue
-		}
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				results[idx] = SubmoduleResult{
+					Path:    path,
+					Name:    path,
+					Success: false,
+					Error:   ctx.Err(),
+				}
+				return
+			}
 
-		// Initialize nested submodules within this submodule
-		subDir := filepath.Join(s.repoRoot, path)
-		cmd := exec.CommandContext(ctx, "git", "-C", subDir, "submodule", "update", "--init", "--recursive")
-		if output, nestedErr := cmd.CombinedOutput(); nestedErr != nil {
-			// Nested failure is non-fatal for the parent submodule
-			result.Error = &SyncError{Op: "nested-init", Submodule: path, Cause: camperrors.Wrapf(ErrNestedSubmodules, "%s", strings.TrimSpace(string(output)))}
-		}
+			results[idx] = s.updateSubmodule(ctx, path)
+		}(i, path)
+	}
+	wg.Wait()
 
-		// Checkout default branch instead of leaving on detached HEAD.
-		branch, checkoutErr := git.CheckoutDefaultBranch(ctx, subDir)
-		if checkoutErr != nil {
-			result.Success = false
-			result.Error = &SyncError{Op: "checkout", Submodule: path, Cause: checkoutErr}
-			results = append(results, result)
-			continue
-		}
-		result.CheckedOutBranch = branch
-		if warning, driftErr := s.reconcileCheckoutDrift(ctx, path, subDir, branch); driftErr != nil {
-			result.Success = false
-			result.Error = &SyncError{Op: "drift", Submodule: path, Cause: driftErr}
-		} else if warning != "" {
-			result.DriftWarning = warning
-		}
-
-		results = append(results, result)
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	return results, nil
+}
+
+// updateSubmodule runs the full update pipeline for a single submodule:
+// graceful init, nested submodule init, default-branch checkout, and
+// gitlink drift reconciliation.
+func (s *Syncer) updateSubmodule(ctx context.Context, path string) SubmoduleResult {
+	result := SubmoduleResult{
+		Path:    path,
+		Name:    path,
+		Success: true,
+	}
+
+	// Use shared graceful init (handles stale refs with fallback)
+	if err := git.InitSubmoduleGraceful(ctx, s.repoRoot, path); err != nil {
+		result.Success = false
+		result.Error = &SyncError{Op: "init", Submodule: path, Cause: err}
+		return result
+	}
+
+	// Initialize nested submodules within this submodule
+	subDir := filepath.Join(s.repoRoot, path)
+	cmd := exec.CommandContext(ctx, "git", "-C", subDir, "submodule", "update", "--init", "--recursive")
+	if output, nestedErr := cmd.CombinedOutput(); nestedErr != nil {
+		// Nested failure is non-fatal for the parent submodule
+		result.Error = &SyncError{Op: "nested-init", Submodule: path, Cause: camperrors.Wrapf(ErrNestedSubmodules, "%s", strings.TrimSpace(string(output)))}
+	}
+
+	// Checkout default branch instead of leaving on detached HEAD.
+	branch, checkoutErr := git.CheckoutDefaultBranch(ctx, subDir)
+	if checkoutErr != nil {
+		result.Success = false
+		result.Error = &SyncError{Op: "checkout", Submodule: path, Cause: checkoutErr}
+		return result
+	}
+	result.CheckedOutBranch = branch
+	if warning, driftErr := s.reconcileCheckoutDrift(ctx, path, subDir, branch); driftErr != nil {
+		result.Success = false
+		result.Error = &SyncError{Op: "drift", Submodule: path, Cause: driftErr}
+	} else if warning != "" {
+		result.DriftWarning = warning
+	}
+
+	return result
 }
 
 // verifySubmodules checks the status of all submodules after update.

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -148,6 +149,101 @@ func TestSync_ParallelJobs(t *testing.T) {
 	// Both submodules should be in results
 	if len(result.UpdateResults) != 2 {
 		t.Errorf("UpdateResults = %d, want 2", len(result.UpdateResults))
+	}
+}
+
+func TestUpdateSubmodules_PreservesDeclarationOrder(t *testing.T) {
+	ctx := context.Background()
+	repoRoot := setupTestRepo(t)
+	want := []string{"projects/sub1", "projects/sub2", "projects/sub3", "projects/sub4"}
+	for _, p := range want {
+		setupSubmodule(t, repoRoot, p)
+	}
+
+	syncer := NewSyncer(repoRoot, WithParallel(2))
+	results, err := syncer.updateSubmodules(ctx)
+	if err != nil {
+		t.Fatalf("updateSubmodules() error = %v", err)
+	}
+
+	if len(results) != len(want) {
+		t.Fatalf("updateSubmodules() results = %d, want %d", len(results), len(want))
+	}
+	for i, r := range results {
+		if r.Path != want[i] {
+			t.Errorf("results[%d].Path = %q, want %q", i, r.Path, want[i])
+		}
+		if !r.Success {
+			t.Errorf("results[%d] (%s) Success = false, want true: %v", i, r.Path, r.Error)
+		}
+	}
+}
+
+func TestUpdateSubmodules_PartialFailureIsolation(t *testing.T) {
+	ctx := context.Background()
+	repoRoot := setupTestRepo(t)
+	setupSubmodule(t, repoRoot, "projects/healthy")
+	setupSubmodule(t, repoRoot, "projects/broken")
+
+	// Break the second submodule: deinit it, drop its module gitdir, and
+	// remove its source repo so re-init has nowhere to clone from.
+	cmd := exec.Command("git", "-C", repoRoot, "config", "-f", ".gitmodules", "submodule.projects/broken.url")
+	urlBytes, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("reading broken submodule url: %v", err)
+	}
+	sourceRepo := strings.TrimSpace(string(urlBytes))
+	runGit(t, repoRoot, "submodule", "deinit", "-f", "projects/broken")
+	if err := os.RemoveAll(filepath.Join(repoRoot, ".git", "modules", "projects/broken")); err != nil {
+		t.Fatalf("removing module gitdir: %v", err)
+	}
+	if err := os.RemoveAll(sourceRepo); err != nil {
+		t.Fatalf("removing source repo: %v", err)
+	}
+
+	syncer := NewSyncer(repoRoot, WithParallel(2))
+	results, err := syncer.updateSubmodules(ctx)
+	if err != nil {
+		t.Fatalf("updateSubmodules() error = %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("updateSubmodules() results = %d, want 2", len(results))
+	}
+	byPath := make(map[string]SubmoduleResult, len(results))
+	for _, r := range results {
+		byPath[r.Path] = r
+	}
+	if !byPath["projects/healthy"].Success {
+		t.Errorf("healthy submodule Success = false, want true: %v", byPath["projects/healthy"].Error)
+	}
+	broken := byPath["projects/broken"]
+	if broken.Success {
+		t.Error("broken submodule Success = true, want false")
+	}
+	if broken.Error == nil {
+		t.Fatal("broken submodule Error = nil, want error")
+	}
+	syncErr, ok := broken.Error.(*SyncError)
+	if !ok {
+		t.Fatalf("broken submodule error type = %T, want *SyncError", broken.Error)
+	}
+	if syncErr.Op != "init" {
+		t.Errorf("SyncError.Op = %q, want %q", syncErr.Op, "init")
+	}
+}
+
+func TestUpdateSubmodules_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	repoRoot := setupTestRepo(t)
+	setupSubmodule(t, repoRoot, "projects/sub")
+
+	syncer := NewSyncer(repoRoot)
+	_, err := syncer.updateSubmodules(ctx)
+	if err != context.Canceled {
+		t.Errorf("updateSubmodules() error = %v, want context.Canceled", err)
 	}
 }
 


### PR DESCRIPTION
## What

`camp sync`'s submodule update phase ran strictly serially. The `--parallel` flag (default 4) existed and was plumbed into `SyncOptions.Parallel`, but nothing in the update path read it. This wires it up.

## How

- Extracted the per-submodule pipeline (graceful init, nested init, default-branch checkout, drift reconcile) into `updateSubmodule`.
- `updateSubmodules` now runs submodules concurrently under a bounded semaphore, the same worker pattern `internal/clone` has shipped for submodule init since clone parallelization landed. Concurrency safety is identical to clone's: per-submodule work writes only the submodule's own gitdir and worktree.
- Results are index-assigned so output preserves .gitmodules declaration order. Per-submodule failure isolation, error wrapping ops, and the 0/1/2/3 exit-code contract are unchanged.

## Measurement

12-submodule fixture with local remotes, same binary, `updateSubmodules` only:

| parallel | wall time |
| --- | --- |
| 1 | 2.20s |
| 4 | 0.66s |
| 8 | 0.52s |

Local remotes are the conservative case; against network remotes the win grows because per-repo latency dominates and overlaps.

## Tests

New: declaration-order preservation under parallelism, partial-failure isolation (one broken submodule fails with `Op=init`, healthy sibling still syncs), context cancellation on the update path. Full `just gate` passes (3274 tests).

## Context

First slice of the camp-sync-clone-transport design (workitem WI-a82711): the design's measurement pass identified serial update as the cheapest large win, needing no peer machinery.