### PR TITLE
fix(worktrees): clean enumerates via git worktree list

### DIFF
--- a/cmd/camp/worktrees/clean.go
+++ b/cmd/camp/worktrees/clean.go
@@ -13,6 +13,7 @@ import (
 	git "github.com/Obedience-Corp/camp/internal/git"
 	navtui "github.com/Obedience-Corp/camp/internal/nav/tui"
 	"github.com/Obedience-Corp/camp/internal/paths"
+	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/Obedience-Corp/camp/internal/worktree"
 	"github.com/spf13/cobra"
@@ -98,8 +99,9 @@ func runWorktreesClean(cmd *cobra.Command, args []string) error {
 	resolver := paths.NewResolver(campRoot, cfg.Paths())
 	pathManager := worktree.NewPathManager(resolver)
 
-	// Find stale worktrees
-	stale, err := findStaleWorktrees(ctx, pathManager, cfg, cleanProject)
+	// Find stale worktrees (git worktree list is the primary source of truth,
+	// same as camp worktrees list; preferred-dir scan catches orphans only).
+	stale, err := findStaleWorktrees(ctx, campRoot, pathManager, cleanProject)
 	if err != nil {
 		return err
 	}
@@ -202,46 +204,103 @@ func runWorktreesClean(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func findStaleWorktrees(ctx context.Context, pm *worktree.PathManager, cfg *config.CampaignConfig, filterProject string) ([]cleanResult, error) {
+func findStaleWorktrees(ctx context.Context, campRoot string, pm *worktree.PathManager, filterProject string) ([]cleanResult, error) {
 	var stale []cleanResult
+	seen := make(map[string]struct{})
 
-	// Get projects to scan
-	var projectNames []string
-	if filterProject != "" {
-		projectNames = []string{filterProject}
-	} else {
-		projects, err := pm.ListAllProjects()
-		if err != nil {
-			return nil, err
-		}
-		projectNames = projects
+	// Project targets: registered campaign projects (same approach as worktrees list).
+	targets, err := cleanProjectTargets(ctx, campRoot, filterProject)
+	if err != nil {
+		return nil, err
 	}
 
-	// Check each project's worktrees
-	for _, projectName := range projectNames {
-		fsWorktrees, err := pm.ListProjectWorktrees(projectName)
-		if err != nil {
-			continue
+	for _, target := range targets {
+		// Primary: every linked worktree git knows about, wherever it lives.
+		gitEntries, listErr := worktree.NewGitWorktree(target.path).List(ctx)
+		if listErr != nil {
+			if filterProject != "" {
+				return nil, camperrors.Wrapf(listErr, "failed to list git worktrees for project %q", target.name)
+			}
+			// Best-effort when cleaning --all: skip projects that fail list.
+		} else {
+			for _, entry := range gitEntries {
+				if !worktree.IsLinkedWorktree(target.path, entry) {
+					continue
+				}
+				cleanPath := filepath.Clean(entry.Path)
+				if _, ok := seen[cleanPath]; ok {
+					continue
+				}
+				seen[cleanPath] = struct{}{}
+				if cr, ok := staleIfRemovable(target.name, filepath.Base(cleanPath), cleanPath); ok {
+					stale = append(stale, cr)
+				}
+			}
 		}
 
-		for _, name := range fsWorktrees {
-			wtPath := pm.WorktreePath(projectName, name)
-			reason := checkWorktreeStale(wtPath)
-			if reason != "" {
-				if reason == "gitdir target does not exist" || stalenessIsGitDir(reason) {
-					stale = append(stale, cleanResult{
-						project:     projectName,
-						worktree:    name,
-						path:        wtPath,
-						reason:      reason,
-						gitDirEntry: stalenessIsGitDir(reason),
-					})
-				}
+		// Secondary: preferred-location directories that may be orphaned (not in
+		// git worktree list) but still leave broken worktree dirs on disk.
+		fsNames, fsErr := pm.ListProjectWorktrees(target.name)
+		if fsErr != nil {
+			continue
+		}
+		for _, name := range fsNames {
+			wtPath := filepath.Clean(pm.WorktreePath(target.name, name))
+			if _, ok := seen[wtPath]; ok {
+				continue
+			}
+			seen[wtPath] = struct{}{}
+			if cr, ok := staleIfRemovable(target.name, name, wtPath); ok {
+				stale = append(stale, cr)
 			}
 		}
 	}
 
 	return stale, nil
+}
+
+type cleanProjectTarget struct {
+	name string
+	path string
+}
+
+func cleanProjectTargets(ctx context.Context, campRoot, filterProject string) ([]cleanProjectTarget, error) {
+	if filterProject != "" {
+		resolved, err := project.Resolve(ctx, campRoot, filterProject)
+		if err != nil {
+			return nil, err
+		}
+		return []cleanProjectTarget{{name: resolved.Name, path: resolved.Path}}, nil
+	}
+	projects, err := project.List(ctx, campRoot)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "failed to list projects")
+	}
+	out := make([]cleanProjectTarget, 0, len(projects))
+	for _, proj := range projects {
+		out = append(out, cleanProjectTarget{
+			name: proj.Name,
+			path: project.ResolveProjectPath(campRoot, proj),
+		})
+	}
+	return out, nil
+}
+
+func staleIfRemovable(projectName, worktreeName, path string) (cleanResult, bool) {
+	reason := checkWorktreeStale(path)
+	if reason == "" {
+		return cleanResult{}, false
+	}
+	if reason != "gitdir target does not exist" && !stalenessIsGitDir(reason) {
+		return cleanResult{}, false
+	}
+	return cleanResult{
+		project:     projectName,
+		worktree:    worktreeName,
+		path:        path,
+		reason:      reason,
+		gitDirEntry: stalenessIsGitDir(reason),
+	}, true
 }
 
 func checkWorktreeStale(path string) string {

--- a/cmd/camp/worktrees/clean.go
+++ b/cmd/camp/worktrees/clean.go
@@ -13,7 +13,6 @@ import (
 	git "github.com/Obedience-Corp/camp/internal/git"
 	navtui "github.com/Obedience-Corp/camp/internal/nav/tui"
 	"github.com/Obedience-Corp/camp/internal/paths"
-	"github.com/Obedience-Corp/camp/internal/project"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/Obedience-Corp/camp/internal/worktree"
 	"github.com/spf13/cobra"
@@ -33,9 +32,17 @@ var worktreesCleanCmd = &cobra.Command{
 	Short: "Remove stale worktrees",
 	Long: `Remove stale or orphaned worktrees.
 
-Stale worktrees are those where the git worktree reference is broken or
-the directory no longer exists. This command cleans up both the filesystem
-and git's internal worktree tracking.
+Enumeration uses git worktree list as the source of truth (same as
+camp worktrees list), then scans the preferred projects/worktrees/<project>/
+layout for orphan directories not registered with git.
+
+Auto-removal is conservative. Only worktrees whose .git file points at a
+gitdir that no longer exists are removed from disk without further flags.
+Full clones (.git is a directory) are listed and skipped for manual review.
+
+Git-listed entries whose checkout directory (or .git file) is already gone
+are not auto-pruned here; use git worktree prune in the project repo for
+admin-only leftovers after the directory has vanished.
 
 Examples:
   # Preview what would be cleaned
@@ -208,8 +215,8 @@ func findStaleWorktrees(ctx context.Context, campRoot string, pm *worktree.PathM
 	var stale []cleanResult
 	seen := make(map[string]struct{})
 
-	// Project targets: registered campaign projects (same approach as worktrees list).
-	targets, err := cleanProjectTargets(ctx, campRoot, filterProject)
+	// Project targets: shared with list so both commands scan the same set.
+	targets, err := worktreeProjectTargets(ctx, campRoot, filterProject)
 	if err != nil {
 		return nil, err
 	}
@@ -257,33 +264,6 @@ func findStaleWorktrees(ctx context.Context, campRoot string, pm *worktree.PathM
 	}
 
 	return stale, nil
-}
-
-type cleanProjectTarget struct {
-	name string
-	path string
-}
-
-func cleanProjectTargets(ctx context.Context, campRoot, filterProject string) ([]cleanProjectTarget, error) {
-	if filterProject != "" {
-		resolved, err := project.Resolve(ctx, campRoot, filterProject)
-		if err != nil {
-			return nil, err
-		}
-		return []cleanProjectTarget{{name: resolved.Name, path: resolved.Path}}, nil
-	}
-	projects, err := project.List(ctx, campRoot)
-	if err != nil {
-		return nil, camperrors.Wrap(err, "failed to list projects")
-	}
-	out := make([]cleanProjectTarget, 0, len(projects))
-	for _, proj := range projects {
-		out = append(out, cleanProjectTarget{
-			name: proj.Name,
-			path: project.ResolveProjectPath(campRoot, proj),
-		})
-	}
-	return out, nil
 }
 
 func staleIfRemovable(projectName, worktreeName, path string) (cleanResult, bool) {

--- a/cmd/camp/worktrees/clean_test.go
+++ b/cmd/camp/worktrees/clean_test.go
@@ -1,0 +1,61 @@
+package worktrees
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStaleIfRemovable_GitdirMissing(t *testing.T) {
+	dir := t.TempDir()
+	wt := filepath.Join(dir, "orphan-wt")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt, ".git"), []byte("gitdir: /nonexistent/gitdir\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cr, ok := staleIfRemovable("proj", "orphan-wt", wt)
+	if !ok {
+		t.Fatal("expected removable stale entry")
+	}
+	if cr.reason != "gitdir target does not exist" {
+		t.Fatalf("reason = %q", cr.reason)
+	}
+	if cr.gitDirEntry {
+		t.Fatal("should not mark as git dir entry")
+	}
+}
+
+func TestStaleIfRemovable_HealthySkipped(t *testing.T) {
+	dir := t.TempDir()
+	wt := filepath.Join(dir, "healthy")
+	gitdir := filepath.Join(dir, "real-gitdir")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(gitdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wt, ".git"), []byte("gitdir: "+gitdir+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := staleIfRemovable("proj", "healthy", wt); ok {
+		t.Fatal("healthy worktree must not be stale")
+	}
+}
+
+func TestStaleIfRemovable_GitDirClone(t *testing.T) {
+	dir := t.TempDir()
+	wt := filepath.Join(dir, "clone")
+	if err := os.MkdirAll(filepath.Join(wt, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cr, ok := staleIfRemovable("proj", "clone", wt)
+	if !ok {
+		t.Fatal("expected git-dir clone entry for skip path")
+	}
+	if !cr.gitDirEntry {
+		t.Fatal("expected gitDirEntry")
+	}
+}

--- a/cmd/camp/worktrees/list.go
+++ b/cmd/camp/worktrees/list.go
@@ -124,15 +124,10 @@ func runWorktreesList(cmd *cobra.Command, args []string) error {
 	return outputListTable(result)
 }
 
-type listProjectTarget struct {
-	name string
-	path string
-}
-
 func listWorktrees(ctx context.Context, campRoot string, filterProject string, staleOnly bool) (*WorktreeListResult, error) {
 	var allWorktrees []WorktreeListItem
 
-	projectTargets, err := listWorktreeProjectTargets(ctx, campRoot, filterProject)
+	projectTargets, err := worktreeProjectTargets(ctx, campRoot, filterProject)
 	if err != nil {
 		return nil, err
 	}
@@ -187,13 +182,23 @@ func listWorktrees(ctx context.Context, campRoot string, filterProject string, s
 	}, nil
 }
 
-func listWorktreeProjectTargets(ctx context.Context, campRoot, filterProject string) ([]listProjectTarget, error) {
+// worktreeProjectTarget is a registered campaign project used as a scan root
+// for worktree list/clean enumeration.
+type worktreeProjectTarget struct {
+	name string
+	path string
+}
+
+// worktreeProjectTargets resolves the set of projects whose git worktrees
+// should be enumerated. Shared by list and clean so the project set cannot
+// drift between commands (how clean lagged list after git-as-source-of-truth).
+func worktreeProjectTargets(ctx context.Context, campRoot, filterProject string) ([]worktreeProjectTarget, error) {
 	if filterProject != "" {
 		resolved, err := project.Resolve(ctx, campRoot, filterProject)
 		if err != nil {
 			return nil, err
 		}
-		return []listProjectTarget{{
+		return []worktreeProjectTarget{{
 			name: resolved.Name,
 			path: resolved.Path,
 		}}, nil
@@ -204,9 +209,9 @@ func listWorktreeProjectTargets(ctx context.Context, campRoot, filterProject str
 		return nil, camperrors.Wrap(err, "failed to list projects")
 	}
 
-	targets := make([]listProjectTarget, 0, len(projects))
+	targets := make([]worktreeProjectTarget, 0, len(projects))
 	for _, proj := range projects {
-		targets = append(targets, listProjectTarget{
+		targets = append(targets, worktreeProjectTarget{
 			name: proj.Name,
 			path: project.ResolveProjectPath(campRoot, proj),
 		})

--- a/tests/integration/worktrees_clean_test.go
+++ b/tests/integration/worktrees_clean_test.go
@@ -67,6 +67,42 @@ rm -rf $GITDIR
 	assert.False(t, exists, "stale worktree directory should be removed")
 }
 
+// TestWorktreesClean_StaleOutsidePreferredLayout is the #436 regression for
+// clean: a linked worktree outside projects/worktrees/<project>/ must still
+// be found via git worktree list and removed when its gitdir target is gone.
+// Preferred-layout-only scans left these entries invisible after list was
+// fixed in #446.
+//
+// The checkout's .git pointer is broken while git's admin entry is left in
+// place so git worktree list still enumerates the path. (Deleting the admin
+// dir removes the entry from git's list entirely; preferred-layout FS scan
+// would not see a loose path either.)
+func TestWorktreesClean_StaleOutsidePreferredLayout(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath, projPath := setupWorktreeCleanCampaign(t, tc, "wt-clean-loose-stale")
+
+	// loose-stale lives OUTSIDE preferred layout (sibling under worktrees/),
+	// mirroring a worktree created without camp.
+	loosePath := campPath + "/projects/worktrees/loose-stale"
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+git -C %[1]s worktree add %[2]s -b loose-stale
+# Keep admin so git still lists this worktree; break the checkout pointer.
+printf 'gitdir: /nonexistent/loose-stale-gitdir\n' > %[2]s/.git
+test -d %[2]s
+git -C %[1]s worktree list --porcelain | grep -F 'worktree %[2]s'
+`, projPath, loosePath))
+
+	out, err := tc.RunCampInDir(campPath, "worktrees", "clean", "--all", "--yes")
+	require.NoError(t, err, "output:\n%s", out)
+	assert.Contains(t, out, "removed", "clean should report removal of non-preferred stale worktree:\n%s", out)
+	assert.Contains(t, out, "loose-stale", "clean output should name the non-preferred worktree:\n%s", out)
+
+	exists, err := tc.CheckDirExists(loosePath)
+	require.NoError(t, err)
+	assert.False(t, exists, "stale worktree outside preferred layout must be removed via git enumeration")
+}
+
 func TestWorktreesClean_DirtyWorktreeSkipped(t *testing.T) {
 	tc := GetSharedContainer(t)
 	campPath, _ := setupWorktreeCleanCampaign(t, tc, "wt-clean-dirty")


### PR DESCRIPTION
## Summary

- `camp worktrees clean` previously only scanned `projects/worktrees/<project>/`, so stale worktrees registered elsewhere were invisible (same root cause as #436).
- **List** already uses `git worktree list` as source of truth; this PR aligns **clean** with that model.
- Preferred-location directory scan remains as a secondary pass for orphan dirs not present in git's list.
- Unit tests for staleness classification.

Closes #436

## Test plan

- [x] `go test ./cmd/camp/worktrees/`
- [ ] existing integration `worktrees_clean` tests in CI