### PR TITLE
fix: clarify workitem create is tracking metadata only

### DIFF
--- a/internal/commands/workitem/create.go
+++ b/internal/commands/workitem/create.go
@@ -31,7 +31,7 @@ func newCreateCommand() *cobra.Command {
 	var jsonOut bool
 	cmd := &cobra.Command{
 		Use:   "create <slug>",
-		Short: "Create a workitem",
+		Short: "Create workitem tracking metadata",
 		Long: `Create tracking metadata for a new workitem (directory + .workitem marker).
 
 This command does NOT create the substantive work scaffold (no design docs,
@@ -41,12 +41,16 @@ explore notes, or festival structure). It only:
   2. Writes a .workitem marker (id, type, title, ref, optional quest)
 
 Agents and humans must still add real content afterward. For explore/design
-types, the suggested next step is usually:
+types, the recommended structured-workflow scaffold is:
 
   cd workflow/<type>/<slug> && fest create workflow <slug>
 
+For other types (feature, bug, chore, …), no festival scaffold is implied;
+populate campaign-governed content under the new directory as needed.
+
 Use "camp workitem adopt" to attach a marker to an existing directory.
-Use --json for machine-readable identity and an explicit next.command hint.`,
+Use --json for machine-readable identity. next.command is set only for
+explore/design (recommended scaffold); otherwise it is empty/omitted.`,
 		Args: jsoncontract.Args(WorkitemCreateJSONVersion, func() bool { return jsonOut }, cobra.ExactArgs(1)),
 		Annotations: map[string]string{
 			"agent_allowed": "true",
@@ -147,6 +151,7 @@ func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, i
 		Emit(ctx, ledgerkit.KindCreated, ledgerkit.Scope{Workitem: ref, Quest: questID},
 			ledger.WithWhy(title),
 			ledger.WithPayload(map[string]any{"type": typeFlag, "title": title, "path": rel}))
+	nextCommand, nextHint, humanNextLine := createNextGuidance(typeFlag, slug, rel)
 	if jsonOut {
 		payload := struct {
 			SchemaVersion string    `json:"schema_version"`
@@ -161,7 +166,7 @@ func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, i
 				MarkerVersion string `json:"marker_version"`
 			} `json:"workitem"`
 			Next struct {
-				Command string `json:"command"`
+				Command string `json:"command,omitempty"`
 				Cwd     string `json:"cwd"`
 				Hint    string `json:"hint"`
 			} `json:"next"`
@@ -173,9 +178,9 @@ func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, i
 		payload.Workitem.QuestID = questID
 		payload.Workitem.RelativePath = rel
 		payload.Workitem.MarkerVersion = wkitem.WorkitemSchemaVersion
-		payload.Next.Command = "fest create workflow " + slug
+		payload.Next.Command = nextCommand
 		payload.Next.Cwd = rel
-		payload.Next.Hint = "tracking only: marker created; optional next: cd " + rel + " && fest create workflow " + slug
+		payload.Next.Hint = nextHint
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
 		return enc.Encode(payload)
@@ -185,9 +190,35 @@ func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, i
 		questLine = fmt.Sprintf("  quest: %s\n", questID)
 	}
 	fmt.Fprintf(cmd.OutOrStdout(),
-		"created workitem tracking at %s\n  id: %s\n  ref: %s\n  type: %s\n%s  note: directory + .workitem only — not a design/explore/festival scaffold\n  optional next: cd %s && fest create workflow %s\n",
-		rel, id, ref, typeFlag, questLine, rel, slug)
+		"created workitem tracking at %s\n  id: %s\n  ref: %s\n  type: %s\n%s  note: directory + .workitem only — not a design/explore/festival scaffold\n%s",
+		rel, id, ref, typeFlag, questLine, humanNextLine)
 	return nil
+}
+
+// recommendsWorkflowScaffold reports whether fest create workflow is the
+// recommended structured next step for this workitem type (explore/design).
+func recommendsWorkflowScaffold(typeFlag string) bool {
+	switch strings.ToLower(typeFlag) {
+	case "explore", "design":
+		return true
+	default:
+		return false
+	}
+}
+
+// createNextGuidance returns JSON next.command / next.hint and the human
+// stdout next line (including trailing newline, or empty when omitted).
+// explore/design get a recommended fest scaffold; other types get tracking-only
+// guidance with no agent-executable command.
+func createNextGuidance(typeFlag, slug, rel string) (command, hint, humanNextLine string) {
+	if recommendsWorkflowScaffold(typeFlag) {
+		command = "fest create workflow " + slug
+		hint = "tracking only: marker created; recommended next: cd " + rel + " && fest create workflow " + slug
+		humanNextLine = "  recommended next: cd " + rel + " && fest create workflow " + slug + "\n"
+		return command, hint, humanNextLine
+	}
+	hint = "tracking only: marker created; add content under " + rel + " as needed (no festival scaffold implied)"
+	return "", hint, ""
 }
 
 func validateSlug(slug string) error {

--- a/internal/commands/workitem/create.go
+++ b/internal/commands/workitem/create.go
@@ -32,13 +32,21 @@ func newCreateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create <slug>",
 		Short: "Create a workitem",
-		Long: `Create a new workitem directory with minimal v1 metadata.
+		Long: `Create tracking metadata for a new workitem (directory + .workitem marker).
 
-The workitem is created under workflow/<type>/<slug>/ unless --dir supplies a
-different campaign-relative parent directory. A .workitem file is written with
-the id, type, title, ref, creation metadata, and optional quest link. Use --json
-for machine-readable output containing the new workitem identity and next-step
-location.`,
+This command does NOT create the substantive work scaffold (no design docs,
+explore notes, or festival structure). It only:
+
+  1. Creates workflow/<type>/<slug>/ (or --dir/<slug>/)
+  2. Writes a .workitem marker (id, type, title, ref, optional quest)
+
+Agents and humans must still add real content afterward. For explore/design
+types, the suggested next step is usually:
+
+  cd workflow/<type>/<slug> && fest create workflow <slug>
+
+Use "camp workitem adopt" to attach a marker to an existing directory.
+Use --json for machine-readable identity and an explicit next.command hint.`,
 		Args: jsoncontract.Args(WorkitemCreateJSONVersion, func() bool { return jsonOut }, cobra.ExactArgs(1)),
 		Annotations: map[string]string{
 			"agent_allowed": "true",
@@ -167,7 +175,7 @@ func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, i
 		payload.Workitem.MarkerVersion = wkitem.WorkitemSchemaVersion
 		payload.Next.Command = "fest create workflow " + slug
 		payload.Next.Cwd = rel
-		payload.Next.Hint = "cd " + rel + " && fest create workflow " + slug
+		payload.Next.Hint = "tracking only: marker created; optional next: cd " + rel + " && fest create workflow " + slug
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
 		return enc.Encode(payload)
@@ -177,7 +185,7 @@ func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, i
 		questLine = fmt.Sprintf("  quest: %s\n", questID)
 	}
 	fmt.Fprintf(cmd.OutOrStdout(),
-		"created %s\n  id: %s\n  ref: %s\n  type: %s\n%snext: cd %s && fest create workflow %s\n",
+		"created workitem tracking at %s\n  id: %s\n  ref: %s\n  type: %s\n%s  note: directory + .workitem only — not a design/explore/festival scaffold\n  optional next: cd %s && fest create workflow %s\n",
 		rel, id, ref, typeFlag, questLine, rel, slug)
 	return nil
 }

--- a/internal/commands/workitem/create_test.go
+++ b/internal/commands/workitem/create_test.go
@@ -16,6 +16,64 @@ import (
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
 
+func TestRecommendsWorkflowScaffold(t *testing.T) {
+	cases := []struct {
+		typeFlag string
+		want     bool
+	}{
+		{"explore", true},
+		{"design", true},
+		{"Design", true},
+		{"EXPLORE", true},
+		{"feature", false},
+		{"bug", false},
+		{"chore", false},
+		{"incident", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := recommendsWorkflowScaffold(c.typeFlag); got != c.want {
+			t.Errorf("recommendsWorkflowScaffold(%q) = %v, want %v", c.typeFlag, got, c.want)
+		}
+	}
+}
+
+func TestCreateNextGuidance(t *testing.T) {
+	t.Run("explore recommends fest scaffold", func(t *testing.T) {
+		cmd, hint, human := createNextGuidance("explore", "topic", "workflow/explore/topic")
+		if cmd != "fest create workflow topic" {
+			t.Fatalf("command = %q", cmd)
+		}
+		if !strings.Contains(hint, "tracking only") {
+			t.Fatalf("hint missing tracking only: %q", hint)
+		}
+		if !strings.Contains(hint, "recommended next") {
+			t.Fatalf("hint missing recommended next: %q", hint)
+		}
+		if !strings.Contains(human, "recommended next:") {
+			t.Fatalf("human next line = %q", human)
+		}
+		if strings.Contains(human, "optional next:") {
+			t.Fatalf("human must not say optional for explore: %q", human)
+		}
+	})
+	t.Run("feature omits agent command", func(t *testing.T) {
+		cmd, hint, human := createNextGuidance("feature", "demo", "workflow/feature/demo")
+		if cmd != "" {
+			t.Fatalf("command = %q, want empty", cmd)
+		}
+		if human != "" {
+			t.Fatalf("human next line = %q, want empty", human)
+		}
+		if !strings.Contains(hint, "tracking only") {
+			t.Fatalf("hint missing tracking only: %q", hint)
+		}
+		if strings.Contains(hint, "fest create workflow") {
+			t.Fatalf("feature hint must not recommend fest scaffold: %q", hint)
+		}
+	})
+}
+
 func TestValidateSlug(t *testing.T) {
 	cases := []struct {
 		slug string

--- a/tests/integration/workitem_create_test.go
+++ b/tests/integration/workitem_create_test.go
@@ -39,6 +39,8 @@ func TestIntegration_WorkitemCreateAndAdopt(t *testing.T) {
 		require.NoError(t, err, "camp workitem create design: %s", out)
 		assert.Contains(t, out, "created workitem tracking at workflow/design/nav-design")
 		assert.Contains(t, out, "directory + .workitem only")
+		assert.Contains(t, out, "recommended next:")
+		assert.NotContains(t, out, "optional next:")
 
 		out, err = tc.RunCampInDir(campaignDir, "complete", "de")
 		require.NoError(t, err, "completion after workitem create: %s", out)
@@ -56,7 +58,10 @@ func TestIntegration_WorkitemCreateAndAdopt(t *testing.T) {
 		assert.Contains(t, out, "created workitem tracking at workflow/feature/demo-feature")
 		assert.Contains(t, out, "id: feature-demo-feature-")
 		assert.Contains(t, out, "type: feature")
-		assert.Contains(t, out, "optional next:")
+		assert.Contains(t, out, "directory + .workitem only")
+		assert.NotContains(t, out, "optional next:")
+		assert.NotContains(t, out, "recommended next:")
+		assert.NotContains(t, out, "fest create workflow")
 
 		manifest, err := tc.ReadFile(campaignDir + "/workflow/feature/demo-feature/.workitem")
 		require.NoError(t, err)
@@ -189,6 +194,7 @@ func TestIntegration_WorkitemCreateJSON(t *testing.T) {
 	require.NoError(t, err, "camp workitem create --json: %s", out)
 	assert.NotContains(t, out, "created workitem tracking at workflow/feature/agent-json")
 	assert.NotContains(t, out, "\n  optional next:")
+	assert.NotContains(t, out, "\n  recommended next:")
 
 	var payload struct {
 		SchemaVersion string    `json:"schema_version"`
@@ -218,9 +224,45 @@ func TestIntegration_WorkitemCreateJSON(t *testing.T) {
 	assert.Empty(t, payload.Workitem.QuestID)
 	assert.Equal(t, "workflow/feature/agent-json", payload.Workitem.RelativePath)
 	assert.Equal(t, "v1alpha7", payload.Workitem.MarkerVersion)
-	assert.Equal(t, "fest create workflow agent-json", payload.Next.Command)
+	// feature/bug/chore: no agent-executable scaffold command
+	assert.Empty(t, payload.Next.Command,
+		"non-explore/design types must not ship unconditional fest create workflow")
+	assert.NotContains(t, out, `"command"`,
+		"empty next.command should be omitted via omitempty for non-scaffold types")
 	assert.Equal(t, "workflow/feature/agent-json", payload.Next.Cwd)
-	assert.Contains(t, payload.Next.Hint, "cd workflow/feature/agent-json")
+	assert.Contains(t, payload.Next.Hint, "tracking only",
+		"agent-facing hint must lock the metadata-only signal")
+	assert.Contains(t, payload.Next.Hint, "workflow/feature/agent-json")
+	assert.NotContains(t, payload.Next.Hint, "fest create workflow",
+		"feature create must not recommend festival scaffold")
+
+	// explore/design retain recommended next.command + tracking-only hint
+	designOut, err := tc.RunCampInDir(campaignDir,
+		"workitem", "create", "agent-design",
+		"--type", "design",
+		"--title", "Agent Design",
+		"--id", "agent-design-fixed",
+		"--json",
+	)
+	require.NoError(t, err, "camp workitem create design --json: %s", designOut)
+	var designPayload struct {
+		Next struct {
+			Command string `json:"command"`
+			Cwd     string `json:"cwd"`
+			Hint    string `json:"hint"`
+		} `json:"next"`
+		Workitem struct {
+			Type string `json:"type"`
+		} `json:"workitem"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(designOut), &designPayload), "raw=%s", designOut)
+	assert.Equal(t, "design", designPayload.Workitem.Type)
+	assert.Equal(t, "fest create workflow agent-design", designPayload.Next.Command)
+	assert.Equal(t, "workflow/design/agent-design", designPayload.Next.Cwd)
+	assert.Contains(t, designPayload.Next.Hint, "tracking only",
+		"agent-facing hint must lock the metadata-only signal")
+	assert.Contains(t, designPayload.Next.Hint, "recommended next")
+	assert.Contains(t, designPayload.Next.Hint, "cd workflow/design/agent-design")
 
 	resolveOut, err := tc.RunCampInDir(campaignDir,
 		"workitem", "resolve", "--workitem", payload.Workitem.ID, "--json")

