### PR TITLE
feat(worktrees): interactive TUI for `camp worktrees list`

### DIFF
--- a/cmd/camp/worktrees/list.go
+++ b/cmd/camp/worktrees/list.go
@@ -60,6 +60,10 @@ func init() {
 		"Show only stale worktrees")
 	worktreesListCmd.Flags().BoolVar(&listJSON, "json", false,
 		"Output as JSON")
+	worktreesListCmd.Flags().BoolP("interactive", "i", false,
+		"Open the interactive worktree browser (prints the table when stdout is not a terminal)")
+	worktreesListCmd.Flags().String("path-output", "", "Write the selected worktree path to a file (shell integration)")
+	_ = worktreesListCmd.Flags().MarkHidden("path-output")
 	worktreesListCmd.SetFlagErrorFunc(jsoncontract.FlagErrorFunc(WorktreesListJSONVersion, func() bool { return listJSON }))
 }
 
@@ -97,9 +101,23 @@ func runWorktreesList(cmd *cobra.Command, args []string) error {
 	resolver := paths.NewResolver(campRoot, cfg.Paths())
 	pathManager := worktree.NewPathManager(resolver)
 
-	result, err := listWorktrees(ctx, campRoot, pathManager, listProject, listStale)
+	// In a terminal, a bare `camp worktrees list` opens the interactive browser
+	// (the same pattern as `camp list`). The browser holds every worktree and
+	// applies --stale as a live, toggleable filter, so load unfiltered for it;
+	// --json and the shaping flags still print the table/JSON.
+	openTUI := worktreesListTUIRequested(cmd, stdoutIsTTY())
+	loadStale := listStale
+	if openTUI {
+		loadStale = false
+	}
+
+	result, err := listWorktrees(ctx, campRoot, pathManager, listProject, loadStale)
 	if err != nil {
 		return err
+	}
+
+	if openTUI {
+		return runWorktreesListTUI(cmd, result)
 	}
 
 	if listJSON {

--- a/cmd/camp/worktrees/list_tui.go
+++ b/cmd/camp/worktrees/list_tui.go
@@ -1,0 +1,143 @@
+package worktrees
+
+import (
+	"os"
+	"sort"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"golang.org/x/term"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+// stdoutIsTTY reports whether stdout is an interactive terminal. Overridden in
+// tests so dispatch does not depend on the runner's terminal.
+var stdoutIsTTY = func() bool { return term.IsTerminal(int(os.Stdout.Fd())) }
+
+// wtListModel is the interactive worktree browser. It mirrors the campaign
+// browser (camp list): a flat, cursor-navigable list grouped by project, with
+// copy-path, go (cd via shell integration), and a stale-only filter, degrading
+// to a scrolling window when the list outgrows the terminal.
+type wtListModel struct {
+	all     []WorktreeListItem
+	visible []WorktreeListItem
+	cursor  int
+
+	staleOnly bool
+
+	status    string
+	statusErr bool
+
+	// gotoEnabled mirrors camp list: "go" only cds when the shell wrapper
+	// passed --path-output. Without it, enter/g explains how to enable it
+	// rather than silently doing nothing.
+	gotoEnabled bool
+	gotoPath    string
+
+	width    int
+	height   int
+	quitting bool
+}
+
+// worktreesListTUIRequested decides whether bare `camp worktrees list` opens the
+// browser. --json never does; -i forces it; a shaping flag (--project/--stale)
+// prints the table instead; otherwise an interactive terminal opens it.
+func worktreesListTUIRequested(cmd *cobra.Command, isTTY bool) bool {
+	if listJSON {
+		return false
+	}
+	if interactive, _ := cmd.Flags().GetBool("interactive"); interactive {
+		return true
+	}
+	for _, f := range []string{"project", "stale"} {
+		if cmd.Flags().Changed(f) {
+			return false
+		}
+	}
+	return isTTY
+}
+
+// runWorktreesListTUI loads every worktree and runs the interactive browser.
+// -i honors --project/--stale as the initial view (the way camp list -i honors
+// --org); a non-terminal stdout falls back to the table.
+func runWorktreesListTUI(cmd *cobra.Command, result *WorktreeListResult) error {
+	ctx := cmd.Context()
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		if listJSON {
+			return outputListJSON(result)
+		}
+		return outputListTable(result)
+	}
+	pathOutput, _ := cmd.Flags().GetString("path-output")
+	model := newWtListModel(result.Worktrees)
+	model.gotoEnabled = pathOutput != ""
+	model.staleOnly = listStale
+	model.rebuildVisible()
+
+	prog := tea.NewProgram(model, tea.WithContext(ctx), tea.WithAltScreen())
+	final, err := prog.Run()
+	if err != nil {
+		return camperrors.Wrap(err, "running worktree browser")
+	}
+	return writeGotoSelection(final, pathOutput)
+}
+
+// writeGotoSelection persists the worktree path the user chose, for the shell
+// function to cd into. No-op unless a path-output file was supplied and a
+// selection was made.
+func writeGotoSelection(final tea.Model, pathOutput string) error {
+	m, ok := final.(wtListModel)
+	if !ok || pathOutput == "" || m.gotoPath == "" {
+		return nil
+	}
+	return os.WriteFile(pathOutput, []byte(m.gotoPath), 0o600)
+}
+
+// newWtListModel builds a browser over the given worktrees, sorted into a
+// stable grouped order (by project, then name) so project headers render once.
+func newWtListModel(items []WorktreeListItem) wtListModel {
+	all := make([]WorktreeListItem, len(items))
+	copy(all, items)
+	sort.SliceStable(all, func(i, j int) bool {
+		if all[i].Project != all[j].Project {
+			return all[i].Project < all[j].Project
+		}
+		return all[i].Name < all[j].Name
+	})
+	m := wtListModel{all: all}
+	m.rebuildVisible()
+	return m
+}
+
+func (m *wtListModel) rebuildVisible() {
+	out := make([]WorktreeListItem, 0, len(m.all))
+	for _, e := range m.all {
+		if m.staleOnly && !e.Stale {
+			continue
+		}
+		out = append(out, e)
+	}
+	m.visible = out
+	m.cursor = ui.ClampIdx(m.cursor, len(m.visible))
+}
+
+func (m wtListModel) Init() tea.Cmd { return nil }
+
+func (m *wtListModel) copyPath() error {
+	return ui.WriteClipboard(m.visible[m.cursor].Path)
+}
+
+func (m *wtListModel) setStatus(s string, isErr bool) {
+	m.status = s
+	m.statusErr = isErr
+}
+
+func (m wtListModel) distinctProjects() int {
+	seen := map[string]bool{}
+	for _, e := range m.visible {
+		seen[e.Project] = true
+	}
+	return len(seen)
+}

--- a/cmd/camp/worktrees/list_tui_test.go
+++ b/cmd/camp/worktrees/list_tui_test.go
@@ -1,0 +1,206 @@
+package worktrees
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/internal/ui/uitest"
+)
+
+func wtFixture() []WorktreeListItem {
+	return []WorktreeListItem{
+		{Project: "api", Name: "feature-auth", Path: "/w/api/feature-auth", Branch: "feature-auth", LastAccessed: "2 hours ago"},
+		{Project: "api", Name: "bugfix", Path: "/w/api/bugfix", Branch: "bugfix", LastAccessed: "1 day ago", Stale: true, StaleReason: "missing .git"},
+		{Project: "web", Name: "redesign", Path: "/w/web/redesign", Branch: "redesign", LastAccessed: "just now"},
+	}
+}
+
+func wtKey(m wtListModel, s string) wtListModel {
+	var msg tea.KeyMsg
+	switch s {
+	case "enter":
+		msg = tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		msg = tea.KeyMsg{Type: tea.KeyEsc}
+	default:
+		msg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+	next, _ := m.Update(msg)
+	return next.(wtListModel)
+}
+
+func wtSized(m wtListModel, w, h int) wtListModel {
+	next, _ := m.Update(tea.WindowSizeMsg{Width: w, Height: h})
+	return next.(wtListModel)
+}
+
+// newWtListModel sorts into a stable (project, name) order so headers render
+// once and navigation is deterministic.
+func TestWtModel_SortsByProjectThenName(t *testing.T) {
+	m := newWtListModel(wtFixture())
+	got := []string{}
+	for _, e := range m.visible {
+		got = append(got, e.Project+"/"+e.Name)
+	}
+	want := []string{"api/bugfix", "api/feature-auth", "web/redesign"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("order = %v, want %v", got, want)
+	}
+}
+
+func TestWtModel_NavigationWraps(t *testing.T) {
+	m := newWtListModel(wtFixture())
+	if m.cursor != 0 {
+		t.Fatalf("cursor should start at 0, got %d", m.cursor)
+	}
+	m = wtKey(m, "k") // up from top wraps to last
+	if m.cursor != len(m.visible)-1 {
+		t.Fatalf("up from top should wrap to %d, got %d", len(m.visible)-1, m.cursor)
+	}
+	m = wtKey(m, "j") // down wraps back to top
+	if m.cursor != 0 {
+		t.Fatalf("down from bottom should wrap to 0, got %d", m.cursor)
+	}
+}
+
+func TestWtModel_StaleFilterToggle(t *testing.T) {
+	m := newWtListModel(wtFixture())
+	if len(m.visible) != 3 {
+		t.Fatalf("expected 3 visible, got %d", len(m.visible))
+	}
+	m = wtKey(m, "f") // stale-only
+	if len(m.visible) != 1 || !m.visible[0].Stale {
+		t.Fatalf("stale filter should leave the one stale worktree, got %d", len(m.visible))
+	}
+	m = wtKey(m, "f") // back to all
+	if len(m.visible) != 3 {
+		t.Fatalf("toggling filter off should restore all, got %d", len(m.visible))
+	}
+}
+
+func TestWtModel_CopyPath(t *testing.T) {
+	prev := ui.WriteClipboard
+	t.Cleanup(func() { ui.WriteClipboard = prev })
+	var copied string
+	ui.WriteClipboard = func(s string) error { copied = s; return nil }
+
+	m := newWtListModel(wtFixture()) // cursor 0 = api/bugfix
+	m = wtKey(m, "y")
+	if copied != "/w/api/bugfix" {
+		t.Fatalf("copied = %q, want /w/api/bugfix", copied)
+	}
+	if m.status != "copied!" {
+		t.Fatalf("status = %q, want copied!", m.status)
+	}
+}
+
+func TestWtModel_GoNeedsShellIntegration(t *testing.T) {
+	m := newWtListModel(wtFixture())
+	m = wtKey(m, "enter")
+	if m.quitting {
+		t.Fatal("go without shell integration must not quit")
+	}
+	if m.gotoPath != "" {
+		t.Fatalf("go without shell integration must not set a path, got %q", m.gotoPath)
+	}
+	if !m.statusErr || m.status == "" {
+		t.Fatalf("go without shell integration should surface an error status, got %q", m.status)
+	}
+}
+
+func TestWtModel_GoWithShellIntegration(t *testing.T) {
+	m := newWtListModel(wtFixture())
+	m.gotoEnabled = true
+	m.cursor = 2 // web/redesign
+	m = wtKey(m, "enter")
+	if !m.quitting {
+		t.Fatal("go with shell integration should quit")
+	}
+	if m.gotoPath != "/w/web/redesign" {
+		t.Fatalf("gotoPath = %q, want /w/web/redesign", m.gotoPath)
+	}
+}
+
+func TestWtModel_QuitKeys(t *testing.T) {
+	for _, k := range []string{"q", "esc"} {
+		m := wtKey(newWtListModel(wtFixture()), k)
+		if !m.quitting {
+			t.Fatalf("%q should quit", k)
+		}
+	}
+}
+
+func TestWtView_BoundedAtEverySize(t *testing.T) {
+	sizes := []struct{ w, h int }{
+		{120, 40}, {80, 24}, {60, 20}, {40, 10}, {30, 8}, {24, 6}, {20, 5}, {15, 6},
+		{10, 3}, {8, 2}, {1, 1}, {0, 0}, {40, 1}, {1, 40},
+	}
+	for _, s := range sizes {
+		m := wtSized(newWtListModel(wtFixture()), s.w, s.h)
+		m.cursor = 2
+		uitest.AssertBounded(t, m.View(), s.w, s.h)
+	}
+}
+
+func TestWtView_SelectionVisibleWhenScrolled(t *testing.T) {
+	m := wtSized(newWtListModel(wtFixture()), 40, 6)
+	m.cursor = len(m.visible) - 1
+	out := m.View()
+	uitest.AssertBounded(t, out, 40, 6)
+	if !strings.Contains(out, "> ") {
+		t.Fatalf("selected cursor not rendered when scrolled:\n%s", out)
+	}
+}
+
+func wtTestCmd() *cobra.Command {
+	c := &cobra.Command{}
+	c.Flags().BoolP("interactive", "i", false, "")
+	c.Flags().StringP("project", "p", "", "")
+	c.Flags().Bool("stale", false, "")
+	return c
+}
+
+func TestWorktreesListTUIRequested(t *testing.T) {
+	prevJSON := listJSON
+	t.Cleanup(func() { listJSON = prevJSON })
+
+	t.Run("bare TTY opens browser", func(t *testing.T) {
+		listJSON = false
+		if !worktreesListTUIRequested(wtTestCmd(), true) {
+			t.Fatal("bare command in a TTY should open the browser")
+		}
+	})
+	t.Run("no TTY prints table", func(t *testing.T) {
+		listJSON = false
+		if worktreesListTUIRequested(wtTestCmd(), false) {
+			t.Fatal("non-terminal stdout should print the table")
+		}
+	})
+	t.Run("json never opens browser", func(t *testing.T) {
+		listJSON = true
+		if worktreesListTUIRequested(wtTestCmd(), true) {
+			t.Fatal("--json should never open the browser")
+		}
+	})
+	t.Run("shaping flag prints table", func(t *testing.T) {
+		listJSON = false
+		c := wtTestCmd()
+		_ = c.Flags().Set("stale", "true")
+		if worktreesListTUIRequested(c, true) {
+			t.Fatal("--stale should print the filtered table")
+		}
+	})
+	t.Run("interactive forces browser", func(t *testing.T) {
+		listJSON = false
+		c := wtTestCmd()
+		_ = c.Flags().Set("stale", "true")
+		_ = c.Flags().Set("interactive", "true")
+		if !worktreesListTUIRequested(c, false) {
+			t.Fatal("-i should force the browser even with a shaping flag and no TTY")
+		}
+	})
+}

--- a/cmd/camp/worktrees/list_tui_update.go
+++ b/cmd/camp/worktrees/list_tui_update.go
@@ -1,0 +1,60 @@
+package worktrees
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func (m wtListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		return m.updateBrowse(msg)
+	}
+	return m, nil
+}
+
+func (m wtListModel) updateBrowse(key tea.KeyMsg) (tea.Model, tea.Cmd) {
+	m.status = ""
+	switch key.String() {
+	case "ctrl+c", "q", "esc":
+		m.quitting = true
+		return m, tea.Quit
+	case "g", "enter":
+		if len(m.visible) == 0 {
+			return m, nil
+		}
+		if !m.gotoEnabled {
+			m.setStatus("go needs shell integration: run eval \"$(camp shell-init <shell>)\"", true)
+			return m, nil
+		}
+		m.gotoPath = m.visible[m.cursor].Path
+		m.quitting = true
+		return m, tea.Quit
+	case "down", "j":
+		if len(m.visible) > 0 {
+			m.cursor = (m.cursor + 1) % len(m.visible)
+		}
+		return m, nil
+	case "up", "k":
+		if len(m.visible) > 0 {
+			m.cursor = (m.cursor - 1 + len(m.visible)) % len(m.visible)
+		}
+		return m, nil
+	case "y":
+		if len(m.visible) > 0 {
+			if err := m.copyPath(); err != nil {
+				m.setStatus("copy failed: "+err.Error(), true)
+			} else {
+				m.setStatus("copied!", false)
+			}
+		}
+		return m, nil
+	case "f":
+		m.staleOnly = !m.staleOnly
+		m.rebuildVisible()
+		return m, nil
+	}
+	return m, nil
+}

--- a/cmd/camp/worktrees/list_tui_view.go
+++ b/cmd/camp/worktrees/list_tui_view.go
@@ -1,0 +1,280 @@
+package worktrees
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	tuistyles "github.com/Obedience-Corp/camp/internal/intent/tui"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/internal/ui/theme"
+)
+
+var wtPal = theme.TUI()
+
+var (
+	wtTitleStyle = tuistyles.TitleStyle
+	wtHelpStyle  = tuistyles.HelpStyle
+	wtErrStyle   = tuistyles.ErrorStyle
+	wtOkStyle    = tuistyles.SuccessStyle
+	wtProjHeader = lipgloss.NewStyle().Foreground(wtPal.AccentAlt).Bold(true)
+	wtSelStyle   = lipgloss.NewStyle().Foreground(wtPal.Accent).Bold(true)
+	wtNameStyle  = lipgloss.NewStyle().Foreground(wtPal.TextPrimary)
+	wtMutedStyle = lipgloss.NewStyle().Foreground(wtPal.TextMuted)
+	wtBadgeOff   = lipgloss.NewStyle().Foreground(wtPal.Warning)
+	wtBox        = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(wtPal.BorderFocus).Padding(0, 1)
+)
+
+const (
+	wtNameMax   = 24
+	wtNameMin   = 8
+	wtBranchMax = 26
+	wtBranchMin = 6
+	wtStatusW   = 6  // "stale"
+	wtAccessedW = 14 // "12 minutes ago"
+	wtRowPrefix = 4  // two leading spaces plus a two-column cursor
+
+	wtBoxOverhead  = 4
+	wtMinBoxWidth  = 30
+	wtMinBoxHeight = 8
+	wtMinFooterH   = 6
+)
+
+// wtLayout captures the size-dependent shape of a render. cw and listRows of
+// zero or less mean "unbounded" (size not yet known), preserving the full-size
+// layout for tests and the first frame before a WindowSizeMsg arrives.
+type wtLayout struct {
+	cw         int
+	boxed      bool
+	showFooter bool
+	listRows   int
+}
+
+func (m wtListModel) layout() wtLayout {
+	wKnown, hKnown := m.width > 0, m.height > 0
+	l := wtLayout{
+		boxed:      (!wKnown || m.width >= wtMinBoxWidth) && (!hKnown || m.height >= wtMinBoxHeight),
+		showFooter: !hKnown || m.height >= wtMinFooterH,
+	}
+	if wKnown {
+		l.cw = m.width
+		if l.boxed {
+			l.cw -= wtBoxOverhead
+		}
+		l.cw = max(l.cw, 1)
+	}
+	if hKnown {
+		chrome := 2 // title plus blank separator
+		if l.boxed {
+			chrome += 2 // top and bottom border
+		}
+		if l.showFooter {
+			chrome += 2 // blank plus footer
+			if m.status != "" {
+				chrome++
+			}
+		}
+		l.listRows = max(m.height-chrome, 1)
+	}
+	return l
+}
+
+func (m wtListModel) View() string {
+	if m.quitting {
+		return ""
+	}
+	lay := m.layout()
+	lines := []string{m.topBar(), ""}
+	lines = append(lines, m.bodyLines(lay)...)
+	if lay.showFooter {
+		lines = append(lines, "")
+		if s := m.statusLine(); s != "" {
+			lines = append(lines, s)
+		}
+		lines = append(lines, m.footer(lay.cw))
+	}
+	return m.frame(lines, lay)
+}
+
+// frame clamps content to the terminal, hard-capping the line count so a tall
+// render can never overflow a short window, then wraps it in the border when
+// the size allows.
+func (m wtListModel) frame(lines []string, lay wtLayout) string {
+	budget := 0
+	if m.height > 0 {
+		budget = m.height
+		if lay.boxed {
+			budget = max(budget-2, 1)
+		}
+	}
+	content := strings.Join(ui.CapFrame(lines, lay.cw, budget), "\n")
+	if lay.boxed {
+		return ui.FitFullscreenView(wtBox.Render(content), m.height)
+	}
+	return ui.FitFullscreenView(content, m.height)
+}
+
+// bodyLines renders the worktree rows for the current window. Project headers
+// are kept while the whole list fits the height budget; once it must scroll it
+// degrades to a flat, cursor-centered window with a position indicator so the
+// selection always stays on screen.
+func (m wtListModel) bodyLines(lay wtLayout) []string {
+	total := len(m.visible)
+	if total == 0 {
+		return []string{wtMutedStyle.Render("no worktrees to show")}
+	}
+
+	budget := lay.listRows
+	if budget <= 0 || total+m.distinctProjects() <= budget {
+		return m.renderRange(0, total, true, lay.cw)
+	}
+
+	showIndicator := total > budget && budget >= 2
+	rows := budget
+	if showIndicator {
+		rows = budget - 1
+	}
+	start, end := ui.WindowRange(m.cursor, total, rows)
+	out := m.renderRange(start, end, false, lay.cw)
+	if showIndicator {
+		out = append(out, wtMutedStyle.Render(fmt.Sprintf("  [%d-%d of %d]", start+1, end, total)))
+	}
+	return out
+}
+
+func (m wtListModel) renderRange(start, end int, headers bool, cw int) []string {
+	var out []string
+	prevProject := ""
+	for i := start; i < end; i++ {
+		e := m.visible[i]
+		if headers && e.Project != prevProject {
+			out = append(out, wtProjHeader.Render(e.Project))
+			prevProject = e.Project
+		}
+		out = append(out, m.rowLine(e, i == m.cursor, cw))
+	}
+	return out
+}
+
+func (m wtListModel) rowLine(e WorktreeListItem, selected bool, cw int) string {
+	prefix := "  " + ui.CursorGlyph(selected)
+	if cw <= 0 {
+		name := styleWtName(fmt.Sprintf("%-*s", wtNameMax, e.Name), selected)
+		return prefix + name + "  " +
+			wtMutedStyle.Render(fmt.Sprintf("%-*s", wtBranchMin, e.Branch)) + "  " +
+			wtStatusCell(e, wtStatusW) + "  " +
+			wtMutedStyle.Render(e.LastAccessed)
+	}
+
+	rem := cw - wtRowPrefix
+	if rem < 1 {
+		return prefix
+	}
+
+	nameW, branchW, statusW, accessedW := wtColumns(rem)
+	row := prefix + styleWtName(fmt.Sprintf("%-*s", nameW, ui.Truncate(e.Name, nameW)), selected)
+	if branchW > 0 {
+		row += "  " + wtMutedStyle.Render(fmt.Sprintf("%-*s", branchW, ui.Truncate(e.Branch, branchW)))
+	}
+	if statusW > 0 {
+		row += "  " + wtStatusCell(e, statusW)
+	}
+	if accessedW > 0 {
+		row += "  " + wtMutedStyle.Render(ui.Truncate(e.LastAccessed, accessedW))
+	}
+	return row
+}
+
+// wtColumns splits the width remaining after the row prefix into name, branch,
+// status, and last-accessed columns, dropping the rightmost optional columns
+// (accessed, then status, then branch) as space runs out. NAME always shows.
+// Each column's minimum is reserved before the next is admitted, so a wide
+// branch cannot starve the status or accessed columns.
+func wtColumns(rem int) (nameW, branchW, statusW, accessedW int) {
+	const gap = 2
+	if rem < wtNameMin {
+		return max(rem, 1), 0, 0, 0
+	}
+	reserved := wtNameMin
+	hasBranch := rem >= reserved+gap+wtBranchMin
+	if hasBranch {
+		reserved += gap + wtBranchMin
+	}
+	hasStatus := rem >= reserved+gap+wtStatusW
+	if hasStatus {
+		reserved += gap + wtStatusW
+		statusW = wtStatusW
+	}
+	hasAccessed := rem >= reserved+gap+wtAccessedW
+	if hasAccessed {
+		accessedW = wtAccessedW
+	}
+
+	fixed := 0
+	if hasStatus {
+		fixed += gap + wtStatusW
+	}
+	if hasAccessed {
+		fixed += gap + wtAccessedW
+	}
+	nbBudget := rem - fixed // name (+ gap + branch)
+	if !hasBranch {
+		return min(nbBudget, wtNameMax), 0, statusW, accessedW
+	}
+	nameW = min(nbBudget-gap-wtBranchMin, wtNameMax)
+	if nameW < wtNameMin {
+		nameW = wtNameMin
+	}
+	branchW = nbBudget - gap - nameW
+	if branchW > wtBranchMax {
+		branchW = wtBranchMax
+	}
+	return nameW, branchW, statusW, accessedW
+}
+
+func wtStatusCell(e WorktreeListItem, width int) string {
+	label, style := "ok", wtMutedStyle
+	if e.Stale {
+		label, style = "stale", wtBadgeOff
+	}
+	if width > 0 {
+		return style.Render(fmt.Sprintf("%-*s", width, ui.Truncate(label, width)))
+	}
+	return style.Render(label)
+}
+
+func (m wtListModel) topBar() string {
+	mode := "all"
+	if m.staleOnly {
+		mode = "stale only"
+	}
+	return wtTitleStyle.Render("Worktrees") + "  " +
+		wtMutedStyle.Render(fmt.Sprintf("%s  .  showing: %s", ui.CountLabel(len(m.all), "worktree", "worktrees"), mode))
+}
+
+func (m wtListModel) footer(cw int) string {
+	help := ui.CollapseHelp(cw,
+		"g: go . j/k: move . y: copy . f: filter . q: quit",
+		"j/k move . g go . f filter . q quit",
+		"q quit",
+	)
+	return wtHelpStyle.Render(help)
+}
+
+func (m wtListModel) statusLine() string {
+	if m.status == "" {
+		return ""
+	}
+	if m.statusErr {
+		return wtErrStyle.Render(m.status)
+	}
+	return wtOkStyle.Render(m.status)
+}
+
+func styleWtName(s string, selected bool) string {
+	if selected {
+		return wtSelStyle.Render(s)
+	}
+	return wtNameStyle.Render(s)
+}


