### PR TITLE
fix(go): resolve worktrees across all locations, not just preferred

### DIFF
--- a/internal/complete/path_test.go
+++ b/internal/complete/path_test.go
@@ -96,6 +96,12 @@ func TestPathComplete_CaseInsensitive(t *testing.T) {
 	}
 }
 
+// TestCompleteWorktree_NoAt covers project-name completion, which reads the
+// worktrees directory directly and does not depend on git. The project@branch
+// completion (the part that reads the git-backed navigation index) is covered
+// end-to-end in the containerized harness
+// (tests/integration/navigation_worktree_test.go), because it now requires real
+// git worktrees rather than bare directory fixtures.
 func TestCompleteWorktree_NoAt(t *testing.T) {
 	root := t.TempDir()
 	campDir := filepath.Join(root, ".campaign")
@@ -121,77 +127,15 @@ func TestCompleteWorktree_NoAt(t *testing.T) {
 		t.Fatalf("CompleteWorktree failed: %v", err)
 	}
 
-	// Should return project directory name and matching project@branch entries
+	// Should return the matching project directory name.
 	foundDir := false
-	foundBranch := false
 	for _, c := range candidates {
 		if c == "api-service" {
 			foundDir = true
 		}
-		if c == "api-service@feature-x" || c == "api-service@bugfix-y" {
-			foundBranch = true
-		}
 	}
 	if !foundDir {
 		t.Errorf("Expected 'api-service' project dir in candidates: %v", candidates)
-	}
-	if !foundBranch {
-		t.Errorf("Expected project@branch entries in candidates: %v", candidates)
-	}
-}
-
-func TestCompleteWorktree_WithAt(t *testing.T) {
-	root := t.TempDir()
-	campDir := filepath.Join(root, ".campaign")
-	os.MkdirAll(campDir, 0755)
-
-	// Create worktree structure
-	worktreeDir := filepath.Join(root, "projects", "worktrees", "api-service", "feature-x")
-	os.MkdirAll(worktreeDir, 0755)
-	worktreeDir2 := filepath.Join(root, "projects", "worktrees", "api-service", "bugfix-y")
-	os.MkdirAll(worktreeDir2, 0755)
-
-	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(root)
-
-	ctx := context.Background()
-
-	// Test completing with @
-	candidates, err := CompleteWorktree(ctx, "api-service@")
-	if err != nil {
-		t.Fatalf("CompleteWorktree failed: %v", err)
-	}
-
-	if len(candidates) < 2 {
-		t.Errorf("Expected at least 2 candidates for 'api-service@', got %d", len(candidates))
-	}
-}
-
-func TestCompleteWorktree_WithBranchPartial(t *testing.T) {
-	root := t.TempDir()
-	campDir := filepath.Join(root, ".campaign")
-	os.MkdirAll(campDir, 0755)
-
-	// Create worktree structure
-	worktreeDir := filepath.Join(root, "projects", "worktrees", "api-service", "feature-x")
-	os.MkdirAll(worktreeDir, 0755)
-	worktreeDir2 := filepath.Join(root, "projects", "worktrees", "api-service", "bugfix-y")
-	os.MkdirAll(worktreeDir2, 0755)
-
-	oldWd, _ := os.Getwd()
-	defer os.Chdir(oldWd)
-	os.Chdir(root)
-
-	ctx := context.Background()
-
-	candidates, err := CompleteWorktree(ctx, "api-service@feat")
-	if err != nil {
-		t.Fatalf("CompleteWorktree failed: %v", err)
-	}
-
-	if len(candidates) != 1 {
-		t.Errorf("Expected 1 candidate for 'api-service@feat', got %d: %v", len(candidates), candidates)
 	}
 }
 

--- a/internal/nav/index/builder.go
+++ b/internal/nav/index/builder.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/nav"
+	"github.com/Obedience-Corp/camp/internal/project"
+	"github.com/Obedience-Corp/camp/internal/worktree"
 )
 
 // Builder builds the navigation index by scanning campaign directories.
