### PR TITLE
feat(sync,clone): peer-assisted git transport via --from <machine>

### DIFF
--- a/cmd/camp/artifacts.go
+++ b/cmd/camp/artifacts.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/artifacts"
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var artifactsCmd = &cobra.Command{
+	Use:   "artifacts",
+	Short: "Manage declared artifact roots (.campaign/artifacts.yaml)",
+	Long: `Manage the campaign's declared artifact roots: directories of heavy non-git
+payloads (media, renders, datasets) that 'camp sync --from <machine>' moves
+between your machines with rsync instead of git.
+
+The declaration file (.campaign/artifacts.yaml) is committed, so every
+machine knows what belongs to the campaign. Declared roots should be
+gitignored: a root that is also git-tracked would make the same bytes both
+git content and artifact content. Manifests and per-peer sync snapshots are
+machine-local derived state under .campaign/cache (gitignored).`,
+	Example: `  camp artifacts list
+  camp artifacts add media/renders
+  camp artifacts add datasets --policy on-demand
+  camp artifacts remove media/renders
+  camp artifacts manifest media/renders`,
+}
+
+var artifactsListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List declared artifact roots",
+	RunE:    runArtifactsList,
+}
+
+var artifactsAddCmd = &cobra.Command{
+	Use:   "add <path>",
+	Short: "Declare an artifact root",
+	Long: `Declare a campaign-relative directory as an artifact root.
+
+Policy 'always' (default) syncs the root on every 'camp sync --from
+<machine>'; 'on-demand' syncs it only when artifacts are requested
+explicitly (--artifacts-only).`,
+	Args: cobra.ExactArgs(1),
+	RunE: runArtifactsAdd,
+}
+
+var artifactsRemoveCmd = &cobra.Command{
+	Use:     "remove <path>",
+	Aliases: []string{"rm"},
+	Short:   "Remove an artifact root declaration",
+	Long:    `Remove a declared artifact root. Files on disk are not touched.`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    runArtifactsRemove,
+}
+
+var artifactsManifestCmd = &cobra.Command{
+	Use:   "manifest <path>",
+	Short: "Print a declared root's manifest as JSON",
+	Long: `Walk a declared artifact root and print its manifest (relative path, size,
+mtime per file) as JSON. This is the same shape sync snapshots use, so it is
+useful for scripting and for comparing roots across machines.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runArtifactsManifest,
+}
+
+var artifactsOpts struct {
+	json   bool
+	policy string
+}
+
+func init() {
+	artifactsListCmd.Flags().BoolVar(&artifactsOpts.json, "json", false,
+		"Output as JSON for scripting")
+	artifactsAddCmd.Flags().StringVar(&artifactsOpts.policy, "policy", artifacts.PolicyAlways,
+		"Sync policy: always (every peer sync) or on-demand (--artifacts-only)")
+
+	artifactsCmd.AddCommand(artifactsListCmd)
+	artifactsCmd.AddCommand(artifactsAddCmd)
+	artifactsCmd.AddCommand(artifactsRemoveCmd)
+	artifactsCmd.AddCommand(artifactsManifestCmd)
+	rootCmd.AddCommand(artifactsCmd)
+	artifactsCmd.GroupID = "campaign"
+}
+
+type artifactRootJSON struct {
+	Path       string `json:"path"`
+	Policy     string `json:"policy"`
+	Exists     bool   `json:"exists"`
+	Gitignored bool   `json:"gitignored"`
+}
+
+type artifactsListOutput struct {
+	Version int                `json:"version"`
+	Roots   []artifactRootJSON `json:"roots"`
+}
+
+func runArtifactsList(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	campRoot, err := campaign.DetectCached(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign")
+	}
+	cfg, err := artifacts.Load(campRoot)
+	if err != nil {
+		return err
+	}
+
+	out := artifactsListOutput{Version: 1, Roots: []artifactRootJSON{}}
+	for _, r := range cfg.Roots {
+		abs := filepath.Join(campRoot, filepath.FromSlash(artifacts.NormalizeRootPath(r.Path)))
+		info, statErr := os.Stat(abs)
+		out.Roots = append(out.Roots, artifactRootJSON{
+			Path:       artifacts.NormalizeRootPath(r.Path),
+			Policy:     r.EffectivePolicy(),
+			Exists:     statErr == nil && info.IsDir(),
+			Gitignored: isGitignored(cmd, campRoot, r.Path),
+		})
+	}
+
+	if artifactsOpts.json {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+
+	if len(out.Roots) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No artifact roots declared. Add one with 'camp artifacts add <path>'.")
+		return nil
+	}
+	for _, r := range out.Roots {
+		status := ui.SuccessIcon()
+		notes := []string{r.Policy}
+		if !r.Exists {
+			status = ui.WarningIcon()
+			notes = append(notes, "missing locally")
+		}
+		if !r.Gitignored {
+			status = ui.WarningIcon()
+			notes = append(notes, "not gitignored")
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s %s (%s)\n", status, r.Path, strings.Join(notes, ", "))
+	}
+	return nil
+}
+
+func runArtifactsAdd(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	campRoot, err := campaign.DetectCached(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign")
+	}
+	cfg, err := artifacts.Load(campRoot)
+	if err != nil {
+		return err
+	}
+	root := artifacts.Root{Path: args[0], Policy: artifactsOpts.policy}
+	if root.Policy == artifacts.PolicyAlways {
+		root.Policy = "" // default stays implicit in the file
+	}
+	if err := cfg.Add(root); err != nil {
+		return err
+	}
+	if err := cfg.Save(campRoot); err != nil {
+		return err
+	}
+
+	normalized := artifacts.NormalizeRootPath(args[0])
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Declared artifact root %s\n", ui.SuccessIcon(), normalized)
+
+	if hasTrackedFiles(cmd, campRoot, normalized) {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+			"%s %s contains git-tracked files; artifact roots must not overlap git content (untrack them or pick another directory)\n",
+			ui.WarningIcon(), normalized)
+	}
+	if !isGitignored(cmd, campRoot, normalized) {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+			"%s %s is not gitignored; add it to .gitignore so artifact bytes never land in git\n",
+			ui.WarningIcon(), normalized)
+	}
+	return nil
+}
+
+func runArtifactsRemove(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	campRoot, err := campaign.DetectCached(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign")
+	}
+	cfg, err := artifacts.Load(campRoot)
+	if err != nil {
+		return err
+	}
+	if !cfg.Remove(args[0]) {
+		return camperrors.Newf("artifact root %q is not declared", args[0])
+	}
+	if err := cfg.Save(campRoot); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Removed artifact root %s (files on disk untouched)\n",
+		ui.SuccessIcon(), artifacts.NormalizeRootPath(args[0]))
+	return nil
+}
+
+func runArtifactsManifest(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	campRoot, err := campaign.DetectCached(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign")
+	}
+	cfg, err := artifacts.Load(campRoot)
+	if err != nil {
+		return err
+	}
+	root, found := cfg.Find(args[0])
+	if !found {
+		return camperrors.Newf("artifact root %q is not declared (see 'camp artifacts list')", args[0])
+	}
+	m, err := artifacts.BuildManifest(ctx, campRoot, root.Path)
+	if err != nil {
+		return err
+	}
+	data, err := m.EncodeJSON()
+	if err != nil {
+		return err
+	}
+	_, err = cmd.OutOrStdout().Write(data)
+	return err
+}
+
+// isGitignored reports whether git ignores the path (the recommended state
+// for artifact roots).
+func isGitignored(cmd *cobra.Command, campRoot, rel string) bool {
+	check := exec.CommandContext(cmd.Context(), "git", "-C", campRoot, "check-ignore", "-q", "--",
+		filepath.FromSlash(artifacts.NormalizeRootPath(rel)))
+	return check.Run() == nil
+}
+
+// hasTrackedFiles reports whether git tracks anything under the path (a
+// class conflict: the same bytes would be both git content and artifacts).
+func hasTrackedFiles(cmd *cobra.Command, campRoot, rel string) bool {
+	ls := exec.CommandContext(cmd.Context(), "git", "-C", campRoot, "ls-files", "--",
+		filepath.FromSlash(artifacts.NormalizeRootPath(rel)))
+	out, err := ls.Output()
+	return err == nil && len(strings.TrimSpace(string(out))) > 0
+}

--- a/cmd/camp/artifacts.go
+++ b/cmd/camp/artifacts.go
@@ -116,13 +116,24 @@ func runArtifactsList(cmd *cobra.Command, _ []string) error {
 
 	out := artifactsListOutput{Version: 1, Roots: []artifactRootJSON{}}
 	for _, r := range cfg.Roots {
-		abs := filepath.Join(campRoot, filepath.FromSlash(artifacts.NormalizeRootPath(r.Path)))
-		info, statErr := os.Stat(abs)
+		// Validate before stat: a hand-edited artifacts.yaml with a `../..`
+		// root would otherwise make this read-only command stat and report on
+		// files outside the campaign. Invalid roots are listed (so the user
+		// sees the bad declaration) but never touched on disk.
+		normalized, verr := artifacts.EnsureRootWithin(campRoot, r.Path)
+		exists := false
+		if verr == nil {
+			abs := filepath.Join(campRoot, filepath.FromSlash(normalized))
+			info, statErr := os.Stat(abs)
+			exists = statErr == nil && info.IsDir()
+		} else {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  warning: artifact root %q is invalid and was skipped: %v\n", r.Path, verr)
+		}
 		out.Roots = append(out.Roots, artifactRootJSON{
 			Path:       artifacts.NormalizeRootPath(r.Path),
 			Policy:     r.EffectivePolicy(),
-			Exists:     statErr == nil && info.IsDir(),
-			Gitignored: isGitignored(cmd, campRoot, r.Path),
+			Exists:     exists,
+			Gitignored: verr == nil && isGitignored(cmd, campRoot, r.Path),
 		})
 	}
 
@@ -223,6 +234,11 @@ func runArtifactsManifest(cmd *cobra.Command, args []string) error {
 	root, found := cfg.Find(args[0])
 	if !found {
 		return camperrors.Newf("artifact root %q is not declared (see 'camp artifacts list')", args[0])
+	}
+	// Validate before walking: a hand-edited root must not let this read-only
+	// command build a manifest of files outside the campaign.
+	if _, err := artifacts.EnsureRootWithin(campRoot, root.Path); err != nil {
+		return camperrors.Wrapf(err, "artifact root %q", root.Path)
 	}
 	m, err := artifacts.BuildManifest(ctx, campRoot, root.Path)
 	if err != nil {

--- a/cmd/camp/clone.go
+++ b/cmd/camp/clone.go
@@ -3,11 +3,13 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/Obedience-Corp/camp/internal/clone"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/jsoncontract"
+	"github.com/Obedience-Corp/camp/internal/peer"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -69,7 +71,14 @@ EXAMPLES:
   camp clone git@github.com:org/repo.git --no-register
 
   # JSON output for scripting
-  camp clone git@github.com:org/repo.git --json`,
+  camp clone git@github.com:org/repo.git --json
+
+  # Seed from a peer machine in ~/.obey/machines.yaml: root repo and
+  # submodules clone from that machine's copy (LAN/tailnet), then origin is
+  # re-pointed to the URL above and the delta fetched. The result is an
+  # origin replica that arrived over the fast path; peer failures fall back
+  # to plain origin cloning.
+  camp clone git@github.com:org/repo.git --from studio-mac`,
 	Args: jsoncontract.Args(CloneJSONVersion, func() bool { return cloneOpts.json }, cobra.RangeArgs(1, 2)),
 	Annotations: map[string]string{
 		"agent_allowed": "false",
@@ -89,6 +98,7 @@ var cloneOpts struct {
 	noRegister   bool
 	verbose      bool
 	json         bool
+	from         string
 }
 
 func init() {
@@ -108,6 +118,8 @@ func init() {
 		"Show detailed output for each operation")
 	cloneCmd.Flags().BoolVar(&cloneOpts.json, "json", false,
 		"Output results as JSON for scripting")
+	cloneCmd.Flags().StringVar(&cloneOpts.from, "from", "",
+		"Seed git objects from this machine (id from ~/.obey/machines.yaml), then fetch the delta from origin")
 
 	rootCmd.AddCommand(cloneCmd)
 	cloneCmd.GroupID = "setup"
@@ -132,7 +144,7 @@ func runClone(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create cloner with options
-	cloner := clone.NewCloner(
+	clonerOpts := []clone.ClonerOption{
 		clone.WithURL(url),
 		clone.WithDirectory(directory),
 		clone.WithBranch(cloneOpts.branch),
@@ -144,7 +156,23 @@ func runClone(cmd *cobra.Command, args []string) error {
 		clone.WithVerbose(cloneOpts.verbose),
 		clone.WithJSON(cloneOpts.json),
 		clone.WithProgress(progress),
-	)
+	}
+	if cloneOpts.from != "" {
+		// The campaign is looked up on the peer by the name this clone will
+		// register under: the directory argument when given, else the repo
+		// name from the URL.
+		name := clone.RepoNameFromURL(url)
+		if directory != "" {
+			name = filepath.Base(directory)
+		}
+		src, err := peer.FromMachine(ctx, cloneOpts.from, name)
+		if err != nil {
+			formatCloneError(err, cloneOpts.json)
+			return camperrors.NewCommand("camp clone", clone.ExitCloneFailed, "", err)
+		}
+		clonerOpts = append(clonerOpts, clone.WithPeer(src))
+	}
+	cloner := clone.NewCloner(clonerOpts...)
 
 	// Execute clone
 	result, err := cloner.Clone(ctx)

--- a/cmd/camp/clone.go
+++ b/cmd/camp/clone.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -166,15 +167,20 @@ func runClone(cmd *cobra.Command, args []string) error {
 			name = filepath.Base(directory)
 		}
 		src, err := peer.FromMachine(ctx, cloneOpts.from, name)
-		if err != nil {
-			// Help text promises peer failures fall back to a plain origin
-			// clone; a resolve failure (unreachable/typo'd peer) must degrade,
-			// not abort. Warn and clone from origin with no peer configured.
+		switch {
+		case err != nil && errors.Is(err, peer.ErrPeerConfig):
+			// Misconfiguration or typo (unknown machine, bad auth): fail fast
+			// so the user fixes it, rather than silently ignoring --from.
+			formatCloneError(err, cloneOpts.json)
+			return camperrors.NewCommand("camp clone", clone.ExitCloneFailed, "", err)
+		case err != nil:
+			// Reachability failure: help text promises fallback to a plain
+			// origin clone. Warn and clone from origin with no peer configured.
 			if !cloneOpts.json {
-				fmt.Fprintf(os.Stderr, "%s peer %q unavailable (%v); cloning from origin\n",
+				fmt.Fprintf(os.Stderr, "%s peer %q unreachable (%v); cloning from origin\n",
 					ui.WarningIcon(), cloneOpts.from, err)
 			}
-		} else {
+		default:
 			clonerOpts = append(clonerOpts, clone.WithPeer(src))
 		}
 	}

--- a/cmd/camp/clone.go
+++ b/cmd/camp/clone.go
@@ -167,10 +167,16 @@ func runClone(cmd *cobra.Command, args []string) error {
 		}
 		src, err := peer.FromMachine(ctx, cloneOpts.from, name)
 		if err != nil {
-			formatCloneError(err, cloneOpts.json)
-			return camperrors.NewCommand("camp clone", clone.ExitCloneFailed, "", err)
+			// Help text promises peer failures fall back to a plain origin
+			// clone; a resolve failure (unreachable/typo'd peer) must degrade,
+			// not abort. Warn and clone from origin with no peer configured.
+			if !cloneOpts.json {
+				fmt.Fprintf(os.Stderr, "%s peer %q unavailable (%v); cloning from origin\n",
+					ui.WarningIcon(), cloneOpts.from, err)
+			}
+		} else {
+			clonerOpts = append(clonerOpts, clone.WithPeer(src))
 		}
-		clonerOpts = append(clonerOpts, clone.WithPeer(src))
 	}
 	cloner := clone.NewCloner(clonerOpts...)
 

--- a/cmd/camp/exitcode_test.go
+++ b/cmd/camp/exitcode_test.go
@@ -88,13 +88,16 @@ func runSyncExitCodePreflightFailure(t *testing.T) error {
 
 	oldOpts := syncOpts
 	syncOpts = struct {
-		dryRun   bool
-		force    bool
-		verbose  bool
-		parallel int
-		noFetch  bool
-		json     bool
-		from     string
+		dryRun          bool
+		force           bool
+		verbose         bool
+		parallel        int
+		noFetch         bool
+		json            bool
+		from            string
+		gitOnly         bool
+		artifactsOnly   bool
+		verifyArtifacts bool
 	}{}
 	t.Cleanup(func() { syncOpts = oldOpts })
 

--- a/cmd/camp/exitcode_test.go
+++ b/cmd/camp/exitcode_test.go
@@ -94,6 +94,7 @@ func runSyncExitCodePreflightFailure(t *testing.T) error {
 		parallel int
 		noFetch  bool
 		json     bool
+		from     string
 	}{}
 	t.Cleanup(func() { syncOpts = oldOpts })
 

--- a/cmd/camp/sync.go
+++ b/cmd/camp/sync.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
@@ -124,13 +125,18 @@ func runSync(cmd *cobra.Command, args []string) error {
 	}
 	if syncOpts.from != "" {
 		src, err := resolveSyncPeer(ctx, campRoot, syncOpts.from)
-		if err != nil {
-			// Help text promises an unreachable peer degrades to a warning
-			// and the git sync still runs via origin; a resolve failure
-			// (unreachable/typo'd peer) must not abort the whole command.
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "camp: warning: peer %q unavailable (%v); syncing via origin\n",
+		switch {
+		case err != nil && errors.Is(err, peer.ErrPeerConfig):
+			// Misconfiguration or typo (unknown machine, campaign not
+			// registered, bad auth): fail fast so --from is not silently
+			// ignored.
+			return err
+		case err != nil:
+			// Reachability failure: help text promises an unreachable peer
+			// degrades to a warning and the git sync still runs via origin.
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "camp: warning: peer %q unreachable (%v); syncing via origin\n",
 				syncOpts.from, err)
-		} else {
+		default:
 			syncerOpts = append(syncerOpts, sync.WithPeer(src))
 		}
 	}
@@ -185,7 +191,9 @@ func resolveSyncPeer(ctx context.Context, campRoot, machineID string) (*peer.Sou
 	}
 	c, found := reg.FindByPath(campRoot)
 	if !found {
-		return nil, camperrors.Newf(
+		// A setup error, not a reachability one: --from cannot proceed until
+		// the campaign is registered, so mark it ErrPeerConfig to fail fast.
+		return nil, camperrors.WrapJoinf(peer.ErrPeerConfig, nil,
 			"campaign at %s is not in the registry; --from needs the campaign's registered name to resolve it on %q",
 			campRoot, machineID)
 	}

--- a/cmd/camp/sync.go
+++ b/cmd/camp/sync.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
@@ -124,9 +125,14 @@ func runSync(cmd *cobra.Command, args []string) error {
 	if syncOpts.from != "" {
 		src, err := resolveSyncPeer(ctx, campRoot, syncOpts.from)
 		if err != nil {
-			return err
+			// Help text promises an unreachable peer degrades to a warning
+			// and the git sync still runs via origin; a resolve failure
+			// (unreachable/typo'd peer) must not abort the whole command.
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "camp: warning: peer %q unavailable (%v); syncing via origin\n",
+				syncOpts.from, err)
+		} else {
+			syncerOpts = append(syncerOpts, sync.WithPeer(src))
 		}
-		syncerOpts = append(syncerOpts, sync.WithPeer(src))
 	}
 	syncer := sync.NewSyncer(campRoot, syncerOpts...)
 

--- a/cmd/camp/sync.go
+++ b/cmd/camp/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
@@ -62,11 +63,20 @@ EXAMPLES:
 
   # Accelerate over a peer machine from ~/.obey/machines.yaml: for each
   # already-initialized submodule, fetch objects from that machine first
-  # (LAN/tailnet), then run the normal origin-based update. Uninitialized
-  # submodules skip the peer step and init from origin. Preflight, origin
-  # URLs, validation, and exit codes are unchanged; an unreachable peer
-  # degrades to a warning.
-  camp sync --from studio-mac`,
+  # (LAN/tailnet), then run the normal origin-based update, then pull
+  # declared artifact roots (policy=always) from the same machine.
+  # Uninitialized submodules skip the peer step and init from origin.
+  # Preflight, origin URLs, validation, and exit codes are unchanged; an
+  # unreachable peer degrades to a warning.
+  camp sync --from studio-mac
+
+  # Peer git objects only, skip artifacts / artifacts only, skip git phases
+  camp sync --from studio-mac --git-only
+  camp sync --from studio-mac --artifacts-only
+
+  # Check artifact roots against last-transfer snapshots, no transfer
+  camp sync --verify-artifacts
+  camp sync --verify-artifacts --from studio-mac`,
 	Args: cobra.ArbitraryArgs,
 	RunE: jsoncontract.RunE(SyncJSONVersion, func() bool { return syncOpts.json }, runSync),
 }
@@ -74,13 +84,16 @@ EXAMPLES:
 const SyncJSONVersion = "sync/v1alpha1"
 
 var syncOpts struct {
-	dryRun   bool
-	force    bool
-	verbose  bool
-	parallel int
-	noFetch  bool
-	json     bool
-	from     string
+	dryRun          bool
+	force           bool
+	verbose         bool
+	parallel        int
+	noFetch         bool
+	json            bool
+	from            string
+	gitOnly         bool
+	artifactsOnly   bool
+	verifyArtifacts bool
 }
 
 func init() {
@@ -97,7 +110,13 @@ func init() {
 	syncCmd.Flags().BoolVar(&syncOpts.json, "json", false,
 		"Output results as JSON for scripting")
 	syncCmd.Flags().StringVar(&syncOpts.from, "from", "",
-		"Fetch objects for already-initialized submodules from this machine (id from ~/.obey/machines.yaml) before the origin update")
+		"Fetch objects for already-initialized submodules (and declared artifact roots) from this machine (id from ~/.obey/machines.yaml)")
+	syncCmd.Flags().BoolVar(&syncOpts.gitOnly, "git-only", false,
+		"With --from: move git objects only, skip artifact roots")
+	syncCmd.Flags().BoolVar(&syncOpts.artifactsOnly, "artifacts-only", false,
+		"With --from: pull declared artifact roots only, skip git phases")
+	syncCmd.Flags().BoolVar(&syncOpts.verifyArtifacts, "verify-artifacts", false,
+		"Check artifact roots against last-transfer snapshots (no transfer)")
 
 	rootCmd.AddCommand(syncCmd)
 	syncCmd.GroupID = "campaign"
@@ -123,7 +142,14 @@ func runSync(cmd *cobra.Command, args []string) error {
 		sync.WithJSON(syncOpts.json),
 		sync.WithSubmodules(args),
 	}
-	if syncOpts.from != "" {
+	if err := validateSyncFlagCombos(); err != nil {
+		return err
+	}
+	if syncOpts.verifyArtifacts {
+		// Verify is purely local (tree vs recorded snapshots): --from only
+		// scopes which peer's snapshots to check, no ssh dial needed.
+		syncerOpts = append(syncerOpts, sync.WithVerifyArtifacts(true, syncOpts.from))
+	} else if syncOpts.from != "" {
 		src, err := resolveSyncPeer(ctx, campRoot, syncOpts.from)
 		switch {
 		case err != nil && errors.Is(err, peer.ErrPeerConfig):
@@ -131,13 +157,21 @@ func runSync(cmd *cobra.Command, args []string) error {
 			// registered, bad auth): fail fast so --from is not silently
 			// ignored.
 			return err
+		case err != nil && syncOpts.artifactsOnly:
+			// Reachability failure with no origin fallback: --artifacts-only
+			// makes the peer the sole source, so a resolve failure is fatal.
+			return err
 		case err != nil:
 			// Reachability failure: help text promises an unreachable peer
 			// degrades to a warning and the git sync still runs via origin.
 			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "camp: warning: peer %q unreachable (%v); syncing via origin\n",
 				syncOpts.from, err)
 		default:
-			syncerOpts = append(syncerOpts, sync.WithPeer(src))
+			syncerOpts = append(syncerOpts,
+				sync.WithPeer(src),
+				sync.WithGitOnly(syncOpts.gitOnly),
+				sync.WithArtifactsOnly(syncOpts.artifactsOnly),
+			)
 		}
 	}
 	syncer := sync.NewSyncer(campRoot, syncerOpts...)
@@ -159,12 +193,14 @@ func runSync(cmd *cobra.Command, args []string) error {
 
 	// Build options for formatter
 	opts := syncOptions{
-		dryRun:   syncOpts.dryRun,
-		force:    syncOpts.force,
-		verbose:  syncOpts.verbose,
-		parallel: syncOpts.parallel,
-		noFetch:  syncOpts.noFetch,
-		json:     syncOpts.json,
+		dryRun:          syncOpts.dryRun,
+		force:           syncOpts.force,
+		verbose:         syncOpts.verbose,
+		parallel:        syncOpts.parallel,
+		noFetch:         syncOpts.noFetch,
+		json:            syncOpts.json,
+		verifyArtifacts: syncOpts.verifyArtifacts,
+		artifactsOnly:   syncOpts.artifactsOnly,
 	}
 
 	// Format and display output
@@ -179,6 +215,31 @@ func runSync(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// validateSyncFlagCombos rejects contradictory peer-flag combinations with a
+// usage error (exit 2) before any work runs.
+func validateSyncFlagCombos() error {
+	if syncOpts.gitOnly && syncOpts.artifactsOnly {
+		return syncUsageError("--git-only and --artifacts-only are mutually exclusive")
+	}
+	if syncOpts.verifyArtifacts && (syncOpts.gitOnly || syncOpts.artifactsOnly) {
+		return syncUsageError("--verify-artifacts does not combine with --git-only/--artifacts-only")
+	}
+	if (syncOpts.gitOnly || syncOpts.artifactsOnly) && syncOpts.from == "" {
+		return syncUsageError("--git-only/--artifacts-only need --from <machine>")
+	}
+	return nil
+}
+
+// syncUsageError prints the message (human mode; a CommandError's exit code
+// propagates silently by design) and returns the exit-2 contract error. JSON
+// mode leaves printing to the jsoncontract error envelope.
+func syncUsageError(msg string) error {
+	if !syncOpts.json {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", msg)
+	}
+	return camperrors.NewCommand("camp sync", sync.ExitInvalidArgs, msg, nil)
 }
 
 // resolveSyncPeer maps --from to a peer source for this campaign: the local

--- a/cmd/camp/sync.go
+++ b/cmd/camp/sync.go
@@ -58,10 +58,12 @@ EXAMPLES:
   # JSON output for scripting
   camp sync --json
 
-  # Accelerate over a peer machine from ~/.obey/machines.yaml: fetch each
-  # submodule's objects from that machine first (LAN/tailnet), then run the
-  # normal origin-based update. Preflight, origin URLs, validation, and exit
-  # codes are unchanged; an unreachable peer degrades to a warning.
+  # Accelerate over a peer machine from ~/.obey/machines.yaml: for each
+  # already-initialized submodule, fetch objects from that machine first
+  # (LAN/tailnet), then run the normal origin-based update. Uninitialized
+  # submodules skip the peer step and init from origin. Preflight, origin
+  # URLs, validation, and exit codes are unchanged; an unreachable peer
+  # degrades to a warning.
   camp sync --from studio-mac`,
 	Args: cobra.ArbitraryArgs,
 	RunE: jsoncontract.RunE(SyncJSONVersion, func() bool { return syncOpts.json }, runSync),
@@ -93,7 +95,7 @@ func init() {
 	syncCmd.Flags().BoolVar(&syncOpts.json, "json", false,
 		"Output results as JSON for scripting")
 	syncCmd.Flags().StringVar(&syncOpts.from, "from", "",
-		"Fetch submodule objects from this machine (id from ~/.obey/machines.yaml) before the origin update")
+		"Fetch objects for already-initialized submodules from this machine (id from ~/.obey/machines.yaml) before the origin update")
 
 	rootCmd.AddCommand(syncCmd)
 	syncCmd.GroupID = "campaign"

--- a/cmd/camp/sync.go
+++ b/cmd/camp/sync.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"context"
+
 	"github.com/Obedience-Corp/camp/internal/campaign"
+	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/jsoncontract"
+	"github.com/Obedience-Corp/camp/internal/peer"
 	"github.com/Obedience-Corp/camp/internal/sync"
 	"github.com/spf13/cobra"
 )
