### PR TITLE
test: align workflow integration expectations

### DIFF
--- a/tests/integration/workflow_create_test.go
+++ b/tests/integration/workflow_create_test.go
@@ -69,7 +69,7 @@ func TestIntegration_WorkflowCreateCustomWorkflow(t *testing.T) {
 		"--title", "Compare LLMs",
 	)
 	require.NoError(t, err, "camp workitem create custom type: %s", out)
-	assert.Contains(t, out, "created workflow/research/compare-llms")
+	assert.Contains(t, out, "created workitem tracking at workflow/research/compare-llms")
 
 	out, err = tc.RunCampInDir(campaignDir, "complete", "re")
 	require.NoError(t, err, "camp complete re: %s", out)

--- a/tests/integration/workflow_test.go
+++ b/tests/integration/workflow_test.go
@@ -86,7 +86,7 @@ func TestIntegration_WorkflowFullFlow(t *testing.T) {
 		"--title", "Compare LLMs",
 	)
 	require.NoError(t, err, "workitem create: %s", out)
-	assert.Contains(t, out, "created workflow/research/compare-llms")
+	assert.Contains(t, out, "created workitem tracking at workflow/research/compare-llms")
 
 	markerExists, err := tc.CheckFileExists(dir + "/workflow/research/compare-llms/.workitem")
 	require.NoError(t, err)


### PR DESCRIPTION
## What changed\n\n- Align the two workflow integration-test assertions with camp's current workitem-create output.\n- Keep the production behavior unchanged.\n\n## Why\n\nThe tests expected the old phrase "created workflow/research/compare-llms", but current camp correctly emits "created workitem tracking at workflow/research/compare-llms". This stale expectation was the only blocker in the CF0004 testing gate.\n\n## Validation\n\n- just test verbose\n- just build default-build\n- just vet\n- just test integration — 474/474 tests passed\n- Targeted workflow integration rerun passed both affected tests.