### PR TITLE
[obey-campaign:8deed8b4] test: align integration JSON contract assertion with workitems/v1alpha9

### DIFF
--- a/tests/integration/workitem_list_filter_test.go
+++ b/tests/integration/workitem_list_filter_test.go
@@ -40,7 +40,7 @@ func TestIntegration_WorkitemListFiltersNonTTYAndJSON(t *testing.T) {
 		} `json:"items"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(raw[start:]), &payload))
-	assert.Equal(t, "workitems/v1alpha8", payload.SchemaVersion)
+	assert.Equal(t, "workitems/v1alpha9", payload.SchemaVersion)
 	require.NotEmpty(t, payload.Items)
 	for _, item := range payload.Items {
 		assert.True(t, item.AttentionStage == "active" || item.LifecycleStage == "active")


### PR DESCRIPTION
Reader release (#464) bumped the list contract; the integration suite pins the version string and release gates only run the unit suite. Passes at pre-merge base 170d8fa0, fails on main before this fix. Remaining two integration failures pre-date the merge (#459 output change) and are covered by open PR #462.
