### PR TITLE
fix(promote): migrate primary worktree links to the festival on --target festival

### DIFF
--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -219,8 +219,8 @@ func runCommit(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if prefs.TagCommits() {
-			questID, workitemRef := resolveCommitContext(ctx, campRoot, commitWorkitem)
-			message = commitkit.PrependContextTagsFullNamed(cfg.Name, cfg.ID, questID, "", workitemRef, message)
+			questID, festivalRef, workitemRef := resolveCommitContext(ctx, campRoot, commitWorkitem)
+			message = commitkit.PrependContextTagsFullNamed(cfg.Name, cfg.ID, questID, festivalRef, workitemRef, message)
 		}
 	}
 
@@ -255,9 +255,9 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	// Record the landed commit as ledger evidence (D003: after the commit
 	// exists). Tagging and the message above are untouched.
 	if sha, shaErr := commitkit.ShortHash(ctx, target.Path); shaErr == nil {
-		_, workitemRef := resolveCommitContext(ctx, campRoot, commitWorkitem)
+		_, festivalRef, workitemRef := resolveCommitContext(ctx, campRoot, commitWorkitem)
 		ledger.NewFromRoot(ctx, campRoot, ledger.WarnTo(cmd.ErrOrStderr())).
-			CommitEvidence(ctx, ledgerkit.Scope{Workitem: workitemRef}, campRoot, target.Path, sha, message)
+			CommitEvidence(ctx, ledgerkit.Scope{Workitem: workitemRef, Festival: festivalRef}, campRoot, target.Path, sha, message)
 	}
 
 	fmt.Println(ui.Success("Changes committed successfully"))

