### PR TITLE
feat(fresh): configure every fresh.yaml key in the configure TUI, grouped by what you can change

### DIFF
--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -1375,17 +1375,27 @@ camp fresh all [flags]
 
 ## camp fresh configure
 
-Configure camp fresh follow-up commands
+Configure the camp fresh workflow
 
 ### Synopsis
 
-Manage the follow-up command workflows camp fresh runs after a
-successful sync/prune/branch cycle. Configuration lives in
-.campaign/settings/fresh.yaml: a global default list, plus optional
-per-project override lists that replace the global list entirely.
+Configure what camp fresh does after a merge. Configuration lives in
+.campaign/settings/fresh.yaml, as campaign-wide defaults plus optional
+per-project overrides.
 
-Run without a subcommand to open the interactive setup for humans. Use
-show, add, move, and remove for scripts and agents.
+Run without a subcommand to open the interactive setup for humans, which
+groups the fresh sequence by what you can change about each step:
+
+  Sync        checkout, pull, and safety checks; always runs
+  Settings    branch, push_upstream, prune, and prune_remote
+  Follow-ups  your own commands, run after a successful cycle
+
+Press enter on a settings step to change it, and a/e/d/K/J on a follow-up to
+add, edit, delete, or reorder it. prune and prune_remote are campaign-wide,
+so they are changed under Global defaults rather than under a project.
+
+The subcommands below cover follow-ups only, for scripts and agents; edit the
+other keys in the interactive setup or in fresh.yaml directly.
 
 The interactive setup opens on the project you are standing in, resolved the
 same way camp fresh picks its target, so the overrides you edit are the ones

--- a/docs/cli-reference/camp_fresh.md
+++ b/docs/cli-reference/camp_fresh.md
@@ -56,5 +56,5 @@ camp fresh [project-name] [flags]
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
 * [camp fresh all](camp_fresh_all.md)	 - Run fresh across all project submodules
-* [camp fresh configure](camp_fresh_configure.md)	 - Configure camp fresh follow-up commands
+* [camp fresh configure](camp_fresh_configure.md)	 - Configure the camp fresh workflow
 * [camp fresh show-workflow](camp_fresh_show-workflow.md)	 - Show the fresh cycle and configured follow-up steps

--- a/docs/cli-reference/camp_fresh_configure.md
+++ b/docs/cli-reference/camp_fresh_configure.md
@@ -1,16 +1,26 @@
 ## camp fresh configure
 
-Configure camp fresh follow-up commands
+Configure the camp fresh workflow
 
 ### Synopsis
 
-Manage the follow-up command workflows camp fresh runs after a
-successful sync/prune/branch cycle. Configuration lives in
-.campaign/settings/fresh.yaml: a global default list, plus optional
-per-project override lists that replace the global list entirely.
+Configure what camp fresh does after a merge. Configuration lives in
+.campaign/settings/fresh.yaml, as campaign-wide defaults plus optional
+per-project overrides.
 
-Run without a subcommand to open the interactive setup for humans. Use
-show, add, move, and remove for scripts and agents.
+Run without a subcommand to open the interactive setup for humans, which
+groups the fresh sequence by what you can change about each step:
+
+  Sync        checkout, pull, and safety checks; always runs
+  Settings    branch, push_upstream, prune, and prune_remote
+  Follow-ups  your own commands, run after a successful cycle
+
+Press enter on a settings step to change it, and a/e/d/K/J on a follow-up to
+add, edit, delete, or reorder it. prune and prune_remote are campaign-wide,
+so they are changed under Global defaults rather than under a project.
+
+The subcommands below cover follow-ups only, for scripts and agents; edit the
+other keys in the interactive setup or in fresh.yaml directly.
 
 The interactive setup opens on the project you are standing in, resolved the
 same way camp fresh picks its target, so the overrides you edit are the ones

--- a/docs/cli-reference/camp_fresh_configure_add.md
+++ b/docs/cli-reference/camp_fresh_configure_add.md
@@ -30,4 +30,4 @@ camp fresh configure add <name> [flags]
 
 ### SEE ALSO
 
-* [camp fresh configure](camp_fresh_configure.md)	 - Configure camp fresh follow-up commands
+* [camp fresh configure](camp_fresh_configure.md)	 - Configure the camp fresh workflow

--- a/docs/cli-reference/camp_fresh_configure_move.md
+++ b/docs/cli-reference/camp_fresh_configure_move.md
@@ -29,4 +29,4 @@ camp fresh configure move <name> [flags]
 
 ### SEE ALSO
 
-* [camp fresh configure](camp_fresh_configure.md)	 - Configure camp fresh follow-up commands
+* [camp fresh configure](camp_fresh_configure.md)	 - Configure the camp fresh workflow

--- a/docs/cli-reference/camp_fresh_configure_remove.md
+++ b/docs/cli-reference/camp_fresh_configure_remove.md
@@ -27,4 +27,4 @@ camp fresh configure remove <name> [flags]
 
 ### SEE ALSO
 
-* [camp fresh configure](camp_fresh_configure.md)	 - Configure camp fresh follow-up commands
+* [camp fresh configure](camp_fresh_configure.md)	 - Configure the camp fresh workflow

--- a/docs/cli-reference/camp_fresh_configure_show.md
+++ b/docs/cli-reference/camp_fresh_configure_show.md
@@ -26,4 +26,4 @@ camp fresh configure show [flags]
 
 ### SEE ALSO
 
-* [camp fresh configure](camp_fresh_configure.md)	 - Configure camp fresh follow-up commands
+* [camp fresh configure](camp_fresh_configure.md)	 - Configure the camp fresh workflow

