### PR TITLE
fix(workitem): make the help concise and stop it making false claims

### DIFF
--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -49,6 +49,149 @@ camp [flags]
 ```
 ---
 
+## camp artifacts
+
+Manage declared artifact roots (.campaign/artifacts.yaml)
+
+### Synopsis
+
+Manage the campaign's declared artifact roots: directories of heavy non-git
+payloads (media, renders, datasets) that 'camp sync --from <machine>' moves
+between your machines with rsync instead of git.
+
+The declaration file (.campaign/artifacts.yaml) is committed, so every
+machine knows what belongs to the campaign. Declared roots should be
+gitignored: a root that is also git-tracked would make the same bytes both
+git content and artifact content. Manifests and per-peer sync snapshots are
+machine-local derived state under .campaign/cache (gitignored).
+
+### Examples
+
+```
+  camp artifacts list
+  camp artifacts add media/renders
+  camp artifacts add datasets --policy on-demand
+  camp artifacts remove media/renders
+  camp artifacts manifest media/renders
+```
+
+### Options
+
+```
+  -h, --help   help for artifacts
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp artifacts add
+
+Declare an artifact root
+
+### Synopsis
+
+Declare a campaign-relative directory as an artifact root.
+
+Policy 'always' (default) syncs the root on every 'camp sync --from
+<machine>'; 'on-demand' syncs it only when artifacts are requested
+explicitly (--artifacts-only).
+
+```
+camp artifacts add <path> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for add
+      --policy string   Sync policy: always (every peer sync) or on-demand (--artifacts-only) (default "always")
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp artifacts list
+
+List declared artifact roots
+
+```
+camp artifacts list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+      --json   Output as JSON for scripting
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp artifacts manifest
+
+Print a declared root's manifest as JSON
+
+### Synopsis
+
+Walk a declared artifact root and print its manifest (relative path, size,
+mtime per file) as JSON. This is the same shape sync snapshots use, so it is
+useful for scripting and for comparing roots across machines.
+
+```
+camp artifacts manifest <path> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for manifest
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp artifacts remove
+
+Remove an artifact root declaration
+
+### Synopsis
+
+Remove a declared artifact root. Files on disk are not touched.
+
+```
+camp artifacts remove <path> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for remove
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
 ## camp attach
 
 Attach an external directory to a campaign
@@ -86,6 +229,164 @@ camp attach <path> [flags]
   -c, --campaign string   Target campaign by name or ID; omit value to pick interactively
       --force             Overwrite an existing attachment marker
   -h, --help              help for attach
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp audit
+
+Inspect the campaign audit trail
+
+### Synopsis
+
+Inspect the campaign audit trail.
+
+'camp audit doctor' scans linked repos for commits with no captured intent
+linkage and reports them informationally. Untagged commits are a normal mode
+for wrapper-opt-out workflows, not a violation.
+
+### Options
+
+```
+  -h, --help   help for audit
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp audit backfill
+
+Derive a source:backfill event stream from history (opt-in write)
+
+### Synopsis
+
+Derive ledger events from a campaign's existing history - tagged commits across
+linked repos, intent frontmatter, and festival status histories - so a pre-ledger
+campaign (or the pre-ledger history of this one) renders on the same timeline as
+new activity.
+
+Backfill is optional and never required. It is idempotent and live-wins: a fact
+already captured live or by a prior backfill is skipped, so consecutive runs
+produce zero new events. Dry-run by default; --apply writes the source:backfill
+events into the standard shard layout.
+
+```
+camp audit backfill [flags]
+```
+
+### Options
+
+```
+      --apply   write the derived source:backfill events into the ledger
+  -h, --help    help for backfill
+      --json    emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp audit doctor
+
+Scan linked repos for unattributed commits (informational)
+
+### Synopsis
+
+Scan the campaign root and every linked project repo, classifying each
+commit as tagged, degraded, or untagged (no captured intent linkage).
+
+Output is informational: untagged commits are surfaced, never scolded, and the
+command exits 0 even when findings exist. Use --window to bound each repo to its
+most recent N commits (default: full history).
+
+```
+camp audit doctor [flags]
+```
+
+### Options
+
+```
+  -h, --help         help for doctor
+      --json         emit a structured JSON report
+      --window int   scan only the most recent N commits per repo (0 = full history)
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp audit reconcile
+
+Fill ledger gaps from state files (opt-in write)
+
+### Synopsis
+
+Derive the events implied by campaign state files (intent statuses and
+festival status histories), diff them against the ledger, and report the gaps -
+facts the ledger does not yet capture. This covers users who never commit at all.
+
+By default this is a dry run. Pass --apply to append the missing facts as
+reconciled events (idempotent: reconciled ids are content-derived, so re-running
+does not duplicate).
+
+```
+camp audit reconcile [flags]
+```
+
+### Options
+
+```
+      --apply   append the missing facts as reconciled events
+  -h, --help    help for reconcile
+      --json    emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp audit repair
+
+Attribute a commit to a workitem or festival after the fact
+
+### Synopsis
+
+Attribute an already-landed commit to a workitem or festival by appending a
+repaired event. This never rewrites git history; it only records the attribution
+in the ledger (D004). Use it to claim an untagged commit surfaced by
+'camp audit doctor' for a piece of work.
+
+```
+camp audit repair --sha <sha> (--workitem <id> | --festival <id>) --why <reason> [flags]
+```
+
+### Options
+
+```
+      --festival string   festival to attribute the commit to
+  -h, --help              help for repair
+      --repo string       evidence repo label (default: campaign-root)
+      --sha string        commit sha to attribute (required)
+      --why string        reason for the attribution (required)
+      --workitem string   workitem to attribute the commit to
 ```
 
 ### Options inherited from parent commands
@@ -257,6 +558,13 @@ EXAMPLES:
   # JSON output for scripting
   camp clone git@github.com:org/repo.git --json
 
+  # Seed from a peer machine in ~/.obey/machines.yaml: root repo and
+  # submodules clone from that machine's copy (LAN/tailnet), then origin is
+  # re-pointed to the URL above and the delta fetched. The result is an
+  # origin replica that arrived over the fast path; peer failures fall back
+  # to plain origin cloning.
+  camp clone git@github.com:org/repo.git --from studio-mac
+
 ```
 camp clone <url> [directory] [flags]
 ```
@@ -266,6 +574,7 @@ camp clone <url> [directory] [flags]
 ```
   -b, --branch string   Clone specific branch (default: repository default branch)
       --depth int       Shallow clone depth (0 = full history)
+      --from string     Seed git objects from this machine (id from ~/.obey/machines.yaml), then fetch the delta from origin
   -h, --help            help for clone
       --json            Output results as JSON for scripting
       --no-register     Skip auto-registration in global campaign registry
@@ -315,16 +624,16 @@ camp commit [flags]
 ### Options
 
 ```
-  -a, --all               Stage all changes before committing (default true)
-      --amend             Amend the previous commit
-      --auto-write        Run configured commit message writer
-  -h, --help              help for commit
-      --include-refs      Include submodule ref changes when staging at campaign root
-  -m, --message string    Commit message (required unless --auto-write)
-      --no-edit           Amend without editing the commit message (requires --amend)
-  -p, --project string    Operate on a specific project/submodule path
-      --sub               Operate on the submodule detected from current directory
-      --workitem string   explicit workitem selector for the commit tag (overrides cwd-based resolution)
+  -a, --all                   Stage all changes before committing (default true)
+      --amend                 Amend the previous commit
+      --auto-write            Run configured commit message writer
+  -h, --help                  help for commit
+      --include-refs          Include submodule ref changes when staging at campaign root
+  -m, --message stringArray   Commit message (repeatable; multiple -m are joined git-style into subject + body; required unless --auto-write)
+      --no-edit               Amend without editing the commit message (requires --amend)
+  -p, --project string        Operate on a specific project/submodule path
+      --sub                   Operate on the submodule detected from current directory
+      --workitem string       explicit workitem selector for the commit tag (overrides cwd-based resolution)
 ```
 
 ### Options inherited from parent commands
@@ -619,6 +928,7 @@ camp create <name> [flags]
   -n, --name string          Campaign display name (defaults to <name> positional)
       --no-git               Skip git repository initialization
       --no-skills            Skip linking campaign skills into .claude/skills and .agents/skills
+      --org string           Assign the new campaign to this org (created if new; defaults to the fallback org)
       --path string          Override the base campaigns directory (campaign created at <path>/<name>/)
   -t, --type string          Campaign type (product, research, tools, personal) (default "product")
 ```
@@ -997,6 +1307,77 @@ camp dungeon move <item>... [status] [flags]
       --to-docs string   Route triage item into an existing campaign-root docs/<subdir> (requires --triage)
       --triage           Move from parent directory (not from dungeon root)
       --workitem         Resolve item as a campaign workitem and move its directory to the local dungeon
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp event
+
+Record and inspect campaign ledger events
+
+### Synopsis
+
+Record and inspect campaign event-ledger entries.
+
+The ledger is the append-only trail of high-intent actions across a campaign.
+Most events are captured automatically by state-changing camp/fest commands;
+'camp event add' is the explicit escape hatch for actions that never touch git.
+
+### Options
+
+```
+  -h, --help   help for event
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp event add
+
+Record an explicit campaign ledger event
+
+### Synopsis
+
+Record an explicit campaign ledger event for an out-of-band action.
+
+Scope is inferred from the current directory (the workitem or festival you are
+in); flags override inference. Evidence may be a campaign-relative path, a URL,
+or a repo@sha commit reference, and may be repeated.
+
+Examples:
+  # A media-production decision, with the produced file as evidence
+  camp event add --type decided "chose H.265 for the trailer" \
+    --why "smaller files, target players all support it" \
+    --evidence renders/trailer_final_v3.mp4
+
+  # A quick note-to-trail from inside a workitem directory
+  camp event add --type created "kicked off the color grade pass"
+
+```
+camp event add <title> [flags]
+```
+
+### Options
+
+```
+      --action string          join an existing action id (default: a fresh action per invocation)
+      --evidence stringArray   evidence ref: <path> | <url> | <repo>@<sha> (repeatable)
+      --festival string        festival id to scope the event (overrides cwd inference)
+  -h, --help                   help for add
+      --json                   emit a structured JSON result
+      --quest string           quest id to scope the event
+      --type string            event kind (required): created, transitioned, completed, decided, evidence_attached, reconciled, repaired
+      --why string             the reason for the action (rendered prominently)
+      --workitem string        workitem selector to scope the event (overrides cwd inference)
 ```
 
 ### Options inherited from parent commands
@@ -1452,6 +1833,7 @@ camp init [path] [flags]
       --no-git               Skip git repository initialization
       --no-register          Don't add to global registry
       --no-skills            Skip linking campaign skills into .claude/skills and .agents/skills
+      --org string           Assign the new campaign to this org (created if new; defaults to the fallback org)
       --repair               Add missing files to existing campaign
   -t, --type string          Campaign type (product, research, tools, personal) (default "product")
   -v, --verbose              Show skipped optional setup details
@@ -2627,8 +3009,9 @@ with 'camp register'. The registry lives at ~/.obey/campaign/registry.json.
 
 In a terminal, 'camp list' (with no flags) opens an interactive browser where you
 can deactivate/reactivate campaigns (cycle lifecycle status), reassign their org,
-and copy paths. Piped, with --json/--count, or with any filter/sort flag it
-prints the table instead. Home paths display as '~'.
+and copy paths. Pass an org as a positional argument to open the browser filtered
+to that org. Piped, with --json/--count, or with any filter/sort flag it prints
+the table instead. Home paths display as '~'.
 
 Output formats:
   table   - Aligned columns with headers (default)
@@ -2643,15 +3026,22 @@ Sorting options:
 
 Examples:
   camp list                  List all campaigns
+  camp list obey             Browse campaigns in the obey org
   camp list --json           Output as JSON
   camp list --format json    Output as JSON
   camp list --sort name      Sort by name
   camp list --sort org       Sort by org, then name
   camp list --format simple  Names only for scripting
   camp list --count          Print only the total number of campaigns
+  camp list --remote         Also list campaigns on machines in ~/.obey/machines.yaml
+
+--remote runs each machine's own 'camp list --json' through a login shell
+(sh -lc) so PATH entries a login profile exports (~/.profile, etc.) are
+picked up. If camp still can't be found on a machine, set
+CAMP_REMOTE_CAMP_PATH to its exact path there.
 
 ```
