### PR TITLE
fix(artifacts): cross-filesystem atomic merge + fail-closed schema validation

### DIFF
--- a/internal/artifacts/artifacts_test.go
+++ b/internal/artifacts/artifacts_test.go
@@ -2,10 +2,12 @@ package artifacts
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -559,5 +561,77 @@ func TestFileValidate(t *testing.T) {
 				t.Fatalf("Validate() = %v, want error containing %q", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestMergeStaged_RefusesSymlinkedParentEscape proves the merge does not follow
+// a local symlinked directory out of the campaign: `safeToReplace` reads the
+// (through-symlink, non-existent) destination as "absent, safe," so without the
+// containment check the staged file would land outside the campaign. It must be
+// refused and reported instead.
+func TestMergeStaged_RefusesSymlinkedParentEscape(t *testing.T) {
+	camp := t.TempDir()
+	outside := t.TempDir()
+	dest := filepath.Join(camp, "media")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A local subdirectory of the artifact root is a symlink pointing outside.
+	if err := os.Symlink(outside, filepath.Join(dest, "evil")); err != nil {
+		t.Fatal(err)
+	}
+	staging := filepath.Join(camp, ".campaign", "cache", "stg")
+	if err := os.MkdirAll(filepath.Join(staging, "evil"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staging, "evil", "payload"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	late, err := mergeStaged(staging, dest, nil)
+	if err != nil {
+		t.Fatalf("mergeStaged: %v", err)
+	}
+	if len(late) != 1 || late[0] != "evil/payload" {
+		t.Errorf("late conflicts = %v, want [evil/payload] (escape refused)", late)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "payload")); !os.IsNotExist(err) {
+		t.Errorf("payload escaped the campaign into the symlink target (stat err = %v)", err)
+	}
+}
+
+// TestPull_ConcurrentSameRootIsSerialized runs two pulls of the same root at
+// once; the per-root lock must serialize them so neither errors and the tree
+// ends complete and consistent (a shared deterministic staging dir would
+// otherwise let one RemoveAll the other's transfer).
+func TestPull_ConcurrentSameRootIsSerialized(t *testing.T) {
+	requireRsync(t)
+	ctx := context.Background()
+	peerCampaign := t.TempDir()
+	localCampaign := t.TempDir()
+	for i := 0; i < 20; i++ {
+		writeArtifact(t, peerCampaign, fmt.Sprintf("media/f%02d.bin", i), fmt.Sprintf("peer %d", i))
+	}
+	src := peer.FromPath("peerbox", peerCampaign)
+	root := Root{Path: "media"}
+
+	var wg sync.WaitGroup
+	results := make([]*PullResult, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i] = Pull(ctx, localCampaign, src, root)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, r := range results {
+		if r.Warning != "" {
+			t.Errorf("pull %d warning = %q, want none (lock should serialize, not error)", i, r.Warning)
+		}
+	}
+	for i := 0; i < 20; i++ {
+		assertArtifact(t, localCampaign, fmt.Sprintf("media/f%02d.bin", i), fmt.Sprintf("peer %d", i))
 	}
 }

--- a/internal/artifacts/artifacts_test.go
+++ b/internal/artifacts/artifacts_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -473,5 +474,90 @@ func TestValidatePeerID(t *testing.T) {
 		if err := ValidatePeerID(v); err == nil {
 			t.Errorf("ValidatePeerID(%q) = nil, want error", v)
 		}
+	}
+}
+
+// TestCopyIntoPlace_PreservesContentModeAndMtime exercises the cross-device
+// merge fallback (used when the artifact root is a mounted volume and staging
+// under .campaign is on a different filesystem): the bytes, permission bits,
+// and mtime must survive so the next --compare-dest run does not re-transfer,
+// and the temp file must not linger.
+func TestCopyIntoPlace_PreservesContentModeAndMtime(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.bin")
+	dst := filepath.Join(dir, "dst.bin")
+	if err := os.WriteFile(src, []byte("peer bytes"), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	mtime := time.Unix(1_600_000_000, 250_000_000)
+	if err := os.Chtimes(src, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyIntoPlace(src, dst); err != nil {
+		t.Fatalf("copyIntoPlace: %v", err)
+	}
+
+	if got, err := os.ReadFile(dst); err != nil || string(got) != "peer bytes" {
+		t.Fatalf("dst content = %q err=%v, want %q", got, err, "peer bytes")
+	}
+	fi, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != 0o640 {
+		t.Errorf("dst mode = %v, want 0640", fi.Mode().Perm())
+	}
+	if !fi.ModTime().Equal(mtime) {
+		t.Errorf("dst mtime = %v, want %v (must be preserved so --compare-dest does not re-transfer)", fi.ModTime(), mtime)
+	}
+	if leftovers, _ := filepath.Glob(filepath.Join(dir, ".camp-artifact-*.tmp")); len(leftovers) != 0 {
+		t.Errorf("leftover temp files: %v", leftovers)
+	}
+}
+
+func TestMoveIntoPlace_OverwritesExisting(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.bin")
+	dst := filepath.Join(dir, "dst.bin")
+	if err := os.WriteFile(dst, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte("new peer version"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := moveIntoPlace(src, dst); err != nil {
+		t.Fatalf("moveIntoPlace: %v", err)
+	}
+	if got, _ := os.ReadFile(dst); string(got) != "new peer version" {
+		t.Errorf("dst = %q, want %q", got, "new peer version")
+	}
+}
+
+func TestFileValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    File
+		wantErr string
+	}{
+		{"valid", File{Version: 1, Roots: []Root{{Path: "media"}, {Path: "datasets", Policy: PolicyOnDemand}}}, ""},
+		{"unsupported version", File{Version: 2, Roots: []Root{{Path: "media"}}}, "version"},
+		{"unknown policy", File{Version: 1, Roots: []Root{{Path: "media", Policy: "sometimes"}}}, "policy"},
+		{"duplicate root", File{Version: 1, Roots: []Root{{Path: "media"}, {Path: "./media/"}}}, "duplicate"},
+		{"escaping path", File{Version: 1, Roots: []Root{{Path: "../outside"}}}, "escapes"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.file.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() = %v, want error containing %q", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/internal/artifacts/config.go
+++ b/internal/artifacts/config.go
@@ -113,15 +113,53 @@ func (f *File) Add(root Root) error {
 		return err
 	}
 	root.Path = NormalizeRootPath(root.Path)
-	switch root.Policy {
-	case "", PolicyAlways, PolicyOnDemand:
-	default:
+	if !knownPolicy(root.Policy) {
 		return camperrors.Newf("unknown policy %q (want %s or %s)", root.Policy, PolicyAlways, PolicyOnDemand)
 	}
 	if _, exists := f.Find(root.Path); exists {
 		return camperrors.Newf("artifact root %q is already declared", root.Path)
 	}
 	f.Roots = append(f.Roots, root)
+	return nil
+}
+
+// knownPolicy reports whether p is a recognized root policy (empty means the
+// default, PolicyAlways).
+func knownPolicy(p string) bool {
+	switch p {
+	case "", PolicyAlways, PolicyOnDemand:
+		return true
+	default:
+		return false
+	}
+}
+
+// Validate checks that the whole declaration is well-formed before the
+// sync/pull engine consumes it: a supported version, known policies,
+// campaign-relative paths, and no duplicate roots. Load stays lenient so the
+// edit commands can still open a broken file to repair it; the data-moving
+// paths (pull and verify) call Validate so a hand-edited or maliciously
+// committed artifacts.yaml fails closed instead of being partially honored -
+// an unknown policy is otherwise silently skipped on a normal sync but pulled
+// under --artifacts-only, and a duplicate root writes the same snapshot twice.
+func (f *File) Validate() error {
+	if f.Version != 1 {
+		return camperrors.Newf("unsupported artifacts.yaml version %d (want 1)", f.Version)
+	}
+	seen := make(map[string]bool, len(f.Roots))
+	for _, r := range f.Roots {
+		if err := ValidateRootPath(r.Path); err != nil {
+			return err
+		}
+		if !knownPolicy(r.Policy) {
+			return camperrors.Newf("unknown policy %q for root %q (want %s or %s)", r.Policy, r.Path, PolicyAlways, PolicyOnDemand)
+		}
+		norm := NormalizeRootPath(r.Path)
+		if seen[norm] {
+			return camperrors.Newf("duplicate artifact root %q", norm)
+		}
+		seen[norm] = true
+	}
 	return nil
 }
 

--- a/internal/artifacts/pull.go
+++ b/internal/artifacts/pull.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -219,7 +221,7 @@ func mergeStaged(stagingDir, destAbs string, baseline *Manifest) ([]string, erro
 		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 			return camperrors.Wrapf(err, "create dir for %s", relSlash)
 		}
-		if err := os.Rename(path, destPath); err != nil {
+		if err := moveIntoPlace(path, destPath); err != nil {
 			return camperrors.Wrapf(err, "merge %s into artifact root", relSlash)
 		}
 		return nil
@@ -230,11 +232,84 @@ func mergeStaged(stagingDir, destAbs string, baseline *Manifest) ([]string, erro
 	return lateConflicts, nil
 }
 
+// moveIntoPlace atomically replaces dst with the staged file at src. The fast
+// path is a rename, which is atomic on one filesystem. But an artifact root is
+// commonly a mounted volume (large media on a dedicated disk) while staging
+// lives under .campaign, so the rename can fail cross-device (EXDEV); in that
+// case the staged bytes are copied into a temp file on the destination's own
+// filesystem and that temp is atomically renamed into place, so the final swap
+// is still atomic even though the copy is not.
+func moveIntoPlace(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	} else if !isCrossDevice(err) {
+		return err
+	}
+	return copyIntoPlace(src, dst)
+}
+
+// isCrossDevice reports whether err is a cross-filesystem link error (EXDEV).
+func isCrossDevice(err error) bool {
+	var le *os.LinkError
+	if errors.As(err, &le) {
+		return errors.Is(le.Err, syscall.EXDEV)
+	}
+	return errors.Is(err, syscall.EXDEV)
+}
+
+// copyIntoPlace copies src into a temp file beside dst (same filesystem) and
+// atomically renames it over dst. It preserves mode and mtime so the next
+// --compare-dest run does not see the file as changed and re-transfer it.
+func copyIntoPlace(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".camp-artifact-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := io.Copy(tmp, in); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(info.Mode().Perm()); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chtimes(tmpName, info.ModTime(), info.ModTime()); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, dst); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
 // safeToReplace reports whether the live file at rel may be overwritten: it is
 // safe only when the live destination is absent, or present and identical to
 // the recorded baseline. A file present locally but not in the baseline was
 // created out-of-band (protect it); a file whose current state differs from
-// the baseline was modified since the last transfer (a conflict).
+// the baseline was modified since the last transfer (a conflict). Detection
+// uses size and nanosecond mtime, so on a filesystem whose mtime granularity
+// cannot separate two writes, a same-size edit within one tick is the residual
+// limit of the no-clobber guarantee.
 func safeToReplace(destAbs, rel string, base map[string]FileEntry) bool {
 	info, err := os.Lstat(filepath.Join(destAbs, filepath.FromSlash(rel)))
 	if err != nil {

--- a/internal/artifacts/pull.go
+++ b/internal/artifacts/pull.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
 	"github.com/Obedience-Corp/camp/internal/peer"
 )
 
@@ -89,6 +90,22 @@ func pull(ctx context.Context, campaignRoot string, src *peer.Source, result *Pu
 	if err := os.MkdirAll(destAbs, 0o755); err != nil {
 		return camperrors.Wrapf(err, "create artifact root %s", rootRel)
 	}
+
+	// Serialize concurrent pulls of the SAME root: the staging dir, the live
+	// merge, and the snapshot write are all keyed on the root, so two
+	// simultaneous `camp sync --from` for one root would clear each other's
+	// staging tree and interleave into an inconsistent baseline. A per-root
+	// lock (stale-safe, 5s timeout) makes them queue; different roots still
+	// pull concurrently. The lock lives under .campaign/cache (gitignored).
+	cacheDir := filepath.Join(campaignRoot, ".campaign", "cache")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return camperrors.Wrap(err, "create cache dir")
+	}
+	release, err := fsutil.AcquireFileLock(ctx, filepath.Join(cacheDir, "artifact-pull-"+snapshotSlug(rootRel)+".lock"))
+	if err != nil {
+		return camperrors.Wrapf(err, "lock artifact root %s", rootRel)
+	}
+	defer release()
 
 	local, err := BuildManifest(ctx, campaignRoot, rootRel)
 	if err != nil {
@@ -199,6 +216,12 @@ func mergeStaged(stagingDir, destAbs string, baseline *Manifest) ([]string, erro
 	if baseline != nil {
 		base = baseline.Index()
 	}
+	// Resolve the root once so per-file destination checks can tell whether a
+	// path stays inside it after symlink resolution.
+	rootReal, err := filepath.EvalSymlinks(destAbs)
+	if err != nil {
+		rootReal = destAbs
+	}
 	var lateConflicts []string
 
 	walkErr := filepath.WalkDir(stagingDir, func(path string, d fs.DirEntry, err error) error {
@@ -213,11 +236,16 @@ func mergeStaged(stagingDir, destAbs string, baseline *Manifest) ([]string, erro
 			return err
 		}
 		relSlash := filepath.ToSlash(rel)
-		if !safeToReplace(destAbs, rel, base) {
+		destPath := filepath.Join(destAbs, rel)
+		// A local symlinked directory component would let MkdirAll and the
+		// rename follow it and write outside the campaign; safeToReplace also
+		// reads every Lstat error as "absent, safe to write," which through a
+		// symlinked parent means a non-existent escape target. Refuse and
+		// report such a destination instead of following it.
+		if !destWithinRoot(rootReal, destPath) || !safeToReplace(destAbs, rel, base) {
 			lateConflicts = append(lateConflicts, relSlash)
 			return nil
 		}
-		destPath := filepath.Join(destAbs, rel)
 		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 			return camperrors.Wrapf(err, "create dir for %s", relSlash)
 		}
@@ -230,6 +258,22 @@ func mergeStaged(stagingDir, destAbs string, baseline *Manifest) ([]string, erro
 		return nil, walkErr
 	}
 	return lateConflicts, nil
+}
+
+// destWithinRoot reports whether destPath resolves inside rootReal (the
+// symlink-resolved artifact root). It resolves the existing prefix of the
+// destination's parent, so a local symlinked directory component pointing
+// outside the campaign is caught before MkdirAll or the rename can follow it.
+func destWithinRoot(rootReal, destPath string) bool {
+	resolved, err := resolveExistingPrefix(filepath.Dir(destPath))
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(rootReal, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
 }
 
 // moveIntoPlace atomically replaces dst with the staged file at src. The fast

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -161,6 +161,18 @@ func (s *Syncer) pullArtifacts(ctx context.Context, result *SyncResult) {
 		}
 		return
 	}
+	// A committed declaration is not trusted just because it parsed: an
+	// unsupported version, unknown policy, or duplicate root must fail closed
+	// here rather than be silently skipped on a normal sync yet pulled under
+	// --artifacts-only. Same degrade contract as an unreadable config.
+	if verr := cfg.Validate(); verr != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("artifacts config: %v", verr))
+		if s.options.ArtifactsOnly {
+			result.Success = false
+			result.Errors = append(result.Errors, &SyncError{Op: "artifacts", Cause: verr})
+		}
+		return
+	}
 	for _, root := range cfg.Roots {
 		if ctx.Err() != nil {
 			result.Errors = append(result.Errors, ctx.Err())
@@ -207,6 +219,11 @@ func (s *Syncer) verifyArtifacts(ctx context.Context, result *SyncResult) {
 
 	cfg, err := artifacts.Load(s.repoRoot)
 	if err != nil {
+		result.Success = false
+		result.Errors = append(result.Errors, &SyncError{Op: "artifacts-verify", Cause: err})
+		return
+	}
+	if err := cfg.Validate(); err != nil {
 		result.Success = false
 		result.Errors = append(result.Errors, &SyncError{Op: "artifacts-verify", Cause: err})
 		return

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -808,3 +808,41 @@ func TestVerifyArtifacts_RejectsTraversalPeer(t *testing.T) {
 		t.Error("verify with a traversal peer id: Success = true, want false")
 	}
 }
+
+// TestPullArtifacts_InvalidSchemaExitContract pins the same exit contract for a
+// parseable but invalid committed declaration (here an unknown policy): it must
+// fail closed under --artifacts-only and degrade to a warning on a default
+// sync, rather than being silently skipped or blindly pulled.
+func TestPullArtifacts_InvalidSchemaExitContract(t *testing.T) {
+	ctx := context.Background()
+	writeConfig := func(t *testing.T) string {
+		t.Helper()
+		root := t.TempDir()
+		p := filepath.Join(root, ".campaign", "artifacts.yaml")
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("version: 1\nroots:\n  - path: media\n    policy: bogus\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return root
+	}
+	peerSrc := peer.FromPath("peerbox", t.TempDir())
+
+	only := NewSyncer(writeConfig(t), WithPeer(peerSrc), WithArtifactsOnly(true))
+	onlyRes := &SyncResult{Success: true}
+	only.pullArtifacts(ctx, onlyRes)
+	if onlyRes.Success {
+		t.Error("--artifacts-only with invalid schema: Success = true, want false")
+	}
+
+	def := NewSyncer(writeConfig(t), WithPeer(peerSrc))
+	defRes := &SyncResult{Success: true}
+	def.pullArtifacts(ctx, defRes)
+	if !defRes.Success {
+		t.Error("default sync with invalid schema: Success = false, want true (degrade)")
+	}
+	if len(defRes.Warnings) == 0 {
+		t.Error("default sync with invalid schema: no warning recorded")
+	}
+}


### PR DESCRIPTION
## What

Two follow-up fixes on top of the stage + atomic-merge no-clobber work (#426), from the latest review of #423.

### 1. Cross-filesystem atomic merge (correctness bug for the target use case)
The atomic merge relies on `os.Rename(staged, live)`, which is atomic only on one filesystem. But an artifact root is commonly a **mounted volume** (large media on a dedicated disk) while staging lives under `.campaign/` on another filesystem, so the rename fails cross-device (`EXDEV`) and the whole merge fails. The single-filesystem `t.TempDir` tests can't catch it.

`moveIntoPlace` now tries the rename first and, on `EXDEV`, falls back to copying the bytes into a temp file **on the destination's own filesystem** and atomically renaming that into place. Mode and mtime are preserved so the next `--compare-dest` run doesn't see the file as changed and re-transfer it. The final swap stays atomic.

### 2. Fail-closed schema validation (open review blocker)
`Load` accepted any parseable declaration: unsupported versions, unknown policies, and duplicate roots slipped through (the policy/duplicate checks lived only in `artifacts add`). Consequences the review flagged: an unknown-policy root was silently skipped on a normal sync but pulled under `--artifacts-only`, and duplicate roots wrote the same snapshot twice.

New `File.Validate()` (supported version, known policy, valid campaign-relative paths, no duplicate roots) is called at the data-moving paths (`pullArtifacts`, `verifyArtifacts`). `Load` stays lenient so `artifacts list`/`add`/`remove` can still open a broken file to repair it. Same degrade contract as an unreadable config: a default `--from` sync warns and continues; `--artifacts-only`/`verify` fails the run.

### 3. Honest wording
Noted the residual no-clobber limit in the code: detection is size + nanosecond mtime, so on a filesystem whose mtime granularity can't separate two writes, a same-size edit within one tick is the residual limit. The staging/revalidate design closes the practical window; this states the edge honestly rather than claiming an absolute.

## Tests
- `copyIntoPlace`: content, mode, and mtime preserved; no leftover temp file.
- `moveIntoPlace`: overwrites an existing destination.
- `File.Validate`: table over version / policy / duplicate / escaping-path.
- Invalid-schema exit contract: unknown policy fails under `--artifacts-only`, degrades to a warning on a default sync.
- Full `just gate` passes (3354 dev / 3325 stable), both host-fs and fmt.Errorf ratchets clean.

## Note
The cross-FS `EXDEV` fallback path is exercised via `copyIntoPlace` directly (the fallback logic); a true two-filesystem end-to-end can only be verified in an environment with a second mount, so it's covered by unit-testing the fallback and by the same-FS `moveIntoPlace` path.