--- a/cmd/camp/commit_workitem.go
+++ b/cmd/camp/commit_workitem.go
@@ -19,21 +19,19 @@ import (
 // When the resolved workitem is a directory-kind item with no `ref` field
 // (pre-v1alpha6), the ref is auto-backfilled into the .workitem marker on
 // disk so future commits inherit it. A stderr warning notifies the user.
-func resolveCommitContext(ctx context.Context, campaignRoot, explicit string) (questID, workitemRef string) {
+func resolveCommitContext(ctx context.Context, campaignRoot, explicit string) (questID, festivalRef, workitemRef string) {
 	res, err := resolver.Resolve(ctx, campaignRoot, resolver.Options{
 		Explicit: explicit,
 	})
 	if err != nil || res == nil || res.Workitem == nil {
-		return "", ""
+		return "", "", ""
 	}
+	festivalRef = wkitem.FestivalRef(res.Workitem)
 	ref, ensureErr := wkitem.EnsureRefForCommit(ctx, campaignRoot, res.Workitem, os.Stderr)
-	if ensureErr != nil {
-		return res.QuestID, wkitem.RefOf(res.Workitem)
+	if ensureErr != nil || ref == "" {
+		ref = wkitem.RefOf(res.Workitem)
 	}
-	if ref != "" {
-		return res.QuestID, ref
-	}
-	return res.QuestID, wkitem.RefOf(res.Workitem)
+	return res.QuestID, festivalRef, ref
 }
 
 // workitemEnvForCommit resolves the active workitem and returns the

--- a/cmd/camp/commit_workitem_test.go
+++ b/cmd/camp/commit_workitem_test.go
@@ -20,8 +20,8 @@ func TestResolveCommitContext_GracefulOutsideCampaign(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	questID, ref := resolveCommitContext(context.Background(), filepath.Join(tmp, "no-campaign"), "")
-	if questID != "" || ref != "" {
-		t.Fatalf("expected empty strings for non-campaign root, got quest=%q ref=%q", questID, ref)
+	questID, festivalRef, ref := resolveCommitContext(context.Background(), filepath.Join(tmp, "no-campaign"), "")
+	if questID != "" || festivalRef != "" || ref != "" {
+		t.Fatalf("expected empty strings for non-campaign root, got quest=%q festival=%q ref=%q", questID, festivalRef, ref)
 	}
 }

--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -186,10 +186,11 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	// Prepend campaign tag unless tracing is disabled. Resolves the active
-	// workitem so the tag includes WI-<ref> when the project is linked.
+	// workitem so the tag includes WI-<ref> when the project is linked, or
+	// FE-<ref> when the worktree's primary link resolves to a festival.
 	if cfg != nil && commitPrefs.TagCommits() {
-		questID, workitemRef := resolveProjectCommitContext(ctx, campRoot, resolvedPath, projectCommitWorkitem)
-		message = commitkit.PrependContextTagsFullNamed(cfg.Name, cfg.ID, questID, "", workitemRef, message)
+		questID, festivalRef, workitemRef := resolveProjectCommitContext(ctx, campRoot, resolvedPath, projectCommitWorkitem)
+		message = commitkit.PrependContextTagsFullNamed(cfg.Name, cfg.ID, questID, festivalRef, workitemRef, message)
 	}
 
 	// Commit

--- a/cmd/camp/project/commit_workitem.go
+++ b/cmd/camp/project/commit_workitem.go
@@ -10,29 +10,32 @@ import (
 )
 
 // resolveProjectCommitContext runs the workitem resolver against the
-// campaign root and returns the captured quest id and ref for inclusion in
-// the project-commit tag. Resolution failures are non-fatal: empty strings
-// are returned so callers can still produce a quest- and workitem-free tag.
+// campaign root and returns the captured quest id, festival ref, and workitem
+// ref for inclusion in the project-commit tag. Resolution failures are
+// non-fatal: empty strings are returned so callers can still produce a quest-,
+// festival-, and workitem-free tag.
+//
+// A worktree whose primary link resolves to a festival (the state left by
+// `camp workitem promote --target festival`) carries the festival ref (FE-),
+// not a workitem ref (WI-), since a festival has no WI- ref of its own.
 //
 // cwd is the resolved project path used for cwd/link-based resolution.
 // explicit, when non-empty, is the user-supplied --workitem selector and
 // short-circuits cwd-based resolution.
-func resolveProjectCommitContext(ctx context.Context, campaignRoot, cwd, explicit string) (questID, workitemRef string) {
+func resolveProjectCommitContext(ctx context.Context, campaignRoot, cwd, explicit string) (questID, festivalRef, workitemRef string) {
 	res, err := resolver.Resolve(ctx, campaignRoot, resolver.Options{
 		Explicit: explicit,
 		Cwd:      cwd,
 	})
 	if err != nil || res == nil || res.Workitem == nil {
-		return "", ""
+		return "", "", ""
 	}
+	festivalRef = wkitem.FestivalRef(res.Workitem)
 	ref, ensureErr := wkitem.EnsureRefForCommit(ctx, campaignRoot, res.Workitem, os.Stderr)
-	if ensureErr != nil {
-		return res.QuestID, wkitem.RefOf(res.Workitem)
+	if ensureErr != nil || ref == "" {
+		ref = wkitem.RefOf(res.Workitem)
 	}
-	if ref != "" {
-		return res.QuestID, ref
-	}
-	return res.QuestID, wkitem.RefOf(res.Workitem)
+	return res.QuestID, festivalRef, ref
 }
 
 // workitemEnvForProjectCommit resolves the active workitem and returns the

--- a/cmd/camp/project/worktree/add.go
+++ b/cmd/camp/project/worktree/add.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
 	"github.com/Obedience-Corp/camp/internal/workitem/selector"
 	intworktree "github.com/Obedience-Corp/camp/internal/worktree"
@@ -165,16 +166,12 @@ func linkWorktreeToWorkitem(ctx context.Context, campRoot, selectorQuery, relati
 	if err != nil {
 		return links.Link{}, camperrors.Wrap(err, "resolve workitem "+selectorQuery)
 	}
-	workitemID := wi.StableID
-	if workitemID == "" {
-		workitemID = wi.Key
-	}
 	scopePath := relativeWorktreePath
 	if scopePath == "" {
 		return links.Link{}, camperrors.NewValidation("worktree", "missing worktree relative path", nil)
 	}
 	return links.AttachPrimary(ctx, campRoot, links.AttachOptions{
-		WorkitemID:  workitemID,
+		WorkitemID:  wkitem.LinkWorkitemID(wi),
 		WorkitemKey: wi.Key,
 		Scope: links.LinkScope{
 			Kind: links.ScopeWorktree,

--- a/cmd/camp/worktrees/commit.go
+++ b/cmd/camp/worktrees/commit.go
@@ -151,8 +151,8 @@ func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if prefs.TagCommits() {
-		questID, workitemRef := resolveWorktreeCommitContext(ctx, campRoot, wtCtx.WorktreePath, wtCommitWorkitem)
-		message = commitkit.PrependContextTagsFullNamed(cfg.Name, cfg.ID, questID, "", workitemRef, message)
+		questID, festivalRef, workitemRef := resolveWorktreeCommitContext(ctx, campRoot, wtCtx.WorktreePath, wtCommitWorkitem)
+		message = commitkit.PrependContextTagsFullNamed(cfg.Name, cfg.ID, questID, festivalRef, workitemRef, message)
 	}
 
 	// Commit

--- a/cmd/camp/worktrees/commit_workitem.go
+++ b/cmd/camp/worktrees/commit_workitem.go
@@ -9,22 +9,20 @@ import (
 	"github.com/Obedience-Corp/camp/pkg/commitkit"
 )
 
-func resolveWorktreeCommitContext(ctx context.Context, campaignRoot, cwd, explicit string) (questID, workitemRef string) {
+func resolveWorktreeCommitContext(ctx context.Context, campaignRoot, cwd, explicit string) (questID, festivalRef, workitemRef string) {
 	res, err := resolver.Resolve(ctx, campaignRoot, resolver.Options{
 		Explicit: explicit,
 		Cwd:      cwd,
 	})
 	if err != nil || res == nil || res.Workitem == nil {
-		return "", ""
+		return "", "", ""
 	}
+	festivalRef = wkitem.FestivalRef(res.Workitem)
 	ref, ensureErr := wkitem.EnsureRefForCommit(ctx, campaignRoot, res.Workitem, os.Stderr)
-	if ensureErr != nil {
-		return res.QuestID, wkitem.RefOf(res.Workitem)
+	if ensureErr != nil || ref == "" {
+		ref = wkitem.RefOf(res.Workitem)
 	}
-	if ref != "" {
-		return res.QuestID, ref
-	}
-	return res.QuestID, wkitem.RefOf(res.Workitem)
+	return res.QuestID, festivalRef, ref
 }
 
 func workitemEnvForWorktreeCommit(ctx context.Context, campaignRoot, cwd, explicit string) []string {

--- a/cmd/camp/worktrees/create.go
+++ b/cmd/camp/worktrees/create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
 	"github.com/Obedience-Corp/camp/internal/workitem/selector"
 	"github.com/Obedience-Corp/camp/internal/worktree"
@@ -166,12 +167,8 @@ func linkWorktreeToWorkitem(ctx context.Context, campRoot, selectorQuery, relati
 	if err != nil {
 		return links.Link{}, camperrors.Wrap(err, "resolve workitem "+selectorQuery)
 	}
-	workitemID := wi.StableID
-	if workitemID == "" {
-		workitemID = wi.Key
-	}
 	return links.AttachPrimary(ctx, campRoot, links.AttachOptions{
-		WorkitemID:  workitemID,
+		WorkitemID:  wkitem.LinkWorkitemID(wi),
 		WorkitemKey: wi.Key,
 		Scope: links.LinkScope{
 			Kind: links.ScopeWorktree,

--- a/internal/commands/workitem/commit_context.go
+++ b/internal/commands/workitem/commit_context.go
@@ -48,14 +48,9 @@ func ResolveCommitContext(ctx context.Context, campaignRoot, cwd string, errw io
 		ref = wkitem.RefOf(res.Workitem)
 	}
 
-	festivalRef := ""
-	if res.Source == resolver.SourceFestival {
-		festivalRef = festivalRefFromString(festivalID)
-	}
-
 	return CommitContext{
 		QuestID:     res.QuestID,
-		FestivalRef: festivalRef,
+		FestivalRef: festivalRefForResolved(res, festivalID),
 		WorkitemRef: ref,
 	}
 }

--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -53,6 +53,13 @@ type docFinding struct {
 	Message     string `json:"message"`
 	FixHint     string `json:"fix_hint,omitempty"`
 	AutoFixable bool   `json:"auto_fixable"`
+
+	// migrateToID/migrateToKey carry a non-destructive recovery target for a
+	// broken link whose workitem was promoted to a festival: --fix re-points
+	// the link onto that festival instead of removing it. Unexported so they
+	// stay out of the --json contract.
+	migrateToID  string
+	migrateToKey string
 }
 
 // errDoctorIssues triggers a non-zero exit from cobra after we have already
@@ -219,17 +226,28 @@ func collectWorkitemFindings(ctx context.Context, root string, registry *links.L
 		})
 	}
 
+	promotedTargets := promotedFestivalTargets(ctx, root)
 	primarySeen := make(map[string]string)
 	for _, link := range registry.Links {
 		if _, known := knownIDs[link.WorkitemID]; !known {
-			findings = append(findings, docFinding{
+			finding := docFinding{
 				Code:        codeBrokenLink,
 				Severity:    docSeverityError,
 				Target:      "link:" + link.ID,
 				Message:     "workitem_id " + link.WorkitemID + " is not present on disk",
 				FixHint:     "auto-fix removes the link",
 				AutoFixable: true,
-			})
+			}
+			if target, ok := promotedTargets[link.WorkitemID]; ok {
+				finding.Message = "workitem_id " + link.WorkitemID +
+					" is not present on disk; it was promoted to festival " + target.id
+				finding.FixHint = "auto-fix re-links to festival " + target.id +
+					" (or re-link manually: camp workitem link " + target.id +
+					" --worktree <scope> --replace)"
+				finding.migrateToID = target.id
+				finding.migrateToKey = target.key
+			}
+			findings = append(findings, finding)
 		}
 		scopeMissing := !scopeTargetExists(root, link.Scope.Path)
 		if scopeMissing {
@@ -339,7 +357,16 @@ func autoFixWorkitemFindings(ctx context.Context, root string, registry *links.L
 			continue
 		}
 		switch f.Code {
-		case codeBrokenLink, codeBrokenScope:
+		case codeBrokenLink:
+			id := strings.TrimPrefix(f.Target, "link:")
+			if f.migrateToID != "" {
+				if repointLinkByID(registry, id, f.migrateToID, f.migrateToKey) {
+					applied++
+				}
+			} else if registry.RemoveLinkByID(id) {
+				applied++
+			}
+		case codeBrokenScope:
 			id := strings.TrimPrefix(f.Target, "link:")
 			if registry.RemoveLinkByID(id) {
 				applied++
@@ -413,6 +440,12 @@ func workitemIDsOnDisk(ctx context.Context, root string) (map[string]struct{}, e
 		if item.Key != "" {
 			set[item.Key] = struct{}{}
 		}
+		// Festivals are first-class link targets addressed by their fest.yaml
+		// id (e.g. SC0001); keep that id "present on disk" so a link migrated
+		// onto a festival by promote is not reported as broken.
+		if item.WorkflowType == wkitem.WorkflowTypeFestival && item.SourceID != "" {
+			set[item.SourceID] = struct{}{}
+		}
 	}
 	return set, nil
 }
@@ -420,6 +453,62 @@ func workitemIDsOnDisk(ctx context.Context, root string) (map[string]struct{}, e
 func hasErrorFinding(findings []docFinding) bool {
 	for _, f := range findings {
 		if f.Severity == docSeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+// festivalTarget is a resolvable festival link target: its single-segment
+// fest.yaml id and its "festival:<path>" key.
+type festivalTarget struct {
+	id  string
+	key string
+}
+
+// promotedFestivalTargets maps a promoted workitem's stable id to the festival
+// it was promoted to, for every design/explore workitem marker (including
+// shelved ones) that recorded a promoted_to festival that still exists. It lets
+// doctor offer a broken link a non-destructive migration onto that festival
+// instead of only deletion. Best-effort: unreadable markers are skipped.
+func promotedFestivalTargets(ctx context.Context, root string) map[string]festivalTarget {
+	out := map[string]festivalTarget{}
+	cfg, err := config.LoadCampaignConfig(ctx, root)
+	if err != nil {
+		return out
+	}
+	resolver := paths.NewResolverFromConfig(root, cfg)
+	for _, dir := range []string{resolver.Design(), resolver.Explore()} {
+		_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil || d.IsDir() || d.Name() != wkitem.MetadataFilename {
+				return nil
+			}
+			meta, err := wkitem.LoadMetadata(ctx, filepath.Dir(path))
+			if err != nil || meta == nil || meta.ID == "" || meta.PromotedTo == "" {
+				return nil
+			}
+			promotedTo := filepath.ToSlash(meta.PromotedTo)
+			if !strings.HasPrefix(promotedTo, "festivals/") {
+				return nil
+			}
+			festID := readFestivalID(root, promotedTo)
+			if festID == "" {
+				return nil
+			}
+			out[meta.ID] = festivalTarget{id: festID, key: "festival:" + promotedTo}
+			return nil
+		})
+	}
+	return out
+}
+
+// repointLinkByID re-points the link with the given id onto a new workitem id
+// and key. Returns true when a link was updated.
+func repointLinkByID(registry *links.Links, linkID, newID, newKey string) bool {
+	for i := range registry.Links {
+		if registry.Links[i].ID == linkID {
+			registry.Links[i].WorkitemID = newID
+			registry.Links[i].WorkitemKey = newKey
 			return true
 		}
 	}

--- a/internal/commands/workitem/link.go
+++ b/internal/commands/workitem/link.go
@@ -291,6 +291,9 @@ func workitemIDForLink(wi *wkitem.WorkItem, opts linkOptions) string {
 	if wi.StableID != "" {
 		return wi.StableID
 	}
+	if wi.WorkflowType == wkitem.WorkflowTypeFestival && wi.SourceID != "" {
+		return wi.SourceID
+	}
 	if opts.AllowMissing {
 		return opts.Selector
 	}

--- a/internal/commands/workitem/promote.go
+++ b/internal/commands/workitem/promote.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
 	dungeoncmd "github.com/Obedience-Corp/camp/cmd/camp/dungeon"
 	"github.com/Obedience-Corp/camp/internal/config"
@@ -272,6 +273,11 @@ func doFestivalPromote(ctx context.Context, cmd *cobra.Command, opts runWorkitem
 		return nil, camperrors.New("--dest is only valid for --target doc; fest chooses the festival directory")
 	}
 
+	// Capture the source workitem identity before the festival is created and
+	// the source is shelved, so links pointing at it can be migrated onto the
+	// festival afterward.
+	oldID, oldKey := promotedWorkitemIdentity(ctx, campaignRoot, loc, result)
+
 	name := intent.SlugFromTitle(titleFromDoc(docContent, loc.Slug))
 	goal := opts.Goal
 	if goal == "" {
@@ -312,7 +318,23 @@ func doFestivalPromote(ctx context.Context, cmd *cobra.Command, opts runWorkitem
 			filepath.Join(campaignRoot, "festivals", ".festival", ".state"),
 		},
 	}
-	return appendShelve(ctx, opts, campaignRoot, loc, ci, result)
+	ci, err = appendShelve(ctx, opts, campaignRoot, loc, ci, result)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only a shelved source orphans its links; --keep leaves the source in
+	// place and resolvable, so there is nothing to migrate.
+	if !opts.Keep {
+		migrated, mErr := migratePromotedLinks(ctx, campaignRoot, oldID, oldKey, promotedTo)
+		if mErr != nil {
+			return nil, camperrors.Wrap(mErr, "migrate workitem links to festival")
+		}
+		if migrated {
+			ci.destPaths = append(ci.destPaths, links.LinksPath(campaignRoot))
+		}
+	}
+	return ci, nil
 }
 
 func doDocPromote(ctx context.Context, opts runWorkitemPromoteOptions, campaignRoot string, loc *locate.Location, result *workitemPromoteResult) (*commitInputs, error) {
@@ -359,6 +381,96 @@ func doDocPromote(ctx context.Context, opts runWorkitemPromoteOptions, campaignR
 		destPaths:   []string{destDir},
 	}
 	return appendShelve(ctx, opts, campaignRoot, loc, ci, result)
+}
+
+// promotedWorkitemIdentity returns the stable id and key that links may
+// reference for the workitem being promoted, read from its .workitem marker
+// before it is shelved. Returns ("", key) for an unadopted directory (no
+// marker), which has no stable-id links to migrate.
+func promotedWorkitemIdentity(ctx context.Context, campaignRoot string, loc *locate.Location, result *workitemPromoteResult) (id, key string) {
+	key = loc.Type + ":" + result.From
+	if meta, err := wkitem.LoadMetadata(ctx, loc.SourcePath); err == nil && meta != nil {
+		id = meta.ID
+	}
+	return id, key
+}
+
+// migratePromotedLinks re-points every link that referenced the promoted
+// workitem (by its old stable id or key) onto the created festival, addressed
+// by the festival's single-segment fest.yaml id. Returns whether the registry
+// changed. Best-effort: if the festival has no readable id there is no valid
+// single-segment link target, so the links are left untouched.
+func migratePromotedLinks(ctx context.Context, campaignRoot, oldID, oldKey, promotedTo string) (bool, error) {
+	newID := readFestivalID(campaignRoot, promotedTo)
+	if newID == "" || (oldID == "" && oldKey == "") {
+		return false, nil
+	}
+	newKey := "festival:" + promotedTo
+
+	changed := false
+	err := links.WithLock(ctx, campaignRoot, func(reg *links.Links) error {
+		if !rehomePromotedLinks(reg, oldID, oldKey, newID, newKey) {
+			return links.ErrSkipSave
+		}
+		changed = true
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return changed, nil
+}
+
+// rehomePromotedLinks re-points links matching the promoted workitem onto the
+// festival (updating both workitem_id and workitem_key), then drops links that
+// became exact duplicates. Mirrors rehomeGatherLinks, extended to carry the key
+// because a festival's id and key differ from the source workitem's.
+func rehomePromotedLinks(reg *links.Links, oldID, oldKey, newID, newKey string) bool {
+	changed := false
+	for i := range reg.Links {
+		l := &reg.Links[i]
+		matches := (oldID != "" && l.WorkitemID == oldID) || (oldKey != "" && l.WorkitemKey == oldKey)
+		if matches && (l.WorkitemID != newID || l.WorkitemKey != newKey) {
+			l.WorkitemID = newID
+			l.WorkitemKey = newKey
+			changed = true
+		}
+	}
+	if !changed {
+		return false
+	}
+	seen := make(map[string]bool, len(reg.Links))
+	deduped := make([]links.Link, 0, len(reg.Links))
+	for _, link := range reg.Links {
+		key := link.WorkitemID + "|" + string(link.Scope.Kind) + "|" + link.Scope.Path + "|" + string(link.Role)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		deduped = append(deduped, link)
+	}
+	reg.Links = deduped
+	return true
+}
+
+// readFestivalID returns the fest.yaml metadata id (e.g. SC0001) for the
+// festival at promotedTo (a campaign-relative festivals/... path), or "" when
+// it cannot be read. This is the same id discovery exposes as the festival
+// workitem's SourceID, which the selector resolves and links address.
+func readFestivalID(campaignRoot, promotedTo string) string {
+	data, err := os.ReadFile(filepath.Join(campaignRoot, filepath.FromSlash(promotedTo), "fest.yaml"))
+	if err != nil {
+		return ""
+	}
+	var doc struct {
+		Metadata struct {
+			ID string `yaml:"id"`
+		} `yaml:"metadata"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(doc.Metadata.ID)
 }
 
 func recordPromotedTo(ctx context.Context, campaignRoot string, loc *locate.Location, promotedTo string) error {

--- a/internal/commands/workitem/promote_migrate_test.go
+++ b/internal/commands/workitem/promote_migrate_test.go
@@ -1,0 +1,55 @@
+package workitem
+
+import (
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+func TestRehomePromotedLinks(t *testing.T) {
+	const (
+		oldID  = "design-x-2026-07-17"
+		oldKey = "design:workflow/design/x"
+		newID  = "SC0001"
+		newKey = "festival:festivals/planning/x-SC0001"
+	)
+
+	worktreeScope := links.LinkScope{Kind: links.ScopeWorktree, Path: "projects/worktrees/demo/x"}
+
+	t.Run("re-points a matching primary link by id", func(t *testing.T) {
+		reg := &links.Links{Links: []links.Link{
+			{ID: "lnk_1", WorkitemID: oldID, WorkitemKey: oldKey, Scope: worktreeScope, Role: links.RolePrimary},
+		}}
+		if !rehomePromotedLinks(reg, oldID, oldKey, newID, newKey) {
+			t.Fatal("expected registry to change")
+		}
+		got := reg.Links[0]
+		if got.WorkitemID != newID || got.WorkitemKey != newKey {
+			t.Fatalf("link not re-pointed: id=%q key=%q", got.WorkitemID, got.WorkitemKey)
+		}
+	})
+
+	t.Run("no match leaves registry unchanged", func(t *testing.T) {
+		reg := &links.Links{Links: []links.Link{
+			{ID: "lnk_1", WorkitemID: "other-id", WorkitemKey: "design:workflow/design/other", Scope: worktreeScope, Role: links.RolePrimary},
+		}}
+		if rehomePromotedLinks(reg, oldID, oldKey, newID, newKey) {
+			t.Fatal("expected no change for a non-matching link")
+		}
+	})
+
+	t.Run("dedupes links that collide after re-pointing", func(t *testing.T) {
+		// Two links referencing the promoted workitem on the same scope+role
+		// (one already on the festival) collapse into a single entry.
+		reg := &links.Links{Links: []links.Link{
+			{ID: "lnk_1", WorkitemID: oldID, WorkitemKey: oldKey, Scope: worktreeScope, Role: links.RolePrimary},
+			{ID: "lnk_2", WorkitemID: newID, WorkitemKey: newKey, Scope: worktreeScope, Role: links.RolePrimary},
+		}}
+		if !rehomePromotedLinks(reg, oldID, oldKey, newID, newKey) {
+			t.Fatal("expected registry to change")
+		}
+		if len(reg.Links) != 1 {
+			t.Fatalf("expected duplicate links to collapse to 1, got %d", len(reg.Links))
+		}
+	})
+}

--- a/internal/commands/workitem/staging.go
+++ b/internal/commands/workitem/staging.go
@@ -87,6 +87,23 @@ func (p *StagingPlan) addStageNote(path, note string) {
 // matrix row that applies, and returns a StagingPlan that the commit runner
 // can hand to commit.Workitem. Refusal modes (no workitem, empty plan with no
 // override) surface as typed errors so the CLI can map them to exit codes.
+// festivalRefForResolved derives the FE-<ref> segment for a commit tag from a
+// resolver result. It fires in two cases: the festival resolver tier matched
+// (cwd inside a festival, or --festival), or a worktree/link tier resolved to a
+// festival-typed workitem. The latter is how a worktree whose primary link was
+// migrated to a festival by `camp workitem promote --target festival` keeps
+// carrying a context ref (FE-<festival id>) instead of an empty tag. Returns ""
+// for non-festival contexts.
+func festivalRefForResolved(res *resolver.Resolution, festivalID string) string {
+	if res == nil || res.Workitem == nil {
+		return ""
+	}
+	if res.Source == resolver.SourceFestival {
+		return festivalRefFromString(festivalID)
+	}
+	return wkitem.FestivalRef(res.Workitem)
+}
+
 func ComputePlan(ctx context.Context, campaignRoot string, opts PlanOptions) (*StagingPlan, error) {
 	if campaignRoot == "" {
 		return nil, camperrors.NewValidation("root", "campaign root required", nil)
@@ -118,10 +135,7 @@ func ComputePlan(ctx context.Context, campaignRoot string, opts PlanOptions) (*S
 	if err != nil {
 		return nil, err
 	}
-	festivalRef := ""
-	if res.Source == resolver.SourceFestival {
-		festivalRef = festivalRefFromString(festivalID)
-	}
+	festivalRef := festivalRefForResolved(res, festivalID)
 	plan := &StagingPlan{
 		Workitem:    wi,
 		WorkitemRef: ref,

--- a/internal/commands/workitem/staging_festival.go
+++ b/internal/commands/workitem/staging_festival.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
 
 func inferFestivalIDFromCwd(campaignRoot, cwd string) string {
@@ -80,40 +82,7 @@ func festivalMetadataID(campaignRoot, rel string) string {
 }
 
 func festivalRefFromString(value string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return ""
-	}
-	value = filepath.Base(filepath.ToSlash(value))
-	if isFestivalRef(value) {
-		return value
-	}
-	if idx := strings.LastIndex(value, "-"); idx >= 0 {
-		tail := value[idx+1:]
-		if isFestivalRef(tail) {
-			return tail
-		}
-	}
-	return ""
-}
-
-func isFestivalRef(value string) bool {
-	if value == "" || len(value) > 32 {
-		return false
-	}
-	for _, r := range value {
-		if r >= '0' && r <= '9' {
-			continue
-		}
-		if r >= 'A' && r <= 'Z' {
-			continue
-		}
-		if r >= 'a' && r <= 'z' {
-			continue
-		}
-		return false
-	}
-	return true
+	return wkitem.FestivalRefFromID(value)
 }
 
 func relOutsideCampaignRoot(rel string) bool {

--- a/internal/commands/workitem/worktree.go
+++ b/internal/commands/workitem/worktree.go
@@ -256,10 +256,7 @@ func attachWorktreeLink(ctx context.Context, root string, wi *wkitem.WorkItem, r
 	if relativeWorktreePath == "" {
 		return links.Link{}, camperrors.NewValidation("worktree", "missing worktree relative path", nil)
 	}
-	workitemID := wi.StableID
-	if workitemID == "" {
-		workitemID = wi.Key
-	}
+	workitemID := wkitem.LinkWorkitemID(wi)
 	return links.AttachPrimary(ctx, root, links.AttachOptions{
 		WorkitemID:  workitemID,
 		WorkitemKey: wi.Key,

--- a/internal/workitem/festival_ref.go
+++ b/internal/workitem/festival_ref.go
@@ -1,0 +1,56 @@
+package workitem
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// FestivalRefFromID extracts the festival ref token (the FE-<ref> payload) from
+// a festival id or directory name: the trailing id segment, e.g. SC0001 from
+// "sync-clone-transport-SC0001", from "festivals/planning/...-SC0001", or from
+// a bare "SC0001". Returns "" when no ref-shaped token is present.
+func FestivalRefFromID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	value = filepath.Base(filepath.ToSlash(value))
+	if isFestivalRefToken(value) {
+		return value
+	}
+	if idx := strings.LastIndex(value, "-"); idx >= 0 {
+		if tail := value[idx+1:]; isFestivalRefToken(tail) {
+			return tail
+		}
+	}
+	return ""
+}
+
+// FestivalRef returns the festival ref for a festival-typed workitem, derived
+// from its fest.yaml id (SourceID) and falling back to its directory name.
+// Returns "" for any non-festival workitem. This is the FE-<ref> segment a
+// commit made in a festival-linked worktree should carry.
+func FestivalRef(wi *WorkItem) string {
+	if wi == nil || wi.WorkflowType != WorkflowTypeFestival {
+		return ""
+	}
+	src := wi.SourceID
+	if src == "" {
+		src = wi.RelativePath
+	}
+	return FestivalRefFromID(src)
+}
+
+func isFestivalRefToken(value string) bool {
+	if value == "" || len(value) > 32 {
+		return false
+	}
+	for _, r := range value {
+		switch {
+		case r >= '0' && r <= '9', r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/workitem/festival_ref_test.go
+++ b/internal/workitem/festival_ref_test.go
@@ -1,0 +1,57 @@
+package workitem
+
+import "testing"
+
+func TestFestivalRefFromID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare id", "SC0001", "SC0001"},
+		{"dir name with trailing id", "sync-clone-transport-SC0001", "SC0001"},
+		{"campaign-relative festival path", "festivals/planning/sync-clone-transport-SC0001", "SC0001"},
+		{"empty", "", ""},
+		{"non-alphanumeric yields no ref", "weird_slug!", ""},
+		{"whitespace trimmed", "  SC0001  ", "SC0001"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FestivalRefFromID(tt.in); got != tt.want {
+				t.Fatalf("FestivalRefFromID(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFestivalRef(t *testing.T) {
+	tests := []struct {
+		name string
+		wi   *WorkItem
+		want string
+	}{
+		{"nil", nil, ""},
+		{
+			"festival with source id",
+			&WorkItem{WorkflowType: WorkflowTypeFestival, SourceID: "SC0001"},
+			"SC0001",
+		},
+		{
+			"festival falls back to relative path",
+			&WorkItem{WorkflowType: WorkflowTypeFestival, RelativePath: "festivals/planning/sync-clone-transport-SC0001"},
+			"SC0001",
+		},
+		{
+			"design workitem is not a festival",
+			&WorkItem{WorkflowType: WorkflowTypeDesign, SourceID: "whatever", StableID: "design-x"},
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FestivalRef(tt.wi); got != tt.want {
+				t.Fatalf("FestivalRef() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/workitem/link_target.go
+++ b/internal/workitem/link_target.go
@@ -1,0 +1,24 @@
+package workitem
+
+// LinkWorkitemID returns the identifier to store as a link's workitem_id for
+// wi. It is the single-segment id the selector can resolve back to wi:
+//   - an adopted workitem's stable .workitem id, when present;
+//   - a festival's fest.yaml id (e.g. SC0001), which is how a festival becomes
+//     a first-class link target after `camp workitem promote --target festival`;
+//   - otherwise the workitem key.
+//
+// The links validator requires workitem_id to be a single path segment, so a
+// festival's slash-bearing key ("festival:festivals/...") is never a valid id;
+// its fest.yaml id is.
+func LinkWorkitemID(wi *WorkItem) string {
+	if wi == nil {
+		return ""
+	}
+	if wi.StableID != "" {
+		return wi.StableID
+	}
+	if wi.WorkflowType == WorkflowTypeFestival && wi.SourceID != "" {
+		return wi.SourceID
+	}
+	return wi.Key
+}

--- a/internal/workitem/link_target_test.go
+++ b/internal/workitem/link_target_test.go
@@ -1,0 +1,35 @@
+package workitem
+
+import "testing"
+
+func TestLinkWorkitemID(t *testing.T) {
+	tests := []struct {
+		name string
+		wi   *WorkItem
+		want string
+	}{
+		{"nil", nil, ""},
+		{
+			"adopted workitem uses stable id",
+			&WorkItem{StableID: "design-x-2026-07-17", Key: "design:workflow/design/x", WorkflowType: WorkflowTypeDesign},
+			"design-x-2026-07-17",
+		},
+		{
+			"festival uses fest.yaml id, never its slash-bearing key",
+			&WorkItem{WorkflowType: WorkflowTypeFestival, SourceID: "SC0001", Key: "festival:festivals/planning/x-SC0001"},
+			"SC0001",
+		},
+		{
+			"id-less non-festival falls back to key",
+			&WorkItem{WorkflowType: WorkflowTypeDesign, Key: "design:workflow/design/x"},
+			"design:workflow/design/x",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := LinkWorkitemID(tt.wi); got != tt.want {
+				t.Fatalf("LinkWorkitemID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/workitem/selector/festival_test.go
+++ b/internal/workitem/selector/festival_test.go
@@ -1,0 +1,56 @@
+package selector
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFestivalCampaign(t *testing.T, festDir, festID string) string {
+	t.Helper()
+	root := t.TempDir()
+
+	mustWriteFile(t, filepath.Join(root, ".campaign", "campaign.yaml"),
+		"version: campaign/v1\nid: testcampaign\nname: test\ntype: product\n")
+
+	festYAML := "version: fest/v1\nmetadata:\n  id: " + festID + "\n  name: " + festDir + "\n  festival_type: standard\n"
+	mustWriteFile(t, filepath.Join(root, "festivals", "planning", festDir, "fest.yaml"), festYAML)
+	mustWriteFile(t, filepath.Join(root, "festivals", "planning", festDir, "FESTIVAL_GOAL.md"), "# goal\n")
+	return root
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolve_FestivalByFestYAMLID(t *testing.T) {
+	root := writeFestivalCampaign(t, "sync-clone-transport-SC0001", "SC0001")
+
+	for _, query := range []string{"SC0001", "sc0001"} {
+		wi, err := Resolve(context.Background(), root, query, ResolveOptions{})
+		if err != nil {
+			t.Fatalf("Resolve(%q) error: %v", query, err)
+		}
+		if wi.WorkflowType != "festival" {
+			t.Fatalf("Resolve(%q) resolved a %q, want festival", query, wi.WorkflowType)
+		}
+		if wi.SourceID != "SC0001" {
+			t.Fatalf("Resolve(%q) SourceID = %q, want SC0001", query, wi.SourceID)
+		}
+	}
+}
+
+func TestResolve_UnknownFestivalIDIsNotFound(t *testing.T) {
+	root := writeFestivalCampaign(t, "sync-clone-transport-SC0001", "SC0001")
+
+	if _, err := Resolve(context.Background(), root, "SC9999", ResolveOptions{}); err == nil {
+		t.Fatal("Resolve(unknown festival id) should error")
+	}
+}

--- a/internal/workitem/selector/selector.go
+++ b/internal/workitem/selector/selector.go
@@ -39,7 +39,8 @@ var (
 //  2. exact key (`<type>:<path>`)
 //  3. exact RelativePath
 //  4. exact directory-base slug
-//  5. fuzzy substring on key or title (only when opts.AllowFuzzy)
+//  5. exact festival id (`fest.yaml` metadata id, e.g. SC0001)
+//  6. fuzzy substring on key or title (only when opts.AllowFuzzy)
 func Resolve(ctx context.Context, root string, query string, opts ResolveOptions) (*workitem.WorkItem, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -63,6 +64,9 @@ func Resolve(ctx context.Context, root string, query string, opts ResolveOptions
 		{"key", func(w workitem.WorkItem) bool { return strings.EqualFold(w.Key, query) }},
 		{"path", func(w workitem.WorkItem) bool { return w.RelativePath == strings.TrimRight(query, "/") }},
 		{"slug", func(w workitem.WorkItem) bool { return strings.EqualFold(filepath.Base(w.RelativePath), query) }},
+		{"festival_id", func(w workitem.WorkItem) bool {
+			return w.WorkflowType == workitem.WorkflowTypeFestival && w.SourceID != "" && strings.EqualFold(w.SourceID, query)
+		}},
 	}
 	for _, m := range matchers {
 		var matched []workitem.WorkItem

--- a/tests/integration/promote_workitem_festival_test.go
+++ b/tests/integration/promote_workitem_festival_test.go
@@ -1,0 +1,115 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Promoting a design workitem to a festival must migrate its primary worktree
+// link onto the festival (so doctor stays clean) and switch the linked
+// worktree's commit tag from WI-<design ref> to FE-<festival ref>, instead of
+// orphaning the link and dropping the tag entirely.
+func TestIntegration_PromoteWorkitemToFestival_MigratesLinkAndTagsFE(t *testing.T) {
+	if !festAvailable {
+		t.Skip("fest CLI not available in container")
+	}
+	tc := GetSharedContainer(t)
+	path := "/campaigns/promote-wi-festival"
+
+	_, err := tc.InitCampaign(path, "promote-wi-festival", "product")
+	require.NoError(t, err)
+	_, _, err = tc.ExecCommand("sh", "-c", fmt.Sprintf(
+		"mkdir -p %s/festivals/.festival/templates %s/festivals/.festival/.state %s/festivals/planning",
+		path, path, path))
+	require.NoError(t, err)
+
+	slug := "sync-clone-transport"
+	ref := seedDesignWorkitemWithRef(t, tc, path, slug)
+	require.NoError(t, tc.WriteFile(path+"/workflow/design/"+slug+"/README.md",
+		"# "+slug+"\n\nBody paragraph so the festival promote is not empty.\n"))
+
+	_, err = tc.RunCampInDir(path, "project", "new", "demo-app")
+	require.NoError(t, err, "camp project new")
+	_, err = tc.RunCampInDir(path, "project", "worktree", "add", "sync-wt",
+		"--project", "demo-app", "--workitem", slug)
+	require.NoError(t, err, "worktree add --workitem")
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+path+" && git add -A && git commit -m 'setup' --allow-empty")
+	require.NoError(t, err)
+
+	wtRel := "projects/worktrees/demo-app/sync-wt"
+
+	// Before promote: a commit in the worktree carries the design WI-<ref>.
+	require.NoError(t, tc.WriteFile(path+"/"+wtRel+"/before.go", "package x\n"))
+	beforeOut, err := tc.RunCampInDir(path+"/"+wtRel, "p", "commit", "-m", "feat: before promote")
+	require.NoError(t, err, "camp p commit (before): %s", beforeOut)
+	assert.Contains(t, lastCommitSubject(t, tc, path+"/"+wtRel), ref,
+		"pre-promote commit should carry the design WI-<ref>")
+
+	// Promote the design workitem to a festival.
+	promoteOut, err := tc.RunCampInDir(path, "workitem", "promote", slug, "--target", "festival")
+	require.NoError(t, err, "camp workitem promote --target festival: %s", promoteOut)
+
+	festDir := findPlanningFestivalDir(t, tc, path, slug, promoteOut)
+	festID := festDir[strings.LastIndex(festDir, "-")+1:]
+	require.NotEmpty(t, festID, "could not derive festival id from dir %q", festDir)
+
+	// The primary link is migrated onto the festival's single-segment id.
+	linksYAML, err := tc.ReadFile(path + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, linksYAML, "workitem_id: "+festID,
+		"link should be migrated to the festival id; links.yaml:\n%s", linksYAML)
+
+	// Doctor is clean: the migrated link resolves, so no broken-link finding.
+	doctorOut, err := tc.RunCampInDir(path, "workitem", "doctor")
+	require.NoError(t, err, "doctor should exit clean: %s", doctorOut)
+	assert.Contains(t, doctorOut, "0 findings", "doctor should report no findings: %s", doctorOut)
+
+	// After promote: a commit in the same worktree carries FE-<festival ref>
+	// and no longer the retired design WI-<ref>.
+	require.NoError(t, tc.WriteFile(path+"/"+wtRel+"/after.go", "package x\n\n// more\n"))
+	afterOut, err := tc.RunCampInDir(path+"/"+wtRel, "p", "commit", "-m", "feat: after promote")
+	require.NoError(t, err, "camp p commit (after): %s", afterOut)
+	subject := lastCommitSubject(t, tc, path+"/"+wtRel)
+	assert.Contains(t, subject, "FE-"+festID,
+		"post-promote worktree commit should carry FE-<festival ref>: %s", subject)
+	assert.NotContains(t, subject, ref,
+		"post-promote commit should not carry the retired design WI-<ref>: %s", subject)
+
+	// Old-orphaned-state recovery: point the link back at the (dungeoned)
+	// design id to simulate a link orphaned by a pre-fix promote, then confirm
+	// doctor detects the promotion and --fix re-points instead of deleting.
+	designID := readDungeonedDesignID(t, tc, path)
+	require.NotEmpty(t, designID, "could not read dungeoned design id")
+	_, _, err = tc.ExecCommand("sh", "-c", fmt.Sprintf(
+		"sed -i 's|workitem_id: %s|workitem_id: %s|' %s/.campaign/workitems/links.yaml",
+		festID, designID, path))
+	require.NoError(t, err)
+
+	orphanDoctor, _ := tc.RunCampInDir(path, "workitem", "doctor")
+	assert.Contains(t, orphanDoctor, "promoted to festival "+festID,
+		"doctor should detect the promotion, not just offer deletion: %s", orphanDoctor)
+
+	fixOut, err := tc.RunCampInDir(path, "workitem", "doctor", "--fix")
+	require.NoError(t, err, "doctor --fix: %s", fixOut)
+	linksAfterFix, err := tc.ReadFile(path + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, linksAfterFix, "workitem_id: "+festID,
+		"doctor --fix should re-point the orphaned link to the festival, not delete it:\n%s", linksAfterFix)
+}
+
+// readDungeonedDesignID reads the stable id from the shelved design workitem's
+// marker under the (hidden) design dungeon.
+func readDungeonedDesignID(t *testing.T, tc *TestContainer, path string) string {
+	t.Helper()
+	out, _, err := tc.ExecCommand("sh", "-c",
+		"grep -h -m1 '^id:' \"$(find "+path+"/workflow/design -type f -name .workitem | head -1)\"")
+	require.NoError(t, err)
+	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(out), "id:"))
+}


### PR DESCRIPTION
## PRODUCT DECISION FOR REVIEW (Lance can veto)

**This changes post-promote commit tagging in a linked worktree from `WI-<design ref>` to `FE-<festival ref>`.**

Before this PR, `camp workitem promote --target festival` left the worktree's tag in a broken state: the primary link was orphaned and `camp p commit` dropped the context tag entirely (bare `[campaign:<hash>]`, no `WI-` and no `FE-`). So the choice is not "preserve a working WI- tag" vs "switch to FE-"; it is "restore a working tag" vs "leave it broken". I chose `FE-<festival ref>` because after a design is promoted to a festival, the worktree is the festival's implementation surface, and the `FE-` tier is already the established tag for festival-sourced commits (`ComputePlan` sets it for the `SourceFestival` tier); this extends that convention to festivals reached through a worktree link rather than inventing anything. Historical commits keep their `WI-` tags, and the promote transition is recorded (ledger event plus the shelved marker's `promoted_to`), so traceability from the design to the festival survives. If you would rather keep literal `WI-` continuity, say so and I will switch the approach.

No `--json` output shape changed. The only user-visible surface changes are the commit-tag segment (WI- to FE- for this specific post-promote case) and improved `camp workitem doctor` messages/behavior.

Refs intent `camp-workitem-promote-target-festival-20260713-020056`.

## Problem

Reproduced on `origin/main`. Given a design workitem with a primary worktree link:

- Before promote: `camp p commit` in the worktree tags `[p2:<hash>-WI-541bcc]`; `camp workitem doctor` reports 0 findings.
- After `camp workitem promote --target festival`: the source `.workitem` (carrying the stable id and ref) moves to `workflow/design/.dungeon/completed/...`, which discovery skips. `links.yaml` is unchanged, so the primary link's `workitem_id` no longer resolves. `doctor` reports `workitem.link.broken ... is not present on disk` whose only remedy is deletion, and `camp p commit` produces a bare `[p2:<hash>]` with no context tag.
- Re-linking failed both ways the intent describes: the festival path derives an invalid id (`festival:festivals/planning/...`, rejected because `links` requires `workitem_id` to be a single path segment), and the dungeon path is not resolvable.

## Fix

- **Festivals as first-class link targets.** The selector resolves a festival by its `fest.yaml` id (`SC0001`) via a new `festival_id` matcher. A new `workitem.LinkWorkitemID` returns that single-segment id for festivals (never the slash-bearing `festival:...` key), and it is used by every link-creating path (`camp workitem link`, `camp workitem worktree`, `camp project worktree add --workitem`, `camp worktrees create --workitem`). `workitemIDsOnDisk` (doctor) counts festival ids as present, so a migrated link is not reported broken.

- **Promote migrates primary links.** `doFestivalPromote` captures the source workitem's id/key before shelving, and after shelving (only when the source is shelved, not `--keep`) re-points every link that referenced it onto the festival, updating both `workitem_id` and `workitem_key` and dropping links that become exact duplicates. This mirrors the existing `rehomeGatherLinks` used by `camp gather`, extended to also carry the key because a festival's id and key differ from the source workitem's. The updated `links.yaml` is included in the promote auto-commit.

- **FE- tagging for festival-reached worktrees.** The festival-ref derivation is lifted into `internal/workitem` (`FestivalRef`, `FestivalRefFromID`, preserving the previous parsing behavior) and used by all four workitem-context commit tag paths (`camp workitem commit`, `camp p commit`, `camp worktrees commit`, root `camp commit`) plus intent/note auto-commit. Previously `camp p commit` and the sibling paths hardcoded an empty festival-ref argument, so even a resolvable festival link produced no `FE-` segment.

- **Doctor recovery for pre-fix orphans.** For a broken link whose workitem was promoted (detected from the shelved marker's `promoted_to` pointing at an existing festival), `doctor` names the festival in the finding and its `--fix` re-points the link onto that festival instead of removing it. Links with no detectable promotion target keep the existing remove behavior. The recovery hint fields are unexported, so the `--json` finding shape is unchanged.

## Verification

Full chain verified end-to-end on the host with the real `fest` CLI (real output):

```
BEFORE promote:  workitem_id: design-camp-sync-clone-transport-2026-07-17
                 commit subject: [p2:2352d576-WI-541bcc] feat: before promote
                 doctor: 0 findings
AFTER promote:   workitem_id: SC0001          (link migrated)
                 doctor: 0 findings
                 commit subject: [p2:2352d576-FE-SC0001] feat: after promote
re-link SC0001 --worktree ...:  linked SC0001 -> worktree:... (works)
orphan recovery: doctor -> "promoted to festival SC0001"; doctor --fix re-points to SC0001 (not deleted)
```

- New integration test `tests/integration/promote_workitem_festival_test.go` drives the full chain in the container (promote -> link migrated -> doctor 0 findings -> `camp p commit` tags `FE-<id>` and no longer `WI-`, plus the old-orphan `doctor --fix` recovery). It is guarded by `festAvailable`. The container harness locates `fest` as a sibling of `camp`, which does not resolve from a git worktree checkout, so it skips in the worktree run; I verified it PASSES by temporarily pointing the harness at the real `fest` path (that harness edit is not part of this PR).
- New unit tests: `internal/workitem/selector/festival_test.go` (festival resolves by id, case-insensitive; unknown id not found), `internal/workitem/festival_ref_test.go`, `internal/workitem/link_target_test.go`, and `internal/commands/workitem/promote_migrate_test.go` (rehome re-points by id, no-op on non-match, dedupes collisions).
- Gates in the worktree: `just build-camp`, `just test unit` (3435/3435), `just lint` (0 issues; ratchets clean). Existing `TestIntegration_CommitTags_*` (incl. `CampPCommit`, `NoteRefSegment`), `TestIntegration_ProjectCommit_*`, and `TestPromote_*` still pass (23 pass, 2 fest-guarded skips).

## Pre-existing failure (not from this change)

`TestIntegration_CommitTags_NoteNoContext` fails on this branch AND on a clean base checkout (confirmed). Its regex `^\[commit-tags:[0-9a-f]{1,8}\]` predates the `NT-` note-ref segment and contradicts `TestIntegration_CommitTags_NoteRefSegment` (which requires `-NT-`). This change does not touch the note-ref path and adds no new failures.

## Tradeoffs and rejected alternatives

- **Rejected: keep the promoted workitem resolvable from its festival ingest copy** (copy the `.workitem` into `001_INGEST/input_specs/<slug>/` and have discovery resolve it there) to preserve literal `WI-`. This is a discovery-scope shim: the promoted spec would surface as a duplicate workitem living inside the festival, muddying one-workitem-one-home. The repo's standards prefer implementing the real format over marker-file workarounds.
- **Rejected: dungeoned workitems stay broadly resolvable.** That would surface completed/shelved items in `camp workitem` listings and resolution everywhere, a wider behavior change than the chain needs.
- **Scope kept tight:** I did not add read-only resolution of dungeoned design ids or touch adjacent gaps beyond this chain. The migration re-points all roles that reference the promoted workitem (not only primary) so `doctor` stays fully clean; a stale related/blocked_by link would otherwise remain a finding.