-camp list [flags]
+camp list [org] [flags]
 ```
 
 ### Options
@@ -2666,6 +3056,7 @@ camp list [flags]
       --json             Output as JSON (shorthand for --format json)
       --no-group         Suppress org grouping
       --org string       Only campaigns in this org
+      --remote           Also list campaigns on machines in ~/.obey/machines.yaml (ssh)
   -s, --sort string      Sort by (name, accessed, type, org) (default "accessed")
       --status string    Only campaigns in this status (active, inactive, reference)
       --tag strings      Only campaigns carrying this tag (repeat for AND)
@@ -2709,6 +3100,195 @@ camp log [flags]
 
 ```
   -h, --help   help for log
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp machine
+
+Manage remote machines (~/.obey/machines.yaml)
+
+### Synopsis
+
+Manage the fleet of remote machines camp can reach for 'camp switch machine:campaign'
+and 'camp list --remote'.
+
+Machines are stored in ~/.obey/machines.yaml. The current machine is always
+implicitly available as "local" and is never written to that file.
+
+'camp machine diagnose' inspects the per-machine ssh ControlMaster sockets and
+can clear a stale one (the state a sleep or network flap can leave behind, which
+would otherwise hang the next hop until ControlPersist expires).
+
+### Examples
+
+```
+  camp machine list
+  camp machine add devbox --host devbox.tailnet.ts.net --auth tailscale-ssh
+  camp machine add --discover
+  camp machine remove devbox
+  camp machine diagnose
+  camp machine diagnose devbox --reset
+```
+
+### Options
+
+```
+  -h, --help   help for machine
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp machine add
+
+Add or update a machine
+
+### Synopsis
+
+Add a machine to ~/.obey/machines.yaml, or update it if the id already exists
+(idempotent on id: a second 'add' with the same id replaces the entry rather
+than duplicating it).
+
+With --discover, camp runs 'tailscale status --json' and lets you pick a
+tailnet device instead of specifying --host/--auth by hand; the chosen device
+is saved with auth_method=tailscale-ssh. Pass an id positionally with
+--discover to select that device by its derived id non-interactively (skips
+the picker), or use --yes to take the first discovered device.
+
+```
+camp machine add [id] [flags]
+```
+
+### Examples
+
+```
+  camp machine add devbox --host devbox.tailnet.ts.net --auth tailscale-ssh
+  camp machine add buildbox --host 10.0.0.12 --auth ssh-agent --user ci
+  camp machine add --discover
+  camp machine add devbox --discover
+  camp machine add --discover --yes
+```
+
+### Options
+
+```
+      --auth string       Auth method: tailscale-ssh, ssh-agent, ssh-password (default "ssh-agent")
+      --discover          Discover devices via 'tailscale status --json' and pick one
+  -h, --help              help for add
+      --host string       SSH host or Tailscale MagicDNS name (required unless --discover)
+      --identity string   Path to SSH identity file
+      --label string      Human-readable label
+      --user string       SSH user
+      --yes               With --discover, take the first discovered device non-interactively
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp machine diagnose
+
+Inspect (and optionally clear) ssh ControlMaster sockets
+
+### Synopsis
+
+Report the ssh ControlMaster multiplex socket state for each configured machine
+(or one machine if an id is given):
+
+  none   no socket — the next hop opens a fresh master
+  live   socket present and the master answers 'ssh -O check'
+  stale  socket present but the master no longer answers
+
+A stale socket is what a sleep or network flap can leave behind; until it is
+removed (or ControlPersist expires) the next 'camp switch machine:...' or
+'camp list --remote' hop to that machine can hang. Pass --reset to tear down
+stale sockets so the next hop reconnects cleanly. Live and absent sockets are
+left untouched.
+
+```
+camp machine diagnose [id] [flags]
+```
+
+### Examples
+
+```
+  camp machine diagnose
+  camp machine diagnose devbox
+  camp machine diagnose --reset
+  camp machine diagnose devbox --reset --json
+```
+
+### Options
+
+```
+  -h, --help    help for diagnose
+      --json    Output as JSON
+      --reset   Tear down stale ControlMaster sockets so the next hop reconnects
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp machine list
+
+List configured machines
+
+### Synopsis
+
+List every machine in ~/.obey/machines.yaml, plus the implicit "local" machine
+(this machine, never persisted to the file).
+
+```
+camp machine list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+      --json   Output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp machine remove
+
+Remove a machine
+
+### Synopsis
+
+Remove a machine from ~/.obey/machines.yaml. Removing "local" or an unknown id is an error.
+
+```
+camp machine remove <id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for remove
 ```
 
 ### Options inherited from parent commands
@@ -2767,11 +3347,11 @@ Group campaigns into orgs
 
 ### Synopsis
 
-Group related campaigns into orgs.
+Group related campaigns into first-class orgs.
 
-Every campaign belongs to exactly one org (default "default"). Orgs are derived:
-an org exists because a campaign names it, and disappears when its last member
-leaves.
+Every campaign belongs to exactly one org (default "default"). Orgs are first-class:
+they persist in the machine-wide registry, can hold zero members, and are deleted
+explicitly with 'camp org delete'.
 
 In a terminal, 'camp org' (no arguments) opens an interactive browser of orgs
 and their members where you can move, create, rename, and return campaigns. When
@@ -2780,9 +3360,10 @@ piped or with --json it prints the current campaign's org instead; use
 
 Commands:
   which   Print the current campaign's org
-  create  Create an org by joining campaigns (the current campaign if none named)
+  create  Create an org (optionally --empty) and optionally join campaigns
   add     Assign campaigns to an org (also reassigns; single-membership)
   remove  Return campaigns to the default org
+  delete  Delete an org (empty only unless --force)
 
 ```
 camp org [flags]
@@ -2794,8 +3375,10 @@ camp org [flags]
   camp org                                       Browse and manage orgs interactively (TTY)
   camp org which                                 Print the current campaign's org
   camp org create obey                           Add the current campaign to "obey"
+  camp org create empty-org --empty              Create an org with no members
   camp org add obey obey-campaign obey-content   Move campaigns into "obey"
   camp org remove obey-content                   Return a campaign to "default"
+  camp org delete empty-org                      Delete an empty org
 ```
 
 ### Options
@@ -2852,11 +3435,11 @@ camp org add <org> <campaign>... [flags]
 
 ## camp org create
 
-Create an org by joining campaigns (the current campaign if none named)
+Create an org (optionally empty) and join campaigns
 
 ### Synopsis
 
-Create an org by joining campaigns to it.
+Create a first-class org, optionally joining campaigns to it.
 
 Run inside a campaign with no campaign arguments to add the current campaign:
   camp org create obey
@@ -2864,7 +3447,10 @@ Run inside a campaign with no campaign arguments to add the current campaign:
 Or name the campaigns explicitly:
   camp org create obey obey-campaign obey-content
 
-Orgs remain derived: "create" assigns membership and never makes an empty org.
+Create an empty org with no members (works outside a campaign):
+  camp org create obey --empty
+
+Orgs are first-class: they persist in the registry even with zero members.
 Joining an org that already has members is allowed; there is no "already exists"
 error, and a campaign already in the org is reported as unchanged.
 
@@ -2876,14 +3462,56 @@ camp org create <org> [campaign...] [flags]
 
 ```
   camp org create obey
+  camp org create obey --empty
   camp org create client-acme acme-site other-site
 ```
 
 ### Options
 
 ```
-  -h, --help   help for create
-      --json   Output as JSON
+      --empty   Create the org with no members (do not join any campaign)
+  -h, --help    help for create
+      --json    Output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp org delete
+
+Delete an org (empty only unless --force)
+
+### Synopsis
+
+Delete a first-class org from the registry.
+
+Empty orgs delete without flags. Orgs with members require --force, which
+reassigns every member to the fallback org and then deletes the org.
+
+The fallback org cannot be deleted.
+
+```
+camp org delete <name> [flags]
+```
+
+### Examples
+
+```
+  camp org delete empty-org
+  camp org delete obey --force
+  camp org delete empty-org --json
+```
+
+### Options
+
+```
+      --force   Reassign members to the fallback org, then delete
+  -h, --help    help for delete
+      --json    Output as JSON
 ```
 
 ### Options inherited from parent commands
@@ -3143,12 +3771,17 @@ A project can be:
   - a machine-local linked workspace attached via symlink under projects/
 
 Use 'camp project add' for submodules and 'camp project link' / 'camp project unlink'
-for linked workspaces.
+for linked workspaces. Use 'camp project run' (or the 'cr -p' shell shorthand)
+to run a command inside a project from anywhere in the campaign.
 
 Examples:
   camp project list                    List all projects
   camp project add git@github.com:org/repo.git  Add a new project
   camp project link ~/code/my-project  Link an existing local workspace
+  camp project run -p fest -- just build  Run a command inside a project
+  camp project commit -p fest -m "fix"  Commit changes in a project submodule
+  camp project prune                   Delete merged branches in the cwd's project
+  camp project worktree add my-branch --project fest  Create a worktree for a project
   camp project remove api-service      Remove a project
 
 ```
@@ -3243,14 +3876,15 @@ camp project commit [flags]
 ### Options
 
 ```
-  -a, --all               Stage all changes (default true)
-      --amend             Amend the previous commit
-      --auto-write        Run configured commit message writer
-  -h, --help              help for commit
-  -m, --message string    Commit message (required unless --auto-write)
-  -p, --project string    Project name (auto-detected from cwd if not specified)
-      --sync              Sync submodule ref at campaign root after commit (opt-in)
-      --workitem string   explicit workitem selector for the commit tag (overrides cwd-based resolution)
+  -a, --all                   Stage all changes (default true)
+      --amend                 Amend the previous commit
+      --auto-write            Run configured commit message writer
+  -h, --help                  help for commit
+  -m, --message stringArray   Commit message (repeatable; multiple -m are joined git-style into subject + body; required unless --auto-write)
+      --no-sync               Do not sync submodule ref even if settings enable it
+  -p, --project string        Project name (auto-detected from cwd if not specified)
+      --sync                  Sync submodule ref at campaign root after commit (also enabled by commit.sync_project_refs setting)
+      --workitem string       explicit workitem selector for the commit tag (overrides cwd-based resolution)
 ```
 
 ### Options inherited from parent commands
@@ -3761,14 +4395,17 @@ camp project remove <name> [flags]
 
 ## camp project run
 
-Run a command inside a project directory
+Run a command inside a project directory, like cr but project-scoped
 
 ### Synopsis
 
 Run any shell command inside a project directory from anywhere in the campaign.
 
+This is the project-scoped counterpart to 'camp run' (cr): cr runs from the
+campaign root, camp project run (cr -p) runs inside a project.
+
 The project is resolved in this order:
-  1. --project / -p flag (explicit project name)
+  1. --project / -p flag (explicit project name, tab-completes registered projects)
   2. Auto-detect from current working directory
   3. Interactive fuzzy picker (if neither above applies)
 
@@ -3788,6 +4425,10 @@ Examples:
   # Simple commands (no -- needed when no flags)
   camp project run make build
 
+  # Shell shorthand (after 'eval "$(camp shell-init <shell>)"')
+  cr -p fest -- just build
+  cr -p camp go test ./...
+
 ```
 camp project run [--project <name>] [--] <command> [args...] [flags]
 ```
@@ -3795,7 +4436,8 @@ camp project run [--project <name>] [--] <command> [args...] [flags]
 ### Options
 
 ```
-  -h, --help   help for run
+  -h, --help             help for run
+  -p, --project string   Project name (auto-detected from cwd, or interactive picker if omitted)
 ```
 
 ### Options inherited from parent commands
@@ -3975,6 +4617,10 @@ Examples:
   # Explicit project
   camp project worktree add feature --project my-api
 
+  # Link a design/explore workitem so camp p commit in the worktree tags WI-*
+  camp project worktree add fest-list-watch --project fest --workitem WI-2a7950
+  camp project worktree add settings-tui --project camp --workitem workflow/design/camp-settings-tui
+
 ```
 camp project worktree add <name> [flags]
 ```
@@ -3987,6 +4633,7 @@ camp project worktree add <name> [flags]
   -p, --project string       Project name (auto-detected from cwd if not specified)
   -s, --start-point string   Base branch/commit for new branch (default: current branch)
   -t, --track string         Remote branch to track (creates new local tracking branch)
+      --workitem string      workitem selector (ref, path, or id) to primary-link to this worktree for camp p commit tags
 ```
 
 ### Options inherited from parent commands
@@ -4640,12 +5287,25 @@ With no key, prints all settings including the effective theme. With a key,
 prints just that value.
 
 Keys:
-  global.theme           Color theme in ~/.obey/campaign/config.json
-  global.editor          Preferred editor
-  global.campaigns_dir   Where camp create places new campaigns
-  global.verbose         Verbose output
-  global.no_color        Disable colored output
-  local.theme_override   Campaign-local theme override (requires a campaign)
+  global.theme               Color theme in ~/.obey/campaign/config.json
+  global.editor              Preferred editor
+  global.campaigns_dir       Where camp create places new campaigns
+  global.verbose             Verbose output
+  global.no_color            Disable colored output
+  global.commit.sync_project_refs   When true, camp p commit updates campaign-root submodule pointer (default false)
+  global.commit.disable_commit_tags When true, skip [campaign:…] tags on camp commits (default false; tags on)
+  local.theme_override       Campaign-local theme override (requires a campaign)
+  local.commit.sync_project_refs    Campaign override for project-ref sync (true/false/inherit)
+  local.commit.disable_commit_tags  Campaign override to skip commit subject tags (true/false/inherit)
+  local.campaign.name        Campaign name in .campaign/campaign.yaml
+  local.campaign.description Campaign description
+  local.campaign.mission     Campaign mission
+  local.campaign.type        Campaign type (product, research, tools, personal)
+  local.campaign.commit_hook Commit-message hook command
+  effective.commit.*         Resolved commit prefs (get only; local overrides global)
+
+The campaign.yaml list and tree fields (intents.tags, concepts) have no flat
+key and are edited only through the interactive 'camp settings' TUI.
 
 ```
 camp settings get [key] [flags]
@@ -4656,6 +5316,7 @@ camp settings get [key] [flags]
 ```
   camp settings get
   camp settings get global.theme
+  camp settings get effective.commit.sync_project_refs
   camp settings get --json
 ```
 
@@ -5337,6 +5998,15 @@ Use campaign@tab to navigate to a specific location in the target campaign:
   camp switch obey-campaign@p    # Switch and navigate to projects/
   camp switch obey/platform@f    # Switch inside org and navigate to festivals/
 
+Use machine:campaign to resolve a campaign on a machine registered in
+~/.obey/machines.yaml (via the csw shell wrapper, which hops there over ssh):
+  csw devbox:obey-campaign       # Resolve and hop to obey-campaign on devbox
+
+Remote resolution runs the far machine's own 'camp switch' through a login
+shell (sh -lc) so PATH entries a login profile exports (~/.profile, etc.) are
+picked up. If camp still can't be found there, set CAMP_REMOTE_CAMP_PATH to
+its exact path on that machine.
+
 ```
 camp switch [campaign] [flags]
 ```
@@ -5422,6 +6092,23 @@ EXAMPLES:
   # JSON output for scripting
   camp sync --json
 
+  # Accelerate over a peer machine from ~/.obey/machines.yaml: for each
+  # already-initialized submodule, fetch objects from that machine first
+  # (LAN/tailnet), then run the normal origin-based update, then pull
+  # declared artifact roots (policy=always) from the same machine.
+  # Uninitialized submodules skip the peer step and init from origin.
+  # Preflight, origin URLs, validation, and exit codes are unchanged; an
+  # unreachable peer degrades to a warning.
+  camp sync --from studio-mac
+
+  # Peer git objects only, skip artifacts / artifacts only, skip git phases
+  camp sync --from studio-mac --git-only
+  camp sync --from studio-mac --artifacts-only
+
+  # Check artifact roots against last-transfer snapshots, no transfer
+  camp sync --verify-artifacts
+  camp sync --verify-artifacts --from studio-mac
+
 ```
 camp sync [submodule...] [flags]
 ```
@@ -5429,13 +6116,17 @@ camp sync [submodule...] [flags]
 ### Options
 
 ```
-  -n, --dry-run        Show what would happen without making changes
-  -f, --force          Skip safety checks (uncommitted changes warning still shown)
-  -h, --help           help for sync
-      --json           Output results as JSON for scripting
-      --no-fetch       Skip fetching from remote (use local refs only)
-  -p, --parallel int   Number of parallel git operations (default 4)
-  -v, --verbose        Show detailed output for each submodule
+      --artifacts-only     With --from: pull declared artifact roots only, skip git phases
+  -n, --dry-run            Show what would happen without making changes
+  -f, --force              Skip safety checks (uncommitted changes warning still shown)
+      --from string        Fetch objects for already-initialized submodules (and declared artifact roots) from this machine (id from ~/.obey/machines.yaml)
+      --git-only           With --from: move git objects only, skip artifact roots
+  -h, --help               help for sync
+      --json               Output results as JSON for scripting
+      --no-fetch           Skip fetching from remote (use local refs only)
+  -p, --parallel int       Number of parallel git operations (git guards superproject ops with repo lockfiles that fail fast on contention; lower this if a slow disk surfaces transient lock errors) (default 4)
+  -v, --verbose            Show detailed output for each submodule
+      --verify-artifacts   Check artifact roots against last-transfer snapshots (no transfer)
 ```
 
 ### Options inherited from parent commands
