### PR TITLE
fresh: follow-up command workflows and configure subcommand

### DIFF
--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -1455,7 +1455,9 @@ single project name. Use --list to cycle a specific set of projects in one
 run, or 'camp fresh all' to cycle every project submodule in the campaign.
 
 Without configuration, syncs to the default branch and prunes.
-Configure .campaign/settings/fresh.yaml to set a default working branch.
+Configure .campaign/settings/fresh.yaml to set a default working branch, or
+follow-up command workflows (install, build, bootstrap, ...) to run once the
+cycle succeeds. Manage those with 'camp fresh configure'.
 
 Examples:
   camp fresh                            # Sync current project (checkout default, pull, prune)
@@ -1463,7 +1465,8 @@ Examples:
   camp fresh camp -b feat/new-thing     # Sync camp project, create feature branch
   camp fresh --list camp,fest,festival  # Sync a specific set of projects
   camp fresh --no-prune                 # Sync without pruning
-  camp fresh --dry-run                  # Preview what would happen
+  camp fresh --no-follow-up             # Sync without running configured follow-ups
+  camp fresh --dry-run                  # Preview what would happen (follow-ups listed, not run)
 
 ```
 camp fresh [project-name] [flags]
@@ -1477,6 +1480,7 @@ camp fresh [project-name] [flags]
   -h, --help             help for fresh
       --list strings     Comma-separated set of projects to cycle in one run
       --no-branch        Skip branch creation even if configured
+      --no-follow-up     Skip configured follow-up command workflows
       --no-prune         Skip pruning merged branches
       --no-push          Skip pushing the new branch upstream
   -p, --project string   Project name (auto-detected from cwd)
@@ -1521,6 +1525,130 @@ camp fresh all [flags]
   -n, --dry-run         Preview without making changes
       --no-branch       Skip branch creation even if configured
       --no-color        disable colored output
+      --no-follow-up    Skip configured follow-up command workflows
+      --no-prune        Skip pruning merged branches
+      --no-push         Skip pushing the new branch upstream
+```
+---
+
+## camp fresh configure
+
+Manage camp fresh follow-up command workflows
+
+### Synopsis
+
+Manage the follow-up command workflows camp fresh runs after a
+successful sync/prune/branch cycle. Configuration lives in
+.campaign/settings/fresh.yaml: a global default list, plus optional
+per-project override lists that replace the global list entirely.
+
+Examples:
+  camp fresh configure show
+  camp fresh configure add install --run "npm install"
+  camp fresh configure add build --run "go build ./..." --project camp --dir cmd/camp
+  camp fresh configure remove install
+  camp fresh configure remove build --project camp
+
+### Options
+
+```
+  -h, --help   help for configure
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --branch string   Branch to create after syncing (overrides config)
+  -n, --dry-run         Preview without making changes
+      --no-branch       Skip branch creation even if configured
+      --no-color        disable colored output
+      --no-follow-up    Skip configured follow-up command workflows
+      --no-prune        Skip pruning merged branches
+      --no-push         Skip pushing the new branch upstream
+```
+---
+
+## camp fresh configure add
+
+Add a follow-up command workflow step
+
+```
+camp fresh configure add <name> [flags]
+```
+
+### Options
+
+```
+      --continue-on-error   Keep running later follow-ups if this step fails
+      --dir string          Directory relative to the project root to run the command in
+  -h, --help                help for add
+      --project string      Scope this follow-up to a single project (default: global)
+      --run string          Command to run for this follow-up step (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --branch string   Branch to create after syncing (overrides config)
+  -n, --dry-run         Preview without making changes
+      --no-branch       Skip branch creation even if configured
+      --no-color        disable colored output
+      --no-follow-up    Skip configured follow-up command workflows
+      --no-prune        Skip pruning merged branches
+      --no-push         Skip pushing the new branch upstream
+```
+---
+
+## camp fresh configure remove
+
+Remove a follow-up command workflow step
+
+```
+camp fresh configure remove <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help             help for remove
+      --project string   Scope removal to a single project (default: global)
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --branch string   Branch to create after syncing (overrides config)
+  -n, --dry-run         Preview without making changes
+      --no-branch       Skip branch creation even if configured
+      --no-color        disable colored output
+      --no-follow-up    Skip configured follow-up command workflows
+      --no-prune        Skip pruning merged branches
+      --no-push         Skip pushing the new branch upstream
+```
+---
+
+## camp fresh configure show
+
+Show configured follow-up workflows
+
+```
+camp fresh configure show [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --branch string   Branch to create after syncing (overrides config)
+  -n, --dry-run         Preview without making changes
+      --no-branch       Skip branch creation even if configured
+      --no-color        disable colored output
+      --no-follow-up    Skip configured follow-up command workflows
       --no-prune        Skip pruning merged branches
       --no-push         Skip pushing the new branch upstream
 ```

--- a/docs/cli-reference/camp_fresh.md
+++ b/docs/cli-reference/camp_fresh.md
@@ -14,7 +14,9 @@ single project name. Use --list to cycle a specific set of projects in one
 run, or 'camp fresh all' to cycle every project submodule in the campaign.
 
 Without configuration, syncs to the default branch and prunes.
-Configure .campaign/settings/fresh.yaml to set a default working branch.
+Configure .campaign/settings/fresh.yaml to set a default working branch, or
+follow-up command workflows (install, build, bootstrap, ...) to run once the
+cycle succeeds. Manage those with 'camp fresh configure'.
 
 Examples:
   camp fresh                            # Sync current project (checkout default, pull, prune)
@@ -22,7 +24,8 @@ Examples:
   camp fresh camp -b feat/new-thing     # Sync camp project, create feature branch
   camp fresh --list camp,fest,festival  # Sync a specific set of projects
   camp fresh --no-prune                 # Sync without pruning
-  camp fresh --dry-run                  # Preview what would happen
+  camp fresh --no-follow-up             # Sync without running configured follow-ups
+  camp fresh --dry-run                  # Preview what would happen (follow-ups listed, not run)
 
 ```
 camp fresh [project-name] [flags]
@@ -36,6 +39,7 @@ camp fresh [project-name] [flags]
   -h, --help             help for fresh
       --list strings     Comma-separated set of projects to cycle in one run
       --no-branch        Skip branch creation even if configured
+      --no-follow-up     Skip configured follow-up command workflows
       --no-prune         Skip pruning merged branches
       --no-push          Skip pushing the new branch upstream
   -p, --project string   Project name (auto-detected from cwd)
@@ -51,3 +55,4 @@ camp fresh [project-name] [flags]
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
 * [camp fresh all](camp_fresh_all.md)	 - Run fresh across all project submodules
+* [camp fresh configure](camp_fresh_configure.md)	 - Manage camp fresh follow-up command workflows

--- a/docs/cli-reference/camp_fresh_all.md
+++ b/docs/cli-reference/camp_fresh_all.md
@@ -30,6 +30,7 @@ camp fresh all [flags]
   -n, --dry-run         Preview without making changes
       --no-branch       Skip branch creation even if configured
       --no-color        disable colored output
+      --no-follow-up    Skip configured follow-up command workflows
       --no-prune        Skip pruning merged branches
       --no-push         Skip pushing the new branch upstream
 ```

--- a/docs/cli-reference/camp_fresh_configure.md
+++ b/docs/cli-reference/camp_fresh_configure.md
@@ -1,0 +1,42 @@
+## camp fresh configure
+
+Manage camp fresh follow-up command workflows
+
+### Synopsis
+
+Manage the follow-up command workflows camp fresh runs after a
+successful sync/prune/branch cycle. Configuration lives in
+.campaign/settings/fresh.yaml: a global default list, plus optional
+per-project override lists that replace the global list entirely.
+
+Examples:
+  camp fresh configure show
+  camp fresh configure add install --run "npm install"
+  camp fresh configure add build --run "go build ./..." --project camp --dir cmd/camp
+  camp fresh configure remove install
+  camp fresh configure remove build --project camp
+
+### Options
+
+```
+  -h, --help   help for configure
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --branch string   Branch to create after syncing (overrides config)
+  -n, --dry-run         Preview without making changes
+      --no-branch       Skip branch creation even if configured
+      --no-color        disable colored output
+      --no-follow-up    Skip configured follow-up command workflows
+      --no-prune        Skip pruning merged branches
+      --no-push         Skip pushing the new branch upstream
+```
+
+### SEE ALSO
+
+* [camp fresh](camp_fresh.md)	 - Post-merge branch cycling: sync to default branch and optionally create a new working branch
+* [camp fresh configure add](camp_fresh_configure_add.md)	 - Add a follow-up command workflow step
+* [camp fresh configure remove](camp_fresh_configure_remove.md)	 - Remove a follow-up command workflow step
+* [camp fresh configure show](camp_fresh_configure_show.md)	 - Show configured follow-up workflows

