### PR TITLE
feat(fresh): add human follow-up configuration TUI

### DIFF
--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -1457,7 +1457,8 @@ run, or 'camp fresh all' to cycle every project submodule in the campaign.
 Without configuration, syncs to the default branch and prunes.
 Configure .campaign/settings/fresh.yaml to set a default working branch, or
 follow-up command workflows (install, build, bootstrap, ...) to run once the
-cycle succeeds. Manage those with 'camp fresh configure'.
+cycle succeeds. Manage those with 'camp fresh configure'. Inspect the resolved
+sequence with 'camp fresh show-workflow [project-name]'.
 
 Examples:
   camp fresh                            # Sync current project (checkout default, pull, prune)
@@ -1533,7 +1534,7 @@ camp fresh all [flags]
 
 ## camp fresh configure
 
-Manage camp fresh follow-up command workflows
+Configure camp fresh follow-up commands
 
 ### Synopsis
 
@@ -1542,12 +1543,21 @@ successful sync/prune/branch cycle. Configuration lives in
 .campaign/settings/fresh.yaml: a global default list, plus optional
 per-project override lists that replace the global list entirely.
 
+Run without a subcommand to open the interactive setup for humans. Use
+show, add, and remove for scripts and agents.
+
 Examples:
+  camp fresh configure
+  camp fresh show-workflow camp
   camp fresh configure show
   camp fresh configure add install --run "npm install"
   camp fresh configure add build --run "go build ./..." --project camp --dir cmd/camp
   camp fresh configure remove install
   camp fresh configure remove build --project camp
+
+```
+camp fresh configure [flags]
+```
 
 ### Options
 