@@ -5978,17 +6669,16 @@ View active campaign work items
 
 ### Synopsis
 
-View active campaign work items across intents, designs, explore, and festivals.
+View active campaign work items.
 
-Default mode launches an interactive TUI dashboard. Use --json for machine-readable
-output or --print to select and print a path for shell integration.
+Launches an interactive dashboard on a TTY. Non-interactive callers must pass
+--json, --list, or --print.
 
 Examples:
-  camp workitem                              # interactive dashboard
-  camp workitem --json                       # JSON output for agents/scripts
-  camp workitem --json --type design         # filter by type
-  camp workitem --json --type intent --limit 5
-  camp workitem --print                      # select and print path
+  camp workitem                       # interactive dashboard
+  camp workitem --json --type design  # JSON, filtered by type
+  camp workitem --list                # compact grouped list
+  camp workitem --print               # print a path for shell integration
 
 ```
 camp workitem [flags]
@@ -5997,20 +6687,20 @@ camp workitem [flags]
 ### Options
 
 ```
-      --attention-stage stringArray   Filter by attention stage (current, next, active, parked)
-      --category stringArray          Filter by workflow category (builtin: plan, research, pipeline, review, uncategorized; or any category defined under workflows in campaign.yaml)
+      --attention-stage stringArray   Filter by attention stage
+      --category stringArray          Filter by workflow category
       --group stringArray             Filter by workitem group
-      --group-by string               Group JSON/list sections by attention_stage, group, type, or category; --list defaults to group unless set (default "attention_stage")
+      --group-by string               Group sections (default "attention_stage")
   -h, --help                          help for workitem
       --json                          Output as JSON
-      --limit int                     Maximum number of items to return
+      --limit int                     Maximum items to return
       --list                          Output a compact grouped list
-      --print                         Print path only (for shell integration)
-      --query string                  Search query to filter items
-      --show-parked                   include parked attention-stage workitems in default output
-      --stage stringArray             Filter by lifecycle stage (none, inbox, active, ready, planning, ritual, chains)
-      --status stringArray            Filter by displayed status (current, next, active, parked, inbox, ready, plan, ritual, chains, none)
-      --type stringArray              Filter by workflow type (builtin: intent, design, explore, festival; or any slug-safe custom type produced by 'camp workitem create --type <name>')
+      --print                         Print path only
+      --query string                  Filter by search query
+      --show-parked                   Include parked workitems
+      --stage stringArray             Filter by lifecycle stage
+      --status stringArray            Filter by displayed status
+      --type stringArray              Filter by workflow type
 ```
 
 ### Options inherited from parent commands
@@ -6022,7 +6712,7 @@ camp workitem [flags]
 
 ## camp workitem adopt
 
-Attach .workitem metadata to an existing directory
+Adopt an existing directory as a workitem
 
 ### Synopsis
 
@@ -6057,7 +6747,7 @@ camp workitem adopt <dir> [flags]
 
 ## camp workitem commit
 
-Commit changes scoped to the resolved workitem
+Commit changes scoped to a workitem
 
 ### Synopsis
 
@@ -6085,7 +6775,7 @@ camp workitem commit [selector] [flags]
       --include stringArray         additional path to stage (repeatable; relative to repo root)
       --include-submodule-pointer   include dirty project submodule pointers in the plan
       --json                        emit the staging plan and commit result as JSON on stdout
-  -m, --message string              commit message (required unless --dry-run)
+  -m, --message stringArray         commit message (repeatable; multiple -m are joined git-style into subject + body; required unless --dry-run)
       --project string              force project-repo context by name (skips resolver)
       --staged                      commit whatever is already in the git index
       --workitem string             explicit workitem selector (overrides cwd-based resolution)
@@ -6100,17 +6790,22 @@ camp workitem commit [selector] [flags]
 
 ## camp workitem commits
 
-List commits referencing a workitem across linked repos
+List commits referencing a workitem
 
 ### Synopsis
 
-Search the campaign root and every linked project/repo/worktree/festival
-repo for commits whose campaign tag references this workitem's ref.
+List commits referencing this workitem, newest first.
 
-Default sort: most recent first across all repos. Use --json for structured
-output. Repos that are not git checkouts or that fail their git log invocation
-are reported under "errors" in JSON mode; table mode warns on stderr when
-repo queries fail.
+When the campaign event ledger already holds the workitem's commit evidence,
+the answer comes from a single merged ledger read (fast path). Otherwise it
+falls back to scanning the campaign root and every linked
+project/repo/worktree/festival repo for commits whose campaign tag references
+the workitem's ref (pre-ledger history).
+
+Use --json for structured output; the "source" field reports which path
+answered ("ledger" or "scan"). Repos that are not git checkouts or that fail
+their git log invocation are reported under "errors" in JSON mode; table mode
+warns on stderr when repo queries fail.
 
 ```
 camp workitem commits [selector] [flags]
@@ -6124,6 +6819,7 @@ camp workitem commits [selector] [flags]
       --limit int         maximum commits to return (default 100)
       --offset int        number of commits to skip (after sorting)
       --ref string        query by workitem ref directly (e.g. WI-abc123) — skips resolver
+      --source string     where to read commits from: auto (ledger when present, else scan), ledger, or scan (default "auto")
       --workitem string   alias for the positional <selector>
 ```
 
@@ -6136,7 +6832,7 @@ camp workitem commits [selector] [flags]
 
 ## camp workitem create
 
-Create a new workitem with v1 minimum metadata
+Create a workitem
 
 ### Synopsis
 
@@ -6173,7 +6869,7 @@ camp workitem create <slug> [flags]
 
 ## camp workitem current
 
-Get, set, or clear the local current workitem
+Get, set, or clear the current workitem
 
 ### Synopsis
 
@@ -6205,7 +6901,7 @@ camp workitem current [selector] [flags]
 
 ## camp workitem doctor
 
-Report workitem link-registry health issues
+Report link-registry health issues
 
 ### Synopsis
 
@@ -6237,7 +6933,7 @@ camp workitem doctor [flags]
 
 ## camp workitem group
 
-Set or clear the group of a workitem
+Set or clear the group
 
 ```
 camp workitem group <selector> <group|clear> [flags]
@@ -6259,7 +6955,7 @@ camp workitem group <selector> <group|clear> [flags]
 
 ## camp workitem link
 
-Attach a workitem to a project, festival, worktree, or campaign path
+Create a workitem link
 
 ### Synopsis
 
@@ -6269,6 +6965,17 @@ Links are stored in .campaign/workitems/links.yaml and connect a .workitem
 identity to an explicit scope for planning, execution, and lookup. Pass a
 workitem selector plus a path, or use --project, --festival, --worktree, or
 --cwd to derive the scope. Use --json for machine-readable link output.
+
+A primary worktree link is how design/explore workitems under workflow/ get
+into camp p commit tags: when you commit from that worktree, the resolver
+matches the link and stamps WI-<ref> on the subject.
+
+Examples:
+  camp workitem link WI-2a7950 --worktree fest/fest-list-watch
+  camp workitem link workflow/design/fest-list-watch --worktree projects/worktrees/fest/fest-list-watch
+  camp workitem link WI-2a7950 projects/worktrees/fest/fest-list-watch
+  # Or at create time:
+  camp project worktree add fest-list-watch --project fest --workitem WI-2a7950
 
 ```
 camp workitem link <selector> [path] [flags]
@@ -6285,7 +6992,7 @@ camp workitem link <selector> [path] [flags]
       --project string    project name (matches projects/<name>)
       --replace           replace an existing primary link on the same scope
       --role string       primary | related | blocked_by | supersedes (default "primary")
-      --worktree string   worktree relative path under projects/worktrees/
+      --worktree string   worktree path under projects/worktrees/ (project/name or full projects/worktrees/project/name)
 ```
 
 ### Options inherited from parent commands
@@ -6360,11 +7067,11 @@ camp workitem list [type|status|category] [flags]
       --group-by string               Group output sections by attention_stage, group, type, or category
   -h, --help                          help for list
       --json                          Output as JSON
-      --limit int                     Maximum number of items to return
+      --limit int                     Maximum number of items to return (non-interactive / --json only)
       --query string                  Search query to filter items
       --show-parked                   Include parked attention-stage workitems
       --stage stringArray             Filter by lifecycle stage (repeat for OR)
-      --status stringArray            Filter by displayed status (repeat for OR)
+      --status stringArray            Filter by displayed status: current, next, active, parked, inbox, ready, plan, ritual, chains, none (repeat for OR)
       --type stringArray              Filter by workflow type (repeat for OR)
 ```
 
@@ -6377,7 +7084,7 @@ camp workitem list [type|status|category] [flags]
 
 ## camp workitem priority
 
-Set or clear the manual priority of a workitem
+Set or clear the manual priority
 
 ### Synopsis
 
@@ -6414,7 +7121,7 @@ camp workitem priority <selector> <high|medium|low|clear> [flags]
 
 ## camp workitem promote
 
-Promote a workitem to a festival, doc, or dungeon status
+Promote a workitem to a festival, doc, or dungeon
 
 ### Synopsis
 
@@ -6452,9 +7159,46 @@ camp workitem promote [id] --target <target> [flags]
 ```
 ---
 
+## camp workitem repair
+
+Repair a workflow directory into a workitem
+
+### Synopsis
+
+Repair a workflow directory so it carries a valid current-schema .workitem marker.
+
+The directory is never moved or renamed and document contents are never touched.
+When no marker exists one is created; when a legacy or incomplete marker exists
+its schema version, kind, id, type, ref, and title are brought up to the current
+shape. The workflow type is inferred from the path segment after workflow/, the
+title from the first markdown H1 (else the humanized directory name), and id/ref
+from the same rules as create and adopt. Repair is idempotent: a directory that
+is already valid reports no changes. Use --dry-run to preview and --json for a
+machine-readable result.
+
+```
+camp workitem repair <path> [flags]
+```
+
+### Options
+
+```
+      --dry-run       report what would change without writing
+  -h, --help          help for repair
+      --json          emit a structured JSON result
+      --type string   override the workflow type inferred from the path
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
 ## camp workitem resolve
 
-Print the workitem the current context resolves to (read-only)
+Print the workitem for the current context
 
 ### Synopsis
 
@@ -6488,7 +7232,7 @@ camp workitem resolve [flags]
 
 ## camp workitem stage
 
-Set or clear the attention stage of a workitem
+Set or clear the attention stage
 
 ```
 camp workitem stage <selector> <current|next|active|parked|clear> [flags]
@@ -6510,7 +7254,7 @@ camp workitem stage <selector> <current|next|active|parked|clear> [flags]
 
 ## camp workitem unlink
 
-Remove one or more workitem links
+Remove workitem links
 
 ### Synopsis
 