--- a/docs/cli-reference/camp_fresh_configure_add.md
+++ b/docs/cli-reference/camp_fresh_configure_add.md
@@ -1,0 +1,33 @@
+## camp fresh configure add
+
+Add a follow-up command workflow step
+
+```
+camp fresh configure add <name> [flags]
+```
+
+### Options
+
+```
+      --continue-on-error   Keep running later follow-ups if this step fails
+      --dir string          Directory relative to the project root to run the command in
+  -h, --help                help for add
+      --project string      Scope this follow-up to a single project (default: global)
+      --run string          Command to run for this follow-up step (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --branch string   Branch to create after syncing (overrides config)
+  -n, --dry-run         Preview without making changes
+      --no-branch       Skip branch creation even if configured
+      --no-color        disable colored output
+      --no-follow-up    Skip configured follow-up command workflows
+      --no-prune        Skip pruning merged branches
+      --no-push         Skip pushing the new branch upstream
+```
+
+### SEE ALSO
+
+* [camp fresh configure](camp_fresh_configure.md)	 - Manage camp fresh follow-up command workflows

--- a/docs/cli-reference/camp_fresh_configure_remove.md
+++ b/docs/cli-reference/camp_fresh_configure_remove.md
@@ -1,0 +1,30 @@
+## camp fresh configure remove
+
+Remove a follow-up command workflow step
+
+```
+camp fresh configure remove <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help             help for remove
+      --project string   Scope removal to a single project (default: global)
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --branch string   Branch to create after syncing (overrides config)
+  -n, --dry-run         Preview without making changes
+      --no-branch       Skip branch creation even if configured
+      --no-color        disable colored output
+      --no-follow-up    Skip configured follow-up command workflows
+      --no-prune        Skip pruning merged branches
+      --no-push         Skip pushing the new branch upstream
+```
+
+### SEE ALSO
+
+* [camp fresh configure](camp_fresh_configure.md)	 - Manage camp fresh follow-up command workflows

--- a/docs/cli-reference/camp_fresh_configure_show.md
+++ b/docs/cli-reference/camp_fresh_configure_show.md
@@ -1,0 +1,29 @@
+## camp fresh configure show
+
+Show configured follow-up workflows
+
+```
+camp fresh configure show [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --branch string   Branch to create after syncing (overrides config)
+  -n, --dry-run         Preview without making changes
+      --no-branch       Skip branch creation even if configured
+      --no-color        disable colored output
+      --no-follow-up    Skip configured follow-up command workflows
+      --no-prune        Skip pruning merged branches
+      --no-push         Skip pushing the new branch upstream
+```
+
+### SEE ALSO
+
+* [camp fresh configure](camp_fresh_configure.md)	 - Manage camp fresh follow-up command workflows

--- a/internal/commands/fresh/batch.go
+++ b/internal/commands/fresh/batch.go
@@ -19,11 +19,12 @@ import (
 // invocation. It is passed to runFreshBatch so per-project settings can be
 // resolved against the fresh config.
 type freshFlagSet struct {
-	branch   string
-	noBranch bool
-	noPush   bool
-	noPrune  bool
-	dryRun   bool
+	branch     string
+	noBranch   bool
+	noPush     bool
+	noPrune    bool
+	noFollowUp bool
+	dryRun     bool
 }
 
 // freshTarget is a resolved project to run the fresh cycle against.
@@ -39,13 +40,15 @@ func getFreshFlagSet(freshCmd *cobra.Command) freshFlagSet {
 	noBranch, _ := freshCmd.PersistentFlags().GetBool("no-branch")
 	noPush, _ := freshCmd.PersistentFlags().GetBool("no-push")
 	noPrune, _ := freshCmd.PersistentFlags().GetBool("no-prune")
+	noFollowUp, _ := freshCmd.PersistentFlags().GetBool("no-follow-up")
 	dryRun, _ := freshCmd.PersistentFlags().GetBool("dry-run")
 	return freshFlagSet{
-		branch:   branch,
-		noBranch: noBranch,
-		noPush:   noPush,
-		noPrune:  noPrune,
-		dryRun:   dryRun,
+		branch:     branch,
+		noBranch:   noBranch,
+		noPush:     noPush,
+		noPrune:    noPrune,
+		noFollowUp: noFollowUp,
+		dryRun:     dryRun,
 	}
 }
 
@@ -116,12 +119,14 @@ func runFreshBatch(ctx context.Context, cfg *config.FreshConfig, targets []fresh
 		branch := cfg.ResolveFreshBranch(flags.branch, flags.noBranch, t.name)
 		doPrune := !flags.noPrune && cfg.ResolveFreshPrune()
 		doPush := !flags.noPush && cfg.ResolveFreshPushUpstream(t.name)
+		followUps := resolveFreshFollowUps(cfg, t.name, flags.noFollowUp)
 
 		err := executeFresh(ctx, t.name, t.path, freshOptions{
 			branch:      branch,
 			prune:       doPrune,
 			pruneRemote: cfg.ResolveFreshPruneRemote(),
 			push:        doPush,
+			followUps:   followUps,
 			dryRun:      flags.dryRun,
 		})
 		if err != nil {

--- a/internal/commands/fresh/configure.go
+++ b/internal/commands/fresh/configure.go
@@ -1,0 +1,179 @@
+package fresh
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/ui"
+)
+
+// newConfigureCommand builds the non-interactive `camp fresh configure`
+// subcommand group for managing follow-up command workflows stored in
+// .campaign/settings/fresh.yaml.
+func newConfigureCommand() *cobra.Command {
+	configureCmd := &cobra.Command{
+		Use:   "configure",
+		Short: "Manage camp fresh follow-up command workflows",
+		Long: `Manage the follow-up command workflows camp fresh runs after a
+successful sync/prune/branch cycle. Configuration lives in
+.campaign/settings/fresh.yaml: a global default list, plus optional
+per-project override lists that replace the global list entirely.
+
+Examples:
+  camp fresh configure show
+  camp fresh configure add install --run "npm install"
+  camp fresh configure add build --run "go build ./..." --project camp --dir cmd/camp
+  camp fresh configure remove install
+  camp fresh configure remove build --project camp`,
+	}
+
+	configureCmd.AddCommand(newConfigureShowCommand())
+	configureCmd.AddCommand(newConfigureAddCommand())
+	configureCmd.AddCommand(newConfigureRemoveCommand())
+
+	return configureCmd
+}
+
+func newConfigureShowCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show",
+		Short: "Show configured follow-up workflows",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+
+			campRoot, err := campaign.DetectCached(ctx)
+			if err != nil {
+				return camperrors.Wrap(err, "not in a campaign")
+			}
+
+			cfg, err := config.LoadFreshConfig(ctx, campRoot)
+			if err != nil {
+				return camperrors.Wrap(err, "loading fresh config")
+			}
+
+			printFollowUpSection("Global", cfg.FollowUp)
+
+			names := make([]string, 0, len(cfg.Projects))
+			for name, pc := range cfg.Projects {
+				if len(pc.FollowUp) > 0 {
+					names = append(names, name)
+				}
+			}
+			sort.Strings(names)
+
+			for _, name := range names {
+				fmt.Println()
+				printFollowUpSection("Project: "+name, cfg.Projects[name].FollowUp)
+			}
+
+			return nil
+		},
+	}
+}
+
+func printFollowUpSection(label string, steps []config.FollowUpConfig) {
+	fmt.Println(ui.Header(label))
+	if len(steps) == 0 {
+		fmt.Println(ui.Dim("  (none configured)"))
+		return
+	}
+	for _, step := range steps {
+		line := fmt.Sprintf("  %s  %s", ui.Value(step.Name), step.Run)
+		if step.Dir != "" {
+			line += " " + ui.Dim(fmt.Sprintf("(dir: %s)", step.Dir))
+		}
+		if step.ContinueOnError {
+			line += " " + ui.Dim("[continue-on-error]")
+		}
+		fmt.Println(line)
+	}
+}
+
+func newConfigureAddCommand() *cobra.Command {
+	var (
+		run             string
+		project         string
+		dir             string
+		continueOnError bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "add <name>",
+		Short: "Add a follow-up command workflow step",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			name := args[0]
+
+			campRoot, err := campaign.DetectCached(ctx)
+			if err != nil {
+				return camperrors.Wrap(err, "not in a campaign")
+			}
+
+			entry := config.FollowUpConfig{
+				Name:            name,
+				Run:             run,
+				Dir:             dir,
+				ContinueOnError: continueOnError,
+			}
+
+			if err := config.AddFreshFollowUp(ctx, campRoot, project, entry); err != nil {
+				return err
+			}
+
+			fmt.Println(ui.Success(fmt.Sprintf("Added follow-up %q (%s)", name, followUpScopeDescription(project))))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&run, "run", "", "Command to run for this follow-up step (required)")
+	cmd.Flags().StringVar(&project, "project", "", "Scope this follow-up to a single project (default: global)")
+	cmd.Flags().StringVar(&dir, "dir", "", "Directory relative to the project root to run the command in")
+	cmd.Flags().BoolVar(&continueOnError, "continue-on-error", false, "Keep running later follow-ups if this step fails")
+	_ = cmd.MarkFlagRequired("run")
+
+	return cmd
+}
+
+func newConfigureRemoveCommand() *cobra.Command {
+	var project string
+
+	cmd := &cobra.Command{
+		Use:   "remove <name>",
+		Short: "Remove a follow-up command workflow step",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			name := args[0]
+
+			campRoot, err := campaign.DetectCached(ctx)
+			if err != nil {
+				return camperrors.Wrap(err, "not in a campaign")
+			}
+
+			if err := config.RemoveFreshFollowUp(ctx, campRoot, project, name); err != nil {
+				return err
+			}
+
+			fmt.Println(ui.Success(fmt.Sprintf("Removed follow-up %q (%s)", name, followUpScopeDescription(project))))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&project, "project", "", "Scope removal to a single project (default: global)")
+
+	return cmd
+}
+
+func followUpScopeDescription(project string) string {
+	if project == "" {
+		return "global"
+	}
+	return "project " + project
+}