@@ -145,74 +147,94 @@ func (b *Builder) scanCategory(ctx context.Context, cat nav.Category) ([]Target,
 	return targets, nil
 }
 
-// scanWorktrees scans the worktrees directory for git worktree targets.
-// Worktrees are organized as: worktrees/<project>/<branch>
-// Targets are named as "project@branch".
+// scanWorktrees enumerates git worktrees for every project in the campaign,
+// using git as the source of truth. This finds every worktree regardless of
+// where it lives on disk, not just those under the conventional
+// projects/worktrees/<project>/ layout. Targets are named "project@name" where
+// name is the worktree directory basename, preserving navigation ergonomics
+// such as "cgo wt camp@feature".
+//
+// Projects are discovered with project.List (the same source of truth used by
+// "camp worktrees list") rather than the campaign config, because the project
+// set is derived from the projects/ checkout, not from campaign.yaml.
 func (b *Builder) scanWorktrees(ctx context.Context) ([]Target, error) {
-	worktreesDir := filepath.Join(b.root, nav.CategoryWorktrees.Dir())
-
-	// Check context
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
-	}
-
-	// Check if worktrees directory exists
-	info, err := os.Stat(worktreesDir)
-	if os.IsNotExist(err) {
-		return nil, nil // Not an error
-	}
+	projects, err := project.List(ctx, b.root)
 	if err != nil {
-		return nil, err
-	}
-	if !info.IsDir() {
+		// Degrade gracefully: without a project list there are no worktree
+		// targets to add, but the rest of the index is still valid.
 		return nil, nil
 	}
 
-	// List projects
-	projects, err := os.ReadDir(worktreesDir)
-	if err != nil {
-		return nil, err
-	}
-
 	var targets []Target
