### PR TITLE
fix(nav): bump index version to 4 so stale worktree caches self-heal

### DIFF
--- a/internal/nav/index/cache_test.go
+++ b/internal/nav/index/cache_test.go
@@ -478,6 +478,56 @@ func TestGetOrBuild_UsesCache(t *testing.T) {
 	}
 }
 
+// TestGetOrBuild_DiscardsVersionMismatchedCache reproduces the stale-cache
+// scenario: a campaign carries a nav index written by an older binary whose
+// IndexVersion is behind the running binary. GetOrBuild must discard that cache
+// and rebuild without a manual "camp cache rebuild", so campaigns self-heal
+// after the enumeration semantics change.
+func TestGetOrBuild_DiscardsVersionMismatchedCache(t *testing.T) {
+	root := setupTestCampaign(t)
+	ctx := context.Background()
+
+	// A target a fresh build would never produce, tagged with the previous
+	// index version. Everything else about the cache is fresh, so the version
+	// mismatch is the only reason it can be considered stale.
+	stale := &Index{
+		Targets: []Target{{
+			Name:     "ghost@stale-worktree",
+			Path:     filepath.Join(root, "projects", "worktrees", "ghost", "stale-worktree"),
+			Category: nav.CategoryWorktrees,
+		}},
+		BuildTime:    time.Now(),
+		CampaignRoot: root,
+		Version:      IndexVersion - 1,
+	}
+	if err := Save(stale, root); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	idx, err := GetOrBuild(ctx, root, false)
+	if err != nil {
+		t.Fatalf("GetOrBuild() error = %v", err)
+	}
+
+	if idx.Version != IndexVersion {
+		t.Errorf("rebuilt index Version = %d, want %d", idx.Version, IndexVersion)
+	}
+	for _, target := range idx.Targets {
+		if target.Name == "ghost@stale-worktree" {
+			t.Fatalf("stale version-%d target survived; cache was not discarded", IndexVersion-1)
+		}
+	}
+
+	// The self-heal must persist to disk at the current version.
+	reloaded, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if reloaded == nil || reloaded.Version != IndexVersion {
+		t.Errorf("persisted cache = %v, want Version %d", reloaded, IndexVersion)
+	}
+}
+
 func TestGetOrBuild_ForceRebuild(t *testing.T) {
 	root := setupTestCampaign(t)
 

--- a/internal/nav/index/target.go
+++ b/internal/nav/index/target.go
@@ -97,10 +97,17 @@ type Index struct {
 	Version int `json:"version"`
 }
 
-// IndexVersion is the current index format version.
+// IndexVersion is the current index format version. Bump it whenever the
+// meaning of cached contents changes so older on-disk indexes are discarded and
+// rebuilt (see IsStale), not just when the JSON shape changes.
+//
 // Version 3 drops the unused per-target last_access cache field. Navigation
 // history remains in .campaign/cache/state.jsonl.
-const IndexVersion = 3
+//
+// Version 4 enumerates worktree targets from git worktree list rather than the
+// projects/worktrees/<project>/ directory layout, so pre-existing version 3
+// indexes miss worktrees outside the conventional location and must be rebuilt.
+const IndexVersion = 4
 
 // NewIndex creates a new empty index for a campaign root.
 func NewIndex(campaignRoot string) *Index {


### PR DESCRIPTION
## Summary

Follow-up to #429. That PR changed how the navigation index enumerates worktrees, but did not bump the index format version, so campaigns with an existing on-disk nav index were never told their cache was semantically outdated. The new binary read the old index as-is and kept returning the pre-fix results. This bumps `IndexVersion` 3 to 4 so any binary carrying the new enumeration discards old indexes and rebuilds on the next navigation, no manual `camp cache rebuild` needed.

## Reproduction (My_Tools)

Lance installed the #429 binary (dev, commit 0782cc21) and `cgo wt samantha@<tab>` still returned nothing; `command camp go wt samantha@ --print` errored `no targets in category projects/worktrees`. Running `camp cache rebuild` in that campaign fixed it, after which the index gained `samantha@test-audio-crackle-integration` at `/Users/lancerogers/Dev/AI/My_Tools/worktrees/samantha/test-audio-crackle-integration` (a root level `worktrees/` location the new enumeration handles correctly).

The trap: `.campaign/cache/nav-index.json` was a version 3 index, and #429 left `IndexVersion` at 3, so the staleness check saw a matching version and served the stale cache.

## Root cause

`internal/nav/index/cache.go:103`, inside `IsStale`, only forces a rebuild on a version change:

```go
if idx.Version != IndexVersion {
    return true
}
```

`IndexVersion` was `3` (`internal/nav/index/target.go:103`) both before and after #429, so existing version 3 caches were never invalidated by the enumeration change.

There is a second heuristic in `IsStale`: a cache is also stale if the camp binary's mtime is newer than the cache `BuildTime`. That is why some campaigns appeared to self-heal and others did not. It only fires when the binary is newer than the cache. When the cache was written after the binary was installed (or install methods preserve or reset mtimes, for example tarballs, Homebrew bottles, `go install` from the module cache), the binary looks older than the cache and the heuristic never triggers. That mtime race is exactly what happened in My_Tools. A format or semantics change must not depend on file timestamps, so the deterministic fix is the version bump.

## What changed

`internal/nav/index/target.go`: `IndexVersion` 3 to 4, with a comment clarifying that the constant must be bumped whenever the meaning of cached contents changes, not only when the JSON shape changes. Any index written by a pre-#429 binary (version 3) now mismatches and is rebuilt.

## Tradeoffs

- Every campaign rebuilds its nav index once on the first navigation after the new binary lands. Rebuild cost on a large campaign (obey-campaign, 47 projects) is about 1.3s, one time, and it already happens on any topology change.
- Caches written by the already merged #429 binary (also version 3, but with correct enumeration) are rebuilt too. That is a harmless extra rebuild producing an identical result.

## Test

`internal/nav/index/cache_test.go`: `TestGetOrBuild_DiscardsVersionMismatchedCache` writes an on-disk index tagged with the previous version (`IndexVersion - 1`) carrying a target a fresh build would never produce, with a fresh `BuildTime` so the version mismatch is the only possible staleness trigger, then asserts `GetOrBuild` (non-force) discards it, rebuilds at the current version, drops the stale target, and persists the new version to disk. The existing `TestIsStale_VersionMismatch` continues to cover the `IsStale` predicate directly.

## End-to-end verification

Built the branch binary (`camp-v4`, `IndexVersion` 4) and pointed it at obey-campaign after planting a stale version 3 index dated in the future, so the binary-mtime and freshness heuristics both pass and only the version can invalidate it (this recreates the My_Tools condition where the cache is newer than the binary).

Control, the installed version 3 binary (0782cc21) against that stale cache, reproduces the bug (serves stale, no rebuild):

```
$ command camp go wt camp@ --print
  fix-camp-392@internal
  fix-camp-392@cmd
# no camp@fix-camp-392; cache stays version 3, not rebuilt
```

Experiment, the version 4 binary against the same stale cache, with no manual rebuild:

```
$ camp-v4 go wt camp@ --print
  camp@fix-camp-392            <-- surfaced automatically
$ camp-v4 go wt camp@fix-camp-392 --print
/Users/lancerogers/Dev/AI/obey-campaign/projects/worktrees/fix-camp-392
# cache auto-rebuilt: version 4, has camp@fix-camp-392, bogus fix-camp-392@cmd gone
```

## Gate

`just gate` passes: lint 0 issues, no host-fs-test or fmt.Errorf regressions, all 3326 unit tests pass.
