### PR TITLE
fix(scaffold): ignore campaign events by default

### DIFF
--- a/docs/campaign-directory-reference.md
+++ b/docs/campaign-directory-reference.md
@@ -78,7 +78,9 @@ Usually tool-managed; avoid hand-editing unless you are debugging:
 ### `.campaign/.gitignore`
 
 Camp scaffolds a local `.gitignore` here to keep machine-local runtime state
-out of git. It excludes items such as `state.yaml` and `cache/`.
+out of git. It excludes items such as `state.yaml`, `cache/`, and the local
+event ledger under `events/`. Running `camp init --repair` adds missing default
+rules without replacing user-authored entries.
 
 ### `.campaign/campaign.yaml`
 

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -357,6 +357,9 @@ state.yaml
 # Generated cache (navigation index, rebuilt automatically)
 cache/
 
+# Local campaign event ledger (append-only runtime history)
+events/
+
 # Tool-managed state (workitem priorities, regenerated automatically)
 settings/workitems.json
 
@@ -368,8 +371,10 @@ workitems/current.yaml
 			}
 			result.FilesCreated = append(result.FilesCreated, ".campaign/.gitignore")
 		} else if opts.Repair {
-			if err := appendGitignoreEntryIfMissing(absDir, "workitems/current.yaml"); err != nil {
-				return nil, camperrors.Wrap(err, "failed to append workitems/current.yaml to .gitignore")
+			for _, entry := range campaignGitignoreRequiredRules {
+				if err := appendGitignoreEntryIfMissing(absDir, entry); err != nil {
+					return nil, camperrors.Wrapf(err, "failed to append %s to .gitignore", entry)
+				}
 			}
 		}
 	}

--- a/internal/scaffold/repair.go
+++ b/internal/scaffold/repair.go
@@ -676,12 +676,20 @@ func computeMiscFileChanges(absDir string, plan *RepairPlan) {
 		})
 	} else if err == nil {
 		raw, readErr := os.ReadFile(gitignorePath)
-		if readErr == nil && !gitignoreHasRule(string(raw), "workitems/current.yaml") {
+		missing := make([]string, 0, len(campaignGitignoreRequiredRules))
+		if readErr == nil {
+			for _, entry := range campaignGitignoreRequiredRules {
+				if !gitignoreHasRule(string(raw), entry) {
+					missing = append(missing, entry)
+				}
+			}
+		}
+		if len(missing) > 0 {
 			plan.Changes = append(plan.Changes, RepairChange{
 				Type:        RepairModify,
 				Category:    "file",
 				Key:         ".campaign/.gitignore",
-				Description: "missing workitems/current.yaml entry",
+				Description: "missing " + strings.Join(missing, ", ") + " entries",
 			})
 		}
 	}
@@ -718,6 +726,16 @@ func computeMiscFileChanges(absDir string, plan *RepairPlan) {
 	}
 }
 
+const (
+	campaignEventsGitignoreRule  = "events/"
+	currentWorkitemGitignoreRule = "workitems/current.yaml"
+)
+
+var campaignGitignoreRequiredRules = []string{
+	campaignEventsGitignoreRule,
+	currentWorkitemGitignoreRule,
+}
+
 // appendGitignoreEntryIfMissing appends a single line to the campaign
 // .gitignore when the entry is not already present. Presence is detected
 // using gitignore-line semantics (non-comment, trimmed exact match) so a
