### PR TITLE
fix(sync): address parallel-update review findings from #421

### DIFF
--- a/cmd/camp/sync.go
+++ b/cmd/camp/sync.go
@@ -76,7 +76,7 @@ func init() {
 	syncCmd.Flags().BoolVarP(&syncOpts.verbose, "verbose", "v", false,
 		"Show detailed output for each submodule")
 	syncCmd.Flags().IntVarP(&syncOpts.parallel, "parallel", "p", 4,
-		"Number of parallel git operations (git serializes internally via repo lockfiles; lower this if slow disks surface transient lock errors)")
+		"Number of parallel git operations (git guards superproject ops with repo lockfiles that fail fast on contention; lower this if a slow disk surfaces transient lock errors)")
 	syncCmd.Flags().BoolVar(&syncOpts.noFetch, "no-fetch", false,
 		"Skip fetching from remote (use local refs only)")
 	syncCmd.Flags().BoolVar(&syncOpts.json, "json", false,

--- a/cmd/camp/sync.go
+++ b/cmd/camp/sync.go
@@ -76,7 +76,7 @@ func init() {
 	syncCmd.Flags().BoolVarP(&syncOpts.verbose, "verbose", "v", false,
 		"Show detailed output for each submodule")
 	syncCmd.Flags().IntVarP(&syncOpts.parallel, "parallel", "p", 4,
-		"Number of parallel git operations")
+		"Number of parallel git operations (git serializes internally via repo lockfiles; lower this if slow disks surface transient lock errors)")
 	syncCmd.Flags().BoolVar(&syncOpts.noFetch, "no-fetch", false,
 		"Skip fetching from remote (use local refs only)")
 	syncCmd.Flags().BoolVar(&syncOpts.json, "json", false,

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -224,6 +224,12 @@ func (s *Syncer) diffURLs(before, after map[string]string) []URLChange {
 // processed concurrently under a semaphore bounded by SyncOptions.Parallel,
 // mirroring the worker pattern clone uses for submodule initialization; results
 // preserve .gitmodules declaration order.
+//
+// Concurrency tradeoff (shared with clone's parallel init): each worker runs
+// superproject git commands, which git serializes internally via lockfiles.
+// Under high parallelism on slow disks that can surface transient
+// "Unable to create ...lock" failures the serial path never hit; the
+// mitigation is lowering --parallel for that campaign.
 func (s *Syncer) updateSubmodules(ctx context.Context) ([]SubmoduleResult, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
@@ -266,7 +272,7 @@ func (s *Syncer) updateSubmodules(ctx context.Context) ([]SubmoduleResult, error
 					Path:    path,
 					Name:    path,
 					Success: false,
-					Error:   ctx.Err(),
+					Error:   &SyncError{Op: "update", Submodule: path, Cause: ctx.Err()},
 				}
 				return
 			}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -226,10 +226,11 @@ func (s *Syncer) diffURLs(before, after map[string]string) []URLChange {
 // preserve .gitmodules declaration order.
 //
 // Concurrency tradeoff (shared with clone's parallel init): each worker runs
-// superproject git commands, which git serializes internally via lockfiles.
-// Under high parallelism on slow disks that can surface transient
-// "Unable to create ...lock" failures the serial path never hit; the
-// mitigation is lowering --parallel for that campaign.
+// superproject git commands, which git guards with repo lockfiles that fail
+// fast on contention rather than queueing. Under high parallelism on slow
+// disks that can surface transient "Unable to create ...lock" failures the
+// serial path never hit; the mitigation is lowering --parallel for that
+// campaign.
 func (s *Syncer) updateSubmodules(ctx context.Context) ([]SubmoduleResult, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -2,11 +2,14 @@ package sync
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSync_CleanRepo(t *testing.T) {
@@ -230,6 +233,51 @@ func TestUpdateSubmodules_PartialFailureIsolation(t *testing.T) {
 	}
 	if syncErr.Op != "init" {
 		t.Errorf("SyncError.Op = %q, want %q", syncErr.Op, "init")
+	}
+}
+
+// Mid-flight cancellation must abort promptly through the concurrent paths
+// (spawn-loop break, semaphore-wait select, in-flight git subprocesses) and
+// still honor the contract of returning (nil, context.Canceled). Six
+// submodules at parallelism 1 take well over a second of git work, so a
+// 150ms cancel reliably lands while workers are in flight; if timing ever
+// degenerates to cancel-before-entry, the assertions still hold via the
+// entry guard.
+func TestUpdateSubmodules_ContextCanceledMidFlight(t *testing.T) {
+	repoRoot := setupTestRepo(t)
+	for i := range 6 {
+		setupSubmodule(t, repoRoot, fmt.Sprintf("projects/sub%d", i))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+
+	syncer := NewSyncer(repoRoot, WithParallel(1))
+
+	type outcome struct {
+		results []SubmoduleResult
+		err     error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		results, err := syncer.updateSubmodules(ctx)
+		done <- outcome{results, err}
+	}()
+
+	select {
+	case got := <-done:
+		if !errors.Is(got.err, context.Canceled) {
+			t.Fatalf("updateSubmodules() error = %v, want context.Canceled", got.err)
+		}
+		if got.results != nil {
+			t.Errorf("updateSubmodules() results = %v, want nil on cancellation", got.results)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("updateSubmodules() did not return after cancellation")
 	}
 }
 


### PR DESCRIPTION
## What

#421 merged before its review findings landed; this follow-up addresses all three inline comments from that review (none had been applied).

1. **Semaphore-wait cancel error shape** (`internal/sync/sync.go`): the cancellation branch stored a bare `ctx.Err()` where every other `SubmoduleResult.Error` is a `*SyncError`. Dead today (results are discarded on cancel) but a shape leak if cancellation ever returns partial results. Now wrapped as `SyncError{Op: "update", Submodule: path}`.

2. **Mid-flight cancellation test**: the existing test only covered a pre-canceled context (the entry guard). The new test runs six submodules at parallelism 1 and cancels at 150ms, exercising the spawn-loop break, the semaphore-wait select, and in-flight `CommandContext` kills. Asserts prompt return (bounded by a 30s hang guard) and the `(nil, context.Canceled)` contract via `errors.Is`. If timing ever degenerates to cancel-before-entry the assertions still hold, so the test cannot flake in that direction. Ran twice consecutively plus under `-race`, all green.

3. **Lock-contention tradeoff documented**: concurrent workers run superproject git commands that git serializes via lockfiles; under high `-p` on slow disks this can surface transient lock errors the serial path never hit (the same tradeoff clone's parallel init already accepts). Now stated in the `updateSubmodules` doc comment and the `--parallel` flag help, with lowering `-p` as the mitigation. Documentation chosen over a retry loop, per the review's own primary suggestion and consistency with clone.

## Notes

Based on `main` (post-#421). Touches the same files as #422's branch in adjacent-but-different lines; whichever merges second may need a trivial rebase. Full `just gate` passes (3276 tests).