### PR TITLE
feat: v1alpha8 reader schema, forward-compat rule, and JSON contract v1alpha9

### DIFF
--- a/internal/workitem/discover_festivals.go
+++ b/internal/workitem/discover_festivals.go
@@ -103,6 +103,8 @@ func discoverFestivals(ctx context.Context, campaignRoot string, resolver *paths
 				SourceMetadata: map[string]any{
 					"festival_type": meta.FestivalType,
 				},
+				Tags:     []string{},
+				Projects: []string{},
 			}
 			item.SortTimestamp = DeriveSortTimestamp(item.UpdatedAt, item.CreatedAt)
 			if primaryDocAbs != "" {

--- a/internal/workitem/discover_intents.go
+++ b/internal/workitem/discover_intents.go
@@ -67,6 +67,8 @@ func discoverIntents(ctx context.Context, campaignRoot string, resolver *paths.R
 					"concept":     i.Concept,
 					"priority":    string(i.Priority),
 				},
+				Tags:     []string{},
+				Projects: []string{},
 			}
 			item.SortTimestamp = DeriveSortTimestamp(item.UpdatedAt, item.CreatedAt)
 			item.Summary = extractSummary(i.Content, 200)

--- a/internal/workitem/discover_test.go
+++ b/internal/workitem/discover_test.go
@@ -505,3 +505,68 @@ func TestTimestampDerivation(t *testing.T) {
 		}
 	})
 }
+
+func TestDiscovery_TagsProjectsNonNilAtConstruction(t *testing.T) {
+	requireNonNil := func(t *testing.T, name string, s []string) {
+		t.Helper()
+		if s == nil {
+			t.Errorf("%s is nil, want a non-nil empty slice so it marshals to [] not null", name)
+		}
+	}
+
+	t.Run("design via buildWorkflowDirItem", func(t *testing.T) {
+		root, resolver := setupTestCampaign(t)
+		designDir := filepath.Join(root, "workflow/design/tagless-feature")
+		if err := os.MkdirAll(designDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, filepath.Join(designDir, "README.md"), "# Tagless Feature\n\nNo marker, no tags.")
+
+		items, err := discoverDesign(context.Background(), root, resolver)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 1 {
+			t.Fatalf("expected 1 design item, got %d", len(items))
+		}
+		requireNonNil(t, "Tags", items[0].Tags)
+		requireNonNil(t, "Projects", items[0].Projects)
+	})
+
+	t.Run("intent via discoverIntents", func(t *testing.T) {
+		root, resolver := setupTestCampaign(t)
+		writeFile(t, filepath.Join(root, ".campaign/intents/inbox/tagless-intent.md"),
+			"---\nid: tagless-20260101\ntitle: Tagless Intent\nstatus: inbox\ncreated_at: 2026-01-01\ntype: feature\n---\n\n# Tagless Intent\n\nBody.")
+
+		items, err := discoverIntents(context.Background(), root, resolver)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 1 {
+			t.Fatalf("expected 1 intent, got %d", len(items))
+		}
+		requireNonNil(t, "Tags", items[0].Tags)
+		requireNonNil(t, "Projects", items[0].Projects)
+	})
+
+	t.Run("festival via discoverFestivals", func(t *testing.T) {
+		root, resolver := setupTestCampaign(t)
+		festDir := filepath.Join(root, "festivals/active/tagless-fest-TG0001")
+		if err := os.MkdirAll(festDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, filepath.Join(festDir, "fest.yaml"),
+			"version: \"1.0\"\nmetadata:\n  id: TG0001\n  name: tagless-fest\n  festival_type: implementation\n  created_at: 2026-03-01T00:00:00Z\n")
+		writeFile(t, filepath.Join(festDir, "FESTIVAL_GOAL.md"), "# Tagless Fest\n\nGoal.")
+
+		items, err := discoverFestivals(context.Background(), root, resolver)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(items) != 1 {
+			t.Fatalf("expected 1 festival, got %d", len(items))
+		}
+		requireNonNil(t, "Tags", items[0].Tags)
+		requireNonNil(t, "Projects", items[0].Projects)
+	})
+}

