### PR TITLE
feat(shell,org): add cwi alias and corg org-cycle commands

### DIFF
--- a/cmd/camp/org/cycle.go
+++ b/cmd/camp/org/cycle.go
@@ -284,7 +284,10 @@ func emitCycleTarget(w io.Writer, action string, from, to config.RegisteredCampa
 			To:            cycleCampaignOutput{ID: to.ID, Name: to.Name, Org: to.Org, Path: to.Path},
 		})
 	default:
-		_, err := fmt.Fprintf(w, "cd %s\n", to.Path)
+		// Quote like the shell-connect branch: the default also prints a cd
+		// command a user may copy-paste or eval, so a path with spaces (or a
+		// leading dash) must not break.
+		_, err := fmt.Fprintf(w, "cd -- %s\n", remote.ShellQuote(to.Path))
 		return err
 	}
 }

--- a/cmd/camp/org/cycle.go
+++ b/cmd/camp/org/cycle.go
@@ -1,0 +1,290 @@
+package org
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/remote"
+	"github.com/spf13/cobra"
+)
+
+const cycleSchemaVersion = "camp-org-cycle/v1"
+
+var orgNextCmd = &cobra.Command{
+	Use:     "next",
+	Aliases: []string{"cycle"},
+	Short:   "Switch to the next campaign in the current campaign's org",
+	Long: `Switch to the next campaign in the current campaign's org.
+
+Members are ordered by name, so the cycle is stable and predictable
+(a -> b -> c -> a). By default only active campaigns are cycled; use --all to
+include inactive and reference campaigns.
+
+Use with the corg shell function for instant navigation:
+  corg        # cd to the next campaign in this org
+
+The --print flag outputs just the target path for shell integration, and --json
+emits the resolved source and target campaigns.`,
+	Example: `  camp org next            # Print cd to the next org campaign
+  camp org next --print    # Print the target path only
+  camp org next --all      # Include inactive/reference campaigns
+  camp org next --json`,
+	Args: cobra.NoArgs,
+	Annotations: map[string]string{
+		"agent_allowed": "true",
+		"agent_reason":  "Non-interactive; --print/--json resolve the next org campaign without a TUI",
+	},
+	RunE: runOrgNext,
+}
+
+var orgToggleCmd = &cobra.Command{
+	Use:     "toggle",
+	Aliases: []string{"back", "t"},
+	Short:   "Toggle back to the last-visited campaign in the current org",
+	Long: `Toggle back to the most recently visited other campaign in the current org.
+
+"Most recently visited" is tracked by last-access time, which camp updates on
+every 'camp switch' and 'camp org next'/'toggle'. Paired with 'camp org next',
+this gives a natural A <-> B toggle within an org. By default only active
+campaigns are considered; use --all to include inactive and reference campaigns.
+
+Use with the corg shell function for instant navigation:
+  corg t      # cd back to the last org campaign you were in`,
+	Example: `  camp org toggle          # Print cd to the last-visited org campaign
+  camp org toggle --print  # Print the target path only
+  camp org toggle --json`,
+	Args: cobra.NoArgs,
+	Annotations: map[string]string{
+		"agent_allowed": "true",
+		"agent_reason":  "Non-interactive; --print/--json resolve the last-visited org campaign without a TUI",
+	},
+	RunE: runOrgToggle,
+}
+
+func init() {
+	Cmd.AddCommand(orgNextCmd)
+	Cmd.AddCommand(orgToggleCmd)
+	for _, c := range []*cobra.Command{orgNextCmd, orgToggleCmd} {
+		c.Flags().Bool("print", false, "Print the target path only (for shell integration)")
+		c.Flags().Bool("json", false, "Output the resolved source and target campaigns as JSON")
+		c.Flags().Bool("all", false, "Include inactive and reference campaigns in the cycle")
+		c.Flags().Bool("shell-connect", false, "Emit a shell line for the corg wrapper to eval (internal)")
+		_ = c.Flags().MarkHidden("shell-connect")
+	}
+}
+
+// cycleFlags holds the output-mode flags shared by next and toggle.
+type cycleFlags struct {
+	print        bool
+	json         bool
+	all          bool
+	shellConnect bool
+}
+
+func cycleFlagsFrom(cmd *cobra.Command) (cycleFlags, error) {
+	f := cycleFlags{}
+	f.print, _ = cmd.Flags().GetBool("print")
+	f.json, _ = cmd.Flags().GetBool("json")
+	f.all, _ = cmd.Flags().GetBool("all")
+	f.shellConnect, _ = cmd.Flags().GetBool("shell-connect")
+	if f.print && f.json {
+		return f, camperrors.New("cannot use --json with --print")
+	}
+	if f.shellConnect && (f.print || f.json) {
+		return f, camperrors.New("--shell-connect cannot be combined with --print or --json")
+	}
+	return f, nil
+}
+
+func runOrgNext(cmd *cobra.Command, _ []string) error {
+	return runCycle(cmd, "next", nextInOrgCycle)
+}
+
+func runOrgToggle(cmd *cobra.Command, _ []string) error {
+	return runCycle(cmd, "toggle", mostRecentOther)
+}
+
+// cycleResolver picks the target campaign from the ordered org members given the
+// current campaign's ID. ok is false when there is no distinct target.
+type cycleResolver func(members []config.RegisteredCampaign, currentID string) (config.RegisteredCampaign, bool)
+
+func runCycle(cmd *cobra.Command, action string, resolve cycleResolver) error {
+	ctx := cmd.Context()
+	flags, err := cycleFlagsFrom(cmd)
+	if err != nil {
+		return err
+	}
+
+	current, reg, err := currentCampaign(ctx)
+	if err != nil {
+		return err
+	}
+
+	scope := cmdutil.CampaignScope{Org: current.Org, All: flags.all}
+	members := orderedCycleMembers(reg, scope)
+
+	target, ok := resolve(members, current.ID)
+	if !ok {
+		// No distinct target: emit nothing on stdout so the corg wrapper's
+		// `eval "$line"` is a no-op, and explain on stderr.
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "camp: %s\n", noTargetReason(action, current.Org))
+		return nil
+	}
+
+	// Record the visit so a later toggle can find its way back, mirroring how
+	// 'camp switch' maintains last-access ordering.
+	if err := config.UpdateRegistry(ctx, func(r *config.Registry) error {
+		r.UpdateLastAccess(target.ID)
+		return nil
+	}); err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "camp: warning: failed to update last access: %v\n", err)
+	}
+
+	return emitCycleTarget(cmd.OutOrStdout(), action, current, target, flags)
+}
+
+// orderedCycleMembers returns the scoped org members ordered by name then ID so
+// the forward cycle is stable regardless of registry map iteration order.
+func orderedCycleMembers(reg *config.Registry, scope cmdutil.CampaignScope) []config.RegisteredCampaign {
+	members := cmdutil.FilterCampaigns(reg, scope)
+	sort.Slice(members, func(i, j int) bool {
+		if members[i].Name != members[j].Name {
+			return members[i].Name < members[j].Name
+		}
+		return members[i].ID < members[j].ID
+	})
+	return members
+}
+
+// nextInOrgCycle returns the member after currentID in the ordered ring. When
+// the current campaign is not in the set (e.g. it is inactive and --all was not
+// given), the first member is treated as "next". Returns false only when there
+// is no member other than the current campaign.
+func nextInOrgCycle(members []config.RegisteredCampaign, currentID string) (config.RegisteredCampaign, bool) {
+	if len(members) == 0 {
+		return config.RegisteredCampaign{}, false
+	}
+	idx := indexOfID(members, currentID)
+	if idx < 0 {
+		return members[0], members[0].ID != currentID
+	}
+	next := members[(idx+1)%len(members)]
+	return next, next.ID != currentID
+}
+
+// mostRecentOther returns the member with the newest LastAccess other than the
+// current campaign, ties broken by name then ID. Returns false when the org has
+// no other member.
+func mostRecentOther(members []config.RegisteredCampaign, currentID string) (config.RegisteredCampaign, bool) {
+	var best config.RegisteredCampaign
+	found := false
+	for _, c := range members {
+		if c.ID == currentID {
+			continue
+		}
+		if !found || moreRecent(c, best) {
+			best = c
+			found = true
+		}
+	}
+	return best, found
+}
+
+// moreRecent reports whether a should rank ahead of b for toggle: newer
+// last-access first, then name, then ID for a deterministic tiebreak.
+func moreRecent(a, b config.RegisteredCampaign) bool {
+	if !a.LastAccess.Equal(b.LastAccess) {
+		return a.LastAccess.After(b.LastAccess)
+	}
+	if a.Name != b.Name {
+		return a.Name < b.Name
+	}
+	return a.ID < b.ID
+}
+
+func indexOfID(members []config.RegisteredCampaign, id string) int {
+	for i, c := range members {
+		if c.ID == id {
+			return i
+		}
+	}
+	return -1
+}
+
+func noTargetReason(action, org string) string {
+	switch action {
+	case "toggle":
+		return fmt.Sprintf("no other campaign in org %q to toggle to", org)
+	default:
+		return fmt.Sprintf("no other campaign in org %q to cycle to", org)
+	}
+}
+
+// currentCampaign resolves the campaign containing the working directory along
+// with the loaded registry entry, so callers get both the org membership and
+// the shared registry for candidate resolution.
+func currentCampaign(ctx context.Context) (config.RegisteredCampaign, *config.Registry, error) {
+	root, err := campaign.DetectCached(ctx)
+	if err != nil {
+		return config.RegisteredCampaign{}, nil, camperrors.NewValidation("campaign",
+			"not inside a campaign; run 'corg' from within a campaign in the org", err)
+	}
+	cfg, err := config.LoadCampaignConfig(ctx, root)
+	if err != nil {
+		return config.RegisteredCampaign{}, nil, err
+	}
+	reg, err := config.LoadRegistry(ctx)
+	if err != nil {
+		return config.RegisteredCampaign{}, nil, camperrors.Wrap(err, "failed to load registry")
+	}
+	c, ok := reg.GetByID(cfg.ID)
+	if !ok {
+		return config.RegisteredCampaign{}, nil, camperrors.NewValidation("campaign",
+			"current campaign is not registered; run 'camp register' first", nil)
+	}
+	return c, reg, nil
+}
+
+type cycleCampaignOutput struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Org  string `json:"org"`
+	Path string `json:"path"`
+}
+
+type cycleOutput struct {
+	SchemaVersion string              `json:"schema_version"`
+	Action        string              `json:"action"`
+	From          cycleCampaignOutput `json:"from"`
+	To            cycleCampaignOutput `json:"to"`
+}
+
+func emitCycleTarget(w io.Writer, action string, from, to config.RegisteredCampaign, flags cycleFlags) error {
+	switch {
+	case flags.shellConnect:
+		_, err := fmt.Fprintf(w, "cd -- %s\n", remote.ShellQuote(to.Path))
+		return err
+	case flags.print:
+		_, err := fmt.Fprintln(w, to.Path)
+		return err
+	case flags.json:
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(cycleOutput{
+			SchemaVersion: cycleSchemaVersion,
+			Action:        action,
+			From:          cycleCampaignOutput{ID: from.ID, Name: from.Name, Org: from.Org, Path: from.Path},
+			To:            cycleCampaignOutput{ID: to.ID, Name: to.Name, Org: to.Org, Path: to.Path},
+		})
+	default:
+		_, err := fmt.Fprintf(w, "cd %s\n", to.Path)
+		return err
+	}
+}

