### PR TITLE
feat(fresh): reorder follow-up workflow steps

### DIFF
--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -1544,7 +1544,7 @@ successful sync/prune/branch cycle. Configuration lives in
 per-project override lists that replace the global list entirely.
 
 Run without a subcommand to open the interactive setup for humans. Use
-show, add, and remove for scripts and agents.
+show, add, move, and remove for scripts and agents.
 
 Examples:
   camp fresh configure
@@ -1552,6 +1552,7 @@ Examples:
   camp fresh configure show
   camp fresh configure add install --run "npm install"
   camp fresh configure add build --run "go build ./..." --project camp --dir cmd/camp
+  camp fresh configure move build --up --project camp
   camp fresh configure remove install
   camp fresh configure remove build --project camp
 
@@ -1594,6 +1595,36 @@ camp fresh configure add <name> [flags]
   -h, --help                help for add
       --project string      Scope this follow-up to a single project (default: global)
       --run string          Command to run for this follow-up step (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --branch string   Branch to create after syncing (overrides config)
+  -n, --dry-run         Preview without making changes
+      --no-branch       Skip branch creation even if configured
+      --no-color        disable colored output
+      --no-follow-up    Skip configured follow-up command workflows
+      --no-prune        Skip pruning merged branches
+      --no-push         Skip pushing the new branch upstream
+```
+---
+
+## camp fresh configure move
+
+Move a follow-up command workflow step
+
+```
+camp fresh configure move <name> [flags]
+```
+
+### Options
+
+```
+      --down             Move the step later in the workflow
+  -h, --help             help for move
+      --project string   Scope the move to a single project (default: global)
+      --up               Move the step earlier in the workflow
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_fresh_configure.md
+++ b/docs/cli-reference/camp_fresh_configure.md
@@ -10,7 +10,7 @@ successful sync/prune/branch cycle. Configuration lives in
 per-project override lists that replace the global list entirely.
 
 Run without a subcommand to open the interactive setup for humans. Use
-show, add, and remove for scripts and agents.
+show, add, move, and remove for scripts and agents.
 
 Examples:
   camp fresh configure
@@ -18,6 +18,7 @@ Examples:
   camp fresh configure show
   camp fresh configure add install --run "npm install"
   camp fresh configure add build --run "go build ./..." --project camp --dir cmd/camp
+  camp fresh configure move build --up --project camp
   camp fresh configure remove install
   camp fresh configure remove build --project camp
 
@@ -47,5 +48,6 @@ camp fresh configure [flags]
 
 * [camp fresh](camp_fresh.md)	 - Post-merge branch cycling: sync to default branch and optionally create a new working branch
 * [camp fresh configure add](camp_fresh_configure_add.md)	 - Add a follow-up command workflow step
+* [camp fresh configure move](camp_fresh_configure_move.md)	 - Move a follow-up command workflow step
 * [camp fresh configure remove](camp_fresh_configure_remove.md)	 - Remove a follow-up command workflow step
 * [camp fresh configure show](camp_fresh_configure_show.md)	 - Show configured follow-up workflows

--- a/docs/cli-reference/camp_fresh_configure_move.md
+++ b/docs/cli-reference/camp_fresh_configure_move.md
@@ -1,0 +1,32 @@
+## camp fresh configure move
+
+Move a follow-up command workflow step
+
+```
+camp fresh configure move <name> [flags]
+```
+
+### Options
+
+```
+      --down             Move the step later in the workflow
+  -h, --help             help for move
+      --project string   Scope the move to a single project (default: global)
+      --up               Move the step earlier in the workflow
+```
+
+### Options inherited from parent commands
+
+```
+  -b, --branch string   Branch to create after syncing (overrides config)
+  -n, --dry-run         Preview without making changes
+      --no-branch       Skip branch creation even if configured
+      --no-color        disable colored output
+      --no-follow-up    Skip configured follow-up command workflows
+      --no-prune        Skip pruning merged branches
+      --no-push         Skip pushing the new branch upstream
+```
+
+### SEE ALSO
+
+* [camp fresh configure](camp_fresh_configure.md)	 - Configure camp fresh follow-up commands

--- a/internal/commands/fresh/configure.go
+++ b/internal/commands/fresh/configure.go
@@ -26,7 +26,7 @@ successful sync/prune/branch cycle. Configuration lives in
 per-project override lists that replace the global list entirely.
 
 Run without a subcommand to open the interactive setup for humans. Use
-show, add, and remove for scripts and agents.
+show, add, move, and remove for scripts and agents.
 
 Examples:
   camp fresh configure
@@ -34,6 +34,7 @@ Examples:
   camp fresh configure show
   camp fresh configure add install --run "npm install"
   camp fresh configure add build --run "go build ./..." --project camp --dir cmd/camp
+  camp fresh configure move build --up --project camp
   camp fresh configure remove install
   camp fresh configure remove build --project camp`,
 		Args: cobra.NoArgs,
@@ -42,6 +43,7 @@ Examples:
 
 	configureCmd.AddCommand(newConfigureShowCommand())
 	configureCmd.AddCommand(newConfigureAddCommand())
+	configureCmd.AddCommand(newConfigureMoveCommand())
 	configureCmd.AddCommand(newConfigureRemoveCommand())
 
 	return configureCmd
@@ -209,6 +211,59 @@ func newConfigureRemoveCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&project, "project", "", "Scope removal to a single project (default: global)")
+
+	return cmd
+}
+
+func newConfigureMoveCommand() *cobra.Command {
+	var (
+		project string
+		up      bool
+		down    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "move <name>",
+		Short: "Move a follow-up command workflow step",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if up == down {
+				return camperrors.NewValidation("direction", "choose exactly one of --up or --down", nil)
+			}
+
+			ctx := cmd.Context()
+			campRoot, err := campaign.DetectCached(ctx)
+			if err != nil {
+				return camperrors.Wrap(err, "not in a campaign")
+			}
+
+			cfg, err := config.LoadFreshConfig(ctx, campRoot)
+			if err != nil {
+				return camperrors.Wrap(err, "loading fresh config")
+			}
+			name := args[0]
+			delta := 1
+			direction := "down"
+			if up {
+				delta = -1
+				direction = "up"
+			}
+			ordered, err := config.ReorderFreshFollowUps(cfg.ResolveFreshFollowUps(project), name, delta)
+			if err != nil {
+				return err
+			}
+			if err := config.SetFreshFollowUps(ctx, campRoot, project, ordered); err != nil {
+				return err
+			}
+
+			fmt.Println(ui.Success(fmt.Sprintf("Moved follow-up %q %s (%s)", name, direction, followUpScopeDescription(project))))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&project, "project", "", "Scope the move to a single project (default: global)")
+	cmd.Flags().BoolVar(&up, "up", false, "Move the step earlier in the workflow")
+	cmd.Flags().BoolVar(&down, "down", false, "Move the step later in the workflow")
 
 	return cmd
 }

--- a/internal/commands/fresh/configure_tui_update.go
+++ b/internal/commands/fresh/configure_tui_update.go
@@ -45,6 +45,10 @@ func (m *followUpTUIModel) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.moveCursor(-1)
 	case "down", "j":
 		m.moveCursor(1)
+	case "shift+up", "K":
+		return m, m.moveSelectedFollowUp(-1)
+	case "shift+down", "J":
+		return m, m.moveSelectedFollowUp(1)
 	case "left", "h":
 		m.pane = followUpScopesPane
 	case "right", "l", "tab":
@@ -84,6 +88,43 @@ func (m *followUpTUIModel) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.overlay = followUpHelpOverlay
 	}
 	return m, nil
+}
+
+func (m *followUpTUIModel) moveSelectedFollowUp(delta int) tea.Cmd {
+	_, entry, ok := m.selectedFollowUp()
+	if !ok {
+		m.setError(camperrors.New("select a follow-up step to move"))
+		return nil
+	}
+
+	ordered, err := config.ReorderFreshFollowUps(m.effectiveFollowUps(), entry.Name, delta)
+	if err != nil {
+		m.setError(err)
+		return nil
+	}
+
+	scope := m.selectedScope()
+	if err := config.SetFreshFollowUps(m.ctx, m.root, scopeProjectName(scope), ordered); err != nil {
+		m.setError(err)
+		return nil
+	}
+	if err := m.refresh(scope); err != nil {
+		m.setError(err)
+		return nil
+	}
+
+	for i, step := range m.workflowSteps() {
+		if step.Follow != nil && step.Follow.Name == entry.Name {
+			m.stepCursor = i
+			break
+		}
+	}
+	direction := "down"
+	if delta < 0 {
+		direction = "up"
+	}
+	m.setStatus(fmt.Sprintf("moved %q %s", entry.Name, direction))
+	return nil
 }
 
 func (m *followUpTUIModel) moveCursor(delta int) {

--- a/internal/commands/fresh/configure_tui_view.go
+++ b/internal/commands/fresh/configure_tui_view.go
@@ -199,9 +199,9 @@ func (m *followUpTUIModel) frame(lines []string, width, height int) string {
 }
 
 func (m *followUpTUIModel) footer(width int) string {
-	full := "j/k: move · h/l: switch pane · a: add · e: edit · d: delete · r: reload · ?: help · q: quit"
-	mid := "j/k move · h/l pane · a add · e edit · d delete · ? help · q quit"
-	short := "j/k · h/l · a/e/d · ? · q"
+	full := "j/k: select · K/J: move step · h/l: switch pane · a: add · e: edit · d: delete · r: reload · ?: help · q: quit"
+	mid := "j/k select · K/J move · h/l pane · a add · e edit · d delete · ? help · q quit"
+	short := "j/k · K/J · h/l · a/e/d · ? · q"
 	return freshTUIHelpStyle.Render(ui.CollapseHelp(width, full, mid, short, "q: quit"))
 }
 
@@ -228,6 +228,7 @@ func (m *followUpTUIModel) overlayView() string {
 			"",
 			freshPrimary.Render("a  add a follow-up after the core sync steps"),
 			freshPrimary.Render("e  edit the selected follow-up"),
+			freshPrimary.Render("K/J  move the selected follow-up earlier/later"),
 			freshPrimary.Render("d  delete the selected follow-up"),
 			freshPrimary.Render("r  reload fresh.yaml from disk"),
 			freshPrimary.Render("h/l or tab  move between scopes and workflow"),

--- a/internal/config/fresh_followup.go
+++ b/internal/config/fresh_followup.go
@@ -133,6 +133,46 @@ func SetFreshFollowUps(ctx context.Context, campaignRoot, projectName string, en
 	})
 }
 
+// ReorderFreshFollowUps moves the named follow-up one position in the
+// effective workflow. It returns a new slice and leaves entries unchanged.
+// A positive delta moves the step later; a negative delta moves it earlier.
+// Core fresh steps are intentionally outside this helper: follow-ups are the
+// user-defined portion of the workflow and can be safely reordered without
+// violating fresh's sync and branch dependencies.
+func ReorderFreshFollowUps(entries []FollowUpConfig, name string, delta int) ([]FollowUpConfig, error) {
+	if delta != -1 && delta != 1 {
+		return nil, camperrors.NewValidation("delta", "must be -1 or 1", nil)
+	}
+
+	idx := -1
+	for i, entry := range entries {
+		if entry.Name == name {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		names := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name)
+		}
+		return nil, &FollowUpNotFoundError{Name: name, Scope: "workflow", ValidNames: names}
+	}
+
+	target := idx + delta
+	if target < 0 || target >= len(entries) {
+		direction := "first"
+		if delta > 0 {
+			direction = "last"
+		}
+		return nil, camperrors.Newf("follow-up %q is already the %s step", name, direction)
+	}
+
+	ordered := append([]FollowUpConfig(nil), entries...)
+	ordered[idx], ordered[target] = ordered[target], ordered[idx]
+	return ordered, nil
+}
+
 // withFreshConfigLock loads fresh.yaml as a raw YAML document (creating an
 // empty mapping document if the file is missing or has no parseable
 // mapping content), runs mutate against its top-level mapping, then writes

--- a/internal/config/fresh_followup_test.go
+++ b/internal/config/fresh_followup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -43,6 +44,67 @@ func TestFollowUpConfig_Validate(t *testing.T) {
 			}
 			if !tt.wantErr && err != nil {
 				t.Fatalf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestReorderFreshFollowUps(t *testing.T) {
+	entries := []FollowUpConfig{
+		{Name: "install", Run: "npm install"},
+		{Name: "generate", Run: "npm run generate"},
+		{Name: "build", Run: "npm run build"},
+	}
+
+	tests := []struct {
+		name  string
+		step  string
+		delta int
+		want  []string
+	}{
+		{name: "up", step: "build", delta: -1, want: []string{"install", "build", "generate"}},
+		{name: "down", step: "install", delta: 1, want: []string{"generate", "install", "build"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ReorderFreshFollowUps(entries, tt.step, tt.delta)
+			if err != nil {
+				t.Fatalf("ReorderFreshFollowUps() error = %v", err)
+			}
+			var names []string
+			for _, entry := range got {
+				names = append(names, entry.Name)
+			}
+			if !reflect.DeepEqual(names, tt.want) {
+				t.Fatalf("reordered names = %v, want %v", names, tt.want)
+			}
+		})
+	}
+
+	if !reflect.DeepEqual(entries, []FollowUpConfig{
+		{Name: "install", Run: "npm install"},
+		{Name: "generate", Run: "npm run generate"},
+		{Name: "build", Run: "npm run build"},
+	}) {
+		t.Fatal("ReorderFreshFollowUps mutated its input")
+	}
+}
+
+func TestReorderFreshFollowUpsRejectsInvalidMoves(t *testing.T) {
+	entries := []FollowUpConfig{{Name: "install", Run: "npm install"}}
+	for _, tt := range []struct {
+		name  string
+		step  string
+		delta int
+	}{
+		{name: "already first", step: "install", delta: -1},
+		{name: "already last", step: "install", delta: 1},
+		{name: "unknown step", step: "missing", delta: -1},
+		{name: "invalid delta", step: "install", delta: 2},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ReorderFreshFollowUps(entries, tt.step, tt.delta); err == nil {
+				t.Fatal("ReorderFreshFollowUps() error = nil, want error")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- add safe reordering for user-defined `camp fresh` follow-up steps
- support `K`/`J` movement in the human-facing configuration TUI
- add `camp fresh configure move <name> --up|--down` for scripts and agents
- preserve global defaults and project override behavior when an order is edited
- document the new command in the generated CLI reference

## Why

PR #440 makes the resolved `camp fresh` sequence visible. This follow-up makes that sequence actionable: humans can change the order of their follow-up commands instead of editing YAML by hand.

Core sync and branch steps remain protected because their ordering carries safety and dependency guarantees. This PR limits movement to the user-defined follow-up portion of the workflow.

## Usage

In `camp fresh configure`, select a follow-up and press `K` to move it earlier or `J` to move it later. The change is persisted immediately and the selected step stays selected.

For automation:

```sh
camp fresh configure move build --up
camp fresh configure move test --down --project camp
```

## Validation

- `go test ./...`
- `just docs`
- `just lint`
- `just gate-fast` — 3,392/3,392 tests passed
- real PTY + pyte verification of TUI movement, persisted YAML order, and ANSI color output