--- a/internal/commands/fresh/configure.go
+++ b/internal/commands/fresh/configure.go
@@ -23,14 +23,24 @@ var configureProjectFlag string
 func newConfigureCommand() *cobra.Command {
 	configureCmd := &cobra.Command{
 		Use:   "configure",
-		Short: "Configure camp fresh follow-up commands",
-		Long: `Manage the follow-up command workflows camp fresh runs after a
-successful sync/prune/branch cycle. Configuration lives in
-.campaign/settings/fresh.yaml: a global default list, plus optional
-per-project override lists that replace the global list entirely.
+		Short: "Configure the camp fresh workflow",
+		Long: `Configure what camp fresh does after a merge. Configuration lives in
+.campaign/settings/fresh.yaml, as campaign-wide defaults plus optional
+per-project overrides.
 
-Run without a subcommand to open the interactive setup for humans. Use
-show, add, move, and remove for scripts and agents.
+Run without a subcommand to open the interactive setup for humans, which
+groups the fresh sequence by what you can change about each step:
+
+  Sync        checkout, pull, and safety checks; always runs
+  Settings    branch, push_upstream, prune, and prune_remote
+  Follow-ups  your own commands, run after a successful cycle
+
+Press enter on a settings step to change it, and a/e/d/K/J on a follow-up to
+add, edit, delete, or reorder it. prune and prune_remote are campaign-wide,
+so they are changed under Global defaults rather than under a project.
+
+The subcommands below cover follow-ups only, for scripts and agents; edit the
+other keys in the interactive setup or in fresh.yaml directly.
 
 The interactive setup opens on the project you are standing in, resolved the
 same way camp fresh picks its target, so the overrides you edit are the ones

--- a/internal/commands/fresh/configure_tui.go
+++ b/internal/commands/fresh/configure_tui.go
@@ -32,6 +32,38 @@ const (
 	followUpFormOverlay
 	followUpDeleteOverlay
 	followUpHelpOverlay
+	followUpSettingOverlay
+)
+
+// freshSettingAction is what saving the settings editor does to the selected
+// scope's key. Inherit clears it, which is a distinct outcome from writing
+// false: FreshProjectConfig stores pointers precisely so a project can leave a
+// key unset and follow the global value as it changes.
+type freshSettingAction int
+
+const (
+	freshSettingInherit freshSettingAction = iota
+	freshSettingOn
+	freshSettingOff
+	freshSettingNoBranch
+	freshSettingCustomBranch
+)
+
+type freshSettingOption struct {
+	label  string
+	action freshSettingAction
+}
+
+// statusLevel separates a completed change from a note about why a key did
+// nothing. A refusal rendered in the same red as a genuine failure trains
+// users to ignore the status line, and most refusals here are only the TUI
+// saying a row has nothing to configure.
+type statusLevel int
+
+const (
+	statusOK statusLevel = iota
+	statusNotice
+	statusError
 )
 
 type followUpScope struct {
@@ -69,11 +101,19 @@ type followUpTUIModel struct {
 	formError     string
 	pendingDelete string
 
-	status    string
-	statusErr bool
-	width     int
-	height    int
-	quitting  bool
+	// settingStep is the workflow row the settings editor is open on, with the
+	// options and cursor that editor is showing.
+	settingStep    freshWorkflowStep
+	settingOptions []freshSettingOption
+	settingChoice  int
+	settingInput   textinput.Model
+	settingError   string
+
+	status      string
+	statusLevel statusLevel
+	width       int
+	height      int
+	quitting    bool
 }
 
 // runConfigureTUI is the human-facing entry point for `camp fresh configure`.
@@ -150,6 +190,10 @@ func newFollowUpTUIModel(ctx context.Context, root string, projects []project.Pr
 	m.inputs[0].Placeholder = "install"
 	m.inputs[1].Placeholder = "npm install"
 	m.inputs[2].Placeholder = "optional, relative to project root"
+	m.settingInput = textinput.New()
+	m.settingInput.Prompt = "  "
+	m.settingInput.CharLimit = 256
+	m.settingInput.Placeholder = "feat/my-work"
 	m.rebuildScopes(globalFollowUpScope)
 	return m
 }
@@ -180,9 +224,15 @@ func (m *followUpTUIModel) rebuildScopes(selected string) {
 			name:        name,
 			current:     name == m.cwdProject,
 		}
-		if pc, ok := m.cfg.Projects[name]; ok && pc.FollowUp != nil {
-			scope.override = true
-			scope.overrideCount = len(pc.FollowUp)
+		// Count every key the project sets, not just its follow-ups. A project
+		// that overrides only its branch is still a project that deviates from
+		// the global defaults, and the badge is the one place the scopes pane
+		// says so.
+		if pc, ok := m.cfg.Projects[name]; ok {
+			if keys := config.ProjectOverrideKeys(pc); keys > 0 {
+				scope.override = true
+				scope.overrideCount = keys
+			}
 		}
 		scopes = append(scopes, scope)
 	}
@@ -263,12 +313,171 @@ func (m *followUpTUIModel) selectedFollowUp() (int, config.FollowUpConfig, bool)
 
 func (m *followUpTUIModel) setStatus(message string) {
 	m.status = message
-	m.statusErr = false
+	m.statusLevel = statusOK
+}
+
+// setNotice reports that a key did nothing here, which is guidance rather than
+// failure and so is not rendered as an error.
+func (m *followUpTUIModel) setNotice(message string) {
+	m.status = message
+	m.statusLevel = statusNotice
 }
 
 func (m *followUpTUIModel) setError(err error) {
 	m.status = err.Error()
-	m.statusErr = true
+	m.statusLevel = statusError
+}
+
+// selectedStep returns the workflow row under the cursor.
+func (m *followUpTUIModel) selectedStep() (freshWorkflowStep, bool) {
+	steps := m.workflowSteps()
+	if m.stepCursor < 0 || m.stepCursor >= len(steps) {
+		return freshWorkflowStep{}, false
+	}
+	return steps[m.stepCursor], true
+}
+
+func (m *followUpTUIModel) inProjectScope() bool {
+	return m.selectedScope() != globalFollowUpScope
+}
+
+// settingOptionsFor builds the choices the settings editor offers for a step.
+// A project scope gains an inherit option, since clearing the key there is a
+// real third outcome; the global scope has no one to inherit from.
+func (m *followUpTUIModel) settingOptionsFor(step freshWorkflowStep) []freshSettingOption {
+	project := m.inProjectScope()
+
+	if step.Setting == freshSettingBranch {
+		options := make([]freshSettingOption, 0, 3)
+		if project {
+			options = append(options, freshSettingOption{
+				label:  "inherit from global · " + branchSummary(m.cfg.Branch),
+				action: freshSettingInherit,
+			})
+		}
+		return append(options,
+			freshSettingOption{label: "no branch · stay on the default branch", action: freshSettingNoBranch},
+			freshSettingOption{label: "create a branch...", action: freshSettingCustomBranch},
+		)
+	}
+
+	options := make([]freshSettingOption, 0, 3)
+	if project && !step.GlobalOnly {
+		options = append(options, freshSettingOption{
+			label:  "inherit from global · " + onOffWord(m.globalBoolValue(step.Setting)),
+			action: freshSettingInherit,
+		})
+	}
+	return append(options,
+		freshSettingOption{label: "on", action: freshSettingOn},
+		freshSettingOption{label: "off", action: freshSettingOff},
+	)
+}
+
+// currentSettingAction is the option that matches what the selected scope
+// stores today, so the editor opens on the current answer rather than on a
+// default that would silently rewrite the key if the user just pressed enter.
+func (m *followUpTUIModel) currentSettingAction(step freshWorkflowStep) freshSettingAction {
+	scope := scopeProjectName(m.selectedScope())
+	pc, hasProject := m.cfg.Projects[scope]
+
+	switch step.Setting {
+	case freshSettingBranch:
+		if scope != "" {
+			if !hasProject || pc.Branch == nil {
+				return freshSettingInherit
+			}
+			if *pc.Branch == "" {
+				return freshSettingNoBranch
+			}
+			return freshSettingCustomBranch
+		}
+		if m.cfg.Branch == "" {
+			return freshSettingNoBranch
+		}
+		return freshSettingCustomBranch
+	case freshSettingPushUpstream:
+		if scope != "" {
+			if !hasProject || pc.PushUpstream == nil {
+				return freshSettingInherit
+			}
+			return boolAction(*pc.PushUpstream)
+		}
+		return boolAction(m.cfg.ResolveFreshPushUpstream(""))
+	case freshSettingPrune:
+		return boolAction(m.cfg.ResolveFreshPrune())
+	case freshSettingPruneRemote:
+		return boolAction(m.cfg.ResolveFreshPruneRemote())
+	}
+	return freshSettingInherit
+}
+
+// settingScopeBranch is the branch this scope stores on its own, used to seed
+// the text input when the editor opens.
+//
+// It deliberately does not fall back to the global branch. Seeding the field
+// with an inherited value puts text in it that the user never typed and cannot
+// tell apart from their own: switching to "create a branch" and typing then
+// appends, which silently produced branch names like "developfeat/storefront".
+// A scope with no branch of its own opens on an empty field.
+func (m *followUpTUIModel) settingScopeBranch() string {
+	scope := scopeProjectName(m.selectedScope())
+	if scope == "" {
+		return m.cfg.Branch
+	}
+	if pc, ok := m.cfg.Projects[scope]; ok && pc.Branch != nil {
+		return *pc.Branch
+	}
+	return ""
+}
+
+func (m *followUpTUIModel) globalBoolValue(setting freshSettingKey) bool {
+	switch setting {
+	case freshSettingPushUpstream:
+		return m.cfg.ResolveFreshPushUpstream("")
+	case freshSettingPrune:
+		return m.cfg.ResolveFreshPrune()
+	case freshSettingPruneRemote:
+		return m.cfg.ResolveFreshPruneRemote()
+	}
+	return false
+}
+
+func boolAction(on bool) freshSettingAction {
+	if on {
+		return freshSettingOn
+	}
+	return freshSettingOff
+}
+
+func onOffWord(on bool) string {
+	if on {
+		return "on"
+	}
+	return "off"
+}
+
+func branchSummary(branch string) string {
+	if branch == "" {
+		return "no branch"
+	}
+	return branch
+}
+
+// settingTitle names the fresh.yaml key a settings row edits, so the editor
+// header matches what the user would search for in the file.
+func settingTitle(setting freshSettingKey) string {
+	switch setting {
+	case freshSettingPrune:
+		return "prune"
+	case freshSettingPruneRemote:
+		return "prune_remote"
+	case freshSettingBranch:
+		return "branch"
+	case freshSettingPushUpstream:
+		return "push_upstream"
+	}
+	return ""
 }
 
 func (m *followUpTUIModel) Init() tea.Cmd {

--- a/internal/commands/fresh/configure_tui.go
+++ b/internal/commands/fresh/configure_tui.go
@@ -71,8 +71,10 @@ type followUpScope struct {
 	// name is the scope's display name on its own, without decoration, so the
 	// renderer can drop badges rather than the identity when space is short.
 	name string
-	// overrideCount is the length of this project's own follow-up list.
-	// override distinguishes an explicit empty list from no list at all.
+	// overrideCount is how many fresh.yaml keys this project sets for itself
+	// (branch, push_upstream, follow-up list, …), via ProjectOverrideKeys.
+	// override is true when that count is non-zero. An explicit empty
+	// follow-up list still counts as one key, because FollowUp != nil.
 	override      bool
 	overrideCount int
 	// current marks the project detected from the working directory.
@@ -343,7 +345,9 @@ func (m *followUpTUIModel) inProjectScope() bool {
 
 // settingOptionsFor builds the choices the settings editor offers for a step.
 // A project scope gains an inherit option, since clearing the key there is a
-// real third outcome; the global scope has no one to inherit from.
+// real third outcome. The global scope has no one to inherit from, but bool
+// keys still need a third choice: "default" clears the key so the built-in
+// applies, which is distinct from writing an explicit true/false.
 func (m *followUpTUIModel) settingOptionsFor(step freshWorkflowStep) []freshSettingOption {
 	project := m.inProjectScope()
 
@@ -362,9 +366,18 @@ func (m *followUpTUIModel) settingOptionsFor(step freshWorkflowStep) []freshSett
 	}
 
 	options := make([]freshSettingOption, 0, 3)
-	if project && !step.GlobalOnly {
+	switch {
+	case project && !step.GlobalOnly:
 		options = append(options, freshSettingOption{
 			label:  "inherit from global · " + onOffWord(m.globalBoolValue(step.Setting)),
+			action: freshSettingInherit,
+		})
+	case !project:
+		// Built-in defaults for prune / prune_remote / push_upstream are true.
+		// Name the default, not the currently resolved value, so an explicit
+		// "off" does not make the default option read "default · off".
+		options = append(options, freshSettingOption{
+			label:  "default · " + onOffWord(builtInBoolDefault(step.Setting)),
 			action: freshSettingInherit,
 		})
 	}
@@ -377,6 +390,11 @@ func (m *followUpTUIModel) settingOptionsFor(step freshWorkflowStep) []freshSett
 // currentSettingAction is the option that matches what the selected scope
 // stores today, so the editor opens on the current answer rather than on a
 // default that would silently rewrite the key if the user just pressed enter.
+//
+// For global bools this must inspect the stored pointer, not the resolved
+// value: Resolve* collapses a missing key to the built-in default (true), and
+// mapping that to "on" would open the editor on an option that writes an
+// explicit true into a previously absent key.
 func (m *followUpTUIModel) currentSettingAction(step freshWorkflowStep) freshSettingAction {
 	scope := scopeProjectName(m.selectedScope())
 	pc, hasProject := m.cfg.Projects[scope]
@@ -403,13 +421,34 @@ func (m *followUpTUIModel) currentSettingAction(step freshWorkflowStep) freshSet
 			}
 			return boolAction(*pc.PushUpstream)
 		}
-		return boolAction(m.cfg.ResolveFreshPushUpstream(""))
+		if m.cfg.PushUpstream == nil {
+			return freshSettingInherit
+		}
+		return boolAction(*m.cfg.PushUpstream)
 	case freshSettingPrune:
-		return boolAction(m.cfg.ResolveFreshPrune())
+		if m.cfg.Prune == nil {
+			return freshSettingInherit
+		}
+		return boolAction(*m.cfg.Prune)
 	case freshSettingPruneRemote:
-		return boolAction(m.cfg.ResolveFreshPruneRemote())
+		if m.cfg.PruneRemote == nil {
+			return freshSettingInherit
+		}
+		return boolAction(*m.cfg.PruneRemote)
 	}
 	return freshSettingInherit
+}
+
+// builtInBoolDefault is the value Resolve* uses when a global bool key is
+// absent. Kept local so option labels do not re-derive it from a currently
+// written override.
+func builtInBoolDefault(setting freshSettingKey) bool {
+	switch setting {
+	case freshSettingPushUpstream, freshSettingPrune, freshSettingPruneRemote:
+		return true
+	default:
+		return false
+	}
 }
 
 // settingScopeBranch is the branch this scope stores on its own, used to seed
@@ -484,10 +523,13 @@ func (m *followUpTUIModel) Init() tea.Cmd {
 	return textinput.Blink
 }
 
+// configuredProjectNames lists projects that set any fresh.yaml key of their
+// own. It uses ProjectOverrideKeys so a branch-only override is not treated as
+// unconfigured — the same rule the scopes badge applies.
 func configuredProjectNames(cfg *config.FreshConfig) []string {
 	names := make([]string, 0, len(cfg.Projects))
 	for name, pc := range cfg.Projects {
-		if pc.FollowUp != nil {
+		if config.ProjectOverrideKeys(pc) > 0 {
 			names = append(names, name)
 		}
 	}

--- a/internal/commands/fresh/configure_tui_scope_test.go
+++ b/internal/commands/fresh/configure_tui_scope_test.go
@@ -39,7 +39,7 @@ func TestSelectProjectScopeOpensOnDetectedProject(t *testing.T) {
 	if !strings.Contains(m.status, "project web") {
 		t.Errorf("status %q does not name the detected project", m.status)
 	}
-	if m.statusErr {
+	if m.statusLevel == statusError {
 		t.Error("detecting a project scope reported an error status")
 	}
 }

--- a/internal/commands/fresh/configure_tui_settings_test.go
+++ b/internal/commands/fresh/configure_tui_settings_test.go
@@ -19,7 +19,14 @@ func settingsModel(t *testing.T, cfg *config.FreshConfig) *followUpTUIModel {
 // not encode the sequence position of a step that may gain neighbors later.
 func stepIndexFor(t *testing.T, m *followUpTUIModel, setting freshSettingKey) int {
 	t.Helper()
-	for i, step := range m.workflowSteps() {
+	return stepIndexBySetting(t, m.workflowSteps(), setting)
+}
+
+// stepIndexBySetting is the raw-slice form of stepIndexFor for tests that call
+// buildFreshWorkflow directly without a TUI model.
+func stepIndexBySetting(t *testing.T, steps []freshWorkflowStep, setting freshSettingKey) int {
+	t.Helper()
+	for i, step := range steps {
 		if step.Kind == freshStepSetting && step.Setting == setting {
 			return i
 		}
@@ -56,7 +63,7 @@ func TestBuildFreshWorkflowClassifiesSteps(t *testing.T) {
 // the pane renders them differently, so the state has to distinguish them.
 func TestBranchStateSeparatesUnsetFromOff(t *testing.T) {
 	unset := buildFreshWorkflow(&config.FreshConfig{}, "")
-	idx := 5
+	idx := stepIndexBySetting(t, unset, freshSettingBranch)
 	if got := unset[idx].State; got != freshStateUnset {
 		t.Fatalf("unconfigured branch state = %v, want unset", got)
 	}
@@ -75,7 +82,7 @@ func TestBranchStateSeparatesUnsetFromOff(t *testing.T) {
 // something they never touched.
 func TestPushUpstreamBlockedWithoutBranch(t *testing.T) {
 	steps := buildFreshWorkflow(&config.FreshConfig{}, "")
-	push := steps[6]
+	push := steps[stepIndexBySetting(t, steps, freshSettingPushUpstream)]
 	if push.State != freshStateBlocked {
 		t.Fatalf("push state without a branch = %v, want blocked", push.State)
 	}
@@ -85,14 +92,15 @@ func TestPushUpstreamBlockedWithoutBranch(t *testing.T) {
 
 	off := false
 	steps = buildFreshWorkflow(&config.FreshConfig{Branch: "develop", PushUpstream: &off}, "")
-	if got := steps[6].State; got != freshStateOff {
+	if got := steps[stepIndexBySetting(t, steps, freshSettingPushUpstream)].State; got != freshStateOff {
 		t.Fatalf("explicitly disabled push state = %v, want off", got)
 	}
 }
 
 func TestConfigurableExcludesGlobalOnlyKeysInProjectScope(t *testing.T) {
 	steps := buildFreshWorkflow(&config.FreshConfig{}, "api")
-	prune, push := steps[3], steps[6]
+	prune := steps[stepIndexBySetting(t, steps, freshSettingPrune)]
+	push := steps[stepIndexBySetting(t, steps, freshSettingPushUpstream)]
 
 	if prune.Configurable(true) {
 		t.Error("prune reported configurable in a project scope; fresh only reads it globally")
@@ -107,7 +115,7 @@ func TestConfigurableExcludesGlobalOnlyKeysInProjectScope(t *testing.T) {
 
 func TestSettingOptionsAddInheritOnlyInProjectScope(t *testing.T) {
 	m := settingsModel(t, &config.FreshConfig{Branch: "develop"})
-	branchStep := m.workflowSteps()[5]
+	branchStep := m.workflowSteps()[stepIndexFor(t, m, freshSettingBranch)]
 
 	global := m.settingOptionsFor(branchStep)
 	if len(global) != 2 {
@@ -126,6 +134,57 @@ func TestSettingOptionsAddInheritOnlyInProjectScope(t *testing.T) {
 	}
 	if !strings.Contains(project[0].label, "develop") {
 		t.Errorf("inherit label %q does not name the value it inherits", project[0].label)
+	}
+}
+
+// An absent global bool is the built-in default, not an explicit "on". The
+// editor must open on "default" so a pure enter leaves the file alone.
+func TestGlobalBoolOptionsOfferDefaultAndOpenOnAbsentKey(t *testing.T) {
+	m := settingsModel(t, &config.FreshConfig{})
+	pruneStep := m.workflowSteps()[stepIndexFor(t, m, freshSettingPrune)]
+
+	options := m.settingOptionsFor(pruneStep)
+	if len(options) != 3 || options[0].action != freshSettingInherit {
+		t.Fatalf("global prune options = %+v, want default first", options)
+	}
+	if !strings.Contains(options[0].label, "default") {
+		t.Errorf("first option label %q does not say default", options[0].label)
+	}
+	if got := m.currentSettingAction(pruneStep); got != freshSettingInherit {
+		t.Fatalf("absent prune opens on action %v, want default/inherit", got)
+	}
+
+	on := true
+	m.cfg.Prune = &on
+	if got := m.currentSettingAction(pruneStep); got != freshSettingOn {
+		t.Fatalf("explicit prune true opens on action %v, want on", got)
+	}
+	off := false
+	m.cfg.Prune = &off
+	if got := m.currentSettingAction(pruneStep); got != freshSettingOff {
+		t.Fatalf("explicit prune false opens on action %v, want off", got)
+	}
+}
+
+func TestSettingUnchangedShortCircuitsSave(t *testing.T) {
+	m := settingsModel(t, &config.FreshConfig{})
+	m.stepCursor = stepIndexFor(t, m, freshSettingPrune)
+	step, _ := m.selectedStep()
+	m.openSettingEditor(step)
+
+	// Absent key + default selected → no write, notice status.
+	cmd := m.saveSettingEditor()
+	if cmd != nil {
+		t.Fatal("unchanged save returned a command")
+	}
+	if m.overlay != followUpNoOverlay {
+		t.Fatal("unchanged save left the editor open")
+	}
+	if m.statusLevel != statusNotice {
+		t.Errorf("status level = %v, want notice", m.statusLevel)
+	}
+	if !strings.Contains(m.status, "nothing written") {
+		t.Errorf("status %q does not say nothing was written", m.status)
 	}
 }
 

--- a/internal/commands/fresh/configure_tui_settings_test.go
+++ b/internal/commands/fresh/configure_tui_settings_test.go
@@ -1,0 +1,308 @@
+package fresh
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/Obedience-Corp/camp/internal/project"
+)
+
+func settingsModel(t *testing.T, cfg *config.FreshConfig) *followUpTUIModel {
+	t.Helper()
+	return newFollowUpTUIModel(context.Background(), t.TempDir(),
+		[]project.Project{{Name: "api"}, {Name: "web"}}, cfg)
+}
+
+// stepIndexFor locates a step by the fresh.yaml key behind it, so the tests do
+// not encode the sequence position of a step that may gain neighbors later.
+func stepIndexFor(t *testing.T, m *followUpTUIModel, setting freshSettingKey) int {
+	t.Helper()
+	for i, step := range m.workflowSteps() {
+		if step.Kind == freshStepSetting && step.Setting == setting {
+			return i
+		}
+	}
+	t.Fatalf("no settings step for key %v", setting)
+	return -1
+}
+
+func TestBuildFreshWorkflowClassifiesSteps(t *testing.T) {
+	cfg := &config.FreshConfig{
+		FollowUp: []config.FollowUpConfig{{Name: "install", Run: "npm install"}},
+	}
+	steps := buildFreshWorkflow(cfg, "")
+
+	kinds := map[freshStepKind]int{}
+	for _, step := range steps {
+		kinds[step.Kind]++
+	}
+	if kinds[freshStepFixed] != 3 {
+		t.Errorf("fixed steps = %d, want 3", kinds[freshStepFixed])
+	}
+	if kinds[freshStepSetting] != 4 {
+		t.Errorf("setting steps = %d, want 4", kinds[freshStepSetting])
+	}
+	if kinds[freshStepFollowUp] != 1 {
+		t.Errorf("follow-up steps = %d, want 1", kinds[freshStepFollowUp])
+	}
+	if kinds[freshStepDone] != 1 {
+		t.Errorf("done steps = %d, want 1", kinds[freshStepDone])
+	}
+}
+
+// An unconfigured branch and a branch turned off are different answers, and
+// the pane renders them differently, so the state has to distinguish them.
+func TestBranchStateSeparatesUnsetFromOff(t *testing.T) {
+	unset := buildFreshWorkflow(&config.FreshConfig{}, "")
+	idx := 5
+	if got := unset[idx].State; got != freshStateUnset {
+		t.Fatalf("unconfigured branch state = %v, want unset", got)
+	}
+	if got := stepGlyph(unset[idx]); got != "○" {
+		t.Errorf("unconfigured branch glyph = %q, want ○", got)
+	}
+
+	configured := buildFreshWorkflow(&config.FreshConfig{Branch: "develop"}, "")
+	if got := configured[idx].State; got != freshStateOn {
+		t.Fatalf("configured branch state = %v, want on", got)
+	}
+}
+
+// Push upstream defaults to true, so with no branch it is off as a consequence
+// rather than by choice. Reporting that as "off" told users they had disabled
+// something they never touched.
+func TestPushUpstreamBlockedWithoutBranch(t *testing.T) {
+	steps := buildFreshWorkflow(&config.FreshConfig{}, "")
+	push := steps[6]
+	if push.State != freshStateBlocked {
+		t.Fatalf("push state without a branch = %v, want blocked", push.State)
+	}
+	if !strings.Contains(push.Detail, "needs a working branch") {
+		t.Errorf("push detail = %q, want it to name the missing branch", push.Detail)
+	}
+
+	off := false
+	steps = buildFreshWorkflow(&config.FreshConfig{Branch: "develop", PushUpstream: &off}, "")
+	if got := steps[6].State; got != freshStateOff {
+		t.Fatalf("explicitly disabled push state = %v, want off", got)
+	}
+}
+
+func TestConfigurableExcludesGlobalOnlyKeysInProjectScope(t *testing.T) {
+	steps := buildFreshWorkflow(&config.FreshConfig{}, "api")
+	prune, push := steps[3], steps[6]
+
+	if prune.Configurable(true) {
+		t.Error("prune reported configurable in a project scope; fresh only reads it globally")
+	}
+	if !prune.Configurable(false) {
+		t.Error("prune reported unconfigurable in the global scope")
+	}
+	if !push.Configurable(true) {
+		t.Error("push_upstream reported unconfigurable in a project scope")
+	}
+}
+
+func TestSettingOptionsAddInheritOnlyInProjectScope(t *testing.T) {
+	m := settingsModel(t, &config.FreshConfig{Branch: "develop"})
+	branchStep := m.workflowSteps()[5]
+
+	global := m.settingOptionsFor(branchStep)
+	if len(global) != 2 {
+		t.Fatalf("global branch options = %d, want 2", len(global))
+	}
+	for _, option := range global {
+		if option.action == freshSettingInherit {
+			t.Fatal("global scope offered an inherit option with nothing to inherit from")
+		}
+	}
+
+	m.rebuildScopes("api")
+	project := m.settingOptionsFor(branchStep)
+	if len(project) != 3 || project[0].action != freshSettingInherit {
+		t.Fatalf("project branch options = %+v, want inherit first", project)
+	}
+	if !strings.Contains(project[0].label, "develop") {
+		t.Errorf("inherit label %q does not name the value it inherits", project[0].label)
+	}
+}
+
+// Regression: the editor used to seed the branch input from the resolved
+// branch, so a project inheriting "develop" opened with "develop" already in
+// the field. Choosing "create a branch" and typing appended to it, writing
+// names like "developfeat/storefront".
+func TestSettingEditorDoesNotSeedInheritedBranch(t *testing.T) {
+	m := settingsModel(t, &config.FreshConfig{Branch: "develop"})
+	m.rebuildScopes("api")
+
+	m.stepCursor = stepIndexFor(t, m, freshSettingBranch)
+	step, _ := m.selectedStep()
+	m.openSettingEditor(step)
+
+	if got := m.settingInput.Value(); got != "" {
+		t.Fatalf("branch input seeded with %q for an inheriting project, want empty", got)
+	}
+	if got := m.selectedSettingAction(); got != freshSettingInherit {
+		t.Errorf("editor opened on action %v, want inherit", got)
+	}
+}
+
+func TestSettingEditorSeedsOwnBranch(t *testing.T) {
+	own := "feat/api"
+	m := settingsModel(t, &config.FreshConfig{
+		Branch:   "develop",
+		Projects: map[string]config.FreshProjectConfig{"api": {Branch: &own}},
+	})
+	m.rebuildScopes("api")
+
+	m.stepCursor = stepIndexFor(t, m, freshSettingBranch)
+	step, _ := m.selectedStep()
+	m.openSettingEditor(step)
+
+	if got := m.settingInput.Value(); got != own {
+		t.Fatalf("branch input = %q, want the project's own branch %q", got, own)
+	}
+	if got := m.selectedSettingAction(); got != freshSettingCustomBranch {
+		t.Errorf("editor opened on action %v, want custom branch", got)
+	}
+}
+
+// A custom branch with no name would write an empty string, which reads back
+// as "no branch" and silently contradicts the option the user picked.
+func TestResolveBranchActionRejectsEmptyCustomBranch(t *testing.T) {
+	m := settingsModel(t, &config.FreshConfig{})
+	m.settingInput.SetValue("   ")
+
+	if _, _, err := m.resolveBranchAction(freshSettingCustomBranch); err == nil {
+		t.Fatal("empty custom branch accepted")
+	}
+
+	branch, _, err := m.resolveBranchAction(freshSettingNoBranch)
+	if err != nil {
+		t.Fatalf("no-branch rejected: %v", err)
+	}
+	if branch == nil || *branch != "" {
+		t.Errorf("no-branch produced %v, want a pointer to the empty string", branch)
+	}
+
+	if branch, _, err := m.resolveBranchAction(freshSettingInherit); err != nil || branch != nil {
+		t.Errorf("inherit produced (%v, %v), want (nil, nil)", branch, err)
+	}
+}
+
+func TestBoolForAction(t *testing.T) {
+	if got := boolForAction(freshSettingInherit); got != nil {
+		t.Errorf("inherit = %v, want nil so the key is cleared", got)
+	}
+	if got := boolForAction(freshSettingOn); got == nil || !*got {
+		t.Errorf("on = %v, want true", got)
+	}
+	if got := boolForAction(freshSettingOff); got == nil || *got {
+		t.Errorf("off = %v, want false", got)
+	}
+}
+
+// Writing prune under a project would produce a fresh.yaml that looks
+// configured and changes nothing, because fresh resolves prune globally.
+func TestActivateGlobalOnlySettingRedirectsInsteadOfWriting(t *testing.T) {
+	m := settingsModel(t, &config.FreshConfig{})
+	m.rebuildScopes("api")
+	m.pane = followUpWorkflowPane
+	m.stepCursor = stepIndexFor(t, m, freshSettingPrune)
+
+	m.activateSelectedStep()
+
+	if m.overlay != followUpNoOverlay {
+		t.Fatal("opened a settings editor for a campaign-wide key inside a project scope")
+	}
+	if m.statusLevel != statusNotice {
+		t.Errorf("status level = %v, want a notice rather than an error", m.statusLevel)
+	}
+	if !strings.Contains(m.status, "prune") || !strings.Contains(m.status, "Global defaults") {
+		t.Errorf("status %q does not point at where the key lives", m.status)
+	}
+
+	m.rebuildScopes(globalFollowUpScope)
+	m.stepCursor = stepIndexFor(t, m, freshSettingPrune)
+	m.activateSelectedStep()
+	if m.overlay != followUpSettingOverlay {
+		t.Fatal("global scope did not open the editor for prune")
+	}
+}
+
+func TestActivateFixedStepIsANoticeNotAnError(t *testing.T) {
+	m := settingsModel(t, &config.FreshConfig{})
+	m.pane = followUpWorkflowPane
+	m.stepCursor = 0
+
+	m.activateSelectedStep()
+
+	if m.overlay != followUpNoOverlay {
+		t.Fatal("a fixed step opened an editor")
+	}
+	if m.statusLevel == statusError {
+		t.Errorf("pressing enter on a fixed step reported an error: %q", m.status)
+	}
+	if !strings.Contains(m.status, "Safety checks") {
+		t.Errorf("status %q does not name the step", m.status)
+	}
+}
+
+// The pane groups by kind, and the follow-up section has to survive being
+// empty: it is the only place that says adding a step is possible.
+func TestWorkflowRowsAlwaysShowFollowUpSection(t *testing.T) {
+	m := settingsModel(t, &config.FreshConfig{})
+	steps := m.workflowSteps()
+	rows := m.workflowRows(steps)
+
+	headers := make([]string, 0, 3)
+	for _, row := range rows {
+		if row.stepIdx < 0 {
+			headers = append(headers, row.header)
+		}
+	}
+	want := []string{"Sync", "Settings", "Follow-ups"}
+	if len(headers) != len(want) {
+		t.Fatalf("headers = %v, want %v", headers, want)
+	}
+	for i := range want {
+		if headers[i] != want[i] {
+			t.Fatalf("headers = %v, want %v", headers, want)
+		}
+	}
+
+	// Every step still gets exactly one row, in order, so the numbering the
+	// pane prints stays the execution order.
+	seen := 0
+	for _, row := range rows {
+		if row.stepIdx < 0 {
+			continue
+		}
+		if row.stepIdx != seen {
+			t.Fatalf("row %d carries step %d, want %d", seen, row.stepIdx, seen)
+		}
+		seen++
+	}
+	if seen != len(steps) {
+		t.Fatalf("rendered %d steps, want %d", seen, len(steps))
+	}
+}
+
+func TestWorkflowRowsPlaceEmptyFollowUpSectionBeforeDone(t *testing.T) {
+	m := settingsModel(t, &config.FreshConfig{})
+	rows := m.workflowRows(m.workflowSteps())
+
+	last := rows[len(rows)-1]
+	if last.stepIdx < 0 {
+		t.Fatal("the terminal row is a header, not the Ready to work step")
+	}
+	header := rows[len(rows)-2]
+	if header.stepIdx >= 0 || header.header != "Follow-ups" {
+		t.Fatalf("row before the terminal step = %+v, want the Follow-ups header", header)
+	}
+	if !strings.Contains(header.hint, "a: add") {
+		t.Errorf("empty follow-up hint %q does not say how to add one", header.hint)
+	}
+}

--- a/internal/commands/fresh/configure_tui_test.go
+++ b/internal/commands/fresh/configure_tui_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/project"
 )
 
-func TestConfiguredProjectNamesOnlyIncludesFollowUpOverrides(t *testing.T) {
+func TestConfiguredProjectNamesIncludesAnyOverrideKey(t *testing.T) {
 	cfg := &config.FreshConfig{
 		Projects: map[string]config.FreshProjectConfig{
 			"zeta":  {FollowUp: []config.FollowUpConfig{{Name: "build"}}},
@@ -19,7 +19,9 @@ func TestConfiguredProjectNamesOnlyIncludesFollowUpOverrides(t *testing.T) {
 	}
 
 	got := configuredProjectNames(cfg)
-	want := []string{"empty", "zeta"}
+	// alpha has only a branch override; empty has an explicit empty follow-up
+	// list. Both deviate from global defaults and must appear.
+	want := []string{"alpha", "empty", "zeta"}
 	if len(got) != len(want) {
 		t.Fatalf("configuredProjectNames() = %v, want %v", got, want)
 	}

--- a/internal/commands/fresh/configure_tui_update.go
+++ b/internal/commands/fresh/configure_tui_update.go
@@ -59,25 +59,28 @@ func (m *followUpTUIModel) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		if m.pane == followUpScopesPane {
 			m.pane = followUpWorkflowPane
+			return m, nil
 		}
+		return m.activateSelectedStep()
 	case "a":
 		m.openFollowUpForm(false, config.FollowUpConfig{})
 		return m, textinput.Blink
 	case "e":
-		_, entry, ok := m.selectedFollowUp()
-		if ok {
+		if _, entry, ok := m.selectedFollowUp(); ok {
 			m.openFollowUpForm(true, entry)
 			return m, textinput.Blink
 		}
-		m.setError(camperrors.New("select a follow-up step to edit"))
+		// e and enter mean the same thing on a settings row, so a user who
+		// learned "e edits" from the follow-ups section is not bounced off the
+		// section above it.
+		return m.activateSelectedStep()
 	case "d":
-		_, entry, ok := m.selectedFollowUp()
-		if ok {
+		if _, entry, ok := m.selectedFollowUp(); ok {
 			m.pendingDelete = entry.Name
 			m.overlay = followUpDeleteOverlay
 			return m, nil
 		}
-		m.setError(camperrors.New("select a follow-up step to delete"))
+		m.noticeForUnsupportedVerb("delete")
 	case "r":
 		selected := m.selectedScope()
 		if err := m.refresh(selected); err != nil {
@@ -91,10 +94,80 @@ func (m *followUpTUIModel) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// activateSelectedStep opens the editor that fits the row under the cursor.
+// Rows with nothing to configure explain themselves rather than failing: the
+// pane already groups them under a header that says so, and a red error for
+// pressing enter on "Pull" would be noise.
+func (m *followUpTUIModel) activateSelectedStep() (tea.Model, tea.Cmd) {
+	step, ok := m.selectedStep()
+	if !ok {
+		return m, nil
+	}
+
+	switch {
+	case step.Kind == freshStepFollowUp:
+		if _, entry, found := m.selectedFollowUp(); found {
+			m.openFollowUpForm(true, entry)
+			return m, textinput.Blink
+		}
+		return m, nil
+	case step.Kind == freshStepSetting && step.GlobalOnly && m.inProjectScope():
+		// Writing the key under this project would produce a fresh.yaml that
+		// looks configured and changes nothing, because ResolveFreshPrune never
+		// consults a project. Send the user where the key actually lives.
+		m.setNotice(fmt.Sprintf("%s is a campaign-wide setting · select Global defaults to change it",
+			settingTitle(step.Setting)))
+		return m, nil
+	case step.Kind == freshStepSetting:
+		m.openSettingEditor(step)
+		return m, textinput.Blink
+	default:
+		m.setNotice(fmt.Sprintf("%s always runs · nothing to configure", step.Title))
+		return m, nil
+	}
+}
+
+// noticeForUnsupportedVerb explains why a follow-up verb did nothing on the
+// selected row, naming the row rather than restating the requirement.
+func (m *followUpTUIModel) noticeForUnsupportedVerb(verb string) {
+	step, ok := m.selectedStep()
+	if !ok {
+		m.setNotice("select a follow-up step to " + verb)
+		return
+	}
+	if step.Kind == freshStepSetting {
+		m.setNotice(fmt.Sprintf("%q is a fresh setting · press enter to change it, not %s", step.Title, verb))
+		return
+	}
+	m.setNotice(fmt.Sprintf("%q is a built-in step · only follow-ups can be %sd", step.Title, verb))
+}
+
+func (m *followUpTUIModel) openSettingEditor(step freshWorkflowStep) {
+	m.overlay = followUpSettingOverlay
+	m.settingStep = step
+	m.settingError = ""
+	m.settingOptions = m.settingOptionsFor(step)
+
+	current := m.currentSettingAction(step)
+	m.settingChoice = 0
+	for i, option := range m.settingOptions {
+		if option.action == current {
+			m.settingChoice = i
+			break
+		}
+	}
+
+	m.settingInput.SetValue(m.settingScopeBranch())
+	m.settingInput.Blur()
+	if step.Setting == freshSettingBranch && current == freshSettingCustomBranch {
+		m.settingInput.Focus()
+	}
+}
+
 func (m *followUpTUIModel) moveSelectedFollowUp(delta int) tea.Cmd {
 	_, entry, ok := m.selectedFollowUp()
 	if !ok {
-		m.setError(camperrors.New("select a follow-up step to move"))
+		m.noticeForUnsupportedVerb("move")
 		return nil
 	}
 
@@ -201,9 +274,157 @@ func (m *followUpTUIModel) updateOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case followUpFormOverlay:
 		return m.updateForm(msg)
+	case followUpSettingOverlay:
+		return m.updateSettingEditor(msg)
 	default:
 		return m, nil
 	}
+}
+
+func (m *followUpTUIModel) updateSettingEditor(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "esc":
+		m.closeSettingEditor()
+		return m, nil
+	case "up", "shift+tab":
+		m.moveSettingChoice(-1)
+		return m, nil
+	case "down", "tab":
+		m.moveSettingChoice(1)
+		return m, nil
+	case "enter":
+		return m, m.saveSettingEditor()
+	}
+
+	// Typing only reaches the branch input, and only while the custom option is
+	// the selected one. Anywhere else the keystroke would edit a value the user
+	// cannot see, so it is dropped.
+	if m.settingInput.Focused() {
+		var cmd tea.Cmd
+		m.settingInput, cmd = m.settingInput.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m *followUpTUIModel) moveSettingChoice(delta int) {
+	if len(m.settingOptions) == 0 {
+		return
+	}
+	m.settingChoice = (m.settingChoice + delta + len(m.settingOptions)) % len(m.settingOptions)
+	m.settingError = ""
+	if m.selectedSettingAction() == freshSettingCustomBranch {
+		m.settingInput.Focus()
+		return
+	}
+	m.settingInput.Blur()
+}
+
+func (m *followUpTUIModel) selectedSettingAction() freshSettingAction {
+	if m.settingChoice < 0 || m.settingChoice >= len(m.settingOptions) {
+		return freshSettingInherit
+	}
+	return m.settingOptions[m.settingChoice].action
+}
+
+func (m *followUpTUIModel) closeSettingEditor() {
+	m.overlay = followUpNoOverlay
+	m.settingError = ""
+	m.settingInput.Blur()
+}
+
+func (m *followUpTUIModel) saveSettingEditor() tea.Cmd {
+	step := m.settingStep
+	scope := m.selectedScope()
+	projectName := scopeProjectName(scope)
+	action := m.selectedSettingAction()
+
+	var (
+		err     error
+		outcome string
+	)
+	switch step.Setting {
+	case freshSettingBranch:
+		branch, description, verr := m.resolveBranchAction(action)
+		if verr != nil {
+			m.settingError = verr.Error()
+			return nil
+		}
+		outcome = description
+		err = config.SetFreshBranch(m.ctx, m.root, projectName, branch)
+	case freshSettingPushUpstream:
+		value := boolForAction(action)
+		outcome = settingOutcome("push_upstream", value)
+		err = config.SetFreshPushUpstream(m.ctx, m.root, projectName, value)
+	case freshSettingPrune:
+		value := boolForAction(action)
+		outcome = settingOutcome("prune", value)
+		err = config.SetFreshPrune(m.ctx, m.root, value)
+	case freshSettingPruneRemote:
+		value := boolForAction(action)
+		outcome = settingOutcome("prune_remote", value)
+		err = config.SetFreshPruneRemote(m.ctx, m.root, value)
+	default:
+		m.closeSettingEditor()
+		return nil
+	}
+
+	if err != nil {
+		m.settingError = err.Error()
+		return nil
+	}
+	if err := m.refresh(scope); err != nil {
+		m.settingError = err.Error()
+		return nil
+	}
+
+	m.closeSettingEditor()
+	m.setStatus(fmt.Sprintf("%s in %s", outcome, workflowScopeLabel(projectName)))
+	return nil
+}
+
+// resolveBranchAction turns the selected option into the branch value to
+// write, rejecting a custom branch with no name rather than writing an empty
+// string that would read back as "no branch".
+func (m *followUpTUIModel) resolveBranchAction(action freshSettingAction) (*string, string, error) {
+	switch action {
+	case freshSettingInherit:
+		return nil, "branch now inherits the global default", nil
+	case freshSettingNoBranch:
+		empty := ""
+		return &empty, "branch cleared · fresh stays on the default branch", nil
+	default:
+		name := strings.TrimSpace(m.settingInput.Value())
+		if name == "" {
+			return nil, "", camperrors.NewValidation("branch", "must not be empty; choose \"no branch\" to stay on the default branch", nil)
+		}
+		return &name, fmt.Sprintf("branch set to %s", name), nil
+	}
+}
+
+// boolForAction maps an option onto the pointer the config writers take, where
+// nil clears the key.
+func boolForAction(action freshSettingAction) *bool {
+	switch action {
+	case freshSettingOn:
+		on := true
+		return &on
+	case freshSettingOff:
+		off := false
+		return &off
+	default:
+		return nil
+	}
+}
+
+func settingOutcome(key string, value *bool) string {
+	if value == nil {
+		return key + " now inherits the global default"
+	}
+	return fmt.Sprintf("%s set to %s", key, onOffWord(*value))
 }
 
 func (m *followUpTUIModel) updateForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/commands/fresh/configure_tui_update.go
+++ b/internal/commands/fresh/configure_tui_update.go
@@ -289,12 +289,14 @@ func (m *followUpTUIModel) updateSettingEditor(msg tea.KeyMsg) (tea.Model, tea.C
 	case "esc":
 		m.closeSettingEditor()
 		return m, nil
-	case "up", "shift+tab":
-		m.moveSettingChoice(-1)
-		return m, nil
-	case "down", "tab":
-		m.moveSettingChoice(1)
-		return m, nil
+	// j/k match browse mode. They always navigate options, even when the
+	// branch input is focused — typing a branch name that needs those letters
+	// still works via paste or arrow keys; losing vim-motion muscle memory
+	// inside the editor was the worse surprise.
+	case "up", "shift+tab", "k":
+		return m, m.moveSettingChoice(-1)
+	case "down", "tab", "j":
+		return m, m.moveSettingChoice(1)
 	case "enter":
 		return m, m.saveSettingEditor()
 	}
@@ -310,17 +312,21 @@ func (m *followUpTUIModel) updateSettingEditor(msg tea.KeyMsg) (tea.Model, tea.C
 	return m, nil
 }
 
-func (m *followUpTUIModel) moveSettingChoice(delta int) {
+// moveSettingChoice advances the option cursor and focuses the branch field
+// when landing on "create a branch...". Returns textinput.Blink so the caret
+// appears immediately — Focus alone does not schedule a blink.
+func (m *followUpTUIModel) moveSettingChoice(delta int) tea.Cmd {
 	if len(m.settingOptions) == 0 {
-		return
+		return nil
 	}
 	m.settingChoice = (m.settingChoice + delta + len(m.settingOptions)) % len(m.settingOptions)
 	m.settingError = ""
 	if m.selectedSettingAction() == freshSettingCustomBranch {
 		m.settingInput.Focus()
-		return
+		return textinput.Blink
 	}
 	m.settingInput.Blur()
+	return nil
 }
 
 func (m *followUpTUIModel) selectedSettingAction() freshSettingAction {
@@ -342,10 +348,20 @@ func (m *followUpTUIModel) saveSettingEditor() tea.Cmd {
 	projectName := scopeProjectName(scope)
 	action := m.selectedSettingAction()
 
+	// Confirm without changing must not rewrite the file. Scaffolded
+	// fresh.yaml keeps every key commented; a pure enter that materializes
+	// an explicit true is a dirty state the user never asked for.
+	if unchanged, notice := m.settingUnchanged(step, action); unchanged {
+		m.closeSettingEditor()
+		m.setNotice(notice)
+		return nil
+	}
+
 	var (
 		err     error
 		outcome string
 	)
+	project := projectName != ""
 	switch step.Setting {
 	case freshSettingBranch:
 		branch, description, verr := m.resolveBranchAction(action)
@@ -357,15 +373,15 @@ func (m *followUpTUIModel) saveSettingEditor() tea.Cmd {
 		err = config.SetFreshBranch(m.ctx, m.root, projectName, branch)
 	case freshSettingPushUpstream:
 		value := boolForAction(action)
-		outcome = settingOutcome("push_upstream", value)
+		outcome = settingOutcome("push_upstream", value, project)
 		err = config.SetFreshPushUpstream(m.ctx, m.root, projectName, value)
 	case freshSettingPrune:
 		value := boolForAction(action)
-		outcome = settingOutcome("prune", value)
+		outcome = settingOutcome("prune", value, project)
 		err = config.SetFreshPrune(m.ctx, m.root, value)
 	case freshSettingPruneRemote:
 		value := boolForAction(action)
-		outcome = settingOutcome("prune_remote", value)
+		outcome = settingOutcome("prune_remote", value, project)
 		err = config.SetFreshPruneRemote(m.ctx, m.root, value)
 	default:
 		m.closeSettingEditor()
@@ -384,6 +400,39 @@ func (m *followUpTUIModel) saveSettingEditor() tea.Cmd {
 	m.closeSettingEditor()
 	m.setStatus(fmt.Sprintf("%s in %s", outcome, workflowScopeLabel(projectName)))
 	return nil
+}
+
+// settingUnchanged reports that the selected option matches what the scope
+// already stores, so saving would only rewrite the file. Custom branches also
+// compare the typed name to the stored one.
+func (m *followUpTUIModel) settingUnchanged(step freshWorkflowStep, action freshSettingAction) (bool, string) {
+	if action != m.currentSettingAction(step) {
+		return false, ""
+	}
+	if action == freshSettingCustomBranch {
+		if strings.TrimSpace(m.settingInput.Value()) != m.settingScopeBranch() {
+			return false, ""
+		}
+	}
+
+	title := settingTitle(step.Setting)
+	switch action {
+	case freshSettingInherit:
+		if m.inProjectScope() {
+			return true, fmt.Sprintf("%s already inherits · nothing written", title)
+		}
+		return true, fmt.Sprintf("%s already at the built-in default · nothing written", title)
+	case freshSettingOn:
+		return true, fmt.Sprintf("%s already on · nothing written", title)
+	case freshSettingOff:
+		return true, fmt.Sprintf("%s already off · nothing written", title)
+	case freshSettingNoBranch:
+		return true, fmt.Sprintf("%s already cleared · nothing written", title)
+	case freshSettingCustomBranch:
+		return true, fmt.Sprintf("%s already %s · nothing written", title, m.settingScopeBranch())
+	default:
+		return true, fmt.Sprintf("%s unchanged · nothing written", title)
+	}
 }
 
 // resolveBranchAction turns the selected option into the branch value to
@@ -406,7 +455,7 @@ func (m *followUpTUIModel) resolveBranchAction(action freshSettingAction) (*stri
 }
 
 // boolForAction maps an option onto the pointer the config writers take, where
-// nil clears the key.
+// nil clears the key (project inherit, or global restore-to-built-in-default).
 func boolForAction(action freshSettingAction) *bool {
 	switch action {
 	case freshSettingOn:
@@ -420,9 +469,12 @@ func boolForAction(action freshSettingAction) *bool {
 	}
 }
 
-func settingOutcome(key string, value *bool) string {
+func settingOutcome(key string, value *bool, projectScope bool) string {
 	if value == nil {
-		return key + " now inherits the global default"
+		if projectScope {
+			return key + " now inherits the global default"
+		}
+		return key + " restored to the built-in default"
 	}
 	return fmt.Sprintf("%s set to %s", key, onOffWord(*value))
 }

--- a/internal/commands/fresh/configure_tui_view.go
+++ b/internal/commands/fresh/configure_tui_view.go
@@ -31,7 +31,9 @@ var (
 	freshSelected      = lipgloss.NewStyle().Foreground(freshTUIPal.Accent).Bold(true)
 	freshPrimary       = lipgloss.NewStyle().Foreground(freshTUIPal.TextPrimary)
 	freshMuted         = lipgloss.NewStyle().Foreground(freshTUIPal.TextMuted)
-	freshDisabled      = lipgloss.NewStyle().Foreground(freshTUIPal.Warning)
+	freshDisabled      = lipgloss.NewStyle().Foreground(freshTUIPal.TextMuted)
+	freshUnset         = lipgloss.NewStyle().Foreground(freshTUIPal.Warning)
+	freshSection       = lipgloss.NewStyle().Foreground(freshTUIPal.Accent).Bold(true)
 	freshOverlay       = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(freshTUIPal.BorderFocus).Background(freshTUIPal.BgOverlay).Padding(1, 2)
 )
 
@@ -104,8 +106,8 @@ func (m *followUpTUIModel) View() string {
 }
 
 func (m *followUpTUIModel) topBar(width int) string {
-	title := freshTUITitleStyle.Render("Fresh follow-ups")
-	meta := freshMuted.Render("configure the sequence that runs after a successful fresh cycle")
+	title := freshTUITitleStyle.Render("Fresh workflow")
+	meta := freshMuted.Render("configure what camp fresh does after a merge")
 	line := title + "  " + meta
 	return ui.ClampWidth(line, width)
 }
@@ -115,7 +117,7 @@ func (m *followUpTUIModel) renderScopesPane(lay freshTUILayout) string {
 	inner := max(width-4, 1)
 	lines := []string{
 		ui.ClampWidth(freshTUITitleStyle.Render("Scopes"), inner),
-		freshMuted.Render("select where a follow-up runs"),
+		freshMuted.Render("select the scope to configure"),
 	}
 	rows := max(lay.bodyRows-2, 1)
 	start, end := ui.WindowRange(m.scopeCursor, len(m.scopes), rows)
@@ -172,42 +174,147 @@ func scopeRowText(scope followUpScope, width int) string {
 	return ui.Truncate(scope.name, width)
 }
 
+// freshPaneRow is one rendered line of the workflow pane. A row is either a
+// section header or a step; headers carry stepIdx -1 and are skipped by the
+// cursor, so j/k still walks the sequence and never lands on a label.
+type freshPaneRow struct {
+	header  string
+	hint    string
+	stepIdx int
+}
+
+// workflowRows interleaves section headers with the steps they cover. The
+// sections partition the sequence by kind in execution order, which is what
+// lets the pane say which verbs apply where instead of advertising all of them
+// in the footer and rejecting most of them.
+func (m *followUpTUIModel) workflowRows(steps []freshWorkflowStep) []freshPaneRow {
+	rows := make([]freshPaneRow, 0, len(steps)+4)
+	emitted := map[freshStepKind]bool{}
+	followUps := 0
+	for _, step := range steps {
+		if step.Kind == freshStepFollowUp {
+			followUps++
+		}
+	}
+
+	for i, step := range steps {
+		if !emitted[step.Kind] {
+			emitted[step.Kind] = true
+			if header, hint := m.sectionHeader(step.Kind, followUps); header != "" {
+				rows = append(rows, freshPaneRow{header: header, hint: hint, stepIdx: -1})
+			}
+		}
+		rows = append(rows, freshPaneRow{stepIdx: i})
+	}
+
+	// The follow-up section is the only one that can be empty, and an empty one
+	// still has to appear: it is where the a key applies, and a user who cannot
+	// see the section has no reason to believe adding a step is possible.
+	if followUps == 0 {
+		header, hint := m.sectionHeader(freshStepFollowUp, 0)
+		rows = append(rows[:len(rows)-1],
+			freshPaneRow{header: header, hint: hint, stepIdx: -1},
+			rows[len(rows)-1],
+		)
+	}
+	return rows
+}
+
+func (m *followUpTUIModel) sectionHeader(kind freshStepKind, followUps int) (string, string) {
+	switch kind {
+	case freshStepFixed:
+		return "Sync", "always runs · not configurable"
+	case freshStepSetting:
+		if m.inProjectScope() {
+			return "Settings", "enter: change · some keys are campaign-wide"
+		}
+		return "Settings", "enter: change"
+	case freshStepFollowUp:
+		if followUps == 0 {
+			return "Follow-ups", "none yet · a: add one"
+		}
+		hint := "a: add · e: edit · d: delete · K/J: reorder"
+		if m.scopeInheritsGlobal() {
+			hint = "inherited from global · editing makes a project copy"
+		}
+		return "Follow-ups", hint
+	default:
+		return "", ""
+	}
+}
+
 func (m *followUpTUIModel) renderWorkflowPane(lay freshTUILayout) string {
 	width := lay.rightWidth
 	inner := max(width-4, 1)
 	scope := workflowScopeLabel(scopeProjectName(m.selectedScope()))
-	headerDetail := "Follow-ups run only after the sync steps succeed"
-	if m.scopeInheritsGlobal() {
-		headerDetail = "Inherits the global follow-ups · editing here makes a project copy"
-	}
-	steps := m.workflowSteps()
-	if m.pane == followUpWorkflowPane && m.stepCursor >= 0 && m.stepCursor < len(steps) {
-		headerDetail = "Selected · " + steps[m.stepCursor].Detail
+	headerDetail := "the ordered sequence camp fresh runs for this scope"
+	if step, ok := m.selectedStep(); ok && m.pane == followUpWorkflowPane {
+		headerDetail = "Selected · " + step.Detail
 	}
 	lines := []string{
 		ui.ClampWidth(freshTUITitleStyle.Render("Workflow · "+scope), inner),
 		freshMuted.Render(ui.Truncate(headerDetail, max(inner-2, 1))),
 	}
+
+	steps := m.workflowSteps()
+	paneRows := m.workflowRows(steps)
+	cursorRow := 0
+	for i, row := range paneRows {
+		if row.stepIdx == m.stepCursor {
+			cursorRow = i
+			break
+		}
+	}
+
 	rows := max(lay.bodyRows-2, 1)
-	start, end := ui.WindowRange(m.stepCursor, len(steps), rows)
+	start, end := ui.WindowRange(cursorRow, len(paneRows), rows)
 	for i := start; i < end; i++ {
-		lines = append(lines, m.workflowRow(i, steps[i], inner))
+		row := paneRows[i]
+		if row.stepIdx < 0 {
+			lines = append(lines, m.sectionRow(row, inner))
+			continue
+		}
+		lines = append(lines, m.workflowRow(row.stepIdx, steps[row.stepIdx], inner))
 	}
 	return m.finishPane(lines, inner, lay.bodyRows, m.pane == followUpWorkflowPane)
+}
+
+func (m *followUpTUIModel) sectionRow(row freshPaneRow, width int) string {
+	// Hints are dropped before the section name is truncated: a half-spelled
+	// heading costs the reader the grouping itself, while a missing hint only
+	// costs a reminder the help overlay repeats.
+	label := freshSection.Render(row.header)
+	if row.hint != "" {
+		candidate := row.header + "  " + row.hint
+		if lipgloss.Width(candidate) <= max(width-6, 1) {
+			label = freshSection.Render(row.header) + freshMuted.Render("  "+row.hint)
+		}
+	}
+	return ui.ClampWidth(label, max(width-freshPaneTextInset, 1))
+}
+
+// stepGlyph distinguishes the four step states. "Off" and "not configured"
+// looked identical before, which made a setting nobody had chosen yet read as
+// a deliberate decision.
+func stepGlyph(step freshWorkflowStep) string {
+	if step.Enabled {
+		return "✓"
+	}
+	switch step.State {
+	case freshStateUnset:
+		return "○"
+	case freshStateBlocked:
+		return "◌"
+	default:
+		return "·"
+	}
 }
 
 func (m *followUpTUIModel) workflowRow(index int, step freshWorkflowStep, width int) string {
 	selected := index == m.stepCursor
 	focused := selected && m.pane == followUpWorkflowPane
-	icon := "✓"
-	if !step.Enabled {
-		icon = "⚠"
-	}
 	title := fmt.Sprintf("%d. %s", index+1, step.Title)
-	if !step.Enabled {
-		title += " [off]"
-	}
-	row := ui.CursorGlyph(focused) + icon + " " + title
+	row := "  " + ui.CursorGlyph(focused) + stepGlyph(step) + " " + title
 	if width > 44 {
 		row += "  · " + step.Detail
 	}
@@ -218,10 +325,18 @@ func (m *followUpTUIModel) workflowRow(index int, step freshWorkflowStep, width 
 	if selected {
 		return freshSelected.Render(row)
 	}
-	if !step.Enabled {
+	switch {
+	case step.State == freshStateUnset:
+		// An unconfigured setting is the one row worth drawing attention to:
+		// it is a decision nobody has made, not a step that is working.
+		return freshUnset.Render(row)
+	case !step.Enabled:
 		return freshDisabled.Render(row)
+	case step.Kind == freshStepFixed || step.Kind == freshStepDone:
+		return freshMuted.Render(row)
+	default:
+		return freshPrimary.Render(row)
 	}
-	return freshPrimary.Render(row)
 }
 
 func (m *followUpTUIModel) finishPane(lines []string, width, rows int, focused bool) string {
@@ -252,10 +367,28 @@ func (m *followUpTUIModel) frame(lines []string, width, height int) string {
 	return ui.FitFullscreenView(strings.Join(ui.CapFrame(lines, width, height), "\n"), height)
 }
 
+// footer advertises the verbs that apply to the row under the cursor. The old
+// footer listed every verb unconditionally, so on eight rows out of nine it
+// named keys that would be refused.
 func (m *followUpTUIModel) footer(width int) string {
-	full := "j/k: select · K/J: move step · h/l: switch pane · a: add · e: edit · d: delete · r: reload · ?: help · q: quit"
-	mid := "j/k select · K/J move · h/l pane · a add · e edit · d delete · ? help · q quit"
-	short := "j/k · K/J · h/l · a/e/d · ? · q"
+	full := "j/k: select · h/l: switch pane · a: add follow-up · r: reload · ?: help · q: quit"
+	mid := "j/k select · h/l pane · a add · ? help · q quit"
+	short := "j/k · h/l · a · ? · q"
+
+	if m.pane == followUpWorkflowPane {
+		if step, ok := m.selectedStep(); ok {
+			switch {
+			case step.Kind == freshStepFollowUp:
+				full = "enter/e: edit · d: delete · K/J: reorder · a: add · j/k: select · h/l: pane · ?: help · q: quit"
+				mid = "enter edit · d delete · K/J reorder · a add · ? help · q quit"
+				short = "enter · d · K/J · a · q"
+			case step.Kind == freshStepSetting && step.Configurable(m.inProjectScope()):
+				full = "enter: change this setting · a: add follow-up · j/k: select · h/l: pane · ?: help · q: quit"
+				mid = "enter change · a add · j/k select · ? help · q quit"
+				short = "enter · a · j/k · q"
+			}
+		}
+	}
 	return freshTUIHelpStyle.Render(ui.CollapseHelp(width, full, mid, short, "q: quit"))
 }
 
@@ -263,10 +396,14 @@ func (m *followUpTUIModel) statusLine() string {
 	if m.status == "" {
 		return ""
 	}
-	if m.statusErr {
+	switch m.statusLevel {
+	case statusError:
 		return freshTUIErrorStyle.Render("✗ " + m.status)
+	case statusNotice:
+		return freshMuted.Render("· " + m.status)
+	default:
+		return freshTUIOKStyle.Render("✓ " + m.status)
 	}
-	return freshTUIOKStyle.Render("✓ " + m.status)
 }
 
 func (m *followUpTUIModel) overlayView() string {
@@ -275,20 +412,29 @@ func (m *followUpTUIModel) overlayView() string {
 	switch m.overlay {
 	case followUpHelpOverlay:
 		body = []string{
-			freshTUITitleStyle.Render("Fresh follow-up configuration"),
+			freshTUITitleStyle.Render("Fresh workflow configuration"),
 			"",
-			freshPrimary.Render("The right pane is the actual camp fresh sequence."),
-			freshMuted.Render("Select a project on the left to see its resolved overrides."),
+			freshPrimary.Render("The right pane is the actual camp fresh sequence,"),
+			freshPrimary.Render("grouped by what you can change about each step."),
 			"",
+			freshSection.Render("Sync") + freshMuted.Render("  always runs; nothing to configure"),
+			freshSection.Render("Settings") + freshMuted.Render("  fresh.yaml keys · enter to change"),
+			freshSection.Render("Follow-ups") + freshMuted.Render("  your commands · add, edit, reorder"),
+			"",
+			freshPrimary.Render("enter  change the selected setting or follow-up"),
 			freshPrimary.Render("a  add a follow-up after the core sync steps"),
-			freshPrimary.Render("e  edit the selected follow-up"),
 			freshPrimary.Render("K/J  move the selected follow-up earlier/later"),
 			freshPrimary.Render("d  delete the selected follow-up"),
 			freshPrimary.Render("r  reload fresh.yaml from disk"),
 			freshPrimary.Render("h/l or tab  move between scopes and workflow"),
 			"",
+			freshMuted.Render("prune and prune_remote are campaign-wide: change"),
+			freshMuted.Render("them under Global defaults, not under a project."),
+			"",
 			freshTUIHelpStyle.Render("esc or ?  close help"),
 		}
+	case followUpSettingOverlay:
+		body = m.settingOverlayBody()
 	case followUpDeleteOverlay:
 		body = []string{
 			freshTUITitleStyle.Render("Remove follow-up?"),
@@ -340,6 +486,43 @@ func (m *followUpTUIModel) overlayView() string {
 	canvas := lipgloss.Place(lay.width, lay.height, lipgloss.Center, lipgloss.Center, box,
 		lipgloss.WithWhitespaceBackground(freshTUIPal.BgOverlay))
 	return ui.FitFullscreenView(canvas, lay.height)
+}
+
+// settingOverlayBody renders the editor for one fresh.yaml key. It names the
+// key itself rather than only the step title, so the choice made here is
+// traceable to the line it writes in fresh.yaml.
+func (m *followUpTUIModel) settingOverlayBody() []string {
+	step := m.settingStep
+	scope := workflowScopeLabel(scopeProjectName(m.selectedScope()))
+	body := []string{
+		freshTUITitleStyle.Render(step.Title + " · " + scope),
+		freshMuted.Render("fresh.yaml key: " + settingTitle(step.Setting)),
+	}
+	if step.GlobalOnly {
+		body = append(body, freshMuted.Render("This key applies to every project in the campaign."))
+	}
+	body = append(body, "")
+
+	for i, option := range m.settingOptions {
+		prefix := ui.CursorGlyph(i == m.settingChoice)
+		line := prefix + option.label
+		if i == m.settingChoice {
+			body = append(body, freshSelected.Render(line))
+			continue
+		}
+		body = append(body, freshPrimary.Render(line))
+	}
+
+	if step.Setting == freshSettingBranch {
+		body = append(body, "", freshPrimary.Render("Branch name"), m.settingInput.View())
+		if m.selectedSettingAction() != freshSettingCustomBranch {
+			body = append(body, freshMuted.Render("used only with \"create a branch\""))
+		}
+	}
+	if m.settingError != "" {
+		body = append(body, freshTUIErrorStyle.Render("✗ "+m.settingError))
+	}
+	return append(body, "", freshTUIHelpStyle.Render("up/down choose · enter save · esc cancel"))
 }
 
 func failureBehaviorLabel(continueOnError bool) string {

--- a/internal/commands/fresh/workflow.go
+++ b/internal/commands/fresh/workflow.go
@@ -8,6 +8,56 @@ import (
 	"github.com/Obedience-Corp/camp/internal/ui"
 )
 
+// freshStepKind separates the three things a row in the fresh sequence can be.
+// The distinction is what the configure TUI groups on: a user standing in the
+// workflow needs to know whether a step is something they can change, and if
+// so, how, before they press a key at it.
+type freshStepKind int
+
+const (
+	// freshStepFixed always runs and has nothing to configure.
+	freshStepFixed freshStepKind = iota
+	// freshStepSetting is driven by a key in fresh.yaml.
+	freshStepSetting
+	// freshStepFollowUp is a user-defined command.
+	freshStepFollowUp
+	// freshStepDone is the terminal marker. It is fixed like freshStepFixed but
+	// carries its own kind so the pane can group strictly by kind: it trails the
+	// follow-ups, and folding it back in with the leading fixed steps would
+	// scatter one section across two ends of the sequence.
+	freshStepDone
+)
+
+// freshSettingKey names the fresh.yaml key behind a freshStepSetting.
+type freshSettingKey int
+
+const (
+	freshSettingNone freshSettingKey = iota
+	freshSettingPrune
+	freshSettingPruneRemote
+	freshSettingBranch
+	freshSettingPushUpstream
+)
+
+// freshStepState is why a step will or will not run. "Off" and "unset" are
+// deliberately distinct: a step nobody has configured is an invitation, while
+// one explicitly turned off is a decision, and a step held off by a dependency
+// is neither. Collapsing them into a single disabled state is what made the
+// old pane show "Create working branch [off]" next to a step that was off only
+// because no branch was named.
+type freshStepState int
+
+const (
+	// freshStateOn will run.
+	freshStateOn freshStepState = iota
+	// freshStateOff was explicitly turned off.
+	freshStateOff
+	// freshStateUnset has never been configured.
+	freshStateUnset
+	// freshStateBlocked cannot run until another setting changes.
+	freshStateBlocked
+)
+
 // freshWorkflowStep is the human-readable plan for one fresh cycle. It is
 // deliberately shared by the TUI and show-workflow so the two surfaces cannot
 // drift apart from executeFresh's actual order.
@@ -15,7 +65,30 @@ type freshWorkflowStep struct {
 	Title   string
 	Detail  string
 	Enabled bool
-	Follow  *config.FollowUpConfig
+	Kind    freshStepKind
+	Setting freshSettingKey
+	State   freshStepState
+	// GlobalOnly marks a setting fresh.yaml accepts only at the campaign
+	// level, so a project scope can say so rather than offer an edit that
+	// would write a key fresh never reads.
+	GlobalOnly bool
+	Follow     *config.FollowUpConfig
+}
+
+// Configurable reports whether the step has anything the TUI can change in the
+// currently selected scope.
+func (s freshWorkflowStep) Configurable(projectScope bool) bool {
+	switch s.Kind {
+	case freshStepFollowUp:
+		return true
+	case freshStepSetting:
+		if projectScope && s.GlobalOnly {
+			return false
+		}
+		return true
+	default:
+		return false
+	}
 }
 
 func buildFreshWorkflow(cfg *config.FreshConfig, projectName string) []freshWorkflowStep {
@@ -27,24 +100,49 @@ func buildFreshWorkflow(cfg *config.FreshConfig, projectName string) []freshWork
 	push := cfg.ResolveFreshPushUpstream(projectName)
 	prune := cfg.ResolveFreshPrune()
 	pruneRemote := cfg.ResolveFreshPruneRemote()
-	branchDetail := "not configured"
-	if branch != "" {
-		branchDetail = "create " + branch
-	}
-	pushDetail := "after creating the working branch"
-	if branch != "" && !push {
-		pushDetail = "disabled in fresh settings"
-	}
 
 	steps := []freshWorkflowStep{
 		{Title: "Safety checks", Detail: "no merge/rebase in progress; worktree is clean", Enabled: true},
 		{Title: "Checkout default branch", Detail: "use the repository's default branch (or a safe detached ref)", Enabled: true},
 		{Title: "Pull", Detail: "fast-forward only", Enabled: true},
-		{Title: "Prune merged branches", Detail: "remove merged branches and detached worktrees", Enabled: prune},
-		{Title: "Prune remote tracking refs", Detail: "refresh and remove stale refs", Enabled: prune && pruneRemote},
-		{Title: "Create working branch", Detail: branchDetail, Enabled: branch != ""},
-		{Title: "Push branch upstream", Detail: pushDetail, Enabled: branch != "" && push},
 	}
+
+	steps = append(steps,
+		freshWorkflowStep{
+			Title:      "Prune merged branches",
+			Detail:     onOffDetail(prune, "remove merged branches and detached worktrees"),
+			Enabled:    prune,
+			Kind:       freshStepSetting,
+			Setting:    freshSettingPrune,
+			State:      boolState(prune),
+			GlobalOnly: true,
+		},
+		freshWorkflowStep{
+			Title:      "Prune remote tracking refs",
+			Detail:     pruneRemoteDetail(prune, pruneRemote),
+			Enabled:    prune && pruneRemote,
+			Kind:       freshStepSetting,
+			Setting:    freshSettingPruneRemote,
+			State:      dependentState(prune, pruneRemote),
+			GlobalOnly: true,
+		},
+		freshWorkflowStep{
+			Title:   "Create working branch",
+			Detail:  branchDetail(branch),
+			Enabled: branch != "",
+			Kind:    freshStepSetting,
+			Setting: freshSettingBranch,
+			State:   branchState(branch),
+		},
+		freshWorkflowStep{
+			Title:   "Push branch upstream",
+			Detail:  pushDetail(branch, push),
+			Enabled: branch != "" && push,
+			Kind:    freshStepSetting,
+			Setting: freshSettingPushUpstream,
+			State:   dependentState(branch != "", push),
+		},
+	)
 
 	for _, follow := range cfg.ResolveFreshFollowUps(projectName) {
 		step := follow
@@ -52,6 +150,7 @@ func buildFreshWorkflow(cfg *config.FreshConfig, projectName string) []freshWork
 			Title:   "Follow-up: " + follow.Name,
 			Detail:  formatFollowUpDetail(follow),
 			Enabled: true,
+			Kind:    freshStepFollowUp,
 			Follow:  &step,
 		})
 	}
@@ -60,8 +159,72 @@ func buildFreshWorkflow(cfg *config.FreshConfig, projectName string) []freshWork
 		Title:   "Ready to work",
 		Detail:  "fresh completes successfully",
 		Enabled: true,
+		Kind:    freshStepDone,
 	})
 	return steps
+}
+
+func boolState(on bool) freshStepState {
+	if on {
+		return freshStateOn
+	}
+	return freshStateOff
+}
+
+// dependentState reports the state of a step whose own setting is on but whose
+// dependency is not, so the pane can say "waiting on something else" instead
+// of implying the user turned it off.
+func dependentState(dependency, own bool) freshStepState {
+	if !own {
+		return freshStateOff
+	}
+	if !dependency {
+		return freshStateBlocked
+	}
+	return freshStateOn
+}
+
+func branchState(branch string) freshStepState {
+	if branch == "" {
+		return freshStateUnset
+	}
+	return freshStateOn
+}
+
+func onOffDetail(on bool, detail string) string {
+	if on {
+		return detail
+	}
+	return "off · " + detail
+}
+
+func pruneRemoteDetail(prune, pruneRemote bool) string {
+	switch {
+	case !pruneRemote:
+		return "off · refresh and remove stale refs"
+	case !prune:
+		return "needs branch pruning · refresh and remove stale refs"
+	default:
+		return "refresh and remove stale refs"
+	}
+}
+
+func branchDetail(branch string) string {
+	if branch == "" {
+		return "no branch configured · fresh stays on the default branch"
+	}
+	return "create " + branch
+}
+
+func pushDetail(branch string, push bool) string {
+	switch {
+	case !push:
+		return "off · new branches stay local"
+	case branch == "":
+		return "needs a working branch · push with --set-upstream"
+	default:
+		return "push " + branch + " with --set-upstream"
+	}
 }
 
 func formatFollowUpDetail(step config.FollowUpConfig) string {
@@ -101,7 +264,7 @@ func printFreshWorkflow(w io.Writer, cfg *config.FreshConfig, projectName string
 		}
 		title := step.Title
 		if !step.Enabled {
-			title += " (disabled)"
+			title += " (" + stepStateWord(step.State) + ")"
 		}
 		if _, err := fmt.Fprintf(w, "  %s %d. %s\n", icon, i+1, ui.Value(title)); err != nil {
 			return err
@@ -111,4 +274,15 @@ func printFreshWorkflow(w io.Writer, cfg *config.FreshConfig, projectName string
 		}
 	}
 	return nil
+}
+
+func stepStateWord(state freshStepState) string {
+	switch state {
+	case freshStateUnset:
+		return "not configured"
+	case freshStateBlocked:
+		return "blocked"
+	default:
+		return "off"
+	}
 }

--- a/internal/config/fresh_followup.go
+++ b/internal/config/fresh_followup.go
@@ -259,17 +259,9 @@ func mutateFreshDoc(configPath string, mutate func(mapping *yaml.Node) error) er
 // mapping/sequence node along the path is created; when false, a missing
 // node returns (nil, nil) rather than an error.
 func followUpSequence(mapping *yaml.Node, projectName string, create bool) (*yaml.Node, error) {
-	target := mapping
-	if projectName != "" {
-		projectsNode, err := mappingChild(target, "projects", yaml.MappingNode, "!!map", create)
-		if err != nil || projectsNode == nil {
-			return nil, err
-		}
-		projectNode, err := mappingChild(projectsNode, projectName, yaml.MappingNode, "!!map", create)
-		if err != nil || projectNode == nil {
-			return nil, err
-		}
-		target = projectNode
+	target, err := freshScopeMapping(mapping, projectName, create)
+	if err != nil || target == nil {
+		return nil, err
 	}
 	return mappingChild(target, "follow_up", yaml.SequenceNode, "!!seq", create)
 }
@@ -324,22 +316,12 @@ func pruneEmptyFollowUpScope(mapping *yaml.Node, projectName string, seq *yaml.N
 		return
 	}
 
-	projectsNode, _ := mappingChild(mapping, "projects", yaml.MappingNode, "!!map", false)
-	if projectsNode == nil {
-		return
-	}
-	projectNode, _ := mappingChild(projectsNode, projectName, yaml.MappingNode, "!!map", false)
+	projectNode, _ := freshScopeMapping(mapping, projectName, false)
 	if projectNode == nil {
 		return
 	}
-
 	removeMappingKey(projectNode, "follow_up")
-	if len(projectNode.Content) == 0 {
-		removeMappingKey(projectsNode, projectName)
-	}
-	if len(projectsNode.Content) == 0 {
-		removeMappingKey(mapping, "projects")
-	}
+	pruneEmptyProjectScope(mapping, projectName)
 }
 
 // findFollowUpIndex returns the index of the entry named name within seq, or

--- a/internal/config/fresh_settings.go
+++ b/internal/config/fresh_settings.go
@@ -1,0 +1,154 @@
+package config
+
+import (
+	"context"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// SetFreshBranch writes the working branch `camp fresh` creates after syncing.
+// An empty projectName targets the global key; otherwise the per-project
+// override. A nil branch clears the key, restoring inheritance: a project falls
+// back to the global branch, and the global falls back to creating no branch.
+//
+// A non-nil pointer to "" is meaningful only in a project scope, where it
+// records "create no branch for this project" explicitly, so the project keeps
+// that behavior if a global branch is configured later. The global key has no
+// such distinction, since an absent key and an empty one both mean no branch.
+func SetFreshBranch(ctx context.Context, campaignRoot, projectName string, branch *string) error {
+	return withFreshConfigLock(ctx, campaignRoot, func(mapping *yaml.Node) error {
+		if branch == nil || (projectName == "" && *branch == "") {
+			return clearFreshKey(mapping, projectName, "branch")
+		}
+		return setFreshScalar(mapping, projectName, "branch", *branch, "!!str")
+	})
+}
+
+// SetFreshPushUpstream writes whether a newly created working branch is pushed
+// with --set-upstream. An empty projectName targets the global key; otherwise
+// the per-project override. A nil value clears the key, so a project inherits
+// the global setting and the global falls back to the built-in default (true).
+func SetFreshPushUpstream(ctx context.Context, campaignRoot, projectName string, value *bool) error {
+	return withFreshConfigLock(ctx, campaignRoot, func(mapping *yaml.Node) error {
+		return setFreshBool(mapping, projectName, "push_upstream", value)
+	})
+}
+
+// SetFreshPrune writes whether merged branches are pruned. The key is global
+// only: FreshProjectConfig has no per-project counterpart, so a project scope
+// is rejected rather than silently written somewhere fresh will not read it.
+func SetFreshPrune(ctx context.Context, campaignRoot string, value *bool) error {
+	return withFreshConfigLock(ctx, campaignRoot, func(mapping *yaml.Node) error {
+		return setFreshBool(mapping, "", "prune", value)
+	})
+}
+
+// SetFreshPruneRemote writes whether stale remote tracking refs are pruned.
+// Like prune, this key is global only.
+func SetFreshPruneRemote(ctx context.Context, campaignRoot string, value *bool) error {
+	return withFreshConfigLock(ctx, campaignRoot, func(mapping *yaml.Node) error {
+		return setFreshBool(mapping, "", "prune_remote", value)
+	})
+}
+
+// ProjectOverrideKeys counts the fresh.yaml keys a project sets for itself.
+// It is what distinguishes a project that deviates from the global defaults
+// from one that merely exists, and counts keys rather than follow-up steps so
+// a project whose only override is a branch is not reported as unconfigured.
+func ProjectOverrideKeys(pc FreshProjectConfig) int {
+	count := 0
+	if pc.Branch != nil {
+		count++
+	}
+	if pc.PushUpstream != nil {
+		count++
+	}
+	if pc.FollowUp != nil {
+		count++
+	}
+	return count
+}
+
+func setFreshBool(mapping *yaml.Node, projectName, key string, value *bool) error {
+	if value == nil {
+		return clearFreshKey(mapping, projectName, key)
+	}
+	return setFreshScalar(mapping, projectName, key, strconv.FormatBool(*value), "!!bool")
+}
+
+// setFreshScalar writes key: value into the requested scope, creating the
+// projects.<name> wrapper when needed and replacing any existing value in
+// place so surrounding keys and their comments keep their positions.
+func setFreshScalar(mapping *yaml.Node, projectName, key, value, tag string) error {
+	scope, err := freshScopeMapping(mapping, projectName, true)
+	if err != nil {
+		return err
+	}
+	for i := 0; i+1 < len(scope.Content); i += 2 {
+		k := scope.Content[i]
+		if k.Kind == yaml.ScalarNode && k.Value == key {
+			existing := scope.Content[i+1]
+			if existing.Kind != yaml.ScalarNode {
+				return camperrors.NewValidation(key, "has an unexpected shape in fresh.yaml", nil)
+			}
+			existing.Tag = tag
+			existing.Value = value
+			existing.Style = 0
+			return nil
+		}
+	}
+	scope.Content = append(scope.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: tag, Value: value},
+	)
+	return nil
+}
+
+// clearFreshKey removes key from the requested scope and cascades the cleanup
+// upward, so dropping a project's last override does not leave an empty
+// projects.<name> mapping behind.
+func clearFreshKey(mapping *yaml.Node, projectName, key string) error {
+	scope, err := freshScopeMapping(mapping, projectName, false)
+	if err != nil || scope == nil {
+		return err
+	}
+	removeMappingKey(scope, key)
+	pruneEmptyProjectScope(mapping, projectName)
+	return nil
+}
+
+// freshScopeMapping returns the mapping node a scope's keys live under: the
+// document root for the global scope, or projects.<projectName> for a project.
+func freshScopeMapping(mapping *yaml.Node, projectName string, create bool) (*yaml.Node, error) {
+	if projectName == "" {
+		return mapping, nil
+	}
+	projectsNode, err := mappingChild(mapping, "projects", yaml.MappingNode, "!!map", create)
+	if err != nil || projectsNode == nil {
+		return nil, err
+	}
+	return mappingChild(projectsNode, projectName, yaml.MappingNode, "!!map", create)
+}
+
+// pruneEmptyProjectScope drops an emptied projects.<projectName> entry and, in
+// turn, an emptied projects mapping. The global scope is the document root and
+// is never pruned.
+func pruneEmptyProjectScope(mapping *yaml.Node, projectName string) {
+	if projectName == "" {
+		return
+	}
+	projectsNode, _ := mappingChild(mapping, "projects", yaml.MappingNode, "!!map", false)
+	if projectsNode == nil {
+		return
+	}
+	projectNode, _ := mappingChild(projectsNode, projectName, yaml.MappingNode, "!!map", false)
+	if projectNode != nil && len(projectNode.Content) == 0 {
+		removeMappingKey(projectsNode, projectName)
+	}
+	if len(projectsNode.Content) == 0 {
+		removeMappingKey(mapping, "projects")
+	}
+}

--- a/internal/config/fresh_settings.go
+++ b/internal/config/fresh_settings.go
@@ -37,9 +37,11 @@ func SetFreshPushUpstream(ctx context.Context, campaignRoot, projectName string,
 	})
 }
 
-// SetFreshPrune writes whether merged branches are pruned. The key is global
-// only: FreshProjectConfig has no per-project counterpart, so a project scope
-// is rejected rather than silently written somewhere fresh will not read it.
+// SetFreshPrune writes whether merged branches are pruned. Global only: there
+// is no projectName parameter because FreshProjectConfig has no prune field.
+// A nil value clears the key so the built-in default (true) applies. Callers
+// that need to keep a project scope honest (and refuse a project write) live
+// in the configure TUI, which redirects those edits to Global defaults.
 func SetFreshPrune(ctx context.Context, campaignRoot string, value *bool) error {
 	return withFreshConfigLock(ctx, campaignRoot, func(mapping *yaml.Node) error {
 		return setFreshBool(mapping, "", "prune", value)
@@ -47,7 +49,8 @@ func SetFreshPrune(ctx context.Context, campaignRoot string, value *bool) error 
 }
 
 // SetFreshPruneRemote writes whether stale remote tracking refs are pruned.
-// Like prune, this key is global only.
+// Global only, same contract as SetFreshPrune: no projectName parameter, nil
+// clears the key back to the built-in default (true).
 func SetFreshPruneRemote(ctx context.Context, campaignRoot string, value *bool) error {
 	return withFreshConfigLock(ctx, campaignRoot, func(mapping *yaml.Node) error {
 		return setFreshBool(mapping, "", "prune_remote", value)

--- a/internal/config/fresh_settings_test.go
+++ b/internal/config/fresh_settings_test.go
@@ -1,0 +1,294 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func settingsRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, CampaignDir, SettingsDir), 0o755); err != nil {
+		t.Fatalf("create settings dir: %v", err)
+	}
+	return root
+}
+
+func loadSettings(t *testing.T, root string) *FreshConfig {
+	t.Helper()
+	cfg, err := LoadFreshConfig(context.Background(), root)
+	if err != nil {
+		t.Fatalf("LoadFreshConfig: %v", err)
+	}
+	return cfg
+}
+
+func readSettings(t *testing.T, root string) string {
+	t.Helper()
+	raw, err := os.ReadFile(FreshConfigPath(root))
+	if err != nil {
+		t.Fatalf("read fresh.yaml: %v", err)
+	}
+	return string(raw)
+}
+
+func TestSetFreshBranchRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	root := settingsRoot(t)
+
+	develop := "develop"
+	if err := SetFreshBranch(ctx, root, "", &develop); err != nil {
+		t.Fatalf("set global branch: %v", err)
+	}
+	if got := loadSettings(t, root).Branch; got != "develop" {
+		t.Fatalf("global branch = %q, want develop", got)
+	}
+
+	feature := "feat/api"
+	if err := SetFreshBranch(ctx, root, "api", &feature); err != nil {
+		t.Fatalf("set project branch: %v", err)
+	}
+	cfg := loadSettings(t, root)
+	if cfg.Projects["api"].Branch == nil || *cfg.Projects["api"].Branch != "feat/api" {
+		t.Fatalf("project branch = %v, want feat/api", cfg.Projects["api"].Branch)
+	}
+	if got := cfg.ResolveFreshBranch("", false, "api"); got != "feat/api" {
+		t.Errorf("resolved branch = %q, want the project override", got)
+	}
+}
+
+// A project that explicitly wants no branch has to survive a global branch
+// being configured later, which is why the empty string is written rather than
+// the key being dropped.
+func TestSetFreshBranchDistinguishesEmptyFromCleared(t *testing.T) {
+	ctx := context.Background()
+	root := settingsRoot(t)
+
+	develop := "develop"
+	if err := SetFreshBranch(ctx, root, "", &develop); err != nil {
+		t.Fatalf("set global branch: %v", err)
+	}
+
+	empty := ""
+	if err := SetFreshBranch(ctx, root, "api", &empty); err != nil {
+		t.Fatalf("set empty project branch: %v", err)
+	}
+	cfg := loadSettings(t, root)
+	if cfg.Projects["api"].Branch == nil {
+		t.Fatal("explicit empty branch was dropped instead of written")
+	}
+	if got := cfg.ResolveFreshBranch("", false, "api"); got != "" {
+		t.Errorf("resolved branch = %q, want no branch", got)
+	}
+
+	if err := SetFreshBranch(ctx, root, "api", nil); err != nil {
+		t.Fatalf("clear project branch: %v", err)
+	}
+	if got := loadSettings(t, root).ResolveFreshBranch("", false, "api"); got != "develop" {
+		t.Errorf("resolved branch after clearing = %q, want the inherited develop", got)
+	}
+}
+
+// The global key has no inherit/empty distinction: yaml omits an empty string,
+// so both mean "no branch" and neither should leave a stray key behind.
+func TestSetFreshBranchClearsGlobalKey(t *testing.T) {
+	ctx := context.Background()
+	root := settingsRoot(t)
+
+	develop := "develop"
+	if err := SetFreshBranch(ctx, root, "", &develop); err != nil {
+		t.Fatalf("set global branch: %v", err)
+	}
+	empty := ""
+	if err := SetFreshBranch(ctx, root, "", &empty); err != nil {
+		t.Fatalf("clear global branch: %v", err)
+	}
+
+	if strings.Contains(readSettings(t, root), "branch:") {
+		t.Errorf("global branch key survived being cleared:\n%s", readSettings(t, root))
+	}
+}
+
+func TestSetFreshBoolsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	root := settingsRoot(t)
+	off := false
+
+	if err := SetFreshPrune(ctx, root, &off); err != nil {
+		t.Fatalf("set prune: %v", err)
+	}
+	if err := SetFreshPruneRemote(ctx, root, &off); err != nil {
+		t.Fatalf("set prune_remote: %v", err)
+	}
+	if err := SetFreshPushUpstream(ctx, root, "api", &off); err != nil {
+		t.Fatalf("set project push_upstream: %v", err)
+	}
+
+	cfg := loadSettings(t, root)
+	if cfg.ResolveFreshPrune() {
+		t.Error("prune resolved true after being set false")
+	}
+	if cfg.ResolveFreshPruneRemote() {
+		t.Error("prune_remote resolved true after being set false")
+	}
+	if cfg.ResolveFreshPushUpstream("api") {
+		t.Error("project push_upstream resolved true after being set false")
+	}
+	if !cfg.ResolveFreshPushUpstream("other") {
+		t.Error("an unrelated project lost the default push_upstream")
+	}
+}
+
+func TestSetFreshPushUpstreamNilRestoresInheritance(t *testing.T) {
+	ctx := context.Background()
+	root := settingsRoot(t)
+
+	off := false
+	if err := SetFreshPushUpstream(ctx, root, "", &off); err != nil {
+		t.Fatalf("set global push_upstream: %v", err)
+	}
+	on := true
+	if err := SetFreshPushUpstream(ctx, root, "api", &on); err != nil {
+		t.Fatalf("set project push_upstream: %v", err)
+	}
+	if !loadSettings(t, root).ResolveFreshPushUpstream("api") {
+		t.Fatal("project override did not take effect")
+	}
+
+	if err := SetFreshPushUpstream(ctx, root, "api", nil); err != nil {
+		t.Fatalf("clear project push_upstream: %v", err)
+	}
+	if loadSettings(t, root).ResolveFreshPushUpstream("api") {
+		t.Error("cleared project key did not fall back to the global false")
+	}
+}
+
+// Clearing a project's last key should not leave an empty projects.<name>
+// mapping, which would show up in the TUI as a project that overrides nothing.
+func TestClearingLastProjectKeyPrunesTheScope(t *testing.T) {
+	ctx := context.Background()
+	root := settingsRoot(t)
+
+	branch := "feat/api"
+	if err := SetFreshBranch(ctx, root, "api", &branch); err != nil {
+		t.Fatalf("set project branch: %v", err)
+	}
+	if err := SetFreshBranch(ctx, root, "api", nil); err != nil {
+		t.Fatalf("clear project branch: %v", err)
+	}
+
+	raw := readSettings(t, root)
+	if strings.Contains(raw, "projects:") || strings.Contains(raw, "api") {
+		t.Errorf("emptied project scope survived:\n%s", raw)
+	}
+	if len(loadSettings(t, root).Projects) != 0 {
+		t.Error("emptied project scope still parses as a configured project")
+	}
+}
+
+// A project with follow-ups keeps its scope when a different key is cleared.
+func TestClearingOneKeyKeepsOtherProjectKeys(t *testing.T) {
+	ctx := context.Background()
+	root := settingsRoot(t)
+
+	if err := AddFreshFollowUp(ctx, root, "api", FollowUpConfig{Name: "gen", Run: "just gen"}); err != nil {
+		t.Fatalf("add follow-up: %v", err)
+	}
+	branch := "feat/api"
+	if err := SetFreshBranch(ctx, root, "api", &branch); err != nil {
+		t.Fatalf("set project branch: %v", err)
+	}
+	if err := SetFreshBranch(ctx, root, "api", nil); err != nil {
+		t.Fatalf("clear project branch: %v", err)
+	}
+
+	cfg := loadSettings(t, root)
+	if got := cfg.Projects["api"].FollowUp; len(got) != 1 || got[0].Name != "gen" {
+		t.Fatalf("project follow-ups = %+v, want the gen step to survive", got)
+	}
+	if cfg.Projects["api"].Branch != nil {
+		t.Error("cleared branch key survived")
+	}
+}
+
+// The scaffolded fresh.yaml ships fully commented out. Writing a setting to it
+// must not discard that documentation.
+func TestSetFreshSettingPreservesFileComments(t *testing.T) {
+	ctx := context.Background()
+	root := settingsRoot(t)
+	header := "# fresh.yaml - post-merge branch cycling\n# branch: develop\n"
+	if err := os.WriteFile(FreshConfigPath(root), []byte(header), 0o644); err != nil {
+		t.Fatalf("seed fresh.yaml: %v", err)
+	}
+
+	branch := "develop"
+	if err := SetFreshBranch(ctx, root, "", &branch); err != nil {
+		t.Fatalf("set branch: %v", err)
+	}
+
+	raw := readSettings(t, root)
+	if !strings.Contains(raw, "# fresh.yaml - post-merge branch cycling") {
+		t.Errorf("documentation header was discarded:\n%s", raw)
+	}
+	if got := loadSettings(t, root).Branch; got != "develop" {
+		t.Errorf("branch = %q, want develop", got)
+	}
+}
+
+// Rewriting a key must replace its value rather than append a duplicate, which
+// yaml would resolve to the last occurrence and quietly double the file.
+func TestSetFreshSettingReplacesExistingValue(t *testing.T) {
+	ctx := context.Background()
+	root := settingsRoot(t)
+
+	first, second := "one", "two"
+	if err := SetFreshBranch(ctx, root, "", &first); err != nil {
+		t.Fatalf("set branch: %v", err)
+	}
+	if err := SetFreshBranch(ctx, root, "", &second); err != nil {
+		t.Fatalf("rewrite branch: %v", err)
+	}
+
+	raw := readSettings(t, root)
+	if strings.Count(raw, "branch:") != 1 {
+		t.Errorf("branch key written twice:\n%s", raw)
+	}
+	if got := loadSettings(t, root).Branch; got != "two" {
+		t.Errorf("branch = %q, want two", got)
+	}
+}
+
+func TestProjectOverrideKeysCountsEveryKey(t *testing.T) {
+	branch := "feat/api"
+	on := true
+
+	tests := []struct {
+		name string
+		pc   FreshProjectConfig
+		want int
+	}{
+		{name: "empty", pc: FreshProjectConfig{}, want: 0},
+		{name: "branch only", pc: FreshProjectConfig{Branch: &branch}, want: 1},
+		{name: "follow-ups only", pc: FreshProjectConfig{FollowUp: []FollowUpConfig{{Name: "gen"}}}, want: 1},
+		{
+			name: "explicitly empty follow-ups still overrides",
+			pc:   FreshProjectConfig{FollowUp: []FollowUpConfig{}},
+			want: 1,
+		},
+		{
+			name: "every key",
+			pc:   FreshProjectConfig{Branch: &branch, PushUpstream: &on, FollowUp: []FollowUpConfig{{Name: "gen"}}},
+			want: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ProjectOverrideKeys(tt.pc); got != tt.want {
+				t.Errorf("ProjectOverrideKeys() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`camp fresh configure` could only edit `follow_up` — one of the five keys in `fresh.yaml`. The other four (`branch`, `push_upstream`, `prune`, `prune_remote`) had no interactive surface at all.

Worse, the workflow pane rendered every step as one flat numbered list, so a row reading **"Create working branch [off] · not configured"** sat next to a footer advertising **`e: edit`** — and pressing it returned `✗ select a follow-up step to edit`. The pane showed a setting asking to be configured, offered a key to configure it, and refused.

Three genuinely different classes of row looked identical: fixed steps, settings-backed steps, and follow-ups. The only cue that one differed was the literal word "Follow-up:" in its title.

## Changes

**Group the workflow pane by what each step is**, with the verbs that apply on each section header rather than a footer that lists all of them and rejects most:

```
 Sync  always runs · not configurable
   ✓ 1. Safety checks        · no merge/rebase in progress; worktree is clean
   ✓ 2. Checkout default branch
   ✓ 3. Pull                 · fast-forward only
 Settings  enter: change
   ✓ 4. Prune merged branches
   ✓ 5. Prune remote tracking refs
   ○ 6. Create working branch  · no branch configured
   ◌ 7. Push branch upstream   · needs a working branch
 Follow-ups  a: add · e: edit · d: delete · K/J: reorder
   ✓ 8. Follow-up: install   · $ npm install · stop on failure
   ✓ 9. Ready to work
```

**A settings editor on `enter`**, tri-state in a project scope (`inherit` / `on` / `off`) so clearing a key restores inheritance rather than writing `false`. `FreshProjectConfig` uses `*bool` precisely for that distinction; collapsing it to a checkbox would write override keys the user never asked for.

**`prune` / `prune_remote` stay campaign-wide**, matching what `FreshProjectConfig` actually stores. A project scope redirects to Global defaults rather than writing a key `fresh` never reads. Adding per-project prune would change `camp fresh` resolution semantics for existing users, which shouldn't ride along on a TUI fix — happy to file it separately if wanted.

**New config writers** (`SetFreshBranch`, `SetFreshPushUpstream`, `SetFreshPrune`, `SetFreshPruneRemote`) routed through the existing `withFreshConfigLock`, so they inherit the atomic write, comment preservation, and empty-scope cleanup the follow-up writers already had.

**Separate "off" from "not configured"** in glyph and color (`✓` on, `○` unset, `◌` blocked, `·` off), and route refusals through a notice level instead of the red used for real failures.

## Drive-by fix

The scopes-pane override badge counted follow-ups only. A project overriding just `branch` and `push_upstream` showed **no badge at all** — already wrong before this change, since per-project `branch` ships today.

## Verification

Driven in a pty via VHS against a fixture campaign with 10 linked projects, not just unit tests. That caught a bug tests would not have: the branch input was seeded with the *inherited* branch, so selecting "create a branch" and typing appended to it and wrote `developfeat/storefront`. Fixed, and pinned by `TestSettingEditorDoesNotSeedInheritedBranch`.

Confirmed on screen and on disk:
- branch and push_upstream written correctly under `projects.<name>`, file comments preserved
- `web-storefront · here · override 2` — badge counts both keys
- prune in a project scope shows `· prune is a campaign-wide setting · select Global defaults to change it` as a muted notice, not an error
- narrow single-pane mode (700x460) still renders both section headers within the row budget

`just gate`: 3535/3535 tests pass, lint clean.

## Note

The demo for this now lives in the `social-fitness-app` experience-lab campaign rather than in this repo, per that campaign's charter ("capture VHS recordings ... without adding demo-only fixtures to production codebases"):

- fixture builder: `vhs/fixtures/build-fresh-campaign.sh` (10-project fitness campaign, built outside the repo so no username appears in the prompt)
- tape + scenario notes: `vhs/camp/configure-fresh-workflow.{tape,md}`

That leaves `docs/demos/fresh-configure.{tape,gif}` here recording a TUI that no longer exists, under the older in-repo convention. I've deliberately **not** touched it in this PR — removing it implies `machine-tui.tape` follows and `just vhs record` loses its purpose here, which is a call about this repo's demo assets generally, not something to decide inside a TUI change.