@@ -52,7 +56,13 @@ EXAMPLES:
   camp sync --verbose
 
   # JSON output for scripting
-  camp sync --json`,
+  camp sync --json
+
+  # Accelerate over a peer machine from ~/.obey/machines.yaml: fetch each
+  # submodule's objects from that machine first (LAN/tailnet), then run the
+  # normal origin-based update. Preflight, origin URLs, validation, and exit
+  # codes are unchanged; an unreachable peer degrades to a warning.
+  camp sync --from studio-mac`,
 	Args: cobra.ArbitraryArgs,
 	RunE: jsoncontract.RunE(SyncJSONVersion, func() bool { return syncOpts.json }, runSync),
 }
@@ -66,6 +76,7 @@ var syncOpts struct {
 	parallel int
 	noFetch  bool
 	json     bool
+	from     string
 }
 
 func init() {
@@ -81,6 +92,8 @@ func init() {
 		"Skip fetching from remote (use local refs only)")
 	syncCmd.Flags().BoolVar(&syncOpts.json, "json", false,
 		"Output results as JSON for scripting")
+	syncCmd.Flags().StringVar(&syncOpts.from, "from", "",
+		"Fetch submodule objects from this machine (id from ~/.obey/machines.yaml) before the origin update")
 
 	rootCmd.AddCommand(syncCmd)
 	syncCmd.GroupID = "campaign"
@@ -97,7 +110,7 @@ func runSync(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build syncer with options
-	syncer := sync.NewSyncer(campRoot,
+	syncerOpts := []sync.SyncerOption{
 		sync.WithDryRun(syncOpts.dryRun),
 		sync.WithForce(syncOpts.force),
 		sync.WithVerbose(syncOpts.verbose),
@@ -105,7 +118,15 @@ func runSync(cmd *cobra.Command, args []string) error {
 		sync.WithNoFetch(syncOpts.noFetch),
 		sync.WithJSON(syncOpts.json),
 		sync.WithSubmodules(args),
-	)
+	}
+	if syncOpts.from != "" {
+		src, err := resolveSyncPeer(ctx, campRoot, syncOpts.from)
+		if err != nil {
+			return err
+		}
+		syncerOpts = append(syncerOpts, sync.WithPeer(src))
+	}
+	syncer := sync.NewSyncer(campRoot, syncerOpts...)
 
 	// Run preflight once for display, then pass it into Sync to avoid double execution
 	preflight, err := syncer.RunPreflight(ctx)
@@ -144,4 +165,21 @@ func runSync(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// resolveSyncPeer maps --from to a peer source for this campaign: the local
+// registry supplies the campaign's name, and the far machine's own camp
+// resolves where that campaign lives there.
+func resolveSyncPeer(ctx context.Context, campRoot, machineID string) (*peer.Source, error) {
+	reg, err := config.LoadRegistry(ctx)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "load registry")
+	}
+	c, found := reg.FindByPath(campRoot)
+	if !found {
+		return nil, camperrors.Newf(
+			"campaign at %s is not in the registry; --from needs the campaign's registered name to resolve it on %q",
+			campRoot, machineID)
+	}
+	return peer.FromMachine(ctx, machineID, c.Name)
 }

--- a/cmd/camp/sync_output.go
+++ b/cmd/camp/sync_output.go
@@ -52,13 +52,21 @@ func formatSyncHuman(result *sync.SyncResult, opts syncOptions, preflight *sync.
 
 	// Update results section
 	formatUpdateSection(result, opts.verbose)
+	formatArtifactsSection(result, opts.verbose)
 	formatWarningsSection(result.Warnings)
 
 	// Final status
 	fmt.Println()
-	if result.Success {
+	switch {
+	case result.Success && opts.verifyArtifacts:
+		fmt.Println(ui.Success("Artifact verification complete."))
+	case result.Success && opts.artifactsOnly:
+		fmt.Println(ui.Success("Artifacts synchronized successfully."))
+	case result.Success:
 		fmt.Println(ui.Success("Campaign synchronized successfully."))
-	} else {
+	case opts.verifyArtifacts:
+		fmt.Fprintln(os.Stderr, ui.Error("Artifact verification found discrepancies. See details above."))
+	default:
 		fmt.Fprintln(os.Stderr, ui.Error("Sync failed. See errors or warnings above."))
 	}
 }
@@ -223,6 +231,56 @@ func formatFixSuggestions(preflight *sync.PreflightResult) {
 	fmt.Println("  camp sync --force")
 }
 
+// formatArtifactsSection displays artifact pull/verify outcomes; silent when
+// the sync involved no artifacts.
+func formatArtifactsSection(result *sync.SyncResult, verbose bool) {
+	if len(result.Artifacts) == 0 && len(result.ArtifactVerifies) == 0 {
+		return
+	}
+	fmt.Println()
+	fmt.Println("Artifacts:")
+	for _, a := range result.Artifacts {
+		switch {
+		case a.Warning != "":
+			fmt.Fprintf(os.Stderr, "  %s %s: %s\n", ui.ErrorIcon(), a.Root, a.Warning)
+		case a.FirstSync:
+			fmt.Printf("  %s %s (first sync; %d pre-existing local files left untouched)\n",
+				ui.SuccessIcon(), a.Root, a.Protected)
+		case len(a.SkippedConflicts) > 0:
+			fmt.Printf("  %s %s (synced; %d conflicts kept local)\n",
+				ui.WarningIcon(), a.Root, len(a.SkippedConflicts))
+			for i, p := range a.SkippedConflicts {
+				if !verbose && i == 5 {
+					fmt.Printf("      ... and %d more (use --verbose)\n", len(a.SkippedConflicts)-i)
+					break
+				}
+				fmt.Printf("      %s (local edit preserved; remove the file to take the peer's copy)\n", p)
+			}
+		default:
+			fmt.Printf("  %s %s (synced)\n", ui.SuccessIcon(), a.Root)
+		}
+	}
+	for _, v := range result.ArtifactVerifies {
+		if v.Result.Clean() {
+			fmt.Printf("  %s %s vs %s: clean (%d files)\n", ui.SuccessIcon(), v.Result.Root, v.Peer, v.Result.Checked)
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "  %s %s vs %s: %d missing, %d differ, %d extra\n",
+			ui.ErrorIcon(), v.Result.Root, v.Peer, len(v.Result.Missing), len(v.Result.Differ), len(v.Result.Extra))
+		if verbose {
+			for _, p := range v.Result.Missing {
+				fmt.Fprintf(os.Stderr, "      missing: %s\n", p)
+			}
+			for _, p := range v.Result.Differ {
+				fmt.Fprintf(os.Stderr, "      differs: %s\n", p)
+			}
+			for _, p := range v.Result.Extra {
+				fmt.Fprintf(os.Stderr, "      extra:   %s\n", p)
+			}
+		}
+	}
+}
+
 // formatSyncJSON outputs sync results as JSON.
 func formatSyncJSON(result *sync.SyncResult, preflight *sync.PreflightResult) {
 	// Build preflight submodules info
@@ -302,9 +360,38 @@ func formatSyncJSON(result *sync.SyncResult, preflight *sync.PreflightResult) {
 		"warnings":      warnings,
 	}
 
+	// Peer-transport keys appear only when the feature ran, keeping default
+	// `camp sync --json` byte-identical for existing consumers.
+	if len(result.Artifacts) > 0 {
+		output["artifacts"] = result.Artifacts
+	}
+	if len(result.ArtifactVerifies) > 0 {
+		verifies := make([]map[string]interface{}, len(result.ArtifactVerifies))
+		for i, v := range result.ArtifactVerifies {
+			verifies[i] = map[string]interface{}{
+				"peer":    v.Peer,
+				"root":    v.Result.Root,
+				"clean":   v.Result.Clean(),
+				"checked": v.Result.Checked,
+				"missing": emptyIfNil(v.Result.Missing),
+				"differ":  emptyIfNil(v.Result.Differ),
+				"extra":   emptyIfNil(v.Result.Extra),
+			}
+		}
+		output["artifactVerify"] = verifies
+	}
+
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	enc.Encode(output)
+}
+
+// emptyIfNil keeps JSON list fields as [] rather than null.
+func emptyIfNil(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
 }
 
 // countSucceeded counts successful submodule results.
@@ -331,10 +418,12 @@ func countFailed(results []sync.SubmoduleResult) int {
 
 // syncOptions is a copy of the flag struct for passing to formatters.
 type syncOptions struct {
-	dryRun   bool
-	force    bool
-	verbose  bool
-	parallel int
-	noFetch  bool
-	json     bool
+	dryRun          bool
+	force           bool
+	verbose         bool
+	parallel        int
+	noFetch         bool
+	json            bool
+	verifyArtifacts bool
+	artifactsOnly   bool
 }

--- a/internal/artifacts/artifacts_test.go
+++ b/internal/artifacts/artifacts_test.go
@@ -121,8 +121,14 @@ func TestPullLifecycle(t *testing.T) {
 
 	peerCampaign := t.TempDir()
 	localCampaign := t.TempDir()
+	// Ordered, whole-second timestamps an hour apart replace wall-clock sleeps:
+	// they make transfer ordering deterministic (rsync --update and the
+	// conflict predicate both compare mtimes) and cannot be reordered by
+	// rsync -a rounding preserved mtimes to seconds.
+	base := time.Unix(1_600_000_000, 0)
 	writeArtifact(t, peerCampaign, "media/render.mov", "peer render v1")
 	writeArtifact(t, peerCampaign, "media/audio.wav", "peer audio v1")
+	setMTime(t, peerCampaign, "media/render.mov", base)
 	src := peer.FromPath("peerbox", peerCampaign)
 	root := Root{Path: "media"}
 
@@ -137,8 +143,8 @@ func TestPullLifecycle(t *testing.T) {
 	assertArtifact(t, localCampaign, "media/render.mov", "peer render v1")
 
 	// Peer updates a file; local is untouched: the update flows through.
-	time.Sleep(1100 * time.Millisecond) // distinct mtime at unix-second resolution
 	writeArtifact(t, peerCampaign, "media/render.mov", "peer render v2")
+	setMTime(t, peerCampaign, "media/render.mov", base.Add(time.Hour))
 	r2 := Pull(ctx, localCampaign, src, root)
 	if r2.Warning != "" || !r2.Synced || r2.FirstSync {
 		t.Fatalf("second pull = %+v, want clean non-first sync", r2)
@@ -150,9 +156,10 @@ func TestPullLifecycle(t *testing.T) {
 
 	// Both sides change the same file: local wins, conflict reported, and the
 	// protection is sticky on the following pull.
-	time.Sleep(1100 * time.Millisecond)
 	writeArtifact(t, localCampaign, "media/render.mov", "LOCAL edit")
+	setMTime(t, localCampaign, "media/render.mov", base.Add(2*time.Hour))
 	writeArtifact(t, peerCampaign, "media/render.mov", "peer render v3")
+	setMTime(t, peerCampaign, "media/render.mov", base.Add(3*time.Hour))
 	r3 := Pull(ctx, localCampaign, src, root)
 	if r3.Warning != "" || !r3.Synced {
 		t.Fatalf("third pull = %+v, want sync with conflict", r3)
@@ -278,6 +285,17 @@ func writeArtifact(t *testing.T, campaignRoot, rel, content string) {
 	}
 }
 
+// setMTime forces a deterministic modification time on an artifact so tests
+// control transfer ordering and conflict detection without depending on
+// wall-clock timing.
+func setMTime(t *testing.T, campaignRoot, rel string, mtime time.Time) {
+	t.Helper()
+	path := filepath.Join(campaignRoot, filepath.FromSlash(rel))
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("chtimes %s: %v", rel, err)
+	}
+}
+
 func assertArtifact(t *testing.T, campaignRoot, rel, want string) {
 	t.Helper()
 	data, err := os.ReadFile(filepath.Join(campaignRoot, filepath.FromSlash(rel)))
@@ -286,5 +304,82 @@ func assertArtifact(t *testing.T, campaignRoot, rel, want string) {
 	}
 	if string(data) != want {
 		t.Errorf("%s = %q, want %q", rel, string(data), want)
+	}
+}
+
+// TestManifest_SameSecondEditIsDetected proves the no-clobber predicate keys
+// on nanosecond mtime: a same-size in-place edit made in the same wall-clock
+// second as the baseline must still register as a change (second resolution
+// silently overwrote it).
+func TestManifest_SameSecondEditIsDetected(t *testing.T) {
+	ctx := context.Background()
+	campaign := t.TempDir()
+
+	// Skip on a filesystem that does not preserve sub-second mtimes; the fix
+	// depends on them (CI and the container harness do).
+	probe := filepath.Join(campaign, ".mtime-probe")
+	if err := os.WriteFile(probe, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pt := time.Unix(1_600_000_000, 123_456_789)
+	if err := os.Chtimes(probe, pt, pt); err != nil {
+		t.Fatal(err)
+	}
+	if fi, err := os.Stat(probe); err == nil && fi.ModTime().Nanosecond() == 0 {
+		t.Skip("filesystem does not preserve sub-second mtime")
+	}
+
+	writeArtifact(t, campaign, "media/clip.bin", "AAAA")
+	t0 := time.Unix(1_600_000_000, 100_000_000) // .1s
+	setMTime(t, campaign, "media/clip.bin", t0)
+	base, err := BuildManifest(ctx, campaign, "media")
+	if err != nil {
+		t.Fatalf("BuildManifest baseline: %v", err)
+	}
+
+	writeArtifact(t, campaign, "media/clip.bin", "BBBB") // same size, different content
+	t1 := time.Unix(1_600_000_000, 900_000_000)          // .9s, SAME unix second
+	setMTime(t, campaign, "media/clip.bin", t1)
+	after, err := BuildManifest(ctx, campaign, "media")
+	if err != nil {
+		t.Fatalf("BuildManifest after: %v", err)
+	}
+
+	if t0.Unix() != t1.Unix() {
+		t.Fatalf("test setup: timestamps not in the same unix second")
+	}
+	if len(base.Files) != 1 || len(after.Files) != 1 {
+		t.Fatalf("manifest files base=%d after=%d, want 1 each", len(base.Files), len(after.Files))
+	}
+	if sameEntry(after.Files[0], base.Files[0]) {
+		t.Fatalf("same-second same-size edit treated as unchanged: base=%+v after=%+v", base.Files[0], after.Files[0])
+	}
+}
+
+// TestSnapshotSlug_Injective guards against the "/"->"__" collision that let
+// two distinct roots share one baseline file (and thus poison each other).
+func TestSnapshotSlug_Injective(t *testing.T) {
+	collisions := [][2]string{
+		{"a/b", "a__b"},
+		{"media/renders", "media__renders"},
+		{"a%2Fb", "a/b"},
+	}
+	for _, c := range collisions {
+		if snapshotSlug(c[0]) == snapshotSlug(c[1]) {
+			t.Errorf("snapshotSlug(%q) == snapshotSlug(%q) = %q; must be injective", c[0], c[1], snapshotSlug(c[0]))
+		}
+	}
+}
+
+func TestValidatePeerID(t *testing.T) {
+	for _, v := range []string{"studio-mac", "laptop", "box.local", "m1_max"} {
+		if err := ValidatePeerID(v); err != nil {
+			t.Errorf("ValidatePeerID(%q) = %v, want nil", v, err)
+		}
+	}
+	for _, v := range []string{"", "..", "../evil", "a/b", `a\b`, ".hidden", "x/../y", "a\x00b"} {
+		if err := ValidatePeerID(v); err == nil {
+			t.Errorf("ValidatePeerID(%q) = nil, want error", v)
+		}
 	}
 }

--- a/internal/artifacts/artifacts_test.go
+++ b/internal/artifacts/artifacts_test.go
@@ -267,6 +267,98 @@ func TestVerifyAgainstSnapshot(t *testing.T) {
 	}
 }
 
+// mergeStaged must not overwrite a live file that no longer matches the
+// baseline — the case a local writer touching an unprotected path during the
+// transfer window produces. This is the no-clobber guarantee that a
+// pre-transfer exclude scan alone cannot provide.
+func TestMergeStaged_PreservesLateLocalWrite(t *testing.T) {
+	camp := t.TempDir()
+	writeArtifact(t, camp, "media/x.bin", "LOCAL EDIT DURING TRANSFER")
+	dest := filepath.Join(camp, "media")
+
+	// Baseline recorded x.bin as a different (smaller) version, so the current
+	// live file does not match it — exactly what a mid-transfer local edit
+	// looks like at merge time.
+	baseline := &Manifest{Version: 1, Root: "media", Files: []FileEntry{
+		{Path: "x.bin", Size: 2, MTime: 1},
+	}}
+
+	staging := filepath.Join(camp, ".campaign", "cache", "stg")
+	if err := os.MkdirAll(staging, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staging, "x.bin"), []byte("peer version"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	late, err := mergeStaged(staging, dest, baseline)
+	if err != nil {
+		t.Fatalf("mergeStaged() error = %v", err)
+	}
+	if len(late) != 1 || late[0] != "x.bin" {
+		t.Errorf("late conflicts = %v, want [x.bin]", late)
+	}
+	assertArtifact(t, camp, "media/x.bin", "LOCAL EDIT DURING TRANSFER")
+}
+
+func TestMergeStaged_MovesAgreedAndNewFiles(t *testing.T) {
+	ctx := context.Background()
+	camp := t.TempDir()
+	writeArtifact(t, camp, "media/agreed.bin", "v1")
+
+	// Baseline matches the current live agreed.bin exactly.
+	baseline, err := BuildManifest(ctx, camp, "media")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(camp, "media")
+
+	staging := filepath.Join(camp, ".campaign", "cache", "stg")
+	if err := os.MkdirAll(filepath.Join(staging, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staging, "agreed.bin"), []byte("peer-v2"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staging, "sub", "new.bin"), []byte("brand new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	late, err := mergeStaged(staging, dest, baseline)
+	if err != nil {
+		t.Fatalf("mergeStaged() error = %v", err)
+	}
+	if len(late) != 0 {
+		t.Errorf("late conflicts = %v, want none", late)
+	}
+	assertArtifact(t, camp, "media/agreed.bin", "peer-v2")     // agreed -> updated
+	assertArtifact(t, camp, "media/sub/new.bin", "brand new") // new nested file -> created
+}
+
+func TestMergeStaged_ProtectsOutOfBandLocalFile(t *testing.T) {
+	camp := t.TempDir()
+	writeArtifact(t, camp, "media/z.bin", "created locally, not in baseline")
+	dest := filepath.Join(camp, "media")
+
+	staging := filepath.Join(camp, ".campaign", "cache", "stg")
+	if err := os.MkdirAll(staging, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staging, "z.bin"), []byte("peer z"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	baseline := &Manifest{Version: 1, Root: "media"} // empty: z.bin never agreed
+
+	late, err := mergeStaged(staging, dest, baseline)
+	if err != nil {
+		t.Fatalf("mergeStaged() error = %v", err)
+	}
+	if len(late) != 1 || late[0] != "z.bin" {
+		t.Errorf("late conflicts = %v, want [z.bin]", late)
+	}
+	assertArtifact(t, camp, "media/z.bin", "created locally, not in baseline")
+}
+
 func requireRsync(t *testing.T) {
 	t.Helper()
 	if _, err := exec.LookPath("rsync"); err != nil {

--- a/internal/artifacts/artifacts_test.go
+++ b/internal/artifacts/artifacts_test.go
@@ -2,10 +2,12 @@ package artifacts
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -559,5 +561,77 @@ func TestFileValidate(t *testing.T) {
 				t.Fatalf("Validate() = %v, want error containing %q", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestMergeStaged_RefusesSymlinkedParentEscape proves the merge does not follow
+// a local symlinked directory out of the campaign: `safeToReplace` reads the
+// (through-symlink, non-existent) destination as "absent, safe," so without the
+// containment check the staged file would land outside the campaign. It must be
+// refused and reported instead.
+func TestMergeStaged_RefusesSymlinkedParentEscape(t *testing.T) {
+	camp := t.TempDir()
+	outside := t.TempDir()
+	dest := filepath.Join(camp, "media")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A local subdirectory of the artifact root is a symlink pointing outside.
+	if err := os.Symlink(outside, filepath.Join(dest, "evil")); err != nil {
+		t.Fatal(err)
+	}
+	staging := filepath.Join(camp, ".campaign", "cache", "stg")
+	if err := os.MkdirAll(filepath.Join(staging, "evil"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staging, "evil", "payload"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	late, err := mergeStaged(staging, dest, nil)
+	if err != nil {
+		t.Fatalf("mergeStaged: %v", err)
+	}
+	if len(late) != 1 || late[0] != "evil/payload" {
+		t.Errorf("late conflicts = %v, want [evil/payload] (escape refused)", late)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "payload")); !os.IsNotExist(err) {
+		t.Errorf("payload escaped the campaign into the symlink target (stat err = %v)", err)
+	}
+}
+
+// TestPull_ConcurrentSameRootIsSerialized runs two pulls of the same root at
+// once; the per-root lock must serialize them so neither errors and the tree
+// ends complete and consistent (a shared deterministic staging dir would
+// otherwise let one RemoveAll the other's transfer).
+func TestPull_ConcurrentSameRootIsSerialized(t *testing.T) {
+	requireRsync(t)
+	ctx := context.Background()
+	peerCampaign := t.TempDir()
+	localCampaign := t.TempDir()
+	for i := 0; i < 20; i++ {
+		writeArtifact(t, peerCampaign, fmt.Sprintf("media/f%02d.bin", i), fmt.Sprintf("peer %d", i))
+	}
+	src := peer.FromPath("peerbox", peerCampaign)
+	root := Root{Path: "media"}
+
+	var wg sync.WaitGroup
+	results := make([]*PullResult, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i] = Pull(ctx, localCampaign, src, root)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, r := range results {
+		if r.Warning != "" {
+			t.Errorf("pull %d warning = %q, want none (lock should serialize, not error)", i, r.Warning)
+		}
+	}
+	for i := 0; i < 20; i++ {
+		assertArtifact(t, localCampaign, fmt.Sprintf("media/f%02d.bin", i), fmt.Sprintf("peer %d", i))
 	}
 }

--- a/internal/artifacts/artifacts_test.go
+++ b/internal/artifacts/artifacts_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -473,5 +474,90 @@ func TestValidatePeerID(t *testing.T) {
 		if err := ValidatePeerID(v); err == nil {
 			t.Errorf("ValidatePeerID(%q) = nil, want error", v)
 		}
+	}
+}
+
+// TestCopyIntoPlace_PreservesContentModeAndMtime exercises the cross-device
+// merge fallback (used when the artifact root is a mounted volume and staging
+// under .campaign is on a different filesystem): the bytes, permission bits,
+// and mtime must survive so the next --compare-dest run does not re-transfer,
+// and the temp file must not linger.
+func TestCopyIntoPlace_PreservesContentModeAndMtime(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.bin")
+	dst := filepath.Join(dir, "dst.bin")
+	if err := os.WriteFile(src, []byte("peer bytes"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	mtime := time.Unix(1_600_000_000, 250_000_000)
+	if err := os.Chtimes(src, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyIntoPlace(src, dst); err != nil {
+		t.Fatalf("copyIntoPlace: %v", err)
+	}
+
+	if got, err := os.ReadFile(dst); err != nil || string(got) != "peer bytes" {
+		t.Fatalf("dst content = %q err=%v, want %q", got, err, "peer bytes")
+	}
+	fi, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != 0o640 {
+		t.Errorf("dst mode = %v, want 0640", fi.Mode().Perm())
+	}
+	if !fi.ModTime().Equal(mtime) {
+		t.Errorf("dst mtime = %v, want %v (must be preserved so --compare-dest does not re-transfer)", fi.ModTime(), mtime)
+	}
+	if leftovers, _ := filepath.Glob(filepath.Join(dir, ".camp-artifact-*.tmp")); len(leftovers) != 0 {
+		t.Errorf("leftover temp files: %v", leftovers)
+	}
+}
+
+func TestMoveIntoPlace_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.bin")
+	dst := filepath.Join(dir, "dst.bin")
+	if err := os.WriteFile(dst, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte("new peer version"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := moveIntoPlace(src, dst); err != nil {
+		t.Fatalf("moveIntoPlace: %v", err)
+	}
+	if got, _ := os.ReadFile(dst); string(got) != "new peer version" {
+		t.Errorf("dst = %q, want %q", got, "new peer version")
+	}
+}
+
+func TestFileValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    File
+		wantErr string
+	}{
+		{"valid", File{Version: 1, Roots: []Root{{Path: "media"}, {Path: "datasets", Policy: PolicyOnDemand}}}, ""},
+		{"unsupported version", File{Version: 2, Roots: []Root{{Path: "media"}}}, "version"},
+		{"unknown policy", File{Version: 1, Roots: []Root{{Path: "media", Policy: "sometimes"}}}, "policy"},
+		{"duplicate root", File{Version: 1, Roots: []Root{{Path: "media"}, {Path: "./media/"}}}, "duplicate"},
+		{"escaping path", File{Version: 1, Roots: []Root{{Path: "../outside"}}}, "escapes"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.file.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() = %v, want error containing %q", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/internal/artifacts/artifacts_test.go
+++ b/internal/artifacts/artifacts_test.go
@@ -1,0 +1,290 @@
+package artifacts
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Obedience-Corp/camp/internal/peer"
+)
+
+func TestFileAddRemoveValidate(t *testing.T) {
+	f := &File{Version: 1}
+
+	if err := f.Add(Root{Path: "media/renders"}); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+	if err := f.Add(Root{Path: "./media/renders/"}); err == nil {
+		t.Error("Add() duplicate (unnormalized) accepted, want error")
+	}
+	if err := f.Add(Root{Path: "/abs/path"}); err == nil {
+		t.Error("Add() absolute path accepted, want error")
+	}
+	if err := f.Add(Root{Path: "../escape"}); err == nil {
+		t.Error("Add() escaping path accepted, want error")
+	}
+	if err := f.Add(Root{Path: ".campaign/cache"}); err == nil {
+		t.Error("Add() .campaign path accepted, want error")
+	}
+	if err := f.Add(Root{Path: "datasets", Policy: "sometimes"}); err == nil {
+		t.Error("Add() unknown policy accepted, want error")
+	}
+	if err := f.Add(Root{Path: "datasets", Policy: PolicyOnDemand}); err != nil {
+		t.Fatalf("Add() on-demand error = %v", err)
+	}
+
+	if _, found := f.Find("media/renders"); !found {
+		t.Error("Find() did not locate declared root")
+	}
+	if !f.Remove("media/renders/") {
+		t.Error("Remove() = false, want true")
+	}
+	if _, found := f.Find("media/renders"); found {
+		t.Error("Find() located removed root")
+	}
+}
+
+func TestConfigRoundTrip(t *testing.T) {
+	campaignRoot := t.TempDir()
+	f := &File{Version: 1}
+	if err := f.Add(Root{Path: "media", Policy: PolicyOnDemand}); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+	if err := f.Save(campaignRoot); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	loaded, err := Load(campaignRoot)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(loaded.Roots) != 1 || loaded.Roots[0].Path != "media" || loaded.Roots[0].Policy != PolicyOnDemand {
+		t.Errorf("Load() roots = %+v, want media/on-demand", loaded.Roots)
+	}
+
+	empty, err := Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("Load() missing file error = %v", err)
+	}
+	if len(empty.Roots) != 0 {
+		t.Errorf("Load() missing file roots = %d, want 0", len(empty.Roots))
+	}
+}
+
+func TestBuildManifestAndProtectedPaths(t *testing.T) {
+	ctx := context.Background()
+	campaignRoot := t.TempDir()
+	writeArtifact(t, campaignRoot, "media/a.bin", "aaa")
+	writeArtifact(t, campaignRoot, "media/sub/b.bin", "bbbb")
+
+	m, err := BuildManifest(ctx, campaignRoot, "media")
+	if err != nil {
+		t.Fatalf("BuildManifest() error = %v", err)
+	}
+	if len(m.Files) != 2 {
+		t.Fatalf("manifest files = %d, want 2", len(m.Files))
+	}
+	if m.Files[0].Path != "a.bin" || m.Files[1].Path != "sub/b.bin" {
+		t.Errorf("manifest paths = %v, want sorted [a.bin sub/b.bin]", []string{m.Files[0].Path, m.Files[1].Path})
+	}
+
+	// Nil baseline: everything is protected.
+	if got := m.ProtectedPaths(nil); len(got) != 2 {
+		t.Errorf("ProtectedPaths(nil) = %v, want all files", got)
+	}
+	// Baseline identical: nothing protected.
+	if got := m.ProtectedPaths(m); len(got) != 0 {
+		t.Errorf("ProtectedPaths(self) = %v, want none", got)
+	}
+	// Baseline missing one file: that file is protected (never agreed).
+	partial := &Manifest{Version: 1, Root: "media", Files: m.Files[:1]}
+	if got := m.ProtectedPaths(partial); len(got) != 1 || got[0] != "sub/b.bin" {
+		t.Errorf("ProtectedPaths(partial) = %v, want [sub/b.bin]", got)
+	}
+
+	// Missing root directory: empty manifest, no error.
+	empty, err := BuildManifest(ctx, campaignRoot, "does-not-exist")
+	if err != nil {
+		t.Fatalf("BuildManifest() missing root error = %v", err)
+	}
+	if len(empty.Files) != 0 {
+		t.Errorf("missing root manifest files = %d, want 0", len(empty.Files))
+	}
+}
+
+func TestPullLifecycle(t *testing.T) {
+	requireRsync(t)
+	ctx := context.Background()
+
+	peerCampaign := t.TempDir()
+	localCampaign := t.TempDir()
+	writeArtifact(t, peerCampaign, "media/render.mov", "peer render v1")
+	writeArtifact(t, peerCampaign, "media/audio.wav", "peer audio v1")
+	src := peer.FromPath("peerbox", peerCampaign)
+	root := Root{Path: "media"}
+
+	// First sync into an empty local root: everything arrives.
+	r1 := Pull(ctx, localCampaign, src, root)
+	if r1.Warning != "" || !r1.Synced {
+		t.Fatalf("first pull = %+v, want clean sync", r1)
+	}
+	if !r1.FirstSync {
+		t.Error("first pull FirstSync = false, want true")
+	}
+	assertArtifact(t, localCampaign, "media/render.mov", "peer render v1")
+
+	// Peer updates a file; local is untouched: the update flows through.
+	time.Sleep(1100 * time.Millisecond) // distinct mtime at unix-second resolution
+	writeArtifact(t, peerCampaign, "media/render.mov", "peer render v2")
+	r2 := Pull(ctx, localCampaign, src, root)
+	if r2.Warning != "" || !r2.Synced || r2.FirstSync {
+		t.Fatalf("second pull = %+v, want clean non-first sync", r2)
+	}
+	if len(r2.SkippedConflicts) != 0 {
+		t.Errorf("second pull conflicts = %v, want none", r2.SkippedConflicts)
+	}
+	assertArtifact(t, localCampaign, "media/render.mov", "peer render v2")
+
+	// Both sides change the same file: local wins, conflict reported, and the
+	// protection is sticky on the following pull.
+	time.Sleep(1100 * time.Millisecond)
+	writeArtifact(t, localCampaign, "media/render.mov", "LOCAL edit")
+	writeArtifact(t, peerCampaign, "media/render.mov", "peer render v3")
+	r3 := Pull(ctx, localCampaign, src, root)
+	if r3.Warning != "" || !r3.Synced {
+		t.Fatalf("third pull = %+v, want sync with conflict", r3)
+	}
+	if len(r3.SkippedConflicts) != 1 || r3.SkippedConflicts[0] != "render.mov" {
+		t.Errorf("third pull conflicts = %v, want [render.mov]", r3.SkippedConflicts)
+	}
+	assertArtifact(t, localCampaign, "media/render.mov", "LOCAL edit")
+
+	r4 := Pull(ctx, localCampaign, src, root)
+	if len(r4.SkippedConflicts) != 1 {
+		t.Errorf("fourth pull conflicts = %v, want conflict to stay sticky", r4.SkippedConflicts)
+	}
+	assertArtifact(t, localCampaign, "media/render.mov", "LOCAL edit")
+
+	// Resolution: remove the local file to take the peer's copy.
+	if err := os.Remove(filepath.Join(localCampaign, "media", "render.mov")); err != nil {
+		t.Fatalf("removing conflicted file: %v", err)
+	}
+	r5 := Pull(ctx, localCampaign, src, root)
+	if r5.Warning != "" || len(r5.SkippedConflicts) != 0 {
+		t.Fatalf("fifth pull = %+v, want resolved", r5)
+	}
+	assertArtifact(t, localCampaign, "media/render.mov", "peer render v3")
+}
+
+func TestPullProtectsPreexistingLocalFiles(t *testing.T) {
+	requireRsync(t)
+	ctx := context.Background()
+
+	peerCampaign := t.TempDir()
+	localCampaign := t.TempDir()
+	writeArtifact(t, peerCampaign, "media/shared.bin", "peer version")
+	writeArtifact(t, localCampaign, "media/shared.bin", "precious local version")
+
+	src := peer.FromPath("peerbox", peerCampaign)
+	r1 := Pull(ctx, localCampaign, src, Root{Path: "media"})
+	if r1.Warning != "" || !r1.Synced || !r1.FirstSync {
+		t.Fatalf("first pull = %+v, want clean first sync", r1)
+	}
+	if r1.Protected != 1 {
+		t.Errorf("first pull Protected = %d, want 1", r1.Protected)
+	}
+	assertArtifact(t, localCampaign, "media/shared.bin", "precious local version")
+
+	// Still protected on the next pull: it was never agreed state.
+	r2 := Pull(ctx, localCampaign, src, Root{Path: "media"})
+	if r2.Protected != 1 {
+		t.Errorf("second pull Protected = %d, want 1 (protection must persist)", r2.Protected)
+	}
+	assertArtifact(t, localCampaign, "media/shared.bin", "precious local version")
+}
+
+func TestPullUnreachablePeerWarns(t *testing.T) {
+	requireRsync(t)
+	ctx := context.Background()
+	localCampaign := t.TempDir()
+	src := peer.FromPath("ghost", filepath.Join(t.TempDir(), "missing"))
+
+	r := Pull(ctx, localCampaign, src, Root{Path: "media"})
+	if r.Synced {
+		t.Error("pull from missing peer Synced = true, want false")
+	}
+	if r.Warning == "" {
+		t.Error("pull from missing peer Warning empty, want message")
+	}
+}
+
+func TestVerifyAgainstSnapshot(t *testing.T) {
+	requireRsync(t)
+	ctx := context.Background()
+
+	peerCampaign := t.TempDir()
+	localCampaign := t.TempDir()
+	writeArtifact(t, peerCampaign, "media/a.bin", "aaa")
+	writeArtifact(t, peerCampaign, "media/b.bin", "bbb")
+	src := peer.FromPath("peerbox", peerCampaign)
+
+	if r := Pull(ctx, localCampaign, src, Root{Path: "media"}); r.Warning != "" {
+		t.Fatalf("pull warning: %s", r.Warning)
+	}
+
+	local, err := BuildManifest(ctx, localCampaign, "media")
+	if err != nil {
+		t.Fatalf("BuildManifest() error = %v", err)
+	}
+	snapshot, err := LoadSnapshot(localCampaign, "peerbox", "media")
+	if err != nil || snapshot == nil {
+		t.Fatalf("LoadSnapshot() = %v, %v; want snapshot", snapshot, err)
+	}
+	if v := Verify(local, snapshot); !v.Clean() {
+		t.Errorf("Verify() after pull = %+v, want clean", v)
+	}
+
+	if err := os.Remove(filepath.Join(localCampaign, "media", "b.bin")); err != nil {
+		t.Fatalf("removing file: %v", err)
+	}
+	local, err = BuildManifest(ctx, localCampaign, "media")
+	if err != nil {
+		t.Fatalf("BuildManifest() error = %v", err)
+	}
+	v := Verify(local, snapshot)
+	if len(v.Missing) != 1 || v.Missing[0] != "b.bin" {
+		t.Errorf("Verify() missing = %v, want [b.bin]", v.Missing)
+	}
+}
+
+func requireRsync(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("rsync"); err != nil {
+		t.Skip("rsync not available")
+	}
+}
+
+func writeArtifact(t *testing.T, campaignRoot, rel, content string) {
+	t.Helper()
+	path := filepath.Join(campaignRoot, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func assertArtifact(t *testing.T, campaignRoot, rel, want string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(campaignRoot, filepath.FromSlash(rel)))
+	if err != nil {
+		t.Fatalf("reading %s: %v", rel, err)
+	}
+	if string(data) != want {
+		t.Errorf("%s = %q, want %q", rel, string(data), want)
+	}
+}

--- a/internal/artifacts/config.go
+++ b/internal/artifacts/config.go
@@ -113,15 +113,53 @@ func (f *File) Add(root Root) error {
 		return err
 	}
 	root.Path = NormalizeRootPath(root.Path)
-	switch root.Policy {
-	case "", PolicyAlways, PolicyOnDemand:
-	default:
+	if !knownPolicy(root.Policy) {
 		return camperrors.Newf("unknown policy %q (want %s or %s)", root.Policy, PolicyAlways, PolicyOnDemand)
 	}
 	if _, exists := f.Find(root.Path); exists {
 		return camperrors.Newf("artifact root %q is already declared", root.Path)
 	}
 	f.Roots = append(f.Roots, root)
+	return nil
+}
+
+// knownPolicy reports whether p is a recognized root policy (empty means the
+// default, PolicyAlways).
+func knownPolicy(p string) bool {
+	switch p {
+	case "", PolicyAlways, PolicyOnDemand:
+		return true
+	default:
+		return false
+	}
+}
+
+// Validate checks that the whole declaration is well-formed before the
+// sync/pull engine consumes it: a supported version, known policies,
+// campaign-relative paths, and no duplicate roots. Load stays lenient so the
+// edit commands can still open a broken file to repair it; the data-moving
+// paths (pull and verify) call Validate so a hand-edited or maliciously
+// committed artifacts.yaml fails closed instead of being partially honored -
+// an unknown policy is otherwise silently skipped on a normal sync but pulled
+// under --artifacts-only, and a duplicate root writes the same snapshot twice.
+func (f *File) Validate() error {
+	if f.Version != 1 {
+		return camperrors.Newf("unsupported artifacts.yaml version %d (want 1)", f.Version)
+	}
+	seen := make(map[string]bool, len(f.Roots))
+	for _, r := range f.Roots {
+		if err := ValidateRootPath(r.Path); err != nil {
+			return err
+		}
+		if !knownPolicy(r.Policy) {
+			return camperrors.Newf("unknown policy %q for root %q (want %s or %s)", r.Policy, r.Path, PolicyAlways, PolicyOnDemand)
+		}
+		norm := NormalizeRootPath(r.Path)
+		if seen[norm] {
+			return camperrors.Newf("duplicate artifact root %q", norm)
+		}
+		seen[norm] = true
+	}
 	return nil
 }
 

--- a/internal/artifacts/config.go
+++ b/internal/artifacts/config.go
@@ -158,8 +158,65 @@ func ValidateRootPath(path string) error {
 	if !filepath.IsLocal(filepath.FromSlash(normalized)) {
 		return camperrors.Newf("artifact root %q escapes the campaign root", path)
 	}
-	if normalized == ".campaign" || strings.HasPrefix(normalized, ".campaign/") {
+	if strings.EqualFold(normalized, ".campaign") || hasCaseInsensitivePrefix(normalized, ".campaign/") {
 		return camperrors.Newf("artifact root %q may not live under .campaign", path)
 	}
 	return nil
+}
+
+// hasCaseInsensitivePrefix reports whether s starts with prefix, ignoring
+// case. The .campaign guard uses it so a case-insensitive filesystem (APFS,
+// NTFS) cannot smuggle a ".Campaign/" root past the check.
+func hasCaseInsensitivePrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix)
+}
+
+// EnsureRootWithin re-validates a root about to be consumed by the sync/pull
+// engine, not just declared: it re-runs ValidateRootPath (defending against a
+// hand-edited or malicious .campaign/artifacts.yaml that never went through
+// Add) and then resolves symlinks so a symlinked root cannot redirect rsync
+// writes outside the campaign. Returns the cleaned, campaign-relative root on
+// success.
+func EnsureRootWithin(campaignRoot, rootPath string) (string, error) {
+	if err := ValidateRootPath(rootPath); err != nil {
+		return "", err
+	}
+	normalized := NormalizeRootPath(rootPath)
+
+	campReal, err := filepath.EvalSymlinks(campaignRoot)
+	if err != nil {
+		campReal = campaignRoot // campaign root should exist; fall back to literal
+	}
+	abs := filepath.Join(campReal, filepath.FromSlash(normalized))
+
+	// Resolve the longest existing prefix of the target: a not-yet-created
+	// root is fine, but any existing symlink component must stay inside the
+	// campaign.
+	real, err := resolveExistingPrefix(abs)
+	if err != nil {
+		return "", camperrors.Wrapf(err, "resolve artifact root %s", normalized)
+	}
+	rel, err := filepath.Rel(campReal, real)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", camperrors.Newf("artifact root %q resolves outside the campaign root", rootPath)
+	}
+	return normalized, nil
+}
+
+// resolveExistingPrefix EvalSymlinks the longest existing ancestor of p and
+// re-appends the non-existent tail, so a root that does not exist yet can
+// still be checked for symlinked ancestors that escape the campaign.
+func resolveExistingPrefix(p string) (string, error) {
+	if real, err := filepath.EvalSymlinks(p); err == nil {
+		return real, nil
+	}
+	parent := filepath.Dir(p)
+	if parent == p {
+		return p, nil
+	}
+	realParent, err := resolveExistingPrefix(parent)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(realParent, filepath.Base(p)), nil
 }

--- a/internal/artifacts/config.go
+++ b/internal/artifacts/config.go
@@ -1,0 +1,165 @@
+// Package artifacts gives campaign media and other heavy non-git payloads a
+// declared, syncable home. A committed declaration file (.campaign/
+// artifacts.yaml) names artifact roots; a per-machine manifest describes what
+// a root currently holds; and an rsync-based pull moves a peer's copy over
+// the same machine trust the rest of camp's multi-machine stack uses. Git
+// content never travels through this package: declared roots are expected to
+// be gitignored, and everything here is delta transport for the filesystem
+// class of a campaign.
+package artifacts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigRelPath is the campaign-relative path of the committed declaration
+// file. Committed on purpose: a fresh machine learns what it is missing from
+// the declaration, while manifests and snapshots stay machine-local derived
+// state under .campaign/cache.
+const ConfigRelPath = ".campaign/artifacts.yaml"
+
+// Root policies.
+const (
+	// PolicyAlways syncs the root on every peer-assisted sync.
+	PolicyAlways = "always"
+	// PolicyOnDemand syncs the root only when artifacts are requested
+	// explicitly (--artifacts-only).
+	PolicyOnDemand = "on-demand"
+)
+
+// File is the on-disk shape of .campaign/artifacts.yaml.
+type File struct {
+	Version int    `yaml:"version"`
+	Roots   []Root `yaml:"roots"`
+}
+
+// Root declares one artifact root.
+type Root struct {
+	// Path is the campaign-relative directory holding the artifacts.
+	Path string `yaml:"path"`
+	// Policy is PolicyAlways (default when empty) or PolicyOnDemand.
+	Policy string `yaml:"policy,omitempty"`
+}
+
+// EffectivePolicy resolves an empty policy to PolicyAlways.
+func (r Root) EffectivePolicy() string {
+	if r.Policy == "" {
+		return PolicyAlways
+	}
+	return r.Policy
+}
+
+// ConfigPath returns the absolute path of the declaration file.
+func ConfigPath(campaignRoot string) string {
+	return filepath.Join(campaignRoot, filepath.FromSlash(ConfigRelPath))
+}
+
+// Load reads the campaign's artifact declarations. A missing file is an
+// empty declaration, not an error.
+func Load(campaignRoot string) (*File, error) {
+	data, err := os.ReadFile(ConfigPath(campaignRoot))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &File{Version: 1}, nil
+		}
+		return nil, camperrors.Wrap(err, "read artifacts config")
+	}
+	var f File
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return nil, camperrors.Wrap(err, "parse artifacts config")
+	}
+	if f.Version == 0 {
+		f.Version = 1
+	}
+	return &f, nil
+}
+
+// Save writes the declaration file, creating .campaign if needed.
+func (f *File) Save(campaignRoot string) error {
+	path := ConfigPath(campaignRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return camperrors.Wrap(err, "create .campaign directory")
+	}
+	data, err := yaml.Marshal(f)
+	if err != nil {
+		return camperrors.Wrap(err, "encode artifacts config")
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return camperrors.Wrap(err, "write artifacts config")
+	}
+	return nil
+}
+
+// Find returns the declared root matching the (normalized) path.
+func (f *File) Find(path string) (Root, bool) {
+	normalized := NormalizeRootPath(path)
+	for _, r := range f.Roots {
+		if NormalizeRootPath(r.Path) == normalized {
+			return r, true
+		}
+	}
+	return Root{}, false
+}
+
+// Add appends a validated root declaration. The path must be relative,
+// inside the campaign, and not already declared.
+func (f *File) Add(root Root) error {
+	if err := ValidateRootPath(root.Path); err != nil {
+		return err
+	}
+	root.Path = NormalizeRootPath(root.Path)
+	switch root.Policy {
+	case "", PolicyAlways, PolicyOnDemand:
+	default:
+		return camperrors.Newf("unknown policy %q (want %s or %s)", root.Policy, PolicyAlways, PolicyOnDemand)
+	}
+	if _, exists := f.Find(root.Path); exists {
+		return camperrors.Newf("artifact root %q is already declared", root.Path)
+	}
+	f.Roots = append(f.Roots, root)
+	return nil
+}
+
+// Remove drops the declared root matching path, reporting whether it existed.
+func (f *File) Remove(path string) bool {
+	normalized := NormalizeRootPath(path)
+	for i, r := range f.Roots {
+		if NormalizeRootPath(r.Path) == normalized {
+			f.Roots = append(f.Roots[:i], f.Roots[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// NormalizeRootPath cleans a declared path to slash-separated form without
+// leading ./ or trailing /.
+func NormalizeRootPath(path string) string {
+	return strings.Trim(filepath.ToSlash(filepath.Clean(path)), "/")
+}
+
+// ValidateRootPath rejects paths that are absolute, empty, escape the
+// campaign root, or live under .campaign. Absoluteness is checked on the raw
+// input (normalization strips leading slashes); the remaining checks run on
+// the normalized form so ./-prefixed spellings cannot dodge them.
+func ValidateRootPath(path string) error {
+	if filepath.IsAbs(path) {
+		return camperrors.Newf("artifact root %q must be relative to the campaign root", path)
+	}
+	normalized := NormalizeRootPath(path)
+	if normalized == "" || normalized == "." {
+		return camperrors.New("artifact root path must not be empty")
+	}
+	if !filepath.IsLocal(filepath.FromSlash(normalized)) {
+		return camperrors.Newf("artifact root %q escapes the campaign root", path)
+	}
+	if normalized == ".campaign" || strings.HasPrefix(normalized, ".campaign/") {
+		return camperrors.Newf("artifact root %q may not live under .campaign", path)
+	}
+	return nil
+}

--- a/internal/artifacts/manifest.go
+++ b/internal/artifacts/manifest.go
@@ -28,7 +28,14 @@ type Manifest struct {
 type FileEntry struct {
 	Path string `json:"path"` // slash-separated, relative to the root
 	Size int64  `json:"size"`
-	MTime int64 `json:"mtime_unix"`
+	// MTime is nanosecond-resolution modification time. Second resolution let a
+	// same-size in-place edit made within the same wall-clock second as the
+	// baseline pass as unchanged, so it was excluded from protection and
+	// silently overwritten; nanoseconds close that no-clobber hole. The JSON
+	// key is versioned (mtime_unix_nano) so a pre-existing second-resolution
+	// snapshot is simply absent here and degrades to first-sync caution rather
+	// than being misread as nanoseconds.
+	MTime int64 `json:"mtime_unix_nano"`
 	// Symlink marks an entry that is a symbolic link (recorded via lstat, not
 	// followed) so a local symlink participates in conflict protection instead
 	// of being invisible to it.
@@ -79,7 +86,7 @@ func BuildManifest(ctx context.Context, campaignRoot, rootRel string) (*Manifest
 		m.Files = append(m.Files, FileEntry{
 			Path:    filepath.ToSlash(rel),
 			Size:    fi.Size(),
-			MTime:   fi.ModTime().Unix(),
+			MTime:   fi.ModTime().UnixNano(),
 			Symlink: isSymlink,
 		})
 		return nil

--- a/internal/artifacts/manifest.go
+++ b/internal/artifacts/manifest.go
@@ -1,0 +1,178 @@
+package artifacts
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// Manifest describes one artifact root's current contents on one machine:
+// derived state, rebuilt from the filesystem whenever needed, never
+// committed. Size and mtime identify a file version; content hashing is a
+// deliberate non-default for multi-hundred-GB media roots.
+type Manifest struct {
+	Version     int         `json:"version"`
+	Root        string      `json:"root"`
+	GeneratedAt time.Time   `json:"generated_at"`
+	Files       []FileEntry `json:"files"`
+}
+
+// FileEntry is one regular file inside an artifact root.
+type FileEntry struct {
+	Path  string `json:"path"` // slash-separated, relative to the root
+	Size  int64  `json:"size"`
+	MTime int64  `json:"mtime_unix"`
+}
+
+// BuildManifest walks the artifact root and records every regular file.
+// Symlinks and directories are skipped: an artifact root is expected to hold
+// plain payload files. A root directory that does not exist yet yields an
+// empty manifest.
+func BuildManifest(ctx context.Context, campaignRoot, rootRel string) (*Manifest, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	m := &Manifest{Version: 1, Root: NormalizeRootPath(rootRel), GeneratedAt: time.Now().UTC()}
+	rootAbs := filepath.Join(campaignRoot, filepath.FromSlash(m.Root))
+
+	info, err := os.Stat(rootAbs)
+	if os.IsNotExist(err) {
+		return m, nil
+	}
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "stat artifact root %s", m.Root)
+	}
+	if !info.IsDir() {
+		return nil, camperrors.Newf("artifact root %s is not a directory", m.Root)
+	}
+
+	walkErr := filepath.WalkDir(rootAbs, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		fi, err := d.Info()
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(rootAbs, path)
+		if err != nil {
+			return err
+		}
+		m.Files = append(m.Files, FileEntry{
+			Path:  filepath.ToSlash(rel),
+			Size:  fi.Size(),
+			MTime: fi.ModTime().Unix(),
+		})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, camperrors.Wrapf(walkErr, "walk artifact root %s", m.Root)
+	}
+
+	sort.Slice(m.Files, func(i, j int) bool { return m.Files[i].Path < m.Files[j].Path })
+	return m, nil
+}
+
+// Index returns the manifest's files keyed by relative path.
+func (m *Manifest) Index() map[string]FileEntry {
+	idx := make(map[string]FileEntry, len(m.Files))
+	for _, f := range m.Files {
+		idx[f.Path] = f
+	}
+	return idx
+}
+
+// ProtectedPaths lists the local files a pull must not overwrite: everything
+// whose current state is not exactly the last agreed baseline with that peer.
+// That covers files modified since the last transfer AND files the baseline
+// has never seen (unknown provenance). With no baseline at all (first sync
+// with this peer), every existing local file is protected. The rule errs
+// toward never losing local bytes; a pull can only update files whose local
+// state is known-agreed.
+func (m *Manifest) ProtectedPaths(baseline *Manifest) []string {
+	var base map[string]FileEntry
+	if baseline != nil {
+		base = baseline.Index()
+	}
+	var protected []string
+	for _, f := range m.Files {
+		b, ok := base[f.Path]
+		if !ok || b.Size != f.Size || b.MTime != f.MTime {
+			protected = append(protected, f.Path)
+		}
+	}
+	return protected
+}
+
+// VerifyResult compares a local tree against a reference manifest.
+type VerifyResult struct {
+	Root    string   `json:"root"`
+	Checked int      `json:"checked"`
+	Missing []string `json:"missing"`
+	Differ  []string `json:"differ"`
+	Extra   []string `json:"extra"`
+}
+
+// Clean reports whether the verification found no discrepancies.
+func (v *VerifyResult) Clean() bool {
+	return len(v.Missing) == 0 && len(v.Differ) == 0 && len(v.Extra) == 0
+}
+
+// Verify compares the local manifest against a reference (typically the
+// last-transfer snapshot): files the reference has that the local tree lacks
+// (missing), files whose size or mtime differ (differ), and local files the
+// reference does not know about (extra).
+func Verify(local, reference *Manifest) *VerifyResult {
+	result := &VerifyResult{Root: local.Root, Checked: len(reference.Files)}
+	localIdx := local.Index()
+	refIdx := reference.Index()
+
+	for _, f := range reference.Files {
+		l, ok := localIdx[f.Path]
+		if !ok {
+			result.Missing = append(result.Missing, f.Path)
+			continue
+		}
+		if l.Size != f.Size || l.MTime != f.MTime {
+			result.Differ = append(result.Differ, f.Path)
+		}
+	}
+	for _, f := range local.Files {
+		if _, ok := refIdx[f.Path]; !ok {
+			result.Extra = append(result.Extra, f.Path)
+		}
+	}
+	return result
+}
+
+// EncodeJSON renders the manifest for --json consumers (and remote verify).
+func (m *Manifest) EncodeJSON() ([]byte, error) {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return nil, camperrors.Wrap(err, "encode manifest")
+	}
+	return append(data, '\n'), nil
+}
+
+// DecodeManifest parses a manifest produced by EncodeJSON.
+func DecodeManifest(data []byte) (*Manifest, error) {
+	var m Manifest
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &m); err != nil {
+		return nil, camperrors.Wrap(err, "parse manifest")
+	}
+	return &m, nil
+}

--- a/internal/artifacts/manifest.go
+++ b/internal/artifacts/manifest.go
@@ -24,17 +24,20 @@ type Manifest struct {
 	Files       []FileEntry `json:"files"`
 }
 
-// FileEntry is one regular file inside an artifact root.
+// FileEntry is one regular file (or symlink) inside an artifact root.
 type FileEntry struct {
-	Path  string `json:"path"` // slash-separated, relative to the root
-	Size  int64  `json:"size"`
-	MTime int64  `json:"mtime_unix"`
+	Path string `json:"path"` // slash-separated, relative to the root
+	Size int64  `json:"size"`
+	MTime int64 `json:"mtime_unix"`
+	// Symlink marks an entry that is a symbolic link (recorded via lstat, not
+	// followed) so a local symlink participates in conflict protection instead
+	// of being invisible to it.
+	Symlink bool `json:"symlink,omitempty"`
 }
 
-// BuildManifest walks the artifact root and records every regular file.
-// Symlinks and directories are skipped: an artifact root is expected to hold
-// plain payload files. A root directory that does not exist yet yields an
-// empty manifest.
+// BuildManifest walks the artifact root and records every regular file and
+// symlink (symlinks via lstat, never followed). Directories are skipped. A
+// root directory that does not exist yet yields an empty manifest.
 func BuildManifest(ctx context.Context, campaignRoot, rootRel string) (*Manifest, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
@@ -61,10 +64,11 @@ func BuildManifest(ctx context.Context, campaignRoot, rootRel string) (*Manifest
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		if !d.Type().IsRegular() {
+		isSymlink := d.Type()&fs.ModeSymlink != 0
+		if !d.Type().IsRegular() && !isSymlink {
 			return nil
 		}
-		fi, err := d.Info()
+		fi, err := d.Info() // WalkDir uses lstat, so symlinks are not followed
 		if err != nil {
 			return err
 		}
@@ -73,9 +77,10 @@ func BuildManifest(ctx context.Context, campaignRoot, rootRel string) (*Manifest
 			return err
 		}
 		m.Files = append(m.Files, FileEntry{
-			Path:  filepath.ToSlash(rel),
-			Size:  fi.Size(),
-			MTime: fi.ModTime().Unix(),
+			Path:    filepath.ToSlash(rel),
+			Size:    fi.Size(),
+			MTime:   fi.ModTime().Unix(),
+			Symlink: isSymlink,
 		})
 		return nil
 	})
@@ -111,11 +116,19 @@ func (m *Manifest) ProtectedPaths(baseline *Manifest) []string {
 	var protected []string
 	for _, f := range m.Files {
 		b, ok := base[f.Path]
-		if !ok || b.Size != f.Size || b.MTime != f.MTime {
+		if !ok || !sameEntry(b, f) {
 			protected = append(protected, f.Path)
 		}
 	}
 	return protected
+}
+
+// sameEntry reports whether two entries represent the same file version:
+// same size, same mtime, and same kind (a regular file and a symlink at one
+// path are never "the same," so a peer file replacing a local symlink counts
+// as a change and stays protected).
+func sameEntry(a, b FileEntry) bool {
+	return a.Size == b.Size && a.MTime == b.MTime && a.Symlink == b.Symlink
 }
 
 // VerifyResult compares a local tree against a reference manifest.
@@ -147,7 +160,7 @@ func Verify(local, reference *Manifest) *VerifyResult {
 			result.Missing = append(result.Missing, f.Path)
 			continue
 		}
-		if l.Size != f.Size || l.MTime != f.MTime {
+		if !sameEntry(l, f) {
 			result.Differ = append(result.Differ, f.Path)
 		}
 	}

--- a/internal/artifacts/pull.go
+++ b/internal/artifacts/pull.go
@@ -1,0 +1,207 @@
+package artifacts
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/peer"
+)
+
+// PullResult is the outcome of pulling one artifact root from a peer.
+type PullResult struct {
+	Root   string `json:"root"`
+	Policy string `json:"policy"`
+	// Synced reports whether the rsync transfer completed.
+	Synced bool `json:"synced"`
+	// FirstSync marks a pull with no prior snapshot for this peer: every
+	// pre-existing local file was protected, because there is no baseline to
+	// tell local edits from stale copies. Only new files arrived.
+	FirstSync bool `json:"first_sync"`
+	// Protected counts local files excluded from this pull (not overwritable:
+	// modified since the last transfer from this peer, or never agreed with
+	// it). SkippedConflicts lists the modified-since-baseline subset.
+	Protected int `json:"protected"`
+	// SkippedConflicts lists files changed locally since the last transfer
+	// from this peer; they were excluded and left as-is, and stay protected
+	// on future pulls until resolved (e.g. remove the local file to take the
+	// peer's copy on the next sync). Media merge is a human decision.
+	SkippedConflicts []string `json:"skipped_conflicts,omitempty"`
+	// Warning carries a non-fatal transfer problem; the sync itself proceeds.
+	Warning string `json:"warning,omitempty"`
+}
+
+// excludeFromThreshold is where the exclude list moves from argv to a file:
+// a pre-populated root on first sync protects every existing file, which can
+// be far more paths than argv should carry.
+const excludeFromThreshold = 20
+
+// Pull transfers one declared artifact root from the peer, directionally and
+// without deletions (rsync -a --partial over the same ssh options as the
+// rest of the peer stack). A local file is only overwritable when its state
+// exactly matches the last agreed baseline with this peer; everything else
+// is excluded and reported, never clobbered. On success, the agreed state is
+// snapshotted as the new baseline.
+func Pull(ctx context.Context, campaignRoot string, src *peer.Source, root Root) *PullResult {
+	result := &PullResult{Root: NormalizeRootPath(root.Path), Policy: root.EffectivePolicy()}
+	if err := pull(ctx, campaignRoot, src, result); err != nil {
+		result.Warning = err.Error()
+	}
+	return result
+}
+
+func pull(ctx context.Context, campaignRoot string, src *peer.Source, result *PullResult) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if _, err := exec.LookPath("rsync"); err != nil {
+		return camperrors.New("rsync not found on PATH; artifact sync needs rsync on both machines")
+	}
+
+	rootRel := result.Root
+	destAbs := filepath.Join(campaignRoot, filepath.FromSlash(rootRel))
+	if err := os.MkdirAll(destAbs, 0o755); err != nil {
+		return camperrors.Wrapf(err, "create artifact root %s", rootRel)
+	}
+
+	local, err := BuildManifest(ctx, campaignRoot, rootRel)
+	if err != nil {
+		return err
+	}
+	baseline, err := LoadSnapshot(campaignRoot, src.ID(), rootRel)
+	if err != nil {
+		return err
+	}
+
+	protected := local.ProtectedPaths(baseline)
+	result.Protected = len(protected)
+	if baseline == nil {
+		result.FirstSync = true
+	} else {
+		result.SkippedConflicts = modifiedSubset(protected, baseline)
+	}
+
+	args := []string{"-a", "--partial"}
+	if sshCmd := src.SSHCommand(); sshCmd != "" {
+		args = append(args, "-e", sshCmd)
+	}
+	excludeFile, excludeArgs, err := excludeArguments(protected)
+	if err != nil {
+		return err
+	}
+	if excludeFile != "" {
+		defer func() { _ = os.Remove(excludeFile) }()
+	}
+	args = append(args, excludeArgs...)
+	args = append(args, src.RsyncSpec(rootRel), destAbs+string(os.PathSeparator))
+
+	cmd := exec.CommandContext(ctx, "rsync", args...)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return camperrors.Wrapf(err, "rsync %s from %s: %s", rootRel, src.ID(), lastLines(string(output), 3))
+	}
+	result.Synced = true
+
+	after, err := BuildManifest(ctx, campaignRoot, rootRel)
+	if err != nil {
+		return camperrors.Wrap(err, "manifest after pull")
+	}
+	return SaveSnapshot(campaignRoot, src.ID(), rootRel, agreedState(after, baseline, protected))
+}
+
+// agreedState builds the snapshot to record after a pull: files touched or
+// verified by this transfer carry their current state, while protected files
+// keep their previous baseline entry (or none, if they were never agreed).
+// Recording a protected file's current local state would make the next pull
+// treat it as agreed and silently overwrite it with the peer's copy; this
+// keeps conflict protection sticky until the human resolves the file.
+func agreedState(after, baseline *Manifest, protected []string) *Manifest {
+	protectedSet := make(map[string]bool, len(protected))
+	for _, p := range protected {
+		protectedSet[p] = true
+	}
+	var base map[string]FileEntry
+	if baseline != nil {
+		base = baseline.Index()
+	}
+
+	snap := &Manifest{Version: 1, Root: after.Root, GeneratedAt: time.Now().UTC()}
+	for _, f := range after.Files {
+		if !protectedSet[f.Path] {
+			snap.Files = append(snap.Files, f)
+			continue
+		}
+		if b, ok := base[f.Path]; ok {
+			snap.Files = append(snap.Files, b)
+		}
+	}
+	return snap
+}
+
+// modifiedSubset filters the protected list down to paths the baseline knows
+// about: files changed since the last transfer, i.e. genuine conflicts worth
+// reporting. Never-agreed local files are protected too but are not
+// conflicts.
+func modifiedSubset(protected []string, baseline *Manifest) []string {
+	base := baseline.Index()
+	var modified []string
+	for _, p := range protected {
+		if _, ok := base[p]; ok {
+			modified = append(modified, p)
+		}
+	}
+	return modified
+}
+
+// excludeArguments renders the protected paths as rsync exclude flags, or as
+// an --exclude-from temp file when the list is large. Patterns are anchored
+// to the transfer root and glob metacharacters in real filenames are escaped.
+func excludeArguments(protected []string) (tempFile string, args []string, err error) {
+	if len(protected) == 0 {
+		return "", nil, nil
+	}
+	patterns := make([]string, len(protected))
+	for i, p := range protected {
+		patterns[i] = "/" + escapeRsyncPattern(p)
+	}
+	if len(patterns) <= excludeFromThreshold {
+		for _, p := range patterns {
+			args = append(args, "--exclude="+p)
+		}
+		return "", args, nil
+	}
+
+	f, err := os.CreateTemp("", "camp-artifact-excludes-*.txt")
+	if err != nil {
+		return "", nil, camperrors.Wrap(err, "create exclude file")
+	}
+	if _, err := f.WriteString(strings.Join(patterns, "\n") + "\n"); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return "", nil, camperrors.Wrap(err, "write exclude file")
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return "", nil, camperrors.Wrap(err, "close exclude file")
+	}
+	return f.Name(), []string{"--exclude-from=" + f.Name()}, nil
+}
+
+// escapeRsyncPattern escapes rsync glob metacharacters so a literal filename
+// is matched literally.
+func escapeRsyncPattern(p string) string {
+	r := strings.NewReplacer(`[`, `\[`, `]`, `\]`, `*`, `\*`, `?`, `\?`)
+	return r.Replace(p)
+}
+
+// lastLines trims rsync output to its tail, where the actionable error lives.
+func lastLines(s string, n int) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, " | ")
+}

--- a/internal/artifacts/pull.go
+++ b/internal/artifacts/pull.go
@@ -2,6 +2,8 @@ package artifacts
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,16 +14,23 @@ import (
 	"github.com/Obedience-Corp/camp/internal/peer"
 )
 
-// PullResult is the outcome of pulling one artifact root from a peer.
+// PullResult is the outcome of pulling one artifact root from a peer. JSON
+// field names are camelCase to match the sync/v1alpha1 envelope this is
+// embedded in.
 type PullResult struct {
 	Root   string `json:"root"`
 	Policy string `json:"policy"`
-	// Synced reports whether the rsync transfer completed.
+	// Synced reports whether the rsync transfer completed (including a
+	// partial transfer that rsync flagged with exit 23/24).
 	Synced bool `json:"synced"`
 	// FirstSync marks a pull with no prior snapshot for this peer: every
 	// pre-existing local file was protected, because there is no baseline to
 	// tell local edits from stale copies. Only new files arrived.
-	FirstSync bool `json:"first_sync"`
+	FirstSync bool `json:"firstSync"`
+	// Partial marks a transfer rsync reported as incomplete (exit 23/24);
+	// files that did transfer are still snapshotted so they are not poisoned
+	// into never-agreed protection on the next run.
+	Partial bool `json:"partial,omitempty"`
 	// Protected counts local files excluded from this pull (not overwritable:
 	// modified since the last transfer from this peer, or never agreed with
 	// it). SkippedConflicts lists the modified-since-baseline subset.
@@ -30,7 +39,7 @@ type PullResult struct {
 	// from this peer; they were excluded and left as-is, and stay protected
 	// on future pulls until resolved (e.g. remove the local file to take the
 	// peer's copy on the next sync). Media merge is a human decision.
-	SkippedConflicts []string `json:"skipped_conflicts,omitempty"`
+	SkippedConflicts []string `json:"skippedConflicts,omitempty"`
 	// Warning carries a non-fatal transfer problem; the sync itself proceeds.
 	Warning string `json:"warning,omitempty"`
 }
@@ -62,7 +71,14 @@ func pull(ctx context.Context, campaignRoot string, src *peer.Source, result *Pu
 		return camperrors.New("rsync not found on PATH; artifact sync needs rsync on both machines")
 	}
 
-	rootRel := result.Root
+	// Re-validate the root at consume time: a hand-edited or malicious
+	// artifacts.yaml never passed through Add, and a symlinked root must not
+	// redirect the rsync destination outside the campaign.
+	rootRel, err := EnsureRootWithin(campaignRoot, result.Root)
+	if err != nil {
+		return err
+	}
+	result.Root = rootRel
 	destAbs := filepath.Join(campaignRoot, filepath.FromSlash(rootRel))
 	if err := os.MkdirAll(destAbs, 0o755); err != nil {
 		return camperrors.Wrapf(err, "create artifact root %s", rootRel)
@@ -85,7 +101,20 @@ func pull(ctx context.Context, campaignRoot string, src *peer.Source, result *Pu
 		result.SkippedConflicts = modifiedSubset(protected, baseline)
 	}
 
-	args := []string{"-a", "--partial"}
+	// --partial-dir keeps interrupted-transfer bytes OUT of the destination
+	// tree (a bare --partial would leave a truncated file at the real name,
+	// which the post-pull manifest would then record as an agreed baseline
+	// and refuse to repair). The partial dir lives under .campaign/cache
+	// (gitignored, same filesystem as the root so completed files rename
+	// atomically) and is never walked by BuildManifest.
+	// --no-links: never materialize a peer symlink locally (phantom state no
+	// snapshot could track); local symlinks are recorded in the manifest and
+	// so are protected like any other entry.
+	partialDir := filepath.Join(campaignRoot, ".campaign", "cache", "rsync-partial")
+	if err := os.MkdirAll(partialDir, 0o755); err != nil {
+		return camperrors.Wrap(err, "create rsync partial dir")
+	}
+	args := []string{"-a", "--no-links", "--partial-dir=" + partialDir}
 	if sshCmd := src.SSHCommand(); sshCmd != "" {
 		args = append(args, "-e", sshCmd)
 	}
@@ -100,16 +129,61 @@ func pull(ctx context.Context, campaignRoot string, src *peer.Source, result *Pu
 	args = append(args, src.RsyncSpec(rootRel), destAbs+string(os.PathSeparator))
 
 	cmd := exec.CommandContext(ctx, "rsync", args...)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return camperrors.Wrapf(err, "rsync %s from %s: %s", rootRel, src.ID(), lastLines(string(output), 3))
+	output, runErr := cmd.CombinedOutput()
+
+	after, mErr := BuildManifest(ctx, campaignRoot, rootRel)
+	if mErr != nil {
+		return camperrors.Wrap(mErr, "manifest after pull")
+	}
+
+	if runErr != nil {
+		// rsync 23 (partial transfer due to error) and 24 (source files
+		// vanished mid-transfer) can be partial successes: the files that DID
+		// arrive are valid, so snapshotting them avoids poisoning them into
+		// never-agreed protection on the next run. But the SAME exit codes
+		// also cover "source root does not exist," where nothing transferred.
+		// Distinguish by whether any complete file actually changed locally
+		// (--partial-dir keeps incomplete files out of the tree, so an
+		// unchanged tree means nothing landed) and treat a no-op as the hard
+		// failure it is.
+		code := exitCode(runErr)
+		if (code == 23 || code == 24) && !manifestsEqual(local, after) {
+			result.Partial = true
+			result.Warning = fmt.Sprintf("partial transfer (rsync exit %d): %s", code, lastLines(string(output), 3))
+		} else {
+			return camperrors.Wrapf(runErr, "rsync %s from %s: %s", rootRel, src.ID(), lastLines(string(output), 3))
+		}
 	}
 	result.Synced = true
 
-	after, err := BuildManifest(ctx, campaignRoot, rootRel)
-	if err != nil {
-		return camperrors.Wrap(err, "manifest after pull")
-	}
 	return SaveSnapshot(campaignRoot, src.ID(), rootRel, agreedState(after, baseline, protected))
+}
+
+// manifestsEqual reports whether two manifests describe the same set of files
+// with the same versions, so a failed rsync that changed nothing can be told
+// apart from a partial transfer that landed at least one complete file.
+func manifestsEqual(a, b *Manifest) bool {
+	if len(a.Files) != len(b.Files) {
+		return false
+	}
+	bi := b.Index()
+	for _, f := range a.Files {
+		g, ok := bi[f.Path]
+		if !ok || !sameEntry(f, g) {
+			return false
+		}
+	}
+	return true
+}
+
+// exitCode extracts a process exit code from an exec error, or -1 if the
+// error is not an exit status (e.g. the binary could not start).
+func exitCode(err error) int {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
 }
 
 // agreedState builds the snapshot to record after a pull: files touched or
@@ -191,9 +265,11 @@ func excludeArguments(protected []string) (tempFile string, args []string, err e
 }
 
 // escapeRsyncPattern escapes rsync glob metacharacters so a literal filename
-// is matched literally.
+// is matched literally. Backslash is escaped first (and thus mapped by the
+// single Replacer pass, not re-processed) so a filename containing a
+// backslash before a glob char does not produce an active wildcard.
 func escapeRsyncPattern(p string) string {
-	r := strings.NewReplacer(`[`, `\[`, `]`, `\]`, `*`, `\*`, `?`, `\?`)
+	r := strings.NewReplacer(`\`, `\\`, `[`, `\[`, `]`, `\]`, `*`, `\*`, `?`, `\?`)
 	return r.Replace(p)
 }
 

--- a/internal/artifacts/pull.go
+++ b/internal/artifacts/pull.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -50,10 +51,13 @@ type PullResult struct {
 const excludeFromThreshold = 20
 
 // Pull transfers one declared artifact root from the peer, directionally and
-// without deletions (rsync -a --partial over the same ssh options as the
-// rest of the peer stack). A local file is only overwritable when its state
-// exactly matches the last agreed baseline with this peer; everything else
-// is excluded and reported, never clobbered. On success, the agreed state is
+// without deletions. rsync stages the delta into a scratch tree outside the
+// live root (a --compare-dest delta transfer over the same ssh options as the
+// rest of the peer stack), then each staged file is merged into place only
+// after re-checking that the live destination still exactly matches the last
+// agreed baseline. A file that differs from the baseline at merge time —
+// including one a local writer touched during the transfer — is left
+// untouched and reported, never clobbered. On success, the agreed state is
 // snapshotted as the new baseline.
 func Pull(ctx context.Context, campaignRoot string, src *peer.Source, root Root) *PullResult {
 	result := &PullResult{Root: NormalizeRootPath(root.Path), Policy: root.EffectivePolicy()}
@@ -101,28 +105,30 @@ func pull(ctx context.Context, campaignRoot string, src *peer.Source, result *Pu
 		result.SkippedConflicts = modifiedSubset(protected, baseline)
 	}
 
-	// --partial-dir keeps interrupted-transfer bytes OUT of the destination
-	// tree (a bare --partial would leave a truncated file at the real name,
-	// which the post-pull manifest would then record as an agreed baseline
-	// and refuse to repair). The partial dir lives under .campaign/cache
-	// (gitignored, same filesystem as the root so completed files rename
-	// atomically) and is never walked by BuildManifest.
-	// --no-links: never materialize a peer symlink locally (phantom state no
-	// snapshot could track); local symlinks are recorded in the manifest and
-	// so are protected like any other entry.
-	// --update: the protected set is computed from a walk that finished before
-	// this transfer starts, so a file written locally in the window between
-	// the walk and rsync is not in the exclude list. --update skips any
-	// destination that is newer than the peer's copy, which is exactly the
-	// signature of a file a local writer just touched, so a concurrent edit is
-	// not clobbered. This narrows but does not fully eliminate the race (a
-	// concurrent write landing an older-or-equal mtime is still possible on a
-	// truly live tree); the design's guarantee assumes a quiescent root.
-	partialDir := filepath.Join(campaignRoot, ".campaign", "cache", "rsync-partial")
-	if err := os.MkdirAll(partialDir, 0o755); err != nil {
-		return camperrors.Wrap(err, "create rsync partial dir")
+	// Stage the transfer outside the live root, then atomically merge each
+	// file only after re-checking it against the baseline. A pre-transfer
+	// exclude scan alone cannot give no-clobber semantics: a renderer can
+	// write an unprotected path in the window between the walk and the write.
+	// So rsync never touches the live tree directly.
+	//
+	// --compare-dest=<live root> keeps this a delta transfer: rsync compares
+	// each source file against the live copy and only writes the ones that
+	// changed or are new into the staging tree, so unchanged multi-GB media
+	// is not re-copied. --no-links keeps peer symlinks from becoming phantom
+	// local state. No --partial: rsync writes each file to a temp name and
+	// renames on completion, and drops the in-flight temp on interruption, so
+	// the staging tree only ever holds complete files (staging is per-pull and
+	// wiped, so cross-run resume would buy nothing).
+	stagingDir := filepath.Join(campaignRoot, ".campaign", "cache", "rsync-staging", snapshotSlug(rootRel))
+	if err := os.RemoveAll(stagingDir); err != nil {
+		return camperrors.Wrap(err, "clear rsync staging dir")
 	}
-	args := []string{"-a", "--no-links", "--update", "--partial-dir=" + partialDir}
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
+		return camperrors.Wrap(err, "create rsync staging dir")
+	}
+	defer func() { _ = os.RemoveAll(stagingDir) }()
+
+	args := []string{"-a", "--no-links", "--compare-dest=" + destAbs}
 	if sshCmd := src.SSHCommand(); sshCmd != "" {
 		args = append(args, "-e", sshCmd)
 	}
@@ -134,54 +140,147 @@ func pull(ctx context.Context, campaignRoot string, src *peer.Source, result *Pu
 		defer func() { _ = os.Remove(excludeFile) }()
 	}
 	args = append(args, excludeArgs...)
-	args = append(args, src.RsyncSpec(rootRel), destAbs+string(os.PathSeparator))
+	args = append(args, src.RsyncSpec(rootRel), stagingDir+string(os.PathSeparator))
 
 	cmd := exec.CommandContext(ctx, "rsync", args...)
 	output, runErr := cmd.CombinedOutput()
 
-	after, mErr := BuildManifest(ctx, campaignRoot, rootRel)
-	if mErr != nil {
-		return camperrors.Wrap(mErr, "manifest after pull")
+	staged, countErr := countFiles(stagingDir)
+	if countErr != nil {
+		return camperrors.Wrap(countErr, "scan rsync staging dir")
 	}
-
 	if runErr != nil {
 		// rsync 23 (partial transfer due to error) and 24 (source files
-		// vanished mid-transfer) can be partial successes: the files that DID
-		// arrive are valid, so snapshotting them avoids poisoning them into
-		// never-agreed protection on the next run. But the SAME exit codes
-		// also cover "source root does not exist," where nothing transferred.
-		// Distinguish by whether any complete file actually changed locally
-		// (--partial-dir keeps incomplete files out of the tree, so an
-		// unchanged tree means nothing landed) and treat a no-op as the hard
-		// failure it is.
+		// vanished mid-transfer) are partial successes when files actually
+		// staged; the SAME codes also cover "source root does not exist,"
+		// where nothing staged. An empty staging tree on any error is the
+		// hard failure it is.
 		code := exitCode(runErr)
-		if (code == 23 || code == 24) && !manifestsEqual(local, after) {
+		if (code == 23 || code == 24) && staged > 0 {
 			result.Partial = true
 			result.Warning = fmt.Sprintf("partial transfer (rsync exit %d): %s", code, lastLines(string(output), 3))
 		} else {
 			return camperrors.Wrapf(runErr, "rsync %s from %s: %s", rootRel, src.ID(), lastLines(string(output), 3))
 		}
 	}
+
+	// Atomically merge staged files into the live root, re-validating each
+	// destination against the baseline immediately before the rename. A file
+	// a local writer created or changed during the transfer no longer matches
+	// the baseline and is left untouched (a late conflict), so no local byte
+	// stream is ever silently overwritten.
+	lateConflicts, err := mergeStaged(stagingDir, destAbs, baseline)
+	if err != nil {
+		return err
+	}
+	result.SkippedConflicts = appendUnique(result.SkippedConflicts, lateConflicts)
+	result.Protected += len(lateConflicts)
 	result.Synced = true
 
-	return SaveSnapshot(campaignRoot, src.ID(), rootRel, agreedState(after, baseline, protected))
+	after, err := BuildManifest(ctx, campaignRoot, rootRel)
+	if err != nil {
+		return camperrors.Wrap(err, "manifest after pull")
+	}
+	// Protect both the pre-scan protected set and any late conflicts so their
+	// baseline stays sticky rather than being recorded as agreed.
+	return SaveSnapshot(campaignRoot, src.ID(), rootRel,
+		agreedState(after, baseline, append(append([]string{}, protected...), lateConflicts...)))
 }
 
-// manifestsEqual reports whether two manifests describe the same set of files
-// with the same versions, so a failed rsync that changed nothing can be told
-// apart from a partial transfer that landed at least one complete file.
-func manifestsEqual(a, b *Manifest) bool {
-	if len(a.Files) != len(b.Files) {
-		return false
+// mergeStaged moves each file from the staging tree into the live root, but
+// only after re-checking that the live destination still exactly matches the
+// baseline (or is absent). A destination that changed during the transfer is
+// a late conflict: it is left as-is and reported, never overwritten. Renames
+// are atomic because staging and the live root share the campaign filesystem.
+func mergeStaged(stagingDir, destAbs string, baseline *Manifest) ([]string, error) {
+	var base map[string]FileEntry
+	if baseline != nil {
+		base = baseline.Index()
 	}
-	bi := b.Index()
-	for _, f := range a.Files {
-		g, ok := bi[f.Path]
-		if !ok || !sameEntry(f, g) {
-			return false
+	var lateConflicts []string
+
+	walkErr := filepath.WalkDir(stagingDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(stagingDir, path)
+		if err != nil {
+			return err
+		}
+		relSlash := filepath.ToSlash(rel)
+		if !safeToReplace(destAbs, rel, base) {
+			lateConflicts = append(lateConflicts, relSlash)
+			return nil
+		}
+		destPath := filepath.Join(destAbs, rel)
+		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+			return camperrors.Wrapf(err, "create dir for %s", relSlash)
+		}
+		if err := os.Rename(path, destPath); err != nil {
+			return camperrors.Wrapf(err, "merge %s into artifact root", relSlash)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return lateConflicts, nil
+}
+
+// safeToReplace reports whether the live file at rel may be overwritten: it is
+// safe only when the live destination is absent, or present and identical to
+// the recorded baseline. A file present locally but not in the baseline was
+// created out-of-band (protect it); a file whose current state differs from
+// the baseline was modified since the last transfer (a conflict).
+func safeToReplace(destAbs, rel string, base map[string]FileEntry) bool {
+	info, err := os.Lstat(filepath.Join(destAbs, filepath.FromSlash(rel)))
+	if err != nil {
+		return true // absent locally: nothing to clobber
+	}
+	b, ok := base[filepath.ToSlash(rel)]
+	if !ok {
+		return false // created locally out-of-band since the baseline
+	}
+	cur := FileEntry{
+		Size:    info.Size(),
+		MTime:   info.ModTime().UnixNano(),
+		Symlink: info.Mode()&os.ModeSymlink != 0,
+	}
+	return sameEntry(cur, b)
+}
+
+// countFiles returns the number of regular files under dir, used to tell a
+// partial transfer (some files staged) from a total failure (nothing staged).
+func countFiles(dir string) (int, error) {
+	n := 0
+	err := filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type().IsRegular() {
+			n++
+		}
+		return nil
+	})
+	return n, err
+}
+
+// appendUnique appends items to dst, skipping values already present.
+func appendUnique(dst, items []string) []string {
+	seen := make(map[string]bool, len(dst))
+	for _, s := range dst {
+		seen[s] = true
+	}
+	for _, s := range items {
+		if !seen[s] {
+			dst = append(dst, s)
+			seen[s] = true
 		}
 	}
-	return true
+	return dst
 }
 
 // exitCode extracts a process exit code from an exec error, or -1 if the

--- a/internal/artifacts/pull.go
+++ b/internal/artifacts/pull.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -219,7 +221,7 @@ func mergeStaged(stagingDir, destAbs string, baseline *Manifest) ([]string, erro
 		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 			return camperrors.Wrapf(err, "create dir for %s", relSlash)
 		}
-		if err := os.Rename(path, destPath); err != nil {
+		if err := moveIntoPlace(path, destPath); err != nil {
 			return camperrors.Wrapf(err, "merge %s into artifact root", relSlash)
 		}
 		return nil
@@ -230,11 +232,84 @@ func mergeStaged(stagingDir, destAbs string, baseline *Manifest) ([]string, erro
 	return lateConflicts, nil
 }
 
+// moveIntoPlace atomically replaces dst with the staged file at src. The fast
+// path is a rename, which is atomic on one filesystem. But an artifact root is
+// commonly a mounted volume (large media on a dedicated disk) while staging
+// lives under .campaign, so the rename can fail cross-device (EXDEV); in that
+// case the staged bytes are copied into a temp file on the destination's own
+// filesystem and that temp is atomically renamed into place, so the final swap
+// is still atomic even though the copy is not.
+func moveIntoPlace(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	} else if !isCrossDevice(err) {
+		return err
+	}
+	return copyIntoPlace(src, dst)
+}
+
+// isCrossDevice reports whether err is a cross-filesystem link error (EXDEV).
+func isCrossDevice(err error) bool {
+	var le *os.LinkError
+	if errors.As(err, &le) {
+		return errors.Is(le.Err, syscall.EXDEV)
+	}
+	return errors.Is(err, syscall.EXDEV)
+}
+
+// copyIntoPlace copies src into a temp file beside dst (same filesystem) and
+// atomically renames it over dst. It preserves mode and mtime so the next
+// --compare-dest run does not see the file as changed and re-transfer it.
+func copyIntoPlace(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".camp-artifact-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := io.Copy(tmp, in); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(info.Mode().Perm()); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chtimes(tmpName, info.ModTime(), info.ModTime()); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, dst); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
 // safeToReplace reports whether the live file at rel may be overwritten: it is
 // safe only when the live destination is absent, or present and identical to
 // the recorded baseline. A file present locally but not in the baseline was
 // created out-of-band (protect it); a file whose current state differs from
-// the baseline was modified since the last transfer (a conflict).
+// the baseline was modified since the last transfer (a conflict). Detection
+// uses size and nanosecond mtime, so on a filesystem whose mtime granularity
+// cannot separate two writes, a same-size edit within one tick is the residual
+// limit of the no-clobber guarantee.
 func safeToReplace(destAbs, rel string, base map[string]FileEntry) bool {
 	info, err := os.Lstat(filepath.Join(destAbs, filepath.FromSlash(rel)))
 	if err != nil {

--- a/internal/artifacts/pull.go
+++ b/internal/artifacts/pull.go
@@ -110,11 +110,19 @@ func pull(ctx context.Context, campaignRoot string, src *peer.Source, result *Pu
 	// --no-links: never materialize a peer symlink locally (phantom state no
 	// snapshot could track); local symlinks are recorded in the manifest and
 	// so are protected like any other entry.
+	// --update: the protected set is computed from a walk that finished before
+	// this transfer starts, so a file written locally in the window between
+	// the walk and rsync is not in the exclude list. --update skips any
+	// destination that is newer than the peer's copy, which is exactly the
+	// signature of a file a local writer just touched, so a concurrent edit is
+	// not clobbered. This narrows but does not fully eliminate the race (a
+	// concurrent write landing an older-or-equal mtime is still possible on a
+	// truly live tree); the design's guarantee assumes a quiescent root.
 	partialDir := filepath.Join(campaignRoot, ".campaign", "cache", "rsync-partial")
 	if err := os.MkdirAll(partialDir, 0o755); err != nil {
 		return camperrors.Wrap(err, "create rsync partial dir")
 	}
-	args := []string{"-a", "--no-links", "--partial-dir=" + partialDir}
+	args := []string{"-a", "--no-links", "--update", "--partial-dir=" + partialDir}
 	if sshCmd := src.SSHCommand(); sshCmd != "" {
 		args = append(args, "-e", sshCmd)
 	}

--- a/internal/artifacts/pull.go
+++ b/internal/artifacts/pull.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
 	"github.com/Obedience-Corp/camp/internal/peer"
 )
 
@@ -89,6 +90,22 @@ func pull(ctx context.Context, campaignRoot string, src *peer.Source, result *Pu
 	if err := os.MkdirAll(destAbs, 0o755); err != nil {
 		return camperrors.Wrapf(err, "create artifact root %s", rootRel)
 	}
+
+	// Serialize concurrent pulls of the SAME root: the staging dir, the live
+	// merge, and the snapshot write are all keyed on the root, so two
+	// simultaneous `camp sync --from` for one root would clear each other's
+	// staging tree and interleave into an inconsistent baseline. A per-root
+	// lock (stale-safe, 5s timeout) makes them queue; different roots still
+	// pull concurrently. The lock lives under .campaign/cache (gitignored).
+	cacheDir := filepath.Join(campaignRoot, ".campaign", "cache")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return camperrors.Wrap(err, "create cache dir")
+	}
+	release, err := fsutil.AcquireFileLock(ctx, filepath.Join(cacheDir, "artifact-pull-"+snapshotSlug(rootRel)+".lock"))
+	if err != nil {
+		return camperrors.Wrapf(err, "lock artifact root %s", rootRel)
+	}
+	defer release()
 
 	local, err := BuildManifest(ctx, campaignRoot, rootRel)
 	if err != nil {
@@ -199,6 +216,12 @@ func mergeStaged(stagingDir, destAbs string, baseline *Manifest) ([]string, erro
 	if baseline != nil {
 		base = baseline.Index()
 	}
+	// Resolve the root once so per-file destination checks can tell whether a
+	// path stays inside it after symlink resolution.
+	rootReal, err := filepath.EvalSymlinks(destAbs)
+	if err != nil {
+		rootReal = destAbs
+	}
 	var lateConflicts []string
 
 	walkErr := filepath.WalkDir(stagingDir, func(path string, d fs.DirEntry, err error) error {
@@ -213,11 +236,16 @@ func mergeStaged(stagingDir, destAbs string, baseline *Manifest) ([]string, erro
 			return err
 		}
 		relSlash := filepath.ToSlash(rel)
-		if !safeToReplace(destAbs, rel, base) {
+		destPath := filepath.Join(destAbs, rel)
+		// A local symlinked directory component would let MkdirAll and the
+		// rename follow it and write outside the campaign; safeToReplace also
+		// reads every Lstat error as "absent, safe to write," which through a
+		// symlinked parent means a non-existent escape target. Refuse and
+		// report such a destination instead of following it.
+		if !destWithinRoot(rootReal, destPath) || !safeToReplace(destAbs, rel, base) {
 			lateConflicts = append(lateConflicts, relSlash)
 			return nil
 		}
-		destPath := filepath.Join(destAbs, rel)
 		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 			return camperrors.Wrapf(err, "create dir for %s", relSlash)
 		}
@@ -230,6 +258,22 @@ func mergeStaged(stagingDir, destAbs string, baseline *Manifest) ([]string, erro
 		return nil, walkErr
 	}
 	return lateConflicts, nil
+}
+
+// destWithinRoot reports whether destPath resolves inside rootReal (the
+// symlink-resolved artifact root). It resolves the existing prefix of the
+// destination's parent, so a local symlinked directory component pointing
+// outside the campaign is caught before MkdirAll or the rename can follow it.
+func destWithinRoot(rootReal, destPath string) bool {
+	resolved, err := resolveExistingPrefix(filepath.Dir(destPath))
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(rootReal, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
 }
 
 // moveIntoPlace atomically replaces dst with the staged file at src. The fast

--- a/internal/artifacts/snapshot.go
+++ b/internal/artifacts/snapshot.go
@@ -1,0 +1,72 @@
+package artifacts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// Snapshots are the manifest recorded after the last successful transfer
+// from a given peer, stored under .campaign/cache (gitignored, machine-local
+// derived state). They exist so the next pull can tell "changed locally
+// since we last synced with that peer" from "safe to overwrite": conflict
+// detection needs a baseline, and this is it. Losing a snapshot is safe; the
+// next pull just degrades to first-sync caution (--ignore-existing).
+
+const snapshotDir = ".campaign/cache/peersync"
+
+// snapshotPath returns the snapshot file for one (peer, root) pair.
+func snapshotPath(campaignRoot, peerID, rootRel string) string {
+	slug := strings.ReplaceAll(NormalizeRootPath(rootRel), "/", "__")
+	return filepath.Join(campaignRoot, filepath.FromSlash(snapshotDir), peerID, slug+".json")
+}
+
+// LoadSnapshot reads the last-transfer manifest for (peer, root). A missing
+// snapshot returns (nil, nil): first sync with that peer.
+func LoadSnapshot(campaignRoot, peerID, rootRel string) (*Manifest, error) {
+	data, err := os.ReadFile(snapshotPath(campaignRoot, peerID, rootRel))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, camperrors.Wrap(err, "read peer snapshot")
+	}
+	return DecodeManifest(data)
+}
+
+// ListSnapshotPeers returns the peer ids that have recorded snapshots in
+// this campaign (the directories under .campaign/cache/peersync).
+func ListSnapshotPeers(campaignRoot string) ([]string, error) {
+	entries, err := os.ReadDir(filepath.Join(campaignRoot, filepath.FromSlash(snapshotDir)))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, camperrors.Wrap(err, "list snapshot peers")
+	}
+	var peers []string
+	for _, e := range entries {
+		if e.IsDir() {
+			peers = append(peers, e.Name())
+		}
+	}
+	return peers, nil
+}
+
+// SaveSnapshot records the manifest as the last-transfer state for (peer, root).
+func SaveSnapshot(campaignRoot, peerID, rootRel string, m *Manifest) error {
+	path := snapshotPath(campaignRoot, peerID, rootRel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return camperrors.Wrap(err, "create snapshot directory")
+	}
+	data, err := m.EncodeJSON()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return camperrors.Wrap(err, "write peer snapshot")
+	}
+	return nil
+}

--- a/internal/artifacts/snapshot.go
+++ b/internal/artifacts/snapshot.go
@@ -19,8 +19,35 @@ const snapshotDir = ".campaign/cache/peersync"
 
 // snapshotPath returns the snapshot file for one (peer, root) pair.
 func snapshotPath(campaignRoot, peerID, rootRel string) string {
-	slug := strings.ReplaceAll(NormalizeRootPath(rootRel), "/", "__")
-	return filepath.Join(campaignRoot, filepath.FromSlash(snapshotDir), peerID, slug+".json")
+	return filepath.Join(campaignRoot, filepath.FromSlash(snapshotDir), peerID, snapshotSlug(rootRel)+".json")
+}
+
+// snapshotSlug encodes a root path into a single, injective, filesystem-safe
+// filename component. A raw "/"->"__" replace is not injective (the roots
+// "a/b" and "a__b" collapse onto one baseline file, so syncing one poisons
+// the other's baseline). Percent-escaping the escape byte first and then the
+// separator keeps distinct roots distinct while staying human-readable.
+func snapshotSlug(rootRel string) string {
+	norm := NormalizeRootPath(rootRel)
+	norm = strings.ReplaceAll(norm, "%", "%25")
+	norm = strings.ReplaceAll(norm, "/", "%2F")
+	return norm
+}
+
+// ValidatePeerID rejects peer identifiers that could escape the snapshot tree
+// (peer ids are joined into .campaign/cache/peersync/<peer>/...). Ids resolved
+// from the machines file are already constrained, but `--from` in verify mode
+// is raw user input read straight into a filesystem path.
+func ValidatePeerID(id string) error {
+	if id == "" {
+		return camperrors.New("peer id must not be empty")
+	}
+	if strings.HasPrefix(id, ".") ||
+		strings.ContainsAny(id, "/\\\x00") ||
+		strings.Contains(id, "..") {
+		return camperrors.Newf("invalid peer id %q", id)
+	}
+	return nil
 }
 
 // LoadSnapshot reads the last-transfer manifest for (peer, root). A missing

--- a/internal/clone/clone.go
+++ b/internal/clone/clone.go
@@ -37,7 +37,19 @@ func (c *Cloner) Clone(ctx context.Context) (*CloneResult, error) {
 
 	// Phase 1: Clone repository (without --recurse-submodules to avoid all-or-nothing failure)
 	c.progress.StartPhase("Cloning campaign repository")
-	targetDir, err := c.gitClone(ctx)
+	var targetDir string
+	var err error
+	if c.peer != nil {
+		targetDir, err = c.gitCloneFromPeer(ctx)
+		if err != nil {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("peer clone from %s failed, falling back to origin: %v", c.peer.ID(), err))
+			c.progress.Message(fmt.Sprintf("Peer clone from %s failed; cloning from origin", c.peer.ID()))
+			targetDir, err = c.gitClone(ctx)
+		}
+	} else {
+		targetDir, err = c.gitClone(ctx)
+	}
 	if err != nil {
 		c.progress.EndPhase("Clone", false)
 		result.Success = false
@@ -153,14 +165,27 @@ func (c *Cloner) Clone(ctx context.Context) (*CloneResult, error) {
 				r := subInitResult{index: idx}
 				c.progress.Verbose(fmt.Sprintf("Initializing submodule: %s", sub.Path))
 
+				// Step 0: Seed objects from the peer when one is configured;
+				// failure degrades to the normal origin path below.
+				peerSeeded := false
+				if c.peer != nil {
+					if seedErr := c.seedSubmoduleFromPeer(ctx, targetDir, sub); seedErr != nil {
+						r.warnings = append(r.warnings,
+							fmt.Sprintf("peer seed %s: %v (initializing from origin)", sub.Path, seedErr))
+					} else {
+						peerSeeded = true
+					}
+				}
+
 				// Step 1: Initialize submodule gracefully (handles stale refs)
 				subErr := c.initSubmoduleGraceful(ctx, targetDir, sub.Path)
 				r.result = SubmoduleResult{
-					Name:    sub.Name,
-					Path:    sub.Path,
-					URL:     sub.URL,
-					Success: subErr == nil,
-					Error:   subErr,
+					Name:       sub.Name,
+					Path:       sub.Path,
+					URL:        sub.URL,
+					Success:    subErr == nil,
+					Error:      subErr,
+					PeerSeeded: peerSeeded,
 				}
 
 				if subErr != nil {
@@ -219,6 +244,7 @@ func (c *Cloner) Clone(ctx context.Context) (*CloneResult, error) {
 		nestedCount := 0
 		branchCount := 0
 		staleRefCount := 0
+		peerSeededCount := 0
 
 		for _, r := range results {
 			result.Submodules = append(result.Submodules, r.result)
@@ -235,10 +261,16 @@ func (c *Cloner) Clone(ctx context.Context) (*CloneResult, error) {
 			if r.branchOK {
 				branchCount++
 			}
+			if r.result.PeerSeeded {
+				peerSeededCount++
+			}
 		}
 
 		c.progress.EndSubmodules(succeeded, failed)
 
+		if peerSeededCount > 0 && c.peer != nil {
+			c.progress.Message(fmt.Sprintf("Seeded %d submodules from peer %s", peerSeededCount, c.peer.ID()))
+		}
 		if staleRefCount > 0 {
 			c.progress.Message(fmt.Sprintf("Recovered %d submodules with stale commit references", staleRefCount))
 		}

--- a/internal/clone/git.go
+++ b/internal/clone/git.go
@@ -228,6 +228,141 @@ func (c *Cloner) cleanOrphanedGitlinks(ctx context.Context, dir string) ([]strin
 	return removed, nil
 }
 
+// gitCloneFromPeer clones the root repository from the peer copy, then
+// re-points origin at the real URL and fetches the delta, so the resulting
+// checkout is an origin replica that merely arrived over the fast path. Any
+// failure removes the partial clone and returns an error for the caller to
+// fall back to the plain origin clone.
+func (c *Cloner) gitCloneFromPeer(ctx context.Context) (string, error) {
+	if ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+
+	targetDir := c.options.Directory
+	if targetDir == "" {
+		targetDir = extractRepoName(c.options.URL)
+	}
+	if _, err := os.Stat(targetDir); err == nil {
+		return "", camperrors.Newf("target directory %s already exists", targetDir)
+	}
+
+	args := []string{"clone"}
+	if c.options.Branch != "" {
+		args = append(args, "--branch", c.options.Branch)
+	}
+	if c.options.Depth > 0 {
+		args = append(args, "--depth", fmt.Sprintf("%d", c.options.Depth))
+	}
+	args = append(args, c.peer.URL(""), targetDir)
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = c.peer.GitEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return "", camperrors.Wrapf(err, "clone from peer %s: %s", c.peer.ID(), strings.TrimSpace(string(output)))
+	}
+
+	if err := c.repointOrigin(ctx, targetDir); err != nil {
+		_ = os.RemoveAll(targetDir)
+		return "", err
+	}
+
+	absDir, err := filepath.Abs(targetDir)
+	if err != nil {
+		return targetDir, nil
+	}
+	return absDir, nil
+}
+
+// repointOrigin moves a peer-cloned repository onto its real origin: set-url,
+// fetch the delta the peer did not have, and align the checkout with origin's
+// tip of the requested (or default) branch. The reset is safe because the
+// clone is fresh: there is no local work to lose, and clone semantics promise
+// an origin replica.
+func (c *Cloner) repointOrigin(ctx context.Context, dir string) error {
+	steps := [][]string{
+		{"remote", "set-url", "origin", c.options.URL},
+		{"fetch", "--tags", "origin"},
+		{"remote", "set-head", "origin", "--auto"},
+	}
+	for _, step := range steps {
+		cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, step...)...)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return camperrors.Wrapf(err, "re-point origin (git %s): %s",
+				strings.Join(step, " "), strings.TrimSpace(string(output)))
+		}
+	}
+
+	branch := c.options.Branch
+	if branch == "" {
+		cmd := exec.CommandContext(ctx, "git", "-C", dir, "symbolic-ref", "refs/remotes/origin/HEAD")
+		output, err := cmd.Output()
+		if err != nil {
+			return camperrors.Wrap(err, "determine origin default branch")
+		}
+		branch = strings.TrimPrefix(strings.TrimSpace(string(output)), "refs/remotes/origin/")
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "checkout", "-B", branch, "--track", "origin/"+branch)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return camperrors.Wrapf(err, "checkout origin/%s: %s", branch, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// seedSubmoduleFromPeer clones one submodule's objects from the peer copy
+// instead of origin. The peer URL is supplied for that single `git submodule
+// update` invocation via -c, so the parent's persisted config keeps the
+// declared origin URL; afterwards the freshly created module's origin remote
+// (which git set from the -c value) is re-pointed at the declared URL. No
+// origin fetch runs here: the recorded gitlink SHA is either present from the
+// peer (checkout proceeds with zero origin traffic) or the caller's graceful
+// init fetches the delta from origin.
+func (c *Cloner) seedSubmoduleFromPeer(ctx context.Context, repoDir string, sub SubmoduleInfo) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if strings.HasPrefix(sub.URL, "./") || strings.HasPrefix(sub.URL, "../") {
+		return camperrors.New("relative submodule URL; origin init handles it")
+	}
+
+	initCmd := exec.CommandContext(ctx, "git", "-C", repoDir, "submodule", "init", sub.Path)
+	_ = initCmd.Run() // may already be initialized, matching InitSubmoduleGraceful
+
+	updateArgs := []string{"-C", repoDir,
+		"-c", "submodule." + sub.Name + ".url=" + c.peer.URL(sub.Path)}
+	if c.peer.IsFilesystem() {
+		updateArgs = append(updateArgs, "-c", "protocol.file.allow=always")
+	}
+	updateArgs = append(updateArgs, "submodule", "update", sub.Path)
+	updateCmd := exec.CommandContext(ctx, "git", updateArgs...)
+	updateCmd.Env = c.peer.GitEnv()
+	output, updateErr := updateCmd.CombinedOutput()
+
+	// Best-effort re-point even when update failed partway (e.g. peer lacked
+	// the recorded SHA after a successful module clone), so the fallback path
+	// and all future fetches talk to the declared origin.
+	subDir := filepath.Join(repoDir, sub.Path)
+	if _, statErr := os.Stat(filepath.Join(subDir, ".git")); statErr == nil {
+		setURLCmd := exec.CommandContext(ctx, "git", "-C", subDir, "remote", "set-url", "origin", sub.URL)
+		if setOut, setErr := setURLCmd.CombinedOutput(); setErr != nil && updateErr == nil {
+			return camperrors.Wrapf(setErr, "re-point %s origin: %s", sub.Path, strings.TrimSpace(string(setOut)))
+		}
+	}
+
+	if updateErr != nil {
+		return camperrors.Wrapf(updateErr, "seed %s from peer %s: %s",
+			sub.Path, c.peer.ID(), strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// RepoNameFromURL returns the repository name a clone of url would produce,
+// exposed for callers that need the default directory/campaign name (e.g.
+// resolving the same campaign on a peer machine).
+func RepoNameFromURL(url string) string {
+	return extractRepoName(url)
+}
+
 // extractRepoName extracts repository name from a git URL.
 func extractRepoName(url string) string {
 	// Handle various URL formats:

--- a/internal/clone/git.go
+++ b/internal/clone/git.go
@@ -289,9 +289,12 @@ func (c *Cloner) gitCloneFromPeer(ctx context.Context) (string, error) {
 // clone is fresh: there is no local work to lose, and clone semantics promise
 // an origin replica.
 func (c *Cloner) repointOrigin(ctx context.Context, dir string) error {
+	// --prune/--prune-tags drop the peer's branches (as origin/*) and tags that
+	// the real origin does not have, so a peer-seeded clone is a true origin
+	// replica rather than carrying the peer's private refs.
 	steps := [][]string{
 		{"remote", "set-url", "origin", c.options.URL},
-		{"fetch", "--tags", "origin"},
+		{"fetch", "--prune", "--prune-tags", "--tags", "origin"},
 		{"remote", "set-head", "origin", "--auto"},
 	}
 	for _, step := range steps {

--- a/internal/clone/git.go
+++ b/internal/clone/git.go
@@ -375,6 +375,21 @@ func (c *Cloner) seedSubmoduleFromPeer(ctx context.Context, repoDir string, sub 
 	if repointErr != nil {
 		return repointErr
 	}
+
+	// The submodule's origin/* still reflect the PEER (the seed fetched from
+	// the peer URL). Left alone, checkoutSubmoduleBranch would DWIM a local
+	// branch off the peer's stale origin/<branch> and land on the peer's tip,
+	// silently importing un-pushed peer commits instead of origin's state.
+	// Refresh from the now-real origin: a cheap delta (the peer already
+	// supplied the objects) that makes a peer-seeded submodule identical to a
+	// normally-cloned one. A failure here means origin is unusable, so report
+	// it as a seed failure and let graceful init fall back through origin.
+	fetchCmd := exec.CommandContext(ctx, "git", "-C", subDir,
+		"fetch", "--prune", "--prune-tags", "--tags", "origin")
+	if out, err := fetchCmd.CombinedOutput(); err != nil {
+		return camperrors.Wrapf(err, "refresh %s from origin after peer seed: %s",
+			sub.Path, strings.TrimSpace(string(out)))
+	}
 	return nil
 }
 

--- a/internal/clone/git.go
+++ b/internal/clone/git.go
@@ -231,8 +231,8 @@ func (c *Cloner) cleanOrphanedGitlinks(ctx context.Context, dir string) ([]strin
 // gitCloneFromPeer clones the root repository from the peer copy, then
 // re-points origin at the real URL and fetches the delta, so the resulting
 // checkout is an origin replica that merely arrived over the fast path. Any
-// failure removes the partial clone and returns an error for the caller to
-// fall back to the plain origin clone.
+// failure after clone starts removes the partial clone and returns an error
+// for the caller to fall back to the plain origin clone.
 func (c *Cloner) gitCloneFromPeer(ctx context.Context) (string, error) {
 	if ctx.Err() != nil {
 		return "", ctx.Err()
@@ -245,6 +245,16 @@ func (c *Cloner) gitCloneFromPeer(ctx context.Context) (string, error) {
 	if _, err := os.Stat(targetDir); err == nil {
 		return "", camperrors.Newf("target directory %s already exists", targetDir)
 	}
+
+	// Clean up a partial destination on any error after we attempt the clone
+	// (including cancel mid-clone). Without this the origin fallback fails
+	// with "destination already exists".
+	success := false
+	defer func() {
+		if !success {
+			_ = os.RemoveAll(targetDir)
+		}
+	}()
 
 	args := []string{"clone"}
 	if c.options.Branch != "" {
@@ -262,10 +272,10 @@ func (c *Cloner) gitCloneFromPeer(ctx context.Context) (string, error) {
 	}
 
 	if err := c.repointOrigin(ctx, targetDir); err != nil {
-		_ = os.RemoveAll(targetDir)
 		return "", err
 	}
 
+	success = true
 	absDir, err := filepath.Abs(targetDir)
 	if err != nil {
 		return targetDir, nil
@@ -338,20 +348,29 @@ func (c *Cloner) seedSubmoduleFromPeer(ctx context.Context, repoDir string, sub 
 	updateCmd.Env = c.peer.GitEnv()
 	output, updateErr := updateCmd.CombinedOutput()
 
-	// Best-effort re-point even when update failed partway (e.g. peer lacked
-	// the recorded SHA after a successful module clone), so the fallback path
-	// and all future fetches talk to the declared origin.
+	// Always re-point when a module repo exists, even if update failed
+	// partway (e.g. peer lacked the recorded SHA after a successful module
+	// clone). Prefer a loud seed failure over leaving peer as origin.
 	subDir := filepath.Join(repoDir, sub.Path)
+	var repointErr error
 	if _, statErr := os.Stat(filepath.Join(subDir, ".git")); statErr == nil {
 		setURLCmd := exec.CommandContext(ctx, "git", "-C", subDir, "remote", "set-url", "origin", sub.URL)
-		if setOut, setErr := setURLCmd.CombinedOutput(); setErr != nil && updateErr == nil {
-			return camperrors.Wrapf(setErr, "re-point %s origin: %s", sub.Path, strings.TrimSpace(string(setOut)))
+		if setOut, setErr := setURLCmd.CombinedOutput(); setErr != nil {
+			repointErr = camperrors.Wrapf(setErr, "re-point %s origin: %s",
+				sub.Path, strings.TrimSpace(string(setOut)))
 		}
 	}
 
 	if updateErr != nil {
-		return camperrors.Wrapf(updateErr, "seed %s from peer %s: %s",
+		msg := fmt.Sprintf("seed %s from peer %s: %s",
 			sub.Path, c.peer.ID(), strings.TrimSpace(string(output)))
+		if repointErr != nil {
+			return camperrors.Wrapf(updateErr, "%s (also re-point failed: %v)", msg, repointErr)
+		}
+		return camperrors.Wrapf(updateErr, "%s", msg)
+	}
+	if repointErr != nil {
+		return repointErr
 	}
 	return nil
 }

--- a/internal/clone/git_test.go
+++ b/internal/clone/git_test.go
@@ -121,6 +121,29 @@ func TestGitCloneFromPeer_FallsBackToOrigin(t *testing.T) {
 	}
 }
 
+// Peer clone succeeds but re-point to origin fails: the partial destination
+// must be removed so a subsequent origin clone is not blocked by "already exists".
+func TestGitCloneFromPeer_CleansPartialOnRepointFailure(t *testing.T) {
+	ctx := context.Background()
+	peerRoot := setupTestRepo(t)
+
+	target := filepath.Join(t.TempDir(), "cloned")
+	cloner := NewCloner(
+		WithURL("file:///nonexistent/origin-does-not-exist.git"),
+		WithDirectory(target),
+		WithNoRegister(true),
+		WithNoSubmodules(true),
+		WithPeer(peer.FromPath("peerbox", peerRoot)),
+	)
+	_, err := cloner.gitCloneFromPeer(ctx)
+	if err == nil {
+		t.Fatal("gitCloneFromPeer() error = nil, want re-point failure")
+	}
+	if _, statErr := os.Stat(target); !os.IsNotExist(statErr) {
+		t.Errorf("partial peer clone left at %s after failure; want removed for origin fallback", target)
+	}
+}
+
 func TestParseSubmoduleStatus(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/clone/git_test.go
+++ b/internal/clone/git_test.go
@@ -5,8 +5,121 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/peer"
 )
+
+func TestGitCloneFromPeer_SeedsAndRepointsOrigin(t *testing.T) {
+	ctx := context.Background()
+	origin := setupTestRepo(t)
+	setupSubmodule(t, origin, "projects/sub")
+
+	// Peer copy of the campaign: a clone of origin with the submodule
+	// initialized, standing in for the same campaign on another machine.
+	peerRoot := filepath.Join(t.TempDir(), "peer-campaign")
+	runGit(t, t.TempDir(), "clone", origin, peerRoot)
+	runGit(t, peerRoot, "-c", "protocol.file.allow=always", "submodule", "update", "--init")
+
+	target := filepath.Join(t.TempDir(), "cloned")
+	cloner := NewCloner(
+		WithURL(origin),
+		WithDirectory(target),
+		WithNoRegister(true),
+		WithPeer(peer.FromPath("peerbox", peerRoot)),
+	)
+	result, err := cloner.Clone(ctx)
+	if err != nil {
+		t.Fatalf("Clone() error = %v (warnings: %v)", err, result.Warnings)
+	}
+	if !result.Success {
+		t.Fatalf("Clone().Success = false: errors=%v warnings=%v", result.Errors, result.Warnings)
+	}
+
+	// The root repo's origin must be the real origin URL, not the peer.
+	out, err := exec.Command("git", "-C", target, "remote", "get-url", "origin").Output()
+	if err != nil {
+		t.Fatalf("reading root origin url: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != origin {
+		t.Errorf("root origin url = %q, want %q", got, origin)
+	}
+
+	// The submodule must be seeded from the peer and re-pointed at its
+	// declared URL.
+	declaredOut, err := exec.Command("git", "-C", origin,
+		"config", "-f", ".gitmodules", "submodule.projects/sub.url").Output()
+	if err != nil {
+		t.Fatalf("reading declared submodule url: %v", err)
+	}
+	declared := strings.TrimSpace(string(declaredOut))
+
+	subOut, err := exec.Command("git", "-C", filepath.Join(target, "projects/sub"),
+		"remote", "get-url", "origin").Output()
+	if err != nil {
+		t.Fatalf("reading submodule origin url: %v", err)
+	}
+	if got := strings.TrimSpace(string(subOut)); got != declared {
+		t.Errorf("submodule origin url = %q, want declared %q", got, declared)
+	}
+
+	foundSub := false
+	for _, s := range result.Submodules {
+		if s.Path != "projects/sub" {
+			continue
+		}
+		foundSub = true
+		if !s.Success {
+			t.Errorf("submodule Success = false: %v", s.Error)
+		}
+		if !s.PeerSeeded {
+			t.Errorf("submodule PeerSeeded = false, want true (warnings: %v)", result.Warnings)
+		}
+	}
+	if !foundSub {
+		t.Errorf("projects/sub missing from results: %+v", result.Submodules)
+	}
+}
+
+func TestGitCloneFromPeer_FallsBackToOrigin(t *testing.T) {
+	ctx := context.Background()
+	origin := setupTestRepo(t)
+
+	target := filepath.Join(t.TempDir(), "cloned")
+	cloner := NewCloner(
+		WithURL(origin),
+		WithDirectory(target),
+		WithNoRegister(true),
+		WithNoSubmodules(true),
+		WithPeer(peer.FromPath("ghost", filepath.Join(t.TempDir(), "missing"))),
+	)
+	result, err := cloner.Clone(ctx)
+	if err != nil {
+		t.Fatalf("Clone() error = %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Clone().Success = false: errors=%v", result.Errors)
+	}
+
+	hasFallbackWarning := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "peer clone") {
+			hasFallbackWarning = true
+		}
+	}
+	if !hasFallbackWarning {
+		t.Errorf("expected peer fallback warning, got %v", result.Warnings)
+	}
+
+	out, err := exec.Command("git", "-C", target, "remote", "get-url", "origin").Output()
+	if err != nil {
+		t.Fatalf("reading root origin url: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != origin {
+		t.Errorf("root origin url = %q, want %q", got, origin)
+	}
+}
 
 func TestParseSubmoduleStatus(t *testing.T) {
 	tests := []struct {

--- a/internal/clone/git_test.go
+++ b/internal/clone/git_test.go
@@ -144,6 +144,99 @@ func TestGitCloneFromPeer_CleansPartialOnRepointFailure(t *testing.T) {
 	}
 }
 
+// A peer-seeded clone must be a true origin replica: the peer's private
+// branches (as origin/*) and tags that the real origin lacks are pruned by
+// repointOrigin, not carried into the clone.
+func TestGitCloneFromPeer_PrunesPeerOnlyRefs(t *testing.T) {
+	ctx := context.Background()
+	origin := setupTestRepo(t)
+
+	peerRoot := filepath.Join(t.TempDir(), "peer-campaign")
+	runGit(t, t.TempDir(), "clone", origin, peerRoot)
+	// Private refs that exist only on the peer, not on origin.
+	runGit(t, peerRoot, "branch", "peer-wip")
+	runGit(t, peerRoot, "tag", "peer-only-tag")
+
+	target := filepath.Join(t.TempDir(), "cloned")
+	cloner := NewCloner(
+		WithURL(origin),
+		WithDirectory(target),
+		WithNoRegister(true),
+		WithNoSubmodules(true),
+		WithPeer(peer.FromPath("peerbox", peerRoot)),
+	)
+	result, err := cloner.Clone(ctx)
+	if err != nil || !result.Success {
+		t.Fatalf("Clone() err=%v success=%v warnings=%v", err, result.Success, result.Warnings)
+	}
+
+	remotes, err := exec.Command("git", "-C", target, "branch", "-r").Output()
+	if err != nil {
+		t.Fatalf("listing remote branches: %v", err)
+	}
+	if strings.Contains(string(remotes), "peer-wip") {
+		t.Errorf("origin/peer-wip survived; peer-only branch not pruned:\n%s", remotes)
+	}
+
+	tags, err := exec.Command("git", "-C", target, "tag").Output()
+	if err != nil {
+		t.Fatalf("listing tags: %v", err)
+	}
+	if strings.Contains(string(tags), "peer-only-tag") {
+		t.Errorf("peer-only-tag survived; peer-only tag not pruned:\n%s", tags)
+	}
+}
+
+// --branch must be forwarded into the peer clone and honored by the final
+// checkout, so camp clone --from <peer> --branch X lands on X.
+func TestGitCloneFromPeer_ForwardsBranch(t *testing.T) {
+	ctx := context.Background()
+	origin := setupTestRepo(t)
+
+	defOut, err := exec.Command("git", "-C", origin, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("reading default branch: %v", err)
+	}
+	def := strings.TrimSpace(string(defOut))
+
+	// A non-default branch with distinct content on origin.
+	runGit(t, origin, "checkout", "-b", "release")
+	createFile(t, filepath.Join(origin, "release.txt"), "release content")
+	runGit(t, origin, "add", ".")
+	runGit(t, origin, "commit", "-m", "release work")
+	runGit(t, origin, "checkout", def)
+
+	// Peer needs release as a LOCAL branch for --branch to seed from it.
+	peerRoot := filepath.Join(t.TempDir(), "peer-campaign")
+	runGit(t, t.TempDir(), "clone", origin, peerRoot)
+	runGit(t, peerRoot, "branch", "release", "origin/release")
+
+	target := filepath.Join(t.TempDir(), "cloned")
+	cloner := NewCloner(
+		WithURL(origin),
+		WithDirectory(target),
+		WithBranch("release"),
+		WithNoRegister(true),
+		WithNoSubmodules(true),
+		WithPeer(peer.FromPath("peerbox", peerRoot)),
+	)
+	result, err := cloner.Clone(ctx)
+	if err != nil || !result.Success {
+		t.Fatalf("Clone() err=%v success=%v warnings=%v", err, result.Success, result.Warnings)
+	}
+
+	headOut, err := exec.Command("git", "-C", target, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("reading cloned HEAD: %v", err)
+	}
+	if got := strings.TrimSpace(string(headOut)); got != "release" {
+		t.Errorf("cloned checkout on %q, want release", got)
+	}
+	if _, statErr := os.Stat(filepath.Join(target, "release.txt")); statErr != nil {
+		t.Errorf("release.txt missing; clone did not land on the release branch content")
+	}
+}
+
 func TestParseSubmoduleStatus(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/clone/git_test.go
+++ b/internal/clone/git_test.go
@@ -237,6 +237,63 @@ func TestGitCloneFromPeer_ForwardsBranch(t *testing.T) {
 	}
 }
 
+// A peer-seeded submodule must land on ORIGIN's branch tip, not the peer's.
+// If the peer's submodule has commits ahead of origin, re-pointing origin
+// without refreshing refs would make the branch checkout DWIM off the peer's
+// stale origin/<branch> and silently import the peer's un-pushed commits.
+func TestGitCloneFromPeer_SubmoduleLandsOnOriginNotPeerTip(t *testing.T) {
+	ctx := context.Background()
+	origin := setupTestRepo(t)
+	subWork := setupSubmodule(t, origin, "projects/sub") // origin records this submodule commit
+
+	// Peer copy: clone the campaign and advance ITS submodule ahead of origin
+	// with a commit origin does not have.
+	peerRoot := filepath.Join(t.TempDir(), "peer-campaign")
+	runGit(t, t.TempDir(), "clone", origin, peerRoot)
+	runGit(t, peerRoot, "-c", "protocol.file.allow=always", "submodule", "update", "--init")
+	peerSub := filepath.Join(peerRoot, "projects/sub")
+	createFile(t, filepath.Join(peerSub, "peer-only.txt"), "un-pushed peer work")
+	runGit(t, peerSub, "add", ".")
+	runGit(t, peerSub, "commit", "-m", "peer-only commit ahead of origin")
+
+	// Sanity: the peer-only file must not exist in origin's submodule.
+	if _, err := os.Stat(filepath.Join(subWork, "peer-only.txt")); !os.IsNotExist(err) {
+		t.Fatalf("test setup: peer-only.txt leaked into origin submodule")
+	}
+
+	target := filepath.Join(t.TempDir(), "cloned")
+	cloner := NewCloner(
+		WithURL(origin),
+		WithDirectory(target),
+		WithNoRegister(true),
+		WithPeer(peer.FromPath("peerbox", peerRoot)),
+	)
+	result, err := cloner.Clone(ctx)
+	if err != nil || !result.Success {
+		t.Fatalf("Clone() err=%v success=%v warnings=%v", err, result.Success, result.Warnings)
+	}
+
+	// The cloned submodule must be at origin's state: the peer's un-pushed
+	// commit must NOT have been imported.
+	targetSub := filepath.Join(target, "projects/sub")
+	if _, err := os.Stat(filepath.Join(targetSub, "peer-only.txt")); !os.IsNotExist(err) {
+		t.Error("cloned submodule imported the peer's un-pushed commit (peer-only.txt present); want origin's state")
+	}
+
+	// And origin/<branch> in the submodule must reflect the real origin, not
+	// the peer (the peer-only commit must be unreachable from any origin ref).
+	remotes, err := exec.Command("git", "-C", targetSub, "for-each-ref", "--format=%(refname)", "refs/remotes/origin").Output()
+	if err != nil {
+		t.Fatalf("listing submodule origin refs: %v", err)
+	}
+	for _, ref := range strings.Fields(string(remotes)) {
+		logOut, _ := exec.Command("git", "-C", targetSub, "log", "--oneline", ref).Output()
+		if strings.Contains(string(logOut), "peer-only commit") {
+			t.Errorf("submodule %s still reachable to peer-only commit; origin refs not refreshed", ref)
+		}
+	}
+}
+
 func TestParseSubmoduleStatus(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/clone/options.go
+++ b/internal/clone/options.go
@@ -9,7 +9,10 @@
 // This provides a reliable single-command bootstrap experience for new devices.
 package clone
 
-import "github.com/Obedience-Corp/camp/internal/sync"
+import (
+	"github.com/Obedience-Corp/camp/internal/peer"
+	"github.com/Obedience-Corp/camp/internal/sync"
+)
 
 // CloneOptions configures clone behavior.
 type CloneOptions struct {
@@ -93,6 +96,9 @@ type SubmoduleResult struct {
 	Commit string
 	// Error contains any error that occurred during initialization.
 	Error error
+	// PeerSeeded indicates the submodule's objects were cloned from the
+	// configured peer instead of origin.
+	PeerSeeded bool
 }
 
 // ValidationResult tracks post-clone validation checks.
@@ -135,6 +141,7 @@ type Cloner struct {
 	options  CloneOptions
 	syncer   *sync.Syncer     // Optional syncer for post-clone URL synchronization
 	progress ProgressReporter // Progress reporter for output
+	peer     *peer.Source     // Optional peer to seed git objects from
 }
 
 // NewCloner creates a new Cloner with the given options.
@@ -230,6 +237,17 @@ func WithSyncer(s *sync.Syncer) ClonerOption {
 func WithNoRegister(noRegister bool) ClonerOption {
 	return func(c *Cloner) {
 		c.options.NoRegister = noRegister
+	}
+}
+
+// WithPeer configures a peer source to seed git objects from. The root repo
+// and each submodule clone from the peer copy first, then origin is
+// re-pointed to the real URL and the delta fetched, so the final state is an
+// origin replica regardless of how the bytes arrived. Any peer failure falls
+// back to the normal origin path with a warning.
+func WithPeer(p *peer.Source) ClonerOption {
+	return func(c *Cloner) {
+		c.peer = p
 	}
 }
 

--- a/internal/peer/peer.go
+++ b/internal/peer/peer.go
@@ -1,0 +1,125 @@
+// Package peer resolves a transfer source for campaign git repositories: a
+// campaign root on another machine (from ~/.obey/machines.yaml, reached over
+// ssh) or on the local filesystem (a mounted volume or second checkout). It
+// builds the git-facing plumbing for fetching from that source: repository
+// URLs, a namespaced refspec, and a GIT_SSH_COMMAND that rides the same ssh
+// identity and ControlMaster multiplexing as the rest of camp's multi-machine
+// stack. The peer is a transfer optimization only: content fetched from a
+// peer is verified by git on arrival exactly like content fetched from
+// origin, and origin remains the configured origin.
+package peer
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/machines"
+	"github.com/Obedience-Corp/camp/internal/remote"
+)
+
+// Source is a resolved peer campaign root to fetch git objects from.
+type Source struct {
+	id      string
+	root    string
+	target  string // ssh target (user@host); empty for filesystem sources
+	sshOpts []string
+}
+
+// FromMachine resolves machineID in ~/.obey/machines.yaml and asks the far
+// machine's own camp where campaign `remainder` lives (remote registry
+// resolution via `camp switch --print`, never the local filesystem).
+func FromMachine(ctx context.Context, machineID, remainder string) (*Source, error) {
+	file, err := machines.Load()
+	if err != nil {
+		return nil, camperrors.Wrap(err, "load machines file")
+	}
+	m, isLocal, found := file.Lookup(machineID)
+	if !found {
+		return nil, camperrors.Newf("machine %q not found in %s (see 'camp machine list')",
+			machineID, machines.MachinesPath())
+	}
+	if isLocal {
+		return nil, camperrors.Newf("machine %q is this machine; --from needs a different machine", machineID)
+	}
+	if err := remote.EnsureKeyAuth(m); err != nil {
+		return nil, err
+	}
+	root, err := remote.ResolveRoot(ctx, m, remainder)
+	if err != nil {
+		return nil, err
+	}
+	return &Source{id: m.ID, root: root, target: remote.Target(m), sshOpts: remote.Opts(m)}, nil
+}
+
+// FromPath builds a filesystem source rooted at an absolute campaign root on
+// this machine (a mounted volume or a second checkout).
+func FromPath(id, root string) *Source {
+	return &Source{id: id, root: root}
+}
+
+// ID returns the source's machine id, used in refspecs and messages.
+func (s *Source) ID() string { return s.id }
+
+// IsFilesystem reports whether the source is a local filesystem path rather
+// than an ssh machine. Callers cloning submodules from a filesystem source
+// need `-c protocol.file.allow=always` (CVE-2022-39253 restricts file
+// transport in submodule contexts; the URL here is camp-constructed from the
+// user's own peer selection, not attacker-controlled .gitmodules content,
+// matching the precedent in internal/project/add.go).
+func (s *Source) IsFilesystem() bool { return s.target == "" }
+
+// Root returns the campaign root path on the peer.
+func (s *Source) Root() string { return s.root }
+
+// URL returns the git URL for the repository at relPath under the peer's
+// campaign root; "" addresses the campaign root repository itself.
+func (s *Source) URL(relPath string) string {
+	p := path.Join(s.root, relPath)
+	if s.target == "" {
+		return p
+	}
+	return "ssh://" + s.target + p
+}
+
+// Refspec returns the refspec peer fetches use. Fetched heads land under
+// refs/peer/<id>/* so transferred objects stay reachable (no GC exposure)
+// without touching origin's remote-tracking refs.
+func (s *Source) Refspec() string {
+	return "+refs/heads/*:refs/peer/" + s.id + "/*"
+}
+
+// GitEnv returns the environment for git commands that dial this source:
+// os.Environ plus a GIT_SSH_COMMAND carrying the machine's ssh options
+// (BatchMode, ConnectTimeout, ControlMaster multiplexing, identity file).
+// Filesystem sources need no override and return nil, which keeps the
+// calling process environment for exec.Cmd.
+func (s *Source) GitEnv() []string {
+	if s.target == "" {
+		return nil
+	}
+	parts := make([]string, 0, len(s.sshOpts)+1)
+	parts = append(parts, "ssh")
+	for _, o := range s.sshOpts {
+		parts = append(parts, remote.ShellQuote(o))
+	}
+	return append(os.Environ(), "GIT_SSH_COMMAND="+strings.Join(parts, " "))
+}
+
+// Fetch fetches heads from the peer copy of the repository at relPath into
+// the local repository at dir, under the Refspec namespace. It moves objects
+// only: refs outside refs/peer/<id>/* and the working tree are untouched.
+func (s *Source) Fetch(ctx context.Context, dir, relPath string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "fetch", "--no-tags", s.URL(relPath), s.Refspec())
+	cmd.Env = s.GitEnv()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return camperrors.Wrapf(err, "peer fetch %q from %s: %s", relPath, s.id, strings.TrimSpace(string(output)))
+	}
+	return nil
+}

--- a/internal/peer/peer.go
+++ b/internal/peer/peer.go
@@ -85,11 +85,23 @@ func (s *Source) URL(relPath string) string {
 	return "ssh://" + s.target + p
 }
 
-// Refspec returns the refspec peer fetches use. Fetched heads land under
+// Refspecs returns the refspecs peer fetches use. Heads land under
 // refs/peer/<id>/* so transferred objects stay reachable (no GC exposure)
-// without touching origin's remote-tracking refs.
+// without touching origin's remote-tracking refs. HEAD is included so a
+// detached gitlink SHA (common for recorded submodule commits that are not
+// branch tips) still transfers when the peer checkout is detached there.
+func (s *Source) Refspecs() []string {
+	ns := "refs/peer/" + s.id
+	return []string{
+		"+HEAD:" + ns + "/HEAD",
+		"+refs/heads/*:" + ns + "/*",
+	}
+}
+
+// Refspec returns the primary heads refspec (kept for callers/tests that
+// only need the heads mapping). Prefer Refspecs for fetches.
 func (s *Source) Refspec() string {
-	return "+refs/heads/*:refs/peer/" + s.id + "/*"
+	return s.Refspecs()[1]
 }
 
 // GitEnv returns the environment for git commands that dial this source:
@@ -109,14 +121,17 @@ func (s *Source) GitEnv() []string {
 	return append(os.Environ(), "GIT_SSH_COMMAND="+strings.Join(parts, " "))
 }
 
-// Fetch fetches heads from the peer copy of the repository at relPath into
-// the local repository at dir, under the Refspec namespace. It moves objects
-// only: refs outside refs/peer/<id>/* and the working tree are untouched.
+// Fetch fetches heads and HEAD from the peer copy of the repository at
+// relPath into the local repository at dir, under the Refspecs namespace.
+// It moves objects only: refs outside refs/peer/<id>/* and the working tree
+// are untouched.
 func (s *Source) Fetch(ctx context.Context, dir, relPath string) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
-	cmd := exec.CommandContext(ctx, "git", "-C", dir, "fetch", "--no-tags", s.URL(relPath), s.Refspec())
+	args := []string{"-C", dir, "fetch", "--no-tags", s.URL(relPath)}
+	args = append(args, s.Refspecs()...)
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Env = s.GitEnv()
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return camperrors.Wrapf(err, "peer fetch %q from %s: %s", relPath, s.id, strings.TrimSpace(string(output)))

--- a/internal/peer/peer.go
+++ b/internal/peer/peer.go
@@ -148,12 +148,21 @@ func (s *Source) GitEnv() []string {
 // RsyncSpec returns the rsync source spec for the directory at relPath under
 // the peer's campaign root, with a trailing slash so rsync copies contents
 // into the destination directory rather than nesting it.
+//
+// For an ssh source the path after "host:" is handed to the peer's remote
+// login shell, so it is single-quoted: a legitimate media root with a space
+// ("Final Renders/") would otherwise be split into two source arguments, and
+// shell metacharacters in a committed artifacts.yaml path would be
+// interpreted remotely. The trailing slash stays outside the quotes so the
+// local side still sees a copy-contents (not copy-dir) source. Filesystem
+// sources are passed to rsync as a local argv element (no shell), so they are
+// returned unquoted.
 func (s *Source) RsyncSpec(relPath string) string {
 	p := path.Join(s.root, relPath)
 	if s.target == "" {
 		return p + "/"
 	}
-	return s.target + ":" + p + "/"
+	return s.target + ":" + remote.ShellQuote(p) + "/"
 }
 
 // Fetch fetches heads and HEAD from the peer copy of the repository at

--- a/internal/peer/peer.go
+++ b/internal/peer/peer.go
@@ -119,21 +119,41 @@ func (s *Source) Refspec() string {
 	return s.Refspecs()[1]
 }
 
-// GitEnv returns the environment for git commands that dial this source:
-// os.Environ plus a GIT_SSH_COMMAND carrying the machine's ssh options
-// (BatchMode, ConnectTimeout, ControlMaster multiplexing, identity file).
-// Filesystem sources need no override and return nil, which keeps the
-// calling process environment for exec.Cmd.
-func (s *Source) GitEnv() []string {
+// SSHCommand returns the ssh command line (binary plus quoted options) that
+// dials this source, carrying BatchMode, ConnectTimeout, ControlMaster
+// multiplexing, and the identity file. Empty for filesystem sources.
+func (s *Source) SSHCommand() string {
 	if s.target == "" {
-		return nil
+		return ""
 	}
 	parts := make([]string, 0, len(s.sshOpts)+1)
 	parts = append(parts, "ssh")
 	for _, o := range s.sshOpts {
 		parts = append(parts, remote.ShellQuote(o))
 	}
-	return append(os.Environ(), "GIT_SSH_COMMAND="+strings.Join(parts, " "))
+	return strings.Join(parts, " ")
+}
+
+// GitEnv returns the environment for git commands that dial this source:
+// os.Environ plus a GIT_SSH_COMMAND carrying the machine's ssh options.
+// Filesystem sources need no override and return nil, which keeps the
+// calling process environment for exec.Cmd.
+func (s *Source) GitEnv() []string {
+	if s.target == "" {
+		return nil
+	}
+	return append(os.Environ(), "GIT_SSH_COMMAND="+s.SSHCommand())
+}
+
+// RsyncSpec returns the rsync source spec for the directory at relPath under
+// the peer's campaign root, with a trailing slash so rsync copies contents
+// into the destination directory rather than nesting it.
+func (s *Source) RsyncSpec(relPath string) string {
+	p := path.Join(s.root, relPath)
+	if s.target == "" {
+		return p + "/"
+	}
+	return s.target + ":" + p + "/"
 }
 
 // Fetch fetches heads and HEAD from the peer copy of the repository at

--- a/internal/peer/peer.go
+++ b/internal/peer/peer.go
@@ -29,27 +29,42 @@ type Source struct {
 	sshOpts []string
 }
 
+// ErrPeerConfig marks a peer-resolution failure that is a configuration or
+// usage error — an unknown machine id, the reserved "local" id, or unusable
+// auth — as opposed to a reachability failure (the peer is configured but
+// offline/unresolvable). Callers hard-fail on ErrPeerConfig so a typo or
+// misconfiguration is caught immediately, but degrade to the origin path on
+// reachability failures, matching the documented "unreachable peer degrades
+// to a warning" contract.
+var ErrPeerConfig = camperrors.New("peer configuration error")
+
 // FromMachine resolves machineID in ~/.obey/machines.yaml and asks the far
 // machine's own camp where campaign `remainder` lives (remote registry
 // resolution via `camp switch --print`, never the local filesystem).
+//
+// Configuration failures (unknown id, "local", bad auth) are wrapped with
+// ErrPeerConfig; a reachability failure from resolving the root on the peer
+// is returned as-is so callers can degrade rather than abort.
 func FromMachine(ctx context.Context, machineID, remainder string) (*Source, error) {
 	file, err := machines.Load()
 	if err != nil {
-		return nil, camperrors.Wrap(err, "load machines file")
+		return nil, camperrors.WrapJoinf(ErrPeerConfig, err, "load machines file")
 	}
 	m, isLocal, found := file.Lookup(machineID)
 	if !found {
-		return nil, camperrors.Newf("machine %q not found in %s (see 'camp machine list')",
+		return nil, camperrors.WrapJoinf(ErrPeerConfig, nil, "machine %q not found in %s (see 'camp machine list')",
 			machineID, machines.MachinesPath())
 	}
 	if isLocal {
-		return nil, camperrors.Newf("machine %q is this machine; --from needs a different machine", machineID)
+		return nil, camperrors.WrapJoinf(ErrPeerConfig, nil, "machine %q is this machine; --from needs a different machine", machineID)
 	}
 	if err := remote.EnsureKeyAuth(m); err != nil {
-		return nil, err
+		return nil, camperrors.WrapJoin(ErrPeerConfig, err, "")
 	}
 	root, err := remote.ResolveRoot(ctx, m, remainder)
 	if err != nil {
+		// Reachability/resolution failure: not wrapped with ErrPeerConfig, so
+		// callers degrade to origin.
 		return nil, err
 	}
 	return &Source{id: m.ID, root: root, target: remote.Target(m), sshOpts: remote.Opts(m)}, nil

--- a/internal/peer/peer_test.go
+++ b/internal/peer/peer_test.go
@@ -1,0 +1,92 @@
+package peer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSourceURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  *Source
+		relPath string
+		want    string
+	}{
+		{
+			name:    "filesystem root",
+			source:  FromPath("vol", "/Volumes/backup/campaign"),
+			relPath: "",
+			want:    "/Volumes/backup/campaign",
+		},
+		{
+			name:    "filesystem submodule",
+			source:  FromPath("vol", "/Volumes/backup/campaign"),
+			relPath: "projects/camp",
+			want:    "/Volumes/backup/campaign/projects/camp",
+		},
+		{
+			name:    "ssh root",
+			source:  &Source{id: "studio", root: "/Users/me/campaign", target: "me@studio.local"},
+			relPath: "",
+			want:    "ssh://me@studio.local/Users/me/campaign",
+		},
+		{
+			name:    "ssh submodule",
+			source:  &Source{id: "studio", root: "/Users/me/campaign", target: "studio.local"},
+			relPath: "projects/camp",
+			want:    "ssh://studio.local/Users/me/campaign/projects/camp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.source.URL(tt.relPath); got != tt.want {
+				t.Errorf("URL(%q) = %q, want %q", tt.relPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSourceRefspec(t *testing.T) {
+	s := FromPath("studio-mac", "/x")
+	want := "+refs/heads/*:refs/peer/studio-mac/*"
+	if got := s.Refspec(); got != want {
+		t.Errorf("Refspec() = %q, want %q", got, want)
+	}
+}
+
+func TestSourceGitEnv(t *testing.T) {
+	fs := FromPath("vol", "/x")
+	if env := fs.GitEnv(); env != nil {
+		t.Errorf("filesystem source GitEnv() = %v, want nil", env)
+	}
+
+	ssh := &Source{
+		id:      "studio",
+		root:    "/x",
+		target:  "me@studio",
+		sshOpts: []string{"-o", "BatchMode=yes", "-o", "ControlPath=/tmp/has space/x.sock"},
+	}
+	env := ssh.GitEnv()
+	if env == nil {
+		t.Fatal("ssh source GitEnv() = nil, want environment")
+	}
+	var sshCmd string
+	for _, e := range env {
+		if rest, ok := strings.CutPrefix(e, "GIT_SSH_COMMAND="); ok {
+			sshCmd = rest
+		}
+	}
+	if sshCmd == "" {
+		t.Fatal("GIT_SSH_COMMAND not present in GitEnv()")
+	}
+	if !strings.HasPrefix(sshCmd, "ssh ") {
+		t.Errorf("GIT_SSH_COMMAND = %q, want ssh prefix", sshCmd)
+	}
+	if !strings.Contains(sshCmd, "'BatchMode=yes'") {
+		t.Errorf("GIT_SSH_COMMAND = %q, want quoted BatchMode option", sshCmd)
+	}
+	if !strings.Contains(sshCmd, "'ControlPath=/tmp/has space/x.sock'") {
+		t.Errorf("GIT_SSH_COMMAND = %q, want space-containing option single-quoted", sshCmd)
+	}
+}

--- a/internal/peer/peer_test.go
+++ b/internal/peer/peer_test.go
@@ -83,6 +83,47 @@ func TestSourceURL(t *testing.T) {
 	}
 }
 
+func TestSourceRsyncSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  *Source
+		relPath string
+		want    string
+	}{
+		{
+			name:    "filesystem source is an unquoted local path",
+			source:  FromPath("vol", "/Volumes/backup/campaign"),
+			relPath: "media/renders",
+			want:    "/Volumes/backup/campaign/media/renders/",
+		},
+		{
+			name:    "ssh source single-quotes the remote path",
+			source:  &Source{root: "/home/me/campaign", target: "me@studio"},
+			relPath: "media/renders",
+			want:    "me@studio:'/home/me/campaign/media/renders'/",
+		},
+		{
+			name:    "space in an ssh remote path stays one argument",
+			source:  &Source{root: "/home/me/campaign", target: "me@studio"},
+			relPath: "Final Renders",
+			want:    "me@studio:'/home/me/campaign/Final Renders'/",
+		},
+		{
+			name:    "shell metacharacters in an ssh remote path are neutralized",
+			source:  &Source{root: "/root", target: "me@studio"},
+			relPath: "a; rm -rf ~",
+			want:    "me@studio:'/root/a; rm -rf ~'/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.source.RsyncSpec(tt.relPath); got != tt.want {
+				t.Errorf("RsyncSpec(%q) = %q, want %q", tt.relPath, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSourceRefspec(t *testing.T) {
 	s := FromPath("studio-mac", "/x")
 	wantHeads := "+refs/heads/*:refs/peer/studio-mac/*"

--- a/internal/peer/peer_test.go
+++ b/internal/peer/peer_test.go
@@ -49,9 +49,22 @@ func TestSourceURL(t *testing.T) {
 
 func TestSourceRefspec(t *testing.T) {
 	s := FromPath("studio-mac", "/x")
-	want := "+refs/heads/*:refs/peer/studio-mac/*"
-	if got := s.Refspec(); got != want {
-		t.Errorf("Refspec() = %q, want %q", got, want)
+	wantHeads := "+refs/heads/*:refs/peer/studio-mac/*"
+	if got := s.Refspec(); got != wantHeads {
+		t.Errorf("Refspec() = %q, want %q", got, wantHeads)
+	}
+	want := []string{
+		"+HEAD:refs/peer/studio-mac/HEAD",
+		wantHeads,
+	}
+	got := s.Refspecs()
+	if len(got) != len(want) {
+		t.Fatalf("Refspecs() len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Refspecs()[%d] = %q, want %q", i, got[i], want[i])
+		}
 	}
 }
 

--- a/internal/peer/peer_test.go
+++ b/internal/peer/peer_test.go
@@ -1,9 +1,45 @@
 package peer
 
 import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// A config/usage failure (unknown machine id) must be classified ErrPeerConfig
+// so callers fail fast; it must not be mistaken for a reachability failure.
+func TestFromMachine_UnknownMachineIsConfigError(t *testing.T) {
+	machinesFile := filepath.Join(t.TempDir(), "machines.yaml")
+	if err := os.WriteFile(machinesFile, []byte("version: 1\nmachines: []\n"), 0o644); err != nil {
+		t.Fatalf("writing machines file: %v", err)
+	}
+	t.Setenv("CAMP_MACHINES_PATH", machinesFile)
+
+	_, err := FromMachine(context.Background(), "no-such-machine", "campaign")
+	if err == nil {
+		t.Fatal("FromMachine() error = nil, want ErrPeerConfig")
+	}
+	if !errors.Is(err, ErrPeerConfig) {
+		t.Errorf("FromMachine() error = %v, want wrapped ErrPeerConfig", err)
+	}
+}
+
+// The reserved "local" id is a usage error, also ErrPeerConfig.
+func TestFromMachine_LocalIsConfigError(t *testing.T) {
+	machinesFile := filepath.Join(t.TempDir(), "machines.yaml")
+	if err := os.WriteFile(machinesFile, []byte("version: 1\nmachines: []\n"), 0o644); err != nil {
+		t.Fatalf("writing machines file: %v", err)
+	}
+	t.Setenv("CAMP_MACHINES_PATH", machinesFile)
+
+	_, err := FromMachine(context.Background(), "local", "campaign")
+	if err == nil || !errors.Is(err, ErrPeerConfig) {
+		t.Errorf("FromMachine(local) error = %v, want ErrPeerConfig", err)
+	}
+}
 
 func TestSourceURL(t *testing.T) {
 	tests := []struct {

--- a/internal/sync/options.go
+++ b/internal/sync/options.go
@@ -8,6 +8,8 @@
 // This prevents data loss from stale URLs or uncommitted changes during sync operations.
 package sync
 
+import "github.com/Obedience-Corp/camp/internal/peer"
+
 // SyncOptions configures sync behavior.
 type SyncOptions struct {
 	// DryRun shows what would happen without making changes.
@@ -66,6 +68,12 @@ type SubmoduleResult struct {
 	CheckedOutBranch string
 	// DriftWarning describes detected gitlink drift for this submodule.
 	DriftWarning string
+	// PeerFetched indicates objects were fetched from the configured peer
+	// before the origin-based update.
+	PeerFetched bool
+	// PeerWarning describes a peer fetch failure; the submodule still syncs
+	// through origin when this is set.
+	PeerWarning string
 }
 
 // URLChange represents a URL that was updated during synchronization.
@@ -86,6 +94,7 @@ type Syncer struct {
 	repoRoot        string
 	options         SyncOptions
 	cachedPreflight *PreflightResult // Optional pre-computed preflight result
+	peer            *peer.Source     // Optional peer to fetch objects from before origin
 }
 
 // NewSyncer creates a new Syncer for the given repository root.
@@ -168,6 +177,16 @@ func WithJSON(json bool) SyncerOption {
 func WithPreflightResult(pr *PreflightResult) SyncerOption {
 	return func(s *Syncer) {
 		s.cachedPreflight = pr
+	}
+}
+
+// WithPeer configures a peer source to fetch git objects from before each
+// submodule's origin-based update. The peer is a transfer accelerator only:
+// preflight checks, origin URLs, and post-sync validation are unchanged, and
+// a failed peer fetch degrades to the normal origin path with a warning.
+func WithPeer(p *peer.Source) SyncerOption {
+	return func(s *Syncer) {
+		s.peer = p
 	}
 }
 

--- a/internal/sync/options.go
+++ b/internal/sync/options.go
@@ -8,7 +8,10 @@
 // This prevents data loss from stale URLs or uncommitted changes during sync operations.
 package sync
 
-import "github.com/Obedience-Corp/camp/internal/peer"
+import (
+	"github.com/Obedience-Corp/camp/internal/artifacts"
+	"github.com/Obedience-Corp/camp/internal/peer"
+)
 
 // SyncOptions configures sync behavior.
 type SyncOptions struct {
@@ -26,6 +29,17 @@ type SyncOptions struct {
 	JSON bool
 	// Submodules lists specific submodules to sync (empty = all).
 	Submodules []string
+	// GitOnly skips artifact transfer on a peer-assisted sync.
+	GitOnly bool
+	// ArtifactsOnly skips the git phases and only pulls declared artifact
+	// roots from the peer (all policies, since the ask is explicit).
+	ArtifactsOnly bool
+	// VerifyArtifacts checks artifact roots against last-transfer snapshots
+	// (no transfer, no git phases). VerifyPeer scopes it to one peer id;
+	// empty means every peer with a snapshot.
+	VerifyArtifacts bool
+	// VerifyPeer scopes VerifyArtifacts to one peer id.
+	VerifyPeer string
 }
 
 // SyncResult contains the outcome of a sync operation.
@@ -38,10 +52,21 @@ type SyncResult struct {
 	URLChanges []URLChange
 	// UpdateResults contains the outcome for each submodule.
 	UpdateResults []SubmoduleResult
+	// Artifacts contains per-root outcomes of the peer artifact pull.
+	Artifacts []*artifacts.PullResult
+	// ArtifactVerifies contains per-root, per-peer verification outcomes.
+	ArtifactVerifies []ArtifactVerify
 	// Warnings contains non-fatal issues encountered.
 	Warnings []string
 	// Errors contains fatal errors that occurred.
 	Errors []error
+}
+
+// ArtifactVerify pairs a verification result with the peer snapshot it ran
+// against.
+type ArtifactVerify struct {
+	Peer   string
+	Result *artifacts.VerifyResult
 }
 
 // SubmoduleResult tracks the outcome for a single submodule.
@@ -194,6 +219,31 @@ func WithPeer(p *peer.Source) SyncerOption {
 func WithSubmodules(submodules []string) SyncerOption {
 	return func(s *Syncer) {
 		s.options.Submodules = submodules
+	}
+}
+
+// WithGitOnly skips artifact transfer on a peer-assisted sync.
+func WithGitOnly(gitOnly bool) SyncerOption {
+	return func(s *Syncer) {
+		s.options.GitOnly = gitOnly
+	}
+}
+
+// WithArtifactsOnly skips the git phases and only pulls declared artifact
+// roots from the configured peer.
+func WithArtifactsOnly(artifactsOnly bool) SyncerOption {
+	return func(s *Syncer) {
+		s.options.ArtifactsOnly = artifactsOnly
+	}
+}
+
+// WithVerifyArtifacts checks artifact roots against last-transfer snapshots
+// instead of syncing. peerID scopes the check to one peer; empty checks every
+// peer with a snapshot.
+func WithVerifyArtifacts(verify bool, peerID string) SyncerOption {
+	return func(s *Syncer) {
+		s.options.VerifyArtifacts = verify
+		s.options.VerifyPeer = peerID
 	}
 }
 

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -199,34 +199,52 @@ func (s *Syncer) verifyArtifacts(ctx context.Context, result *SyncResult) {
 		}
 	}
 
+	matched := 0
 	for _, root := range cfg.Roots {
 		if ctx.Err() != nil {
 			result.Errors = append(result.Errors, ctx.Err())
 			result.Success = false
 			return
 		}
-		local, err := artifacts.BuildManifest(ctx, s.repoRoot, root.Path)
+		rootRel, err := artifacts.EnsureRootWithin(s.repoRoot, root.Path)
 		if err != nil {
 			result.Success = false
 			result.Errors = append(result.Errors, &SyncError{Op: "artifacts-verify", Submodule: root.Path, Cause: err})
 			continue
 		}
+		local, err := artifacts.BuildManifest(ctx, s.repoRoot, rootRel)
+		if err != nil {
+			result.Success = false
+			result.Errors = append(result.Errors, &SyncError{Op: "artifacts-verify", Submodule: rootRel, Cause: err})
+			continue
+		}
 		for _, peerID := range peers {
-			snapshot, err := artifacts.LoadSnapshot(s.repoRoot, peerID, root.Path)
+			snapshot, err := artifacts.LoadSnapshot(s.repoRoot, peerID, rootRel)
 			if err != nil {
 				result.Success = false
-				result.Errors = append(result.Errors, &SyncError{Op: "artifacts-verify", Submodule: root.Path, Cause: err})
+				result.Errors = append(result.Errors, &SyncError{Op: "artifacts-verify", Submodule: rootRel, Cause: err})
 				continue
 			}
 			if snapshot == nil {
 				continue
 			}
+			matched++
 			verify := artifacts.Verify(local, snapshot)
 			result.ArtifactVerifies = append(result.ArtifactVerifies, ArtifactVerify{Peer: peerID, Result: verify})
 			if !verify.Clean() {
 				result.Success = false
 			}
 		}
+	}
+
+	// A --from-scoped verify that matched no snapshot for any root is almost
+	// always a typo'd or never-synced peer id: report it rather than exiting
+	// 0 "complete" having checked nothing.
+	if s.options.VerifyPeer != "" && matched == 0 && len(cfg.Roots) > 0 {
+		result.Success = false
+		result.Errors = append(result.Errors, &SyncError{Op: "artifacts-verify",
+			Cause: camperrors.Newf("no snapshots recorded for peer %q; check the machine id or run 'camp sync --from %s' first",
+				s.options.VerifyPeer, s.options.VerifyPeer)})
 	}
 }
 

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -161,6 +161,18 @@ func (s *Syncer) pullArtifacts(ctx context.Context, result *SyncResult) {
 		}
 		return
 	}
+	// A committed declaration is not trusted just because it parsed: an
+	// unsupported version, unknown policy, or duplicate root must fail closed
+	// here rather than be silently skipped on a normal sync yet pulled under
+	// --artifacts-only. Same degrade contract as an unreadable config.
+	if verr := cfg.Validate(); verr != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("artifacts config: %v", verr))
+		if s.options.ArtifactsOnly {
+			result.Success = false
+			result.Errors = append(result.Errors, &SyncError{Op: "artifacts", Cause: verr})
+		}
+		return
+	}
 	for _, root := range cfg.Roots {
 		if ctx.Err() != nil {
 			result.Errors = append(result.Errors, ctx.Err())
@@ -207,6 +219,11 @@ func (s *Syncer) verifyArtifacts(ctx context.Context, result *SyncResult) {
 
 	cfg, err := artifacts.Load(s.repoRoot)
 	if err != nil {
+		result.Success = false
+		result.Errors = append(result.Errors, &SyncError{Op: "artifacts-verify", Cause: err})
+		return
+	}
+	if err := cfg.Validate(); err != nil {
 		result.Success = false
 		result.Errors = append(result.Errors, &SyncError{Op: "artifacts-verify", Cause: err})
 		return

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -150,7 +150,15 @@ func (s *Syncer) pullArtifacts(ctx context.Context, result *SyncResult) {
 	}
 	cfg, err := artifacts.Load(s.repoRoot)
 	if err != nil {
+		// A default `--from` sync degrades artifact failures to warnings (the
+		// accelerated path must never be worse than a plain sync), but under
+		// --artifacts-only the artifacts were the entire ask, so an unreadable
+		// config is a hard failure rather than a silent exit 0.
 		result.Warnings = append(result.Warnings, fmt.Sprintf("artifacts config: %v", err))
+		if s.options.ArtifactsOnly {
+			result.Success = false
+			result.Errors = append(result.Errors, &SyncError{Op: "artifacts", Cause: err})
+		}
 		return
 	}
 	for _, root := range cfg.Roots {
@@ -164,6 +172,15 @@ func (s *Syncer) pullArtifacts(ctx context.Context, result *SyncResult) {
 		}
 		pr := artifacts.Pull(ctx, s.repoRoot, s.peer, root)
 		result.Artifacts = append(result.Artifacts, pr)
+		// The top-of-loop guard cannot catch a cancellation that lands during
+		// this root's transfer (the last root has no next iteration), so
+		// re-check here: a cancelled sync must fail regardless of mode rather
+		// than reporting the interrupted transfer as a warning and exiting 0.
+		if ctx.Err() != nil {
+			result.Success = false
+			result.Errors = append(result.Errors, ctx.Err())
+			return
+		}
 		if pr.Warning != "" {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("artifacts %s: %s", pr.Root, pr.Warning))
 			if s.options.ArtifactsOnly {
@@ -177,6 +194,17 @@ func (s *Syncer) pullArtifacts(ctx context.Context, result *SyncResult) {
 // snapshots: no transfer, no git phases. Discrepancies fail the run so
 // scripting can rely on the exit code.
 func (s *Syncer) verifyArtifacts(ctx context.Context, result *SyncResult) {
+	// VerifyPeer comes straight from --from and is joined into the snapshot
+	// path (.campaign/cache/peersync/<peer>/...); validate it before it can
+	// traverse on read (e.g. --verify-artifacts --from ../../..).
+	if s.options.VerifyPeer != "" {
+		if err := artifacts.ValidatePeerID(s.options.VerifyPeer); err != nil {
+			result.Success = false
+			result.Errors = append(result.Errors, &SyncError{Op: "artifacts-verify", Cause: err})
+			return
+		}
+	}
+
 	cfg, err := artifacts.Load(s.repoRoot)
 	if err != nil {
 		result.Success = false

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	gosync "sync"
 
+	"github.com/Obedience-Corp/camp/internal/artifacts"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/git"
 )
@@ -57,6 +58,17 @@ func (s *Syncer) Sync(ctx context.Context) (*SyncResult, error) {
 	if s.options.DryRun {
 		// Add potential URL changes to result
 		result.URLChanges = s.predictURLChanges(preflight)
+		return result, nil
+	}
+
+	// Artifact-only variants keep the preflight above (every sync variant
+	// runs it) but skip the git phases entirely.
+	if s.options.VerifyArtifacts {
+		s.verifyArtifacts(ctx, result)
+		return result, nil
+	}
+	if s.options.ArtifactsOnly {
+		s.pullArtifacts(ctx, result)
 		return result, nil
 	}
 
@@ -115,7 +127,107 @@ func (s *Syncer) Sync(ctx context.Context) (*SyncResult, error) {
 		result.Errors = append(result.Errors, err)
 	}
 
+	// Phase 5: Artifact pull rides the peer connection when one is
+	// configured; policy=always roots only, and failures degrade to
+	// warnings (the accelerated sync must not be worse than a plain one).
+	if s.peer != nil && !s.options.GitOnly {
+		s.pullArtifacts(ctx, result)
+	}
+
 	return result, nil
+}
+
+// pullArtifacts transfers declared artifact roots from the configured peer.
+// Default syncs move policy=always roots; an explicit --artifacts-only run
+// moves every declared root and treats per-root failures as sync failures
+// (the artifacts were the whole ask).
+func (s *Syncer) pullArtifacts(ctx context.Context, result *SyncResult) {
+	if s.peer == nil {
+		result.Success = false
+		result.Errors = append(result.Errors, &SyncError{Op: "artifacts",
+			Cause: camperrors.New("artifact sync needs a peer (--from <machine>)")})
+		return
+	}
+	cfg, err := artifacts.Load(s.repoRoot)
+	if err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("artifacts config: %v", err))
+		return
+	}
+	for _, root := range cfg.Roots {
+		if ctx.Err() != nil {
+			result.Errors = append(result.Errors, ctx.Err())
+			result.Success = false
+			return
+		}
+		if !s.options.ArtifactsOnly && root.EffectivePolicy() != artifacts.PolicyAlways {
+			continue
+		}
+		pr := artifacts.Pull(ctx, s.repoRoot, s.peer, root)
+		result.Artifacts = append(result.Artifacts, pr)
+		if pr.Warning != "" {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("artifacts %s: %s", pr.Root, pr.Warning))
+			if s.options.ArtifactsOnly {
+				result.Success = false
+			}
+		}
+	}
+}
+
+// verifyArtifacts compares each declared root against last-transfer
+// snapshots: no transfer, no git phases. Discrepancies fail the run so
+// scripting can rely on the exit code.
+func (s *Syncer) verifyArtifacts(ctx context.Context, result *SyncResult) {
+	cfg, err := artifacts.Load(s.repoRoot)
+	if err != nil {
+		result.Success = false
+		result.Errors = append(result.Errors, &SyncError{Op: "artifacts-verify", Cause: err})
+		return
+	}
+
+	peers := []string{s.options.VerifyPeer}
+	if s.options.VerifyPeer == "" {
+		peers, err = artifacts.ListSnapshotPeers(s.repoRoot)
+		if err != nil {
+			result.Success = false
+			result.Errors = append(result.Errors, &SyncError{Op: "artifacts-verify", Cause: err})
+			return
+		}
+		if len(peers) == 0 {
+			result.Warnings = append(result.Warnings,
+				"no peer snapshots recorded yet; nothing to verify against (run 'camp sync --from <machine>' first)")
+			return
+		}
+	}
+
+	for _, root := range cfg.Roots {
+		if ctx.Err() != nil {
+			result.Errors = append(result.Errors, ctx.Err())
+			result.Success = false
+			return
+		}
+		local, err := artifacts.BuildManifest(ctx, s.repoRoot, root.Path)
+		if err != nil {
+			result.Success = false
+			result.Errors = append(result.Errors, &SyncError{Op: "artifacts-verify", Submodule: root.Path, Cause: err})
+			continue
+		}
+		for _, peerID := range peers {
+			snapshot, err := artifacts.LoadSnapshot(s.repoRoot, peerID, root.Path)
+			if err != nil {
+				result.Success = false
+				result.Errors = append(result.Errors, &SyncError{Op: "artifacts-verify", Submodule: root.Path, Cause: err})
+				continue
+			}
+			if snapshot == nil {
+				continue
+			}
+			verify := artifacts.Verify(local, snapshot)
+			result.ArtifactVerifies = append(result.ArtifactVerifies, ArtifactVerify{Peer: peerID, Result: verify})
+			if !verify.Clean() {
+				result.Success = false
+			}
+		}
+	}
 }
 
 // collectWarnings gathers warning messages from preflight results.

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -102,6 +103,9 @@ func (s *Syncer) Sync(ctx context.Context) (*SyncResult, error) {
 		if sub.DriftWarning != "" {
 			result.Success = false
 			result.Warnings = append(result.Warnings, sub.DriftWarning)
+		}
+		if sub.PeerWarning != "" {
+			result.Warnings = append(result.Warnings, sub.PeerWarning)
 		}
 	}
 
@@ -300,6 +304,15 @@ func (s *Syncer) updateSubmodule(ctx context.Context, path string) SubmoduleResu
 		Success: true,
 	}
 
+	if s.peer != nil {
+		fetched, peerErr := s.peerFetch(ctx, path)
+		result.PeerFetched = fetched
+		if peerErr != nil {
+			result.PeerWarning = fmt.Sprintf("%s: peer fetch from %s failed, continuing via origin: %v",
+				path, s.peer.ID(), peerErr)
+		}
+	}
+
 	// Use shared graceful init (handles stale refs with fallback)
 	if err := git.InitSubmoduleGraceful(ctx, s.repoRoot, path); err != nil {
 		result.Success = false
@@ -331,6 +344,22 @@ func (s *Syncer) updateSubmodule(ctx context.Context, path string) SubmoduleResu
 	}
 
 	return result
+}
+
+// peerFetch pulls objects for one submodule from the configured peer ahead of
+// the origin-based update. It returns (false, nil) for a submodule that is not
+// initialized locally: there is no repository to fetch into yet, and the
+// normal init path handles it from origin. A fetch failure is returned for
+// the caller to surface as a warning; sync then proceeds via origin.
+func (s *Syncer) peerFetch(ctx context.Context, path string) (bool, error) {
+	subDir := filepath.Join(s.repoRoot, path)
+	if _, err := os.Stat(filepath.Join(subDir, ".git")); err != nil {
+		return false, nil
+	}
+	if err := s.peer.Fetch(ctx, subDir, path); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // verifySubmodules checks the status of all submodules after update.

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -304,7 +304,9 @@ func (s *Syncer) updateSubmodule(ctx context.Context, path string) SubmoduleResu
 		Success: true,
 	}
 
-	if s.peer != nil {
+	// --no-fetch promises local refs only, so it suppresses the peer network
+	// fetch too (a peer fetch is still a network transfer).
+	if s.peer != nil && !s.options.NoFetch {
 		fetched, peerErr := s.peerFetch(ctx, path)
 		result.PeerFetched = fetched
 		if peerErr != nil {

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Obedience-Corp/camp/internal/peer"
 )
 
 func TestSync_CleanRepo(t *testing.T) {
@@ -278,6 +280,77 @@ func TestUpdateSubmodules_ContextCanceledMidFlight(t *testing.T) {
 		}
 	case <-time.After(30 * time.Second):
 		t.Fatal("updateSubmodules() did not return after cancellation")
+	}
+}
+
+func TestUpdateSubmodules_PeerFetch(t *testing.T) {
+	ctx := context.Background()
+	repoRoot := setupTestRepo(t)
+	setupSubmodule(t, repoRoot, "projects/sub")
+
+	// Build a peer campaign mirroring the layout: projects/sub is a clone of
+	// the same source repo with a branch the local copy has never seen.
+	cmd := exec.Command("git", "-C", repoRoot, "config", "-f", ".gitmodules", "submodule.projects/sub.url")
+	urlBytes, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("reading submodule url: %v", err)
+	}
+	sourceRepo := strings.TrimSpace(string(urlBytes))
+
+	peerRoot := t.TempDir()
+	peerSub := filepath.Join(peerRoot, "projects", "sub")
+	runGit(t, t.TempDir(), "clone", sourceRepo, peerSub)
+	runGit(t, peerSub, "config", "user.email", "test@test.com")
+	runGit(t, peerSub, "config", "user.name", "Test")
+	runGit(t, peerSub, "checkout", "-b", "peer-work")
+	createFile(t, filepath.Join(peerSub, "peer-only.txt"), "only on the peer")
+	runGit(t, peerSub, "add", ".")
+	runGit(t, peerSub, "commit", "-m", "peer-only work")
+
+	syncer := NewSyncer(repoRoot, WithPeer(peer.FromPath("peerbox", peerRoot)))
+	results, err := syncer.updateSubmodules(ctx)
+	if err != nil {
+		t.Fatalf("updateSubmodules() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("updateSubmodules() results = %d, want 1", len(results))
+	}
+	if !results[0].Success {
+		t.Fatalf("submodule Success = false: %v", results[0].Error)
+	}
+	if !results[0].PeerFetched {
+		t.Errorf("PeerFetched = false, want true (warning: %q)", results[0].PeerWarning)
+	}
+
+	// Peer heads land under refs/peer/<id>/*, bringing their objects along.
+	localSub := filepath.Join(repoRoot, "projects/sub")
+	verify := exec.Command("git", "-C", localSub, "rev-parse", "--verify", "refs/peer/peerbox/peer-work")
+	if out, verifyErr := verify.CombinedOutput(); verifyErr != nil {
+		t.Errorf("refs/peer/peerbox/peer-work not present after peer fetch: %s", strings.TrimSpace(string(out)))
+	}
+}
+
+func TestUpdateSubmodules_PeerUnreachableDegrades(t *testing.T) {
+	ctx := context.Background()
+	repoRoot := setupTestRepo(t)
+	setupSubmodule(t, repoRoot, "projects/sub")
+
+	syncer := NewSyncer(repoRoot, WithPeer(peer.FromPath("ghost", filepath.Join(t.TempDir(), "missing"))))
+	results, err := syncer.updateSubmodules(ctx)
+	if err != nil {
+		t.Fatalf("updateSubmodules() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("updateSubmodules() results = %d, want 1", len(results))
+	}
+	if !results[0].Success {
+		t.Errorf("submodule Success = false, want true (peer failure must degrade): %v", results[0].Error)
+	}
+	if results[0].PeerFetched {
+		t.Error("PeerFetched = true, want false for unreachable peer")
+	}
+	if results[0].PeerWarning == "" {
+		t.Error("PeerWarning empty, want degradation warning")
 	}
 }
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -330,6 +330,36 @@ func TestUpdateSubmodules_PeerFetch(t *testing.T) {
 	}
 }
 
+// --no-fetch promises local refs only, so it must suppress the peer network
+// fetch even when a peer is configured.
+func TestUpdateSubmodules_NoFetchSuppressesPeer(t *testing.T) {
+	ctx := context.Background()
+	repoRoot := setupTestRepo(t)
+	setupSubmodule(t, repoRoot, "projects/sub")
+
+	syncer := NewSyncer(repoRoot,
+		WithPeer(peer.FromPath("peerbox", t.TempDir())),
+		WithNoFetch(true),
+	)
+	results, err := syncer.updateSubmodules(ctx)
+	if err != nil {
+		t.Fatalf("updateSubmodules() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("updateSubmodules() results = %d, want 1", len(results))
+	}
+	if results[0].PeerFetched {
+		t.Error("PeerFetched = true with --no-fetch, want false (no network transfer)")
+	}
+	// No peer refs should have been created.
+	localSub := filepath.Join(repoRoot, "projects/sub")
+	check := exec.Command("git", "-C", localSub, "for-each-ref", "refs/peer")
+	out, _ := check.Output()
+	if strings.TrimSpace(string(out)) != "" {
+		t.Errorf("refs/peer/* created despite --no-fetch:\n%s", out)
+	}
+}
+
 func TestUpdateSubmodules_PeerUnreachableDegrades(t *testing.T) {
 	ctx := context.Background()
 	repoRoot := setupTestRepo(t)

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -354,6 +354,66 @@ func TestUpdateSubmodules_PeerUnreachableDegrades(t *testing.T) {
 	}
 }
 
+// Peer submodule sitting detached at a commit that is not a branch tip: HEAD
+// must still transfer so gitlink objects accelerate without origin.
+func TestUpdateSubmodules_PeerFetchDetachedHEAD(t *testing.T) {
+	ctx := context.Background()
+	repoRoot := setupTestRepo(t)
+	setupSubmodule(t, repoRoot, "projects/sub")
+
+	cmd := exec.Command("git", "-C", repoRoot, "config", "-f", ".gitmodules", "submodule.projects/sub.url")
+	urlBytes, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("reading submodule url: %v", err)
+	}
+	sourceRepo := strings.TrimSpace(string(urlBytes))
+
+	peerRoot := t.TempDir()
+	peerSub := filepath.Join(peerRoot, "projects", "sub")
+	runGit(t, t.TempDir(), "clone", sourceRepo, peerSub)
+	runGit(t, peerSub, "config", "user.email", "test@test.com")
+	runGit(t, peerSub, "config", "user.name", "Test")
+	// Detached commit reachable only via HEAD (delete the only branch tip).
+	runGit(t, peerSub, "checkout", "--detach")
+	createFile(t, filepath.Join(peerSub, "detached-only.txt"), "only on detached peer HEAD")
+	runGit(t, peerSub, "add", ".")
+	runGit(t, peerSub, "commit", "-m", "detached peer tip")
+	shaOut, err := exec.Command("git", "-C", peerSub, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("peer HEAD: %v", err)
+	}
+	detachedSHA := strings.TrimSpace(string(shaOut))
+	// Drop all local branches so heads refspec alone would miss this object.
+	branches, err := exec.Command("git", "-C", peerSub, "for-each-ref", "--format=%(refname:short)", "refs/heads").Output()
+	if err != nil {
+		t.Fatalf("list branches: %v", err)
+	}
+	for _, b := range strings.Fields(string(branches)) {
+		runGit(t, peerSub, "branch", "-D", b)
+	}
+
+	syncer := NewSyncer(repoRoot, WithPeer(peer.FromPath("peerbox", peerRoot)))
+	results, err := syncer.updateSubmodules(ctx)
+	if err != nil {
+		t.Fatalf("updateSubmodules() error = %v", err)
+	}
+	if len(results) != 1 || !results[0].Success {
+		t.Fatalf("update failed: %+v", results)
+	}
+	if !results[0].PeerFetched {
+		t.Fatalf("PeerFetched = false (warning: %q)", results[0].PeerWarning)
+	}
+
+	localSub := filepath.Join(repoRoot, "projects/sub")
+	if out, verifyErr := exec.Command("git", "-C", localSub, "cat-file", "-e", detachedSHA).CombinedOutput(); verifyErr != nil {
+		t.Errorf("detached peer HEAD object %s missing after peer fetch: %s",
+			detachedSHA, strings.TrimSpace(string(out)))
+	}
+	if out, verifyErr := exec.Command("git", "-C", localSub, "rev-parse", "--verify", "refs/peer/peerbox/HEAD").CombinedOutput(); verifyErr != nil {
+		t.Errorf("refs/peer/peerbox/HEAD not present: %s", strings.TrimSpace(string(out)))
+	}
+}
+
 func TestUpdateSubmodules_ContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -808,3 +808,41 @@ func TestVerifyArtifacts_RejectsTraversalPeer(t *testing.T) {
 		t.Error("verify with a traversal peer id: Success = true, want false")
 	}
 }
+
+// TestPullArtifacts_InvalidSchemaExitContract pins the same exit contract for a
+// parseable but invalid committed declaration (here an unknown policy): it must
+// fail closed under --artifacts-only and degrade to a warning on a default
+// sync, rather than being silently skipped or blindly pulled.
+func TestPullArtifacts_InvalidSchemaExitContract(t *testing.T) {
+	ctx := context.Background()
+	writeConfig := func(t *testing.T) string {
+		t.Helper()
+		root := t.TempDir()
+		p := filepath.Join(root, ".campaign", "artifacts.yaml")
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("version: 1\nroots:\n  - path: media\n    policy: bogus\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return root
+	}
+	peerSrc := peer.FromPath("peerbox", t.TempDir())
+
+	only := NewSyncer(writeConfig(t), WithPeer(peerSrc), WithArtifactsOnly(true))
+	onlyRes := &SyncResult{Success: true}
+	only.pullArtifacts(ctx, onlyRes)
+	if onlyRes.Success {
+		t.Error("--artifacts-only with invalid schema: Success = true, want false")
+	}
+
+	def := NewSyncer(writeConfig(t), WithPeer(peerSrc))
+	defRes := &SyncResult{Success: true}
+	def.pullArtifacts(ctx, defRes)
+	if !defRes.Success {
+		t.Error("default sync with invalid schema: Success = false, want true (degrade)")
+	}
+	if len(defRes.Warnings) == 0 {
+		t.Error("default sync with invalid schema: no warning recorded")
+	}
+}

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -761,3 +761,50 @@ func containsHelper(s, substr string) bool {
 	}
 	return false
 }
+
+// TestPullArtifacts_ConfigLoadExitContract pins the exit-code contract for an
+// unreadable artifacts config: --artifacts-only fails the run (the artifacts
+// were the whole ask), a default --from sync degrades to a warning and keeps
+// exit 0 (the accelerated path must never be worse than a plain sync).
+func TestPullArtifacts_ConfigLoadExitContract(t *testing.T) {
+	ctx := context.Background()
+	repoRoot := t.TempDir()
+	// A directory where .campaign/artifacts.yaml must be forces a read error
+	// in artifacts.Load regardless of YAML-parser leniency.
+	if err := os.MkdirAll(filepath.Join(repoRoot, ".campaign", "artifacts.yaml"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	peerSrc := peer.FromPath("peerbox", t.TempDir())
+
+	only := NewSyncer(repoRoot, WithPeer(peerSrc), WithArtifactsOnly(true))
+	onlyRes := &SyncResult{Success: true}
+	only.pullArtifacts(ctx, onlyRes)
+	if onlyRes.Success {
+		t.Error("--artifacts-only with unreadable config: Success = true, want false")
+	}
+	if len(onlyRes.Errors) == 0 {
+		t.Error("--artifacts-only with unreadable config: no error recorded")
+	}
+
+	def := NewSyncer(repoRoot, WithPeer(peerSrc))
+	defRes := &SyncResult{Success: true}
+	def.pullArtifacts(ctx, defRes)
+	if !defRes.Success {
+		t.Error("default sync with unreadable config: Success = false, want true (degrade)")
+	}
+	if len(defRes.Warnings) == 0 {
+		t.Error("default sync with unreadable config: no warning recorded")
+	}
+}
+
+// TestVerifyArtifacts_RejectsTraversalPeer ensures a --from value that could
+// escape the snapshot tree is rejected before it is joined into a path.
+func TestVerifyArtifacts_RejectsTraversalPeer(t *testing.T) {
+	ctx := context.Background()
+	s := NewSyncer(t.TempDir(), WithVerifyArtifacts(true, "../../etc"))
+	res := &SyncResult{Success: true}
+	s.verifyArtifacts(ctx, res)
+	if res.Success {
+		t.Error("verify with a traversal peer id: Success = true, want false")
+	}
+}


### PR DESCRIPTION
## What

Class A (git content) slice of the camp-sync-clone-transport design (workitem WI-a82711, design: `workflow/design/camp-sync-clone-transport/`): move git objects between the user's own machines over the LAN/tailnet instead of round-tripping through origin, while git stays the source of truth and verifies everything on arrival.

**Stacked on #421** (parallel submodule update); merge that first. This PR's base is `sync-parallel-submodule-update`.

## Surface

```
camp sync --from studio-mac     # fetch submodule objects from that machine, then normal origin update
camp clone <url> --from studio-mac   # seed root + submodules from that machine, re-point origin, fetch delta
```

`--from` takes machine ids from `~/.obey/machines.yaml`, the same vocabulary as `camp switch machine:campaign` and `camp list --remote`.

## How

**New `internal/peer`**: resolves a transfer source from the machines file (key-auth guard, campaign root via `remote.ResolveRoot`, i.e. the far machine's own registry decides) or from a local filesystem path (mounted volume / second checkout, also the test seam). Builds peer repo URLs (`ssh://user@host/root/subpath`), a namespaced refspec (`+refs/heads/*:refs/peer/<id>/*` so fetched objects stay GC-reachable without touching origin's remote-tracking refs), and a `GIT_SSH_COMMAND` from `remote.Opts`, so every git fetch shares the machine's ControlMaster socket: ~20 submodule fetches, one ssh handshake.

**sync**: peer fetch per initialized submodule runs inside the existing parallel update workers, ahead of the origin-based update. Preflight semantics, origin URLs, post-sync validation, and the 0/1/2/3 exit contract are unchanged. Unreachable peer = per-submodule warning + origin path (degrade, never fail). Uninitialized submodules skip peer fetch silently; origin init handles them.

**clone**: root clones from the peer, then `remote set-url origin <url>`, delta fetch, `remote set-head --auto`, and checkout aligned to origin's branch tip. The final state is an origin replica regardless of how the bytes arrived (clone's contract; peer-side unpushed work is not this command's business). Submodules seed via `git -c submodule.<name>.url=<peer> submodule update`, so the per-invocation override never touches persisted config, then the module's origin remote is re-pointed to the declared URL. No origin fetch per submodule unless the recorded SHA was missing on the peer, in which case the shipped graceful-init fallback handles it. Filesystem sources add `-c protocol.file.allow=always`, matching the CVE-2022-39253 precedent in `internal/project/add.go` (camp-constructed URL, not attacker-controlled .gitmodules content). Any peer failure falls back to plain origin cloning with a warning.

## Safety invariants (from the design)

1. Class A content is git-verified on arrival: everything lands via git fetch/clone (pack indexing, ref updates, checkout by git). No raw sync of working trees or `.git` anywhere.
2. Origin remains the configured origin on every path.
3. All accelerated paths terminate in the same validation and exit-code contract as today.
4. No new credentials or listeners: ssh identity and ControlMaster from the shipped machines stack (MM0001).

## Tests

- `internal/peer`: URL construction (fs + ssh), refspec, GIT_SSH_COMMAND quoting (space-containing ControlPath).
- `internal/sync`: peer fetch brings `refs/peer/<id>/*` and objects into the local submodule; unreachable peer degrades with warning, sync still succeeds.
- `internal/clone`: peer-seeded clone ends with root origin = real URL, submodule origin = declared URL, `PeerSeeded` reported; bogus peer falls back to origin clone with warning.
- E2E: built binary; `--from` on an unregistered campaign errors clearly; plain `camp sync` byte-identical behavior.
- Full `just gate` passes (3281 tests).

## Not in this PR

Class B artifacts (declared roots + rsync engine) is the next slice; live two-machine ssh smoke belongs to the integration harness like MM0001's.