### PR TITLE
test(integration): loopback-ssh smoke coverage for peer transports (+ rsync secluded-args fix)

### DIFF
--- a/internal/artifacts/pull.go
+++ b/internal/artifacts/pull.go
@@ -147,11 +147,8 @@ func pull(ctx context.Context, campaignRoot string, src *peer.Source, result *Pu
 	}
 	defer func() { _ = os.RemoveAll(stagingDir) }()
 
-	// -s (--secluded-args) transmits each path over the rsync protocol without
-	// a remote shell parsing it, so a peer.RsyncSpec path with spaces or shell
-	// metacharacters is safe unquoted. It also matches what rsync 3.2.4+ does by
-	// default; passing it explicitly keeps 3.0-3.2.3 correct for spaced roots
-	// too. (The remote path must therefore NOT be pre-quoted; see RsyncSpec.)
+	// Send paths through rsync's protocol so spaces and shell metacharacters do
+	// not depend on remote-shell parsing.
 	args := []string{"-a", "-s", "--no-links", "--compare-dest=" + destAbs}
 	if sshCmd := src.SSHCommand(); sshCmd != "" {
 		args = append(args, "-e", sshCmd)

--- a/internal/artifacts/pull.go
+++ b/internal/artifacts/pull.go
@@ -147,7 +147,12 @@ func pull(ctx context.Context, campaignRoot string, src *peer.Source, result *Pu
 	}
 	defer func() { _ = os.RemoveAll(stagingDir) }()
 
-	args := []string{"-a", "--no-links", "--compare-dest=" + destAbs}
+	// -s (--secluded-args) transmits each path over the rsync protocol without
+	// a remote shell parsing it, so a peer.RsyncSpec path with spaces or shell
+	// metacharacters is safe unquoted. It also matches what rsync 3.2.4+ does by
+	// default; passing it explicitly keeps 3.0-3.2.3 correct for spaced roots
+	// too. (The remote path must therefore NOT be pre-quoted; see RsyncSpec.)
+	args := []string{"-a", "-s", "--no-links", "--compare-dest=" + destAbs}
 	if sshCmd := src.SSHCommand(); sshCmd != "" {
 		args = append(args, "-e", sshCmd)
 	}

--- a/internal/peer/peer.go
+++ b/internal/peer/peer.go
@@ -149,20 +149,27 @@ func (s *Source) GitEnv() []string {
 // the peer's campaign root, with a trailing slash so rsync copies contents
 // into the destination directory rather than nesting it.
 //
-// For an ssh source the path after "host:" is handed to the peer's remote
-// login shell, so it is single-quoted: a legitimate media root with a space
-// ("Final Renders/") would otherwise be split into two source arguments, and
-// shell metacharacters in a committed artifacts.yaml path would be
-// interpreted remotely. The trailing slash stays outside the quotes so the
-// local side still sees a copy-contents (not copy-dir) source. Filesystem
-// sources are passed to rsync as a local argv element (no shell), so they are
-// returned unquoted.
+// The remote path is NOT shell-quoted. rsync 3.2.4+ defaults to secluded
+// (protected) args and no longer hands the remote path to a login shell, so a
+// caller-added quote is taken literally: `host:'/media'/` makes the remote
+// side look for a directory whose name begins with a single quote and fails
+// with change_dir(2). Spaces and shell metacharacters in a committed
+// artifacts.yaml path ("Final Renders/") are instead kept safe by the
+// -s/--secluded-args flag the artifact pull passes, which transmits each arg
+// over the rsync protocol with no shell parsing on either end. The trailing
+// slash keeps this a copy-contents (not copy-dir) source. Filesystem sources
+// are a local argv element (no shell) and are likewise returned unquoted.
+//
+// Tradeoff: -s and this unquoted form require rsync >= 3.0.0 on both ends
+// (2008; every current Homebrew/Linux build). rsync 2.6.9, the ancient Apple
+// bundle, would need the old shell-quoted form instead; version-adaptive
+// quoting is the deferred rsync/openrsync probing work, not this path.
 func (s *Source) RsyncSpec(relPath string) string {
 	p := path.Join(s.root, relPath)
 	if s.target == "" {
 		return p + "/"
 	}
-	return s.target + ":" + remote.ShellQuote(p) + "/"
+	return s.target + ":" + p + "/"
 }
 
 // Fetch fetches heads and HEAD from the peer copy of the repository at

--- a/internal/peer/peer.go
+++ b/internal/peer/peer.go
@@ -149,21 +149,10 @@ func (s *Source) GitEnv() []string {
 // the peer's campaign root, with a trailing slash so rsync copies contents
 // into the destination directory rather than nesting it.
 //
-// The remote path is NOT shell-quoted. rsync 3.2.4+ defaults to secluded
-// (protected) args and no longer hands the remote path to a login shell, so a
-// caller-added quote is taken literally: `host:'/media'/` makes the remote
-// side look for a directory whose name begins with a single quote and fails
-// with change_dir(2). Spaces and shell metacharacters in a committed
-// artifacts.yaml path ("Final Renders/") are instead kept safe by the
-// -s/--secluded-args flag the artifact pull passes, which transmits each arg
-// over the rsync protocol with no shell parsing on either end. The trailing
-// slash keeps this a copy-contents (not copy-dir) source. Filesystem sources
-// are a local argv element (no shell) and are likewise returned unquoted.
-//
-// Tradeoff: -s and this unquoted form require rsync >= 3.0.0 on both ends
-// (2008; every current Homebrew/Linux build). rsync 2.6.9, the ancient Apple
-// bundle, would need the old shell-quoted form instead; version-adaptive
-// quoting is the deferred rsync/openrsync probing work, not this path.
+// The remote path is intentionally unquoted. rsync 3.2.4 added shell escaping
+// that treats caller-added quotes literally; artifact pulls pass -s so the path
+// is sent through the rsync protocol instead. This requires rsync >= 3.0.0 on
+// both ends. The trailing slash keeps this a copy-contents source.
 func (s *Source) RsyncSpec(relPath string) string {
 	p := path.Join(s.root, relPath)
 	if s.target == "" {

--- a/internal/peer/peer_test.go
+++ b/internal/peer/peer_test.go
@@ -97,10 +97,6 @@ func TestSourceRsyncSpec(t *testing.T) {
 			want:    "/Volumes/backup/campaign/media/renders/",
 		},
 		{
-			// The remote path is unquoted: rsync 3.2.4+ protects args itself
-			// (no remote shell), so a caller quote would be taken literally.
-			// The pull's -s/--secluded-args flag is what keeps spaces and
-			// metacharacters safe over the wire.
 			name:    "ssh source leaves the remote path unquoted",
 			source:  &Source{root: "/home/me/campaign", target: "me@studio"},
 			relPath: "media/renders",

--- a/internal/peer/peer_test.go
+++ b/internal/peer/peer_test.go
@@ -97,22 +97,26 @@ func TestSourceRsyncSpec(t *testing.T) {
 			want:    "/Volumes/backup/campaign/media/renders/",
 		},
 		{
-			name:    "ssh source single-quotes the remote path",
+			// The remote path is unquoted: rsync 3.2.4+ protects args itself
+			// (no remote shell), so a caller quote would be taken literally.
+			// The pull's -s/--secluded-args flag is what keeps spaces and
+			// metacharacters safe over the wire.
+			name:    "ssh source leaves the remote path unquoted",
 			source:  &Source{root: "/home/me/campaign", target: "me@studio"},
 			relPath: "media/renders",
-			want:    "me@studio:'/home/me/campaign/media/renders'/",
+			want:    "me@studio:/home/me/campaign/media/renders/",
 		},
 		{
-			name:    "space in an ssh remote path stays one argument",
+			name:    "space in an ssh remote path stays unquoted (protected by -s)",
 			source:  &Source{root: "/home/me/campaign", target: "me@studio"},
 			relPath: "Final Renders",
-			want:    "me@studio:'/home/me/campaign/Final Renders'/",
+			want:    "me@studio:/home/me/campaign/Final Renders/",
 		},
 		{
-			name:    "shell metacharacters in an ssh remote path are neutralized",
+			name:    "shell metacharacters in an ssh remote path stay unquoted (protected by -s)",
 			source:  &Source{root: "/root", target: "me@studio"},
 			relPath: "a; rm -rf ~",
-			want:    "me@studio:'/root/a; rm -rf ~'/",
+			want:    "me@studio:/root/a; rm -rf ~/",
 		},
 	}
 	for _, tt := range tests {

--- a/tests/integration/artifacts_from_ssh_test.go
+++ b/tests/integration/artifacts_from_ssh_test.go
@@ -5,102 +5,72 @@ package integration
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// TestArtifactsPullOverSSH_TransfersAndProtects drives `camp sync
-// --artifacts-only --from self` end to end over a real loopback ssh hop and
-// proves the two guarantees the unit tests cannot reach (they build a
-// filesystem peer.Source and never dial ssh, so rsync-over-ssh, the ssh
-// GIT_SSH_COMMAND wiring, and a genuine source!=dest transfer are all
-// unexercised there):
-//
-//  1. Bytes actually move: declared artifact files present only on the peer
-//     arrive in the local root, transferred by rsync over the same ssh options
-//     the rest of the peer stack uses.
-//  2. No-clobber holds across a divergent second pull: a file the local user
-//     edited after the last transfer is protected (kept local), while a file
-//     that still matches the recorded baseline is updated to the peer's copy.
-//
-// The peer is an unprivileged `peer` login user with its own HOME and camp
-// registry, so the campaign name resolves to a different root on each end;
-// root's local checkout is the pull destination.
+// TestArtifactsPullOverSSH_TransfersAndProtects verifies SSH artifact transfer,
+// including a spaced root and no-clobber behavior.
 func TestArtifactsPullOverSSH_TransfersAndProtects(t *testing.T) {
 	tc := GetSharedContainer(t)
 	ensurePeerAccount(t, tc)
 	registerLoopbackMachine(t, tc)
 
-	const name = "media-camp"
+	const (
+		name         = "media-camp"
+		artifactRoot = "Final Renders"
+	)
 	peerRoot := peerCampaignsDir + "/" + name
 	localRoot := "/campaigns/" + name
+	peerArtifactRoot := shQuote(peerRoot + "/" + artifactRoot)
+	localArtifactRoot := localRoot + "/" + artifactRoot
 
-	// --- Peer side: a same-named campaign holding the source artifacts, in
-	// PEER's registry so `camp switch <name> --print` over ssh resolves it.
 	peerSSH(t, tc, fmt.Sprintf(`
 set -e
 camp create %[1]s -d 'artifact source' -m 'hold media' --no-git --path %[2]s
-mkdir -p %[3]s/media
-printf 'ALPHA-v1' > %[3]s/media/alpha.bin
-printf 'BETA-v1'  > %[3]s/media/beta.bin
-`, name, peerCampaignsDir, peerRoot))
+mkdir -p %[3]s
+printf 'ALPHA-v1' > %[3]s/alpha.bin
+printf 'BETA-v1'  > %[3]s/beta.bin
+`, name, peerCampaignsDir, peerArtifactRoot))
 
-	// --- Local side: the same-named campaign (root's registry) that declares
-	// `media` as an artifact root. Its media dir starts empty, so the first
-	// pull is a pure arrival.
 	createOut, err := tc.RunCamp("create", name,
 		"-d", "artifact dest", "-m", "pull media", "--path", "/campaigns")
 	require.NoError(t, err, "local camp create failed: %s", createOut)
-	addOut, err := tc.RunCampInDir(localRoot, "artifacts", "add", "media")
+	addOut, err := tc.RunCampInDir(localRoot, "artifacts", "add", artifactRoot)
 	require.NoError(t, err, "artifacts add failed: %s", addOut)
 
-	// --- Pull #1: first sync. Both files are new locally, so both transfer;
-	// there is no baseline yet, so nothing is protected.
 	out1, err := tc.RunCampInDir(localRoot, "sync", "--artifacts-only", "--from", loopbackMachineID)
 	require.NoError(t, err, "first artifact sync failed: %s", out1)
 	require.Contains(t, out1, "first sync", "first pull should report first-sync semantics: %s", out1)
 
-	requireFileContent(t, tc, localRoot+"/media/alpha.bin", "ALPHA-v1")
-	requireFileContent(t, tc, localRoot+"/media/beta.bin", "BETA-v1")
+	requireFileContent(t, tc, localArtifactRoot+"/alpha.bin", "ALPHA-v1")
+	requireFileContent(t, tc, localArtifactRoot+"/beta.bin", "BETA-v1")
 
-	// A baseline snapshot for this peer+root must be recorded so the next pull
-	// can tell a local edit from a stale copy. Root "media" slugs to "media".
-	snapshot := localRoot + "/.campaign/cache/peersync/" + loopbackMachineID + "/media.json"
+	snapshot := localRoot + "/.campaign/cache/peersync/" + loopbackMachineID + "/" + artifactRoot + ".json"
 	exists, err := tc.CheckFileExists(snapshot)
 	require.NoError(t, err)
 	require.True(t, exists, "peer snapshot %s should exist after first sync", snapshot)
 
-	// --- Diverge: the peer advances both files; locally the user edits alpha
-	// (so it no longer matches the baseline) but leaves beta at the synced
-	// bytes. Sizes are distinct so conflict detection is unambiguous even where
-	// the filesystem's mtime granularity is coarse.
 	peerSSH(t, tc, fmt.Sprintf(`
 set -e
-printf 'ALPHA-PEER-V2'       > %[1]s/media/alpha.bin
-printf 'BETA-PEER-V2-LONGER' > %[1]s/media/beta.bin
-`, peerRoot))
-	require.NoError(t, tc.WriteFile(localRoot+"/media/alpha.bin", "ALPHA-LOCAL-EDIT"))
+printf 'ALPHA-PEER-V2'       > %[1]s/alpha.bin
+printf 'BETA-PEER-V2-LONGER' > %[1]s/beta.bin
+`, peerArtifactRoot))
+	tc.Shell(t, fmt.Sprintf("printf 'ALPHA-LOCAL-EDIT' > %s/alpha.bin", shQuote(localArtifactRoot)))
 
-	// --- Pull #2: no-clobber under a real transfer. alpha differs from the
-	// baseline (local edit) and must be kept; beta still matches the baseline
-	// and must be updated to the peer's copy.
 	out2, err := tc.RunCampInDir(localRoot, "sync", "--artifacts-only", "--from", loopbackMachineID)
 	require.NoError(t, err, "second artifact sync failed: %s", out2)
 	require.Contains(t, out2, "conflicts kept local", "second pull should report the kept conflict: %s", out2)
-	// Conflicts are reported relative to the artifact root ("alpha.bin", not
-	// "media/alpha.bin").
 	require.Contains(t, out2, "alpha.bin (local edit preserved", "the conflicting file should be named: %s", out2)
 
-	requireFileContent(t, tc, localRoot+"/media/alpha.bin", "ALPHA-LOCAL-EDIT")
-	requireFileContent(t, tc, localRoot+"/media/beta.bin", "BETA-PEER-V2-LONGER")
+	requireFileContent(t, tc, localArtifactRoot+"/alpha.bin", "ALPHA-LOCAL-EDIT")
+	requireFileContent(t, tc, localArtifactRoot+"/beta.bin", "BETA-PEER-V2-LONGER")
 }
 
-// requireFileContent asserts the container file at path holds exactly want.
 func requireFileContent(t *testing.T, tc *TestContainer, path, want string) {
 	t.Helper()
 	got, err := tc.ReadFile(path)
 	require.NoError(t, err, "read %s", path)
-	require.Equal(t, want, strings.TrimRight(got, "\n"), "content of %s", path)
+	require.Equal(t, want, got, "content of %s", path)
 }

--- a/tests/integration/artifacts_from_ssh_test.go
+++ b/tests/integration/artifacts_from_ssh_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestArtifactsPullOverSSH_TransfersAndProtects drives `camp sync
+// --artifacts-only --from self` end to end over a real loopback ssh hop and
+// proves the two guarantees the unit tests cannot reach (they build a
+// filesystem peer.Source and never dial ssh, so rsync-over-ssh, the ssh
+// GIT_SSH_COMMAND wiring, and a genuine source!=dest transfer are all
+// unexercised there):
+//
+//  1. Bytes actually move: declared artifact files present only on the peer
+//     arrive in the local root, transferred by rsync over the same ssh options
+//     the rest of the peer stack uses.
+//  2. No-clobber holds across a divergent second pull: a file the local user
+//     edited after the last transfer is protected (kept local), while a file
+//     that still matches the recorded baseline is updated to the peer's copy.
+//
+// The peer is an unprivileged `peer` login user with its own HOME and camp
+// registry, so the campaign name resolves to a different root on each end;
+// root's local checkout is the pull destination.
+func TestArtifactsPullOverSSH_TransfersAndProtects(t *testing.T) {
+	tc := GetSharedContainer(t)
+	ensurePeerAccount(t, tc)
+	registerLoopbackMachine(t, tc)
+
+	const name = "media-camp"
+	peerRoot := peerCampaignsDir + "/" + name
+	localRoot := "/campaigns/" + name
+
+	// --- Peer side: a same-named campaign holding the source artifacts, in
+	// PEER's registry so `camp switch <name> --print` over ssh resolves it.
+	peerSSH(t, tc, fmt.Sprintf(`
+set -e
+camp create %[1]s -d 'artifact source' -m 'hold media' --no-git --path %[2]s
+mkdir -p %[3]s/media
+printf 'ALPHA-v1' > %[3]s/media/alpha.bin
+printf 'BETA-v1'  > %[3]s/media/beta.bin
+`, name, peerCampaignsDir, peerRoot))
+
+	// --- Local side: the same-named campaign (root's registry) that declares
+	// `media` as an artifact root. Its media dir starts empty, so the first
+	// pull is a pure arrival.
+	createOut, err := tc.RunCamp("create", name,
+		"-d", "artifact dest", "-m", "pull media", "--path", "/campaigns")
+	require.NoError(t, err, "local camp create failed: %s", createOut)
+	addOut, err := tc.RunCampInDir(localRoot, "artifacts", "add", "media")
+	require.NoError(t, err, "artifacts add failed: %s", addOut)
+
+	// --- Pull #1: first sync. Both files are new locally, so both transfer;
+	// there is no baseline yet, so nothing is protected.
+	out1, err := tc.RunCampInDir(localRoot, "sync", "--artifacts-only", "--from", loopbackMachineID)
+	require.NoError(t, err, "first artifact sync failed: %s", out1)
+	require.Contains(t, out1, "first sync", "first pull should report first-sync semantics: %s", out1)
+
+	requireFileContent(t, tc, localRoot+"/media/alpha.bin", "ALPHA-v1")
+	requireFileContent(t, tc, localRoot+"/media/beta.bin", "BETA-v1")
+
+	// A baseline snapshot for this peer+root must be recorded so the next pull
+	// can tell a local edit from a stale copy. Root "media" slugs to "media".
+	snapshot := localRoot + "/.campaign/cache/peersync/" + loopbackMachineID + "/media.json"
+	exists, err := tc.CheckFileExists(snapshot)
+	require.NoError(t, err)
+	require.True(t, exists, "peer snapshot %s should exist after first sync", snapshot)
+
+	// --- Diverge: the peer advances both files; locally the user edits alpha
+	// (so it no longer matches the baseline) but leaves beta at the synced
+	// bytes. Sizes are distinct so conflict detection is unambiguous even where
+	// the filesystem's mtime granularity is coarse.
+	peerSSH(t, tc, fmt.Sprintf(`
+set -e
+printf 'ALPHA-PEER-V2'       > %[1]s/media/alpha.bin
+printf 'BETA-PEER-V2-LONGER' > %[1]s/media/beta.bin
+`, peerRoot))
+	require.NoError(t, tc.WriteFile(localRoot+"/media/alpha.bin", "ALPHA-LOCAL-EDIT"))
+
+	// --- Pull #2: no-clobber under a real transfer. alpha differs from the
+	// baseline (local edit) and must be kept; beta still matches the baseline
+	// and must be updated to the peer's copy.
+	out2, err := tc.RunCampInDir(localRoot, "sync", "--artifacts-only", "--from", loopbackMachineID)
+	require.NoError(t, err, "second artifact sync failed: %s", out2)
+	require.Contains(t, out2, "conflicts kept local", "second pull should report the kept conflict: %s", out2)
+	// Conflicts are reported relative to the artifact root ("alpha.bin", not
+	// "media/alpha.bin").
+	require.Contains(t, out2, "alpha.bin (local edit preserved", "the conflicting file should be named: %s", out2)
+
+	requireFileContent(t, tc, localRoot+"/media/alpha.bin", "ALPHA-LOCAL-EDIT")
+	requireFileContent(t, tc, localRoot+"/media/beta.bin", "BETA-PEER-V2-LONGER")
+}
+
+// requireFileContent asserts the container file at path holds exactly want.
+func requireFileContent(t *testing.T, tc *TestContainer, path, want string) {
+	t.Helper()
+	got, err := tc.ReadFile(path)
+	require.NoError(t, err, "read %s", path)
+	require.Equal(t, want, strings.TrimRight(got, "\n"), "content of %s", path)
+}

--- a/tests/integration/clone_from_ssh_test.go
+++ b/tests/integration/clone_from_ssh_test.go
@@ -1,0 +1,57 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCloneFromPeerOverSSH_SeedsAndRepointsOrigin drives `camp clone <url>
+// <dir> --from self` over a real loopback ssh hop and proves the peer-seeded
+// clone path: the campaign is cloned from the peer's copy over ssh (fast path),
+// then origin is re-pointed to the canonical url and the delta fetched — so the
+// result is an origin replica that arrived over the peer. The unit tests build
+// a filesystem peer.Source and never dial ssh, so this ssh clone path is
+// otherwise unexercised.
+//
+// The peer owns a registered campaign it has pushed to a bare origin under /tmp
+// (peer-writable). marker.txt is content unique to the peer's checkout, present
+// only because the seed came from the peer.
+func TestCloneFromPeerOverSSH_SeedsAndRepointsOrigin(t *testing.T) {
+	tc := GetSharedContainer(t)
+	ensurePeerAccount(t, tc)
+	registerLoopbackMachine(t, tc)
+
+	const name = "cloneproj"
+	peerRoot := peerCampaignsDir + "/" + name
+	const campOrigin = "/tmp/camp-origin.git"
+
+	peerSSH(t, tc, fmt.Sprintf(`
+set -e
+rm -rf %[4]s
+camp create %[1]s -d 'peer clone source' -m 'seed from peer' --path %[2]s
+cd %[3]s
+printf 'peer-seeded\n' > marker.txt
+git add marker.txt && git commit -qm 'add marker'
+git init -q --bare %[4]s
+git remote add origin %[4]s
+git push -q origin "$(git rev-parse --abbrev-ref HEAD)"
+`, name, peerCampaignsDir, peerRoot, campOrigin))
+
+	// Clone: seed from the peer over ssh, then re-point origin to campOrigin.
+	localRoot := "/campaigns/" + name
+	out, err := tc.RunCampInDir("/campaigns", "clone", campOrigin, localRoot,
+		"--from", loopbackMachineID, "--no-submodules")
+	require.NoError(t, err, "clone --from peer failed: %s", out)
+
+	// The peer-seeded content arrived.
+	requireFileContent(t, tc, localRoot+"/marker.txt", "peer-seeded")
+
+	// Origin was re-pointed to the canonical url, not left as the peer path.
+	require.Equal(t, campOrigin, tc.GitOutput(t, localRoot, "remote", "get-url", "origin"),
+		"origin should be re-pointed to the canonical url after seeding from the peer")
+}

--- a/tests/integration/clone_from_ssh_test.go
+++ b/tests/integration/clone_from_ssh_test.go
@@ -10,17 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCloneFromPeerOverSSH_SeedsAndRepointsOrigin drives `camp clone <url>
-// <dir> --from self` over a real loopback ssh hop and proves the peer-seeded
-// clone path: the campaign is cloned from the peer's copy over ssh (fast path),
-// then origin is re-pointed to the canonical url and the delta fetched — so the
-// result is an origin replica that arrived over the peer. The unit tests build
-// a filesystem peer.Source and never dial ssh, so this ssh clone path is
-// otherwise unexercised.
-//
-// The peer owns a registered campaign it has pushed to a bare origin under /tmp
-// (peer-writable). marker.txt is content unique to the peer's checkout, present
-// only because the seed came from the peer.
+// TestCloneFromPeerOverSSH_SeedsAndRepointsOrigin verifies peer-seeded cloning.
 func TestCloneFromPeerOverSSH_SeedsAndRepointsOrigin(t *testing.T) {
 	tc := GetSharedContainer(t)
 	ensurePeerAccount(t, tc)
@@ -42,16 +32,13 @@ git remote add origin %[4]s
 git push -q origin "$(git rev-parse --abbrev-ref HEAD)"
 `, name, peerCampaignsDir, peerRoot, campOrigin))
 
-	// Clone: seed from the peer over ssh, then re-point origin to campOrigin.
 	localRoot := "/campaigns/" + name
 	out, err := tc.RunCampInDir("/campaigns", "clone", campOrigin, localRoot,
 		"--from", loopbackMachineID, "--no-submodules")
 	require.NoError(t, err, "clone --from peer failed: %s", out)
 
-	// The peer-seeded content arrived.
-	requireFileContent(t, tc, localRoot+"/marker.txt", "peer-seeded")
+	requireFileContent(t, tc, localRoot+"/marker.txt", "peer-seeded\n")
 
-	// Origin was re-pointed to the canonical url, not left as the peer path.
 	require.Equal(t, campOrigin, tc.GitOutput(t, localRoot, "remote", "get-url", "origin"),
 		"origin should be re-pointed to the canonical url after seeding from the peer")
 }

--- a/tests/integration/helpers_ssh.go
+++ b/tests/integration/helpers_ssh.go
@@ -61,6 +61,11 @@ func ensureSSHDaemon(t *testing.T, tc *TestContainer) {
 	tc.Shell(t, `
 set -e
 ssh-keygen -A >/dev/null 2>&1
+# The peer-transport tests share submodule/campaign origins between the root
+# ("local") and peer accounts, so each side reads repos the other owns. Trust
+# all repos regardless of owner — git's dubious-ownership guard is not
+# meaningful in a single-tenant test container.
+git config --global --add safe.directory '*'
 mkdir -p /root/.ssh
 chmod 700 /root/.ssh
 [ -f /root/.ssh/id_ed25519 ] || ssh-keygen -t ed25519 -N '' -f /root/.ssh/id_ed25519 >/dev/null
@@ -113,8 +118,11 @@ mkdir -p %[2]s/.ssh
 cat /root/.ssh/id_ed25519.pub > %[2]s/.ssh/authorized_keys
 chmod 700 %[2]s/.ssh
 chmod 600 %[2]s/.ssh/authorized_keys
-# camp runs git for any campaign op; give peer a committer identity.
-su %[1]s -c 'git config --global user.email peer@test.com && git config --global user.name Peer'
+# camp runs git for any campaign op; give peer a committer identity. peer also
+# operates on repos root created (a shared submodule origin), so trust all repos
+# regardless of owner — git's dubious-ownership guard is not meaningful in a
+# single-tenant test container.
+su %[1]s -c 'git config --global user.email peer@test.com && git config --global user.name Peer && git config --global --add safe.directory "*"'
 rm -rf %[2]s/.obey %[2]s/.config %[3]s
 mkdir -p %[3]s
 # sshd StrictModes: peer must own its HOME, .ssh, and authorized_keys, and

--- a/tests/integration/helpers_ssh.go
+++ b/tests/integration/helpers_ssh.go
@@ -1,0 +1,165 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These helpers stand up a loopback ssh "peer" inside the pooled container so
+// the peer transports (camp sync/clone --from <machine>, artifact rsync pull)
+// can be exercised end to end over a real ssh hop — the path unit tests skip
+// entirely because they construct a filesystem peer.Source (peer.FromPath) and
+// never dial ssh.
+//
+// A genuine A->B transfer needs the source and destination to be DIFFERENT
+// campaign roots. camp resolves --from by running the peer's own
+// `camp switch <name> --print`, which reads the peer login user's HOME
+// registry. Root and an unprivileged `peer` user therefore give two distinct
+// registries, so one campaign name resolves to two different paths — root's
+// local checkout and peer's source checkout. Reusing root for both ends would
+// resolve one name to one path and make every transfer a no-op self-copy.
+const (
+	peerUser          = "peer"
+	peerHome          = "/home/peer"
+	peerCampaignsDir  = "/home/peer/campaigns"
+	loopbackMachineID = "self"
+	rootIdentity      = "/root/.ssh/id_ed25519"
+)
+
+// shQuote single-quotes s for safe embedding in a POSIX shell command, matching
+// remote.ShellQuote. Applying it at each nesting layer (root sh -lc -> ssh ->
+// peer sh -lc) keeps arbitrary script text intact through the hops.
+func shQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// ensureSSHDaemon provisions and starts sshd (plus rsync) in the pooled
+// container, idempotently, and generates root's loopback key so key auth to
+// localhost works. Every step is check-then-act: Reset() does not uninstall
+// packages or kill processes, so a later test reusing this same pooled
+// container must not redo (or break) work an earlier one already did.
+//
+// It Skips (not fails) when openssh cannot be installed, so the suite still runs
+// in a sandbox with no package mirror.
+func ensureSSHDaemon(t *testing.T, tc *TestContainer) {
+	t.Helper()
+
+	apkOut, apkExit, apkErr := tc.ExecCommand("sh", "-c",
+		"apk info -e openssh-server >/dev/null 2>&1 && apk info -e rsync >/dev/null 2>&1 || "+
+			"apk add --no-cache openssh openssh-server rsync")
+	require.NoError(t, apkErr, "apk add exec failed to run")
+	if apkExit != 0 {
+		t.Skipf("cannot install openssh-server/rsync in this container environment: %s", apkOut)
+	}
+
+	tc.Shell(t, `
+set -e
+ssh-keygen -A >/dev/null 2>&1
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+[ -f /root/.ssh/id_ed25519 ] || ssh-keygen -t ed25519 -N '' -f /root/.ssh/id_ed25519 >/dev/null
+cat /root/.ssh/id_ed25519.pub > /root/.ssh/authorized_keys
+chmod 600 /root/.ssh/authorized_keys
+if grep -q '^PermitRootLogin' /etc/ssh/sshd_config; then
+  sed -i 's/^PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+else
+  printf '%s\n' 'PermitRootLogin yes' >> /etc/ssh/sshd_config
+fi
+ln -sf /camp /usr/bin/camp
+pgrep sshd >/dev/null 2>&1 || /usr/sbin/sshd
+`)
+
+	// sshd daemonizes on start; retry briefly so the sanity check is not racing
+	// the listener coming up.
+	sshCheck := tc.Shell(t, `
+out=""
+for i in 1 2 3 4 5; do
+  out=$(ssh -i /root/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new -o BatchMode=yes root@localhost 'echo SSHOK' 2>&1) && break
+  sleep 1
+done
+echo "$out"
+`)
+	require.Contains(t, sshCheck, "SSHOK", "loopback ssh sanity check failed: %s", sshCheck)
+}
+
+// ensurePeerAccount adds an unprivileged `peer` login user (idempotently) that
+// accepts root's key, so a `self` machine with ssh_user=peer reaches a distinct
+// HOME — and thus a distinct camp registry — from root's. It builds on
+// ensureSSHDaemon and verifies both that root can log in as peer and that camp
+// is on peer's login-shell PATH (the exact channel ResolveRoot uses).
+func ensurePeerAccount(t *testing.T, tc *TestContainer) {
+	t.Helper()
+	ensureSSHDaemon(t, tc)
+
+	// The user, keys, and git identity are durable/idempotent (Reset() never
+	// touches /home/peer), but the peer registry and its campaigns must start
+	// clean every test, or a name a prior test registered would still resolve.
+	// Campaigns live under a dedicated dir so wiping registry state never
+	// endangers .ssh or .gitconfig.
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+id %[1]s >/dev/null 2>&1 || adduser -D -s /bin/sh -h %[2]s %[1]s
+# adduser -D leaves the account LOCKED ('!' in /etc/shadow); OpenSSH refuses
+# pubkey auth for a locked account. Flip it to '*' (unlocked, still no
+# password login) so key auth is accepted while password login stays off.
+sed -i 's/^%[1]s:!/%[1]s:*/' /etc/shadow
+mkdir -p %[2]s/.ssh
+cat /root/.ssh/id_ed25519.pub > %[2]s/.ssh/authorized_keys
+chmod 700 %[2]s/.ssh
+chmod 600 %[2]s/.ssh/authorized_keys
+# camp runs git for any campaign op; give peer a committer identity.
+su %[1]s -c 'git config --global user.email peer@test.com && git config --global user.name Peer'
+rm -rf %[2]s/.obey %[2]s/.config %[3]s
+mkdir -p %[3]s
+# sshd StrictModes: peer must own its HOME, .ssh, and authorized_keys, and
+# none may be group/world-writable.
+chown -R %[1]s:%[1]s %[2]s
+`, peerUser, peerHome, peerCampaignsDir))
+
+	check := tc.Shell(t, fmt.Sprintf(`
+out=""
+for i in 1 2 3 4 5; do
+  out=$(ssh -i %[1]s -o StrictHostKeyChecking=accept-new -o BatchMode=yes %[2]s@localhost 'sh -lc "command -v camp >/dev/null 2>&1 && echo PEEROK"' 2>&1) && break
+  sleep 1
+done
+echo "$out"
+`, rootIdentity, peerUser))
+	require.Contains(t, check, "PEEROK", "loopback ssh to peer failed or camp not on peer PATH: %s", check)
+}
+
+// registerLoopbackMachine writes root's ~/.obey/machines.yaml with a `self`
+// machine that ssh's to peer@localhost with root's key. From root's camp,
+// `--from self` therefore resolves campaigns in PEER's registry.
+func registerLoopbackMachine(t *testing.T, tc *TestContainer) {
+	t.Helper()
+	yaml := fmt.Sprintf(`version: 1
+machines:
+  - id: %[1]s
+    label: Loopback peer (integration smoke)
+    host: localhost
+    auth_method: ssh-agent
+    ssh_user: %[2]s
+    identity_file: %[3]s
+`, loopbackMachineID, peerUser, rootIdentity)
+	require.NoError(t, tc.WriteFile("/root/.obey/machines.yaml", yaml))
+}
+
+// peerSSH runs script on the peer account over loopback ssh through a login
+// shell (sh -lc), the same way camp's own ResolveRoot reaches a peer, and
+// returns combined output. It fails the test on a non-zero exit. Use it to set
+// up the peer-side campaign (created in PEER's registry) that root then pulls
+// from.
+func peerSSH(t *testing.T, tc *TestContainer, script string) string {
+	t.Helper()
+	remote := "sh -lc " + shQuote(script)
+	full := fmt.Sprintf(
+		"ssh -i %s -o StrictHostKeyChecking=accept-new -o BatchMode=yes %s@localhost %s",
+		rootIdentity, peerUser, shQuote(remote))
+	return tc.Shell(t, full)
+}

--- a/tests/integration/helpers_ssh.go
+++ b/tests/integration/helpers_ssh.go
@@ -11,19 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// These helpers stand up a loopback ssh "peer" inside the pooled container so
-// the peer transports (camp sync/clone --from <machine>, artifact rsync pull)
-// can be exercised end to end over a real ssh hop — the path unit tests skip
-// entirely because they construct a filesystem peer.Source (peer.FromPath) and
-// never dial ssh.
-//
-// A genuine A->B transfer needs the source and destination to be DIFFERENT
-// campaign roots. camp resolves --from by running the peer's own
-// `camp switch <name> --print`, which reads the peer login user's HOME
-// registry. Root and an unprivileged `peer` user therefore give two distinct
-// registries, so one campaign name resolves to two different paths — root's
-// local checkout and peer's source checkout. Reusing root for both ends would
-// resolve one name to one path and make every transfer a no-op self-copy.
 const (
 	peerUser          = "peer"
 	peerHome          = "/home/peer"
@@ -32,21 +19,12 @@ const (
 	rootIdentity      = "/root/.ssh/id_ed25519"
 )
 
-// shQuote single-quotes s for safe embedding in a POSIX shell command, matching
-// remote.ShellQuote. Applying it at each nesting layer (root sh -lc -> ssh ->
-// peer sh -lc) keeps arbitrary script text intact through the hops.
+// shQuote quotes a string for a POSIX shell command.
 func shQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
-// ensureSSHDaemon provisions and starts sshd (plus rsync) in the pooled
-// container, idempotently, and generates root's loopback key so key auth to
-// localhost works. Every step is check-then-act: Reset() does not uninstall
-// packages or kill processes, so a later test reusing this same pooled
-// container must not redo (or break) work an earlier one already did.
-//
-// It Skips (not fails) when openssh cannot be installed, so the suite still runs
-// in a sandbox with no package mirror.
+// ensureSSHDaemon provisions the loopback SSH and rsync services.
 func ensureSSHDaemon(t *testing.T, tc *TestContainer) {
 	t.Helper()
 
@@ -61,10 +39,6 @@ func ensureSSHDaemon(t *testing.T, tc *TestContainer) {
 	tc.Shell(t, `
 set -e
 ssh-keygen -A >/dev/null 2>&1
-# The peer-transport tests share submodule/campaign origins between the root
-# ("local") and peer accounts, so each side reads repos the other owns. Trust
-# all repos regardless of owner — git's dubious-ownership guard is not
-# meaningful in a single-tenant test container.
 git config --global --add safe.directory '*'
 mkdir -p /root/.ssh
 chmod 700 /root/.ssh
@@ -80,8 +54,6 @@ ln -sf /camp /usr/bin/camp
 pgrep sshd >/dev/null 2>&1 || /usr/sbin/sshd
 `)
 
-	// sshd daemonizes on start; retry briefly so the sanity check is not racing
-	// the listener coming up.
 	sshCheck := tc.Shell(t, `
 out=""
 for i in 1 2 3 4 5; do
@@ -93,40 +65,22 @@ echo "$out"
 	require.Contains(t, sshCheck, "SSHOK", "loopback ssh sanity check failed: %s", sshCheck)
 }
 
-// ensurePeerAccount adds an unprivileged `peer` login user (idempotently) that
-// accepts root's key, so a `self` machine with ssh_user=peer reaches a distinct
-// HOME — and thus a distinct camp registry — from root's. It builds on
-// ensureSSHDaemon and verifies both that root can log in as peer and that camp
-// is on peer's login-shell PATH (the exact channel ResolveRoot uses).
+// ensurePeerAccount provisions the isolated peer login used by transfer tests.
 func ensurePeerAccount(t *testing.T, tc *TestContainer) {
 	t.Helper()
 	ensureSSHDaemon(t, tc)
 
-	// The user, keys, and git identity are durable/idempotent (Reset() never
-	// touches /home/peer), but the peer registry and its campaigns must start
-	// clean every test, or a name a prior test registered would still resolve.
-	// Campaigns live under a dedicated dir so wiping registry state never
-	// endangers .ssh or .gitconfig.
 	tc.Shell(t, fmt.Sprintf(`
 set -e
 id %[1]s >/dev/null 2>&1 || adduser -D -s /bin/sh -h %[2]s %[1]s
-# adduser -D leaves the account LOCKED ('!' in /etc/shadow); OpenSSH refuses
-# pubkey auth for a locked account. Flip it to '*' (unlocked, still no
-# password login) so key auth is accepted while password login stays off.
 sed -i 's/^%[1]s:!/%[1]s:*/' /etc/shadow
 mkdir -p %[2]s/.ssh
 cat /root/.ssh/id_ed25519.pub > %[2]s/.ssh/authorized_keys
 chmod 700 %[2]s/.ssh
 chmod 600 %[2]s/.ssh/authorized_keys
-# camp runs git for any campaign op; give peer a committer identity. peer also
-# operates on repos root created (a shared submodule origin), so trust all repos
-# regardless of owner — git's dubious-ownership guard is not meaningful in a
-# single-tenant test container.
 su %[1]s -c 'git config --global user.email peer@test.com && git config --global user.name Peer && git config --global --add safe.directory "*"'
 rm -rf %[2]s/.obey %[2]s/.config %[3]s
 mkdir -p %[3]s
-# sshd StrictModes: peer must own its HOME, .ssh, and authorized_keys, and
-# none may be group/world-writable.
 chown -R %[1]s:%[1]s %[2]s
 `, peerUser, peerHome, peerCampaignsDir))
 
@@ -141,9 +95,7 @@ echo "$out"
 	require.Contains(t, check, "PEEROK", "loopback ssh to peer failed or camp not on peer PATH: %s", check)
 }
 
-// registerLoopbackMachine writes root's ~/.obey/machines.yaml with a `self`
-// machine that ssh's to peer@localhost with root's key. From root's camp,
-// `--from self` therefore resolves campaigns in PEER's registry.
+// registerLoopbackMachine points the test machine at the isolated peer.
 func registerLoopbackMachine(t *testing.T, tc *TestContainer) {
 	t.Helper()
 	yaml := fmt.Sprintf(`version: 1
@@ -158,11 +110,7 @@ machines:
 	require.NoError(t, tc.WriteFile("/root/.obey/machines.yaml", yaml))
 }
 
-// peerSSH runs script on the peer account over loopback ssh through a login
-// shell (sh -lc), the same way camp's own ResolveRoot reaches a peer, and
-// returns combined output. It fails the test on a non-zero exit. Use it to set
-// up the peer-side campaign (created in PEER's registry) that root then pulls
-// from.
+// peerSSH runs a setup script through the same login-shell path camp uses.
 func peerSSH(t *testing.T, tc *TestContainer, script string) string {
 	t.Helper()
 	remote := "sh -lc " + shQuote(script)

--- a/tests/integration/remote_switch_ssh_test.go
+++ b/tests/integration/remote_switch_ssh_test.go
@@ -11,28 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestRemoteSwitchLocalhostSshSmoke proves, end to end, that
-// `camp switch <machine>:<campaign> --shell-connect` resolves a remote
-// campaign root over a real ssh hop and that the resolve step
-// (internal/remote.ResolveRoot) and the interactive hop share a single
-// ControlMaster connection.
-//
-// The container plays both "local" and "remote": the registered machine
-// ("self") points ssh at localhost, so root == remote root by construction.
-// This is a loopback smoke test of the ssh plumbing in
-// internal/remote/ssh.go and cmd/camp/switch.go's runRemoteSwitch, not a
-// test of true cross-host behavior.
+// TestRemoteSwitchLocalhostSshSmoke verifies the loopback SSH hop and its
+// ControlMaster reuse.
 func TestRemoteSwitchLocalhostSshSmoke(t *testing.T) {
 	tc := GetSharedContainer(t)
 
-	// Provision sshd + root loopback key (idempotent; shared with the peer
-	// transport smoke tests). This test drives the ssh hop as root, so the
-	// `self` machine it registers below uses ssh_user=root and resolves the
-	// one campaign identically on both ends.
+	// Provision shared loopback SSH state.
 	ensureSSHDaemon(t, tc)
 
-	// --- Create a campaign that both the "local" and "remote" camp switch
-	// resolve identically, since remote == local == this container here.
 	const base = "/campaigns"
 	const campaignName = "remote-smoke-campaign"
 	createOut, err := tc.RunCamp("create", campaignName,
@@ -48,7 +34,6 @@ func TestRemoteSwitchLocalhostSshSmoke(t *testing.T) {
 	root := strings.TrimSpace(printOut)
 	require.NotEmpty(t, root, "resolved campaign root must not be empty")
 
-	// --- Register the loopback machine in ~/.obey/machines.yaml.
 	machinesYAML := `version: 1
 machines:
   - id: self
@@ -60,8 +45,6 @@ machines:
 `
 	require.NoError(t, tc.WriteFile("/root/.obey/machines.yaml", machinesYAML))
 
-	// --- The feature under test: resolve the remote root over ssh and emit
-	// the shell-connect line.
 	shellConnectOut, err := tc.RunCamp("switch", "self:"+campaignName, "--shell-connect")
 	require.NoError(t, err, "camp switch self:%s --shell-connect should succeed; output: %s", campaignName, shellConnectOut)
 
@@ -71,17 +54,11 @@ machines:
 	require.Contains(t, trimmed, "cd ", "shell-connect line must cd into the resolved root: %q", trimmed)
 	require.Contains(t, trimmed, root, "shell-connect line must reference the resolved remote campaign root %q: %q", root, trimmed)
 
-	// ResolveRoot's ssh call (the one that produced `root` above, over the
-	// wire via the remote's own `camp switch --print`) must have created the
-	// per-machine ControlMaster socket.
 	const socketPath = "/root/.obey/ssh-ctl/self.sock"
 	_, socketExitCode, err := tc.ExecCommand("test", "-S", socketPath)
 	require.NoError(t, err)
 	require.Equal(t, 0, socketExitCode, "ControlMaster socket %s should exist after resolve", socketPath)
 
-	// --- Execute the hop for real (the non-`exec` variant, so the test
-	// process survives) using the same ssh options camp emits, and confirm it
-	// lands in the resolved campaign root.
 	hopCmd := fmt.Sprintf(
 		`ssh -i /root/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new -o BatchMode=yes `+
 			`-o ControlMaster=auto -o ControlPath=%s -o ControlPersist=30s root@localhost "cd %s && pwd"`,
@@ -90,8 +67,6 @@ machines:
 	hopOut := tc.Shell(t, hopCmd)
 	require.Equal(t, root, strings.TrimSpace(hopOut), "hop over ssh should land in the resolved campaign root")
 
-	// Resolve + hop must reuse ONE ControlMaster connection: exactly one
-	// socket file under ~/.obey/ssh-ctl.
 	countOut := tc.Shell(t, "ls /root/.obey/ssh-ctl/ | wc -l")
 	require.Equal(t, "1", strings.TrimSpace(countOut), "resolve and hop should share a single ControlMaster socket")
 }

--- a/tests/integration/remote_switch_ssh_test.go
+++ b/tests/integration/remote_switch_ssh_test.go
@@ -25,49 +25,11 @@ import (
 func TestRemoteSwitchLocalhostSshSmoke(t *testing.T) {
 	tc := GetSharedContainer(t)
 
-	// --- Provision sshd idempotently. ------------------------------------
-	// The pooled container is shared across tests and Reset() does not
-	// uninstall packages or kill processes (it only clears /test,
-	// /campaigns, /root/.obey*, /root/.camp). So package install, host key
-	// generation, and starting sshd must all check-then-act, or a later test
-	// reusing this same container would redo (and potentially break) work
-	// that already succeeded.
-	apkOut, apkExitCode, apkErr := tc.ExecCommand("sh", "-c",
-		"apk info -e openssh-server >/dev/null 2>&1 || apk add --no-cache openssh openssh-server")
-	require.NoError(t, apkErr, "apk add exec failed to run")
-	if apkExitCode != 0 {
-		t.Skipf("cannot install openssh-server in this container environment: %s", apkOut)
-	}
-
-	tc.Shell(t, `
-set -e
-ssh-keygen -A >/dev/null 2>&1
-mkdir -p /root/.ssh
-chmod 700 /root/.ssh
-[ -f /root/.ssh/id_ed25519 ] || ssh-keygen -t ed25519 -N '' -f /root/.ssh/id_ed25519 >/dev/null
-cat /root/.ssh/id_ed25519.pub > /root/.ssh/authorized_keys
-chmod 600 /root/.ssh/authorized_keys
-if grep -q '^PermitRootLogin' /etc/ssh/sshd_config; then
-  sed -i 's/^PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
-else
-  printf '%s\n' 'PermitRootLogin yes' >> /etc/ssh/sshd_config
-fi
-ln -sf /camp /usr/bin/camp
-pgrep sshd >/dev/null 2>&1 || /usr/sbin/sshd
-`)
-
-	// Sanity-check loopback ssh actually works before trusting camp's hop.
-	// sshd daemonizes on start, so retry briefly in case it isn't accepting
-	// connections the instant the provisioning script returns.
-	sshCheck := tc.Shell(t, `
-out=""
-for i in 1 2 3 4 5; do
-  out=$(ssh -i /root/.ssh/id_ed25519 -o StrictHostKeyChecking=accept-new -o BatchMode=yes root@localhost 'echo SSHOK' 2>&1) && break
-  sleep 1
-done
-echo "$out"
-`)
-	require.Contains(t, sshCheck, "SSHOK", "loopback ssh sanity check failed: %s", sshCheck)
+	// Provision sshd + root loopback key (idempotent; shared with the peer
+	// transport smoke tests). This test drives the ssh hop as root, so the
+	// `self` machine it registers below uses ssh_user=root and resolves the
+	// one campaign identically on both ends.
+	ensureSSHDaemon(t, tc)
 
 	// --- Create a campaign that both the "local" and "remote" camp switch
 	// resolve identically, since remote == local == this container here.

--- a/tests/integration/sync_from_ssh_test.go
+++ b/tests/integration/sync_from_ssh_test.go
@@ -11,18 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSyncFromPeerOverSSH_FetchesObjectsIntoPeerNamespace drives
-// `camp sync --from self --git-only` over a real loopback ssh hop and proves
-// the git peer transport: submodule objects that exist only on the peer are
-// fetched over ssh (via GIT_SSH_COMMAND, a different channel than the artifact
-// rsync's -e) into the local repository's refs/peer/<id>/* namespace, while the
-// checkout itself stays on origin's tip. The unit tests build a filesystem
-// peer.Source and never dial ssh, so this ssh fetch path is otherwise
-// unexercised.
-//
-// Fixture: a shared submodule origin holds C1. The peer's copy of the submodule
-// is advanced to C2 (a child of C1) that is committed on the peer but never
-// pushed to origin, so C2 can only reach the local repo through the peer fetch.
+// TestSyncFromPeerOverSSH_FetchesObjectsIntoPeerNamespace verifies SSH peer
+// object transfer without changing the checkout.
 func TestSyncFromPeerOverSSH_FetchesObjectsIntoPeerNamespace(t *testing.T) {
 	tc := GetSharedContainer(t)
 	ensurePeerAccount(t, tc)
@@ -33,7 +23,6 @@ func TestSyncFromPeerOverSSH_FetchesObjectsIntoPeerNamespace(t *testing.T) {
 	localRoot := "/campaigns/" + name
 	const origin = "/test/sub-origin.git"
 
-	// Shared submodule origin with C1 on main.
 	tc.Shell(t, fmt.Sprintf(`
 set -e
 git init -q --bare %[1]s
@@ -47,8 +36,6 @@ git --git-dir %[1]s symbolic-ref HEAD refs/heads/main
 `, origin))
 	c1 := tc.GitOutput(t, origin, "rev-parse", "main")
 
-	// Peer campaign: submodule advanced to C2, committed but not pushed. The
-	// resulting sha is written to a shared path root can read back.
 	peerSSH(t, tc, fmt.Sprintf(`
 set -e
 camp create %[1]s -d 'peer git source' -m 'advance sub' --path %[2]s
@@ -64,7 +51,6 @@ git rev-parse main > /tmp/peer-c2.sha
 	c2 := strings.TrimSpace(c2raw)
 	require.NotEqual(t, c1, c2, "peer submodule tip C2 must differ from origin C1")
 
-	// Local campaign: same submodule at C1 (from origin), initialized.
 	createOut, err := tc.RunCamp("create", name, "-d", "local dest", "-m", "sync from peer", "--path", "/campaigns")
 	require.NoError(t, err, "local camp create failed: %s", createOut)
 	tc.Shell(t, fmt.Sprintf(`

--- a/tests/integration/sync_from_ssh_test.go
+++ b/tests/integration/sync_from_ssh_test.go
@@ -1,0 +1,91 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSyncFromPeerOverSSH_FetchesObjectsIntoPeerNamespace drives
+// `camp sync --from self --git-only` over a real loopback ssh hop and proves
+// the git peer transport: submodule objects that exist only on the peer are
+// fetched over ssh (via GIT_SSH_COMMAND, a different channel than the artifact
+// rsync's -e) into the local repository's refs/peer/<id>/* namespace, while the
+// checkout itself stays on origin's tip. The unit tests build a filesystem
+// peer.Source and never dial ssh, so this ssh fetch path is otherwise
+// unexercised.
+//
+// Fixture: a shared submodule origin holds C1. The peer's copy of the submodule
+// is advanced to C2 (a child of C1) that is committed on the peer but never
+// pushed to origin, so C2 can only reach the local repo through the peer fetch.
+func TestSyncFromPeerOverSSH_FetchesObjectsIntoPeerNamespace(t *testing.T) {
+	tc := GetSharedContainer(t)
+	ensurePeerAccount(t, tc)
+	registerLoopbackMachine(t, tc)
+
+	const name = "gitproj"
+	peerRoot := peerCampaignsDir + "/" + name
+	localRoot := "/campaigns/" + name
+	const origin = "/test/sub-origin.git"
+
+	// Shared submodule origin with C1 on main.
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+git init -q --bare %[1]s
+rm -rf /test/sub-seed
+git init -q /test/sub-seed
+cd /test/sub-seed
+git config user.email t@t.co && git config user.name T
+printf 'v1\n' > f.txt && git add . && git commit -qm C1
+git branch -M main && git push -q %[1]s main
+git --git-dir %[1]s symbolic-ref HEAD refs/heads/main
+`, origin))
+	c1 := tc.GitOutput(t, origin, "rev-parse", "main")
+
+	// Peer campaign: submodule advanced to C2, committed but not pushed. The
+	// resulting sha is written to a shared path root can read back.
+	peerSSH(t, tc, fmt.Sprintf(`
+set -e
+camp create %[1]s -d 'peer git source' -m 'advance sub' --path %[2]s
+cd %[3]s
+GIT_ALLOW_PROTOCOL=file git submodule add %[4]s projects/sub
+git commit -qm 'add sub'
+cd projects/sub
+printf 'v2\n' > f.txt && git add . && git commit -qm C2
+git rev-parse main > /tmp/peer-c2.sha
+`, name, peerCampaignsDir, peerRoot, origin))
+	c2raw, err := tc.ReadFile("/tmp/peer-c2.sha")
+	require.NoError(t, err)
+	c2 := strings.TrimSpace(c2raw)
+	require.NotEqual(t, c1, c2, "peer submodule tip C2 must differ from origin C1")
+
+	// Local campaign: same submodule at C1 (from origin), initialized.
+	createOut, err := tc.RunCamp("create", name, "-d", "local dest", "-m", "sync from peer", "--path", "/campaigns")
+	require.NoError(t, err, "local camp create failed: %s", createOut)
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+cd %[1]s
+GIT_ALLOW_PROTOCOL=file git submodule add %[2]s projects/sub
+git commit -qm 'add sub'
+`, localRoot, origin))
+	require.Equal(t, c1, tc.GitOutput(t, localRoot+"/projects/sub", "rev-parse", "HEAD"),
+		"local submodule should start at origin tip C1")
+
+	// Sync git objects from the peer over ssh (skip artifacts).
+	out, err := tc.RunCampInDir(localRoot, "sync", "--from", loopbackMachineID, "--git-only")
+	require.NoError(t, err, "git-only peer sync failed: %s", out)
+
+	// C2 arrived over ssh into the peer namespace: objects moved.
+	require.Equal(t, c2, tc.GitOutput(t, localRoot+"/projects/sub", "rev-parse", "refs/peer/self/main"),
+		"peer commit C2 should be fetched into refs/peer/self/main over ssh")
+
+	// Peer transport is objects-only: the working tree stays on origin's tip
+	// (C1), never the peer's un-pushed C2.
+	require.Equal(t, c1, tc.GitOutput(t, localRoot+"/projects/sub", "rev-parse", "HEAD"),
+		"submodule checkout must stay on origin tip C1, not the peer's un-pushed C2")
+}


### PR DESCRIPTION
## What

Stands up the deferred **localhost-ssh-smoke integration slice** for camp's peer transports (`camp sync/clone --from <machine>`, artifact rsync pull), driving all three end to end over a **real loopback ssh hop** inside the container harness. The filesystem-peer unit tests (`peer.FromPath`) never dial ssh, so the entire ssh transport — auth, ControlMaster multiplexing, `GIT_SSH_COMMAND`, rsync `-e`, remote-path handling, and genuine A→B content movement — was previously unexercised.

Building it surfaced and fixed a real transport bug (below).

## The bug it found

`camp sync --from` artifact pulls were **broken on every machine with rsync ≥ 3.2.4** (Homebrew macOS, current Linux):

```
rsync: [sender] change_dir "/home/peer/'/home/peer/campaigns/media-camp/media'" failed (2)
```

rsync ≥ 3.2.4 defaults to secluded/protected args and no longer runs the remote path through a login shell, so `peer.RsyncSpec`'s `ShellQuote` injected **literal** single quotes that corrupted the path. Confirmed across variants in a throwaway container (quoted → fail; unquoted → ok; `-s` + spaced path → ok).

**Fix:** `RsyncSpec` returns the remote path unquoted and the artifact pull passes `-s`/`--secluded-args`, which protects spaces and shell metacharacters over the protocol with no shell parsing on either end. Requires rsync ≥ 3.0.0 (2008; every current build); adaptive quoting for the ancient rsync 2.6.9 Apple bundle stays the already-deferred rsync/openrsync version-probing work.

## Tests added (all pass in-container)

- **`artifacts_from_ssh_test.go`** — `camp sync --artifacts-only --from self`: bytes move, a baseline snapshot is recorded, and **no-clobber holds on a divergent second pull** (locally-edited file kept; peer-only change applied). This is the case that surfaced the quoting bug.
- **`sync_from_ssh_test.go`** — `camp sync --from self --git-only`: a submodule commit that exists only on the peer is fetched into `refs/peer/<id>/*` over ssh, while the checkout stays on origin's tip (objects-only transport).
- **`clone_from_ssh_test.go`** — `camp clone <url> <dir> --from self`: the campaign is seeded from the peer over ssh, then origin is re-pointed to the canonical url.
- **`helpers_ssh.go`** — reusable loopback-peer harness: an unprivileged `peer` login user with its own HOME/registry (so one campaign name resolves to two distinct roots — a single registry would make every transfer a no-op self-copy). Idempotent for the pooled container.
- `remote_switch_ssh_test.go` refactored to reuse the shared sshd provisioner (no behavior change).

## Scope / not in scope

This closes the genuine gap (no real-transport coverage; the transport bug). It does **not** drain the host-FS test ratchet allowlist for `internal/clone`/`internal/sync` — migrating those unit tests is a separate mechanical follow-up, still tracked; the pure-logic unit tests stay unit.

## Gates

`just lint` clean (0 issues; host-FS ratchet clean; no fmt.Errorf regressions). Unit tests green. Integration tests run under `-tags=integration` (require Docker; CI is intentionally paused for cost, run locally).