### PR TITLE
fix: converge camp worktrees list and camp project worktree list on git-derived enumeration

### DIFF
--- a/cmd/camp/project/worktree/list.go
+++ b/cmd/camp/project/worktree/list.go
@@ -3,12 +3,12 @@ package worktree
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
 	"github.com/Obedience-Corp/camp/internal/campaign"
-	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
-	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	intworktree "github.com/Obedience-Corp/camp/internal/worktree"
@@ -52,11 +52,6 @@ func runProjectWorktreeList(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "not in a campaign")
 	}
 
-	cfg, err := config.LoadCampaignConfig(ctx, campRoot)
-	if err != nil {
-		return camperrors.Wrap(err, "failed to load campaign config")
-	}
-
 	resolved, err := project.Resolve(ctx, campRoot, wtListProject)
 	if err != nil {
 		var notFound *project.ProjectNotFoundError
@@ -70,21 +65,23 @@ func runProjectWorktreeList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	resolver := paths.NewResolver(campRoot, cfg.Paths())
-	pathManager := intworktree.NewPathManager(resolver)
-
 	git := intworktree.NewGitWorktree(resolved.Path)
 	entries, err := git.List(ctx)
 	if err != nil {
 		return camperrors.Wrap(err, "failed to list worktrees")
 	}
 
-	names, err := pathManager.ListProjectWorktrees(projectName)
-	if err != nil {
-		return camperrors.Wrap(err, "failed to list worktree directories")
+	// git worktree list is the source of truth: it finds every linked
+	// worktree regardless of where it lives on disk, not just those under
+	// the conventional projects/worktrees/<project>/ layout.
+	var linked []intworktree.GitWorktreeEntry
+	for _, entry := range entries {
+		if intworktree.IsLinkedWorktree(resolved.Path, entry) {
+			linked = append(linked, entry)
+		}
 	}
 
-	if len(names) == 0 {
+	if len(linked) == 0 {
 		fmt.Printf("No worktrees for project %s\n", ui.Value(projectName))
 		fmt.Println(ui.Dim("Create one with: camp project worktree add <name>"))
 		return nil
@@ -92,25 +89,29 @@ func runProjectWorktreeList(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Worktrees for %s:\n\n", ui.Value(projectName))
 
-	entryMap := make(map[string]intworktree.GitWorktreeEntry)
-	for _, e := range entries {
-		entryMap[e.Path] = e
-	}
-
-	for _, name := range names {
-		wtPath := pathManager.WorktreePath(projectName, name)
-		relPath := pathManager.RelativeWorktreePath(projectName, name)
+	for _, entry := range linked {
+		clean := filepath.Clean(entry.Path)
+		name := filepath.Base(clean)
 
 		fmt.Printf("  %s\n", ui.Value(name))
-		if entry, ok := entryMap[wtPath]; ok {
-			fmt.Printf("    Branch: %s\n", ui.Dim(entry.Branch))
-			if entry.IsLocked {
-				fmt.Printf("    Status: %s\n", ui.Warning("locked"))
-			}
+		fmt.Printf("    Branch: %s\n", ui.Dim(entry.Branch))
+		if entry.IsLocked {
+			fmt.Printf("    Status: %s\n", ui.Warning("locked"))
 		}
-		fmt.Printf("    Path:   %s\n", ui.Dim(relPath))
+		fmt.Printf("    Path:   %s\n", ui.Dim(displayWorktreePath(campRoot, clean)))
 		fmt.Println()
 	}
 
 	return nil
+}
+
+// displayWorktreePath renders path relative to campRoot when it lives inside
+// the campaign, falling back to the absolute path for worktrees created
+// outside the campaign root.
+func displayWorktreePath(campRoot, path string) string {
+	rel, err := filepath.Rel(campRoot, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return path
+	}
+	return rel
 }

--- a/cmd/camp/worktrees/list.go
+++ b/cmd/camp/worktrees/list.go
@@ -13,10 +13,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
-	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/jsoncontract"
-	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/Obedience-Corp/camp/internal/worktree"
@@ -93,14 +91,6 @@ func runWorktreesList(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "not in a campaign")
 	}
 
-	cfg, err := config.LoadCampaignConfig(ctx, campRoot)
-	if err != nil {
-		return camperrors.Wrap(err, "failed to load campaign config")
-	}
-
-	resolver := paths.NewResolver(campRoot, cfg.Paths())
-	pathManager := worktree.NewPathManager(resolver)
-
 	// In a terminal, a bare `camp worktrees list` opens the interactive browser
 	// (the same pattern as `camp list`). The browser holds every worktree and
 	// applies --stale as a live, toggleable filter, so load unfiltered for it;
@@ -111,7 +101,7 @@ func runWorktreesList(cmd *cobra.Command, args []string) error {
 		loadStale = false
 	}
 
-	result, err := listWorktrees(ctx, campRoot, pathManager, listProject, loadStale)
+	result, err := listWorktrees(ctx, campRoot, listProject, loadStale)
 	if err != nil {
 		return err
 	}
@@ -132,7 +122,7 @@ type listProjectTarget struct {
 	path string
 }
 
-func listWorktrees(ctx context.Context, campRoot string, pm *worktree.PathManager, filterProject string, staleOnly bool) (*WorktreeListResult, error) {
+func listWorktrees(ctx context.Context, campRoot string, filterProject string, staleOnly bool) (*WorktreeListResult, error) {
 	var allWorktrees []WorktreeListItem
 
 	projectTargets, err := listWorktreeProjectTargets(ctx, campRoot, filterProject)
@@ -140,7 +130,9 @@ func listWorktrees(ctx context.Context, campRoot string, pm *worktree.PathManage
 		return nil, err
 	}
 
-	// Scan each project
+	// Scan each project. git worktree list is the source of truth: it finds
+	// every linked worktree regardless of where it lives on disk, not just
+	// those under the conventional projects/worktrees/<project>/ layout.
 	for _, target := range projectTargets {
 		gitEntries, err := worktree.NewGitWorktree(target.path).List(ctx)
 		if err != nil {
@@ -151,14 +143,12 @@ func listWorktrees(ctx context.Context, campRoot string, pm *worktree.PathManage
 		}
 
 		projectName := target.name
-		fsWorktrees, err := pm.ListProjectWorktrees(projectName)
-		if err != nil {
-			continue // Skip projects with errors
-		}
-
-		for _, name := range filterRegisteredWorktreeNames(projectName, fsWorktrees, gitEntries, pm) {
-			wtPath := pm.WorktreePath(projectName, name)
-			info := buildWorktreeListItem(projectName, name, wtPath)
+		for _, entry := range gitEntries {
+			if !worktree.IsLinkedWorktree(target.path, entry) {
+				continue
+			}
+			name := filepath.Base(filepath.Clean(entry.Path))
+			info := buildWorktreeListItem(projectName, name, entry.Path)
 			allWorktrees = append(allWorktrees, info)
 		}
 	}
@@ -208,21 +198,6 @@ func listWorktreeProjectTargets(ctx context.Context, campRoot, filterProject str
 		})
 	}
 	return targets, nil
-}
-
-func filterRegisteredWorktreeNames(projectName string, names []string, entries []worktree.GitWorktreeEntry, pm *worktree.PathManager) []string {
-	registered := make(map[string]struct{}, len(entries))
-	for _, entry := range entries {
-		registered[filepath.Clean(entry.Path)] = struct{}{}
-	}
-
-	filtered := make([]string, 0, len(names))
-	for _, name := range names {
-		if _, ok := registered[filepath.Clean(pm.WorktreePath(projectName, name))]; ok {
-			filtered = append(filtered, name)
-		}
-	}
-	return filtered
 }
 
 func buildWorktreeListItem(project, name, path string) WorktreeListItem {

--- a/cmd/camp/worktrees/list.go
+++ b/cmd/camp/worktrees/list.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
@@ -20,7 +21,13 @@ import (
 	"github.com/Obedience-Corp/camp/internal/worktree"
 )
 
-const WorktreesListJSONVersion = "worktrees-list/v1alpha1"
+// WorktreesListJSONVersion is bumped to v1alpha2 because git-derived
+// enumeration changed the meaning of the emitted path and name fields: path is
+// now the worktree's real on-disk location (which may be outside the
+// conventional projects/worktrees/<project>/ layout), and name is
+// disambiguated to a campaign-relative path when two linked worktrees share a
+// basename. Clients can key on this version to detect the new semantics.
+const WorktreesListJSONVersion = "worktrees-list/v1alpha2"
 
 var (
 	listProject string
@@ -153,6 +160,13 @@ func listWorktrees(ctx context.Context, campRoot string, filterProject string, s
 		}
 	}
 
+	// git-derived enumeration can surface two linked worktrees for the same
+	// project whose directory basenames match (a preferred
+	// projects/worktrees/<project>/foo and a loose /elsewhere/foo). Basename
+	// alone would collapse them to one name in the table/JSON, so rewrite
+	// colliding names to a unique, path-derived form.
+	disambiguateWorktreeNames(campRoot, allWorktrees)
+
 	// Filter if needed
 	var result []WorktreeListItem
 	staleCount := 0
@@ -198,6 +212,37 @@ func listWorktreeProjectTargets(ctx context.Context, campRoot, filterProject str
 		})
 	}
 	return targets, nil
+}
+
+// disambiguateWorktreeNames rewrites the Name of any worktrees that share a
+// (project, basename) so every table row and JSON entry stays uniquely
+// identifiable. A colliding name becomes the campaign-relative path (or the
+// cleaned absolute path when the worktree lives outside the campaign tree),
+// which is unique because git worktree paths are unique.
+func disambiguateWorktreeNames(campRoot string, worktrees []WorktreeListItem) {
+	counts := make(map[string]int, len(worktrees))
+	for _, wt := range worktrees {
+		counts[wt.Project+"\x00"+wt.Name]++
+	}
+	for i := range worktrees {
+		if counts[worktrees[i].Project+"\x00"+worktrees[i].Name] > 1 {
+			worktrees[i].Name = worktreeUniqueName(campRoot, worktrees[i].Path)
+		}
+	}
+}
+
+// worktreeUniqueName returns a stable, unique display name for a worktree whose
+// basename collides with another: the campaign-relative path when the worktree
+// is inside the campaign, otherwise the cleaned absolute path.
+func worktreeUniqueName(campRoot, path string) string {
+	clean := filepath.Clean(path)
+	if campRoot != "" {
+		if rel, err := filepath.Rel(campRoot, clean); err == nil &&
+			rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return rel
+		}
+	}
+	return clean
 }
 
 func buildWorktreeListItem(project, name, path string) WorktreeListItem {

--- a/cmd/camp/worktrees/list_test.go
+++ b/cmd/camp/worktrees/list_test.go
@@ -3,14 +3,8 @@ package worktrees
 import (
 	"io"
 	"os"
-	"path/filepath"
-	"slices"
 	"strings"
 	"testing"
-
-	"github.com/Obedience-Corp/camp/internal/config"
-	"github.com/Obedience-Corp/camp/internal/paths"
-	intworktree "github.com/Obedience-Corp/camp/internal/worktree"
 )
 
 func captureWorktreesStdout(fn func() error) (string, error) {
@@ -98,23 +92,5 @@ func TestOutputListTable_StaleReasonInStatus(t *testing.T) {
 	}
 	if !strings.Contains(out, "missing .git") {
 		t.Errorf("outputListTable missing stale reason in output, got:\n%s", out)
-	}
-}
-
-func TestFilterRegisteredWorktreeNames_DropsCopiedCheckoutChildren(t *testing.T) {
-	root := filepath.Join(string(filepath.Separator), "campaign")
-	pm := intworktree.NewPathManager(paths.NewResolver(root, config.DefaultCampaignPaths()))
-
-	got := filterRegisteredWorktreeNames("fest-gif-review",
-		[]string{"bin", "node_modules", "scripts", "src", "real-review"},
-		[]intworktree.GitWorktreeEntry{{
-			Path: pm.WorktreePath("fest-gif-review", "real-review"),
-		}},
-		pm,
-	)
-	want := []string{"real-review"}
-
-	if !slices.Equal(got, want) {
-		t.Fatalf("filterRegisteredWorktreeNames() = %v, want %v", got, want)
 	}
 }

--- a/cmd/camp/worktrees/list_test.go
+++ b/cmd/camp/worktrees/list_test.go
@@ -3,6 +3,7 @@ package worktrees
 import (
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -58,6 +59,40 @@ func TestOutputListTable_RendersColumns(t *testing.T) {
 	}
 	if !strings.Contains(out, "(1 stale)") {
 		t.Errorf("outputListTable missing stale count, got:\n%s", out)
+	}
+}
+
+func TestDisambiguateWorktreeNames_SameBasenameDifferentPath(t *testing.T) {
+	campRoot := "/camp"
+	worktrees := []WorktreeListItem{
+		// Two linked worktrees for the same project sharing a basename "foo":
+		// one preferred (inside the campaign), one loose (outside).
+		{Project: "proj", Name: "foo", Path: "/camp/projects/worktrees/proj/foo"},
+		{Project: "proj", Name: "foo", Path: "/elsewhere/foo"},
+		// A distinct basename in the same project must be left untouched.
+		{Project: "proj", Name: "bar", Path: "/camp/projects/worktrees/proj/bar"},
+		// A same basename under a DIFFERENT project does not collide.
+		{Project: "other", Name: "foo", Path: "/camp/projects/worktrees/other/foo"},
+	}
+
+	disambiguateWorktreeNames(campRoot, worktrees)
+
+	// The colliding "proj/foo" pair is rewritten to unique, path-derived names.
+	if worktrees[0].Name != filepath.FromSlash("projects/worktrees/proj/foo") {
+		t.Errorf("preferred colliding worktree name = %q, want campaign-relative path", worktrees[0].Name)
+	}
+	if worktrees[1].Name != filepath.FromSlash("/elsewhere/foo") {
+		t.Errorf("loose colliding worktree name = %q, want absolute path", worktrees[1].Name)
+	}
+	if worktrees[0].Name == worktrees[1].Name {
+		t.Errorf("colliding worktrees must get distinct names, both = %q", worktrees[0].Name)
+	}
+	// Non-colliding entries keep their basename.
+	if worktrees[2].Name != "bar" {
+		t.Errorf("non-colliding name changed: %q, want bar", worktrees[2].Name)
+	}
+	if worktrees[3].Name != "foo" {
+		t.Errorf("same basename in another project must not be disambiguated: %q, want foo", worktrees[3].Name)
 	}
 }
 

--- a/internal/nav/index/builder.go
+++ b/internal/nav/index/builder.go
@@ -202,39 +202,19 @@ func (b *Builder) scanWorktrees(ctx context.Context) ([]Target, error) {
 // worktreeTarget builds a navigation target for a linked worktree entry. It
 // reports ok=false for entries that are not navigable parallel worktrees: the
 // project's own main working tree, bare entries, git-internal paths, and hidden
-// directories.
+// directories. The classification itself lives in worktree.IsLinkedWorktree so
+// every enumerator (nav index, camp worktrees list, camp project worktree
+// list) agrees on what counts as a linked worktree.
 func worktreeTarget(projectName, projectPath string, entry worktree.GitWorktreeEntry) (Target, bool) {
-	if entry.IsBare || entry.Path == "" {
+	if !worktree.IsLinkedWorktree(projectPath, entry) {
 		return Target{}, false
 	}
 
-	clean := filepath.Clean(entry.Path)
-
-	// Skip the project's own checkout (the main working tree). For submodules
-	// git reports the main worktree under <superproject>/.git/modules/<name>,
-	// so also skip any path that lives inside a .git directory.
-	if clean == filepath.Clean(projectPath) || containsGitDir(clean) {
-		return Target{}, false
-	}
-
-	name := filepath.Base(clean)
-	if name == "" || name == "." || strings.HasPrefix(name, ".") {
-		return Target{}, false
-	}
+	name := filepath.Base(filepath.Clean(entry.Path))
 
 	return Target{
 		Name:     projectName + "@" + name,
 		Path:     entry.Path,
 		Category: nav.CategoryWorktrees,
 	}, true
-}
-
-// containsGitDir reports whether path has a ".git" path component.
-func containsGitDir(path string) bool {
-	for _, part := range strings.Split(path, string(filepath.Separator)) {
-		if part == ".git" {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/nav/index/builder_test.go
+++ b/internal/nav/index/builder_test.go
@@ -308,25 +308,6 @@ func TestWorktreeTarget(t *testing.T) {
 	}
 }
 
-func TestContainsGitDir(t *testing.T) {
-	tests := []struct {
-		path string
-		want bool
-	}{
-		{"/campaign/.git/modules/projects/camp", true},
-		{"/campaign/projects/worktrees/camp/feature", false},
-		{"/campaign/projects/worktrees/fix-camp-392", false},
-		{".git/worktrees/x", true},
-		{"/campaign/projects/camp", false},
-	}
-
-	for _, tc := range tests {
-		if got := containsGitDir(tc.path); got != tc.want {
-			t.Errorf("containsGitDir(%q) = %v, want %v", tc.path, got, tc.want)
-		}
-	}
-}
-
 func TestBuilder_scanWorktrees_NoProjects(t *testing.T) {
 	root := t.TempDir()
 	root, _ = filepath.EvalSymlinks(root)

--- a/internal/worktree/filter.go
+++ b/internal/worktree/filter.go
@@ -1,0 +1,40 @@
+package worktree
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// IsLinkedWorktree reports whether entry represents a real, navigable linked
+// worktree for the project rooted at projectPath: not the project's own main
+// working tree, not bare, not a git-internal path (including the submodule
+// main-worktree case reported under <superproject>/.git/modules/<name>), and
+// not a hidden directory.
+//
+// Callers that enumerate worktrees for a project should filter git worktree
+// list entries through this before displaying or navigating to them, rather
+// than intersecting with a directory scan of a conventional location: git is
+// the source of truth for which worktrees exist and where they live.
+func IsLinkedWorktree(projectPath string, entry GitWorktreeEntry) bool {
+	if entry.IsBare || entry.Path == "" {
+		return false
+	}
+
+	clean := filepath.Clean(entry.Path)
+	if clean == filepath.Clean(projectPath) || containsGitDir(clean) {
+		return false
+	}
+
+	name := filepath.Base(clean)
+	return name != "" && name != "." && !strings.HasPrefix(name, ".")
+}
+
+// containsGitDir reports whether path has a ".git" path component.
+func containsGitDir(path string) bool {
+	for _, part := range strings.Split(path, string(filepath.Separator)) {
+		if part == ".git" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/worktree/filter_test.go
+++ b/internal/worktree/filter_test.go
@@ -1,0 +1,81 @@
+package worktree
+
+import "testing"
+
+func TestIsLinkedWorktree(t *testing.T) {
+	const projectPath = "/campaign/projects/camp"
+
+	tests := []struct {
+		name  string
+		entry GitWorktreeEntry
+		want  bool
+	}{
+		{
+			name:  "bare entry skipped",
+			entry: GitWorktreeEntry{Path: "/campaign/projects/worktrees/camp/x", IsBare: true},
+			want:  false,
+		},
+		{
+			name:  "empty path skipped",
+			entry: GitWorktreeEntry{Path: ""},
+			want:  false,
+		},
+		{
+			name:  "main working tree skipped",
+			entry: GitWorktreeEntry{Path: projectPath, Branch: "main"},
+			want:  false,
+		},
+		{
+			name:  "submodule main worktree under .git skipped",
+			entry: GitWorktreeEntry{Path: "/campaign/.git/modules/projects/camp", Branch: "main"},
+			want:  false,
+		},
+		{
+			name:  "hidden worktree directory skipped",
+			entry: GitWorktreeEntry{Path: "/campaign/projects/worktrees/camp/.tmp"},
+			want:  false,
+		},
+		{
+			name:  "preferred-location worktree",
+			entry: GitWorktreeEntry{Path: "/campaign/projects/worktrees/camp/feature-auth", Branch: "feature-auth"},
+			want:  true,
+		},
+		{
+			name:  "non-preferred-location worktree still resolves",
+			entry: GitWorktreeEntry{Path: "/campaign/projects/worktrees/fix-camp-392", IsDetached: true},
+			want:  true,
+		},
+		{
+			name:  "worktree entirely outside the worktrees dir still resolves",
+			entry: GitWorktreeEntry{Path: "/tmp/scratch/camp-experiment", Branch: "experiment"},
+			want:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsLinkedWorktree(projectPath, tc.entry); got != tc.want {
+				t.Errorf("IsLinkedWorktree() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestContainsGitDir(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/campaign/.git/modules/projects/camp", true},
+		{"/campaign/projects/worktrees/camp/feature", false},
+		{"/campaign/projects/worktrees/fix-camp-392", false},
+		{".git/worktrees/x", true},
+		{"/campaign/projects/camp", false},
+	}
+
+	for _, tc := range tests {
+		if got := containsGitDir(tc.path); got != tc.want {
+			t.Errorf("containsGitDir(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}

--- a/tests/integration/worktrees_list_test.go
+++ b/tests/integration/worktrees_list_test.go
@@ -6,6 +6,7 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,4 +75,52 @@ mkdir -p %[2]s/projects/worktrees/proj/not-a-worktree
 	assert.Contains(t, out, "projects/worktrees/loose-wt")
 	assert.NotContains(t, out, "projects/worktrees/proj/loose-wt")
 	assert.NotContains(t, out, "not-a-worktree")
+}
+
+// TestWorktreesList_DisambiguatesSameBasename verifies that two linked
+// worktrees for the same project whose directory basenames match (a preferred
+// projects/worktrees/proj/dup and a loose projects/worktrees/dup) do not
+// collapse to one "dup" name in --json: each keeps a unique, path-derived name.
+func TestWorktreesList_DisambiguatesSameBasename(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath, projPath := setupWorktreeNavCampaign(t, tc, "wt-list-dup-basename")
+
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+git -C %[1]s worktree add %[2]s/projects/worktrees/proj/dup -b dup-pref
+git -C %[1]s worktree add %[2]s/projects/worktrees/dup -b dup-loose
+`, projPath, campPath))
+
+	out, err := tc.RunCampInDir(campPath, "worktrees", "list", "--json")
+	require.NoError(t, err, "output:\n%s", out)
+
+	var result struct {
+		Worktrees []struct {
+			Name string `json:"name"`
+			Path string `json:"path"`
+		} `json:"worktrees"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &result), "parse JSON: %s", out)
+
+	nameByPathSuffix := map[string]string{}
+	names := map[string]int{}
+	for _, wt := range result.Worktrees {
+		names[wt.Name]++
+		switch {
+		case strings.HasSuffix(wt.Path, "/projects/worktrees/proj/dup"):
+			nameByPathSuffix["proj/dup"] = wt.Name
+		case strings.HasSuffix(wt.Path, "/projects/worktrees/dup"):
+			nameByPathSuffix["dup"] = wt.Name
+		}
+	}
+
+	prefName, hasPref := nameByPathSuffix["proj/dup"]
+	looseName, hasLoose := nameByPathSuffix["dup"]
+	require.True(t, hasPref, "preferred dup worktree missing: %s", out)
+	require.True(t, hasLoose, "loose dup worktree missing: %s", out)
+	assert.NotEqual(t, prefName, looseName, "same-basename worktrees must get distinct names")
+	assert.Equal(t, 1, names[prefName], "disambiguated name %q must be unique in output", prefName)
+	assert.Equal(t, 1, names[looseName], "disambiguated name %q must be unique in output", looseName)
+	assert.Contains(t, prefName, "projects/worktrees/proj/dup")
+	assert.Contains(t, looseName, "projects/worktrees/dup")
 }

--- a/tests/integration/worktrees_list_test.go
+++ b/tests/integration/worktrees_list_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWorktreesList_ResolvesAcrossAllLocations verifies that `camp worktrees
+// list --json` and `camp project worktree list` use git as the source of
+// truth for enumeration, so they report every worktree for a project, not
+// only those under the conventional projects/worktrees/<project>/ layout.
+// This is the same regression PR #429 fixed for `cgo wt` navigation; see
+// TestGoWorktree_ResolvesAcrossAllLocations in navigation_worktree_test.go.
+func TestWorktreesList_ResolvesAcrossAllLocations(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath, projPath := setupWorktreeNavCampaign(t, tc, "wt-list-all-locations")
+
+	// pref-wt lives in the preferred location: projects/worktrees/proj/pref-wt
+	// loose-wt lives OUTSIDE the preferred location, a sibling directly under
+	// projects/worktrees/ (mirroring a real worktree created without camp).
+	// not-a-worktree is a plain directory under the preferred location that
+	// git does not track as a worktree, so it must never be listed.
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+git -C %[1]s worktree add %[2]s/projects/worktrees/proj/pref-wt -b pref-wt
+git -C %[1]s worktree add %[2]s/projects/worktrees/loose-wt -b loose-wt
+mkdir -p %[2]s/projects/worktrees/proj/not-a-worktree
+`, projPath, campPath))
+
+	out, err := tc.RunCampInDir(campPath, "worktrees", "list", "--json")
+	require.NoError(t, err, "output:\n%s", out)
+
+	var result struct {
+		Worktrees []struct {
+			Project string `json:"project"`
+			Name    string `json:"name"`
+			Path    string `json:"path"`
+			Branch  string `json:"branch"`
+		} `json:"worktrees"`
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &result), "parse JSON: %s", out)
+
+	pathByName := make(map[string]string, len(result.Worktrees))
+	for _, wt := range result.Worktrees {
+		pathByName[wt.Name] = wt.Path
+	}
+
+	prefPath, hasPref := pathByName["pref-wt"]
+	require.True(t, hasPref, "preferred-location worktree missing from JSON output: %+v", result.Worktrees)
+	assert.Contains(t, prefPath, "projects/worktrees/proj/pref-wt")
+
+	loosePath, hasLoose := pathByName["loose-wt"]
+	require.True(t, hasLoose, "worktree outside the preferred location must appear in camp worktrees list --json")
+	assert.Contains(t, loosePath, "projects/worktrees/loose-wt")
+	assert.NotContains(t, loosePath, "projects/worktrees/proj/loose-wt",
+		"loose worktree must report its real path, not the preferred layout")
+
+	_, hasCruft := pathByName["not-a-worktree"]
+	assert.False(t, hasCruft, "a directory that is not a git worktree must not be listed")
+
+	// camp project worktree list agrees: same worktrees, real paths.
+	out, err = tc.RunCampInDir(campPath, "project", "worktree", "list", "--project", "proj")
+	require.NoError(t, err, "output:\n%s", out)
+	assert.Contains(t, out, "pref-wt")
+	assert.Contains(t, out, "loose-wt")
+	assert.Contains(t, out, "projects/worktrees/loose-wt")
+	assert.NotContains(t, out, "projects/worktrees/proj/loose-wt")
+	assert.NotContains(t, out, "not-a-worktree")
+}


### PR DESCRIPTION
## Problem

PR #429 fixed worktree enumeration for `cgo wt` / `camp go wt` navigation:
`internal/nav/index/builder.go` now uses `git worktree list --porcelain`
per project instead of walking `projects/worktrees/<project>/<child>`.
`camp worktrees list` and `camp project worktree list` still enumerated the
old way: scan the conventional `projects/worktrees/<project>/` directory,
then intersect with `git worktree list`. Any worktree living outside that
layout was silently dropped from both commands even though git tracked it.
This was deliberately excluded from #429 because fixing it changes the
`--json` output shape, which is a real contract change and deserves its
own review.

Real repro against this campaign's own `camp` project (not a synthetic
fixture): `camp-main-tests`, `camp-wi-ref-selector`, and the
`camp-worktree-list` worktree this PR was written in all live flat under
`projects/worktrees/`, one level up from the conventional
`projects/worktrees/camp/<name>` layout, alongside the original repro
`projects/worktrees/fix-camp-392`. All four were invisible to both
commands before this fix.

## Fix

Both commands now enumerate directly from `git worktree list`, filtered
through a shared `worktree.IsLinkedWorktree(projectPath, entry)` helper
that excludes the project's own main working tree, bare entries,
git-internal paths (including the submodule `.git/modules/<name>` case),
and hidden directories.

`IsLinkedWorktree` is extracted from `nav/index/builder.go`'s
`worktreeTarget` (unchanged behavior, same test cases now live in
`internal/worktree/filter_test.go`) into `internal/worktree` so every
enumerator agrees on the same rule instead of three copies drifting
independently:

- `internal/nav/index/builder.go` (`cgo wt`, unchanged behavior, just
  delegates now)
- `cmd/camp/worktrees/list.go` (`camp worktrees list [--json]`)
- `cmd/camp/project/worktree/list.go` (`camp project worktree list`)

The old `projects/worktrees/<project>/` directory scan and its
intersection helper (`filterRegisteredWorktreeNames`, and
`pathManager.ListProjectWorktrees`/`WorktreePath` reconstruction) are
removed from both list commands. `camp project worktree add/remove` still
use `PathManager` for creating/removing worktrees at the conventional
location; that is unchanged and out of scope here, only the two `list`
paths moved to git-derived enumeration.

## --json contract change (camp worktrees list --json)

Schema version stays `worktrees-list/v1alpha1` (already documented in
`docs/json-contracts.md` as a deprecated compatibility surface; only the
error envelope is versioned, the success payload has no `schema_version`
field to bump). Field names and types on `WorktreeListItem` /
`WorktreeListResult` are unchanged. What changes:

- **Enumeration is a strict superset.** Every worktree previously listed
  is still listed, with identical field values (verified below: 17/17
  pre-existing entries byte-identical before and after). Worktrees outside
  the conventional location now additionally appear.
- **`path` is now always the real git-reported path**, not a path
  reconstructed from `projects/worktrees/<project>/<name>`. For
  conventional-location worktrees these were already identical, so no
  value changes there. For non-conventional worktrees, `path` is now
  correct instead of simply absent.
- **`name` is the worktree's real directory basename** (`filepath.Base` of
  the git-reported path) rather than a directory-scan entry name. Same
  value for conventional worktrees, newly correct for the rest.

No change to `branch`, `lastAccessed`, `stale`, `staleReason`, `total`, or
`stale` count semantics; `buildWorktreeListItem` is unchanged, it is now
just called with the real path instead of a reconstructed one.

### Before / after (real campaign data, `camp worktrees list --project camp --json`)

Built the pre-fix `main` binary and the fixed binary and ran both
read-only against this actual campaign (17 conventional-location `camp`
worktrees plus the 4 non-conventional ones above):

**Before** (`main`, `total: 17`): only conventional-location worktrees,
e.g.
```json
{
  "project": "camp",
  "name": "camp-dead-surface",
  "path": "/Users/.../projects/worktrees/camp/camp-dead-surface",
  "branch": "camp-dead-surface",
  "lastAccessed": "5 days ago",
  "stale": false
}
```
`camp-main-tests`, `camp-wi-ref-selector`, `camp-worktree-list`,
`fix-camp-392` are entirely absent from the array.

**After** (this branch, `total: 21`): the same 17 entries, byte-identical,
plus the 4 previously-missing worktrees, e.g.
```json
{
  "project": "camp",
  "name": "camp-worktree-list",
  "path": "/Users/.../projects/worktrees/camp-worktree-list",
  "branch": "fix/worktree-list-git-enumeration",
  "lastAccessed": "5 minutes ago",
  "stale": false
},
{
  "project": "camp",
  "name": "fix-camp-392",
  "path": "/Users/.../projects/worktrees/fix-camp-392",
  "branch": "1e6f94a (detached)",
  "lastAccessed": "5 days ago",
  "stale": false
}
```

### Before / after (`camp project worktree list --project camp`, human text, no --json flag on this command)

Before: `fix-camp-392` / `camp-main-tests` / `camp-wi-ref-selector` /
`camp-worktree-list` never appear in the output (0 matches). After:
```
  camp-main-tests
    Branch: fix/main-integration-workitem-tests
    Path:   projects/worktrees/camp-main-tests

  fix-camp-392
    Branch: HEAD (detached)
    Path:   projects/worktrees/fix-camp-392
```
paths now render relative to campaign root the same way conventional
worktrees always did (`displayWorktreePath`, `filepath.Rel` against
campRoot, falling back to the absolute path only if the worktree lives
outside the campaign root entirely).

## Consumers checked

- Grepped `WorktreeListResult`/`WorktreeListItem`/`worktrees-list` across
  the whole campaign (camp, camp-graph, obey-platform-monorepo,
  festival-app, workflow/design, festivals/). No script or app parses this
  JSON structurally.
- `festival-app`'s "Worktree List" action
  (`src-tauri/src/commands/projects.rs` `ProjectActionRequest::WorktreeList`,
  wired from `src/lib/explorerActions.ts`) shells out to
  `camp project worktree list --project <name>` (the human-text command,
  no `--json`) and displays raw stdout in a log view; it does not parse
  fields, so this change only improves what's shown to the user (correct
  paths, previously-missing worktrees).
- `docs/json-contracts.md` already marks `camp worktrees list --json` as a
  deprecated compatibility surface with no `schema_version` on the success
  body; left unchanged, still accurate.
- The `camp` copies vendored inside `festival-app/camp/` and
  `obey-platform-monorepo/camp/` are bundled dev-profile source checkouts
  of this same repo, not independent consumers of the contract.

## Tests

- `internal/worktree/filter_test.go` (new): table-driven unit tests for
  `IsLinkedWorktree` covering bare, empty path, main working tree,
  submodule `.git/modules` case, hidden directory, preferred-location
  worktree, non-preferred-location worktree, and a worktree entirely
  outside the worktrees directory. Mirrors the existing
  `TestWorktreeTarget` cases in `internal/nav/index/builder_test.go`
  (unchanged, still passing since `worktreeTarget`'s behavior is
  identical, just delegates now). `TestContainsGitDir` moved alongside
  `IsLinkedWorktree`.
- `cmd/camp/worktrees/list_test.go`: removed
  `TestFilterRegisteredWorktreeNames_DropsCopiedCheckoutChildren`, its
  target function is deleted. The property it protected (a copied
  build-artifact directory like `node_modules`/`bin` sitting next to a
  real worktree must not be listed) now holds by construction: enumeration
  comes straight from `git worktree list`, so a directory git never
  registered can never produce an entry to filter in the first place.
- `tests/integration/worktrees_list_test.go` (new,
  `//go:build integration`): `TestWorktreesList_ResolvesAcrossAllLocations`
  builds a real campaign + submodule project in a container, creates a
  preferred-location worktree, a worktree outside the preferred location,
  and a plain (non-git) directory under the preferred location, then
  asserts `camp worktrees list --json` and `camp project worktree list`
  both report the two real worktrees with correct paths and both exclude
  the plain directory. Reuses the `setupWorktreeNavCampaign` helper
  already shared with `navigation_worktree_test.go`.

## Verification

Run from `/Users/lancerogers/Dev/AI/obey-campaign/projects/worktrees/camp-worktree-list`:

- `just build default-build`: clean (vet + build, 124/124 packages).
- `just test unit`: 3429/3429 tests passed, 106 packages, no failures. No
  pre-existing `TestIntegration_Workitem*` failures encountered (those are
  integration-only, not part of this run).
- `just lint`: `0 issues`, `lint-no-host-fs-tests: clean`,
  `lint-no-fmt-errorf: clean`.
- `go vet ./...` and `go vet -tags=integration ./...`: clean.
- `just test integration-run TestWorktreesList_ResolvesAcrossAllLocations`:
  PASS (new test).
- `just test integration-run` for
  `TestGoWorktree_ResolvesAcrossAllLocations`,
  `TestCompleteWorktree_BranchesAcrossLocations`, and all
  `TestWorktreesClean_*` cases (the tests most likely to regress from the
  `internal/worktree`/`nav/index` refactor): all PASS.

## Other changes worth flagging

- `camp project worktree list` no longer calls
  `config.LoadCampaignConfig` (it only existed to build the now-unused
  `PathManager`). `project.Resolve` still resolves the project and surfaces
  a campaign-config error through its own path if the config is malformed,
  so error coverage is preserved, just through a different call site.
- `camp project worktree list`'s branch label for detached worktrees
  (`HEAD (detached)`, from git's own parsed entry) already differed from
  `camp worktrees list --json`'s label (short SHA + `(detached)`, from a
  separate disk-read helper) before this change; verified with the `main`
  binary against `workitem-validate-repair` in this campaign. This PR does
  not touch that inconsistency, flagging it as a pre-existing, unrelated
  follow-up.

## Residual risks

- `camp worktrees list --json`'s `path` field is now always the real git
  path; any external script that assumed the conventional
  `projects/worktrees/<project>/<name>` shape for every entry (rather than
  reading the `path` field) would need to adjust. No such consumer was
  found in this campaign or its projects.
- Docs (`docs/json-contracts.md`) were left as-is since the schema version
  and field shapes are unchanged; happy to add a note there if reviewers
  want the enumeration-completeness fix called out explicitly in that
  table.

Ref: intent `camp-worktrees-list-and-camp-20260715-024134`.