--- a/internal/workitem/discover_workflow_docs.go
+++ b/internal/workitem/discover_workflow_docs.go
@@ -79,6 +79,8 @@ func buildWorkflowDirItem(ctx context.Context, campaignRoot, dirPath string, wfT
 		SourceMetadata: map[string]any{
 			"has_readme": primaryDocAbs != "" && filepath.Base(primaryDocAbs) == "README.md",
 		},
+		Tags:     []string{},
+		Projects: []string{},
 	}
 	item.SortTimestamp = DeriveSortTimestamp(item.UpdatedAt, item.CreatedAt)
 	if primaryDocAbs != "" {

--- a/internal/workitem/json.go
+++ b/internal/workitem/json.go
@@ -26,7 +26,11 @@ import (
 //     attention/group vocabularies, grouping metadata, and reusable section rows.
 //   - v1alpha8: add config-derived workflow_category per item, category_vocabulary,
 //     category_counts, and category in available_group_by and section rows.
-const SchemaVersion = "workitems/v1alpha8"
+//   - v1alpha9: add tags and projects fields (free-form topic labels and
+//     campaign-relative related-project paths, both non-nil empty slices
+//     when absent). See internal/workitem/metadata.go for the marker-level
+//     v1alpha8 schema these are sourced from.
+const SchemaVersion = "workitems/v1alpha9"
 
 // Payload is the top-level JSON output for camp workitem --json.
 type Payload struct {

--- a/internal/workitem/json_test.go
+++ b/internal/workitem/json_test.go
@@ -154,9 +154,9 @@ func TestWorkItemWorkflow_ZeroValuesAreEmitted(t *testing.T) {
 	}
 }
 
-func TestSchemaVersion_IsV1Alpha8(t *testing.T) {
-	if SchemaVersion != "workitems/v1alpha8" {
-		t.Errorf("SchemaVersion = %q, want workitems/v1alpha8", SchemaVersion)
+func TestSchemaVersion_IsV1Alpha9(t *testing.T) {
+	if SchemaVersion != "workitems/v1alpha9" {
+		t.Errorf("SchemaVersion = %q, want workitems/v1alpha9", SchemaVersion)
 	}
 }
 
@@ -229,6 +229,82 @@ func TestWorkItem_WorkflowCategoryOmitEmpty(t *testing.T) {
 	if !strings.Contains(string(data), `"workflow_category":"plan"`) {
 		t.Errorf("workflow_category should be present, got: %s", data)
 	}
+}
+
+func TestApplyMetadata_EmptyTagsProjectsNeverNull(t *testing.T) {
+	item, err := ApplyMetadata(
+		WorkItem{Key: "design:foo", RelativePath: "workflow/design/foo"},
+		&Metadata{ID: "design-foo", Type: "design"},
+	)
+	if err != nil {
+		t.Fatalf("ApplyMetadata: %v", err)
+	}
+	data, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, field := range []string{"tags", "projects"} {
+		val, ok := raw[field]
+		if !ok {
+			t.Errorf("%s key missing, want []", field)
+			continue
+		}
+		if string(val) != "[]" {
+			t.Errorf("%s = %s, want []", field, val)
+		}
+	}
+}
+
+func TestWorkItem_PopulatedTagsProjectsRoundTrip(t *testing.T) {
+	item, err := ApplyMetadata(
+		WorkItem{Key: "design:foo", RelativePath: "workflow/design/foo"},
+		&Metadata{
+			ID:       "design-foo",
+			Type:     "design",
+			Tags:     []string{"ux", "public-launch"},
+			Projects: []string{"projects/camp", "projects/fest"},
+		},
+	)
+	if err != nil {
+		t.Fatalf("ApplyMetadata: %v", err)
+	}
+	got := string(mustMarshal(t, item))
+	if !strings.Contains(got, `"tags":["ux","public-launch"]`) {
+		t.Errorf("tags not preserved in order: %s", got)
+	}
+	if !strings.Contains(got, `"projects":["projects/camp","projects/fest"]`) {
+		t.Errorf("projects not preserved in order: %s", got)
+	}
+}
+
+func TestNewPayload_TagsProjectsSerialization(t *testing.T) {
+	items := []WorkItem{
+		{Key: "a", Title: "A", WorkflowType: WorkflowTypeDesign, Tags: []string{"ux"}, Projects: []string{"projects/camp"}},
+		{Key: "b", Title: "B", WorkflowType: WorkflowTypeIntent, Tags: []string{}, Projects: []string{}},
+	}
+	got := string(mustMarshal(t, NewPayloadWithGrouping("/tmp", items, "type")))
+	if !strings.Contains(got, `"tags":["ux"]`) {
+		t.Errorf("populated tags missing from payload: %s", got)
+	}
+	if !strings.Contains(got, `"tags":[]`) {
+		t.Errorf("empty tags should serialize as [] in payload: %s", got)
+	}
+	if strings.Contains(got, `"tags":null`) || strings.Contains(got, `"projects":null`) {
+		t.Errorf("payload must never contain null tags or projects: %s", got)
+	}
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return data
 }
 
 func containsString(vals []string, want string) bool {

--- a/internal/workitem/merge.go
+++ b/internal/workitem/merge.go
@@ -31,5 +31,14 @@ func ApplyMetadata(item WorkItem, md *Metadata) (WorkItem, error) {
 			item.SourceMetadata["quest_id"] = md.QuestID
 		}
 	}
+	item.Tags = nonNilStrings(md.Tags)
+	item.Projects = nonNilStrings(md.Projects)
 	return item, nil
+}
+
+func nonNilStrings(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
 }

--- a/internal/workitem/metadata.go
+++ b/internal/workitem/metadata.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -17,6 +19,8 @@ import (
 var (
 	refShape     = regexp.MustCompile(`^WI-[0-9a-f]{6}$`)
 	questIDShape = regexp.MustCompile(`^qst_[A-Za-z0-9_-]{1,40}$`)
+	tagShape     = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,63}$`)
+	versionShape = regexp.MustCompile(`^v1alpha([0-9]+)$`)
 )
 
 const MetadataFilename = ".workitem"
@@ -27,12 +31,16 @@ const MetadataKind = "workitem"
 
 // acceptedWorkitemVersions are loadable .workitem schema versions. v1alpha4
 // through v1alpha6 are accepted for backward compatibility; v1alpha7 is the
-// current shape and gains the GatheredInto and GatheredAt fields.
+// current write version (GatheredInto/GatheredAt fields); v1alpha8 adds the
+// Tags and Projects fields and is loadable ahead of the writer release, per the
+// two-phase rollout. validateMetadata additionally accepts unknown future
+// v1alphaN via the forward-compat rule.
 var acceptedWorkitemVersions = map[string]bool{
 	"v1alpha4": true,
 	"v1alpha5": true,
 	"v1alpha6": true,
 	"v1alpha7": true,
+	"v1alpha8": true,
 }
 
 type Metadata struct {
@@ -61,6 +69,15 @@ type Metadata struct {
 	GatheredInto string `yaml:"gathered_into,omitempty"`
 	// GatheredAt is the RFC3339 UTC timestamp of the gather. Added in v1alpha7.
 	GatheredAt string `yaml:"gathered_at,omitempty"`
+	// Tags is a free-form list of topic labels. Normalized to lowercase
+	// kebab-case on write; validated against tagShape on load. Added in v1alpha8.
+	Tags []string `yaml:"tags,omitempty"`
+	// Projects is a set of campaign-relative paths under projects/ this
+	// workitem is semantically related to. Added in v1alpha8. The
+	// authoritative store for this fact; see internal/workitem/links for the
+	// separate operational link registry (primary/worktree/blocked_by/supersedes).
+	// See workflow/design/workitem-schema-tags-and-projects/04-projects-and-links.md.
+	Projects []string `yaml:"projects,omitempty"`
 }
 
 // LoadMetadata reads .workitem from dir on the host filesystem.
@@ -107,7 +124,12 @@ func LoadMetadataFS(ctx context.Context, fsys fs.FS, path string) (*Metadata, er
 }
 
 func validateMetadata(m *Metadata) error {
-	if !acceptedWorkitemVersions[m.Version] {
+	switch {
+	case acceptedWorkitemVersions[m.Version]:
+	case IsForwardCompatVersion(m.Version):
+		slog.Default().Warn("workitem schema version is newer than this binary; loading via forward-compat and dropping unknown fields",
+			"version", m.Version, "current", WorkitemSchemaVersion)
+	default:
 		return camperrors.NewValidation("version",
 			"unsupported .workitem schema version (got "+m.Version+", supported: "+
 				strings.Join(supportedWorkitemVersions(), ", ")+"); update .workitem `version:` to "+WorkitemSchemaVersion, nil)
@@ -130,6 +152,49 @@ func validateMetadata(m *Metadata) error {
 		return camperrors.NewValidation("quest_id",
 			"quest_id must match qst_<id>, got "+m.QuestID, nil)
 	}
+	if err := validateTags(m.Tags); err != nil {
+		return err
+	}
+	if err := validateProjects(m.Projects); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateTags(tags []string) error {
+	seen := make(map[string]bool, len(tags))
+	for _, tag := range tags {
+		if !tagShape.MatchString(tag) {
+			return camperrors.NewValidation("tags",
+				"tag must match "+tagShape.String()+", got "+tag, nil)
+		}
+		if seen[tag] {
+			return camperrors.NewValidation("tags", "duplicate tag: "+tag, nil)
+		}
+		seen[tag] = true
+	}
+	return nil
+}
+
+func validateProjects(paths []string) error {
+	seen := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		if p == "" {
+			return camperrors.NewValidation("projects", "project path must not be empty", nil)
+		}
+		if filepath.IsAbs(p) {
+			return camperrors.NewValidation("projects",
+				"project path must be campaign-relative, got absolute path "+p, nil)
+		}
+		if strings.HasPrefix(filepath.Clean(p), "..") {
+			return camperrors.NewValidation("projects",
+				"project path must not escape the campaign root, got "+p, nil)
+		}
+		if seen[p] {
+			return camperrors.NewValidation("projects", "duplicate project path: "+p, nil)
+		}
+		seen[p] = true
+	}
 	return nil
 }
 
@@ -150,6 +215,39 @@ func IsAcceptedVersion(v string) bool {
 // IsCurrentVersion reports whether v is the current .workitem schema version.
 func IsCurrentVersion(v string) bool {
 	return v == WorkitemSchemaVersion
+}
+
+// IsForwardCompatVersion reports whether v is a v1alphaN schema version newer
+// than every accepted version. Such a marker loads under the forward-compat
+// rule with a warning, and fields the loader does not model are dropped by the
+// non-strict YAML parse. It returns false for accepted or legacy versions.
+func IsForwardCompatVersion(v string) bool {
+	if acceptedWorkitemVersions[v] {
+		return false
+	}
+	match := versionShape.FindStringSubmatch(v)
+	if match == nil {
+		return false
+	}
+	n, err := strconv.Atoi(match[1])
+	if err != nil {
+		return false
+	}
+	return n > maxAcceptedVersion()
+}
+
+func maxAcceptedVersion() int {
+	highest := 0
+	for v := range acceptedWorkitemVersions {
+		match := versionShape.FindStringSubmatch(v)
+		if match == nil {
+			continue
+		}
+		if n, err := strconv.Atoi(match[1]); err == nil && n > highest {
+			highest = n
+		}
+	}
+	return highest
 }
 
 // ValidRef reports whether s is a well-formed workitem ref (WI-<6 hex>).

--- a/internal/workitem/metadata_test.go
+++ b/internal/workitem/metadata_test.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"testing/fstest"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"gopkg.in/yaml.v3"
 )
 
 func mapFSWith(body string) fstest.MapFS {
@@ -263,5 +265,165 @@ title: T
 	}
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("error %v should wrap context.Canceled", err)
+	}
+}
+
+func TestMetadata_TagsProjectsRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		in   Metadata
+	}{
+		{"nil tags and projects", Metadata{Version: WorkitemSchemaVersion, Kind: MetadataKind, ID: "x", Type: "design"}},
+		{"populated tags and projects", Metadata{
+			Version:  WorkitemSchemaVersion,
+			Kind:     MetadataKind,
+			ID:       "x",
+			Type:     "design",
+			Tags:     []string{"public-launch", "schema"},
+			Projects: []string{"projects/camp", "projects/fest"},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := yaml.Marshal(&tc.in)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var out Metadata
+			if err := yaml.Unmarshal(raw, &out); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(out.Tags, tc.in.Tags) {
+				t.Errorf("Tags = %#v, want %#v", out.Tags, tc.in.Tags)
+			}
+			if !reflect.DeepEqual(out.Projects, tc.in.Projects) {
+				t.Errorf("Projects = %#v, want %#v", out.Projects, tc.in.Projects)
+			}
+		})
+	}
+}
+
+func TestValidateMetadata_VersionAcceptance(t *testing.T) {
+	cases := []struct {
+		name              string
+		version           string
+		wantErr           bool
+		wantForwardCompat bool
+	}{
+		{"unknown old version rejected", "v1alpha3", true, false},
+		{"non-alpha series rejected", "v1beta1", true, false},
+		{"malformed alpha suffix rejected", "v1alpha7x", true, false},
+		{"v1alpha4 accepted", "v1alpha4", false, false},
+		{"v1alpha5 accepted", "v1alpha5", false, false},
+		{"v1alpha6 accepted", "v1alpha6", false, false},
+		{"v1alpha7 accepted", "v1alpha7", false, false},
+		{"v1alpha8 accepted", "v1alpha8", false, false},
+		{"future version accepted via forward-compat", "v1alpha12", false, true},
+		{"leading-zero future version accepted via forward-compat", "v1alpha09", false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := "version: " + tc.version + "\nkind: workitem\nid: x\ntype: design\ntitle: T\n"
+			md, err := LoadMetadataFS(context.Background(), mapFSWith(body), fixturePath)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %s, got md=%+v", tc.version, md)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected %s to load, got %v", tc.version, err)
+			}
+			if got := IsForwardCompatVersion(md.Version); got != tc.wantForwardCompat {
+				t.Errorf("IsForwardCompatVersion(%q) = %v, want %v", md.Version, got, tc.wantForwardCompat)
+			}
+		})
+	}
+}
+
+func TestValidateMetadata_TagsProjects(t *testing.T) {
+	base := Metadata{Version: WorkitemSchemaVersion, Kind: MetadataKind, ID: "x", Type: "design"}
+	cases := []struct {
+		name      string
+		mutate    func(*Metadata)
+		wantErr   bool
+		wantField string
+	}{
+		{"malformed tag", func(m *Metadata) { m.Tags = []string{"Public-Launch"} }, true, "tags"},
+		{"duplicate tag", func(m *Metadata) { m.Tags = []string{"public-launch", "public-launch"} }, true, "tags"},
+		{"empty project", func(m *Metadata) { m.Projects = []string{""} }, true, "projects"},
+		{"absolute project", func(m *Metadata) { m.Projects = []string{"/etc/passwd"} }, true, "projects"},
+		{"escaping project", func(m *Metadata) { m.Projects = []string{"../outside"} }, true, "projects"},
+		{"duplicate project", func(m *Metadata) { m.Projects = []string{"projects/camp", "projects/camp"} }, true, "projects"},
+		{"nonexistent project accepted", func(m *Metadata) { m.Projects = []string{"projects/does-not-exist"} }, false, ""},
+		{"well-formed tags and projects", func(m *Metadata) {
+			m.Tags = []string{"ux", "perf"}
+			m.Projects = []string{"projects/camp", "projects/fest"}
+		}, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := base
+			tc.mutate(&m)
+			err := validateMetadata(&m)
+			if !tc.wantErr {
+				if err != nil {
+					t.Fatalf("expected no error for %s, got %v", tc.name, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+			var verr *camperrors.ValidationError
+			if !errors.As(err, &verr) {
+				t.Fatalf("expected ValidationError, got %T: %v", err, err)
+			}
+			if verr.Field != tc.wantField {
+				t.Errorf("Field = %q, want %q", verr.Field, tc.wantField)
+			}
+		})
+	}
+}
+
+func TestLoadMetadata_V1Alpha7MarkerUnaffectedByReaderChanges(t *testing.T) {
+	body := `version: v1alpha7
+kind: workitem
+id: design-thing-2026-07-18
+type: design
+title: A thing
+ref: WI-abcdef
+quest_id: qst_20260718_abc123
+`
+	md, err := LoadMetadataFS(context.Background(), mapFSWith(body), fixturePath)
+	if err != nil {
+		t.Fatalf("v1alpha7 marker should load: %v", err)
+	}
+	if md == nil {
+		t.Fatal("expected metadata")
+	}
+	if md.Version != "v1alpha7" {
+		t.Errorf("Version = %q, want v1alpha7", md.Version)
+	}
+	if md.ID != "design-thing-2026-07-18" {
+		t.Errorf("ID = %q", md.ID)
+	}
+	if md.Type != "design" {
+		t.Errorf("Type = %q", md.Type)
+	}
+	if md.Title != "A thing" {
+		t.Errorf("Title = %q", md.Title)
+	}
+	if md.Ref != "WI-abcdef" {
+		t.Errorf("Ref = %q", md.Ref)
+	}
+	if md.QuestID != "qst_20260718_abc123" {
+		t.Errorf("QuestID = %q", md.QuestID)
+	}
+	if md.Tags != nil {
+		t.Errorf("Tags = %#v, want nil for a marker with no tags", md.Tags)
+	}
+	if md.Projects != nil {
+		t.Errorf("Projects = %#v, want nil for a marker with no projects", md.Projects)
 	}
 }

--- a/internal/workitem/model.go
+++ b/internal/workitem/model.go
@@ -53,6 +53,8 @@ type WorkItem struct {
 
 	StableID     string            `json:"stable_id,omitempty"`
 	WorkflowMeta *WorkItemWorkflow `json:"workflow,omitempty"`
+	Tags         []string          `json:"tags"`
+	Projects     []string          `json:"projects"`
 }
 
 // WorkItemWorkflow carries local runtime progress when .workflow/ is present


### PR DESCRIPTION
## Summary

This is the reader half of a two-phase rollout of the v1alpha8 workitem marker schema (tags + projects fields). It makes every read path tolerant of the new schema before any write path emits it.

- `Metadata` gains `Tags []string` and `Projects []string` (yaml omitempty); loader allowlist widens to v1alpha4-v1alpha8.
- New forward-compat rule: an unknown future `v1alphaN` with a numeric suffix greater than the current max loads with a warning instead of failing closed, so the bump after v1alpha8 will not need this two-phase dance again. Exported as `IsForwardCompatVersion`.
- Tag validation (`^[a-z0-9][a-z0-9-]{0,63}$`, duplicate rejection) and projects validation (relative, non-escaping, duplicate rejection; existence deliberately not checked at load).
- JSON list contract bumps `workitems/v1alpha8` -> `workitems/v1alpha9`: `WorkItem` carries `tags`/`projects`, always serialized as `[]` when empty, never `null`, guaranteed at every construction path (ApplyMetadata plus the three marker-less discovery sites) and pinned by tests that invoke the real discovery functions.

**No write path changed.** `WorkitemSchemaVersion` still stamps `v1alpha7`; `create`/`adopt`/`repair`/`gather` and `links.yaml` handling are untouched, verified by diff scope (only `internal/workitem/{metadata,model,merge,json,discover_*}.go` and tests).

## Rollout contract

The writer release (003_WRITER_RELEASE) is blocked until this release is cut as an rc and reaches an installed channel. A pre-reader binary hard-fails on a v1alpha8 marker by design; that documented behavior gets an explicit contract test in the hardening phase.

Full context: `obey-campaign` festival `festivals/active/workitem-schema-tags-and-projects-WS0001` (design package `workflow/design/workitem-schema-tags-and-projects/`, docs 01-09).

## Testing

- `go build ./...`, `go test ./...` (whole module), `just lint` all green.
- New tests: version acceptance table (legacy, current, v1alpha8, forward-compat incl. leading-zero corner, malformed rejects), tag/project validation table, v1alpha7-marker-unaffected rollout test, JSON never-null tests including real-invocation coverage of all three marker-less discovery construction sites with a verified mutation check.