### PR TITLE
fix(workitem): resolve WI-<ref> selectors and guard worktree links

### DIFF
--- a/cmd/camp/project/worktree/add.go
+++ b/cmd/camp/project/worktree/add.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
 	"github.com/Obedience-Corp/camp/internal/workitem/selector"
 	intworktree "github.com/Obedience-Corp/camp/internal/worktree"
@@ -104,6 +105,19 @@ func runProjectWorktreeAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Resolve and validate the workitem before creating anything, so a bad or
+	// unadopted selector fails fast instead of leaving a dangling worktree.
+	var linkTarget *wkitem.WorkItem
+	if wtAddWorkitem != "" {
+		linkTarget, err = selector.Resolve(ctx, campRoot, wtAddWorkitem, selector.ResolveOptions{})
+		if err != nil {
+			return camperrors.Wrap(err, "resolve workitem "+wtAddWorkitem)
+		}
+		if wkitem.NeedsAdoption(linkTarget) {
+			return wkitem.NotAdoptedError(linkTarget.RelativePath)
+		}
+	}
+
 	resolver := paths.NewResolver(campRoot, cfg.Paths())
 	creator := intworktree.NewCreator(resolver, cfg)
 	opts := &intworktree.CreateOptions{
@@ -136,6 +150,13 @@ func runProjectWorktreeAdd(cmd *cobra.Command, args []string) error {
 
 	result, err := creator.Create(ctx, opts)
 	if err != nil {
+		if errors.Is(err, intworktree.ErrBranchExists) {
+			return camperrors.Wrap(err, fmt.Sprintf(
+				"branch %q already exists (a previous worktree may have been removed "+
+					"without deleting its branch); reuse it with --branch %s, choose a "+
+					"different name, or delete it with 'git branch -D %s'",
+				opts.Branch, opts.Branch, opts.Branch))
+		}
 		return err
 	}
 
@@ -143,8 +164,8 @@ func runProjectWorktreeAdd(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Path:   %s\n", ui.Value(result.Path))
 	fmt.Printf("  Branch: %s\n", ui.Value(result.Branch))
 
-	if wtAddWorkitem != "" {
-		link, lerr := linkWorktreeToWorkitem(ctx, campRoot, wtAddWorkitem, filepath.ToSlash(result.RelativePath))
+	if linkTarget != nil {
+		link, lerr := attachWorktreeLink(ctx, campRoot, linkTarget, filepath.ToSlash(result.RelativePath))
 		if lerr != nil {
 			return camperrors.Wrap(lerr, "worktree created but workitem link failed")
 		}
@@ -158,13 +179,11 @@ func runProjectWorktreeAdd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// linkWorktreeToWorkitem attaches a primary worktree link so the resolver
+// attachWorktreeLink attaches a primary worktree link so the resolver
 // (and therefore camp p commit) picks up the workitem ref inside that tree.
-func linkWorktreeToWorkitem(ctx context.Context, campRoot, selectorQuery, relativeWorktreePath string) (links.Link, error) {
-	wi, err := selector.Resolve(ctx, campRoot, selectorQuery, selector.ResolveOptions{})
-	if err != nil {
-		return links.Link{}, camperrors.Wrap(err, "resolve workitem "+selectorQuery)
-	}
+// The workitem is resolved and validated by the caller before the worktree is
+// created, so a bad selector never leaves a dangling worktree behind.
+func attachWorktreeLink(ctx context.Context, campRoot string, wi *wkitem.WorkItem, relativeWorktreePath string) (links.Link, error) {
 	workitemID := wi.StableID
 	if workitemID == "" {
 		workitemID = wi.Key

--- a/cmd/camp/worktrees/create.go
+++ b/cmd/camp/worktrees/create.go
@@ -2,6 +2,7 @@ package worktrees
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
 	"github.com/Obedience-Corp/camp/internal/workitem/selector"
 	"github.com/Obedience-Corp/camp/internal/worktree"
@@ -97,6 +99,19 @@ func runWorktreesCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Resolve and validate the workitem before creating anything, so a bad or
+	// unadopted selector fails fast instead of leaving a dangling worktree.
+	var linkTarget *wkitem.WorkItem
+	if createWorkitem != "" {
+		linkTarget, err = selector.Resolve(ctx, campRoot, createWorkitem, selector.ResolveOptions{})
+		if err != nil {
+			return camperrors.Wrap(err, "resolve workitem "+createWorkitem)
+		}
+		if wkitem.NeedsAdoption(linkTarget) {
+			return wkitem.NotAdoptedError(linkTarget.RelativePath)
+		}
+	}
+
 	// Build options based on new semantics:
 	// - Default: create new branch with worktree name, based on current branch
 	// - --branch: checkout existing branch
@@ -138,6 +153,13 @@ func runWorktreesCreate(cmd *cobra.Command, args []string) error {
 	// Execute creation
 	result, err := creator.Create(ctx, opts)
 	if err != nil {
+		if errors.Is(err, worktree.ErrBranchExists) {
+			return camperrors.Wrap(err, fmt.Sprintf(
+				"branch %q already exists (a previous worktree may have been removed "+
+					"without deleting its branch); reuse it with --branch %s, choose a "+
+					"different name, or delete it with 'git branch -D %s'",
+				opts.Branch, opts.Branch, opts.Branch))
+		}
 		return err
 	}
 
@@ -146,8 +168,8 @@ func runWorktreesCreate(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Path:   %s\n", ui.Value(result.Path))
 	fmt.Printf("  Branch: %s\n", ui.Value(result.Branch))
 
-	if createWorkitem != "" {
-		link, lerr := linkWorktreeToWorkitem(ctx, campRoot, createWorkitem, filepath.ToSlash(result.RelativePath))
+	if linkTarget != nil {
+		link, lerr := attachWorktreeLink(ctx, campRoot, linkTarget, filepath.ToSlash(result.RelativePath))
 		if lerr != nil {
 			return camperrors.Wrap(lerr, "worktree created but workitem link failed")
 		}
@@ -161,11 +183,10 @@ func runWorktreesCreate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func linkWorktreeToWorkitem(ctx context.Context, campRoot, selectorQuery, relativeWorktreePath string) (links.Link, error) {
-	wi, err := selector.Resolve(ctx, campRoot, selectorQuery, selector.ResolveOptions{})
-	if err != nil {
-		return links.Link{}, camperrors.Wrap(err, "resolve workitem "+selectorQuery)
-	}
+// attachWorktreeLink attaches a primary worktree link for an already-resolved
+// workitem so the resolver (and therefore camp p commit) picks up the workitem
+// ref inside that tree.
+func attachWorktreeLink(ctx context.Context, campRoot string, wi *wkitem.WorkItem, relativeWorktreePath string) (links.Link, error) {
 	workitemID := wi.StableID
 	if workitemID == "" {
 		workitemID = wi.Key

--- a/internal/commands/workitem/worktree.go
+++ b/internal/commands/workitem/worktree.go
@@ -102,6 +102,9 @@ func runWorktree(cmd *cobra.Command, opts worktreeOptions) error {
 	if err != nil {
 		return camperrors.Wrap(err, "resolve workitem "+opts.Selector)
 	}
+	if wkitem.NeedsAdoption(wi) {
+		return wkitem.NotAdoptedError(wi.RelativePath)
+	}
 
 	registry, err := links.Load(ctx, root)
 	if err != nil {
@@ -185,6 +188,12 @@ func createWorktree(
 			return nil, camperrors.Wrap(err,
 				fmt.Sprintf("link it with 'camp workitem link %s --worktree %s/%s' or choose another --name",
 					name, resolved.Name, name))
+		}
+		if errors.Is(err, intworktree.ErrBranchExists) {
+			return nil, camperrors.Wrap(err,
+				fmt.Sprintf("branch %q already exists (a previous worktree may have been removed "+
+					"without deleting its branch); pass --name to pick a different name, or delete "+
+					"it with 'git branch -D %s'", name, name))
 		}
 		return nil, err
 	}

--- a/internal/workitem/adoption.go
+++ b/internal/workitem/adoption.go
@@ -1,0 +1,23 @@
+package workitem
+
+import camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
+// NeedsAdoption reports whether wi is a builtin doc-type work item (design or
+// explore) that was discovered by location but has no .workitem marker, so it
+// carries neither a stable id nor a ref. Such an item cannot back a primary
+// worktree link: camp p commit would have no ref to stamp, and the link layer
+// would try to store the bare "<type>:<path>" key as a workitem id (which its
+// validator rejects for containing a slash).
+func NeedsAdoption(wi *WorkItem) bool {
+	return wi != nil && wi.StableID == "" && IsBuiltinDocType(wi.WorkflowType)
+}
+
+// NotAdoptedError reports that the work item at relPath must be adopted before
+// it can back a primary worktree link. The message names the exact adopt
+// command so the caller can recover in one step.
+func NotAdoptedError(relPath string) error {
+	return camperrors.NewValidation("workitem",
+		"workitem at "+relPath+" is not adopted (no .workitem marker); run "+
+			"'camp workitem adopt "+relPath+"' to give it a stable id and ref "+
+			"before linking a worktree", nil)
+}

--- a/internal/workitem/adoption.go
+++ b/internal/workitem/adoption.go
@@ -1,6 +1,11 @@
 package workitem
 
-import camperrors "github.com/Obedience-Corp/camp/internal/errors"
+import (
+	"regexp"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/remote"
+)
 
 // NeedsAdoption reports whether wi is a builtin doc-type work item (design or
 // explore) that was discovered by location but has no .workitem marker, so it
@@ -12,12 +17,28 @@ func NeedsAdoption(wi *WorkItem) bool {
 	return wi != nil && wi.StableID == "" && IsBuiltinDocType(wi.WorkflowType)
 }
 
+// adoptCommandSafeUnquoted matches paths that are safe to paste into a shell
+// unquoted (the kebab-case slugs camp generates under workflow/). A hand-edited
+// path outside this set is single-quoted so the recovery command stays
+// copy-paste safe, mirroring workitem validate's repairCommandFor.
+var adoptCommandSafeUnquoted = regexp.MustCompile(`^[A-Za-z0-9._/-]+$`)
+
+// adoptCommand returns the `camp workitem adopt <path>` recovery command with
+// the path shell-quoted when it contains characters (e.g. spaces in a
+// hand-created design/explore dir) that would otherwise break a copy-paste.
+func adoptCommand(relPath string) string {
+	if adoptCommandSafeUnquoted.MatchString(relPath) {
+		return "camp workitem adopt " + relPath
+	}
+	return "camp workitem adopt " + remote.ShellQuote(relPath)
+}
+
 // NotAdoptedError reports that the work item at relPath must be adopted before
 // it can back a primary worktree link. The message names the exact adopt
 // command so the caller can recover in one step.
 func NotAdoptedError(relPath string) error {
 	return camperrors.NewValidation("workitem",
 		"workitem at "+relPath+" is not adopted (no .workitem marker); run "+
-			"'camp workitem adopt "+relPath+"' to give it a stable id and ref "+
+			adoptCommand(relPath)+" to give it a stable id and ref "+
 			"before linking a worktree", nil)
 }

--- a/internal/workitem/adoption_test.go
+++ b/internal/workitem/adoption_test.go
@@ -57,3 +57,25 @@ func TestNotAdoptedError_NamesAdoptCommandAndPath(t *testing.T) {
 		t.Errorf("message should name the adopt command: %s", msg)
 	}
 }
+
+func TestNotAdoptedError_ShellQuotesUnsafePath(t *testing.T) {
+	// A hand-created design dir may contain spaces; the recovery command must
+	// stay copy-paste safe, mirroring workitem validate's repair command.
+	err := NotAdoptedError("workflow/design/my feature")
+	msg := err.Error()
+	if !strings.Contains(msg, "camp workitem adopt 'workflow/design/my feature'") {
+		t.Errorf("adopt command must single-quote a spaced path: %s", msg)
+	}
+	if strings.Contains(msg, "camp workitem adopt workflow/design/my feature ") {
+		t.Errorf("spaced path must not be emitted unquoted: %s", msg)
+	}
+}
+
+func TestAdoptCommand_LeavesSlugPathsUnquoted(t *testing.T) {
+	if got := adoptCommand("workflow/design/thing"); got != "camp workitem adopt workflow/design/thing" {
+		t.Errorf("slug path should stay unquoted, got %q", got)
+	}
+	if got := adoptCommand("workflow/design/my feature"); got != "camp workitem adopt 'workflow/design/my feature'" {
+		t.Errorf("spaced path should be quoted, got %q", got)
+	}
+}

--- a/internal/workitem/adoption_test.go
+++ b/internal/workitem/adoption_test.go
@@ -1,0 +1,59 @@
+package workitem
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNeedsAdoption(t *testing.T) {
+	tests := []struct {
+		name string
+		wi   *WorkItem
+		want bool
+	}{
+		{"nil", nil, false},
+		{
+			"unadopted design dir",
+			&WorkItem{WorkflowType: WorkflowTypeDesign, StableID: ""},
+			true,
+		},
+		{
+			"unadopted explore dir",
+			&WorkItem{WorkflowType: WorkflowTypeExplore, StableID: ""},
+			true,
+		},
+		{
+			"adopted design dir has stable id",
+			&WorkItem{WorkflowType: WorkflowTypeDesign, StableID: "design-x-2026-07-17"},
+			false,
+		},
+		{
+			"festival is id-less but not adoptable",
+			&WorkItem{WorkflowType: WorkflowTypeFestival, StableID: ""},
+			false,
+		},
+		{
+			"intent is id-less but not adoptable",
+			&WorkItem{WorkflowType: WorkflowTypeIntent, StableID: ""},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NeedsAdoption(tt.wi); got != tt.want {
+				t.Fatalf("NeedsAdoption() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNotAdoptedError_NamesAdoptCommandAndPath(t *testing.T) {
+	err := NotAdoptedError("workflow/design/thing")
+	msg := err.Error()
+	if !strings.Contains(msg, "workflow/design/thing") {
+		t.Errorf("message should name the path: %s", msg)
+	}
+	if !strings.Contains(msg, "camp workitem adopt workflow/design/thing") {
+		t.Errorf("message should name the adopt command: %s", msg)
+	}
+}

--- a/internal/workitem/selector/selector.go
+++ b/internal/workitem/selector/selector.go
@@ -35,11 +35,12 @@ var (
 //   - a wrapped ErrSelectorNotFound when nothing matches.
 //
 // Resolution order:
-//  1. exact stable .workitem id
-//  2. exact key (`<type>:<path>`)
-//  3. exact RelativePath
-//  4. exact directory-base slug
-//  5. fuzzy substring on key or title (only when opts.AllowFuzzy)
+//  1. exact workitem ref (`WI-<6 hex>`, case-insensitive)
+//  2. exact stable .workitem id
+//  3. exact key (`<type>:<path>`)
+//  4. exact RelativePath
+//  5. exact directory-base slug
+//  6. fuzzy substring on key or title (only when opts.AllowFuzzy)
 func Resolve(ctx context.Context, root string, query string, opts ResolveOptions) (*workitem.WorkItem, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -59,6 +60,10 @@ func Resolve(ctx context.Context, root string, query string, opts ResolveOptions
 		eq   func(workitem.WorkItem) bool
 	}
 	matchers := []matcher{
+		{"ref", func(w workitem.WorkItem) bool {
+			ref, _ := w.SourceMetadata["ref"].(string)
+			return ref != "" && strings.EqualFold(ref, query)
+		}},
 		{"id", func(w workitem.WorkItem) bool { return w.StableID != "" && w.StableID == query }},
 		{"key", func(w workitem.WorkItem) bool { return strings.EqualFold(w.Key, query) }},
 		{"path", func(w workitem.WorkItem) bool { return w.RelativePath == strings.TrimRight(query, "/") }},

--- a/internal/workitem/selector/selector_test.go
+++ b/internal/workitem/selector/selector_test.go
@@ -1,0 +1,91 @@
+package selector
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeCampaignWithDesignWorkitem lays down a minimal campaign containing one
+// adopted design work item whose .workitem marker carries the given ref, then
+// returns the campaign root.
+func writeCampaignWithDesignWorkitem(t *testing.T, slug, id, ref string) string {
+	t.Helper()
+	root := t.TempDir()
+
+	campaignYAML := "version: campaign/v1\nid: testcampaign\nname: test\ntype: product\n"
+	mustWrite(t, filepath.Join(root, ".campaign", "campaign.yaml"), campaignYAML)
+
+	marker := "version: v1alpha6\nkind: workitem\nid: " + id +
+		"\ntype: design\ntitle: " + slug + "\nref: " + ref + "\n"
+	mustWrite(t, filepath.Join(root, "workflow", "design", slug, ".workitem"), marker)
+	mustWrite(t, filepath.Join(root, "workflow", "design", slug, "README.md"), "# "+slug+"\n")
+	return root
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolve_MatchesEverySelectorFormForAdoptedWorkitem(t *testing.T) {
+	const (
+		slug = "camp-sync-clone-transport"
+		id   = "design-camp-sync-clone-transport-2026-07-17"
+		ref  = "WI-541bcc"
+	)
+	root := writeCampaignWithDesignWorkitem(t, slug, id, ref)
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{"ref lowercase", ref},
+		{"ref uppercase", "WI-541BCC"},
+		{"stable id", id},
+		{"key", "design:workflow/design/" + slug},
+		{"relative path", "workflow/design/" + slug},
+		{"slug", slug},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wi, err := Resolve(context.Background(), root, tt.query, ResolveOptions{})
+			if err != nil {
+				t.Fatalf("Resolve(%q) returned error: %v", tt.query, err)
+			}
+			if wi.StableID != id {
+				t.Fatalf("Resolve(%q) matched %q, want stable id %q", tt.query, wi.StableID, id)
+			}
+		})
+	}
+}
+
+func TestResolve_UnknownRefIsNotFound(t *testing.T) {
+	root := writeCampaignWithDesignWorkitem(t, "thing", "design-thing-2026-07-17", "WI-541bcc")
+
+	_, err := Resolve(context.Background(), root, "WI-000000", ResolveOptions{})
+	if !errors.Is(err, ErrSelectorNotFound) {
+		t.Fatalf("Resolve(unknown ref) error = %v, want ErrSelectorNotFound", err)
+	}
+}
+
+func TestResolve_AmbiguousRefReportsBothKeys(t *testing.T) {
+	// Two adopted design items hand-edited to share a ref: the ref tier must
+	// surface an ambiguity error rather than silently pick one.
+	root := writeCampaignWithDesignWorkitem(t, "one", "design-one-2026-07-17", "WI-541bcc")
+	marker := "version: v1alpha6\nkind: workitem\nid: design-two-2026-07-17\ntype: design\ntitle: two\nref: WI-541bcc\n"
+	mustWrite(t, filepath.Join(root, "workflow", "design", "two", ".workitem"), marker)
+	mustWrite(t, filepath.Join(root, "workflow", "design", "two", "README.md"), "# two\n")
+
+	_, err := Resolve(context.Background(), root, "WI-541bcc", ResolveOptions{})
+	if !errors.Is(err, ErrSelectorAmbiguous) {
+		t.Fatalf("Resolve(shared ref) error = %v, want ErrSelectorAmbiguous", err)
+	}
+}

--- a/internal/worktree/create.go
+++ b/internal/worktree/create.go
@@ -90,6 +90,12 @@ func (c *Creator) Create(ctx context.Context, opts *CreateOptions) (*CreateResul
 		if branchName == "" {
 			branchName = opts.Name
 		}
+		// Detect a leftover branch before git does, so callers can surface an
+		// actionable hint instead of a raw "fatal: a branch named ... already
+		// exists" from git worktree add.
+		if git.LocalBranchExists(ctx, branchName) {
+			return nil, BranchAlreadyExists(opts.Project, branchName)
+		}
 		if err := git.Add(ctx, wtPath, branchName, true, opts.StartPoint); err != nil {
 			return nil, err
 		}

--- a/internal/worktree/errors.go
+++ b/internal/worktree/errors.go
@@ -13,6 +13,7 @@ const (
 	ErrCodeWorktreeExists   = "WORKTREE_ALREADY_EXISTS"
 	ErrCodeWorktreeNotFound = "WORKTREE_NOT_FOUND"
 	ErrCodeBranchNotFound   = "WORKTREE_BRANCH_NOT_FOUND"
+	ErrCodeBranchExists     = "WORKTREE_BRANCH_EXISTS"
 	ErrCodeInvalidName      = "WORKTREE_INVALID_NAME"
 	ErrCodeGitFailed        = "WORKTREE_GIT_FAILED"
 	ErrCodeStaleWorktree    = "WORKTREE_STALE"
@@ -29,6 +30,7 @@ var (
 	ErrWorktreeExists   = camperrors.Wrap(camperrors.ErrAlreadyExists, "worktree already exists")
 	ErrWorktreeNotFound = camperrors.Wrap(camperrors.ErrNotFound, "worktree not found")
 	ErrBranchNotFound   = camperrors.Wrap(camperrors.ErrNotFound, "branch not found")
+	ErrBranchExists     = camperrors.Wrap(camperrors.ErrAlreadyExists, "branch already exists")
 	ErrInvalidName      = camperrors.Wrap(camperrors.ErrInvalidInput, "invalid worktree name")
 	ErrNotInWorktree    = errors.New("not inside a worktree")
 	ErrStaleWorktree    = errors.New("worktree is stale")
@@ -129,6 +131,16 @@ func BranchNotFoundError(project, branch string) error {
 		WithProject(project).
 		WithBranch(branch).
 		WithCause(ErrBranchNotFound)
+}
+
+// BranchAlreadyExists creates an error for a new-branch worktree whose target
+// branch already exists locally (commonly a branch left behind by a prior
+// 'worktree remove', which does not delete the branch).
+func BranchAlreadyExists(project, branch string) error {
+	return NewError(ErrCodeBranchExists).
+		WithProject(project).
+		WithBranch(branch).
+		WithCause(ErrBranchExists)
 }
 
 // InvalidWorktreeName creates an error for invalid name.

--- a/internal/worktree/git.go
+++ b/internal/worktree/git.go
@@ -202,6 +202,20 @@ func (g *GitWorktree) Prune(ctx context.Context, dryRun bool) ([]string, error) 
 	return pruned, nil
 }
 
+// LocalBranchExists reports whether a local branch (refs/heads/<branch>)
+// exists. Unlike BranchExists it ignores remote-tracking refs, because
+// 'git worktree add -b <branch>' only conflicts with a local branch of the
+// same name; a matching origin/<branch> is created locally, not rejected.
+func (g *GitWorktree) LocalBranchExists(ctx context.Context, branch string) bool {
+	ctx, cancel := context.WithTimeout(ctx, g.timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "show-ref", "--verify", "--quiet",
+		"refs/heads/"+branch)
+	cmd.Dir = g.projectPath
+	return cmd.Run() == nil
+}
+
 // BranchExists checks if a branch exists.
 func (g *GitWorktree) BranchExists(ctx context.Context, branch string) bool {
 	ctx, cancel := context.WithTimeout(ctx, g.timeout)

--- a/tests/integration/workitem_worktree_selector_test.go
+++ b/tests/integration/workitem_worktree_selector_test.go
@@ -1,0 +1,100 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A freshly created/adopted design workitem must be resolvable by its WI-<ref>
+// selector, not just by path/slug. This is the WI-<ref> selector fix: the
+// worktree link and the resulting commit tag must both work when the selector
+// is the ref.
+func TestIntegration_WorktreeAdd_ResolvesByRef(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/worktree-add-by-ref"
+	initCommitTagsCampaign(t, tc, dir)
+	ref := seedDesignWorkitemWithRef(t, tc, dir, "sync-transport")
+
+	_, err := tc.RunCampInDir(dir, "project", "new", "demo-app")
+	require.NoError(t, err, "camp project new")
+
+	out, err := tc.RunCampInDir(dir, "project", "worktree", "add", "sync-wt",
+		"--project", "demo-app", "--workitem", ref)
+	require.NoError(t, err, "worktree add --workitem <ref>: %s", out)
+
+	wtRel := "projects/worktrees/demo-app/sync-wt"
+	exists, err := tc.CheckDirExists(dir + "/" + wtRel)
+	require.NoError(t, err)
+	require.True(t, exists, "worktree dir should exist at %s; output:\n%s", wtRel, out)
+
+	require.NoError(t, tc.WriteFile(dir+"/"+wtRel+"/foo.go", "package x\n"))
+	commitOut, err := tc.RunCampInDir(dir+"/"+wtRel, "p", "commit", "-m", "feat: stub")
+	require.NoError(t, err, "camp p commit inside worktree: %s", commitOut)
+
+	subject := lastCommitSubject(t, tc, dir+"/"+wtRel)
+	assert.Contains(t, subject, ref,
+		"commit in a worktree linked via WI-<ref> should carry the ref: %s", subject)
+}
+
+// Linking an unadopted design directory (a directory under workflow/design with
+// no .workitem marker) must fail fast with a clear "not adopted" error, and
+// must NOT leave a dangling worktree behind.
+func TestIntegration_WorktreeAdd_UnadoptedDesignDirErrors(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/worktree-add-unadopted"
+	initCommitTagsCampaign(t, tc, dir)
+
+	_, err := tc.RunCampInDir(dir, "project", "new", "demo-app")
+	require.NoError(t, err, "camp project new")
+
+	// A design directory with content but no .workitem marker: discovered by
+	// location, but has no stable id or ref.
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/loose/README.md", "# loose\n"))
+
+	out, err := tc.RunCampInDir(dir, "project", "worktree", "add", "loose-wt",
+		"--project", "demo-app", "--workitem", "workflow/design/loose")
+	require.Error(t, err, "must reject an unadopted design dir; output:\n%s", out)
+	assert.Contains(t, out, "not adopted", "error should name the not-adopted cause: %s", out)
+	assert.Contains(t, out, "camp workitem adopt", "error should name the adopt command: %s", out)
+
+	exists, err := tc.CheckDirExists(dir + "/projects/worktrees/demo-app/loose-wt")
+	require.NoError(t, err)
+	assert.False(t, exists, "a rejected link must not leave a dangling worktree behind")
+}
+
+// git worktree remove keeps the branch it created; re-adding a worktree with
+// the same name must surface an actionable hint (naming the leftover branch and
+// the --branch recovery) instead of a raw git "fatal: a branch named ... already
+// exists". The --branch recovery it suggests must then succeed.
+func TestIntegration_WorktreeAdd_LeftoverBranchHint(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/worktree-add-leftover-branch"
+	initCommitTagsCampaign(t, tc, dir)
+
+	_, err := tc.RunCampInDir(dir, "project", "new", "demo-app")
+	require.NoError(t, err, "camp project new")
+
+	_, err = tc.RunCampInDir(dir, "project", "worktree", "add", "reuse-wt", "--project", "demo-app")
+	require.NoError(t, err, "first worktree add")
+
+	_, err = tc.RunCampInDir(dir, "project", "worktree", "remove", "reuse-wt", "--project", "demo-app")
+	require.NoError(t, err, "worktree remove")
+
+	out, err := tc.RunCampInDir(dir, "project", "worktree", "add", "reuse-wt", "--project", "demo-app")
+	require.Error(t, err, "re-add over a leftover branch must error; output:\n%s", out)
+	assert.Contains(t, out, "already exists", "error should name the leftover branch: %s", out)
+	assert.Contains(t, out, "--branch", "error should point at the --branch recovery: %s", out)
+
+	recoverOut, err := tc.RunCampInDir(dir, "project", "worktree", "add", "reuse-wt",
+		"--project", "demo-app", "--branch", "reuse-wt")
+	require.NoError(t, err, "recovery via --branch should succeed: %s", recoverOut)
+
+	exists, err := tc.CheckDirExists(dir + "/projects/worktrees/demo-app/reuse-wt")
+	require.NoError(t, err)
+	assert.True(t, exists, "recovered worktree should exist")
+}


### PR DESCRIPTION
## Problem

Intent `camp-workitem-wi-ref-selector-20260712-214306`.

Three related worktree/selector bugs, all reproduced on the current `origin/main`:

1. **`WI-<ref>` selector does not resolve.** A freshly created/adopted `workflow/design` (or `workflow/explore`) workitem writes its ref to `.workitem` (e.g. `WI-541bcc`), but `camp workitem link WI-541bcc ...`, `camp workitem worktree WI-541bcc`, and `camp project worktree add --workitem WI-541bcc` all error `no workitem matched selector`, while the path/slug selector for the same directory resolves fine and doctor reports 0 findings. The `--workitem` help text already advertises `(ref, path, or id)`, so the ref case was simply unimplemented.

2. **Unadopted design dir derives an invalid id.** `camp project worktree add --workitem <path>` (and `camp worktrees create --workitem <path>`) against a `workflow/design` directory with no `.workitem` marker created the worktree, then failed the link deep in the links validator with `invalid workitem_id design:workflow/design/...: must not contain '/'`, leaving a dangling worktree behind.

3. **`worktree remove` leaves the branch behind.** `git worktree remove` keeps the branch it created, so re-adding a worktree of the same name failed with a raw `fatal: a branch named '...' already exists`, and the user had to discover `--branch` on their own.

Root cause for (1): `selector.Resolve` matched `id`, `key`, `path`, and `slug`, but never the ref, which lives in `SourceMetadata["ref"]` (the `.workitem` `id` becomes `StableID`, not the ref). All four commands route through `selector.Resolve`, so none of them accepted a ref.

## Fix

- **Ref matcher (`internal/workitem/selector/selector.go`).** Added a `ref` tier as the first matcher, comparing the query against `SourceMetadata["ref"]` case-insensitively (consistent with the existing `key`/`slug` `EqualFold` tiers). Refs are `WI-<6 hex>` and unique per workitem, so the tier is unambiguous; two hand-edited items sharing a ref surface an `ErrSelectorAmbiguous` rather than a silent pick.

- **Not-adopted guard (`internal/workitem/adoption.go`).** New `NeedsAdoption(wi)` returns true only for a builtin doc-type item (design/explore) discovered by location with no stable id, plus `NotAdoptedError(path)` that names the exact `camp workitem adopt <path>` recovery. The three worktree-link commands (`camp workitem worktree`, `camp project worktree add --workitem`, `camp worktrees create --workitem`) now resolve and validate the workitem *before* creating the worktree, so a bad or unadopted selector fails fast with a clear message and never leaves a dangling worktree.

- **Leftover-branch hint (`internal/worktree`).** Added a local-only `LocalBranchExists` check and a `WORKTREE_BRANCH_EXISTS` sentinel/constructor. The creator now detects a leftover local branch before `git worktree add` runs and returns `ErrBranchExists`; the `project worktree add` and `worktrees create` commands wrap it with `reuse it with --branch <name>, choose a different name, or delete it with 'git branch -D <name>'`, and `camp workitem worktree` (which has `--name`, not `--branch`) wraps it with a `--name`/delete hint.

## Tradeoffs and rejected alternatives

- **Not-adopted scope.** The guard is deliberately narrow to design/explore doc dirs (via the existing `IsBuiltinDocType`). Festivals and intents are also id-less but are legitimate, non-adoptable surfaces, and custom types cannot be discovered without a marker at all, so broadening the guard to "any id-less item" would have changed behavior for a tool with real users. A primary worktree link needs a ref for `camp p commit` to stamp, and only adopted doc dirs are missing one they should have.

- **Leftover branch: hint vs auto-delete.** I chose the actionable error (the intent's "clear hint" option) over adding a `--delete-branch` flag to `worktree remove`. Deleting a branch on remove risks silently discarding unpushed commits, so making the failure discoverable is the safer default and matches camp's existing pattern of wrapping worktree errors with next-step hints (the `ErrWorktreeExists` wrap already in `createWorktree`). A `--delete-branch` flag remains a reasonable future follow-up.

- **Local-only branch check.** `LocalBranchExists` intentionally ignores remote-tracking refs; `git worktree add -b foo` only conflicts with a local `foo`, and would happily create a local branch when only `origin/foo` exists, so checking the existing `BranchExists` (which also matches remotes) would have produced false rejections.

## Behavior / contract notes (camp has real users)

- **Additive selector change:** `WI-<ref>` now resolves where it previously errored. No previously-resolving selector changes meaning (a ref-shaped query cannot collide with an id/key/path/slug).
- **Error-message-only changes:** the unadopted-dir case and the leftover-branch case were already errors (non-zero exit); only the messages improved and, for the unadopted case, the worktree is no longer created before the error. No `--json` shape changed.

## Verification

- New unit tests: `internal/workitem/selector/selector_test.go` (ref resolves lowercase + uppercase, alongside id/key/path/slug; unknown ref is `ErrSelectorNotFound`; duplicate ref is `ErrSelectorAmbiguous`) and `internal/workitem/adoption_test.go` (table-driven `NeedsAdoption` incl. festival/intent negative cases; error message content).
- New integration tests: `tests/integration/workitem_worktree_selector_test.go` drives the real CLI in the container harness for all three behaviors (`--workitem <ref>` links and tags the commit; unadopted design dir errors with no dangling worktree; remove-then-readd surfaces the hint and `--branch` recovery succeeds).
- Gates in the worktree: `just build-camp`, `just test unit` (3434/3434 passed), `just lint` (0 issues; ratchets clean). Targeted integration: the 3 new tests pass, and the existing `TestIntegration_WorkitemWorktree_*`, `TestIntegration_ProjectCommit_*`, and `TestIntegration_WorkitemLink_*` tests still pass.
- Pre-existing failures on this branch are the known `TestIntegration_WorkitemCommits_*` (CrossRepo, FiltersFalsePositives, IncludesCampaignAndLinkedProject) and `TestIntegration_WorkitemValidate_ReportsFindings`, which live in commits-query/validate paths this change does not touch and which a separate agent is fixing. This change adds no new failures.