@@ -1639,6 +1649,41 @@ camp fresh configure show [flags]
 
 ```
   -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --branch string   Branch to create after syncing (overrides config)
+  -n, --dry-run         Preview without making changes
+      --no-branch       Skip branch creation even if configured
+      --no-color        disable colored output
+      --no-follow-up    Skip configured follow-up command workflows
+      --no-prune        Skip pruning merged branches
+      --no-push         Skip pushing the new branch upstream
+```
+---
+
+## camp fresh show-workflow
+
+Show the fresh cycle and configured follow-up steps
+
+### Synopsis
+
+Show the ordered steps camp fresh will use, including disabled steps
+and the follow-up commands resolved for a project.
+
+With no project name, the global defaults are shown. Pass a project name to
+include its branch, pruning, and follow-up overrides.
+
+```
+camp fresh show-workflow [project-name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show-workflow
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_fresh.md
+++ b/docs/cli-reference/camp_fresh.md
@@ -16,7 +16,8 @@ run, or 'camp fresh all' to cycle every project submodule in the campaign.
 Without configuration, syncs to the default branch and prunes.
 Configure .campaign/settings/fresh.yaml to set a default working branch, or
 follow-up command workflows (install, build, bootstrap, ...) to run once the
-cycle succeeds. Manage those with 'camp fresh configure'.
+cycle succeeds. Manage those with 'camp fresh configure'. Inspect the resolved
+sequence with 'camp fresh show-workflow [project-name]'.
 
 Examples:
   camp fresh                            # Sync current project (checkout default, pull, prune)
@@ -55,4 +56,5 @@ camp fresh [project-name] [flags]
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
 * [camp fresh all](camp_fresh_all.md)	 - Run fresh across all project submodules
-* [camp fresh configure](camp_fresh_configure.md)	 - Manage camp fresh follow-up command workflows
+* [camp fresh configure](camp_fresh_configure.md)	 - Configure camp fresh follow-up commands
+* [camp fresh show-workflow](camp_fresh_show-workflow.md)	 - Show the fresh cycle and configured follow-up steps

--- a/docs/cli-reference/camp_fresh_configure.md
+++ b/docs/cli-reference/camp_fresh_configure.md
@@ -1,6 +1,6 @@
 ## camp fresh configure
 
-Manage camp fresh follow-up command workflows
+Configure camp fresh follow-up commands
 
 ### Synopsis
 
@@ -9,12 +9,21 @@ successful sync/prune/branch cycle. Configuration lives in
 .campaign/settings/fresh.yaml: a global default list, plus optional
 per-project override lists that replace the global list entirely.
 
+Run without a subcommand to open the interactive setup for humans. Use
+show, add, and remove for scripts and agents.
+
 Examples:
+  camp fresh configure
+  camp fresh show-workflow camp
   camp fresh configure show
   camp fresh configure add install --run "npm install"
   camp fresh configure add build --run "go build ./..." --project camp --dir cmd/camp
   camp fresh configure remove install
   camp fresh configure remove build --project camp
+
+```
+camp fresh configure [flags]
+```
 
 ### Options
 

--- a/docs/cli-reference/camp_fresh_configure_add.md
+++ b/docs/cli-reference/camp_fresh_configure_add.md
@@ -30,4 +30,4 @@ camp fresh configure add <name> [flags]
 
 ### SEE ALSO
 
-* [camp fresh configure](camp_fresh_configure.md)	 - Manage camp fresh follow-up command workflows
+* [camp fresh configure](camp_fresh_configure.md)	 - Configure camp fresh follow-up commands

--- a/docs/cli-reference/camp_fresh_configure_remove.md
+++ b/docs/cli-reference/camp_fresh_configure_remove.md
@@ -27,4 +27,4 @@ camp fresh configure remove <name> [flags]
 
 ### SEE ALSO
 
-* [camp fresh configure](camp_fresh_configure.md)	 - Manage camp fresh follow-up command workflows
+* [camp fresh configure](camp_fresh_configure.md)	 - Configure camp fresh follow-up commands

--- a/docs/cli-reference/camp_fresh_configure_show.md
+++ b/docs/cli-reference/camp_fresh_configure_show.md
@@ -26,4 +26,4 @@ camp fresh configure show [flags]
 
 ### SEE ALSO
 
-* [camp fresh configure](camp_fresh_configure.md)	 - Manage camp fresh follow-up command workflows
+* [camp fresh configure](camp_fresh_configure.md)	 - Configure camp fresh follow-up commands

--- a/docs/cli-reference/camp_fresh_show-workflow.md
+++ b/docs/cli-reference/camp_fresh_show-workflow.md
@@ -1,0 +1,37 @@
+## camp fresh show-workflow
+
+Show the fresh cycle and configured follow-up steps
+
+### Synopsis
+
+Show the ordered steps camp fresh will use, including disabled steps
+and the follow-up commands resolved for a project.
+
+With no project name, the global defaults are shown. Pass a project name to
+include its branch, pruning, and follow-up overrides.
+
+```
+camp fresh show-workflow [project-name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show-workflow
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --branch string   Branch to create after syncing (overrides config)
+  -n, --dry-run         Preview without making changes
+      --no-branch       Skip branch creation even if configured
+      --no-color        disable colored output
+      --no-follow-up    Skip configured follow-up command workflows
+      --no-prune        Skip pruning merged branches
+      --no-push         Skip pushing the new branch upstream
+```
+
+### SEE ALSO
+
+* [camp fresh](camp_fresh.md)	 - Post-merge branch cycling: sync to default branch and optionally create a new working branch

--- a/internal/commands/fresh/configure.go
+++ b/internal/commands/fresh/configure.go
@@ -18,18 +18,24 @@ import (
 func newConfigureCommand() *cobra.Command {
 	configureCmd := &cobra.Command{
 		Use:   "configure",
-		Short: "Manage camp fresh follow-up command workflows",
+		Short: "Configure camp fresh follow-up commands",
 		Long: `Manage the follow-up command workflows camp fresh runs after a
 successful sync/prune/branch cycle. Configuration lives in
 .campaign/settings/fresh.yaml: a global default list, plus optional
 per-project override lists that replace the global list entirely.
 
+Run without a subcommand to open the interactive setup for humans. Use
+show, add, and remove for scripts and agents.
+
 Examples:
+  camp fresh configure
   camp fresh configure show
   camp fresh configure add install --run "npm install"
   camp fresh configure add build --run "go build ./..." --project camp --dir cmd/camp
   camp fresh configure remove install
   camp fresh configure remove build --project camp`,
+		Args: cobra.NoArgs,
+		RunE: runConfigureTUI,
 	}
 
 	configureCmd.AddCommand(newConfigureShowCommand())

--- a/internal/commands/fresh/configure.go
+++ b/internal/commands/fresh/configure.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
 )
 
@@ -29,6 +30,7 @@ show, add, and remove for scripts and agents.
 
 Examples:
   camp fresh configure
+  camp fresh show-workflow camp
   camp fresh configure show
   camp fresh configure add install --run "npm install"
   camp fresh configure add build --run "go build ./..." --project camp --dir cmd/camp
@@ -43,6 +45,40 @@ Examples:
 	configureCmd.AddCommand(newConfigureRemoveCommand())
 
 	return configureCmd
+}
+
+func newShowWorkflowCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show-workflow [project-name]",
+		Short: "Show the fresh cycle and configured follow-up steps",
+		Long: `Show the ordered steps camp fresh will use, including disabled steps
+and the follow-up commands resolved for a project.
+
+With no project name, the global defaults are shown. Pass a project name to
+include its branch, pruning, and follow-up overrides.`,
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completeProjectName,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			campRoot, err := campaign.DetectCached(ctx)
+			if err != nil {
+				return camperrors.Wrap(err, "not in a campaign")
+			}
+			cfg, err := config.LoadFreshConfig(ctx, campRoot)
+			if err != nil {
+				return camperrors.Wrap(err, "loading fresh config")
+			}
+			projectName := ""
+			if len(args) == 1 {
+				resolved, err := project.Resolve(ctx, campRoot, args[0])
+				if err != nil {
+					return err
+				}
+				projectName = resolved.Name
+			}
+			return printFreshWorkflow(cmd.OutOrStdout(), cfg, projectName)
+		},
+	}
 }
 
 func newConfigureShowCommand() *cobra.Command {

--- a/internal/commands/fresh/configure_tui.go
+++ b/internal/commands/fresh/configure_tui.go
@@ -2,23 +2,68 @@ package fresh
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
-
-	"github.com/charmbracelet/huh"
-	"github.com/spf13/cobra"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
-	"github.com/Obedience-Corp/camp/internal/ui/theme"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
 )
 
 const globalFollowUpScope = "__global__"
+
+type followUpPane int
+
+const (
+	followUpScopesPane followUpPane = iota
+	followUpWorkflowPane
+)
+
+type followUpOverlay int
+
+const (
+	followUpNoOverlay followUpOverlay = iota
+	followUpFormOverlay
+	followUpDeleteOverlay
+	followUpHelpOverlay
+)
+
+type followUpScope struct {
+	projectName string
+	label       string
+}
+
+type followUpTUIModel struct {
+	ctx      context.Context
+	root     string
+	projects []project.Project
+	cfg      *config.FreshConfig
+	scopes   []followUpScope
+
+	pane        followUpPane
+	scopeCursor int
+	stepCursor  int
+
+	overlay       followUpOverlay
+	inputs        [3]textinput.Model
+	formField     int
+	formEditName  string
+	formContinue  bool
+	formError     string
+	pendingDelete string
+
+	status    string
+	statusErr bool
+	width     int
+	height    int
+	quitting  bool
+}
 
 // runConfigureTUI is the human-facing entry point for `camp fresh configure`.
 // The child commands remain available for scripts and agents that need a
@@ -34,213 +79,49 @@ func runConfigureTUI(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return camperrors.Wrap(err, "not in a campaign")
 	}
-
 	projects, err := project.List(ctx, campRoot)
 	if err != nil {
 		return camperrors.Wrap(err, "listing campaign projects")
 	}
-
-	return runFollowUpMenu(ctx, campRoot, projects)
-}
-
-func runFollowUpMenu(ctx context.Context, campRoot string, projects []project.Project) error {
-	for {
-		var action string
-		form := huh.NewForm(huh.NewGroup(
-			huh.NewSelect[string]().
-				Title("Fresh follow-ups").
-				Description("Commands run after a successful camp fresh cycle.").
-				Options(
-					huh.NewOption("Add a follow-up command", "add"),
-					huh.NewOption("Remove a follow-up command", "remove"),
-					huh.NewOption("Review configured commands", "review"),
-					huh.NewOption("Done", "done"),
-				).
-				Value(&action),
-		))
-
-		if err := theme.RunForm(ctx, form); err != nil {
-			if theme.IsCancelled(err) {
-				return nil
-			}
-			return err
-		}
-
-		switch action {
-		case "add":
-			if err := addFollowUpTUI(ctx, campRoot, projects); err != nil {
-				if errors.Is(err, errFollowUpTUIBack) {
-					continue
-				}
-				return err
-			}
-		case "remove":
-			if err := removeFollowUpTUI(ctx, campRoot, projects); err != nil {
-				if errors.Is(err, errFollowUpTUIBack) {
-					continue
-				}
-				return err
-			}
-		case "review":
-			cfg, err := config.LoadFreshConfig(ctx, campRoot)
-			if err != nil {
-				return camperrors.Wrap(err, "loading fresh config")
-			}
-			fmt.Println()
-			printFollowUpSection("Global default", cfg.FollowUp)
-			for _, name := range configuredProjectNames(cfg) {
-				fmt.Println()
-				printFollowUpSection("Project: "+name, cfg.Projects[name].FollowUp)
-			}
-			fmt.Println()
-		case "done", "":
-			return nil
-		}
-	}
-}
-
-var errFollowUpTUIBack = errors.New("follow-up TUI back")
-
-func addFollowUpTUI(ctx context.Context, campRoot string, projects []project.Project) error {
-	scope, err := selectFollowUpScope(ctx, projects, nil)
-	if err != nil {
-		if theme.IsCancelled(err) {
-			return errFollowUpTUIBack
-		}
-		return err
-	}
-
-	var name, run, dir string
-	continueOnError := false
-	form := huh.NewForm(huh.NewGroup(
-		huh.NewInput().
-			Title("Command name").
-			Description("A short label, such as install or build.").
-			Placeholder("install").
-			Value(&name).
-			Validate(requiredField("command name")),
-		huh.NewInput().
-			Title("Command").
-			Description("Runs after camp fresh finishes syncing.").
-			Placeholder("npm install").
-			Value(&run).
-			Validate(requiredField("command")),
-		huh.NewInput().
-			Title("Working directory (optional)").
-			Description("Relative to the project root; leave blank for the root.").
-			Placeholder("cmd/camp").
-			Value(&dir),
-		huh.NewConfirm().
-			Title("Continue if this command fails?").
-			Description("Choose No to stop the fresh cycle on failure.").
-			Affirmative("Continue").
-			Negative("Stop").
-			Value(&continueOnError),
-	).Title("Add follow-up").Description(scopeDescription(scope)))
-
-	if err := theme.RunForm(ctx, form); err != nil {
-		if theme.IsCancelled(err) {
-			return errFollowUpTUIBack
-		}
-		return err
-	}
-
-	entry := config.FollowUpConfig{
-		Name:            strings.TrimSpace(name),
-		Run:             strings.TrimSpace(run),
-		Dir:             strings.TrimSpace(dir),
-		ContinueOnError: continueOnError,
-	}
-	if err := config.AddFreshFollowUp(ctx, campRoot, scopeProjectName(scope), entry); err != nil {
-		return err
-	}
-
-	fmt.Println(ui.Success(fmt.Sprintf("Added %q to %s.", entry.Name, scopeDescription(scope))))
-	return nil
-}
-
-func removeFollowUpTUI(ctx context.Context, campRoot string, projects []project.Project) error {
 	cfg, err := config.LoadFreshConfig(ctx, campRoot)
 	if err != nil {
 		return camperrors.Wrap(err, "loading fresh config")
 	}
 
-	scope, err := selectFollowUpScope(ctx, projects, cfg)
-	if err != nil {
-		if theme.IsCancelled(err) {
-			return errFollowUpTUIBack
-		}
-		return err
+	program := tea.NewProgram(newFollowUpTUIModel(ctx, campRoot, projects, cfg), tea.WithContext(ctx), tea.WithAltScreen())
+	if _, err := program.Run(); err != nil {
+		return camperrors.Wrap(err, "running fresh configuration TUI")
 	}
-
-	steps := followUpsForScope(cfg, scope)
-	if len(steps) == 0 {
-		fmt.Println(ui.Warning(fmt.Sprintf("No follow-up commands are configured for %s.", scopeDescription(scope))))
-		return errFollowUpTUIBack
-	}
-
-	options := make([]huh.Option[string], 0, len(steps))
-	for _, step := range steps {
-		label := fmt.Sprintf("%-16s %s", step.Name, step.Run)
-		if step.Dir != "" {
-			label += "  (dir: " + step.Dir + ")"
-		}
-		options = append(options, huh.NewOption(label, step.Name))
-	}
-
-	var name string
-	form := huh.NewForm(huh.NewGroup(
-		huh.NewSelect[string]().
-			Title("Remove follow-up").
-			Description(scopeDescription(scope)).
-			Options(options...).
-			Value(&name),
-	))
-	if err := theme.RunForm(ctx, form); err != nil {
-		if theme.IsCancelled(err) {
-			return errFollowUpTUIBack
-		}
-		return err
-	}
-
-	var confirm bool
-	confirmForm := huh.NewForm(huh.NewGroup(
-		huh.NewConfirm().
-			Title(fmt.Sprintf("Remove %q?", name)).
-			Affirmative("Remove").
-			Negative("Keep").
-			Value(&confirm),
-	))
-	if err := theme.RunForm(ctx, confirmForm); err != nil {
-		if theme.IsCancelled(err) {
-			return errFollowUpTUIBack
-		}
-		return err
-	}
-	if !confirm {
-		return errFollowUpTUIBack
-	}
-
-	if err := config.RemoveFreshFollowUp(ctx, campRoot, scopeProjectName(scope), name); err != nil {
-		return err
-	}
-	fmt.Println(ui.Success(fmt.Sprintf("Removed %q from %s.", name, scopeDescription(scope))))
 	return nil
 }
 
-func selectFollowUpScope(ctx context.Context, projects []project.Project, cfg *config.FreshConfig) (string, error) {
-	options := []huh.Option[string]{huh.NewOption("Global default (all projects)", globalFollowUpScope)}
-
-	names := make(map[string]bool)
-	for _, p := range projects {
-		names[p.Name] = true
+func newFollowUpTUIModel(ctx context.Context, root string, projects []project.Project, cfg *config.FreshConfig) *followUpTUIModel {
+	m := &followUpTUIModel{
+		ctx:      ctx,
+		root:     root,
+		projects: projects,
+		cfg:      cfg,
 	}
-	if cfg != nil {
-		for name, pc := range cfg.Projects {
-			if pc.FollowUp != nil {
-				names[name] = true
-			}
-		}
+	for i := range m.inputs {
+		m.inputs[i] = textinput.New()
+		m.inputs[i].Prompt = "  "
+		m.inputs[i].CharLimit = 256
+	}
+	m.inputs[0].Placeholder = "install"
+	m.inputs[1].Placeholder = "npm install"
+	m.inputs[2].Placeholder = "optional, relative to project root"
+	m.rebuildScopes(globalFollowUpScope)
+	return m
+}
+
+func (m *followUpTUIModel) rebuildScopes(selected string) {
+	scopes := []followUpScope{{projectName: globalFollowUpScope, label: "Global defaults"}}
+	names := make(map[string]struct{}, len(m.projects)+len(m.cfg.Projects))
+	for _, p := range m.projects {
+		names[p.Name] = struct{}{}
+	}
+	for name := range m.cfg.Projects {
+		names[name] = struct{}{}
 	}
 	projectNames := make([]string, 0, len(names))
 	for name := range names {
@@ -248,36 +129,91 @@ func selectFollowUpScope(ctx context.Context, projects []project.Project, cfg *c
 	}
 	sort.Strings(projectNames)
 	for _, name := range projectNames {
-		label := name
-		if cfg != nil {
-			if steps := cfg.Projects[name].FollowUp; steps != nil {
-				label = fmt.Sprintf("%s (%d configured)", name, len(steps))
-			}
+		label := name + " · inherits global"
+		if pc, ok := m.cfg.Projects[name]; ok && pc.FollowUp != nil {
+			label = fmt.Sprintf("%s · project override (%d)", name, len(pc.FollowUp))
 		}
-		options = append(options, huh.NewOption(label, name))
+		scopes = append(scopes, followUpScope{projectName: name, label: label})
 	}
-
-	var scope string
-	form := huh.NewForm(huh.NewGroup(
-		huh.NewSelect[string]().
-			Title("Where should this apply?").
-			Description("Global commands apply to projects without their own override.").
-			Options(options...).
-			Value(&scope),
-	))
-	if err := theme.RunForm(ctx, form); err != nil {
-		return "", err
+	m.scopes = scopes
+	m.scopeCursor = 0
+	for i, scope := range scopes {
+		if scope.projectName == selected {
+			m.scopeCursor = i
+			break
+		}
 	}
-	return scope, nil
+	m.stepCursor = min(m.stepCursor, max(len(m.workflowSteps())-1, 0))
 }
 
-func requiredField(label string) func(string) error {
-	return func(value string) error {
-		if strings.TrimSpace(value) == "" {
-			return fmt.Errorf("%s is required", label)
-		}
-		return nil
+func (m *followUpTUIModel) refresh(selected string) error {
+	cfg, err := config.LoadFreshConfig(m.ctx, m.root)
+	if err != nil {
+		return camperrors.Wrap(err, "loading fresh config")
 	}
+	m.cfg = cfg
+	m.rebuildScopes(selected)
+	return nil
+}
+
+func (m *followUpTUIModel) selectedScope() string {
+	if len(m.scopes) == 0 {
+		return globalFollowUpScope
+	}
+	return m.scopes[m.scopeCursor].projectName
+}
+
+func (m *followUpTUIModel) workflowSteps() []freshWorkflowStep {
+	return buildFreshWorkflow(m.cfg, scopeProjectName(m.selectedScope()))
+}
+
+func (m *followUpTUIModel) effectiveFollowUps() []config.FollowUpConfig {
+	return m.cfg.ResolveFreshFollowUps(scopeProjectName(m.selectedScope()))
+}
+
+func (m *followUpTUIModel) selectedFollowUp() (int, config.FollowUpConfig, bool) {
+	steps := m.workflowSteps()
+	if m.stepCursor < 0 || m.stepCursor >= len(steps) || steps[m.stepCursor].Follow == nil {
+		return -1, config.FollowUpConfig{}, false
+	}
+	for i, follow := range m.effectiveFollowUps() {
+		if follow.Name == steps[m.stepCursor].Follow.Name {
+			return i, follow, true
+		}
+	}
+	return -1, config.FollowUpConfig{}, false
+}
+
+func (m *followUpTUIModel) setStatus(message string) {
+	m.status = message
+	m.statusErr = false
+}
+
+func (m *followUpTUIModel) setError(err error) {
+	m.status = err.Error()
+	m.statusErr = true
+}
+
+func (m *followUpTUIModel) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func configuredProjectNames(cfg *config.FreshConfig) []string {
+	names := make([]string, 0, len(cfg.Projects))
+	for name, pc := range cfg.Projects {
+		if pc.FollowUp != nil {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func followUpsForScope(cfg *config.FreshConfig, scope string) []config.FollowUpConfig {
+	if scope == globalFollowUpScope {
+		return cfg.FollowUp
+	}
+	return cfg.Projects[scope].FollowUp
 }
 
 func scopeProjectName(scope string) string {
@@ -294,20 +230,11 @@ func scopeDescription(scope string) string {
 	return "project " + scope
 }
 
-func followUpsForScope(cfg *config.FreshConfig, scope string) []config.FollowUpConfig {
-	if scope == globalFollowUpScope {
-		return cfg.FollowUp
-	}
-	return cfg.Projects[scope].FollowUp
-}
-
-func configuredProjectNames(cfg *config.FreshConfig) []string {
-	names := make([]string, 0, len(cfg.Projects))
-	for name, pc := range cfg.Projects {
-		if pc.FollowUp != nil {
-			names = append(names, name)
+func requiredField(label string) func(string) error {
+	return func(value string) error {
+		if strings.TrimSpace(value) == "" {
+			return camperrors.NewValidation(label, "must not be empty", nil)
 		}
+		return nil
 	}
-	sort.Strings(names)
-	return names
 }

--- a/internal/commands/fresh/configure_tui.go
+++ b/internal/commands/fresh/configure_tui.go
@@ -1,0 +1,313 @@
+package fresh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/project"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/internal/ui/theme"
+)
+
+const globalFollowUpScope = "__global__"
+
+// runConfigureTUI is the human-facing entry point for `camp fresh configure`.
+// The child commands remain available for scripts and agents that need a
+// non-interactive interface.
+func runConfigureTUI(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	if !ui.IsTerminal() {
+		return camperrors.Wrap(camperrors.ErrInvalidInput,
+			"fresh configure requires an interactive terminal; use configure show|add|remove for automation")
+	}
+
+	campRoot, err := campaign.DetectCached(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign")
+	}
+
+	projects, err := project.List(ctx, campRoot)
+	if err != nil {
+		return camperrors.Wrap(err, "listing campaign projects")
+	}
+
+	return runFollowUpMenu(ctx, campRoot, projects)
+}
+
+func runFollowUpMenu(ctx context.Context, campRoot string, projects []project.Project) error {
+	for {
+		var action string
+		form := huh.NewForm(huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Fresh follow-ups").
+				Description("Commands run after a successful camp fresh cycle.").
+				Options(
+					huh.NewOption("Add a follow-up command", "add"),
+					huh.NewOption("Remove a follow-up command", "remove"),
+					huh.NewOption("Review configured commands", "review"),
+					huh.NewOption("Done", "done"),
+				).
+				Value(&action),
+		))
+
+		if err := theme.RunForm(ctx, form); err != nil {
+			if theme.IsCancelled(err) {
+				return nil
+			}
+			return err
+		}
+
+		switch action {
+		case "add":
+			if err := addFollowUpTUI(ctx, campRoot, projects); err != nil {
+				if errors.Is(err, errFollowUpTUIBack) {
+					continue
+				}
+				return err
+			}
+		case "remove":
+			if err := removeFollowUpTUI(ctx, campRoot, projects); err != nil {
+				if errors.Is(err, errFollowUpTUIBack) {
+					continue
+				}
+				return err
+			}
+		case "review":
+			cfg, err := config.LoadFreshConfig(ctx, campRoot)
+			if err != nil {
+				return camperrors.Wrap(err, "loading fresh config")
+			}
+			fmt.Println()
+			printFollowUpSection("Global default", cfg.FollowUp)
+			for _, name := range configuredProjectNames(cfg) {
+				fmt.Println()
+				printFollowUpSection("Project: "+name, cfg.Projects[name].FollowUp)
+			}
+			fmt.Println()
+		case "done", "":
+			return nil
+		}
+	}
+}
+
+var errFollowUpTUIBack = errors.New("follow-up TUI back")
+
+func addFollowUpTUI(ctx context.Context, campRoot string, projects []project.Project) error {
+	scope, err := selectFollowUpScope(ctx, projects, nil)
+	if err != nil {
+		if theme.IsCancelled(err) {
+			return errFollowUpTUIBack
+		}
+		return err
+	}
+
+	var name, run, dir string
+	continueOnError := false
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewInput().
+			Title("Command name").
+			Description("A short label, such as install or build.").
+			Placeholder("install").
+			Value(&name).
+			Validate(requiredField("command name")),
+		huh.NewInput().
+			Title("Command").
+			Description("Runs after camp fresh finishes syncing.").
+			Placeholder("npm install").
+			Value(&run).
+			Validate(requiredField("command")),
+		huh.NewInput().
+			Title("Working directory (optional)").
+			Description("Relative to the project root; leave blank for the root.").
+			Placeholder("cmd/camp").
+			Value(&dir),
+		huh.NewConfirm().
+			Title("Continue if this command fails?").
+			Description("Choose No to stop the fresh cycle on failure.").
+			Affirmative("Continue").
+			Negative("Stop").
+			Value(&continueOnError),
+	).Title("Add follow-up").Description(scopeDescription(scope)))
+
+	if err := theme.RunForm(ctx, form); err != nil {
+		if theme.IsCancelled(err) {
+			return errFollowUpTUIBack
+		}
+		return err
+	}
+
+	entry := config.FollowUpConfig{
+		Name:            strings.TrimSpace(name),
+		Run:             strings.TrimSpace(run),
+		Dir:             strings.TrimSpace(dir),
+		ContinueOnError: continueOnError,
+	}
+	if err := config.AddFreshFollowUp(ctx, campRoot, scopeProjectName(scope), entry); err != nil {
+		return err
+	}
+
+	fmt.Println(ui.Success(fmt.Sprintf("Added %q to %s.", entry.Name, scopeDescription(scope))))
+	return nil
+}
+
+func removeFollowUpTUI(ctx context.Context, campRoot string, projects []project.Project) error {
+	cfg, err := config.LoadFreshConfig(ctx, campRoot)
+	if err != nil {
+		return camperrors.Wrap(err, "loading fresh config")
+	}
+
+	scope, err := selectFollowUpScope(ctx, projects, cfg)
+	if err != nil {
+		if theme.IsCancelled(err) {
+			return errFollowUpTUIBack
+		}
+		return err
+	}
+
+	steps := followUpsForScope(cfg, scope)
+	if len(steps) == 0 {
+		fmt.Println(ui.Warning(fmt.Sprintf("No follow-up commands are configured for %s.", scopeDescription(scope))))
+		return errFollowUpTUIBack
+	}
+
+	options := make([]huh.Option[string], 0, len(steps))
+	for _, step := range steps {
+		label := fmt.Sprintf("%-16s %s", step.Name, step.Run)
+		if step.Dir != "" {
+			label += "  (dir: " + step.Dir + ")"
+		}
+		options = append(options, huh.NewOption(label, step.Name))
+	}
+
+	var name string
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewSelect[string]().
+			Title("Remove follow-up").
+			Description(scopeDescription(scope)).
+			Options(options...).
+			Value(&name),
+	))
+	if err := theme.RunForm(ctx, form); err != nil {
+		if theme.IsCancelled(err) {
+			return errFollowUpTUIBack
+		}
+		return err
+	}
+
+	var confirm bool
+	confirmForm := huh.NewForm(huh.NewGroup(
+		huh.NewConfirm().
+			Title(fmt.Sprintf("Remove %q?", name)).
+			Affirmative("Remove").
+			Negative("Keep").
+			Value(&confirm),
+	))
+	if err := theme.RunForm(ctx, confirmForm); err != nil {
+		if theme.IsCancelled(err) {
+			return errFollowUpTUIBack
+		}
+		return err
+	}
+	if !confirm {
+		return errFollowUpTUIBack
+	}
+
+	if err := config.RemoveFreshFollowUp(ctx, campRoot, scopeProjectName(scope), name); err != nil {
+		return err
+	}
+	fmt.Println(ui.Success(fmt.Sprintf("Removed %q from %s.", name, scopeDescription(scope))))
+	return nil
+}
+
+func selectFollowUpScope(ctx context.Context, projects []project.Project, cfg *config.FreshConfig) (string, error) {
+	options := []huh.Option[string]{huh.NewOption("Global default (all projects)", globalFollowUpScope)}
+
+	names := make(map[string]bool)
+	for _, p := range projects {
+		names[p.Name] = true
+	}
+	if cfg != nil {
+		for name, pc := range cfg.Projects {
+			if pc.FollowUp != nil {
+				names[name] = true
+			}
+		}
+	}
+	projectNames := make([]string, 0, len(names))
+	for name := range names {
+		projectNames = append(projectNames, name)
+	}
+	sort.Strings(projectNames)
+	for _, name := range projectNames {
+		label := name
+		if cfg != nil {
+			if steps := cfg.Projects[name].FollowUp; steps != nil {
+				label = fmt.Sprintf("%s (%d configured)", name, len(steps))
+			}
+		}
+		options = append(options, huh.NewOption(label, name))
+	}
+
+	var scope string
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewSelect[string]().
+			Title("Where should this apply?").
+			Description("Global commands apply to projects without their own override.").
+			Options(options...).
+			Value(&scope),
+	))
+	if err := theme.RunForm(ctx, form); err != nil {
+		return "", err
+	}
+	return scope, nil
+}
+
+func requiredField(label string) func(string) error {
+	return func(value string) error {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s is required", label)
+		}
+		return nil
+	}
+}
+
+func scopeProjectName(scope string) string {
+	if scope == globalFollowUpScope {
+		return ""
+	}
+	return scope
+}
+
+func scopeDescription(scope string) string {
+	if scope == globalFollowUpScope {
+		return "the global default"
+	}
+	return "project " + scope
+}
+
+func followUpsForScope(cfg *config.FreshConfig, scope string) []config.FollowUpConfig {
+	if scope == globalFollowUpScope {
+		return cfg.FollowUp
+	}
+	return cfg.Projects[scope].FollowUp
+}
+
+func configuredProjectNames(cfg *config.FreshConfig) []string {
+	names := make([]string, 0, len(cfg.Projects))
+	for name, pc := range cfg.Projects {
+		if pc.FollowUp != nil {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/commands/fresh/configure_tui_test.go
+++ b/internal/commands/fresh/configure_tui_test.go
@@ -1,0 +1,72 @@
+package fresh
+
+import (
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+)
+
+func TestConfiguredProjectNamesOnlyIncludesFollowUpOverrides(t *testing.T) {
+	cfg := &config.FreshConfig{
+		Projects: map[string]config.FreshProjectConfig{
+			"zeta":  {FollowUp: []config.FollowUpConfig{{Name: "build"}}},
+			"empty": {FollowUp: []config.FollowUpConfig{}},
+			"unset": {},
+			"alpha": {Branch: stringPtr("develop")},
+		},
+	}
+
+	got := configuredProjectNames(cfg)
+	want := []string{"empty", "zeta"}
+	if len(got) != len(want) {
+		t.Fatalf("configuredProjectNames() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("configuredProjectNames() = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestFollowUpsForScope(t *testing.T) {
+	cfg := &config.FreshConfig{
+		FollowUp: []config.FollowUpConfig{{Name: "install"}},
+		Projects: map[string]config.FreshProjectConfig{
+			"camp": {FollowUp: []config.FollowUpConfig{{Name: "build"}}},
+		},
+	}
+
+	if got := followUpsForScope(cfg, globalFollowUpScope); len(got) != 1 || got[0].Name != "install" {
+		t.Fatalf("global follow-ups = %v, want install", got)
+	}
+	if got := followUpsForScope(cfg, "camp"); len(got) != 1 || got[0].Name != "build" {
+		t.Fatalf("camp follow-ups = %v, want build", got)
+	}
+}
+
+func TestScopeHelpers(t *testing.T) {
+	if got := scopeProjectName(globalFollowUpScope); got != "" {
+		t.Fatalf("scopeProjectName(global) = %q, want empty", got)
+	}
+	if got := scopeProjectName("camp"); got != "camp" {
+		t.Fatalf("scopeProjectName(camp) = %q, want camp", got)
+	}
+	if got := scopeDescription(globalFollowUpScope); got != "the global default" {
+		t.Fatalf("scopeDescription(global) = %q", got)
+	}
+	if got := scopeDescription("camp"); got != "project camp" {
+		t.Fatalf("scopeDescription(camp) = %q", got)
+	}
+}
+
+func TestRequiredField(t *testing.T) {
+	validate := requiredField("command")
+	if err := validate("  "); err == nil {
+		t.Fatal("requiredField accepted whitespace-only input")
+	}
+	if err := validate("npm install"); err != nil {
+		t.Fatalf("requiredField rejected valid input: %v", err)
+	}
+}
+
+func stringPtr(value string) *string { return &value }

--- a/internal/commands/fresh/configure_tui_test.go
+++ b/internal/commands/fresh/configure_tui_test.go
@@ -1,9 +1,11 @@
 package fresh
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/Obedience-Corp/camp/internal/project"
 )
 
 func TestConfiguredProjectNamesOnlyIncludesFollowUpOverrides(t *testing.T) {
@@ -66,6 +68,43 @@ func TestRequiredField(t *testing.T) {
 	}
 	if err := validate("npm install"); err != nil {
 		t.Fatalf("requiredField rejected valid input: %v", err)
+	}
+}
+
+func TestFollowUpTUIModelVisualizesResolvedWorkflow(t *testing.T) {
+	cfg := &config.FreshConfig{
+		Branch:   "work",
+		FollowUp: []config.FollowUpConfig{{Name: "install", Run: "npm install"}},
+		Projects: map[string]config.FreshProjectConfig{
+			"web-app": {FollowUp: []config.FollowUpConfig{{Name: "build", Run: "npm run build"}}},
+		},
+	}
+	projects := []project.Project{{Name: "web-app"}, {Name: "camp"}}
+	m := newFollowUpTUIModel(context.Background(), "/campaign", projects, cfg)
+
+	if got := m.scopes[0].label; got != "Global defaults" {
+		t.Fatalf("global scope label = %q", got)
+	}
+	if len(m.workflowSteps()) != 9 {
+		t.Fatalf("global workflow steps = %d, want 9", len(m.workflowSteps()))
+	}
+
+	m.rebuildScopes("web-app")
+	steps := m.workflowSteps()
+	if got := workflowScopeLabel(scopeProjectName(m.selectedScope())); got != "project web-app" {
+		t.Fatalf("selected scope = %q", got)
+	}
+	if len(steps) != 9 || steps[7].Follow == nil || steps[7].Follow.Name != "build" {
+		t.Fatalf("project workflow = %+v, want resolved build follow-up", steps)
+	}
+}
+
+func TestFailureBehaviorLabel(t *testing.T) {
+	if got := failureBehaviorLabel(false); got != "Stop fresh if this command fails" {
+		t.Fatalf("failureBehaviorLabel(false) = %q", got)
+	}
+	if got := failureBehaviorLabel(true); got != "Continue to later steps if this command fails" {
+		t.Fatalf("failureBehaviorLabel(true) = %q", got)
 	}
 }
 

--- a/internal/commands/fresh/configure_tui_update.go
+++ b/internal/commands/fresh/configure_tui_update.go
@@ -1,0 +1,277 @@
+package fresh
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func (m *followUpTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		if m.overlay != followUpNoOverlay {
+			return m.updateOverlay(msg)
+		}
+		return m.updateBrowse(msg)
+	}
+	return m, nil
+}
+
+func (m *followUpTUIModel) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+	if key != "r" && m.status != "" {
+		m.status = ""
+	}
+
+	switch key {
+	case "q", "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "esc":
+		if m.pane == followUpWorkflowPane {
+			m.pane = followUpScopesPane
+			return m, nil
+		}
+		m.quitting = true
+		return m, tea.Quit
+	case "up", "k":
+		m.moveCursor(-1)
+	case "down", "j":
+		m.moveCursor(1)
+	case "left", "h":
+		m.pane = followUpScopesPane
+	case "right", "l", "tab":
+		m.pane = followUpWorkflowPane
+	case "shift+tab":
+		m.pane = followUpScopesPane
+	case "enter":
+		if m.pane == followUpScopesPane {
+			m.pane = followUpWorkflowPane
+		}
+	case "a":
+		m.openFollowUpForm(false, config.FollowUpConfig{})
+		return m, textinput.Blink
+	case "e":
+		_, entry, ok := m.selectedFollowUp()
+		if ok {
+			m.openFollowUpForm(true, entry)
+			return m, textinput.Blink
+		}
+		m.setError(camperrors.New("select a follow-up step to edit"))
+	case "d":
+		_, entry, ok := m.selectedFollowUp()
+		if ok {
+			m.pendingDelete = entry.Name
+			m.overlay = followUpDeleteOverlay
+			return m, nil
+		}
+		m.setError(camperrors.New("select a follow-up step to delete"))
+	case "r":
+		selected := m.selectedScope()
+		if err := m.refresh(selected); err != nil {
+			m.setError(err)
+		} else {
+			m.setStatus("reloaded fresh.yaml")
+		}
+	case "?":
+		m.overlay = followUpHelpOverlay
+	}
+	return m, nil
+}
+
+func (m *followUpTUIModel) moveCursor(delta int) {
+	if m.pane == followUpScopesPane {
+		if len(m.scopes) == 0 {
+			return
+		}
+		m.scopeCursor = (m.scopeCursor + delta + len(m.scopes)) % len(m.scopes)
+		m.stepCursor = 0
+		return
+	}
+	steps := m.workflowSteps()
+	if len(steps) == 0 {
+		return
+	}
+	m.stepCursor = (m.stepCursor + delta + len(steps)) % len(steps)
+}
+
+func (m *followUpTUIModel) openFollowUpForm(edit bool, entry config.FollowUpConfig) {
+	m.overlay = followUpFormOverlay
+	m.formError = ""
+	m.formEditName = ""
+	m.formContinue = entry.ContinueOnError
+	if edit {
+		m.formEditName = entry.Name
+	}
+	m.inputs[0].SetValue(entry.Name)
+	m.inputs[1].SetValue(entry.Run)
+	m.inputs[2].SetValue(entry.Dir)
+	m.formField = 0
+	m.focusFormField()
+}
+
+func (m *followUpTUIModel) focusFormField() {
+	for i := range m.inputs {
+		m.inputs[i].Blur()
+	}
+	if m.formField < len(m.inputs) {
+		m.inputs[m.formField].Focus()
+	}
+}
+
+func (m *followUpTUIModel) moveFormField(delta int) {
+	m.formField = (m.formField + delta + 4) % 4
+	m.focusFormField()
+}
+
+func (m *followUpTUIModel) updateOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.overlay {
+	case followUpHelpOverlay:
+		switch msg.String() {
+		case "esc", "?", "enter":
+			m.overlay = followUpNoOverlay
+		}
+		return m, nil
+	case followUpDeleteOverlay:
+		switch msg.String() {
+		case "ctrl+c":
+			m.quitting = true
+			return m, tea.Quit
+		case "esc", "n":
+			m.overlay = followUpNoOverlay
+			m.pendingDelete = ""
+		case "y", "enter":
+			return m, m.deletePendingFollowUp()
+		}
+		return m, nil
+	case followUpFormOverlay:
+		return m.updateForm(msg)
+	default:
+		return m, nil
+	}
+}
+
+func (m *followUpTUIModel) updateForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "esc":
+		m.closeOverlay()
+		return m, nil
+	case "tab", "down":
+		m.moveFormField(1)
+		return m, nil
+	case "shift+tab", "up":
+		m.moveFormField(-1)
+		return m, nil
+	case " ":
+		if m.formField == 3 {
+			m.formContinue = !m.formContinue
+			return m, nil
+		}
+	case "enter":
+		if m.formField < 3 {
+			m.moveFormField(1)
+			return m, nil
+		}
+		return m, m.saveForm()
+	}
+	if m.formField >= len(m.inputs) {
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.inputs[m.formField], cmd = m.inputs[m.formField].Update(msg)
+	return m, cmd
+}
+
+func (m *followUpTUIModel) closeOverlay() {
+	m.overlay = followUpNoOverlay
+	m.formError = ""
+	for i := range m.inputs {
+		m.inputs[i].Blur()
+	}
+}
+
+func (m *followUpTUIModel) saveForm() tea.Cmd {
+	entry := config.FollowUpConfig{
+		Name:            strings.TrimSpace(m.inputs[0].Value()),
+		Run:             strings.TrimSpace(m.inputs[1].Value()),
+		Dir:             strings.TrimSpace(m.inputs[2].Value()),
+		ContinueOnError: m.formContinue,
+	}
+	if err := entry.Validate(); err != nil {
+		m.formError = err.Error()
+		return nil
+	}
+
+	entries := append([]config.FollowUpConfig(nil), m.effectiveFollowUps()...)
+	if m.formEditName != "" {
+		found := false
+		for i := range entries {
+			if entries[i].Name == m.formEditName {
+				entries[i] = entry
+				found = true
+				break
+			}
+		}
+		if !found {
+			m.formError = fmt.Sprintf("follow-up %q is no longer configured; reload and try again", m.formEditName)
+			return nil
+		}
+	} else {
+		entries = append(entries, entry)
+	}
+
+	if err := config.SetFreshFollowUps(m.ctx, m.root, scopeProjectName(m.selectedScope()), entries); err != nil {
+		m.formError = err.Error()
+		return nil
+	}
+	selected := m.selectedScope()
+	if err := m.refresh(selected); err != nil {
+		m.formError = err.Error()
+		return nil
+	}
+	m.closeOverlay()
+	if m.formEditName != "" {
+		m.setStatus(fmt.Sprintf("updated %q", entry.Name))
+	} else {
+		m.setStatus(fmt.Sprintf("added %q to %s", entry.Name, workflowScopeLabel(scopeProjectName(selected))))
+	}
+	return nil
+}
+
+func (m *followUpTUIModel) deletePendingFollowUp() tea.Cmd {
+	entries := make([]config.FollowUpConfig, 0, len(m.effectiveFollowUps()))
+	for _, entry := range m.effectiveFollowUps() {
+		if entry.Name != m.pendingDelete {
+			entries = append(entries, entry)
+		}
+	}
+	name := m.pendingDelete
+	selected := m.selectedScope()
+	if err := config.SetFreshFollowUps(m.ctx, m.root, scopeProjectName(selected), entries); err != nil {
+		m.setError(err)
+		m.pendingDelete = ""
+		m.overlay = followUpNoOverlay
+		return nil
+	}
+	if err := m.refresh(selected); err != nil {
+		m.setError(err)
+		m.pendingDelete = ""
+		m.overlay = followUpNoOverlay
+		return nil
+	}
+	m.pendingDelete = ""
+	m.overlay = followUpNoOverlay
+	m.stepCursor = min(m.stepCursor, max(len(m.workflowSteps())-1, 0))
+	m.setStatus(fmt.Sprintf("removed %q", name))
+	return nil
+}

--- a/internal/commands/fresh/configure_tui_view.go
+++ b/internal/commands/fresh/configure_tui_view.go
@@ -1,0 +1,285 @@
+package fresh
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/intent/tui"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/internal/ui/theme"
+	"github.com/charmbracelet/lipgloss"
+)
+
+var freshTUIPal = theme.TUI()
+
+var (
+	freshTUITitleStyle = tui.TitleStyle
+	freshTUIHelpStyle  = tui.HelpStyle
+	freshTUIErrorStyle = tui.ErrorStyle
+	freshTUIOKStyle    = tui.SuccessStyle
+	freshPaneFocused   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(freshTUIPal.BorderFocus).Padding(0, 1)
+	freshPaneBlurred   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(freshTUIPal.Border).Padding(0, 1)
+	freshSelected      = lipgloss.NewStyle().Foreground(freshTUIPal.Accent).Bold(true)
+	freshPrimary       = lipgloss.NewStyle().Foreground(freshTUIPal.TextPrimary)
+	freshMuted         = lipgloss.NewStyle().Foreground(freshTUIPal.TextMuted)
+	freshDisabled      = lipgloss.NewStyle().Foreground(freshTUIPal.Warning)
+	freshOverlay       = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(freshTUIPal.BorderFocus).Background(freshTUIPal.BgOverlay).Padding(1, 2)
+)
+
+type freshTUILayout struct {
+	width      int
+	height     int
+	dual       bool
+	leftWidth  int
+	rightWidth int
+	bodyRows   int
+	showFooter bool
+}
+
+func (m *followUpTUIModel) layout() freshTUILayout {
+	w, h := m.width, m.height
+	if w <= 0 {
+		w = 100
+	}
+	if h <= 0 {
+		h = 30
+	}
+	dual := w >= 78
+	left := w
+	right := w
+	if dual {
+		left = max(w/3, 28)
+		right = max(w-left-2, 30)
+	}
+	// Leave room for the title, status, footer, and the pane borders. Keeping
+	// this conservative prevents the footer from being evicted on short PTYs.
+	bodyRows := max(h-8, 4)
+	return freshTUILayout{
+		width:      w,
+		height:     h,
+		dual:       dual,
+		leftWidth:  left,
+		rightWidth: right,
+		bodyRows:   bodyRows,
+		showFooter: h >= 8,
+	}
+}
+
+func (m *followUpTUIModel) View() string {
+	if m.quitting {
+		return ""
+	}
+	if m.overlay != followUpNoOverlay {
+		return m.overlayView()
+	}
+
+	lay := m.layout()
+	lines := []string{m.topBar(lay.width)}
+	if lay.dual {
+		left := m.renderScopesPane(lay)
+		right := m.renderWorkflowPane(lay)
+		joined := lipgloss.JoinHorizontal(lipgloss.Top, left, " ", right)
+		lines = append(lines, strings.Split(joined, "\n")...)
+	} else if m.pane == followUpScopesPane {
+		lines = append(lines, strings.Split(m.renderScopesPane(lay), "\n")...)
+	} else {
+		lines = append(lines, strings.Split(m.renderWorkflowPane(lay), "\n")...)
+	}
+	if lay.showFooter {
+		if status := m.statusLine(); status != "" {
+			lines = append(lines, status)
+		}
+		lines = append(lines, m.footer(lay.width))
+	}
+	return m.frame(lines, lay.width, lay.height)
+}
+
+func (m *followUpTUIModel) topBar(width int) string {
+	title := freshTUITitleStyle.Render("Fresh follow-ups")
+	meta := freshMuted.Render("configure the sequence that runs after a successful fresh cycle")
+	line := title + "  " + meta
+	return ui.ClampWidth(line, width)
+}
+
+func (m *followUpTUIModel) renderScopesPane(lay freshTUILayout) string {
+	width := lay.leftWidth
+	inner := max(width-4, 1)
+	lines := []string{
+		ui.ClampWidth(freshTUITitleStyle.Render("Scopes"), inner),
+		freshMuted.Render("Global · project overrides"),
+	}
+	rows := max(lay.bodyRows-2, 1)
+	start, end := ui.WindowRange(m.scopeCursor, len(m.scopes), rows)
+	for i := start; i < end; i++ {
+		scope := m.scopes[i]
+		selected := i == m.scopeCursor
+		prefix := ui.CursorGlyph(selected && m.pane == followUpScopesPane)
+		style := freshPrimary
+		if selected {
+			style = freshSelected
+		}
+		lines = append(lines, ui.ClampWidth(prefix+style.Render(scope.label), inner))
+	}
+	if len(m.scopes) == 0 {
+		lines = append(lines, freshMuted.Render("no projects found"))
+	}
+	return m.finishPane(lines, inner, lay.bodyRows, m.pane == followUpScopesPane)
+}
+
+func (m *followUpTUIModel) renderWorkflowPane(lay freshTUILayout) string {
+	width := lay.rightWidth
+	inner := max(width-4, 1)
+	scope := workflowScopeLabel(scopeProjectName(m.selectedScope()))
+	headerDetail := "Follow-ups run only after the sync steps succeed"
+	steps := m.workflowSteps()
+	if m.pane == followUpWorkflowPane && m.stepCursor >= 0 && m.stepCursor < len(steps) {
+		headerDetail = "Selected · " + steps[m.stepCursor].Detail
+	}
+	lines := []string{
+		ui.ClampWidth(freshTUITitleStyle.Render("Workflow · "+scope), inner),
+		freshMuted.Render(ui.Truncate(headerDetail, max(inner-2, 1))),
+	}
+	rows := max(lay.bodyRows-2, 1)
+	start, end := ui.WindowRange(m.stepCursor, len(steps), rows)
+	for i := start; i < end; i++ {
+		lines = append(lines, m.workflowRow(i, steps[i], inner))
+	}
+	return m.finishPane(lines, inner, lay.bodyRows, m.pane == followUpWorkflowPane)
+}
+
+func (m *followUpTUIModel) workflowRow(index int, step freshWorkflowStep, width int) string {
+	selected := index == m.stepCursor
+	focused := selected && m.pane == followUpWorkflowPane
+	icon := "✓"
+	if !step.Enabled {
+		icon = "⚠"
+	}
+	title := fmt.Sprintf("%d. %s", index+1, step.Title)
+	if !step.Enabled {
+		title += " [off]"
+	}
+	row := ui.CursorGlyph(focused) + icon + " " + title
+	if width > 44 {
+		row += "  · " + step.Detail
+	}
+	// The pane style adds border and padding around the inner width. Reserve a
+	// few cells here so a row remains one visual line instead of being wrapped
+	// by lipgloss after truncation.
+	row = ui.Truncate(row, max(width-6, 1))
+	if selected {
+		return freshSelected.Render(row)
+	}
+	if !step.Enabled {
+		return freshDisabled.Render(row)
+	}
+	return freshPrimary.Render(row)
+}
+
+func (m *followUpTUIModel) finishPane(lines []string, width, rows int, focused bool) string {
+	want := rows + 2
+	for len(lines) < want {
+		lines = append(lines, "")
+	}
+	if len(lines) > want {
+		lines = lines[:want]
+	}
+	content := strings.Join(ui.ClampLines(lines, width), "\n")
+	if m.layout().dual || m.width <= 0 {
+		style := freshPaneBlurred
+		if focused {
+			style = freshPaneFocused
+		}
+		return style.Width(width).Render(content)
+	}
+	return content
+}
+
+func (m *followUpTUIModel) frame(lines []string, width, height int) string {
+	return ui.FitFullscreenView(strings.Join(ui.CapFrame(lines, width, height), "\n"), height)
+}
+
+func (m *followUpTUIModel) footer(width int) string {
+	full := "j/k: move · h/l: switch pane · a: add · e: edit · d: delete · r: reload · ?: help · q: quit"
+	mid := "j/k move · h/l pane · a add · e edit · d delete · ? help · q quit"
+	short := "j/k · h/l · a/e/d · ? · q"
+	return freshTUIHelpStyle.Render(ui.CollapseHelp(width, full, mid, short, "q: quit"))
+}
+
+func (m *followUpTUIModel) statusLine() string {
+	if m.status == "" {
+		return ""
+	}
+	if m.statusErr {
+		return freshTUIErrorStyle.Render("✗ " + m.status)
+	}
+	return freshTUIOKStyle.Render("✓ " + m.status)
+}
+
+func (m *followUpTUIModel) overlayView() string {
+	lay := m.layout()
+	var body []string
+	switch m.overlay {
+	case followUpHelpOverlay:
+		body = []string{
+			freshTUITitleStyle.Render("Fresh follow-up configuration"),
+			"",
+			freshPrimary.Render("The right pane is the actual camp fresh sequence."),
+			freshMuted.Render("Select a project on the left to see its resolved overrides."),
+			"",
+			freshPrimary.Render("a  add a follow-up after the core sync steps"),
+			freshPrimary.Render("e  edit the selected follow-up"),
+			freshPrimary.Render("d  delete the selected follow-up"),
+			freshPrimary.Render("r  reload fresh.yaml from disk"),
+			freshPrimary.Render("h/l or tab  move between scopes and workflow"),
+			"",
+			freshTUIHelpStyle.Render("esc or ?  close help"),
+		}
+	case followUpDeleteOverlay:
+		body = []string{
+			freshTUITitleStyle.Render("Remove follow-up?"),
+			"",
+			freshPrimary.Render(fmt.Sprintf("Remove %q from %s?", m.pendingDelete, workflowScopeLabel(scopeProjectName(m.selectedScope())))),
+			freshMuted.Render("The remaining workflow steps will stay in order."),
+			"",
+			freshTUIHelpStyle.Render("y/enter remove · n/esc cancel"),
+		}
+	case followUpFormOverlay:
+		title := "Add follow-up"
+		if m.formEditName != "" {
+			title = "Edit follow-up"
+		}
+		body = []string{
+			freshTUITitleStyle.Render(title + " · " + workflowScopeLabel(scopeProjectName(m.selectedScope()))),
+			freshMuted.Render("This command runs after checkout, pull, prune, and branch setup."),
+			"",
+			freshPrimary.Render("Name"),
+			m.inputs[0].View(),
+			freshPrimary.Render("Command"),
+			m.inputs[1].View(),
+			freshPrimary.Render("Working directory (optional)"),
+			m.inputs[2].View(),
+			freshPrimary.Render("Failure behavior"),
+			freshSelected.Render(failureBehaviorLabel(m.formContinue)),
+		}
+		if m.formError != "" {
+			body = append(body, freshTUIErrorStyle.Render("✗ "+m.formError))
+		}
+		body = append(body, "", freshTUIHelpStyle.Render("tab/shift+tab move · space toggle · enter save · esc cancel"))
+	}
+
+	boxWidth := min(max(lay.width-6, 30), 76)
+	box := freshOverlay.Width(max(boxWidth-6, 24)).Render(strings.Join(ui.ClampLines(body, max(boxWidth-6, 24)), "\n"))
+	canvas := lipgloss.NewStyle().
+		Width(lay.width).
+		Height(lay.height).
+		Background(freshTUIPal.BgOverlay).
+		Render(lipgloss.Place(lay.width, lay.height, lipgloss.Center, lipgloss.Center, box))
+	return ui.FitFullscreenView(canvas, lay.height)
+}
+
+func failureBehaviorLabel(continueOnError bool) string {
+	if continueOnError {
+		return "Continue to later steps if this command fails"
+	}
+	return "Stop fresh if this command fails"
+}

--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -55,7 +55,8 @@ run, or 'camp fresh all' to cycle every project submodule in the campaign.
 Without configuration, syncs to the default branch and prunes.
 Configure .campaign/settings/fresh.yaml to set a default working branch, or
 follow-up command workflows (install, build, bootstrap, ...) to run once the
-cycle succeeds. Manage those with 'camp fresh configure'.
+cycle succeeds. Manage those with 'camp fresh configure'. Inspect the resolved
+sequence with 'camp fresh show-workflow [project-name]'.
 
 Examples:
   camp fresh                            # Sync current project (checkout default, pull, prune)
@@ -157,6 +158,7 @@ Examples:
 	// Add subcommands
 	freshCmd.AddCommand(newAllCommand(freshCmd))
 	freshCmd.AddCommand(newConfigureCommand())
+	freshCmd.AddCommand(newShowWorkflowCommand())
 
 	return freshCmd
 }

--- a/internal/commands/fresh/workflow.go
+++ b/internal/commands/fresh/workflow.go
@@ -1,0 +1,114 @@
+package fresh
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/Obedience-Corp/camp/internal/ui"
+)
+
+// freshWorkflowStep is the human-readable plan for one fresh cycle. It is
+// deliberately shared by the TUI and show-workflow so the two surfaces cannot
+// drift apart from executeFresh's actual order.
+type freshWorkflowStep struct {
+	Title   string
+	Detail  string
+	Enabled bool
+	Follow  *config.FollowUpConfig
+}
+
+func buildFreshWorkflow(cfg *config.FreshConfig, projectName string) []freshWorkflowStep {
+	if cfg == nil {
+		cfg = &config.FreshConfig{}
+	}
+
+	branch := cfg.ResolveFreshBranch("", false, projectName)
+	push := cfg.ResolveFreshPushUpstream(projectName)
+	prune := cfg.ResolveFreshPrune()
+	pruneRemote := cfg.ResolveFreshPruneRemote()
+	branchDetail := "not configured"
+	if branch != "" {
+		branchDetail = "create " + branch
+	}
+	pushDetail := "after creating the working branch"
+	if branch != "" && !push {
+		pushDetail = "disabled in fresh settings"
+	}
+
+	steps := []freshWorkflowStep{
+		{Title: "Safety checks", Detail: "no merge/rebase in progress; worktree is clean", Enabled: true},
+		{Title: "Checkout default branch", Detail: "use the repository's default branch (or a safe detached ref)", Enabled: true},
+		{Title: "Pull", Detail: "fast-forward only", Enabled: true},
+		{Title: "Prune merged branches", Detail: "remove merged branches and detached worktrees", Enabled: prune},
+		{Title: "Prune remote tracking refs", Detail: "refresh and remove stale refs", Enabled: prune && pruneRemote},
+		{Title: "Create working branch", Detail: branchDetail, Enabled: branch != ""},
+		{Title: "Push branch upstream", Detail: pushDetail, Enabled: branch != "" && push},
+	}
+
+	for _, follow := range cfg.ResolveFreshFollowUps(projectName) {
+		step := follow
+		steps = append(steps, freshWorkflowStep{
+			Title:   "Follow-up: " + follow.Name,
+			Detail:  formatFollowUpDetail(follow),
+			Enabled: true,
+			Follow:  &step,
+		})
+	}
+
+	steps = append(steps, freshWorkflowStep{
+		Title:   "Ready to work",
+		Detail:  "fresh completes successfully",
+		Enabled: true,
+	})
+	return steps
+}
+
+func formatFollowUpDetail(step config.FollowUpConfig) string {
+	detail := "$ " + step.Run
+	if step.Dir != "" {
+		detail += " · in " + step.Dir
+	}
+	if step.ContinueOnError {
+		detail += " · continue on failure"
+	} else {
+		detail += " · stop on failure"
+	}
+	return detail
+}
+
+func workflowScopeLabel(projectName string) string {
+	if projectName == "" {
+		return "global defaults"
+	}
+	return "project " + projectName
+}
+
+func printFreshWorkflow(w io.Writer, cfg *config.FreshConfig, projectName string) error {
+	if _, err := fmt.Fprintf(w, "%s\n", ui.Header("camp fresh workflow · "+workflowScopeLabel(projectName))); err != nil {
+		return err
+	}
+	if projectName == "" {
+		if _, err := fmt.Fprintln(w, ui.Dim("Pass a project name to see its resolved overrides.")); err != nil {
+			return err
+		}
+	}
+
+	for i, step := range buildFreshWorkflow(cfg, projectName) {
+		icon := ui.SuccessIcon()
+		if !step.Enabled {
+			icon = ui.WarningIcon()
+		}
+		title := step.Title
+		if !step.Enabled {
+			title += " (disabled)"
+		}
+		if _, err := fmt.Fprintf(w, "  %s %d. %s\n", icon, i+1, ui.Value(title)); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "     %s\n", ui.Dim(step.Detail)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/config/fresh_followup.go
+++ b/internal/config/fresh_followup.go
@@ -96,6 +96,43 @@ func RemoveFreshFollowUp(ctx context.Context, campaignRoot, projectName, name st
 	})
 }
 
+// SetFreshFollowUps replaces the ordered follow-up list for a scope. It is
+// used by interactive editors that need to preserve the effective workflow
+// while changing one project override at a time. A project scope with an
+// empty list is kept as an explicit override, which intentionally disables
+// inherited global follow-ups for that project.
+func SetFreshFollowUps(ctx context.Context, campaignRoot, projectName string, entries []FollowUpConfig) error {
+	seen := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		if err := entry.Validate(); err != nil {
+			return err
+		}
+		if _, ok := seen[entry.Name]; ok {
+			return camperrors.NewValidation("name", fmt.Sprintf("follow-up %q appears more than once", entry.Name), nil)
+		}
+		seen[entry.Name] = struct{}{}
+	}
+
+	return withFreshConfigLock(ctx, campaignRoot, func(mapping *yaml.Node) error {
+		seq, err := followUpSequence(mapping, projectName, true)
+		if err != nil {
+			return err
+		}
+		seq.Content = nil
+		for _, entry := range entries {
+			var node yaml.Node
+			if err := node.Encode(entry); err != nil {
+				return camperrors.Wrap(err, "encode follow-up entry")
+			}
+			seq.Content = append(seq.Content, &node)
+		}
+		if projectName == "" {
+			pruneEmptyFollowUpScope(mapping, projectName, seq)
+		}
+		return nil
+	})
+}
+
 // withFreshConfigLock loads fresh.yaml as a raw YAML document (creating an
 // empty mapping document if the file is missing or has no parseable
 // mapping content), runs mutate against its top-level mapping, then writes

--- a/internal/config/fresh_followup_test.go
+++ b/internal/config/fresh_followup_test.go
@@ -328,3 +328,42 @@ func TestRemoveFreshFollowUp_ContextCanceled(t *testing.T) {
 	}
 }
 
+func TestSetFreshFollowUps_PreservesInheritedStepsForProjectEdits(t *testing.T) {
+	root := t.TempDir()
+	ctx := context.Background()
+	global := []FollowUpConfig{{Name: "install", Run: "npm install"}}
+	if err := SetFreshFollowUps(ctx, root, "", global); err != nil {
+		t.Fatalf("SetFreshFollowUps(global) error = %v", err)
+	}
+
+	projectSteps := append(append([]FollowUpConfig(nil), global...), FollowUpConfig{Name: "build", Run: "npm run build"})
+	if err := SetFreshFollowUps(ctx, root, "web-app", projectSteps); err != nil {
+		t.Fatalf("SetFreshFollowUps(project) error = %v", err)
+	}
+
+	cfg, err := LoadFreshConfig(ctx, root)
+	if err != nil {
+		t.Fatalf("LoadFreshConfig() error = %v", err)
+	}
+	got := cfg.ResolveFreshFollowUps("web-app")
+	if len(got) != 2 || got[0].Name != "install" || got[1].Name != "build" {
+		t.Fatalf("project follow-ups = %+v, want inherited install followed by build", got)
+	}
+}
+
+func TestSetFreshFollowUps_ProjectEmptyListRemainsExplicit(t *testing.T) {
+	root := t.TempDir()
+	ctx := context.Background()
+	if err := SetFreshFollowUps(ctx, root, "web-app", nil); err != nil {
+		t.Fatalf("SetFreshFollowUps(empty project) error = %v", err)
+	}
+
+	cfg, err := LoadFreshConfig(ctx, root)
+	if err != nil {
+		t.Fatalf("LoadFreshConfig() error = %v", err)
+	}
+	steps, ok := cfg.Projects["web-app"]
+	if !ok || steps.FollowUp == nil {
+		t.Fatalf("project empty override = %+v, want explicit empty follow_up list", cfg.Projects)
+	}
+}


### PR DESCRIPTION
## Summary

Reworks `camp fresh configure` into a human-facing workflow dashboard.

- The left pane selects global defaults or a project scope and shows whether the project inherits or overrides the global list.
- The right pane shows the ordered `camp fresh` sequence, including disabled settings and follow-up commands at the point where they run.
- Add, edit, and delete follow-ups use focused overlays; project edits preserve inherited global steps before materializing an override.
- Adds non-interactive `camp fresh show-workflow [project-name]` for the same ordered view in terminals, scripts, and review output.
- Existing `configure show|add|remove` commands remain available for automation.
- Stacked on `fresh-follow-up-workflows` (#432).

## Reused camp TUI patterns

The implementation follows the existing `cmd/camp/org` and `internal/tui/status` dashboard patterns, using the shared adaptive palette, intent TUI styles, and layout helpers for pane sizing, truncation, scrolling, help collapse, and short terminals.

## Verification

- `just gate-fast` — stable/dev builds, vet, lint, and 3,390 dev-profile tests.
- `just docs` — regenerated CLI reference, including `camp fresh show-workflow`.
- Manual PTY verification drove the real binary with `pyte`, confirmed the dashboard/form rendering, and verified the YAML write and inherited-project behavior.
- Real VHS/PTY demo recorded from the actual camp binary:

![camp fresh workflow TUI](https://gist.githubusercontent.com/lancekrogers/fe76a7918d4d28dff3232e18d9b4e2e7/raw/tui-camp-fresh-configure-opt.gif)