+	seen := make(map[string]struct{})
+
 	for _, proj := range projects {
-		// Check context
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
 
-		if !proj.IsDir() {
-			continue
-		}
-		if strings.HasPrefix(proj.Name(), ".") {
-			continue
-		}
-		if proj.Name() == "dungeon" {
-			continue
-		}
+		projectPath := project.ResolveProjectPath(b.root, proj)
 
-		// Each subdirectory is a worktree branch
-		projDir := filepath.Join(worktreesDir, proj.Name())
-		worktrees, err := os.ReadDir(projDir)
+		entries, err := worktree.NewGitWorktree(projectPath).List(ctx)
 		if err != nil {
+			// Not a git repo, a missing checkout, or a git failure: skip this
+			// project rather than failing the whole index build.
 			continue
 		}
 
-		for _, wt := range worktrees {
-			if !wt.IsDir() {
+		for _, entry := range entries {
+			target, ok := worktreeTarget(proj.Name, projectPath, entry)
+			if !ok {
 				continue
 			}
-			if strings.HasPrefix(wt.Name(), ".") {
+			clean := filepath.Clean(entry.Path)
+			if _, dup := seen[clean]; dup {
 				continue
 			}
-
-			targets = append(targets, Target{
-				Name:     proj.Name() + "@" + wt.Name(),
-				Path:     filepath.Join(projDir, wt.Name()),
-				Category: nav.CategoryWorktrees,
-			})
+			seen[clean] = struct{}{}
+			targets = append(targets, target)
 		}
 	}
 
 	return targets, nil
+}
+
+// worktreeTarget builds a navigation target for a linked worktree entry. It
+// reports ok=false for entries that are not navigable parallel worktrees: the
+// project's own main working tree, bare entries, git-internal paths, and hidden
+// directories.
+func worktreeTarget(projectName, projectPath string, entry worktree.GitWorktreeEntry) (Target, bool) {
+	if entry.IsBare || entry.Path == "" {
+		return Target{}, false
+	}
+
+	clean := filepath.Clean(entry.Path)
+
+	// Skip the project's own checkout (the main working tree). For submodules
+	// git reports the main worktree under <superproject>/.git/modules/<name>,
+	// so also skip any path that lives inside a .git directory.
+	if clean == filepath.Clean(projectPath) || containsGitDir(clean) {
+		return Target{}, false
+	}
+
+	name := filepath.Base(clean)
+	if name == "" || name == "." || strings.HasPrefix(name, ".") {
+		return Target{}, false
+	}
+
+	return Target{
+		Name:     projectName + "@" + name,
+		Path:     entry.Path,
+		Category: nav.CategoryWorktrees,
+	}, true
+}
+
+// containsGitDir reports whether path has a ".git" path component.
+func containsGitDir(path string) bool {
+	for _, part := range strings.Split(path, string(filepath.Separator)) {
+		if part == ".git" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/nav/index/builder_test.go
+++ b/internal/nav/index/builder_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Obedience-Corp/camp/internal/nav"
+	"github.com/Obedience-Corp/camp/internal/worktree"
 )
 
 func TestNewBuilder(t *testing.T) {
@@ -220,87 +221,113 @@ func TestBuilder_scanCategory_SkipsFiles(t *testing.T) {
 	}
 }
 
-func TestBuilder_scanWorktrees(t *testing.T) {
-	root := t.TempDir()
-	root, _ = filepath.EvalSymlinks(root)
+// TestWorktreeTarget covers the pure classification of git worktree entries
+// into navigation targets. The filesystem/git enumeration in scanWorktrees is
+// exercised end-to-end in the containerized integration harness
+// (tests/integration/navigation_worktree_test.go).
+func TestWorktreeTarget(t *testing.T) {
+	const (
+		project     = "camp"
+		projectPath = "/campaign/projects/camp"
+	)
 
-	// Create worktrees directory structure: projects/worktrees/<project>/<branch>
-	worktreesDir := filepath.Join(root, "projects", "worktrees")
-	if err := os.MkdirAll(filepath.Join(worktreesDir, "myproject", "feature-branch"), 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(worktreesDir, "myproject", "main"), 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(worktreesDir, "other-proj", "dev"), 0755); err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name     string
+		entry    worktree.GitWorktreeEntry
+		wantOK   bool
+		wantName string
+		wantPath string
+	}{
+		{
+			name:   "bare entry skipped",
+			entry:  worktree.GitWorktreeEntry{Path: "/campaign/projects/worktrees/camp/x", IsBare: true},
+			wantOK: false,
+		},
+		{
+			name:   "empty path skipped",
+			entry:  worktree.GitWorktreeEntry{Path: ""},
+			wantOK: false,
+		},
+		{
+			name:   "main working tree skipped",
+			entry:  worktree.GitWorktreeEntry{Path: projectPath, Branch: "main"},
+			wantOK: false,
+		},
+		{
+			name:   "submodule main worktree under .git skipped",
+			entry:  worktree.GitWorktreeEntry{Path: "/campaign/.git/modules/projects/camp", Branch: "main"},
+			wantOK: false,
+		},
+		{
+			name:   "hidden worktree directory skipped",
+			entry:  worktree.GitWorktreeEntry{Path: "/campaign/projects/worktrees/camp/.tmp"},
+			wantOK: false,
+		},
+		{
+			name:     "preferred-location worktree",
+			entry:    worktree.GitWorktreeEntry{Path: "/campaign/projects/worktrees/camp/feature-auth", Branch: "feature-auth"},
+			wantOK:   true,
+			wantName: "camp@feature-auth",
+			wantPath: "/campaign/projects/worktrees/camp/feature-auth",
+		},
+		{
+			name:     "non-preferred-location worktree still resolves",
+			entry:    worktree.GitWorktreeEntry{Path: "/campaign/projects/worktrees/fix-camp-392", IsDetached: true},
+			wantOK:   true,
+			wantName: "camp@fix-camp-392",
+			wantPath: "/campaign/projects/worktrees/fix-camp-392",
+		},
+		{
+			name:     "worktree entirely outside the worktrees dir still resolves",
+			entry:    worktree.GitWorktreeEntry{Path: "/tmp/scratch/camp-experiment", Branch: "experiment"},
+			wantOK:   true,
+			wantName: "camp@camp-experiment",
+			wantPath: "/tmp/scratch/camp-experiment",
+		},
 	}
 
-	builder := NewBuilder(root)
-	ctx := context.Background()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := worktreeTarget(project, projectPath, tc.entry)
+			if ok != tc.wantOK {
+				t.Fatalf("worktreeTarget() ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if got.Name != tc.wantName {
+				t.Errorf("Name = %q, want %q", got.Name, tc.wantName)
+			}
+			if got.Path != tc.wantPath {
+				t.Errorf("Path = %q, want %q", got.Path, tc.wantPath)
+			}
+			if got.Category != nav.CategoryWorktrees {
+				t.Errorf("Category = %q, want %q", got.Category, nav.CategoryWorktrees)
+			}
+		})
+	}
+}
 
-	targets, err := builder.scanWorktrees(ctx)
-	if err != nil {
-		t.Fatalf("scanWorktrees() error = %v", err)
+func TestContainsGitDir(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/campaign/.git/modules/projects/camp", true},
+		{"/campaign/projects/worktrees/camp/feature", false},
+		{"/campaign/projects/worktrees/fix-camp-392", false},
+		{".git/worktrees/x", true},
+		{"/campaign/projects/camp", false},
 	}
 
-	if len(targets) != 3 {
-		t.Errorf("Expected 3 worktree targets, got %d", len(targets))
-	}
-
-	// Verify naming convention: project@branch
-	names := make(map[string]bool)
-	for _, target := range targets {
-		names[target.Name] = true
-		if target.Category != nav.CategoryWorktrees {
-			t.Errorf("Worktree category = %q, want %q", target.Category, nav.CategoryWorktrees)
+	for _, tc := range tests {
+		if got := containsGitDir(tc.path); got != tc.want {
+			t.Errorf("containsGitDir(%q) = %v, want %v", tc.path, got, tc.want)
 		}
 	}
-
-	if !names["myproject@feature-branch"] {
-		t.Error("Expected myproject@feature-branch in targets")
-	}
-	if !names["myproject@main"] {
-		t.Error("Expected myproject@main in targets")
-	}
-	if !names["other-proj@dev"] {
-		t.Error("Expected other-proj@dev in targets")
-	}
 }
 
-func TestBuilder_scanWorktrees_SkipsHidden(t *testing.T) {
-	root := t.TempDir()
-	root, _ = filepath.EvalSymlinks(root)
-
-	worktreesDir := filepath.Join(root, "projects", "worktrees")
-	if err := os.MkdirAll(filepath.Join(worktreesDir, ".hidden-proj", "main"), 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(worktreesDir, "visible-proj", ".hidden-branch"), 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(worktreesDir, "visible-proj", "visible-branch"), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	builder := NewBuilder(root)
-	ctx := context.Background()
-
-	targets, err := builder.scanWorktrees(ctx)
-	if err != nil {
-		t.Fatalf("scanWorktrees() error = %v", err)
-	}
-
-	if len(targets) != 1 {
-		t.Errorf("Expected 1 target (hidden skipped), got %d", len(targets))
-	}
-
-	if len(targets) > 0 && targets[0].Name != "visible-proj@visible-branch" {
-		t.Errorf("Expected visible-proj@visible-branch, got %s", targets[0].Name)
-	}
-}
-
-func TestBuilder_scanWorktrees_NoWorktreesDir(t *testing.T) {
+func TestBuilder_scanWorktrees_NoProjects(t *testing.T) {
 	root := t.TempDir()
 	root, _ = filepath.EvalSymlinks(root)
 
@@ -313,7 +340,7 @@ func TestBuilder_scanWorktrees_NoWorktreesDir(t *testing.T) {
 	}
 
 	if len(targets) != 0 {
-		t.Errorf("Expected 0 targets for missing worktrees dir, got %d", len(targets))
+		t.Errorf("Expected 0 targets when no projects are registered, got %d", len(targets))
 	}
 }
 

--- a/tests/integration/navigation_worktree_test.go
+++ b/tests/integration/navigation_worktree_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupWorktreeNavCampaign creates a campaign with a single submodule project
+// and returns the campaign and project paths inside the container.
+func setupWorktreeNavCampaign(t *testing.T, tc *TestContainer, name string) (campPath, projPath string) {
+	t.Helper()
+	campPath = "/campaigns/" + name
+	bareDir := "/test/" + name + "-origin.git"
+	seedDir := "/test/" + name + "-seed"
+
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+git init --bare %[1]s
+git clone %[1]s %[2]s
+git -C %[2]s config user.email test@test.com
+git -C %[2]s config user.name Test
+printf '# Test\n' > %[2]s/README.md
+git -C %[2]s add . && git -C %[2]s commit -m 'init'
+git -C %[2]s branch -M main
+git -C %[2]s push origin main
+git --git-dir %[1]s symbolic-ref HEAD refs/heads/main
+`, bareDir, seedDir))
+
+	_, err := tc.InitCampaign(campPath, name, "product")
+	require.NoError(t, err)
+
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+cd %[1]s
+GIT_ALLOW_PROTOCOL=file git submodule add %[2]s projects/proj
+git commit -m 'add proj'
+`, campPath, bareDir))
+
+	return campPath, campPath + "/projects/proj"
+}
+
+// TestGoWorktree_ResolvesAcrossAllLocations verifies that worktree navigation
+// (cgo wt <project>@) uses git as the source of truth and finds every worktree
+// for a project, not only those under the conventional
+// projects/worktrees/<project>/ layout. It also verifies that plain directories
+// which are not registered git worktrees are excluded.
+func TestGoWorktree_ResolvesAcrossAllLocations(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath, projPath := setupWorktreeNavCampaign(t, tc, "wt-nav-all-locations")
+
+	// pref-wt lives in the preferred location: projects/worktrees/proj/pref-wt
+	// loose-wt lives OUTSIDE the preferred location, a sibling directly under
+	// projects/worktrees/ (mirroring a real worktree created without camp).
+	// not-a-worktree is a plain directory under the preferred location that git
+	// does not track as a worktree, so it must never resolve.
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+git -C %[1]s worktree add %[2]s/projects/worktrees/proj/pref-wt -b pref-wt
+git -C %[1]s worktree add %[2]s/projects/worktrees/loose-wt -b loose-wt
+mkdir -p %[2]s/projects/worktrees/proj/not-a-worktree
+`, projPath, campPath))
+
+	// Force a fresh navigation index so the assertions do not depend on cache
+	// staleness heuristics.
+	_, err := tc.RunCampInDir(campPath, "cache", "rebuild")
+	require.NoError(t, err)
+
+	// The preferred-location worktree resolves.
+	out, err := tc.RunCampInDir(campPath, "go", "wt", "proj@pref-wt", "--print")
+	require.NoError(t, err, "output:\n%s", out)
+	assert.Contains(t, out, "projects/worktrees/proj/pref-wt",
+		"preferred-location worktree should resolve")
+
+	// The non-preferred-location worktree resolves too. This is the regression:
+	// before the fix it was dropped because enumeration scanned only the
+	// preferred directory instead of git worktree list.
+	out, err = tc.RunCampInDir(campPath, "go", "wt", "proj@loose-wt", "--print")
+	require.NoError(t, err, "output:\n%s", out)
+	assert.Contains(t, out, "projects/worktrees/loose-wt",
+		"worktree outside the preferred location must resolve")
+	assert.NotContains(t, out, "projects/worktrees/proj/loose-wt",
+		"loose worktree must resolve to its real path, not the preferred layout")
+
+	// The ambiguous query lists both worktrees and excludes the plain directory.
+	out, err = tc.RunCampInDir(campPath, "go", "wt", "proj@", "--print")
+	require.NoError(t, err, "output:\n%s", out)
+	assert.Contains(t, out, "proj@pref-wt", "preferred worktree should be listed")
+	assert.Contains(t, out, "proj@loose-wt", "non-preferred worktree should be listed")
+	assert.NotContains(t, out, "not-a-worktree",
+		"a directory that is not a git worktree must not be listed")
+}
+
+// TestCompleteWorktree_BranchesAcrossLocations verifies that shell completion of
+// project@branch pulls from the git-backed navigation index, so worktrees are
+// offered regardless of where they live on disk.
+func TestCompleteWorktree_BranchesAcrossLocations(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath, projPath := setupWorktreeNavCampaign(t, tc, "wt-nav-complete")
+
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+git -C %[1]s worktree add %[2]s/projects/worktrees/proj/pref-wt -b pref-wt
+git -C %[1]s worktree add %[2]s/projects/worktrees/loose-wt -b loose-wt
+`, projPath, campPath))
+
+	_, err := tc.RunCampInDir(campPath, "cache", "rebuild")
+	require.NoError(t, err)
+
+	out, err := tc.RunCampInDir(campPath, "complete", "wt", "proj@")
+	require.NoError(t, err, "output:\n%s", out)
+	assert.Contains(t, out, "proj@pref-wt", "completion should offer the preferred worktree")
+	assert.Contains(t, out, "proj@loose-wt",
+		"completion should offer the worktree outside the preferred location")
+}


### PR DESCRIPTION
## Summary

`cgo wt <project>@` (worktree navigation) only surfaced worktrees that lived under the conventional `projects/worktrees/<project>/` directory. Worktrees registered to a project but sitting anywhere else on disk were invisible. This changes the navigation index to enumerate worktrees with `git worktree list` as the source of truth, so every worktree for a project resolves regardless of where it lives.

## Reproduction (before)

This campaign has a real camp worktree outside the preferred location: `projects/worktrees/fix-camp-392` (a sibling directly under `projects/worktrees/`, not under `projects/worktrees/camp/`). Git knows it belongs to camp:

```
$ git -C projects/camp worktree list
.../projects/worktrees/camp/camp-dead-surface            [camp-dead-surface]
.../projects/worktrees/camp/campaign-audit-trail-core    [campaign-audit-trail]
... (8 under projects/worktrees/camp/) ...
.../projects/worktrees/fix-camp-392                       (detached HEAD)
```

But `cgo wt camp@` never offered it, and instead invented bogus entries by treating that worktree's own subdirectories as worktrees:

```
$ command camp go wt camp@ --print
Multiple matches found:
  ... camp@campaign-audit-trail-core, camp@intent-commit-context, (8 total) ...
  fix-camp-392@internal
  fix-camp-392@cmd
  fix-camp-392@tools
  ...
```

Note there is no `camp@fix-camp-392`, and `fix-camp-392@cmd` / `@internal` etc. are not worktrees at all, they are the checkout's source directories. The same omission shows up in `camp worktrees list --project camp` and `camp p worktree list --project camp`: git reports 9 camp worktrees, both commands print only the 8 under the preferred directory.

## Root cause

`internal/nav/index/builder.go:scanWorktrees` enumerated worktrees by walking the filesystem: it read `projects/worktrees/`, treated each subdirectory as a project, and each of that subdirectory's children as a worktree named `project@child`. It never consulted git, so:

1. A real worktree outside `projects/worktrees/<project>/` was attributed to the wrong "project" (its own directory name), never to the owning project.
2. Non worktree directories under `projects/worktrees/<project>/` were offered as fake worktrees.

This is not a single regressing commit: the nav path has scanned the directory tree since the navigation feature was introduced in `04584970` ("feat: add navigation, project management, and completion features"). It is a long standing architectural limitation rather than a recent contract change. The most recent adjacent work, `931cad61` ("fix: filter registered worktrees in list", Jul 6), tightened `camp worktrees list` to drop non git directories, but it did not introduce and does not fix the missing worktree symptom (it still enumerates only the preferred directory). No test asserts that non preferred worktrees must be excluded, so there is no intentional narrowing to preserve.

## What changed

`internal/nav/index/builder.go`:

- `scanWorktrees` now discovers projects with `project.List` (the same source of truth `camp worktrees list` uses, derived from the `projects/` checkout rather than `campaign.yaml`, which does not list projects in this campaign), then runs `git worktree list --porcelain` per project via the existing `internal/worktree.GitWorktree.List`.
- New pure helper `worktreeTarget` classifies each git entry: it skips bare entries, the project's own main working tree (including the submodule case where git reports the main worktree under `.git/modules/<name>`), git internal paths, and hidden directories. Everything else becomes a `project@<basename>` target at the worktree's real path.
- Results are de duplicated by cleaned path. The `project@name` naming and the directory basename convention are preserved, so existing muscle memory (`cgo wt camp@feature`) is unchanged.

Context is propagated throughout, git failures for a project are skipped rather than failing the whole index build, and there is no `fmt.Errorf`.

## Tradeoffs

- Index rebuilds now shell out to git once per project (plus `project.List`). Measured cost on this campaign (47 projects) is about 1.3s, and this only runs on a cache rebuild (worktree topology change or 24h expiry), not on every `cgo`. This matches what `camp worktrees list` already does.
- Scope is intentionally limited to the reported navigation path (`cgo wt <project>@`). `camp worktrees list` and `camp p worktree list` share the same directory scan root cause (`cmd/camp/worktrees/list.go`, `cmd/camp/project/worktree/list.go`, both iterate `PathManager.ListProjectWorktrees`) and still drop non preferred worktrees. I left those out of this PR to avoid changing their `--json` output contract in a bug fix, and recommend a focused follow up.

## Verification (after)

Built from this branch and driven against this campaign's real worktrees:

```
$ camp cache rebuild        # 1.33s, 173 targets
$ camp go wt camp@ --print
Multiple matches found:
  camp@camp-dead-surface
  camp@campaign-audit-trail-core
  ... (all 8 preferred) ...
  camp@fix-wt-lookup-all-locations
  camp@fix-camp-392          <-- previously missing, now present
  (the bogus fix-camp-392@cmd / @internal entries are gone)

$ camp go wt camp@fix-camp-392 --print
/Users/.../obey-campaign/projects/worktrees/fix-camp-392

$ camp go wt camp@sync-ssh --print
/Users/.../obey-campaign/projects/worktrees/camp/sync-ssh-smoke-tests
```

The nav target count for `camp@` (10) now equals git's linked worktree count (11 entries minus the main working tree).

## Tests

- Unit (`internal/nav/index/builder_test.go`): table driven `TestWorktreeTarget` and `TestContainsGitDir` cover the pure classification (main working tree, submodule `.git` path, bare, hidden, preferred and non preferred, fully external paths), error/skip cases first.
- Integration (`tests/integration/navigation_worktree_test.go`, containerized, `//go:build integration`): `TestGoWorktree_ResolvesAcrossAllLocations` creates a submodule project with a preferred worktree, a non preferred worktree, and a plain non worktree directory, then asserts both worktrees resolve and the plain directory does not. `TestCompleteWorktree_BranchesAcrossLocations` asserts `camp complete wt proj@` offers both locations. The three former `internal/complete` unit tests that relied on git less directory fixtures were pared to the git independent project name path, with the git backed `project@branch` behavior moved to the container harness (git mutation must be containerized per repo convention).
- Gate: `just gate` passes (lint 0 issues, no host fs test or fmt.Errorf regressions, all 3325 unit tests). The worktree, navigation, fresh, and prune integration suites pass (46 tests, no failures).