--- a/tests/integration/workitem_create_test.go
+++ b/tests/integration/workitem_create_test.go
@@ -37,7 +37,8 @@ func TestIntegration_WorkitemCreateAndAdopt(t *testing.T) {
 
 		out, err := tc.RunCampInDir(campaignDir, "workitem", "create", "nav-design", "--type", "design", "--title", "Navigation Design")
 		require.NoError(t, err, "camp workitem create design: %s", out)
-		assert.Contains(t, out, "created workflow/design/nav-design")
+		assert.Contains(t, out, "created workitem tracking at workflow/design/nav-design")
+		assert.Contains(t, out, "directory + .workitem only")
 
 		out, err = tc.RunCampInDir(campaignDir, "complete", "de")
 		require.NoError(t, err, "completion after workitem create: %s", out)
@@ -52,9 +53,10 @@ func TestIntegration_WorkitemCreateAndAdopt(t *testing.T) {
 	t.Run("CreateBuildsDirectoryAndWorkitem", func(t *testing.T) {
 		out, err := tc.RunCampInDir(campaignDir, "workitem", "create", "demo-feature", "--type", "feature", "--title", "Demo")
 		require.NoError(t, err, "camp workitem create: %s", out)
-		assert.Contains(t, out, "created workflow/feature/demo-feature")
+		assert.Contains(t, out, "created workitem tracking at workflow/feature/demo-feature")
 		assert.Contains(t, out, "id: feature-demo-feature-")
 		assert.Contains(t, out, "type: feature")
+		assert.Contains(t, out, "optional next:")
 
 		manifest, err := tc.ReadFile(campaignDir + "/workflow/feature/demo-feature/.workitem")
 		require.NoError(t, err)
@@ -185,8 +187,8 @@ func TestIntegration_WorkitemCreateJSON(t *testing.T) {
 		"--json",
 	)
 	require.NoError(t, err, "camp workitem create --json: %s", out)
-	assert.NotContains(t, out, "created workflow/feature/agent-json")
-	assert.NotContains(t, out, "\nnext:")
+	assert.NotContains(t, out, "created workitem tracking at workflow/feature/agent-json")
+	assert.NotContains(t, out, "\n  optional next:")
 
 	var payload struct {
 		SchemaVersion string    `json:"schema_version"`


### PR DESCRIPTION
## Summary

- Clarify that `camp workitem create` only creates a directory + `.workitem` marker, not a design/explore/festival scaffold.
- Update Long help, human stdout, and JSON `next.hint` so agents do not treat create as full scaffolding.
- Adjust integration assertions for the new wording.

Closes #456

## Test plan

- [x] `go test ./internal/commands/workitem/`
- [ ] integration workitem create tests (CI / local container)