@@ -6535,6 +7279,98 @@ camp workitem unlink [selector] [path] [flags]
       --json              emit a structured JSON result
       --project string    project scope filter
       --worktree string   worktree scope filter
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp workitem validate
+
+Validate workitem directories
+
+### Synopsis
+
+Validate that workflow work item directories carry a correct .workitem marker.
+
+Without an argument, every work item directory under workflow/ is scanned:
+builtin doc directories (workflow/design, workflow/explore) are always work
+items, custom type directories surface only when they carry a marker, and
+dungeon/hidden control areas are ignored. With a path argument, only that
+directory is validated.
+
+Each problem prints the exact repair command, for example
+"camp workitem repair workflow/design/foo". Use --json for stable finding
+codes. The command exits non-zero when any error-severity finding is present.
+
+```
+camp workitem validate [path] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for validate
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp workitem worktree
+
+Create a project worktree from a workitem
+
+### Synopsis
+
+Create a git worktree for a workitem and primary-link it, so commits in
+that worktree carry the workitem's WI-* tag.
+
+This is the workitem-first counterpart to 'camp project worktree add': instead
+of naming a worktree and optionally tagging a workitem, you name a workitem and
+the worktree name, branch, and link are derived from it.
+
+Project resolution:
+  The target project is taken from the workitem's linked project (see
+  'camp workitem link --project'). When the workitem has no project link, or
+  is linked to more than one, pass --project explicitly.
+
+Re-entry:
+  If the workitem already has a primary worktree link, the existing path is
+  printed and no new worktree is created.
+
+Examples:
+  # Festival workitem already linked to a project
+  camp workitem worktree WI-2a7950
+
+  # Design/explore/intent workitem: name the project
+  camp workitem worktree workflow/design/camp-settings-tui --project camp
+
+  # Override the derived worktree name
+  camp workitem worktree WI-2a7950 --name grok-list-fix
+
+  # Print only the path (for shell integration)
+  cd "$(camp workitem worktree WI-2a7950 --print)"
+
+```
+camp workitem worktree <selector> [flags]
+```
+
+### Options
+
+```
+  -h, --help                 help for worktree
+      --name string          Worktree/branch name (derived from the workitem if omitted)
+      --print                Print only the worktree path
+  -p, --project string       Project name (inferred from the workitem's project link if omitted)
+  -s, --start-point string   Base branch/commit for the new branch (default: current branch)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp.md
+++ b/docs/cli-reference/camp.md
@@ -41,7 +41,9 @@ camp [flags]
 
 ### SEE ALSO
 
+* [camp artifacts](camp_artifacts.md)	 - Manage declared artifact roots (.campaign/artifacts.yaml)
 * [camp attach](camp_attach.md)	 - Attach an external directory to a campaign
+* [camp audit](camp_audit.md)	 - Inspect the campaign audit trail
 * [camp cache](camp_cache.md)	 - Manage the navigation index cache
 * [camp clone](camp_clone.md)	 - Clone a campaign with full submodule setup
 * [camp commit](camp_commit.md)	 - Commit changes in the campaign root
@@ -53,6 +55,7 @@ camp [flags]
 * [camp detach](camp_detach.md)	 - Remove the attachment marker from a directory
 * [camp doctor](camp_doctor.md)	 - Diagnose and fix campaign health issues
 * [camp dungeon](camp_dungeon.md)	 - Manage the campaign dungeon
+* [camp event](camp_event.md)	 - Record and inspect campaign ledger events
 * [camp festivals](camp_festivals.md)	 - List festivals across campaigns, filtered by org/tag
 * [camp fresh](camp_fresh.md)	 - Post-merge branch cycling: sync to default branch and optionally create a new working branch
 * [camp gather](camp_gather.md)	 - Gather related work into unified items

--- a/docs/cli-reference/camp_artifacts.md
+++ b/docs/cli-reference/camp_artifacts.md
@@ -1,0 +1,45 @@
+## camp artifacts
+
+Manage declared artifact roots (.campaign/artifacts.yaml)
+
+### Synopsis
+
+Manage the campaign's declared artifact roots: directories of heavy non-git
+payloads (media, renders, datasets) that 'camp sync --from <machine>' moves
+between your machines with rsync instead of git.
+
+The declaration file (.campaign/artifacts.yaml) is committed, so every
+machine knows what belongs to the campaign. Declared roots should be
+gitignored: a root that is also git-tracked would make the same bytes both
+git content and artifact content. Manifests and per-peer sync snapshots are
+machine-local derived state under .campaign/cache (gitignored).
+
+### Examples
+
+```
+  camp artifacts list
+  camp artifacts add media/renders
+  camp artifacts add datasets --policy on-demand
+  camp artifacts remove media/renders
+  camp artifacts manifest media/renders
+```
+
+### Options
+
+```
+  -h, --help   help for artifacts
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
+* [camp artifacts add](camp_artifacts_add.md)	 - Declare an artifact root
+* [camp artifacts list](camp_artifacts_list.md)	 - List declared artifact roots
+* [camp artifacts manifest](camp_artifacts_manifest.md)	 - Print a declared root's manifest as JSON
+* [camp artifacts remove](camp_artifacts_remove.md)	 - Remove an artifact root declaration

--- a/docs/cli-reference/camp_artifacts_add.md
+++ b/docs/cli-reference/camp_artifacts_add.md
@@ -1,0 +1,32 @@
+## camp artifacts add
+
+Declare an artifact root
+
+### Synopsis
+
+Declare a campaign-relative directory as an artifact root.
+
+Policy 'always' (default) syncs the root on every 'camp sync --from
+<machine>'; 'on-demand' syncs it only when artifacts are requested
+explicitly (--artifacts-only).
+
+```
+camp artifacts add <path> [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for add
+      --policy string   Sync policy: always (every peer sync) or on-demand (--artifacts-only) (default "always")
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp artifacts](camp_artifacts.md)	 - Manage declared artifact roots (.campaign/artifacts.yaml)

--- a/docs/cli-reference/camp_artifacts_list.md
+++ b/docs/cli-reference/camp_artifacts_list.md
@@ -1,0 +1,24 @@
+## camp artifacts list
+
+List declared artifact roots
+
+```
+camp artifacts list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+      --json   Output as JSON for scripting
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp artifacts](camp_artifacts.md)	 - Manage declared artifact roots (.campaign/artifacts.yaml)

--- a/docs/cli-reference/camp_artifacts_manifest.md
+++ b/docs/cli-reference/camp_artifacts_manifest.md
@@ -1,0 +1,29 @@
+## camp artifacts manifest
+
+Print a declared root's manifest as JSON
+
+### Synopsis
+
+Walk a declared artifact root and print its manifest (relative path, size,
+mtime per file) as JSON. This is the same shape sync snapshots use, so it is
+useful for scripting and for comparing roots across machines.
+
+```
+camp artifacts manifest <path> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for manifest
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp artifacts](camp_artifacts.md)	 - Manage declared artifact roots (.campaign/artifacts.yaml)

--- a/docs/cli-reference/camp_artifacts_remove.md
+++ b/docs/cli-reference/camp_artifacts_remove.md
@@ -1,0 +1,27 @@
+## camp artifacts remove
+
+Remove an artifact root declaration
+
+### Synopsis
+
+Remove a declared artifact root. Files on disk are not touched.
+
+```
+camp artifacts remove <path> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for remove
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp artifacts](camp_artifacts.md)	 - Manage declared artifact roots (.campaign/artifacts.yaml)

--- a/docs/cli-reference/camp_audit.md
+++ b/docs/cli-reference/camp_audit.md
@@ -1,0 +1,31 @@
+## camp audit
+
+Inspect the campaign audit trail
+
+### Synopsis
+
+Inspect the campaign audit trail.
+
+'camp audit doctor' scans linked repos for commits with no captured intent
+linkage and reports them informationally. Untagged commits are a normal mode
+for wrapper-opt-out workflows, not a violation.
+
+### Options
+
+```
+  -h, --help   help for audit
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
+* [camp audit backfill](camp_audit_backfill.md)	 - Derive a source:backfill event stream from history (opt-in write)
+* [camp audit doctor](camp_audit_doctor.md)	 - Scan linked repos for unattributed commits (informational)
+* [camp audit reconcile](camp_audit_reconcile.md)	 - Fill ledger gaps from state files (opt-in write)
+* [camp audit repair](camp_audit_repair.md)	 - Attribute a commit to a workitem or festival after the fact

--- a/docs/cli-reference/camp_audit_backfill.md
+++ b/docs/cli-reference/camp_audit_backfill.md
@@ -1,0 +1,37 @@
+## camp audit backfill
+
+Derive a source:backfill event stream from history (opt-in write)
+
+### Synopsis
+
+Derive ledger events from a campaign's existing history - tagged commits across
+linked repos, intent frontmatter, and festival status histories - so a pre-ledger
+campaign (or the pre-ledger history of this one) renders on the same timeline as
+new activity.
+
+Backfill is optional and never required. It is idempotent and live-wins: a fact
+already captured live or by a prior backfill is skipped, so consecutive runs
+produce zero new events. Dry-run by default; --apply writes the source:backfill
+events into the standard shard layout.
+
+```
+camp audit backfill [flags]
+```
+
+### Options
+
+```
+      --apply   write the derived source:backfill events into the ledger
+  -h, --help    help for backfill
+      --json    emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp audit](camp_audit.md)	 - Inspect the campaign audit trail

--- a/docs/cli-reference/camp_audit_doctor.md
+++ b/docs/cli-reference/camp_audit_doctor.md
@@ -1,0 +1,34 @@
+## camp audit doctor
+
+Scan linked repos for unattributed commits (informational)
+
+### Synopsis
+
+Scan the campaign root and every linked project repo, classifying each
+commit as tagged, degraded, or untagged (no captured intent linkage).
+
+Output is informational: untagged commits are surfaced, never scolded, and the
+command exits 0 even when findings exist. Use --window to bound each repo to its
+most recent N commits (default: full history).
+
+```
+camp audit doctor [flags]
+```
+
+### Options
+
+```
+  -h, --help         help for doctor
+      --json         emit a structured JSON report
+      --window int   scan only the most recent N commits per repo (0 = full history)
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp audit](camp_audit.md)	 - Inspect the campaign audit trail

--- a/docs/cli-reference/camp_audit_reconcile.md
+++ b/docs/cli-reference/camp_audit_reconcile.md
@@ -1,0 +1,35 @@
+## camp audit reconcile
+
+Fill ledger gaps from state files (opt-in write)
+
+### Synopsis
+
+Derive the events implied by campaign state files (intent statuses and
+festival status histories), diff them against the ledger, and report the gaps -
+facts the ledger does not yet capture. This covers users who never commit at all.
+
+By default this is a dry run. Pass --apply to append the missing facts as
+reconciled events (idempotent: reconciled ids are content-derived, so re-running
+does not duplicate).
+
+```
+camp audit reconcile [flags]
+```
+
+### Options
+
+```
+      --apply   append the missing facts as reconciled events
+  -h, --help    help for reconcile
+      --json    emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp audit](camp_audit.md)	 - Inspect the campaign audit trail

--- a/docs/cli-reference/camp_audit_repair.md
+++ b/docs/cli-reference/camp_audit_repair.md
@@ -1,0 +1,35 @@
+## camp audit repair
+
+Attribute a commit to a workitem or festival after the fact
+
+### Synopsis
+
+Attribute an already-landed commit to a workitem or festival by appending a
+repaired event. This never rewrites git history; it only records the attribution
+in the ledger (D004). Use it to claim an untagged commit surfaced by
+'camp audit doctor' for a piece of work.
+
+```
+camp audit repair --sha <sha> (--workitem <id> | --festival <id>) --why <reason> [flags]
+```
+
+### Options
+
+```
+      --festival string   festival to attribute the commit to
+  -h, --help              help for repair
+      --repo string       evidence repo label (default: campaign-root)
+      --sha string        commit sha to attribute (required)
+      --why string        reason for the attribution (required)
+      --workitem string   workitem to attribute the commit to
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp audit](camp_audit.md)	 - Inspect the campaign audit trail

--- a/docs/cli-reference/camp_clone.md
+++ b/docs/cli-reference/camp_clone.md
@@ -60,6 +60,13 @@ EXAMPLES:
   # JSON output for scripting
   camp clone git@github.com:org/repo.git --json
 
+  # Seed from a peer machine in ~/.obey/machines.yaml: root repo and
+  # submodules clone from that machine's copy (LAN/tailnet), then origin is
+  # re-pointed to the URL above and the delta fetched. The result is an
+  # origin replica that arrived over the fast path; peer failures fall back
+  # to plain origin cloning.
+  camp clone git@github.com:org/repo.git --from studio-mac
+
 ```
 camp clone <url> [directory] [flags]
 ```
@@ -69,6 +76,7 @@ camp clone <url> [directory] [flags]
 ```
   -b, --branch string   Clone specific branch (default: repository default branch)
       --depth int       Shallow clone depth (0 = full history)
+      --from string     Seed git objects from this machine (id from ~/.obey/machines.yaml), then fetch the delta from origin
   -h, --help            help for clone
       --json            Output results as JSON for scripting
       --no-register     Skip auto-registration in global campaign registry

--- a/docs/cli-reference/camp_commit.md
+++ b/docs/cli-reference/camp_commit.md
@@ -31,16 +31,16 @@ camp commit [flags]
 ### Options
 
 ```
-  -a, --all               Stage all changes before committing (default true)
-      --amend             Amend the previous commit
-      --auto-write        Run configured commit message writer
-  -h, --help              help for commit
-      --include-refs      Include submodule ref changes when staging at campaign root
-  -m, --message string    Commit message (required unless --auto-write)
-      --no-edit           Amend without editing the commit message (requires --amend)
-  -p, --project string    Operate on a specific project/submodule path
-      --sub               Operate on the submodule detected from current directory
-      --workitem string   explicit workitem selector for the commit tag (overrides cwd-based resolution)
+  -a, --all                   Stage all changes before committing (default true)
+      --amend                 Amend the previous commit
+      --auto-write            Run configured commit message writer
+  -h, --help                  help for commit
+      --include-refs          Include submodule ref changes when staging at campaign root
+  -m, --message stringArray   Commit message (repeatable; multiple -m are joined git-style into subject + body; required unless --auto-write)
+      --no-edit               Amend without editing the commit message (requires --amend)
+  -p, --project string        Operate on a specific project/submodule path
+      --sub                   Operate on the submodule detected from current directory
+      --workitem string       explicit workitem selector for the commit tag (overrides cwd-based resolution)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_create.md
+++ b/docs/cli-reference/camp_create.md
@@ -29,6 +29,7 @@ camp create <name> [flags]
   -n, --name string          Campaign display name (defaults to <name> positional)
       --no-git               Skip git repository initialization
       --no-skills            Skip linking campaign skills into .claude/skills and .agents/skills
+      --org string           Assign the new campaign to this org (created if new; defaults to the fallback org)
       --path string          Override the base campaigns directory (campaign created at <path>/<name>/)
   -t, --type string          Campaign type (product, research, tools, personal) (default "product")
 ```

--- a/docs/cli-reference/camp_event.md
+++ b/docs/cli-reference/camp_event.md
@@ -1,0 +1,28 @@
+## camp event
+
+Record and inspect campaign ledger events
+
+### Synopsis
+
+Record and inspect campaign event-ledger entries.
+
+The ledger is the append-only trail of high-intent actions across a campaign.
+Most events are captured automatically by state-changing camp/fest commands;
+'camp event add' is the explicit escape hatch for actions that never touch git.
+
+### Options
+
+```
+  -h, --help   help for event
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
+* [camp event add](camp_event_add.md)	 - Record an explicit campaign ledger event

--- a/docs/cli-reference/camp_event_add.md
+++ b/docs/cli-reference/camp_event_add.md
@@ -1,0 +1,48 @@
+## camp event add
+
+Record an explicit campaign ledger event
+
+### Synopsis
+
+Record an explicit campaign ledger event for an out-of-band action.
+
+Scope is inferred from the current directory (the workitem or festival you are
+in); flags override inference. Evidence may be a campaign-relative path, a URL,
+or a repo@sha commit reference, and may be repeated.
+
+Examples:
+  # A media-production decision, with the produced file as evidence
+  camp event add --type decided "chose H.265 for the trailer" \
+    --why "smaller files, target players all support it" \
+    --evidence renders/trailer_final_v3.mp4
+
+  # A quick note-to-trail from inside a workitem directory
+  camp event add --type created "kicked off the color grade pass"
+
+```
+camp event add <title> [flags]
+```
+
+### Options
+
+```
+      --action string          join an existing action id (default: a fresh action per invocation)
+      --evidence stringArray   evidence ref: <path> | <url> | <repo>@<sha> (repeatable)
+      --festival string        festival id to scope the event (overrides cwd inference)
+  -h, --help                   help for add
+      --json                   emit a structured JSON result
+      --quest string           quest id to scope the event
+      --type string            event kind (required): created, transitioned, completed, decided, evidence_attached, reconciled, repaired
+      --why string             the reason for the action (rendered prominently)
+      --workitem string        workitem selector to scope the event (overrides cwd inference)
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp event](camp_event.md)	 - Record and inspect campaign ledger events

--- a/docs/cli-reference/camp_init.md
+++ b/docs/cli-reference/camp_init.md
@@ -52,6 +52,7 @@ camp init [path] [flags]
       --no-git               Skip git repository initialization
       --no-register          Don't add to global registry
       --no-skills            Skip linking campaign skills into .claude/skills and .agents/skills
+      --org string           Assign the new campaign to this org (created if new; defaults to the fallback org)
       --repair               Add missing files to existing campaign
   -t, --type string          Campaign type (product, research, tools, personal) (default "product")
   -v, --verbose              Show skipped optional setup details

--- a/docs/cli-reference/camp_list.md
+++ b/docs/cli-reference/camp_list.md
@@ -11,8 +11,9 @@ with 'camp register'. The registry lives at ~/.obey/campaign/registry.json.
 
 In a terminal, 'camp list' (with no flags) opens an interactive browser where you
 can deactivate/reactivate campaigns (cycle lifecycle status), reassign their org,
-and copy paths. Piped, with --json/--count, or with any filter/sort flag it
-prints the table instead. Home paths display as '~'.
+and copy paths. Pass an org as a positional argument to open the browser filtered
+to that org. Piped, with --json/--count, or with any filter/sort flag it prints
+the table instead. Home paths display as '~'.
 
 Output formats:
   table   - Aligned columns with headers (default)
@@ -27,15 +28,22 @@ Sorting options:
 
 Examples:
   camp list                  List all campaigns
+  camp list obey             Browse campaigns in the obey org
   camp list --json           Output as JSON
   camp list --format json    Output as JSON
   camp list --sort name      Sort by name
   camp list --sort org       Sort by org, then name
   camp list --format simple  Names only for scripting
   camp list --count          Print only the total number of campaigns
+  camp list --remote         Also list campaigns on machines in ~/.obey/machines.yaml
+
+--remote runs each machine's own 'camp list --json' through a login shell
+(sh -lc) so PATH entries a login profile exports (~/.profile, etc.) are
+picked up. If camp still can't be found on a machine, set
+CAMP_REMOTE_CAMP_PATH to its exact path there.
 
 ```