@@ -736,9 +754,20 @@ func appendGitignoreEntryIfMissing(absDir, entry string) error {
 	if len(raw) > 0 && raw[len(raw)-1] != '\n' {
 		suffix = "\n\n"
 	}
-	addition := suffix + "# Per-machine current-workitem selection (do not share across machines)\n" + entry + "\n"
+	addition := suffix + campaignGitignoreRuleComment(entry) + "\n" + entry + "\n"
 	// TODO(seq06-lock): concurrent repair runs can still race this read-modify-write append.
 	return fsutil.WriteFileAtomically(gitignorePath, append(raw, []byte(addition)...), 0o644)
+}
+
+func campaignGitignoreRuleComment(entry string) string {
+	switch entry {
+	case campaignEventsGitignoreRule:
+		return "# Local campaign event ledger (append-only runtime history)"
+	case currentWorkitemGitignoreRule:
+		return "# Per-machine current-workitem selection (do not share across machines)"
+	default:
+		return "# Machine-local campaign state"
+	}
 }
 
 // gitignoreHasRule reports whether content contains an active gitignore

--- a/internal/scaffold/repair_test.go
+++ b/internal/scaffold/repair_test.go
@@ -278,7 +278,7 @@ func TestComputeMiscFileChanges_FilesExist(t *testing.T) {
 
 	// Create the files
 	gitignorePath := filepath.Join(dir, config.CampaignDir, ".gitignore")
-	if err := os.WriteFile(gitignorePath, []byte("state.yaml\nworkitems/current.yaml\n"), 0644); err != nil {
+	if err := os.WriteFile(gitignorePath, []byte("state.yaml\nevents/\nworkitems/current.yaml\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	rootGitignorePath := filepath.Join(dir, ".gitignore")

--- a/tests/integration/repair_test.go
+++ b/tests/integration/repair_test.go
@@ -157,7 +157,7 @@ func TestInitRepair_PreservesUserShortcuts(t *testing.T) {
 	assert.Contains(t, output, path+"/my-stuff")
 }
 
-func TestIntegration_Init_GitignoreCurrentYaml(t *testing.T) {
+func TestIntegration_Init_GitignoreLocalState(t *testing.T) {
 	tc := GetSharedContainer(t)
 	path := setupRepairCampaign(t, tc, "init-gitignore-current")
 
@@ -165,6 +165,8 @@ func TestIntegration_Init_GitignoreCurrentYaml(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, gi, "workitems/current.yaml",
 		"camp init must seed .campaign/.gitignore with workitems/current.yaml: %s", gi)
+	assert.Contains(t, gi, "events/",
+		"camp init must seed .campaign/.gitignore with events/: %s", gi)
 }
 
 func TestIntegration_InitRepair_AppendsCurrentYamlIfMissing(t *testing.T) {
@@ -183,6 +185,23 @@ func TestIntegration_InitRepair_AppendsCurrentYamlIfMissing(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, after, "workitems/current.yaml",
 		"repair must append workitems/current.yaml when missing")
+}
+
+func TestIntegration_InitRepair_AppendsEventsIfMissing(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRepairCampaign(t, tc, "repair-gitignore-events")
+
+	gi, err := tc.ReadFile(path + "/.campaign/.gitignore")
+	require.NoError(t, err)
+	stripped := strings.ReplaceAll(gi, "events/\n", "")
+	require.NotEqual(t, gi, stripped, "fixture must have the events rule so we can remove it")
+	require.NoError(t, tc.WriteFile(path+"/.campaign/.gitignore", stripped))
+
+	runRepair(t, tc, path)
+
+	after, err := tc.ReadFile(path + "/.campaign/.gitignore")
+	require.NoError(t, err)
+	assert.Contains(t, after, "events/", "repair must append events/ when missing")
 }
 
 func TestIntegration_InitRepair_AppendsCurrentYamlWhenCommentedOut(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `events/` to the scaffolded `.campaign/.gitignore`
- make `camp init --repair` append the rule to existing campaigns without replacing user entries
- document the local event-ledger behavior and cover init/repair in the container harness

## Why

Campaign event shards are generated runtime history under `.campaign/events/`. New and repaired campaigns should ignore those local files by default instead of surfacing them as repository changes.

## Validation

- stable and dev builds
- `just lint` (0 new issues)
- pure gitignore rule test
- container integration tests for new init, missing `events/`, missing `workitems/current.yaml`, and commented current-workitem rules