### PR TITLE
style(notice): render campaign notices as warnings

### DIFF
--- a/internal/notice/notice.go
+++ b/internal/notice/notice.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+
+	"github.com/Obedience-Corp/camp/internal/ui"
 )
 
 // Notice is one advisory about campaign state.
@@ -56,8 +58,16 @@ func Detect(ctx context.Context, campaignRoot string, detectors ...Detector) []N
 }
 
 // Render writes notices to w.
+//
+// A notice shares stderr with the command's own output, so it is styled like
+// the rest of camp's advisories: a warning icon and label carry the severity,
+// and the fix is accented so the line a user should act on stands out from the
+// line that explains why. Styling collapses to plain text under --no-color and
+// on non-terminal writers, which keeps the notice greppable in scripts and in
+// the integration tests that assert on its text.
 func Render(w io.Writer, notices []Notice) {
 	for _, n := range notices {
-		_, _ = fmt.Fprintf(w, "notice: %s\n  run: %s\n", n.Message, n.Command)
+		_, _ = fmt.Fprintf(w, "%s %s %s\n", ui.WarningIcon(), ui.Warning("notice:"), n.Message)
+		_, _ = fmt.Fprintf(w, "  %s %s\n", ui.Dim("run:"), ui.Accent(n.Command))
 	}
 }

--- a/internal/notice/notice_test.go
+++ b/internal/notice/notice_test.go
@@ -1,0 +1,56 @@
+package notice
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+func withColorProfile(t *testing.T, p termenv.Profile) {
+	t.Helper()
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(p)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+}
+
+func TestRender_PlainWhenColorDisabled(t *testing.T) {
+	withColorProfile(t, termenv.Ascii)
+
+	var out strings.Builder
+	Render(&out, []Notice{{ID: "x", Message: "campaign has drifted", Command: "camp fix it"}})
+
+	want := "⚠ notice: campaign has drifted\n  run: camp fix it\n"
+	if got := out.String(); got != want {
+		t.Fatalf("Render() = %q, want %q", got, want)
+	}
+}
+
+func TestRender_StyledWhenColorEnabled(t *testing.T) {
+	withColorProfile(t, termenv.TrueColor)
+
+	var out strings.Builder
+	Render(&out, []Notice{{ID: "x", Message: "campaign has drifted", Command: "camp fix it"}})
+
+	got := out.String()
+	if !strings.Contains(got, "\x1b[") {
+		t.Fatalf("Render() emitted no ANSI styling: %q", got)
+	}
+	for _, want := range []string{"⚠", "notice:", "campaign has drifted", "run:", "camp fix it"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Render() missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestRender_NoNoticesWritesNothing(t *testing.T) {
+	withColorProfile(t, termenv.Ascii)
+
+	var out strings.Builder
+	Render(&out, nil)
+
+	if got := out.String(); got != "" {
+		t.Fatalf("Render(nil) = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Problem

`camp status` in a legacy campaign emitted the dungeon-migration notice as flat,
unstyled text on stderr:

```
notice: this campaign uses the visible dungeon/ layout; new campaigns hide it as .dungeon/
  run: camp dungeon migrate
```

Sitting directly above `git status` output, it reads as ordinary program chatter.
Nothing signals that it is an advisory the user should act on.

## Change

`notice.Render` now goes through the existing `internal/ui` vocabulary already used
elsewhere in camp for diagnostics:

- yellow `⚠` icon plus bold yellow `notice:` label carries the severity
- dim `run:` prefix with the fix command in bold cyan, so the actionable line
  separates visually from the explanatory one

Real output in a pty (`TERM=xterm-256color`):

```
\x1b[38;5;220m⚠\x1b[0m \x1b[1;38;5;220mnotice:\x1b[0m this campaign uses the visible dungeon/ layout; new campaigns hide it as .dungeon/
  \x1b[38;5;253mrun:\x1b[0m \x1b[1;38;5;51mcamp dungeon migrate\x1b[0m
```

## Compatibility

Styling collapses to plain text off a terminal and under `--no-color` (lipgloss
profile is set in the root `PersistentPreRun`). Verified with `od -c` on piped
output: no escape bytes, and the message and command text are unchanged apart
from the leading `⚠ `. The integration tests asserting `stderr` contains
`camp dungeon migrate` (`dungeon_migrate_test.go`, `dungeon_hidden_test.go`)
are unaffected.

## Tests

New `internal/notice/notice_test.go` covers the three claims: plain rendering
under `termenv.Ascii`, ANSI present under `termenv.TrueColor`, and empty output
for an empty notice list.

`just gate-fast` passes: vet + lint across stable/dev/integration profiles,
3467/3467 unit tests.