-camp list [flags]
+camp list [org] [flags]
 ```
 
 ### Options

--- a/docs/cli-reference/camp_org.md
+++ b/docs/cli-reference/camp_org.md
@@ -4,11 +4,11 @@ Group campaigns into orgs
 
 ### Synopsis
 
-Group related campaigns into orgs.
+Group related campaigns into first-class orgs.
 
-Every campaign belongs to exactly one org (default "default"). Orgs are derived:
-an org exists because a campaign names it, and disappears when its last member
-leaves.
+Every campaign belongs to exactly one org (default "default"). Orgs are first-class:
+they persist in the machine-wide registry, can hold zero members, and are deleted
+explicitly with 'camp org delete'.
 
 In a terminal, 'camp org' (no arguments) opens an interactive browser of orgs
 and their members where you can move, create, rename, and return campaigns. When
@@ -17,9 +17,10 @@ piped or with --json it prints the current campaign's org instead; use
 
 Commands:
   which   Print the current campaign's org
-  create  Create an org by joining campaigns (the current campaign if none named)
+  create  Create an org (optionally --empty) and optionally join campaigns
   add     Assign campaigns to an org (also reassigns; single-membership)
   remove  Return campaigns to the default org
+  delete  Delete an org (empty only unless --force)
 
 ```
 camp org [flags]
@@ -31,8 +32,10 @@ camp org [flags]
   camp org                                       Browse and manage orgs interactively (TTY)
   camp org which                                 Print the current campaign's org
   camp org create obey                           Add the current campaign to "obey"
+  camp org create empty-org --empty              Create an org with no members
   camp org add obey obey-campaign obey-content   Move campaigns into "obey"
   camp org remove obey-content                   Return a campaign to "default"
+  camp org delete empty-org                      Delete an empty org
 ```
 
 ### Options
@@ -53,7 +56,8 @@ camp org [flags]
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
 * [camp org add](camp_org_add.md)	 - Assign campaigns to an org (reassigns; single-membership)
-* [camp org create](camp_org_create.md)	 - Create an org by joining campaigns (the current campaign if none named)
+* [camp org create](camp_org_create.md)	 - Create an org (optionally empty) and join campaigns
+* [camp org delete](camp_org_delete.md)	 - Delete an org (empty only unless --force)
 * [camp org list](camp_org_list.md)	 - List orgs with member and active counts
 * [camp org remove](camp_org_remove.md)	 - Return campaigns to the default org
 * [camp org rename](camp_org_rename.md)	 - Rename an org, reassigning all members atomically

--- a/docs/cli-reference/camp_org_create.md
+++ b/docs/cli-reference/camp_org_create.md
@@ -1,10 +1,10 @@
 ## camp org create
 
-Create an org by joining campaigns (the current campaign if none named)
+Create an org (optionally empty) and join campaigns
 
 ### Synopsis
 
-Create an org by joining campaigns to it.
+Create a first-class org, optionally joining campaigns to it.
 
 Run inside a campaign with no campaign arguments to add the current campaign:
   camp org create obey
@@ -12,7 +12,10 @@ Run inside a campaign with no campaign arguments to add the current campaign:
 Or name the campaigns explicitly:
   camp org create obey obey-campaign obey-content
 
-Orgs remain derived: "create" assigns membership and never makes an empty org.
+Create an empty org with no members (works outside a campaign):
+  camp org create obey --empty
+
+Orgs are first-class: they persist in the registry even with zero members.
 Joining an org that already has members is allowed; there is no "already exists"
 error, and a campaign already in the org is reported as unchanged.
 
@@ -24,14 +27,16 @@ camp org create <org> [campaign...] [flags]
 
 ```
   camp org create obey
+  camp org create obey --empty
   camp org create client-acme acme-site other-site
 ```
 
 ### Options
 
 ```
-  -h, --help   help for create
-      --json   Output as JSON
+      --empty   Create the org with no members (do not join any campaign)
+  -h, --help    help for create
+      --json    Output as JSON
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_org_delete.md
+++ b/docs/cli-reference/camp_org_delete.md
@@ -1,0 +1,42 @@
+## camp org delete
+
+Delete an org (empty only unless --force)
+
+### Synopsis
+
+Delete a first-class org from the registry.
+
+Empty orgs delete without flags. Orgs with members require --force, which
+reassigns every member to the fallback org and then deletes the org.
+
+The fallback org cannot be deleted.
+
+```
+camp org delete <name> [flags]
+```
+
+### Examples
+
+```
+  camp org delete empty-org
+  camp org delete obey --force
+  camp org delete empty-org --json
+```
+
+### Options
+
+```
+      --force   Reassign members to the fallback org, then delete
+  -h, --help    help for delete
+      --json    Output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp org](camp_org.md)	 - Group campaigns into orgs

--- a/docs/cli-reference/camp_project.md
+++ b/docs/cli-reference/camp_project.md
@@ -11,12 +11,17 @@ A project can be:
   - a machine-local linked workspace attached via symlink under projects/
 
 Use 'camp project add' for submodules and 'camp project link' / 'camp project unlink'
-for linked workspaces.
+for linked workspaces. Use 'camp project run' (or the 'cr -p' shell shorthand)
+to run a command inside a project from anywhere in the campaign.
 
 Examples:
   camp project list                    List all projects
   camp project add git@github.com:org/repo.git  Add a new project
   camp project link ~/code/my-project  Link an existing local workspace
+  camp project run -p fest -- just build  Run a command inside a project
+  camp project commit -p fest -m "fix"  Commit changes in a project submodule
+  camp project prune                   Delete merged branches in the cwd's project
+  camp project worktree add my-branch --project fest  Create a worktree for a project
   camp project remove api-service      Remove a project
 
 ```
@@ -46,7 +51,7 @@ camp project [flags]
 * [camp project prune](camp_project_prune.md)	 - Delete merged branches in a project
 * [camp project remote](camp_project_remote.md)	 - Manage remotes for a project
 * [camp project remove](camp_project_remove.md)	 - Remove a project from campaign
-* [camp project run](camp_project_run.md)	 - Run a command inside a project directory
+* [camp project run](camp_project_run.md)	 - Run a command inside a project directory, like cr but project-scoped
 * [camp project stage](camp_project_stage.md)	 - Stage changes in a project submodule
 * [camp project unlink](camp_project_unlink.md)	 - Unlink a linked project from a campaign
 * [camp project worktree](camp_project_worktree.md)	 - Manage worktrees for a project

--- a/docs/cli-reference/camp_project_commit.md
+++ b/docs/cli-reference/camp_project_commit.md
@@ -24,14 +24,15 @@ camp project commit [flags]
 ### Options
 
 ```
-  -a, --all               Stage all changes (default true)
-      --amend             Amend the previous commit
-      --auto-write        Run configured commit message writer
-  -h, --help              help for commit
-  -m, --message string    Commit message (required unless --auto-write)
-  -p, --project string    Project name (auto-detected from cwd if not specified)
-      --sync              Sync submodule ref at campaign root after commit (opt-in)
-      --workitem string   explicit workitem selector for the commit tag (overrides cwd-based resolution)
+  -a, --all                   Stage all changes (default true)
+      --amend                 Amend the previous commit
+      --auto-write            Run configured commit message writer
+  -h, --help                  help for commit
+  -m, --message stringArray   Commit message (repeatable; multiple -m are joined git-style into subject + body; required unless --auto-write)
+      --no-sync               Do not sync submodule ref even if settings enable it
+  -p, --project string        Project name (auto-detected from cwd if not specified)
+      --sync                  Sync submodule ref at campaign root after commit (also enabled by commit.sync_project_refs setting)
+      --workitem string       explicit workitem selector for the commit tag (overrides cwd-based resolution)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_project_run.md
+++ b/docs/cli-reference/camp_project_run.md
@@ -1,13 +1,16 @@
 ## camp project run
 
-Run a command inside a project directory
+Run a command inside a project directory, like cr but project-scoped
 
 ### Synopsis
 
 Run any shell command inside a project directory from anywhere in the campaign.
 
+This is the project-scoped counterpart to 'camp run' (cr): cr runs from the
+campaign root, camp project run (cr -p) runs inside a project.
+
 The project is resolved in this order:
-  1. --project / -p flag (explicit project name)
+  1. --project / -p flag (explicit project name, tab-completes registered projects)
   2. Auto-detect from current working directory
   3. Interactive fuzzy picker (if neither above applies)
 
@@ -27,6 +30,10 @@ Examples:
   # Simple commands (no -- needed when no flags)
   camp project run make build
 
+  # Shell shorthand (after 'eval "$(camp shell-init <shell>)"')
+  cr -p fest -- just build
+  cr -p camp go test ./...
+
 ```
 camp project run [--project <name>] [--] <command> [args...] [flags]
 ```
@@ -34,7 +41,8 @@ camp project run [--project <name>] [--] <command> [args...] [flags]
 ### Options
 
 ```
-  -h, --help   help for run
+  -h, --help             help for run
+  -p, --project string   Project name (auto-detected from cwd, or interactive picker if omitted)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_project_worktree_add.md
+++ b/docs/cli-reference/camp_project_worktree_add.md
@@ -30,6 +30,10 @@ Examples:
   # Explicit project
   camp project worktree add feature --project my-api
 
+  # Link a design/explore workitem so camp p commit in the worktree tags WI-*
+  camp project worktree add fest-list-watch --project fest --workitem WI-2a7950
+  camp project worktree add settings-tui --project camp --workitem workflow/design/camp-settings-tui
+
 ```
 camp project worktree add <name> [flags]
 ```
@@ -42,6 +46,7 @@ camp project worktree add <name> [flags]
   -p, --project string       Project name (auto-detected from cwd if not specified)
   -s, --start-point string   Base branch/commit for new branch (default: current branch)
   -t, --track string         Remote branch to track (creates new local tracking branch)
+      --workitem string      workitem selector (ref, path, or id) to primary-link to this worktree for camp p commit tags
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_settings_get.md
+++ b/docs/cli-reference/camp_settings_get.md
@@ -10,12 +10,25 @@ With no key, prints all settings including the effective theme. With a key,
 prints just that value.
 
 Keys:
-  global.theme           Color theme in ~/.obey/campaign/config.json
-  global.editor          Preferred editor
-  global.campaigns_dir   Where camp create places new campaigns
-  global.verbose         Verbose output
-  global.no_color        Disable colored output
-  local.theme_override   Campaign-local theme override (requires a campaign)
+  global.theme               Color theme in ~/.obey/campaign/config.json
+  global.editor              Preferred editor
+  global.campaigns_dir       Where camp create places new campaigns
+  global.verbose             Verbose output
+  global.no_color            Disable colored output
+  global.commit.sync_project_refs   When true, camp p commit updates campaign-root submodule pointer (default false)
+  global.commit.disable_commit_tags When true, skip [campaign:…] tags on camp commits (default false; tags on)
+  local.theme_override       Campaign-local theme override (requires a campaign)
+  local.commit.sync_project_refs    Campaign override for project-ref sync (true/false/inherit)
+  local.commit.disable_commit_tags  Campaign override to skip commit subject tags (true/false/inherit)
+  local.campaign.name        Campaign name in .campaign/campaign.yaml
+  local.campaign.description Campaign description
+  local.campaign.mission     Campaign mission
+  local.campaign.type        Campaign type (product, research, tools, personal)
+  local.campaign.commit_hook Commit-message hook command
+  effective.commit.*         Resolved commit prefs (get only; local overrides global)
+
+The campaign.yaml list and tree fields (intents.tags, concepts) have no flat
+key and are edited only through the interactive 'camp settings' TUI.
 
 ```
 camp settings get [key] [flags]
@@ -26,6 +39,7 @@ camp settings get [key] [flags]
 ```
   camp settings get
   camp settings get global.theme
+  camp settings get effective.commit.sync_project_refs
   camp settings get --json
 ```
 

--- a/docs/cli-reference/camp_switch.md
+++ b/docs/cli-reference/camp_switch.md
@@ -23,6 +23,15 @@ Use campaign@tab to navigate to a specific location in the target campaign:
   camp switch obey-campaign@p    # Switch and navigate to projects/
   camp switch obey/platform@f    # Switch inside org and navigate to festivals/
 
+Use machine:campaign to resolve a campaign on a machine registered in
+~/.obey/machines.yaml (via the csw shell wrapper, which hops there over ssh):
+  csw devbox:obey-campaign       # Resolve and hop to obey-campaign on devbox
+
+Remote resolution runs the far machine's own 'camp switch' through a login
+shell (sh -lc) so PATH entries a login profile exports (~/.profile, etc.) are
+picked up. If camp still can't be found there, set CAMP_REMOTE_CAMP_PATH to
+its exact path on that machine.
+
 ```
 camp switch [campaign] [flags]
 ```

--- a/docs/cli-reference/camp_sync.md
+++ b/docs/cli-reference/camp_sync.md
@@ -47,6 +47,23 @@ EXAMPLES:
   # JSON output for scripting
   camp sync --json
 
+  # Accelerate over a peer machine from ~/.obey/machines.yaml: for each
+  # already-initialized submodule, fetch objects from that machine first
+  # (LAN/tailnet), then run the normal origin-based update, then pull
+  # declared artifact roots (policy=always) from the same machine.
+  # Uninitialized submodules skip the peer step and init from origin.
+  # Preflight, origin URLs, validation, and exit codes are unchanged; an
+  # unreachable peer degrades to a warning.
+  camp sync --from studio-mac
+
+  # Peer git objects only, skip artifacts / artifacts only, skip git phases
+  camp sync --from studio-mac --git-only
+  camp sync --from studio-mac --artifacts-only
+
+  # Check artifact roots against last-transfer snapshots, no transfer
+  camp sync --verify-artifacts
+  camp sync --verify-artifacts --from studio-mac
+
 ```
 camp sync [submodule...] [flags]
 ```
@@ -54,13 +71,17 @@ camp sync [submodule...] [flags]
 ### Options
 
 ```
