### PR TITLE
deps: bump obey-shared to v0.4.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Obedience-Corp/camp
 go 1.25.6
 
 require (
-	github.com/Obedience-Corp/obey-shared v0.4.4
+	github.com/Obedience-Corp/obey-shared v0.4.5
 	github.com/alecthomas/chroma/v2 v2.23.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Obedience-Corp/obey-shared v0.4.4 h1:BLsOvnvZ0ViHLFVOQ5i1zC3+sa+XLMXhsX67ueMTGpY=
 github.com/Obedience-Corp/obey-shared v0.4.4/go.mod h1:X7xXZJ/S8Ek7s6dsihrnpFLnBykOkv2dQnHv+sRHx/Q=
+github.com/Obedience-Corp/obey-shared v0.4.5 h1:xc79WYccpToLTKOjLqcdRDyGp2Mu9U0WUAwfDaIHX5M=
+github.com/Obedience-Corp/obey-shared v0.4.5/go.mod h1:VZ9rp2YklgdlipSr7aUlOHbmNjrRjif4qHybkLdn6ic=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.23.1 h1:nv2AVZdTyClGbVQkIzlDm/rnhk1E9bU9nXwmZ/Vk/iY=


### PR DESCRIPTION
## What changed\n\n- Bump github.com/Obedience-Corp/obey-shared from v0.4.4 to v0.4.5.\n- Update the corresponding go.sum entries.\n\n## Why\n\nConsume the released shared brand theme and flame-logo primitives from the clean remote-main consumer branch.\n\n## Validation\n\n- go mod verify\n- just test verbose\n- just build default-build\n- just vet\n\nThe camp container integration suite reports 3/475 failures in the existing TestIntegration_WorkflowCreateCustomWorkflow and TestIntegration_WorkflowFullFlow assertions. An isolated rerun reproduces the stale expected text on the latest-remote-main-derived branch: tests expect "created workflow/research/compare-llms", while camp emits "created workitem tracking at workflow/research/compare-llms". The PR diff is dependency-only; this is recorded as a baseline issue rather than attributed to the shared bump.