--- a/internal/commands/fresh/followup.go
+++ b/internal/commands/fresh/followup.go
@@ -1,0 +1,98 @@
+package fresh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/ui"
+)
+
+// resolveFreshFollowUps resolves the follow-up steps for a project, honoring
+// --no-follow-up by resolving to no steps regardless of configuration.
+func resolveFreshFollowUps(cfg *config.FreshConfig, projectName string, noFollowUp bool) []config.FollowUpConfig {
+	if noFollowUp {
+		return nil
+	}
+	return cfg.ResolveFreshFollowUps(projectName)
+}
+
+// runFreshFollowUps runs the configured follow-up command steps, in order,
+// after a successful sync/prune/branch cycle. On dry-run each step is listed
+// but never executed. A step that fails without continue_on_error aborts the
+// remaining steps and the fresh cycle for this project.
+func runFreshFollowUps(ctx context.Context, path string, steps []config.FollowUpConfig, dryRun bool) error {
+	if len(steps) == 0 {
+		return nil
+	}
+
+	prefix := "  "
+	fmt.Println()
+	if dryRun {
+		fmt.Printf("%s── Follow-ups (%d)                 %s\n", prefix, len(steps), freshStepDim.Render("preview only"))
+	} else {
+		fmt.Printf("%s── Follow-ups (%d)\n", prefix, len(steps))
+	}
+
+	for _, step := range steps {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if dryRun {
+			fmt.Printf("%s   %s %s\n", prefix, ui.Value(step.Name),
+				freshStepDim.Render(fmt.Sprintf("(would run: %s)", step.Run)))
+			continue
+		}
+
+		fmt.Printf("%s   %s %s\n", prefix, ui.Value(step.Name), freshStepDim.Render("$ "+step.Run))
+
+		workDir := path
+		if step.Dir != "" {
+			workDir = filepath.Join(path, step.Dir)
+		}
+
+		if err := runFollowUpCommand(ctx, workDir, step.Run); err != nil {
+			if step.ContinueOnError {
+				fmt.Printf("%s   %s %s\n", prefix, ui.Value(step.Name),
+					ui.Warning("failed (continuing): "+err.Error()))
+				continue
+			}
+			fmt.Printf("%s   %s %s\n", prefix, ui.Value(step.Name), ui.Error("failed"))
+			return camperrors.Wrapf(err, "follow-up %q", step.Name)
+		}
+
+		fmt.Printf("%s   %s %s\n", prefix, ui.Value(step.Name), freshStepGreen.Render("done"))
+	}
+
+	return nil
+}
+
+// runFollowUpCommand runs command through the shell in dir, streaming its
+// stdout/stderr directly to the terminal so long-running steps (installs,
+// builds) show live progress rather than a silent pause.
+func runFollowUpCommand(ctx context.Context, dir, command string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return camperrors.NewCommand(command, exitErr.ExitCode(), "", exitErr)
+		}
+		return camperrors.Wrapf(err, "execute %q", command)
+	}
+
+	return nil
+}

--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -34,6 +34,7 @@ func NewFreshCommand() *cobra.Command {
 		freshNoBranch    bool
 		freshNoPush      bool
 		freshNoPrune     bool
+		freshNoFollowUp  bool
 		freshDryRun      bool
 		freshProjectFlag string
 		freshList        []string
@@ -52,7 +53,9 @@ single project name. Use --list to cycle a specific set of projects in one
 run, or 'camp fresh all' to cycle every project submodule in the campaign.
 
 Without configuration, syncs to the default branch and prunes.
-Configure .campaign/settings/fresh.yaml to set a default working branch.
+Configure .campaign/settings/fresh.yaml to set a default working branch, or
+follow-up command workflows (install, build, bootstrap, ...) to run once the
+cycle succeeds. Manage those with 'camp fresh configure'.
 
 Examples:
   camp fresh                            # Sync current project (checkout default, pull, prune)
@@ -60,7 +63,8 @@ Examples:
   camp fresh camp -b feat/new-thing     # Sync camp project, create feature branch
   camp fresh --list camp,fest,festival  # Sync a specific set of projects
   camp fresh --no-prune                 # Sync without pruning
-  camp fresh --dry-run                  # Preview what would happen`,
+  camp fresh --no-follow-up             # Sync without running configured follow-ups
+  camp fresh --dry-run                  # Preview what would happen (follow-ups listed, not run)`,
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: completeProjectName,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -78,11 +82,12 @@ Examples:
 			}
 
 			flags := freshFlagSet{
-				branch:   freshBranch,
-				noBranch: freshNoBranch,
-				noPush:   freshNoPush,
-				noPrune:  freshNoPrune,
-				dryRun:   freshDryRun,
+				branch:     freshBranch,
+				noBranch:   freshNoBranch,
+				noPush:     freshNoPush,
+				noPrune:    freshNoPrune,
+				noFollowUp: freshNoFollowUp,
+				dryRun:     freshDryRun,
 			}
 
 			// --list runs a batch across an explicit set of projects. It is
@@ -123,12 +128,14 @@ Examples:
 			branch := cfg.ResolveFreshBranch(freshBranch, freshNoBranch, result.Name)
 			doPrune := !freshNoPrune && cfg.ResolveFreshPrune()
 			doPush := !freshNoPush && cfg.ResolveFreshPushUpstream(result.Name)
+			followUps := resolveFreshFollowUps(cfg, result.Name, freshNoFollowUp)
 
 			return executeFresh(ctx, result.Name, result.Path, freshOptions{
 				branch:      branch,
 				prune:       doPrune,
 				pruneRemote: cfg.ResolveFreshPruneRemote(),
 				push:        doPush,
+				followUps:   followUps,
 				dryRun:      freshDryRun,
 			})
 		},
@@ -139,6 +146,7 @@ Examples:
 	freshCmd.PersistentFlags().BoolVar(&freshNoBranch, "no-branch", false, "Skip branch creation even if configured")
 	freshCmd.PersistentFlags().BoolVar(&freshNoPush, "no-push", false, "Skip pushing the new branch upstream")
 	freshCmd.PersistentFlags().BoolVar(&freshNoPrune, "no-prune", false, "Skip pruning merged branches")
+	freshCmd.PersistentFlags().BoolVar(&freshNoFollowUp, "no-follow-up", false, "Skip configured follow-up command workflows")
 	freshCmd.PersistentFlags().BoolVarP(&freshDryRun, "dry-run", "n", false, "Preview without making changes")
 	freshCmd.Flags().StringVarP(&freshProjectFlag, "project", "p", "", "Project name (auto-detected from cwd)")
 	freshCmd.RegisterFlagCompletionFunc("project", completeProjectName)
@@ -146,8 +154,9 @@ Examples:
 	_ = freshCmd.RegisterFlagCompletionFunc("list", completeProjectName)
 	freshCmd.MarkFlagsMutuallyExclusive("project", "list")
 
-	// Add subcommand
+	// Add subcommands
 	freshCmd.AddCommand(newAllCommand(freshCmd))
+	freshCmd.AddCommand(newConfigureCommand())
 
 	return freshCmd
 }
@@ -157,6 +166,7 @@ type freshOptions struct {
 	prune       bool
 	pruneRemote bool
 	push        bool
+	followUps   []config.FollowUpConfig
 	dryRun      bool
 }
 
@@ -331,6 +341,13 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 				fmt.Printf("%s── Push %-28s %s\n", prefix, opts.branch+" -> origin", freshStepGreen.Render("done"))
 			}
 		}