-  -n, --dry-run        Show what would happen without making changes
-  -f, --force          Skip safety checks (uncommitted changes warning still shown)
-  -h, --help           help for sync
-      --json           Output results as JSON for scripting
-      --no-fetch       Skip fetching from remote (use local refs only)
-  -p, --parallel int   Number of parallel git operations (default 4)
-  -v, --verbose        Show detailed output for each submodule
+      --artifacts-only     With --from: pull declared artifact roots only, skip git phases
+  -n, --dry-run            Show what would happen without making changes
+  -f, --force              Skip safety checks (uncommitted changes warning still shown)
+      --from string        Fetch objects for already-initialized submodules (and declared artifact roots) from this machine (id from ~/.obey/machines.yaml)
+      --git-only           With --from: move git objects only, skip artifact roots
+  -h, --help               help for sync
+      --json               Output results as JSON for scripting
+      --no-fetch           Skip fetching from remote (use local refs only)
+  -p, --parallel int       Number of parallel git operations (git guards superproject ops with repo lockfiles that fail fast on contention; lower this if a slow disk surfaces transient lock errors) (default 4)
+  -v, --verbose            Show detailed output for each submodule
+      --verify-artifacts   Check artifact roots against last-transfer snapshots (no transfer)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_workitem.md
+++ b/docs/cli-reference/camp_workitem.md
@@ -4,17 +4,16 @@ View active campaign work items
 
 ### Synopsis
 
-View active campaign work items across intents, designs, explore, and festivals.
+View active campaign work items.
 
-Default mode launches an interactive TUI dashboard. Use --json for machine-readable
-output or --print to select and print a path for shell integration.
+Launches an interactive dashboard on a TTY. Non-interactive callers must pass
+--json, --list, or --print.
 
 Examples:
-  camp workitem                              # interactive dashboard
-  camp workitem --json                       # JSON output for agents/scripts
-  camp workitem --json --type design         # filter by type
-  camp workitem --json --type intent --limit 5
-  camp workitem --print                      # select and print path
+  camp workitem                       # interactive dashboard
+  camp workitem --json --type design  # JSON, filtered by type
+  camp workitem --list                # compact grouped list
+  camp workitem --print               # print a path for shell integration
 
 ```
 camp workitem [flags]
@@ -23,20 +22,20 @@ camp workitem [flags]
 ### Options
 
 ```
-      --attention-stage stringArray   Filter by attention stage (current, next, active, parked)
-      --category stringArray          Filter by workflow category (builtin: plan, research, pipeline, review, uncategorized; or any category defined under workflows in campaign.yaml)
+      --attention-stage stringArray   Filter by attention stage
+      --category stringArray          Filter by workflow category
       --group stringArray             Filter by workitem group
-      --group-by string               Group JSON/list sections by attention_stage, group, type, or category; --list defaults to group unless set (default "attention_stage")
+      --group-by string               Group sections (default "attention_stage")
   -h, --help                          help for workitem
       --json                          Output as JSON
-      --limit int                     Maximum number of items to return
+      --limit int                     Maximum items to return
       --list                          Output a compact grouped list
-      --print                         Print path only (for shell integration)
-      --query string                  Search query to filter items
-      --show-parked                   include parked attention-stage workitems in default output
-      --stage stringArray             Filter by lifecycle stage (none, inbox, active, ready, planning, ritual, chains)
-      --status stringArray            Filter by displayed status (current, next, active, parked, inbox, ready, plan, ritual, chains, none)
-      --type stringArray              Filter by workflow type (builtin: intent, design, explore, festival; or any slug-safe custom type produced by 'camp workitem create --type <name>')
+      --print                         Print path only
+      --query string                  Filter by search query
+      --show-parked                   Include parked workitems
+      --stage stringArray             Filter by lifecycle stage
+      --status stringArray            Filter by displayed status
+      --type stringArray              Filter by workflow type
 ```
 
 ### Options inherited from parent commands
@@ -48,19 +47,21 @@ camp workitem [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-* [camp workitem adopt](camp_workitem_adopt.md)	 - Attach .workitem metadata to an existing directory
-* [camp workitem commit](camp_workitem_commit.md)	 - Commit changes scoped to the resolved workitem
-* [camp workitem commits](camp_workitem_commits.md)	 - List commits referencing a workitem across linked repos
-* [camp workitem create](camp_workitem_create.md)	 - Create a new workitem with v1 minimum metadata
-* [camp workitem current](camp_workitem_current.md)	 - Get, set, or clear the local current workitem
-* [camp workitem doctor](camp_workitem_doctor.md)	 - Report workitem link-registry health issues
-* [camp workitem group](camp_workitem_group.md)	 - Set or clear the group of a workitem
-* [camp workitem link](camp_workitem_link.md)	 - Attach a workitem to a project, festival, worktree, or campaign path
+* [camp workitem adopt](camp_workitem_adopt.md)	 - Adopt an existing directory as a workitem
+* [camp workitem commit](camp_workitem_commit.md)	 - Commit changes scoped to a workitem
+* [camp workitem commits](camp_workitem_commits.md)	 - List commits referencing a workitem
+* [camp workitem create](camp_workitem_create.md)	 - Create a workitem
+* [camp workitem current](camp_workitem_current.md)	 - Get, set, or clear the current workitem
+* [camp workitem doctor](camp_workitem_doctor.md)	 - Report link-registry health issues
+* [camp workitem group](camp_workitem_group.md)	 - Set or clear the group
+* [camp workitem link](camp_workitem_link.md)	 - Create a workitem link
 * [camp workitem links](camp_workitem_links.md)	 - List workitem links
 * [camp workitem list](camp_workitem_list.md)	 - List or browse filtered workitems
-* [camp workitem priority](camp_workitem_priority.md)	 - Set or clear the manual priority of a workitem
-* [camp workitem promote](camp_workitem_promote.md)	 - Promote a workitem to a festival, doc, or dungeon status
-* [camp workitem resolve](camp_workitem_resolve.md)	 - Print the workitem the current context resolves to (read-only)
-* [camp workitem stage](camp_workitem_stage.md)	 - Set or clear the attention stage of a workitem
-* [camp workitem unlink](camp_workitem_unlink.md)	 - Remove one or more workitem links
+* [camp workitem priority](camp_workitem_priority.md)	 - Set or clear the manual priority
+* [camp workitem promote](camp_workitem_promote.md)	 - Promote a workitem to a festival, doc, or dungeon
+* [camp workitem repair](camp_workitem_repair.md)	 - Repair a workflow directory into a workitem
+* [camp workitem resolve](camp_workitem_resolve.md)	 - Print the workitem for the current context
+* [camp workitem stage](camp_workitem_stage.md)	 - Set or clear the attention stage
+* [camp workitem unlink](camp_workitem_unlink.md)	 - Remove workitem links
+* [camp workitem validate](camp_workitem_validate.md)	 - Validate workitem directories
 * [camp workitem worktree](camp_workitem_worktree.md)	 - Create a project worktree from a workitem

--- a/docs/cli-reference/camp_workitem_adopt.md
+++ b/docs/cli-reference/camp_workitem_adopt.md
@@ -1,6 +1,6 @@
 ## camp workitem adopt
 
-Attach .workitem metadata to an existing directory
+Adopt an existing directory as a workitem
 
 ### Synopsis
 

--- a/docs/cli-reference/camp_workitem_commit.md
+++ b/docs/cli-reference/camp_workitem_commit.md
@@ -1,6 +1,6 @@
 ## camp workitem commit
 
-Commit changes scoped to the resolved workitem
+Commit changes scoped to a workitem
 
 ### Synopsis
 
@@ -28,7 +28,7 @@ camp workitem commit [selector] [flags]
       --include stringArray         additional path to stage (repeatable; relative to repo root)
       --include-submodule-pointer   include dirty project submodule pointers in the plan
       --json                        emit the staging plan and commit result as JSON on stdout
-  -m, --message string              commit message (required unless --dry-run)
+  -m, --message stringArray         commit message (repeatable; multiple -m are joined git-style into subject + body; required unless --dry-run)
       --project string              force project-repo context by name (skips resolver)
       --staged                      commit whatever is already in the git index
       --workitem string             explicit workitem selector (overrides cwd-based resolution)

--- a/docs/cli-reference/camp_workitem_commits.md
+++ b/docs/cli-reference/camp_workitem_commits.md
@@ -1,16 +1,21 @@
 ## camp workitem commits
 
-List commits referencing a workitem across linked repos
+List commits referencing a workitem
 
 ### Synopsis
 
-Search the campaign root and every linked project/repo/worktree/festival
-repo for commits whose campaign tag references this workitem's ref.
+List commits referencing this workitem, newest first.
 
-Default sort: most recent first across all repos. Use --json for structured
-output. Repos that are not git checkouts or that fail their git log invocation
-are reported under "errors" in JSON mode; table mode warns on stderr when
-repo queries fail.
+When the campaign event ledger already holds the workitem's commit evidence,
+the answer comes from a single merged ledger read (fast path). Otherwise it
+falls back to scanning the campaign root and every linked
+project/repo/worktree/festival repo for commits whose campaign tag references
+the workitem's ref (pre-ledger history).
+
+Use --json for structured output; the "source" field reports which path
+answered ("ledger" or "scan"). Repos that are not git checkouts or that fail
+their git log invocation are reported under "errors" in JSON mode; table mode
+warns on stderr when repo queries fail.
 
 ```
 camp workitem commits [selector] [flags]
@@ -24,6 +29,7 @@ camp workitem commits [selector] [flags]
       --limit int         maximum commits to return (default 100)
       --offset int        number of commits to skip (after sorting)
       --ref string        query by workitem ref directly (e.g. WI-abc123) — skips resolver
+      --source string     where to read commits from: auto (ledger when present, else scan), ledger, or scan (default "auto")
       --workitem string   alias for the positional <selector>
 ```
 

--- a/docs/cli-reference/camp_workitem_create.md
+++ b/docs/cli-reference/camp_workitem_create.md
@@ -1,6 +1,6 @@
 ## camp workitem create
 
-Create a new workitem with v1 minimum metadata
+Create a workitem
 
 ### Synopsis
 

--- a/docs/cli-reference/camp_workitem_current.md
+++ b/docs/cli-reference/camp_workitem_current.md
@@ -1,6 +1,6 @@
 ## camp workitem current
 
-Get, set, or clear the local current workitem
+Get, set, or clear the current workitem
 
 ### Synopsis
 

--- a/docs/cli-reference/camp_workitem_doctor.md
+++ b/docs/cli-reference/camp_workitem_doctor.md
@@ -1,6 +1,6 @@
 ## camp workitem doctor
 
-Report workitem link-registry health issues
+Report link-registry health issues
 
 ### Synopsis
 

--- a/docs/cli-reference/camp_workitem_group.md
+++ b/docs/cli-reference/camp_workitem_group.md
@@ -1,6 +1,6 @@
 ## camp workitem group
 
-Set or clear the group of a workitem
+Set or clear the group
 
 ```
 camp workitem group <selector> <group|clear> [flags]

--- a/docs/cli-reference/camp_workitem_link.md
+++ b/docs/cli-reference/camp_workitem_link.md
@@ -1,6 +1,6 @@
 ## camp workitem link
 
-Attach a workitem to a project, festival, worktree, or campaign path
+Create a workitem link
 
 ### Synopsis
 
@@ -10,6 +10,17 @@ Links are stored in .campaign/workitems/links.yaml and connect a .workitem
 identity to an explicit scope for planning, execution, and lookup. Pass a
 workitem selector plus a path, or use --project, --festival, --worktree, or
 --cwd to derive the scope. Use --json for machine-readable link output.
+
+A primary worktree link is how design/explore workitems under workflow/ get
+into camp p commit tags: when you commit from that worktree, the resolver
+matches the link and stamps WI-<ref> on the subject.
+
+Examples:
+  camp workitem link WI-2a7950 --worktree fest/fest-list-watch
+  camp workitem link workflow/design/fest-list-watch --worktree projects/worktrees/fest/fest-list-watch
+  camp workitem link WI-2a7950 projects/worktrees/fest/fest-list-watch
+  # Or at create time:
+  camp project worktree add fest-list-watch --project fest --workitem WI-2a7950
 
 ```
 camp workitem link <selector> [path] [flags]
@@ -26,7 +37,7 @@ camp workitem link <selector> [path] [flags]
       --project string    project name (matches projects/<name>)
       --replace           replace an existing primary link on the same scope
       --role string       primary | related | blocked_by | supersedes (default "primary")
-      --worktree string   worktree relative path under projects/worktrees/
+      --worktree string   worktree path under projects/worktrees/ (project/name or full projects/worktrees/project/name)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_workitem_list.md
+++ b/docs/cli-reference/camp_workitem_list.md
@@ -32,11 +32,11 @@ camp workitem list [type|status|category] [flags]
       --group-by string               Group output sections by attention_stage, group, type, or category
   -h, --help                          help for list
       --json                          Output as JSON
-      --limit int                     Maximum number of items to return
+      --limit int                     Maximum number of items to return (non-interactive / --json only)
       --query string                  Search query to filter items
       --show-parked                   Include parked attention-stage workitems
       --stage stringArray             Filter by lifecycle stage (repeat for OR)
-      --status stringArray            Filter by displayed status (repeat for OR)
+      --status stringArray            Filter by displayed status: current, next, active, parked, inbox, ready, plan, ritual, chains, none (repeat for OR)
       --type stringArray              Filter by workflow type (repeat for OR)
 ```
 

--- a/docs/cli-reference/camp_workitem_priority.md
+++ b/docs/cli-reference/camp_workitem_priority.md
@@ -1,6 +1,6 @@
 ## camp workitem priority
 
-Set or clear the manual priority of a workitem
+Set or clear the manual priority
 
 ### Synopsis
 

--- a/docs/cli-reference/camp_workitem_promote.md
+++ b/docs/cli-reference/camp_workitem_promote.md
@@ -1,6 +1,6 @@
 ## camp workitem promote
 