--- a/cmd/camp/org/cycle_test.go
+++ b/cmd/camp/org/cycle_test.go
@@ -177,13 +177,17 @@ func TestEmitCycleTarget(t *testing.T) {
 		}
 	})
 
-	t.Run("plain emits cd", func(t *testing.T) {
+	t.Run("plain emits a quoted cd", func(t *testing.T) {
 		var buf bytes.Buffer
 		if err := emitCycleTarget(&buf, "next", from, to, cycleFlags{}); err != nil {
 			t.Fatal(err)
 		}
-		if got := buf.String(); got != "cd "+to.Path+"\n" {
-			t.Fatalf("plain output = %q, want %q", got, "cd "+to.Path+"\n")
+		got := buf.String()
+		if !strings.HasPrefix(got, "cd -- ") {
+			t.Fatalf("plain output %q missing 'cd -- ' prefix", got)
+		}
+		if strings.Contains(got, "/camps/needs quote\n") {
+			t.Fatalf("plain path with a space was not quoted: %q", got)
 		}
 	})
 

--- a/cmd/camp/org/cycle_test.go
+++ b/cmd/camp/org/cycle_test.go
@@ -1,0 +1,242 @@
+package org
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
+	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func mkCampaign(id, name string, last time.Time) config.RegisteredCampaign {
+	return config.RegisteredCampaign{ID: id, Name: name, Org: "obey", Status: config.StatusActive, LastAccess: last}
+}
+
+func ids(members []config.RegisteredCampaign) []string {
+	out := make([]string, len(members))
+	for i, m := range members {
+		out[i] = m.ID
+	}
+	return out
+}
+
+func TestNextInOrgCycle(t *testing.T) {
+	t0 := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+	ring := []config.RegisteredCampaign{
+		mkCampaign("A-1", "alpha", t0),
+		mkCampaign("B-2", "beta", t0),
+		mkCampaign("C-3", "gamma", t0),
+	}
+
+	tests := []struct {
+		name    string
+		members []config.RegisteredCampaign
+		current string
+		wantID  string
+		wantOK  bool
+	}{
+		{"advance from first", ring, "A-1", "B-2", true},
+		{"advance from middle", ring, "B-2", "C-3", true},
+		{"wrap from last", ring, "C-3", "A-1", true},
+		{"current absent falls to first", ring, "Z-9", "A-1", true},
+		{"single member has no next", ring[:1], "A-1", "", false},
+		{"empty set", nil, "A-1", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := nextInOrgCycle(tt.members, tt.current)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ok && got.ID != tt.wantID {
+				t.Errorf("next = %q, want %q", got.ID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestMostRecentOther(t *testing.T) {
+	early := time.Date(2026, 6, 16, 8, 0, 0, 0, time.UTC)
+	mid := time.Date(2026, 6, 16, 9, 0, 0, 0, time.UTC)
+	late := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+
+	members := []config.RegisteredCampaign{
+		mkCampaign("A-1", "alpha", early),
+		mkCampaign("B-2", "beta", late),
+		mkCampaign("C-3", "gamma", mid),
+	}
+
+	t.Run("picks newest other", func(t *testing.T) {
+		got, ok := mostRecentOther(members, "A-1")
+		if !ok || got.ID != "B-2" {
+			t.Fatalf("got %q ok=%v, want B-2", got.ID, ok)
+		}
+	})
+
+	t.Run("excludes current even when newest", func(t *testing.T) {
+		got, ok := mostRecentOther(members, "B-2")
+		if !ok || got.ID != "C-3" {
+			t.Fatalf("got %q ok=%v, want C-3", got.ID, ok)
+		}
+	})
+
+	t.Run("tie broken by name", func(t *testing.T) {
+		tied := []config.RegisteredCampaign{
+			mkCampaign("X-9", "zeta", late),
+			mkCampaign("Y-8", "delta", late),
+			mkCampaign("Z-7", "self", early),
+		}
+		got, ok := mostRecentOther(tied, "Z-7")
+		if !ok || got.Name != "delta" {
+			t.Fatalf("got %q ok=%v, want delta", got.Name, ok)
+		}
+	})
+
+	t.Run("no other member", func(t *testing.T) {
+		if _, ok := mostRecentOther(members[:1], "A-1"); ok {
+			t.Fatal("expected ok=false with only the current campaign")
+		}
+	})
+}
+
+func TestOrderedCycleMembers(t *testing.T) {
+	t0 := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+	reg := &config.Registry{Campaigns: map[string]config.RegisteredCampaign{
+		"B-2": {ID: "B-2", Name: "beta", Org: "obey", Status: config.StatusActive, LastAccess: t0},
+		"A-1": {ID: "A-1", Name: "alpha", Org: "obey", Status: config.StatusActive, LastAccess: t0},
+		"C-3": {ID: "C-3", Name: "gamma", Org: "obey", Status: config.StatusInactive, LastAccess: t0},
+		"D-4": {ID: "D-4", Name: "delta", Org: "other", Status: config.StatusActive, LastAccess: t0},
+	}}
+
+	t.Run("active org members sorted by name", func(t *testing.T) {
+		got := orderedCycleMembers(reg, cmdutil.CampaignScope{Org: "obey"})
+		if want := []string{"A-1", "B-2"}; !equalStrings(ids(got), want) {
+			t.Errorf("ids = %v, want %v", ids(got), want)
+		}
+	})
+
+	t.Run("all includes inactive", func(t *testing.T) {
+		got := orderedCycleMembers(reg, cmdutil.CampaignScope{Org: "obey", All: true})
+		if want := []string{"A-1", "B-2", "C-3"}; !equalStrings(ids(got), want) {
+			t.Errorf("ids = %v, want %v", ids(got), want)
+		}
+	})
+
+	t.Run("scope excludes other orgs", func(t *testing.T) {
+		got := orderedCycleMembers(reg, cmdutil.CampaignScope{Org: "obey", All: true})
+		for _, m := range got {
+			if m.ID == "D-4" {
+				t.Fatal("member from org 'other' leaked into 'obey' cycle")
+			}
+		}
+	})
+}
+
+func TestOrderedCycleMembersNameTieBrokenByID(t *testing.T) {
+	t0 := time.Date(2026, 6, 16, 10, 0, 0, 0, time.UTC)
+	reg := &config.Registry{Campaigns: map[string]config.RegisteredCampaign{
+		"B-2": {ID: "B-2", Name: "dup", Org: "obey", Status: config.StatusActive, LastAccess: t0},
+		"A-1": {ID: "A-1", Name: "dup", Org: "obey", Status: config.StatusActive, LastAccess: t0},
+	}}
+	got := orderedCycleMembers(reg, cmdutil.CampaignScope{Org: "obey"})
+	if want := []string{"A-1", "B-2"}; !equalStrings(ids(got), want) {
+		t.Errorf("ids = %v, want %v (name tie must break by ID)", ids(got), want)
+	}
+}
+
+func TestEmitCycleTarget(t *testing.T) {
+	from := config.RegisteredCampaign{ID: "A-1", Name: "alpha", Org: "obey", Path: "/camps/alpha"}
+	to := config.RegisteredCampaign{ID: "B-2", Name: "beta", Org: "obey", Path: "/camps/needs quote"}
+
+	t.Run("shell-connect quotes the path", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := emitCycleTarget(&buf, "next", from, to, cycleFlags{shellConnect: true}); err != nil {
+			t.Fatal(err)
+		}
+		got := buf.String()
+		if !strings.HasPrefix(got, "cd -- ") {
+			t.Fatalf("shell-connect output %q missing 'cd -- ' prefix", got)
+		}
+		if strings.Contains(got, "/camps/needs quote\n") {
+			t.Fatalf("path with a space was not quoted: %q", got)
+		}
+	})
+
+	t.Run("print emits path only", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := emitCycleTarget(&buf, "next", from, to, cycleFlags{print: true}); err != nil {
+			t.Fatal(err)
+		}
+		if got := buf.String(); got != to.Path+"\n" {
+			t.Fatalf("print output = %q, want %q", got, to.Path+"\n")
+		}
+	})
+
+	t.Run("plain emits cd", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := emitCycleTarget(&buf, "next", from, to, cycleFlags{}); err != nil {
+			t.Fatal(err)
+		}
+		if got := buf.String(); got != "cd "+to.Path+"\n" {
+			t.Fatalf("plain output = %q, want %q", got, "cd "+to.Path+"\n")
+		}
+	})
+
+	t.Run("json carries source and target", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := emitCycleTarget(&buf, "toggle", from, to, cycleFlags{json: true}); err != nil {
+			t.Fatal(err)
+		}
+		var out cycleOutput
+		if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+			t.Fatalf("invalid json: %v", err)
+		}
+		if out.SchemaVersion != cycleSchemaVersion {
+			t.Errorf("schema = %q, want %q", out.SchemaVersion, cycleSchemaVersion)
+		}
+		if out.Action != "toggle" {
+			t.Errorf("action = %q, want toggle", out.Action)
+		}
+		if out.From.ID != "A-1" || out.To.ID != "B-2" || out.To.Path != to.Path {
+			t.Errorf("unexpected from/to: %+v", out)
+		}
+	})
+}
+
+func TestCycleFlagsConflicts(t *testing.T) {
+	newCmd := func(print, jsonOut, shell bool) *cobra.Command {
+		c := &cobra.Command{}
+		c.Flags().Bool("print", print, "")
+		c.Flags().Bool("json", jsonOut, "")
+		c.Flags().Bool("all", false, "")
+		c.Flags().Bool("shell-connect", shell, "")
+		return c
+	}
+
+	if _, err := cycleFlagsFrom(newCmd(true, true, false)); err == nil {
+		t.Error("expected error for --print with --json")
+	}
+	if _, err := cycleFlagsFrom(newCmd(true, false, true)); err == nil {
+		t.Error("expected error for --shell-connect with --print")
+	}
+	if _, err := cycleFlagsFrom(newCmd(false, false, true)); err != nil {
+		t.Errorf("shell-connect alone should be valid: %v", err)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -40,6 +40,8 @@ var manifestAgentAllowedReasons = map[string]string{
 	"machine diagnose":           "Read path (socket status) is safe; never pass --reset from an agent",
 	"machine list":               "Read-only listing of ~/.obey/machines.yaml",
 	"machine remove":             "Non-interactive removal with explicit id argument",
+	"org next":                   "Non-interactive; --print/--json resolve the next org campaign without a TUI",
+	"org toggle":                 "Non-interactive; --print/--json resolve the last-visited org campaign without a TUI",
 	"project list":               "Read-only project listing",
 	"project remote list":        "Read-only project remote listing",
 	"promote":                    "Routes to a type-specific promote; needs an explicit id and --target in non-interactive use",

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -3731,6 +3731,53 @@ camp org list [flags]
 ```
 ---
 
+## camp org next
+
+Switch to the next campaign in the current campaign's org
+
+### Synopsis
+
+Switch to the next campaign in the current campaign's org.
+
+Members are ordered by name, so the cycle is stable and predictable
+(a -> b -> c -> a). By default only active campaigns are cycled; use --all to
+include inactive and reference campaigns.
+
+Use with the corg shell function for instant navigation:
+  corg        # cd to the next campaign in this org
+
+The --print flag outputs just the target path for shell integration, and --json
+emits the resolved source and target campaigns.
+
+```
+camp org next [flags]
+```
+
+### Examples
+
+```
+  camp org next            # Print cd to the next org campaign
+  camp org next --print    # Print the target path only
+  camp org next --all      # Include inactive/reference campaigns
+  camp org next --json
+```
+
+### Options
+
+```
+      --all     Include inactive and reference campaigns in the cycle
+  -h, --help    help for next
+      --json    Output the resolved source and target campaigns as JSON
+      --print   Print the target path only (for shell integration)
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
 ## camp org remove
 
 Return campaigns to the default org
@@ -3821,6 +3868,50 @@ camp org show <org> [flags]
 ```
   -h, --help   help for show
       --json   Output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
+## camp org toggle
+
+Toggle back to the last-visited campaign in the current org
+
+### Synopsis
+
+Toggle back to the most recently visited other campaign in the current org.
+
+"Most recently visited" is tracked by last-access time, which camp updates on
+every 'camp switch' and 'camp org next'/'toggle'. Paired with 'camp org next',
+this gives a natural A <-> B toggle within an org. By default only active
+campaigns are considered; use --all to include inactive and reference campaigns.
+
+Use with the corg shell function for instant navigation:
+  corg t      # cd back to the last org campaign you were in
+
+```
+camp org toggle [flags]
+```
+
+### Examples
+
+```
+  camp org toggle          # Print cd to the last-visited org campaign
+  camp org toggle --print  # Print the target path only
+  camp org toggle --json
+```
+
+### Options
+
+```
+      --all     Include inactive and reference campaigns in the cycle
+  -h, --help    help for toggle
+      --json    Output the resolved source and target campaigns as JSON
+      --print   Print the target path only (for shell integration)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_org.md
+++ b/docs/cli-reference/camp_org.md
@@ -59,7 +59,9 @@ camp org [flags]
 * [camp org create](camp_org_create.md)	 - Create an org (optionally empty) and join campaigns
 * [camp org delete](camp_org_delete.md)	 - Delete an org (empty only unless --force)
 * [camp org list](camp_org_list.md)	 - List orgs with member and active counts
+* [camp org next](camp_org_next.md)	 - Switch to the next campaign in the current campaign's org
 * [camp org remove](camp_org_remove.md)	 - Return campaigns to the default org
 * [camp org rename](camp_org_rename.md)	 - Rename an org, reassigning all members atomically
 * [camp org show](camp_org_show.md)	 - Show an org's member campaigns
+* [camp org toggle](camp_org_toggle.md)	 - Toggle back to the last-visited campaign in the current org
 * [camp org which](camp_org_which.md)	 - Print the current campaign's org

--- a/docs/cli-reference/camp_org_next.md
+++ b/docs/cli-reference/camp_org_next.md
@@ -1,0 +1,49 @@
+## camp org next
+
+Switch to the next campaign in the current campaign's org
+
+### Synopsis
+
+Switch to the next campaign in the current campaign's org.
+
+Members are ordered by name, so the cycle is stable and predictable
+(a -> b -> c -> a). By default only active campaigns are cycled; use --all to
+include inactive and reference campaigns.
+
+Use with the corg shell function for instant navigation:
+  corg        # cd to the next campaign in this org
+
+The --print flag outputs just the target path for shell integration, and --json
+emits the resolved source and target campaigns.
+
+```
+camp org next [flags]
+```
+
+### Examples
+
+```
+  camp org next            # Print cd to the next org campaign
+  camp org next --print    # Print the target path only
+  camp org next --all      # Include inactive/reference campaigns
+  camp org next --json
+```
+
+### Options
+
+```
+      --all     Include inactive and reference campaigns in the cycle
+  -h, --help    help for next
+      --json    Output the resolved source and target campaigns as JSON
+      --print   Print the target path only (for shell integration)
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp org](camp_org.md)	 - Group campaigns into orgs

--- a/docs/cli-reference/camp_org_toggle.md
+++ b/docs/cli-reference/camp_org_toggle.md
@@ -1,0 +1,46 @@
+## camp org toggle
+
+Toggle back to the last-visited campaign in the current org
+
+### Synopsis
+
+Toggle back to the most recently visited other campaign in the current org.
+
+"Most recently visited" is tracked by last-access time, which camp updates on
+every 'camp switch' and 'camp org next'/'toggle'. Paired with 'camp org next',
+this gives a natural A <-> B toggle within an org. By default only active
+campaigns are considered; use --all to include inactive and reference campaigns.
+
+Use with the corg shell function for instant navigation:
+  corg t      # cd back to the last org campaign you were in
+
+```
+camp org toggle [flags]
+```
+
+### Examples
+
+```
+  camp org toggle          # Print cd to the last-visited org campaign
+  camp org toggle --print  # Print the target path only
+  camp org toggle --json
+```
+
+### Options
+
+```
+      --all     Include inactive and reference campaigns in the cycle
+  -h, --help    help for toggle
+      --json    Output the resolved source and target campaigns as JSON
+      --print   Print the target path only (for shell integration)
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp org](camp_org.md)	 - Group campaigns into orgs

--- a/internal/shell/templates/bash.sh.tmpl
+++ b/internal/shell/templates/bash.sh.tmpl
@@ -302,6 +302,39 @@ csw() {
   camp switch "$@"
 }
 
+# Camp workitem shorthand.
+# Routes through the camp() wrapper, so selecting a work item cd's to it.
+# Usage: cwi [filters]
+cwi() {
+  camp workitem "$@"
+}
+
+# Cycle through campaigns in the current campaign's org.
+# Usage:
+#   corg        cd to the next campaign in this org (stable, name-ordered)
+#   corg t      cd back to the last-visited campaign in this org
+#   corg --all  include inactive/reference campaigns in the cycle
+# Inspection flags (--print/--json/--help) print without changing directory.
+corg() {
+  local action=next line arg
+  case "${1:-}" in
+    t|toggle|back)
+      action=toggle
+      shift
+      ;;
+  esac
+  for arg in "$@"; do
+    case "$arg" in
+      --help|-h|--print|--print=*|--json|--json=*)
+        command camp org "$action" "$@"
+        return
+        ;;
+    esac
+  done
+  line=$(command camp org "$action" --shell-connect "$@") || return $?
+  [ -n "$line" ] && eval "$line"
+}
+
 # Quick intent capture
 # Usage: cint "my idea"
 cint() {

--- a/internal/shell/templates/fish.sh.tmpl
+++ b/internal/shell/templates/fish.sh.tmpl
@@ -314,6 +314,46 @@ function csw --description "Switch campaigns (shorthand for camp switch)"
     camp switch $argv
 end
 
+# Camp workitem shorthand.
+# Routes through the camp wrapper, so selecting a work item cd's to it.
+# Usage: cwi [filters]
+function cwi --description "Camp workitem shorthand (cd's to the selected item)"
+    camp workitem $argv
+end
+
+# Cycle through campaigns in the current campaign's org.
+# Usage:
+#   corg        cd to the next campaign in this org (stable, name-ordered)
+#   corg t      cd back to the last-visited campaign in this org
+#   corg --all  include inactive/reference campaigns in the cycle
+function corg --description "Cycle through campaigns in the current org"
+    set -l action next
+    set -l rest $argv
+    if test (count $rest) -gt 0
+        switch "$rest[1]"
+            case t toggle back
+                set action toggle
+                set rest $rest[2..-1]
+        end
+    end
+    # Inspection flags print without changing directory.
+    for arg in $rest
+        switch "$arg"
+            case --help -h --print '--print=*' --json '--json=*'
+                command camp org $action $rest
+                return $status
+        end
+    end
+    set -l line (command camp org $action --shell-connect $rest)
+    set -l cmd_status $status
+    if test "$cmd_status" -ne 0
+        return $cmd_status
+    end
+    if test -n "$line"
+        eval "$line"
+    end
+end
+
 # Quick intent capture
 # Usage: cint "my idea"
 function cint --description "Quick intent capture"

--- a/internal/shell/templates/zsh.sh.tmpl
+++ b/internal/shell/templates/zsh.sh.tmpl
@@ -387,6 +387,39 @@ _csw() {
 
   (( ${#campaigns} )) && compadd -a campaigns
 }
+# Camp workitem shorthand.
+# Routes through the camp() wrapper, so selecting a work item cd's to it.
+# Usage: cwi [filters]
+cwi() {
+  camp workitem "$@"
+}
+
+# Cycle through campaigns in the current campaign's org.
+# Usage:
+#   corg        cd to the next campaign in this org (stable, name-ordered)
+#   corg t      cd back to the last-visited campaign in this org
+#   corg --all  include inactive/reference campaigns in the cycle
+# Inspection flags (--print/--json/--help) print without changing directory.
+corg() {
+  local action=next line arg
+  case "${1:-}" in
+    t|toggle|back)
+      action=toggle
+      shift
+      ;;
+  esac
+  for arg in "$@"; do
+    case "$arg" in
+      --help|-h|--print|--print=*|--json|--json=*)
+        command camp org "$action" "$@"
+        return
+        ;;
+    esac
+  done
+  line=$(command camp org "$action" --shell-connect "$@") || return $?
+  [[ -n "$line" ]] && eval "$line"
+}
+
 # Quick intent capture
 # Usage: cint "my idea"
 cint() {

--- a/internal/shell/zsh_test.go
+++ b/internal/shell/zsh_test.go
@@ -25,6 +25,11 @@ func TestGenerateZsh(t *testing.T) {
 		{"cint implementation", "camp intent add"},
 		{"cnote function", "cnote()"},
 		{"cnote implementation", "camp intent note"},
+		{"cwi function", "cwi()"},
+		{"cwi implementation", "camp workitem"},
+		{"corg function", "corg()"},
+		{"corg next call", "camp org \"$action\" --shell-connect"},
+		{"corg toggle dispatch", "t|toggle|back)"},
 		{"cd command", "cd \"$dest\""},
 		{"camp go call", "camp go"},
 		{"command camp binary call", "command camp"},
@@ -264,6 +269,12 @@ func TestGenerateBash_Basic(t *testing.T) {
 	if !strings.Contains(output, "cgo()") {
 		t.Error("bash init missing cgo function")
 	}
+	if !strings.Contains(output, "cwi()") {
+		t.Error("bash init missing cwi function")
+	}
+	if !strings.Contains(output, "corg()") {
+		t.Error("bash init missing corg function")
+	}
 }
 
 func TestGenerateFish_Basic(t *testing.T) {
@@ -276,6 +287,12 @@ func TestGenerateFish_Basic(t *testing.T) {
 	// Check for cgo function
 	if !strings.Contains(output, "function cgo") {
 		t.Error("fish init missing cgo function")
+	}
+	if !strings.Contains(output, "function cwi") {
+		t.Error("fish init missing cwi function")
+	}
+	if !strings.Contains(output, "function corg") {
+		t.Error("fish init missing corg function")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds two shell conveniences to the camp shell integration:

- **`cwi`** — alias for `camp workitem`. Routes through the `camp()` wrapper, so selecting a work item cd's to it (mirrors `csw`/`cgo`).
- **`corg`** — cycle campaigns within the current campaign's org:
  - `corg` → next active campaign, name-ordered (stable `A→B→C→A` ring, wraps)
  - `corg t` → toggle back to the most-recently-visited *other* campaign in the org
  - `corg --all` → include inactive/reference campaigns
  - Inspection flags (`--print`/`--json`/`--help`) print without changing directory

## Design

The cycle logic lives in Go as two new subcommands, `camp org next` and `camp org toggle`, each emitting a `cd` line the shell evals via `--shell-connect` — the same mechanism `camp switch` already uses. `corg` is a thin dispatcher in the zsh/bash/fish templates.

Toggle reuses the registry's existing `LastAccess` timestamp (maintained by `switch` and by these commands), so:
- `corg` + `corg t` form a natural A↔B toggle
- it composes with regular `csw` navigation
- no new registry state or schema bump is needed

Both subcommands support `--print`/`--json`/`--all`, resolve the current campaign from cwd via the existing `campaign.DetectCached` path, scope to the current campaign's org via `cmdutil.FilterCampaigns`, and are registered `agent_allowed` (parity with `switch`).

## Behavior notes

- Single-member org: emits nothing on stdout (so the shell `eval` is a no-op) plus a stderr note.
- Not inside a registered campaign: clean validation error, non-zero exit.

## Tests / verification

- Unit coverage for cycle resolution (wrap, current-absent, single-member), toggle ordering (newest-other, current-excluded, tie-break), scope filtering (active-only vs `--all`, cross-org isolation), and output emission (shell-connect quoting, print, json, plain).
- Shell template tests assert `cwi`/`corg` across zsh/bash/fish; rendered init passes `zsh -n` / `bash -n`.
- Drove the real zsh integration end-to-end: `corg` walked `alpha→beta→gamma→alpha`; `corg t` toggled `gamma↔alpha`.
- `just gate-fast`: 3390/3390 tests pass, lint clean.

CLI reference docs regenerated in a separate commit.