+	}
+
+	// Step 6: Run configured follow-up command workflows. Only reachable once
+	// every prior step has succeeded, so a failed sync/prune/branch cycle
+	// never triggers follow-ups.
+	if err := runFreshFollowUps(ctx, path, opts.followUps, opts.dryRun); err != nil {
+		return err
 	}
 
 	// Summary

--- a/internal/config/fresh_followup.go
+++ b/internal/config/fresh_followup.go
@@ -1,0 +1,326 @@
+package config
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+)
+
+// FollowUpNotFoundError is returned by RemoveFreshFollowUp when name does not
+// match any configured follow-up step within the requested scope.
+type FollowUpNotFoundError struct {
+	Name       string
+	Scope      string
+	ValidNames []string
+}
+
+// Error implements the error interface, listing the valid names for the
+// scope that was searched so the caller can correct a typo without a
+// separate `configure show` round trip.
+func (e *FollowUpNotFoundError) Error() string {
+	if len(e.ValidNames) == 0 {
+		return fmt.Sprintf("follow-up %q not found in %s scope (none configured there)", e.Name, e.Scope)
+	}
+	return fmt.Sprintf("follow-up %q not found in %s scope; valid names: %s",
+		e.Name, e.Scope, strings.Join(e.ValidNames, ", "))
+}
+
+// AddFreshFollowUp appends a follow-up step to fresh.yaml. An empty
+// projectName targets the global follow-up list; otherwise the step is added
+// to the per-project override list for projectName, which replaces the
+// global list entirely for that project.
+//
+// The write creates .campaign/settings/fresh.yaml (and its parent directory)
+// if missing, and preserves every key it does not touch.
+func AddFreshFollowUp(ctx context.Context, campaignRoot, projectName string, entry FollowUpConfig) error {
+	if err := entry.Validate(); err != nil {
+		return err
+	}
+
+	return withFreshConfigLock(ctx, campaignRoot, func(mapping *yaml.Node) error {
+		seq, err := followUpSequence(mapping, projectName, true)
+		if err != nil {
+			return err
+		}
+
+		if findFollowUpIndex(seq, entry.Name) >= 0 {
+			return camperrors.NewValidation("name", fmt.Sprintf(
+				"follow-up %q already exists in %s scope; remove it first to redefine it",
+				entry.Name, followUpScopeLabel(projectName)), nil)
+		}
+
+		var node yaml.Node
+		if err := node.Encode(entry); err != nil {
+			return camperrors.Wrap(err, "encode follow-up entry")
+		}
+		seq.Content = append(seq.Content, &node)
+		return nil
+	})
+}
+
+// RemoveFreshFollowUp removes the named follow-up step from fresh.yaml. An
+// empty projectName targets the global follow-up list; otherwise the
+// per-project override list for projectName. Returns a *FollowUpNotFoundError
+// listing the valid names in that scope when name is not found.
+//
+// Once a scope's follow-up list becomes empty, the now-redundant follow_up
+// key (and any now-empty project/projects wrapper) is dropped so the file
+// stays clean.
+func RemoveFreshFollowUp(ctx context.Context, campaignRoot, projectName, name string) error {
+	return withFreshConfigLock(ctx, campaignRoot, func(mapping *yaml.Node) error {
+		seq, err := followUpSequence(mapping, projectName, false)
+		if err != nil {
+			return err
+		}
+
+		idx := findFollowUpIndex(seq, name)
+		if idx < 0 {
+			return &FollowUpNotFoundError{
+				Name:       name,
+				Scope:      followUpScopeLabel(projectName),
+				ValidNames: followUpNames(seq),
+			}
+		}
+
+		seq.Content = append(seq.Content[:idx], seq.Content[idx+1:]...)
+		pruneEmptyFollowUpScope(mapping, projectName, seq)
+		return nil
+	})
+}
+
+// withFreshConfigLock loads fresh.yaml as a raw YAML document (creating an
+// empty mapping document if the file is missing or has no parseable
+// mapping content), runs mutate against its top-level mapping, then writes
+// the result back atomically under an exclusive file lock so concurrent
+// `configure` invocations cannot interleave their read-modify-write cycles.
+func withFreshConfigLock(ctx context.Context, campaignRoot string, mutate func(mapping *yaml.Node) error) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	configPath := FreshConfigPath(campaignRoot)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return camperrors.Wrap(err, "create settings directory")
+	}
+
+	release, err := fsutil.AcquireFileLock(ctx, configPath+".lock")
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	return mutateFreshDoc(configPath, mutate)
+}
+
+func mutateFreshDoc(configPath string, mutate func(mapping *yaml.Node) error) error {
+	raw, err := os.ReadFile(configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return camperrors.Wrapf(err, "read fresh config %s", configPath)
+	}
+
+	var doc yaml.Node
+	if err == nil {
+		if uerr := yaml.Unmarshal(raw, &doc); uerr != nil {
+			return camperrors.Wrapf(uerr, "parse fresh config %s", configPath)
+		}
+	}
+
+	// A missing file, an empty file, and a file containing only comments
+	// (the scaffolded fresh.yaml template ships fully commented out) all
+	// decode to a zero-value Node: yaml.v3 has no mapping node to attach
+	// top-level comments to, so it drops them rather than returning one.
+	// Preserve the original bytes verbatim ahead of the mapping we build so
+	// that documentation header is not silently discarded on first write.
+	var headerPreserve []byte
+	if doc.Kind == 0 {
+		if len(bytes.TrimSpace(raw)) > 0 {
+			headerPreserve = raw
+		}
+		doc = yaml.Node{
+			Kind:    yaml.DocumentNode,
+			Content: []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}},
+		}
+	}
+
+	mapping := freshMappingRoot(&doc)
+	if mapping == nil {
+		return camperrors.NewValidation("fresh.yaml", "top-level content must be a mapping", nil)
+	}
+
+	if err := mutate(mapping); err != nil {
+		return err
+	}
+
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return camperrors.Wrap(err, "marshal fresh config")
+	}
+
+	if len(headerPreserve) > 0 {
+		combined := make([]byte, 0, len(headerPreserve)+len(out)+1)
+		combined = append(combined, headerPreserve...)
+		if !bytes.HasSuffix(headerPreserve, []byte("\n")) {
+			combined = append(combined, '\n')
+		}
+		out = append(combined, out...)
+	}
+
+	return fsutil.WriteFileAtomically(configPath, out, 0o644)
+}
+
+// followUpSequence locates the follow_up sequence node for the given scope.
+// An empty projectName targets the top-level follow_up key; otherwise the
+// projects.<projectName>.follow_up key. When create is true, any missing
+// mapping/sequence node along the path is created; when false, a missing
+// node returns (nil, nil) rather than an error.
+func followUpSequence(mapping *yaml.Node, projectName string, create bool) (*yaml.Node, error) {
+	target := mapping
+	if projectName != "" {
+		projectsNode, err := mappingChild(target, "projects", yaml.MappingNode, "!!map", create)
+		if err != nil || projectsNode == nil {
+			return nil, err
+		}
+		projectNode, err := mappingChild(projectsNode, projectName, yaml.MappingNode, "!!map", create)
+		if err != nil || projectNode == nil {
+			return nil, err
+		}
+		target = projectNode
+	}
+	return mappingChild(target, "follow_up", yaml.SequenceNode, "!!seq", create)
+}
+
+// mappingChild returns the value node for key within mapping. If key is
+// absent and create is false, it returns (nil, nil). If key is absent and
+// create is true, a new node of the given kind/tag is appended and returned.
+// An existing value whose Kind does not match is reported as an error rather
+// than silently overwritten.
+func mappingChild(mapping *yaml.Node, key string, kind yaml.Kind, tag string, create bool) (*yaml.Node, error) {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		k := mapping.Content[i]
+		if k.Kind == yaml.ScalarNode && k.Value == key {
+			v := mapping.Content[i+1]
+			if v.Kind != kind {
+				return nil, camperrors.NewValidation(key, "has an unexpected shape in fresh.yaml", nil)
+			}
+			return v, nil
+		}
+	}
+	if !create {
+		return nil, nil
+	}
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
+	valueNode := &yaml.Node{Kind: kind, Tag: tag}
+	mapping.Content = append(mapping.Content, keyNode, valueNode)
+	return valueNode, nil
+}
+
+// removeMappingKey removes key (and its value) from mapping, reporting
+// whether it was present.
+func removeMappingKey(mapping *yaml.Node, key string) bool {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Kind == yaml.ScalarNode && mapping.Content[i].Value == key {
+			mapping.Content = append(mapping.Content[:i], mapping.Content[i+2:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// pruneEmptyFollowUpScope drops the now-redundant follow_up key once seq is
+// empty, cascading up through an emptied project entry and, in turn, an
+// emptied projects mapping, so removing the last follow-up leaves a clean
+// fresh.yaml rather than dangling empty containers.
+func pruneEmptyFollowUpScope(mapping *yaml.Node, projectName string, seq *yaml.Node) {
+	if len(seq.Content) > 0 {
+		return
+	}
+	if projectName == "" {
+		removeMappingKey(mapping, "follow_up")
+		return
+	}
+
+	projectsNode, _ := mappingChild(mapping, "projects", yaml.MappingNode, "!!map", false)
+	if projectsNode == nil {
+		return
+	}
+	projectNode, _ := mappingChild(projectsNode, projectName, yaml.MappingNode, "!!map", false)
+	if projectNode == nil {
+		return
+	}
+
+	removeMappingKey(projectNode, "follow_up")
+	if len(projectNode.Content) == 0 {
+		removeMappingKey(projectsNode, projectName)
+	}
+	if len(projectsNode.Content) == 0 {
+		removeMappingKey(mapping, "projects")
+	}
+}
+
+// findFollowUpIndex returns the index of the entry named name within seq, or
+// -1 if seq is nil or has no such entry.
+func findFollowUpIndex(seq *yaml.Node, name string) int {
+	if seq == nil {
+		return -1
+	}
+	for i, item := range seq.Content {
+		if followUpEntryName(item) == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// followUpNames collects the name field of every entry in seq, in order.
+func followUpNames(seq *yaml.Node) []string {
+	if seq == nil {
+		return nil
+	}
+	names := make([]string, 0, len(seq.Content))
+	for _, item := range seq.Content {
+		if name := followUpEntryName(item); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func followUpEntryName(item *yaml.Node) string {
+	if item == nil || item.Kind != yaml.MappingNode {
+		return ""
+	}
+	for i := 0; i+1 < len(item.Content); i += 2 {
+		k := item.Content[i]
+		v := item.Content[i+1]
+		if k.Kind == yaml.ScalarNode && k.Value == "name" && v.Kind == yaml.ScalarNode {
+			return v.Value
+		}
+	}
+	return ""
+}
+
+func followUpScopeLabel(projectName string) string {
+	if projectName == "" {
+		return "global"
+	}
+	return "project " + projectName
+}
+
+func freshMappingRoot(doc *yaml.Node) *yaml.Node {
+	root := doc
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
+		root = root.Content[0]
+	}
+	if root.Kind != yaml.MappingNode {
+		return nil
+	}
+	return root
+}

--- a/internal/config/fresh_followup_test.go
+++ b/internal/config/fresh_followup_test.go
@@ -1,0 +1,330 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestFollowUpConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		entry   FollowUpConfig
+		wantErr bool
+	}{
+		{
+			name:    "empty run is rejected",
+			entry:   FollowUpConfig{Name: "install", Run: ""},
+			wantErr: true,
+		},
+		{
+			name:    "whitespace-only run is rejected",
+			entry:   FollowUpConfig{Name: "install", Run: "   "},
+			wantErr: true,
+		},
+		{
+			name:    "empty name is rejected",
+			entry:   FollowUpConfig{Name: "", Run: "npm install"},
+			wantErr: true,
+		},
+		{
+			name:    "well-formed entry is accepted",
+			entry:   FollowUpConfig{Name: "install", Run: "npm install"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.entry.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatalf("Validate() = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestResolveFreshFollowUps_Precedence(t *testing.T) {
+	global := []FollowUpConfig{{Name: "install", Run: "npm install"}}
+	override := []FollowUpConfig{{Name: "build", Run: "make build"}}
+
+	cfg := &FreshConfig{
+		FollowUp: global,
+		Projects: map[string]FreshProjectConfig{
+			"camp":  {FollowUp: override},
+			"empty": {FollowUp: []FollowUpConfig{}},
+		},
+	}
+
+	t.Run("project override replaces global entirely", func(t *testing.T) {
+		got := cfg.ResolveFreshFollowUps("camp")
+		if len(got) != 1 || got[0].Name != "build" {
+			t.Fatalf("ResolveFreshFollowUps(camp) = %+v, want [build]", got)
+		}
+	})
+
+	t.Run("explicit empty override suppresses global follow-ups", func(t *testing.T) {
+		got := cfg.ResolveFreshFollowUps("empty")
+		if len(got) != 0 {
+			t.Fatalf("ResolveFreshFollowUps(empty) = %+v, want empty", got)
+		}
+	})
+
+	t.Run("project without an override falls back to global", func(t *testing.T) {
+		got := cfg.ResolveFreshFollowUps("fest")
+		if len(got) != 1 || got[0].Name != "install" {
+			t.Fatalf("ResolveFreshFollowUps(fest) = %+v, want [install]", got)
+		}
+	})
+}
+
+func TestAddFreshFollowUp_RejectsInvalidEntry(t *testing.T) {
+	root := t.TempDir()
+
+	err := AddFreshFollowUp(context.Background(), root, "", FollowUpConfig{Name: "install", Run: ""})
+	if err == nil {
+		t.Fatal("AddFreshFollowUp() with empty run = nil, want error")
+	}
+
+	if _, statErr := os.Stat(FreshConfigPath(root)); !os.IsNotExist(statErr) {
+		t.Fatal("AddFreshFollowUp() should not create fresh.yaml when validation fails")
+	}
+}
+
+func TestAddFreshFollowUp_CreatesFileWhenMissing(t *testing.T) {
+	root := t.TempDir()
+	ctx := context.Background()
+
+	err := AddFreshFollowUp(ctx, root, "", FollowUpConfig{Name: "install", Run: "npm install"})
+	if err != nil {
+		t.Fatalf("AddFreshFollowUp() error = %v", err)
+	}
+
+	cfg, err := LoadFreshConfig(ctx, root)
+	if err != nil {
+		t.Fatalf("LoadFreshConfig() error = %v", err)
+	}
+	if len(cfg.FollowUp) != 1 || cfg.FollowUp[0].Name != "install" || cfg.FollowUp[0].Run != "npm install" {
+		t.Fatalf("cfg.FollowUp = %+v, want single install step", cfg.FollowUp)
+	}
+}
+
+func TestAddFreshFollowUp_ProjectScope(t *testing.T) {
+	root := t.TempDir()
+	ctx := context.Background()
+
+	err := AddFreshFollowUp(ctx, root, "camp", FollowUpConfig{
+		Name: "build",
+		Run:  "go build ./...",
+		Dir:  "cmd/camp",
+	})
+	if err != nil {
+		t.Fatalf("AddFreshFollowUp() error = %v", err)
+	}
+
+	cfg, err := LoadFreshConfig(ctx, root)
+	if err != nil {
+		t.Fatalf("LoadFreshConfig() error = %v", err)
+	}
+	if len(cfg.FollowUp) != 0 {
+		t.Fatalf("global FollowUp = %+v, want empty (step was project-scoped)", cfg.FollowUp)
+	}
+	pc, ok := cfg.Projects["camp"]
+	if !ok || len(pc.FollowUp) != 1 || pc.FollowUp[0].Name != "build" || pc.FollowUp[0].Dir != "cmd/camp" {
+		t.Fatalf("cfg.Projects[camp].FollowUp = %+v, want single build step with dir", pc.FollowUp)
+	}
+}
+
+func TestAddFreshFollowUp_PreservesUnknownKeysAndExistingSettings(t *testing.T) {
+	root := t.TempDir()
+	ctx := context.Background()
+
+	settingsDir := SettingsDirPath(root)
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatalf("failed to create settings dir: %v", err)
+	}
+	initial := "branch: develop\n" +
+		"push_upstream: false\n" +
+		"custom_future_key: keep-me\n"
+	if err := os.WriteFile(FreshConfigPath(root), []byte(initial), 0o644); err != nil {
+		t.Fatalf("failed to seed fresh config: %v", err)
+	}
+
+	if err := AddFreshFollowUp(ctx, root, "", FollowUpConfig{Name: "install", Run: "npm install"}); err != nil {
+		t.Fatalf("AddFreshFollowUp() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(FreshConfigPath(root))
+	if err != nil {
+		t.Fatalf("failed to read fresh config: %v", err)
+	}
+	rawStr := string(raw)
+	if !strings.Contains(rawStr, "custom_future_key: keep-me") {
+		t.Fatalf("fresh.yaml lost an unrecognized top-level key:\n%s", rawStr)
+	}
+
+	cfg, err := LoadFreshConfig(ctx, root)
+	if err != nil {
+		t.Fatalf("LoadFreshConfig() error = %v", err)
+	}
+	if cfg.Branch != "develop" {
+		t.Fatalf("cfg.Branch = %q, want %q (existing setting must survive the write)", cfg.Branch, "develop")
+	}
+	if cfg.PushUpstream == nil || *cfg.PushUpstream {
+		t.Fatalf("cfg.PushUpstream = %v, want false (existing setting must survive the write)", cfg.PushUpstream)
+	}
+	if len(cfg.FollowUp) != 1 || cfg.FollowUp[0].Name != "install" {
+		t.Fatalf("cfg.FollowUp = %+v, want single install step", cfg.FollowUp)
+	}
+}
+
+func TestAddFreshFollowUp_PreservesCommentOnlyHeaderOnFirstWrite(t *testing.T) {
+	root := t.TempDir()
+	ctx := context.Background()
+
+	settingsDir := SettingsDirPath(root)
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatalf("failed to create settings dir: %v", err)
+	}
+	header := "# fresh.yaml -- scaffolded defaults, fully commented out.\n# branch: develop\n"
+	if err := os.WriteFile(FreshConfigPath(root), []byte(header), 0o644); err != nil {
+		t.Fatalf("failed to seed fresh config: %v", err)
+	}
+
+	if err := AddFreshFollowUp(ctx, root, "", FollowUpConfig{Name: "install", Run: "npm install"}); err != nil {
+		t.Fatalf("AddFreshFollowUp() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(FreshConfigPath(root))
+	if err != nil {
+		t.Fatalf("failed to read fresh config: %v", err)
+	}
+	rawStr := string(raw)
+	if !strings.Contains(rawStr, "# fresh.yaml -- scaffolded defaults, fully commented out.") {
+		t.Fatalf("fresh.yaml lost its comment-only header on first write:\n%s", rawStr)
+	}
+
+	cfg, err := LoadFreshConfig(ctx, root)
+	if err != nil {
+		t.Fatalf("LoadFreshConfig() error = %v", err)
+	}
+	if len(cfg.FollowUp) != 1 || cfg.FollowUp[0].Name != "install" {
+		t.Fatalf("cfg.FollowUp = %+v, want single install step", cfg.FollowUp)
+	}
+}
+
+func TestAddFreshFollowUp_RejectsDuplicateName(t *testing.T) {
+	root := t.TempDir()
+	ctx := context.Background()
+
+	if err := AddFreshFollowUp(ctx, root, "", FollowUpConfig{Name: "install", Run: "npm install"}); err != nil {
+		t.Fatalf("first AddFreshFollowUp() error = %v", err)
+	}
+
+	err := AddFreshFollowUp(ctx, root, "", FollowUpConfig{Name: "install", Run: "npm ci"})
+	if err == nil {
+		t.Fatal("second AddFreshFollowUp() with duplicate name = nil, want error")
+	}
+
+	cfg, err := LoadFreshConfig(ctx, root)
+	if err != nil {
+		t.Fatalf("LoadFreshConfig() error = %v", err)
+	}
+	if len(cfg.FollowUp) != 1 || cfg.FollowUp[0].Run != "npm install" {
+		t.Fatalf("cfg.FollowUp = %+v, want the original entry left untouched", cfg.FollowUp)
+	}
+}
+
+func TestRemoveFreshFollowUp_RemovesEntryAndPrunesEmptyContainers(t *testing.T) {
+	root := t.TempDir()
+	ctx := context.Background()
+
+	if err := AddFreshFollowUp(ctx, root, "camp", FollowUpConfig{Name: "build", Run: "go build ./..."}); err != nil {
+		t.Fatalf("AddFreshFollowUp() error = %v", err)
+	}
+
+	if err := RemoveFreshFollowUp(ctx, root, "camp", "build"); err != nil {
+		t.Fatalf("RemoveFreshFollowUp() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(FreshConfigPath(root))
+	if err != nil {
+		t.Fatalf("failed to read fresh config: %v", err)
+	}
+	rawStr := string(raw)
+	if strings.Contains(rawStr, "follow_up") || strings.Contains(rawStr, "projects") {
+		t.Fatalf("expected empty follow_up/projects containers to be pruned, got:\n%s", rawStr)
+	}
+
+	cfg, err := LoadFreshConfig(ctx, root)
+	if err != nil {
+		t.Fatalf("LoadFreshConfig() error = %v", err)
+	}
+	if len(cfg.Projects) != 0 {
+		t.Fatalf("cfg.Projects = %+v, want empty after pruning", cfg.Projects)
+	}
+}
+
+func TestRemoveFreshFollowUp_UnknownNameListsValidNames(t *testing.T) {
+	root := t.TempDir()
+	ctx := context.Background()
+
+	if err := AddFreshFollowUp(ctx, root, "", FollowUpConfig{Name: "install", Run: "npm install"}); err != nil {
+		t.Fatalf("AddFreshFollowUp() error = %v", err)
+	}
+
+	err := RemoveFreshFollowUp(ctx, root, "", "does-not-exist")
+	if err == nil {
+		t.Fatal("RemoveFreshFollowUp() with unknown name = nil, want error")
+	}
+
+	var notFound *FollowUpNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("RemoveFreshFollowUp() error = %v (%T), want *FollowUpNotFoundError", err, err)
+	}
+	if len(notFound.ValidNames) != 1 || notFound.ValidNames[0] != "install" {
+		t.Fatalf("notFound.ValidNames = %v, want [install]", notFound.ValidNames)
+	}
+}
+
+func TestRemoveFreshFollowUp_MissingFileReportsNoneConfigured(t *testing.T) {
+	root := t.TempDir()
+
+	err := RemoveFreshFollowUp(context.Background(), root, "", "install")
+	if err == nil {
+		t.Fatal("RemoveFreshFollowUp() on a campaign with no fresh.yaml = nil, want error")
+	}
+
+	var notFound *FollowUpNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("RemoveFreshFollowUp() error = %v (%T), want *FollowUpNotFoundError", err, err)
+	}
+	if len(notFound.ValidNames) != 0 {
+		t.Fatalf("notFound.ValidNames = %v, want empty", notFound.ValidNames)
+	}
+}
+
+func TestAddFreshFollowUp_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := AddFreshFollowUp(ctx, t.TempDir(), "", FollowUpConfig{Name: "install", Run: "npm install"})
+	if err == nil {
+		t.Fatal("AddFreshFollowUp() expected context error")
+	}
+}
+
+func TestRemoveFreshFollowUp_ContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := RemoveFreshFollowUp(ctx, t.TempDir(), "", "install")
+	if err == nil {
+		t.Fatal("RemoveFreshFollowUp() expected context error")
+	}
+}
+

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -210,6 +211,10 @@ type FreshConfig struct {
 	Prune *bool `yaml:"prune,omitempty"`
 	// PruneRemote controls whether to prune stale remote tracking refs.
 	PruneRemote *bool `yaml:"prune_remote,omitempty"`
+	// FollowUp lists command workflow steps run, in order, after a successful
+	// sync/prune/branch cycle. A project override in Projects replaces this
+	// list entirely; it is never merged with it.
+	FollowUp []FollowUpConfig `yaml:"follow_up,omitempty"`
 	// Projects holds per-project overrides keyed by project name.
 	Projects map[string]FreshProjectConfig `yaml:"projects,omitempty"`
 }
@@ -219,6 +224,36 @@ type FreshConfig struct {
 type FreshProjectConfig struct {
 	Branch       *string `yaml:"branch,omitempty"`
 	PushUpstream *bool   `yaml:"push_upstream,omitempty"`
+	// FollowUp, when non-nil (including an explicit empty list), entirely
+	// replaces the global FollowUp list for this project.
+	FollowUp []FollowUpConfig `yaml:"follow_up,omitempty"`
+}
+
+// FollowUpConfig defines a single post-sync command workflow step that
+// `camp fresh` runs after a successful sync/prune/branch cycle.
+type FollowUpConfig struct {
+	// Name identifies the step for display and `camp fresh configure remove`.
+	Name string `yaml:"name"`
+	// Run is the shell command executed for this step.
+	Run string `yaml:"run"`
+	// Dir is a working directory relative to the project root. Empty runs
+	// the command in the project root.
+	Dir string `yaml:"dir,omitempty"`
+	// ContinueOnError lets the fresh cycle keep running later steps (and
+	// complete successfully) if this step's command fails.
+	ContinueOnError bool `yaml:"continue_on_error,omitempty"`
+}
+
+// Validate reports whether the follow-up step is well-formed. An empty Run
+// is always rejected, since it cannot be meaningfully executed.
+func (f FollowUpConfig) Validate() error {
+	if strings.TrimSpace(f.Name) == "" {
+		return camperrors.NewValidation("name", "must not be empty", nil)
+	}
+	if strings.TrimSpace(f.Run) == "" {
+		return camperrors.NewValidation("run", "must not be empty", nil)
+	}
+	return nil
 }
 
 // FreshConfigPath returns the path to fresh.yaml for a given campaign root.
@@ -291,4 +326,14 @@ func (c *FreshConfig) ResolveFreshPruneRemote() bool {
 		return *c.PruneRemote
 	}
 	return true
+}
+
+// ResolveFreshFollowUps resolves the follow-up steps to run for projectName
+// using the priority chain: project override (if defined at all, even as an
+// explicit empty list) > global default list.
+func (c *FreshConfig) ResolveFreshFollowUps(projectName string) []FollowUpConfig {
+	if pc, ok := c.Projects[projectName]; ok && pc.FollowUp != nil {
+		return pc.FollowUp
+	}
+	return c.FollowUp
 }

--- a/internal/scaffold/campaign/templates/.campaign/settings/fresh.yaml.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/settings/fresh.yaml.tmpl
@@ -29,3 +29,29 @@
 #   fest:
 #     branch: feat/fest
 #     push_upstream: false
+
+# Follow-up command workflows run, in order, after a successful sync/prune/
+# branch cycle. Manage these with `camp fresh configure show|add|remove`
+# instead of hand-editing this list, though hand-editing works too.
+#
+# Each step: name (required, unique within its scope), run (required shell
+# command), dir (optional, relative to the project root), and
+# continue_on_error (optional, default false — set true to keep running
+# later steps even if this one fails).
+#
+# follow_up:
+#   - name: install
+#     run: npm install
+
+# A project's follow_up list under `projects` replaces the global list above
+# entirely for that project; it is never merged with it.
+# projects:
+#   camp:
+#     follow_up:
+#       - name: build
+#         run: go build ./...
+#         dir: cmd/camp
+#         continue_on_error: false
+
+# Skip follow-ups for a single run with `camp fresh --no-follow-up`. They are
+# never executed on `camp fresh --dry-run`, only listed in the preview.

--- a/internal/scaffold/campaign/templates/.campaign/settings/fresh.yaml.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/settings/fresh.yaml.tmpl
@@ -36,7 +36,7 @@
 #
 # Each step: name (required, unique within its scope), run (required shell
 # command), dir (optional, relative to the project root), and
-# continue_on_error (optional, default false — set true to keep running
+# continue_on_error (optional, default false; set true to keep running
 # later steps even if this one fails).
 #
 # follow_up:

--- a/tests/integration/fresh_followup_test.go
+++ b/tests/integration/fresh_followup_test.go
@@ -1,0 +1,224 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFreshConfigure_ShowAddRemoveRoundTrip exercises the non-interactive
+// `camp fresh configure` subcommand group end to end: an empty campaign
+// shows nothing configured, add registers a step, a duplicate add is
+// rejected, remove of an unknown name lists the valid ones, and remove of a
+// real name restores the empty state.
+func TestFreshConfigure_ShowAddRemoveRoundTrip(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-configure-roundtrip"
+	campaignPath, _, _ := setupFreshCampaignWithSubmodule(t, tc, name)
+
+	output, err := tc.RunCampInDir(campaignPath, "fresh", "configure", "show")
+	require.NoError(t, err, "configure show on an empty campaign should succeed:\n%s", output)
+	assert.Contains(t, output, "(none configured)")
+
+	output, err = tc.RunCampInDir(campaignPath, "fresh", "configure", "add", "install", "--run", "npm install")
+	require.NoError(t, err, "configure add should succeed:\n%s", output)
+	assert.Contains(t, output, "install")
+
+	output, err = tc.RunCampInDir(campaignPath, "fresh", "configure", "show")
+	require.NoError(t, err, "configure show after add should succeed:\n%s", output)
+	assert.Contains(t, output, "install")
+	assert.Contains(t, output, "npm install")
+
+	output, err = tc.RunCampInDir(campaignPath, "fresh", "configure", "add", "install", "--run", "npm ci")
+	require.Error(t, err, "configure add with a duplicate name should fail:\n%s", output)
+
+	output, err = tc.RunCampInDir(campaignPath, "fresh", "configure", "remove", "does-not-exist")
+	require.Error(t, err, "configure remove with an unknown name should fail:\n%s", output)
+	assert.Contains(t, output, "install", "error should list the valid follow-up names")
+
+	output, err = tc.RunCampInDir(campaignPath, "fresh", "configure", "remove", "install")
+	require.NoError(t, err, "configure remove should succeed:\n%s", output)
+
+	output, err = tc.RunCampInDir(campaignPath, "fresh", "configure", "show")
+	require.NoError(t, err, "configure show after remove should succeed:\n%s", output)
+	assert.Contains(t, output, "(none configured)")
+}
+
+// TestFreshConfigure_AddRejectsEmptyRun verifies the CLI rejects an empty
+// --run value rather than persisting an unusable step.
+func TestFreshConfigure_AddRejectsEmptyRun(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-configure-empty-run"
+	campaignPath, _, _ := setupFreshCampaignWithSubmodule(t, tc, name)
+
+	output, err := tc.RunCampInDir(campaignPath, "fresh", "configure", "add", "bad", "--run", "")
+	require.Error(t, err, "configure add with an empty --run should fail:\n%s", output)
+
+	output, err = tc.RunCampInDir(campaignPath, "fresh", "configure", "show")
+	require.NoError(t, err, "configure show should still succeed:\n%s", output)
+	assert.Contains(t, output, "(none configured)", "the rejected step must not have been persisted")
+}
+
+// TestFreshFollowUp_RunsConfiguredStepsInOrder verifies `camp fresh` runs
+// every configured global follow-up, in configuration order, after a
+// successful sync cycle.
+func TestFreshFollowUp_RunsConfiguredStepsInOrder(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-followup-order"
+	campaignPath, projectDir, _ := setupFreshCampaignWithSubmodule(t, tc, name)
+
+	_, err := tc.RunCampInDir(campaignPath, "fresh", "configure", "add", "step1", "--run", "echo step1 >> follow-up.log")
+	require.NoError(t, err)
+	_, err = tc.RunCampInDir(campaignPath, "fresh", "configure", "add", "step2", "--run", "echo step2 >> follow-up.log")
+	require.NoError(t, err)
+
+	output, err := tc.RunCampInDir(projectDir, "fresh", "--no-push")
+	require.NoError(t, err, "camp fresh should run configured follow-ups:\n%s", output)
+	assert.Contains(t, output, "step1")
+	assert.Contains(t, output, "step2")
+
+	log, err := tc.ReadFile(projectDir + "/follow-up.log")
+	require.NoError(t, err, "follow-up.log should have been created by the steps")
+	assert.Equal(t, "step1\nstep2\n", log, "follow-ups must run in configured order")
+}
+
+// TestFreshFollowUp_NoFollowUpSkipsSteps verifies --no-follow-up skips every
+// configured step without affecting the rest of the sync cycle.
+func TestFreshFollowUp_NoFollowUpSkipsSteps(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-followup-skip"
+	campaignPath, projectDir, _ := setupFreshCampaignWithSubmodule(t, tc, name)
+
+	_, err := tc.RunCampInDir(campaignPath, "fresh", "configure", "add", "marker", "--run", "touch ran.marker")
+	require.NoError(t, err)
+
+	output, err := tc.RunCampInDir(projectDir, "fresh", "--no-push", "--no-follow-up")
+	require.NoError(t, err, "camp fresh --no-follow-up should still complete the sync cycle:\n%s", output)
+	assert.NotContains(t, output, "Follow-ups", "no follow-up section should print when steps are skipped")
+
+	_, exitCode, err := tc.ExecCommand("test", "-f", projectDir+"/ran.marker")
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, exitCode, "--no-follow-up must not execute configured steps")
+}
+
+// TestFreshFollowUp_DryRunListsButDoesNotExecute verifies --dry-run previews
+// configured follow-ups without running any of them.
+func TestFreshFollowUp_DryRunListsButDoesNotExecute(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-followup-dryrun"
+	campaignPath, projectDir, _ := setupFreshCampaignWithSubmodule(t, tc, name)
+
+	_, err := tc.RunCampInDir(campaignPath, "fresh", "configure", "add", "install", "--run", "touch ran.marker")
+	require.NoError(t, err)
+
+	output, err := tc.RunCampInDir(projectDir, "fresh", "--dry-run")
+	require.NoError(t, err, "camp fresh --dry-run should succeed:\n%s", output)
+	assert.Contains(t, output, "install", "dry-run preview should list the configured step by name")
+	assert.Contains(t, output, "would run", "dry-run preview should mark the step as not executed")
+
+	_, exitCode, err := tc.ExecCommand("test", "-f", projectDir+"/ran.marker")
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, exitCode, "--dry-run must never execute follow-up commands")
+}
+
+// TestFreshFollowUp_ContinueOnErrorKeepsGoing verifies a failed step marked
+// continue_on_error lets the remaining steps run and the overall cycle
+// succeed.
+func TestFreshFollowUp_ContinueOnErrorKeepsGoing(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-followup-continue"
+	campaignPath, projectDir, _ := setupFreshCampaignWithSubmodule(t, tc, name)
+
+	_, err := tc.RunCampInDir(campaignPath, "fresh", "configure", "add", "flaky", "--run", "exit 1", "--continue-on-error")
+	require.NoError(t, err)
+	_, err = tc.RunCampInDir(campaignPath, "fresh", "configure", "add", "after", "--run", "touch after.marker")
+	require.NoError(t, err)
+
+	output, err := tc.RunCampInDir(projectDir, "fresh", "--no-push")
+	require.NoError(t, err, "camp fresh should succeed when the failing step allows continuing:\n%s", output)
+
+	_, exitCode, err := tc.ExecCommand("test", "-f", projectDir+"/after.marker")
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode, "the step after a continue_on_error failure should still run")
+}
+
+// TestFreshFollowUp_StopsOnFailureWithoutContinueOnError verifies a failed
+// step without continue_on_error aborts the remaining follow-ups and fails
+// the overall command.
+func TestFreshFollowUp_StopsOnFailureWithoutContinueOnError(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-followup-stop"
+	campaignPath, projectDir, _ := setupFreshCampaignWithSubmodule(t, tc, name)
+
+	_, err := tc.RunCampInDir(campaignPath, "fresh", "configure", "add", "flaky", "--run", "exit 1")
+	require.NoError(t, err)
+	_, err = tc.RunCampInDir(campaignPath, "fresh", "configure", "add", "after", "--run", "touch after.marker")
+	require.NoError(t, err)
+
+	output, err := tc.RunCampInDir(projectDir, "fresh", "--no-push")
+	require.Error(t, err, "camp fresh should fail when a follow-up fails without continue_on_error:\n%s", output)
+
+	_, exitCode, err := tc.ExecCommand("test", "-f", projectDir+"/after.marker")
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, exitCode, "a step after an unrecovered failure must not run")
+}
+
+// TestFreshFollowUp_ProjectOverrideReplacesGlobal verifies a per-project
+// follow-up list entirely replaces the global list for that project, rather
+// than merging with it.
+func TestFreshFollowUp_ProjectOverrideReplacesGlobal(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-followup-override"
+	campaignPath, projectDir, _ := setupFreshCampaignWithSubmodule(t, tc, name)
+
+	_, err := tc.RunCampInDir(campaignPath, "fresh", "configure", "add", "global-step", "--run", "touch global.marker")
+	require.NoError(t, err)
+	_, err = tc.RunCampInDir(campaignPath, "fresh", "configure", "add", "project-step",
+		"--run", "touch project.marker", "--project", "test-project")
+	require.NoError(t, err)
+
+	output, err := tc.RunCampInDir(projectDir, "fresh", "--no-push")
+	require.NoError(t, err, "camp fresh should succeed:\n%s", output)
+
+	_, exitCode, err := tc.ExecCommand("test", "-f", projectDir+"/project.marker")
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode, "the project-scoped follow-up should have run")
+
+	_, exitCode, err = tc.ExecCommand("test", "-f", projectDir+"/global.marker")
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, exitCode, "the project override should replace the global list, not merge with it")
+}
+
+// TestFreshFollowUp_ListBatchRunsFollowUpsPerProject verifies follow-ups are
+// resolved and run for each project in a `camp fresh --list` batch, not just
+// for a single-project invocation.
+func TestFreshFollowUp_ListBatchRunsFollowUpsPerProject(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-followup-batch"
+	campaignPath, projectDirA, projectDirB := setupFreshCampaignWithTwoSubmodules(t, tc, name)
+
+	_, err := tc.RunCampInDir(campaignPath, "fresh", "configure", "add", "marker", "--run", "touch batch.marker")
+	require.NoError(t, err)
+
+	output, err := tc.RunCampInDir(campaignPath, "fresh", "--list", "test-a,test-b", "--no-push")
+	require.NoError(t, err, "camp fresh --list should run follow-ups for each project:\n%s", output)
+
+	for _, dir := range []string{projectDirA, projectDirB} {
+		_, exitCode, err := tc.ExecCommand("test", "-f", dir+"/batch.marker")
+		require.NoError(t, err)
+		assert.Equal(t, 0, exitCode, "follow-up should have run in %s", dir)
+	}
+}


### PR DESCRIPTION
## Summary

Extends `camp fresh` with post-sync follow-up command workflows, addressing the recurring pain of running an install/build/bootstrap command after every fresh cycle (intent camp-fresh-workflow-configurator-20260712-144017).

- `.campaign/settings/fresh.yaml` gains a `follow_up` list: a global default plus optional per-project overrides. Each entry has `name`, `run`, optional `dir` (relative to the project root), and optional `continue_on_error` (default false). A project override replaces the global list entirely rather than merging with it, matching the existing precedence pattern for `branch` and `push_upstream`.
- `camp fresh` runs the resolved follow-up steps, in order, after a successful sync/prune/branch cycle, streaming each step's output with a per-step header and a done/failed status line. A step that fails without `continue_on_error` aborts the remaining steps and fails the command; a step with `continue_on_error: true` logs the failure and moves on.
- `--no-follow-up` skips follow-ups for a single run. `--dry-run` lists configured follow-ups (name and command) without executing any of them, consistent with how dry-run previews the rest of the cycle.
- New non-interactive `camp fresh configure` subcommand group: `show` (lists global and per-project follow-ups), `add <name> --run <cmd> [--project X] [--dir D] [--continue-on-error]`, and `remove <name> [--project X]`. No interactive TUI in this PR, per the pinned v1 scope.
- Config writes create `.campaign/settings/fresh.yaml` if missing, reject an empty `run` (or empty name), reject adding a duplicate name in the same scope, and report a clear error listing the valid names in scope when removing an unknown name. Writes preserve every key they do not touch (including a best-effort preservation of a comment-only file's header, since the scaffolded default fresh.yaml ships fully commented out and yaml.v3 has no node to attach top-level comments to when there is no mapping content).

## Why

`camp fresh` already resets a project to a clean branch state, but almost every real workflow needs a follow-up step afterward (`npm install`, `go build`, a bootstrap script). Users were re-running that command by hand every time. This lets them configure it once, globally or per project.

## Verification

- Unit tests: `internal/config/fresh_followup_test.go` covers `FollowUpConfig.Validate`, `ResolveFreshFollowUps` precedence (project override replaces global entirely, including an explicit empty override suppressing global follow-ups), `AddFreshFollowUp`/`RemoveFreshFollowUp` (file creation, project scoping, duplicate rejection, unknown-name errors with the valid-name list, pruning now-empty `follow_up`/`projects` containers, preserving an unrelated top-level key across a write, and preserving a comment-only header on first write), and context cancellation.
- Integration tests (containerized, Docker via Colima): `tests/integration/fresh_followup_test.go` covers the full `configure show/add/remove` round trip including duplicate and unknown-name rejection, follow-up execution order via a real project directory, `--no-follow-up` skipping execution, `--dry-run` listing without executing, `continue_on_error` allowing later steps to run after a failure, a failing step without `continue_on_error` stopping the remaining steps, project-override-replaces-global precedence end to end, and follow-ups running per project in a `camp fresh --list` batch.
- Ran `DOCKER_HOST="unix://$HOME/.colima/default/docker.sock" TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock go test -tags=integration ./tests/integration/... -run "TestFreshFollowUp|TestFreshConfigure|TestFresh_"`: all 20 tests passed (9 new, 11 pre-existing fresh tests unaffected).
- Ran `just gate` at the worktree root: stable and dev builds succeeded, `go vet` clean on stable/dev/integration tags, `just lint` reported 0 issues on both profiles with both ratchets (`lint-no-host-fs-tests`, `lint-no-fmt-errorf`) clean, and the full unit suite passed on both profiles (3378/3378 dev, 3349/3349 stable).
- Ran `just docs` to regenerate the CLI reference and committed it separately from the feature commit, since the regen also picked up drift from other already-merged commands unrelated to this change.

## Known limitations

- No interactive TUI configurator; that is intentionally out of scope for this PR per the pinned intent notes.
- The persistent flags on `camp fresh` (`--branch`, `--dry-run`, `--no-branch`, `--no-push`, `--no-prune`) are inherited by `camp fresh configure` and its subcommands via cobra's persistent-flag cascade, even though they have no effect there. This is cosmetic (visible in `--help` output) and not new to this change; scoping them out would require restructuring how the parent command declares its flags.
- If `.campaign/settings/fresh.yaml` contains only comments and no actual keys (the scaffolded default), the first `configure add`/`remove` write preserves the original bytes verbatim ahead of the new content rather than merging comments node-by-node, since yaml.v3 does not retain top-level comments when there is no mapping to attach them to. Subsequent writes go through the normal node-preserving path once real content exists.
- `camp fresh configure show` only prints project sections that have a non-empty `follow_up` list, so an explicit empty per-project override (`follow_up: []`), which suppresses the global follow-ups for that project, is not visible in `show` output. Follow-up candidate for the interactive configurator pass.