-Promote a workitem to a festival, doc, or dungeon status
+Promote a workitem to a festival, doc, or dungeon
 
 ### Synopsis
 

--- a/docs/cli-reference/camp_workitem_repair.md
+++ b/docs/cli-reference/camp_workitem_repair.md
@@ -1,0 +1,39 @@
+## camp workitem repair
+
+Repair a workflow directory into a workitem
+
+### Synopsis
+
+Repair a workflow directory so it carries a valid current-schema .workitem marker.
+
+The directory is never moved or renamed and document contents are never touched.
+When no marker exists one is created; when a legacy or incomplete marker exists
+its schema version, kind, id, type, ref, and title are brought up to the current
+shape. The workflow type is inferred from the path segment after workflow/, the
+title from the first markdown H1 (else the humanized directory name), and id/ref
+from the same rules as create and adopt. Repair is idempotent: a directory that
+is already valid reports no changes. Use --dry-run to preview and --json for a
+machine-readable result.
+
+```
+camp workitem repair <path> [flags]
+```
+
+### Options
+
+```
+      --dry-run       report what would change without writing
+  -h, --help          help for repair
+      --json          emit a structured JSON result
+      --type string   override the workflow type inferred from the path
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/docs/cli-reference/camp_workitem_resolve.md
+++ b/docs/cli-reference/camp_workitem_resolve.md
@@ -1,6 +1,6 @@
 ## camp workitem resolve
 
-Print the workitem the current context resolves to (read-only)
+Print the workitem for the current context
 
 ### Synopsis
 

--- a/docs/cli-reference/camp_workitem_stage.md
+++ b/docs/cli-reference/camp_workitem_stage.md
@@ -1,6 +1,6 @@
 ## camp workitem stage
 
-Set or clear the attention stage of a workitem
+Set or clear the attention stage
 
 ```
 camp workitem stage <selector> <current|next|active|parked|clear> [flags]

--- a/docs/cli-reference/camp_workitem_unlink.md
+++ b/docs/cli-reference/camp_workitem_unlink.md
@@ -1,6 +1,6 @@
 ## camp workitem unlink
 
-Remove one or more workitem links
+Remove workitem links
 
 ### Synopsis
 

--- a/docs/cli-reference/camp_workitem_validate.md
+++ b/docs/cli-reference/camp_workitem_validate.md
@@ -1,0 +1,38 @@
+## camp workitem validate
+
+Validate workitem directories
+
+### Synopsis
+
+Validate that workflow work item directories carry a correct .workitem marker.
+
+Without an argument, every work item directory under workflow/ is scanned:
+builtin doc directories (workflow/design, workflow/explore) are always work
+items, custom type directories surface only when they carry a marker, and
+dungeon/hidden control areas are ignored. With a path argument, only that
+directory is validated.
+
+Each problem prints the exact repair command, for example
+"camp workitem repair workflow/design/foo". Use --json for stable finding
+codes. The command exits non-zero when any error-severity finding is present.
+
+```
+camp workitem validate [path] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for validate
+      --json   emit a structured JSON result
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/internal/commands/workitem/adopt.go
+++ b/internal/commands/workitem/adopt.go
@@ -23,7 +23,7 @@ func newAdoptCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "adopt <dir>",
 		Aliases: []string{"init"},
-		Short:   "Attach .workitem metadata to an existing directory",
+		Short:   "Adopt an existing directory as a workitem",
 		Long: `Attach workitem metadata to an existing campaign directory without moving it.
 
 The target directory must already exist and must not already contain a

--- a/internal/commands/workitem/commit.go
+++ b/internal/commands/workitem/commit.go
@@ -44,7 +44,7 @@ func newCommitCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "commit [selector]",
-		Short: "Commit changes scoped to the resolved workitem",
+		Short: "Commit changes scoped to a workitem",
 		Long: `Stage and commit changes belonging to a resolved workitem.
 
 The staging plan is computed from the resolver context (cwd-aware, with

--- a/internal/commands/workitem/commits.go
+++ b/internal/commands/workitem/commits.go
@@ -67,7 +67,7 @@ func newCommitsCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "commits [selector]",
-		Short: "List commits referencing a workitem across linked repos",
+		Short: "List commits referencing a workitem",
 		Long: `List commits referencing this workitem, newest first.
 
 When the campaign event ledger already holds the workitem's commit evidence,

--- a/internal/commands/workitem/create.go
+++ b/internal/commands/workitem/create.go
@@ -31,7 +31,7 @@ func newCreateCommand() *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "create <slug>",
-		Short: "Create a new workitem with v1 minimum metadata",
+		Short: "Create a workitem",
 		Long: `Create a new workitem directory with minimal v1 metadata.
 
 The workitem is created under workflow/<type>/<slug>/ unless --dir supplies a

--- a/internal/commands/workitem/current.go
+++ b/internal/commands/workitem/current.go
@@ -19,7 +19,7 @@ func newCurrentCommand() *cobra.Command {
 	var clear, jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "current [selector]",
-		Short: "Get, set, or clear the local current workitem",
+		Short: "Get, set, or clear the current workitem",
 		Long: `Get, set, or clear the campaign-local current workitem pointer.
 
 The selection is stored in .campaign/workitems/current.yaml and is used by

