### PR TITLE
feat(gather): schema bump for gather lineage fields, register gather explore

### DIFF
--- a/cmd/camp/gather.go
+++ b/cmd/camp/gather.go
@@ -15,6 +15,7 @@ var gatherCmd = &cobra.Command{
 Available sources:
   feedback    Import feedback observations from festivals into intents
   design      Combine selected design workitems into one gathered package
+  explore     Combine selected explore workitems into one gathered package
 
 For gathering intents by tag, hashtag, or similarity, see 'camp intent gather'.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -25,4 +26,5 @@ For gathering intents by tag, hashtag, or similarity, see 'camp intent gather'.`
 func init() {
 	rootCmd.AddCommand(gatherCmd)
 	gatherCmd.AddCommand(workitemcmd.NewGatherCommand("design"))
+	gatherCmd.AddCommand(workitemcmd.NewGatherCommand("explore"))
 }

--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -27,6 +27,7 @@ var manifestAgentAllowedReasons = map[string]string{
 	"flow show":                  "Read-only flow structure display",
 	"flow status":                "Read-only flow statistics",
 	"gather design":              "Non-interactive with explicit selectors and --title; interactive picker otherwise",
+	"gather explore":             "Non-interactive with explicit selectors and --title; interactive picker otherwise",
 	"go":                         "Non-interactive path resolution when used with explicit arguments",
 	"id":                         "Read-only campaign ID output",
 	"intent add":                 "Programmatic create path is safe with title/body flags; agents must not use TUI-only flags",
@@ -102,10 +103,11 @@ var manifestAgentAllowedReasons = map[string]string{
 }
 
 var manifestAllowedInteractivePaths = map[string]bool{
-	"create":        true,
-	"gather design": true,
-	"intent add":    true,
-	"switch":        true,
+	"create":         true,
+	"gather design":  true,
+	"gather explore": true,
+	"intent add":     true,
+	"switch":         true,
 }
 
 var manifestInteractivePaths = map[string]bool{

--- a/docs/OBEY.md
+++ b/docs/OBEY.md
@@ -53,3 +53,5 @@ campaigns.
 - [migrations/intent-path-targeting-upgrade-2026-03.md](migrations/intent-path-targeting-upgrade-2026-03.md)
 - [migrations/workitem-v1alpha6-2026-05.md](migrations/workitem-v1alpha6-2026-05.md) —
   `.workitem` schema bump (added `ref` and `quest_id`).
+- [migrations/workitem-v1alpha7-2026-07.md](migrations/workitem-v1alpha7-2026-07.md) —
+  `.workitem` schema bump (added `gathered_into` and `gathered_at`).

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -1537,6 +1537,7 @@ Gather related work into unified items.
 Available sources:
   feedback    Import feedback observations from festivals into intents
   design      Combine selected design workitems into one gathered package
+  explore     Combine selected explore workitems into one gathered package
 
 For gathering intents by tag, hashtag, or similarity, see 'camp intent gather'.
 
@@ -1597,6 +1598,59 @@ camp gather design [selectors...] [flags]
       --dry-run        Print the planned gather, change nothing
       --force          Gather sources even when one has an active workflow run
   -h, --help           help for design
+      --json           Output result as a single JSON object
+      --no-commit      Skip the auto-commit
+      --slug string    Directory slug override (default: derived from title)
+  -t, --title string   Title for the gathered workitem (required unless prompted interactively)
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp gather explore
+
+Combine selected explore workitems into one gathered package
+
+### Synopsis
+
+Combine selected explore workitems into one gathered package.
+
+Sources are always chosen explicitly: pass 2 or more selectors (stable id,
+key, path, or directory slug), or run with no arguments in a terminal for an
+interactive picker. There is no automatic discovery mode.
+
+The gather process:
+  1. Create workflow/explore/<slug>/ with a fresh .workitem and a
+     generated README.md indexing the gathered packages
+  2. Move each source directory inside the new package (git history follows
+     the rename)
+  3. Stamp gathered_into/gathered_at on each source .workitem
+  4. Migrate manual priority state and re-home workitem links
+  5. Commit the move (unless --no-commit)
+
+Moved sources stop appearing as separate workitems because discovery only
+scans the top level of workflow/explore/.
+
+Examples:
+  camp gather explore pkg-one pkg-two --title "Unified topic"
+  camp gather explore pkg-one pkg-two pkg-three -t "Unified topic" --slug unified-topic
+  camp gather explore                # interactive picker (TTY only)
+  camp gather explore pkg-one pkg-two -t "Unified topic" --dry-run
+
+```
+camp gather explore [selectors...] [flags]
+```
+
+### Options
+
+```
+      --dry-run        Print the planned gather, change nothing
+      --force          Gather sources even when one has an active workflow run
+  -h, --help           help for explore
       --json           Output result as a single JSON object
       --no-commit      Skip the auto-commit
       --slug string    Directory slug override (default: derived from title)

--- a/docs/cli-reference/camp_gather.md
+++ b/docs/cli-reference/camp_gather.md
@@ -9,6 +9,7 @@ Gather related work into unified items.
 Available sources:
   feedback    Import feedback observations from festivals into intents
   design      Combine selected design workitems into one gathered package
+  explore     Combine selected explore workitems into one gathered package
 
 For gathering intents by tag, hashtag, or similarity, see 'camp intent gather'.
 
@@ -32,4 +33,5 @@ camp gather [flags]
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
 * [camp gather design](camp_gather_design.md)	 - Combine selected design workitems into one gathered package
+* [camp gather explore](camp_gather_explore.md)	 - Combine selected explore workitems into one gathered package
 * [camp gather feedback](camp_gather_feedback.md)	 - Gather feedback observations from festivals into intents

--- a/docs/cli-reference/camp_gather_explore.md
+++ b/docs/cli-reference/camp_gather_explore.md
@@ -1,0 +1,55 @@
+## camp gather explore
+
+Combine selected explore workitems into one gathered package
+
+### Synopsis
+
+Combine selected explore workitems into one gathered package.
+
+Sources are always chosen explicitly: pass 2 or more selectors (stable id,
+key, path, or directory slug), or run with no arguments in a terminal for an
+interactive picker. There is no automatic discovery mode.
+
+The gather process:
+  1. Create workflow/explore/<slug>/ with a fresh .workitem and a
+     generated README.md indexing the gathered packages
+  2. Move each source directory inside the new package (git history follows
+     the rename)
+  3. Stamp gathered_into/gathered_at on each source .workitem
+  4. Migrate manual priority state and re-home workitem links
+  5. Commit the move (unless --no-commit)
+
+Moved sources stop appearing as separate workitems because discovery only
+scans the top level of workflow/explore/.
+
+Examples:
+  camp gather explore pkg-one pkg-two --title "Unified topic"
+  camp gather explore pkg-one pkg-two pkg-three -t "Unified topic" --slug unified-topic
+  camp gather explore                # interactive picker (TTY only)
+  camp gather explore pkg-one pkg-two -t "Unified topic" --dry-run
+
+```
+camp gather explore [selectors...] [flags]
+```
+
+### Options
+
+```
+      --dry-run        Print the planned gather, change nothing
+      --force          Gather sources even when one has an active workflow run
+  -h, --help           help for explore
+      --json           Output result as a single JSON object
+      --no-commit      Skip the auto-commit
+      --slug string    Directory slug override (default: derived from title)
+  -t, --title string   Title for the gathered workitem (required unless prompted interactively)
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp gather](camp_gather.md)	 - Gather related work into unified items

--- a/docs/migrations/workitem-v1alpha7-2026-07.md
+++ b/docs/migrations/workitem-v1alpha7-2026-07.md
@@ -1,0 +1,84 @@
+# Workitem `.workitem` Schema v1alpha7 Upgrade Guide (July 2026)
+
+This note covers the v1alpha7 schema bump delivered alongside `camp gather
+design`/`camp gather explore` (directory-based workitem gathering).
+
+## Scope
+
+1. `.workitem` files now use `version: v1alpha7`.
+2. Two new optional fields are introduced, both written only on source
+   workitems that get gathered.
+   - `gathered_into` records the id of the combined workitem a source was
+     moved into.
+   - `gathered_at` is the RFC3339 UTC timestamp of the gather.
+
+## Why
+
+`camp gather <type>` moves selected directory-based workitems inside a new
+gathered package. Sources need durable lineage back to the package they were
+folded into, recorded on the source's own marker so `git blame`/`git log -M`
+and any downstream tooling can follow the move without depending on commit
+message parsing.
+
+## What Changed
+
+### Schema
+
+The accepted set is now `v1alpha4` through `v1alpha7`. New workitems written
+by `camp workitem create` and `camp workitem adopt` emit v1alpha7. Existing
+workitems are untouched until repaired or gathered.
+
+```yaml
+version: v1alpha7
+kind: workitem
+id: design-auth-flow-2026-07-01
+type: design
+title: Auth Flow
+ref: WI-a1b2c3
+```
+
+A gathered source additionally carries:
+
+```yaml
+version: v1alpha7
+kind: workitem
+id: design-auth-flow-2026-07-01
+type: design
+gathered_into: design-unified-auth-2026-07-15
+gathered_at: 2026-07-15T18:04:00Z
+title: Auth Flow
+ref: WI-a1b2c3
+```
+
+### Reader Compatibility
+
+`v1alpha4` through `v1alpha6` `.workitem` files remain readable.
+
+- `LoadMetadata` accepts all four versions through `acceptedWorkitemVersions`
+  in `internal/workitem/metadata.go`.
+- `gathered_into`/`gathered_at` are absent (empty) on every workitem that has
+  never been gathered, including legacy ones.
+
+## Migration Path
+
+No operator action is required. `camp workitem doctor --fix` and `camp
+workitem repair` bump a legacy marker's `version` to the current value as
+part of their existing repair pass; there is no field to backfill for
+`gathered_into`/`gathered_at` since they are only ever set by `camp gather`
+itself at the moment a source is moved.
+
+## Reference Links
+
+CLI reference:
+
+- `docs/cli-reference/camp_gather_design.md`
+- `docs/cli-reference/camp_gather_explore.md`
+- `docs/cli-reference/camp_workitem_create.md`
+- `docs/cli-reference/camp_workitem_repair.md`
+
+Source:
+
+- `internal/workitem/metadata.go` (schema definition and accepted version
+  set)
+- `internal/commands/workitem/gather_exec.go` (writes `gathered_into` and
+  `gathered_at` via `internal/workitem.RecordGather`)

--- a/internal/commands/workitem/validate_test.go
+++ b/internal/commands/workitem/validate_test.go
@@ -41,19 +41,19 @@ func TestClassifyMarker(t *testing.T) {
 		{
 			name:      "unparseable marker",
 			present:   true,
-			raw:       "version: v1alpha6\n[not: yaml{{{\n",
+			raw:       "version: v1alpha7\n[not: yaml{{{\n",
 			wantCodes: []string{codeMarkerMalformed},
 		},
 		{
 			name:      "valid current marker",
 			present:   true,
-			raw:       "version: v1alpha6\nkind: workitem\nid: design-foo-2026-05-25\ntype: design\ntitle: Foo\nref: WI-abc123\n",
+			raw:       "version: v1alpha7\nkind: workitem\nid: design-foo-2026-05-25\ntype: design\ntitle: Foo\nref: WI-abc123\n",
 			wantCodes: nil,
 		},
 		{
 			name:      "missing ref only",
 			present:   true,
-			raw:       "version: v1alpha6\nkind: workitem\nid: design-foo-2026-05-25\ntype: design\ntitle: Foo\n",
+			raw:       "version: v1alpha7\nkind: workitem\nid: design-foo-2026-05-25\ntype: design\ntitle: Foo\n",
 			wantCodes: []string{codeMissingRefField},
 		},
 		{
@@ -65,7 +65,7 @@ func TestClassifyMarker(t *testing.T) {
 		{
 			name:      "type mismatch",
 			present:   true,
-			raw:       "version: v1alpha6\nkind: workitem\nid: design-foo-2026-05-25\ntype: feature\ntitle: Foo\nref: WI-abc123\n",
+			raw:       "version: v1alpha7\nkind: workitem\nid: design-foo-2026-05-25\ntype: feature\ntitle: Foo\nref: WI-abc123\n",
 			wantCodes: []string{codeTypeMismatch},
 		},
 		{
@@ -77,13 +77,13 @@ func TestClassifyMarker(t *testing.T) {
 		{
 			name:      "empty id and wrong kind are malformed",
 			present:   true,
-			raw:       "version: v1alpha6\nkind: note\ntype: design\nref: WI-abc123\n",
+			raw:       "version: v1alpha7\nkind: note\ntype: design\nref: WI-abc123\n",
 			wantCodes: []string{codeMarkerMalformed},
 		},
 		{
 			name:      "invalid ref shape is malformed",
 			present:   true,
-			raw:       "version: v1alpha6\nkind: workitem\nid: design-foo-2026-05-25\ntype: design\nref: nope\n",
+			raw:       "version: v1alpha7\nkind: workitem\nid: design-foo-2026-05-25\ntype: design\nref: nope\n",
 			wantCodes: []string{codeMarkerMalformed},
 		},
 		{

--- a/internal/workitem/metadata.go
+++ b/internal/workitem/metadata.go
@@ -21,17 +21,18 @@ var (
 
 const MetadataFilename = ".workitem"
 
-const WorkitemSchemaVersion = "v1alpha6"
+const WorkitemSchemaVersion = "v1alpha7"
 
 const MetadataKind = "workitem"
 
 // acceptedWorkitemVersions are loadable .workitem schema versions. v1alpha4
-// and v1alpha5 are accepted for backward compatibility; v1alpha6 is the
-// current shape and gains the Ref and QuestID fields.
+// through v1alpha6 are accepted for backward compatibility; v1alpha7 is the
+// current shape and gains the GatheredInto and GatheredAt fields.
 var acceptedWorkitemVersions = map[string]bool{
 	"v1alpha4": true,
 	"v1alpha5": true,
 	"v1alpha6": true,
+	"v1alpha7": true,
 }
 
 type Metadata struct {
@@ -56,11 +57,9 @@ type Metadata struct {
 	PromotedAt string `yaml:"promoted_at,omitempty"`
 	// GatheredInto records the id of the combined workitem this workitem was
 	// merged into by `camp gather`. Set on source workitems when their
-	// directories are moved inside the gathered package. Added without a
-	// schema version bump, following the promoted_to precedent; loaders use
-	// non-strict YAML so older binaries ignore the field.
+	// directories are moved inside the gathered package. Added in v1alpha7.
 	GatheredInto string `yaml:"gathered_into,omitempty"`
-	// GatheredAt is the RFC3339 UTC timestamp of the gather.
+	// GatheredAt is the RFC3339 UTC timestamp of the gather. Added in v1alpha7.
 	GatheredAt string `yaml:"gathered_at,omitempty"`
 }
 

--- a/internal/workitem/metadata_test.go
+++ b/internal/workitem/metadata_test.go
@@ -114,7 +114,7 @@ id: x
 type: design
 title: T
 `,
-			wantSubstr: "v1alpha6",
+			wantSubstr: "v1alpha7",
 		},
 		{
 			name: "wrong kind",

--- a/internal/workitem/testdata/workitem_full.yaml
+++ b/internal/workitem/testdata/workitem_full.yaml
@@ -1,4 +1,4 @@
-version: v1alpha6
+version: v1alpha7
 kind: workitem
 
 id: design-thin-start-workflow-ladder-2026-04-25

--- a/tests/integration/gather_explore_test.go
+++ b/tests/integration/gather_explore_test.go
@@ -1,0 +1,87 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createExploreWorkitem(t *testing.T, tc *TestContainer, campaign, slug, title, body string) {
+	t.Helper()
+	_, err := tc.RunCampInDir(campaign, "workitem", "create", slug, "--type", "explore", "--title", title)
+	require.NoError(t, err, "create explore workitem %s", slug)
+	require.NoError(t, tc.WriteFile(campaign+"/workflow/explore/"+slug+"/README.md", body))
+}
+
+// TestGatherExplore_MovesSourcesIntoGatheredPackage proves the gather engine
+// generalizes to a second directory-based workitem type by registration
+// alone: `camp gather explore` reuses every planning, execution, and
+// bookkeeping path already exercised for `camp gather design`.
+func TestGatherExplore_MovesSourcesIntoGatheredPackage(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaign := "/campaigns/gather-explore"
+
+	_, err := tc.InitCampaign(campaign, "gather-explore", "product")
+	require.NoError(t, err)
+
+	createExploreWorkitem(t, tc, campaign, "spike-cache", "Cache Spike", "# Cache Spike\n\nExploring cache eviction.\n")
+	createExploreWorkitem(t, tc, campaign, "spike-queue", "Queue Spike", "# Queue Spike\n\nExploring queue backpressure.\n")
+	tc.GitOutput(t, campaign, "add", "-A")
+	tc.GitOutput(t, campaign, "commit", "-m", "seed explore workitems")
+
+	output, err := tc.RunCampInDir(campaign, "gather", "explore", "spike-cache", "spike-queue", "--title", "Unified Spikes", "--json")
+	require.NoError(t, err, "gather output: %s", output)
+
+	var result struct {
+		Gathered struct {
+			ID           string `json:"id"`
+			Type         string `json:"type"`
+			RelativePath string `json:"relative_path"`
+		} `json:"gathered"`
+		Sources []struct {
+			Slug string `json:"slug"`
+		} `json:"sources"`
+		Committed bool     `json:"committed"`
+		Warnings  []string `json:"warnings"`
+	}
+	jsonStart := strings.Index(output, "{")
+	require.GreaterOrEqual(t, jsonStart, 0, "no JSON in output: %s", output)
+	require.NoError(t, json.Unmarshal([]byte(output[jsonStart:]), &result), "output: %s", output)
+
+	assert.Equal(t, "explore", result.Gathered.Type)
+	assert.Equal(t, "workflow/explore/unified-spikes", result.Gathered.RelativePath)
+	assert.Len(t, result.Sources, 2)
+	assert.True(t, result.Committed, "gather should auto-commit")
+	assert.Empty(t, result.Warnings, "gather should complete without warnings")
+
+	for _, slug := range []string{"spike-cache", "spike-queue"} {
+		moved, err := tc.CheckDirExists(campaign + "/workflow/explore/unified-spikes/" + slug)
+		require.NoError(t, err)
+		assert.True(t, moved, "%s should live inside the gathered package", slug)
+
+		old, err := tc.CheckDirExists(campaign + "/workflow/explore/" + slug)
+		require.NoError(t, err)
+		assert.False(t, old, "%s should no longer exist at the top level", slug)
+	}
+
+	marker, err := tc.ReadFile(campaign + "/workflow/explore/unified-spikes/spike-cache/.workitem")
+	require.NoError(t, err)
+	assert.Contains(t, marker, "gathered_into: "+result.Gathered.ID)
+	assert.Contains(t, marker, "gathered_at:")
+	assert.Contains(t, marker, "version: v1alpha7")
+
+	listOutput, err := tc.RunCampInDir(campaign, "workitem", "--json", "--type", "explore")
+	require.NoError(t, err)
+	assert.Contains(t, listOutput, "workflow/explore/unified-spikes")
+	assert.NotContains(t, listOutput, `"relative_path": "workflow/explore/spike-cache"`)
+	assert.NotContains(t, listOutput, `"relative_path": "workflow/explore/spike-queue"`)
+
+	gitStatus := tc.GitOutput(t, campaign, "status", "--porcelain")
+	assert.Empty(t, strings.TrimSpace(gitStatus), "working tree should be clean after gather commit")
+}

--- a/tests/integration/workitem_create_test.go
+++ b/tests/integration/workitem_create_test.go
@@ -58,7 +58,7 @@ func TestIntegration_WorkitemCreateAndAdopt(t *testing.T) {
 
 		manifest, err := tc.ReadFile(campaignDir + "/workflow/feature/demo-feature/.workitem")
 		require.NoError(t, err)
-		assert.Contains(t, manifest, "version: v1alpha6")
+		assert.Contains(t, manifest, "version: v1alpha7")
 		assert.Contains(t, manifest, "kind: workitem")
 		assert.Contains(t, manifest, "type: feature")
 		assert.Contains(t, manifest, "title: Demo")
@@ -215,7 +215,7 @@ func TestIntegration_WorkitemCreateJSON(t *testing.T) {
 	assert.Equal(t, "Agent JSON", payload.Workitem.Title)
 	assert.Empty(t, payload.Workitem.QuestID)
 	assert.Equal(t, "workflow/feature/agent-json", payload.Workitem.RelativePath)
-	assert.Equal(t, "v1alpha6", payload.Workitem.MarkerVersion)
+	assert.Equal(t, "v1alpha7", payload.Workitem.MarkerVersion)
 	assert.Equal(t, "fest create workflow agent-json", payload.Next.Command)
 	assert.Equal(t, "workflow/feature/agent-json", payload.Next.Cwd)
 	assert.Contains(t, payload.Next.Hint, "cd workflow/feature/agent-json")

--- a/tests/integration/workitem_validate_repair_test.go
+++ b/tests/integration/workitem_validate_repair_test.go
@@ -156,11 +156,11 @@ func TestIntegration_WorkitemRepair_CreatesMarkerFromH1(t *testing.T) {
 	assert.Equal(t, "design", rep.Workitem.Type)
 	assert.Equal(t, "Legacy Design Title", rep.Workitem.Title, "title must come from the README H1")
 	assert.Regexp(t, `^WI-[0-9a-f]{6}$`, rep.Workitem.Ref)
-	assert.Equal(t, "v1alpha6", rep.Workitem.MarkerVersion)
+	assert.Equal(t, "v1alpha7", rep.Workitem.MarkerVersion)
 
 	marker, err := tc.ReadFile(dir + "/" + target + "/.workitem")
 	require.NoError(t, err)
-	assert.Contains(t, marker, "version: v1alpha6")
+	assert.Contains(t, marker, "version: v1alpha7")
 	assert.Contains(t, marker, "type: design")
 	assert.Contains(t, marker, "title: Legacy Design Title")
 
@@ -183,7 +183,7 @@ func TestIntegration_WorkitemRepair_UpgradesLegacyMarkerIdempotently(t *testing.
 
 	marker, err := tc.ReadFile(dir + "/" + target + "/.workitem")
 	require.NoError(t, err)
-	assert.Contains(t, marker, "version: v1alpha6", "schema upgraded")
+	assert.Contains(t, marker, "version: v1alpha7", "schema upgraded")
 	assert.Contains(t, marker, "type: design", "type aligned to path")
 	assert.Contains(t, marker, "id: design-legacy-marker-2026-05-25", "existing id preserved")
 	assert.Regexp(t, `ref: WI-[0-9a-f]{6}`, marker, "ref backfilled")


### PR DESCRIPTION
## Summary

Completes the remaining items from intent camp-gather-design-combine-selected-20260709-130537. The core `camp gather design` feature (explicit multi-source selection, directory move into a new package, README generation, priority/link re-homing, active-run guard, selective commit, dry-run/no-commit) already shipped in PR #385 and PR #420. Those PRs made one explicit design tradeoff and left one extension point open for later:

- `gathered_into`/`gathered_at` were added to `.workitem` without bumping the schema version, to avoid a version ripple for two optional fields.
- Only `design` was registered as a gather source; the planner was already written generic over the workflow type so a second type would be close to free.

This PR does both of the deferred pieces:

1. Bumps the `.workitem` schema from v1alpha6 to v1alpha7 (the current version verified directly in `internal/workitem/metadata.go`, not the guessed v1alpha7/v1alpha8 confusion in the intent notes, which was conflating the marker schema with the unrelated `workitems/v1alpha8` JSON output contract in `internal/workitem/json.go`). v1alpha4 through v1alpha6 remain accepted for backward compatibility. Added a migration note at `docs/migrations/workitem-v1alpha7-2026-07.md` following the existing v1alpha6 note's format.
2. Registers `camp gather explore`, reusing the same planning/execution/bookkeeping path as `camp gather design` (`gatherRootDir` already had the `explore` case; it just wasn't wired to a subcommand). Added manifest annotations for the new command and a containerized integration test (`TestGatherExplore_MovesSourcesIntoGatheredPackage`) proving the move, lineage stamp, discovery de-listing, and clean single commit all work unchanged for the second type.
3. Regenerated `docs/cli-reference` via `just docs`, which also picked up pre-existing drift for several commands (artifacts, audit, event, org delete, workitem repair/validate) that had never been regenerated; committed separately from the feature commits.

## Known limitation

The interactive multi-select TTY picker (`camp gather design`/`camp gather explore` with no arguments on a terminal) already exists from PR #385 and was not touched here; it is not part of this PR's scope trim.

## Verification

- `go build ./...` and `go vet ./...` / `go vet -tags=integration ./...`: clean.
- `just lint`: 0 issues on both stable and dev profiles.
- `just gate`: full local gate passed, both build profiles, both lint profiles, and all unit tests (3365/3365 dev-profile tests, 3336/3336 stable-profile tests).
- Containerized integration tests (`just test integration-run`) targeted at the changed behavior: `TestGatherDesign_MovesSourcesIntoGatheredPackage`, `TestGatherDesign_PriorityMigratesToGatheredItem`, `TestGatherDesign_AuditFailureIsWarningNotError`, `TestGatherDesign_Guards`, and the new `TestGatherExplore_MovesSourcesIntoGatheredPackage` all pass. Also ran the broader `TestIntegration_Workitem*` suite; four pre-existing failures (`TestIntegration_WorkitemValidate_ReportsFindings`, `TestIntegration_WorkitemCommits_FiltersFalsePositives`, `TestIntegration_WorkitemCommits_CrossRepo`, `TestIntegration_WorkitemCommits_IncludesCampaignAndLinkedProject`) were confirmed present on unmodified origin/main by stashing this branch's changes and re-running them, so they are unrelated to this change and were left untouched.