### PR DESCRIPTION
## What

Brings the campaign-wide `camp worktrees list` to the same interactive-browser pattern as `camp list`. In a terminal, a bare `camp worktrees list` now opens a bubbletea browser; `--json`, `--project`, `--stale`, and a non-terminal stdout still print the existing table/JSON (same dispatch shape as `camp list`).

## The browser

- **Grouped by project** (project headers, like `camp list`'s org headers)
- **`j`/`k`** navigate (wrap), **`y`** copy the selected worktree path, **`g`/`enter`** go/cd (the `--path-output` shell-integration mechanism `camp list` uses; hints if the shell wrapper isn't wired), **`f`** toggle a stale-only filter, **`q`** quit
- Reuses the shared `internal/ui` responsive helpers: scroll windowing with an `[x-y of z]` indicator when the list outgrows the terminal, collapsing footer help, bordered frame, shared theme — so it looks and behaves like the campaign browser
- Columns: NAME · BRANCH · STATUS · LAST ACCESSED, dropped right-to-left as width shrinks

## Verification

Per the repo rule that green tests don't verify a TUI, I drove the real binary in a **pyte PTY** against the live campaign's 35 worktrees:

- grouped-header render (projects `camp`, `fest`, `festival-app`, `obey`, `termcast`, …)
- scroll windowing + `[1-23 of 35]` indicator at a short terminal
- stale-filter toggle (`showing: all` ⇄ `showing: stale only`)
- clean quit (exit 0)

Model behavior — sort/group, navigation wrap, filter, copy (clipboard stubbed), go with/without shell integration, and the TUI-vs-table dispatch — is covered by unit tests (`list_tui_test.go`), including `uitest.AssertBounded` across a matrix of terminal sizes.

## Scope note

`camp worktrees` is the **deprecated** campaign-wide surface, but it's the genuine analog of `camp list` (browse everything across the workspace — the canonical `camp project worktree list` is single-project). The TUI is factored (`newWtListModel` takes a plain `[]WorktreeListItem`) so it can be lifted to a canonical home later. Say the word if you'd rather it live on `camp project worktree list`.

## Gates

Build + `go vet` clean, unit tests green, `just lint` 0 issues (host-FS ratchet clean, no fmt.Errorf regressions). CI is paused for cost; run locally.