--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -68,7 +68,7 @@ func newDoctorCommand() *cobra.Command {
 	var jsonOut, fix bool
 	cmd := &cobra.Command{
 		Use:   "doctor",
-		Short: "Report workitem link-registry health issues",
+		Short: "Report link-registry health issues",
 		Long: `Report health issues in the campaign workitem link registry.
 
 The command reads .campaign/workitems/links.yaml, scans .workitem metadata on

--- a/internal/commands/workitem/group.go
+++ b/internal/commands/workitem/group.go
@@ -25,7 +25,7 @@ func newGroupCommand() *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "group <selector> <group|clear>",
-		Short: "Set or clear the group of a workitem",
+		Short: "Set or clear the group",
 		Args:  jsoncontract.Args(WorkitemGroupJSONVersion, func() bool { return jsonOut }, cobra.ExactArgs(2)),
 		RunE: jsoncontract.RunE(WorkitemGroupJSONVersion, func() bool { return jsonOut }, func(cmd *cobra.Command, args []string) error {
 			return runGroup(cmd.Context(), cmd, args[0], args[1], jsonOut)

--- a/internal/commands/workitem/link.go
+++ b/internal/commands/workitem/link.go
@@ -34,7 +34,7 @@ func newLinkCommand() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "link <selector> [path]",
-		Short: "Attach a workitem to a project, festival, worktree, or campaign path",
+		Short: "Create a workitem link",
 		Long: `Attach a workitem to a project, festival, worktree, or campaign path.
 
 Links are stored in .campaign/workitems/links.yaml and connect a .workitem

--- a/internal/commands/workitem/priority.go
+++ b/internal/commands/workitem/priority.go
@@ -25,7 +25,7 @@ func newPriorityCommand() *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "priority <selector> <high|medium|low|clear>",
-		Short: "Set or clear the manual priority of a workitem",
+		Short: "Set or clear the manual priority",
 		Long: `Set or clear the manual priority of a workitem.
 
 The selector accepts the same forms as 'camp workitem current': a stable

--- a/internal/commands/workitem/promote.go
+++ b/internal/commands/workitem/promote.go
@@ -73,7 +73,7 @@ func newPromoteCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "promote [id] --target <target>",
-		Short: "Promote a workitem to a festival, doc, or dungeon status",
+		Short: "Promote a workitem to a festival, doc, or dungeon",
 		Long: `Promote the workitem identified by [id], by cwd, or by the current pointer.
 
 TARGETS:

--- a/internal/commands/workitem/repair.go
+++ b/internal/commands/workitem/repair.go
@@ -47,7 +47,7 @@ func newRepairCommand() *cobra.Command {
 	var typeOverride string
 	cmd := &cobra.Command{
 		Use:   "repair <path>",
-		Short: "Repair a workflow directory into a current-schema work item",
+		Short: "Repair a workflow directory into a workitem",
 		Long: `Repair a workflow directory so it carries a valid current-schema .workitem marker.
 
 The directory is never moved or renamed and document contents are never touched.

--- a/internal/commands/workitem/resolve.go
+++ b/internal/commands/workitem/resolve.go
@@ -24,7 +24,7 @@ func newResolveCommand() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "resolve",
-		Short: "Print the workitem the current context resolves to (read-only)",
+		Short: "Print the workitem for the current context",
 		Long: `Resolve the active workitem from the current campaign context.
 
 Resolution checks explicit selectors, cwd, festival context, linked scopes,

--- a/internal/commands/workitem/stage.go
+++ b/internal/commands/workitem/stage.go
@@ -25,7 +25,7 @@ func newStageCommand() *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "stage <selector> <current|next|active|parked|clear>",
-		Short: "Set or clear the attention stage of a workitem",
+		Short: "Set or clear the attention stage",
 		Args:  jsoncontract.Args(WorkitemStageJSONVersion, func() bool { return jsonOut }, cobra.ExactArgs(2)),
 		RunE: jsoncontract.RunE(WorkitemStageJSONVersion, func() bool { return jsonOut }, func(cmd *cobra.Command, args []string) error {
 			return runStage(cmd.Context(), cmd, args[0], args[1], jsonOut)

--- a/internal/commands/workitem/unlink.go
+++ b/internal/commands/workitem/unlink.go
@@ -25,7 +25,7 @@ func newUnlinkCommand() *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "unlink [selector] [path]",
-		Short: "Remove one or more workitem links",
+		Short: "Remove workitem links",
 		Long: `Remove workitem links from the campaign link registry.
 
 The command updates .campaign/workitems/links.yaml by link id, workitem

--- a/internal/commands/workitem/validate.go
+++ b/internal/commands/workitem/validate.go
@@ -55,7 +55,7 @@ func newValidateCommand() *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "validate [path]",
-		Short: "Validate workflow work item directories and their .workitem markers",
+		Short: "Validate workitem directories",
 		Long: `Validate that workflow work item directories carry a correct .workitem marker.
 
 Without an argument, every work item directory under workflow/ is scanned:

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -45,17 +45,16 @@ func NewWorkitemCommand() *cobra.Command {
 		Use:     "workitem",
 		Aliases: []string{"wi", "workitems"},
 		Short:   "View active campaign work items",
-		Long: `View active campaign work items across intents, designs, explore, and festivals.
+		Long: `View active campaign work items.
 
-Default mode launches an interactive TUI dashboard. Use --json for machine-readable
-output or --print to select and print a path for shell integration.
+Launches an interactive dashboard on a TTY. Non-interactive callers must pass
+--json, --list, or --print.
 
 Examples:
-  camp workitem                              # interactive dashboard
-  camp workitem --json                       # JSON output for agents/scripts
-  camp workitem --json --type design         # filter by type
-  camp workitem --json --type intent --limit 5
-  camp workitem --print                      # select and print path`,
+  camp workitem                       # interactive dashboard
+  camp workitem --json --type design  # JSON, filtered by type
+  camp workitem --list                # compact grouped list
+  camp workitem --print               # print a path for shell integration`,
 		Annotations: map[string]string{
 			"agent_allowed": "true",
 			"agent_reason":  "Supports --json for non-interactive output",
@@ -71,7 +70,7 @@ Examples:
 			}
 
 			interactive := isInteractive()
-			if !interactive && !flagJSON && !flagList && !flagPrint && flagPathOutput == "" {
+			if needsExplicitOutputMode(interactive, flagJSON, flagList, flagPrint, flagPathOutput) {
 				return camperrors.New("non-interactive use requires --json, --list, or --print flag")
 			}
 
@@ -124,19 +123,19 @@ Examples:
 
 	cmd.Flags().BoolVar(&flagJSON, "json", false, "Output as JSON")
 	cmd.Flags().BoolVar(&flagList, "list", false, "Output a compact grouped list")
-	cmd.Flags().BoolVar(&flagPrint, "print", false, "Print path only (for shell integration)")
-	cmd.Flags().StringVar(&flagPathOutput, "path-output", "", "Write selected relative path to file (shell integration)")
+	cmd.Flags().BoolVar(&flagPrint, "print", false, "Print path only")
+	cmd.Flags().StringVar(&flagPathOutput, "path-output", "", "Write selected relative path to file")
 	_ = cmd.Flags().MarkHidden("path-output")
-	cmd.Flags().StringArrayVar(&flagTypes, "type", nil, "Filter by workflow type (builtin: intent, design, explore, festival; or any slug-safe custom type produced by 'camp workitem create --type <name>')")
-	cmd.Flags().StringArrayVar(&flagCategories, "category", nil, "Filter by workflow category (builtin: plan, research, pipeline, review, uncategorized; or any category defined under workflows in campaign.yaml)")
-	cmd.Flags().StringArrayVar(&flagStatuses, "status", nil, "Filter by displayed status (current, next, active, parked, inbox, ready, plan, ritual, chains, none)")
-	cmd.Flags().StringArrayVar(&flagStages, "stage", nil, "Filter by lifecycle stage (none, inbox, active, ready, planning, ritual, chains)")
-	cmd.Flags().StringArrayVar(&flagAttentionStages, "attention-stage", nil, "Filter by attention stage (current, next, active, parked)")
+	cmd.Flags().StringArrayVar(&flagTypes, "type", nil, "Filter by workflow type")
+	cmd.Flags().StringArrayVar(&flagCategories, "category", nil, "Filter by workflow category")
+	cmd.Flags().StringArrayVar(&flagStatuses, "status", nil, "Filter by displayed status")
+	cmd.Flags().StringArrayVar(&flagStages, "stage", nil, "Filter by lifecycle stage")
+	cmd.Flags().StringArrayVar(&flagAttentionStages, "attention-stage", nil, "Filter by attention stage")
 	cmd.Flags().StringArrayVar(&flagGroups, "group", nil, "Filter by workitem group")
-	cmd.Flags().StringVar(&flagGroupBy, "group-by", "attention_stage", "Group JSON/list sections by attention_stage, group, type, or category; --list defaults to group unless set")
-	cmd.Flags().BoolVar(&flagShowParked, "show-parked", false, "include parked attention-stage workitems in default output")
-	cmd.Flags().IntVar(&flagLimit, "limit", 0, "Maximum number of items to return")
-	cmd.Flags().StringVar(&flagQuery, "query", "", "Search query to filter items")
+	cmd.Flags().StringVar(&flagGroupBy, "group-by", "attention_stage", "Group sections")
+	cmd.Flags().BoolVar(&flagShowParked, "show-parked", false, "Include parked workitems")
+	cmd.Flags().IntVar(&flagLimit, "limit", 0, "Maximum items to return")
+	cmd.Flags().StringVar(&flagQuery, "query", "", "Filter by search query")
 
 	cmd.AddCommand(newCreateCommand())
 	cmd.AddCommand(newAdoptCommand())
@@ -262,6 +261,12 @@ func openSelectedItem(ctx context.Context, item wkitem.WorkItem, campaignRoot st
 		return camperrors.Wrap(err, "opening selected work item")
 	}
 	return nil
+}
+
+// needsExplicitOutputMode reports whether an invocation has no way to present
+// results: no terminal for the TUI and no explicit non-interactive output mode.
+func needsExplicitOutputMode(interactive, jsonMode, listMode, printMode bool, pathOutput string) bool {
+	return !interactive && !jsonMode && !listMode && !printMode && pathOutput == ""
 }
 
 func isInteractive() bool {

--- a/internal/commands/workitem/workitem_test.go
+++ b/internal/commands/workitem/workitem_test.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode"
+
+	"github.com/spf13/pflag"
 
 	"github.com/Obedience-Corp/camp/internal/config"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
@@ -384,5 +387,97 @@ func TestValidateFlagsRejectsListConflicts(t *testing.T) {
 				t.Fatal("validateFlags() error = nil, want conflict")
 			}
 		})
+	}
+}
+
+func TestNeedsExplicitOutputMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		interactive bool
+		jsonMode    bool
+		listMode    bool
+		printMode   bool
+		pathOutput  string
+		want        bool
+	}{
+		{name: "non-interactive with no output mode is rejected", want: true},
+		{name: "non-interactive with json", jsonMode: true},
+		{name: "non-interactive with list", listMode: true},
+		{name: "non-interactive with print", printMode: true},
+		{name: "non-interactive with path-output", pathOutput: "/tmp/selected"},
+		{name: "interactive with no output mode", interactive: true},
+		{name: "interactive with json", interactive: true, jsonMode: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := needsExplicitOutputMode(tt.interactive, tt.jsonMode, tt.listMode, tt.printMode, tt.pathOutput)
+			if got != tt.want {
+				t.Fatalf("needsExplicitOutputMode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorkitemLongDocumentsNonInteractiveRequirement(t *testing.T) {
+	long := NewWorkitemCommand().Long
+	for _, want := range []string{"--json", "--list", "--print"} {
+		if !strings.Contains(long, want) {
+			t.Fatalf("Long does not mention %q required for non-interactive use:\n%s", want, long)
+		}
+	}
+}
+
+func TestWorkitemDescriptionsStayConcise(t *testing.T) {
+	const maxDescription = 50
+
+	cmd := NewWorkitemCommand()
+
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+		t.Run("flag/"+f.Name, func(t *testing.T) {
+			if len(f.Usage) > maxDescription {
+				t.Fatalf("--%s usage is %d chars, want <= %d: %q", f.Name, len(f.Usage), maxDescription, f.Usage)
+			}
+			if r := []rune(f.Usage); len(r) > 0 && unicode.IsLower(r[0]) {
+				t.Fatalf("--%s usage should start capitalized: %q", f.Name, f.Usage)
+			}
+		})
+	})
+
+	for _, child := range cmd.Commands() {
+		t.Run("subcommand/"+child.Name(), func(t *testing.T) {
+			if len(child.Short) > maxDescription {
+				t.Fatalf("%q Short is %d chars, want <= %d: %q", child.Name(), len(child.Short), maxDescription, child.Short)
+			}
+		})
+	}
+}
+
+func TestWorkitemSubcommandsStayRegisteredAndVisible(t *testing.T) {
+	cmd := NewWorkitemCommand()
+
+	want := []string{
+		"adopt", "commit", "commits", "create", "current", "doctor", "group",
+		"link", "links", "list", "priority", "promote", "repair", "resolve",
+		"stage", "unlink", "validate", "worktree",
+	}
+
+	for _, name := range want {
+		t.Run(name, func(t *testing.T) {
+			child, _, err := cmd.Find([]string{name})
+			if err != nil || child == cmd || child.Name() != name {
+				t.Fatalf("subcommand %q not registered: child=%v err=%v", name, child, err)
+			}
+			if child.Hidden {
+				t.Fatalf("subcommand %q is hidden: it would drop out of the agent manifest and generated docs", name)
+			}
+		})
+	}
+
+	if got := len(cmd.Commands()); got != len(want) {
+		t.Fatalf("registered subcommand count = %d, want %d", got, len(want))
 	}
 }


### PR DESCRIPTION
## What changed and why

`camp workitem --help` flooded the reader. Two flag descriptions ran to paragraph length, and ten lines wrapped past 80 columns, one of them to 185 characters. Every description now fits on one line at 80 columns, and nothing in the help wraps.

The enumerated values did not need to live in flag help, because they are already in two places the reader reaches on demand:

1. The error messages print them on a bad value: `workitem.go:291` for `--stage`, `:310` for `--group-by`, `:337` for `--status` via `DisplayStatusVocabulary()`. Pass a bad value, get the list.
2. The generated CLI reference carries the full detail.

Implementation detail is gone from the subcommand descriptions too, including `v1 minimum metadata`, `current-schema`, and `.workitem markers`.

## Corrections beyond brevity

- **The non-interactive claim was false.** The description said default mode launches a TUI and never mentioned that `workitem.go:74-75` errors with `non-interactive use requires --json, --list, or --print flag` when no terminal is attached. Anything calling it from a pipe or a script read the help and walked into that error. It now states the requirement in one sentence.
- **`--stage` advertised combinations the code rejects.** It listed a flat vocabulary, but validation calls `IsValidStageForTypes`, which accepts stages per `--type`. `--type intent --stage planning` is an error, and there is an existing test asserting exactly that. The vocabulary is gone, and the error message tells the truth per type.
- **`--group-by` read as a contradiction.** It ended with `--list defaults to group unless set` directly beside the `(default "attention_stage")` cobra appends.
- **The summary was stale.** It enumerated intents, designs, explore, and festivals. `internal/workitem/discover_custom.go:9` confirms those are exactly the builtins, but the command also surfaces custom types created through `camp workitem create --type <name>` and discovered via explicit `.workitem` markers. This campaign uses them, for example `workflow/bugs/` and `workflow/audits/`, both of which carry markers. Dropping the enumeration fixes the staleness and the verbosity in one move, rather than replacing it with a longer and more accurate enumeration.
- **`--print` did not select.** It claimed it selects a path; non-interactively `workitem.go:116-119` takes `items[0]` with no selection.
- **The examples were redundant and incomplete.** `--type` was demonstrated twice while `--list`, one of the three modes a non-TTY caller must pass, appeared in no example. There are now four examples covering every mode with no repetition.
- **`--show-parked` started lowercase** while every other description was capitalized.

## Nothing was removed, renamed, or hidden

No flag or subcommand is removed or renamed, no accepted value changed, and no `--json` output changed. All 18 subcommands remain visible.

Hiding niche subcommands was considered and deliberately rejected, because in this repo `Hidden` is not presentation only:

1. `cmd/camp/manifest.go:60` skips `Hidden` commands when building `camp __manifest`, described in that file as the manifest for daemon enforcement. `workitem validate`, `repair`, and `resolve` all carry `agent_allowed: "true"`, so hiding any of them would drop it from that manifest and the daemon could stop permitting it. The `continue` also skips recursion, so children of a hidden command would vanish too.
2. `cmd/camp/gendocs.go:47` calls `removeGeneratedDocs` to wipe the reference directory before regenerating, and cobra's doc generator skips `Hidden` commands, which `gendocs.go:157` notes directly. Hiding would permanently delete `docs/cli-reference/camp_workitem_<cmd>.md`.

A regression test now fails if any workitem subcommand is marked `Hidden`, recording the reason.

## Measurements

Logical line count barely moves, because the real noise was wrapping. The rendered number at a fixed 80 columns is what a user actually sees:

| | `wc -l` | rendered at 80 (`fold -w 80 \| wc -l`) | lines over 80 cols |
| --- | --- | --- | --- |
| before | 59 | 72 | 10 (longest 185 chars) |
| after | 58 | 58 | 0 |

## How this was verified

- `just gate` passes: builds stable and dev, `go vet` stable, dev, and integration, lint stable and dev, and unit tests on both profiles (3369 dev, 3340 stable). Exit 0.
- `camp __manifest` before and after is byte identical, all 19 workitem paths intact.
- `camp workitem --json` and `camp workitem --list` are identical before and after when captured against the same disk state, apart from the `generated_at` timestamp.
- All 18 subcommands still execute: `camp workitem <name> --help` returns 0 for each.
- New tests cover the non-TTY error path, that every visible description stays within the length budget and starts capitalized, that every subcommand stays registered and unhidden, and that the description keeps documenting the `--json`/`--list`/`--print` requirement.

The non-TTY gate was extracted into `needsExplicitOutputMode`, a pure function, so the test does not depend on whether the test runner's stdout happens to be a terminal. Testing it through `Execute` would launch the TUI and hang if run from a terminal.

## Known limitations

- `--status`, `--stage`, and `--attention-stage` remain three overlapping filters whose vocabularies are close to a union of each other, and `plan` versus `planning` still differ across flags. `internal/workitem/status.go:26-32` normalizes `planning` to `plan`, so both are accepted. Consolidating them means deprecating flags, so it is out of scope here.
- `--group-by` is now terse enough that its accepted values are only discoverable through the error message or the generated reference. That is the deliberate tradeoff, and the reason its description is shorter than the others is that cobra appends `(default "attention_stage")` to the same line, which would otherwise push it past 80 columns.
- Related and worth calling out explicitly: the old description resolved its own contradiction by stating `--list defaults to group unless set`, and that clause was true. `workitem.go:93-94` still overrides the grouping to `group` when `--list` is passed without an explicit `--group-by`, so that behavior is unchanged but is no longer documented in the flag help. Restoring it inline is what made the line self-contradictory and over-length in the first place, since cobra appends the flag's registered default regardless. The behavior is observable by running `camp workitem --list`, and the generated reference is the place to describe it properly. Flagging it so the omission is a recorded decision rather than an accident.
- The docs regen is a separate commit and drags in unrelated drift accumulated since the last regen, which is expected in this repo.

## BEFORE (59 logical lines, 72 rendered at 80 columns)

```
View active campaign work items across intents, designs, explore, and festivals.

Default mode launches an interactive TUI dashboard. Use --json for machine-readable
output or --print to select and print a path for shell integration.

Examples:
  camp workitem                              # interactive dashboard
  camp workitem --json                       # JSON output for agents/scripts
  camp workitem --json --type design         # filter by type
  camp workitem --json --type intent --limit 5
  camp workitem --print                      # select and print path

Usage:
  camp workitem [flags]
  camp workitem [command]

Aliases:
  workitem, wi, workitems

Available Commands:
  adopt       Attach .workitem metadata to an existing directory
  commit      Commit changes scoped to the resolved workitem
  commits     List commits referencing a workitem across linked repos
  create      Create a new workitem with v1 minimum metadata
  current     Get, set, or clear the local current workitem
  doctor      Report workitem link-registry health issues
  group       Set or clear the group of a workitem
  link        Attach a workitem to a project, festival, worktree, or campaign path
  links       List workitem links
  list        List or browse filtered workitems
  priority    Set or clear the manual priority of a workitem
  promote     Promote a workitem to a festival, doc, or dungeon status
  repair      Repair a workflow directory into a current-schema work item
  resolve     Print the workitem the current context resolves to (read-only)
  stage       Set or clear the attention stage of a workitem
  unlink      Remove one or more workitem links
  validate    Validate workflow work item directories and their .workitem markers
  worktree    Create a project worktree from a workitem

Flags:
      --attention-stage stringArray   Filter by attention stage (current, next, active, parked)
      --category stringArray          Filter by workflow category (builtin: plan, research, pipeline, review, uncategorized; or any category defined under workflows in campaign.yaml)
      --group stringArray             Filter by workitem group
      --group-by string               Group JSON/list sections by attention_stage, group, type, or category; --list defaults to group unless set (default "attention_stage")
  -h, --help                          help for workitem
      --json                          Output as JSON
      --limit int                     Maximum number of items to return
      --list                          Output a compact grouped list
      --print                         Print path only (for shell integration)
      --query string                  Search query to filter items
      --show-parked                   include parked attention-stage workitems in default output
      --stage stringArray             Filter by lifecycle stage (none, inbox, active, ready, planning, ritual, chains)
      --status stringArray            Filter by displayed status (current, next, active, parked, inbox, ready, plan, ritual, chains, none)
      --type stringArray              Filter by workflow type (builtin: intent, design, explore, festival; or any slug-safe custom type produced by 'camp workitem create --type <name>')

Global Flags:
      --no-color   disable colored output

Use "camp workitem [command] --help" for more information about a command.
```

## AFTER (58 logical lines, 58 rendered at 80 columns)

```
View active campaign work items.

Launches an interactive dashboard on a TTY. Non-interactive callers must pass
--json, --list, or --print.

Examples:
  camp workitem                       # interactive dashboard
  camp workitem --json --type design  # JSON, filtered by type
  camp workitem --list                # compact grouped list
  camp workitem --print               # print a path for shell integration

Usage:
  camp workitem [flags]
  camp workitem [command]

Aliases:
  workitem, wi, workitems

Available Commands:
  adopt       Adopt an existing directory as a workitem
  commit      Commit changes scoped to a workitem
  commits     List commits referencing a workitem
  create      Create a workitem
  current     Get, set, or clear the current workitem
  doctor      Report link-registry health issues
  group       Set or clear the group
  link        Create a workitem link
  links       List workitem links
  list        List or browse filtered workitems
  priority    Set or clear the manual priority
  promote     Promote a workitem to a festival, doc, or dungeon
  repair      Repair a workflow directory into a workitem
  resolve     Print the workitem for the current context
  stage       Set or clear the attention stage
  unlink      Remove workitem links
  validate    Validate workitem directories
  worktree    Create a project worktree from a workitem

Flags:
      --attention-stage stringArray   Filter by attention stage
      --category stringArray          Filter by workflow category
      --group stringArray             Filter by workitem group
      --group-by string               Group sections (default "attention_stage")
  -h, --help                          help for workitem
      --json                          Output as JSON
      --limit int                     Maximum items to return
      --list                          Output a compact grouped list
      --print                         Print path only
      --query string                  Filter by search query
      --show-parked                   Include parked workitems
      --stage stringArray             Filter by lifecycle stage
      --status stringArray            Filter by displayed status
      --type stringArray              Filter by workflow type

Global Flags:
      --no-color   disable colored output

Use "camp workitem [command] --help" for more information about a command.
```

