### PR TITLE
feat: v1alpha8 writer release: tags, projects, filters, file workitems, lifecycle verbs

### DIFF
--- a/cmd/camp/manifest_test.go
+++ b/cmd/camp/manifest_test.go
@@ -183,6 +183,7 @@ func TestManifestCommand_AllRestrictedCommandsPresent(t *testing.T) {
 	}
 	if workitemCommandRegistered() {
 		expectedCommands["workitem"] = false
+		expectedCommands["workitem adopt"] = false
 		expectedCommands["workitem create"] = false
 		expectedCommands["workitem current"] = false
 		expectedCommands["workitem link"] = false

--- a/internal/commands/workitem/adopt.go
+++ b/internal/commands/workitem/adopt.go
@@ -19,23 +19,40 @@ import (
 )
 
 func newAdoptCommand() *cobra.Command {
-	var typeFlag, title, idOverride, questSelector string
+	var typeFlag, title, idOverride, questSelector, fileFlag string
 	var tags []string
 	var projects []string
+	var force bool
 	cmd := &cobra.Command{
-		Use:     "adopt <dir>",
+		Use:     "adopt [dir]",
 		Aliases: []string{"init"},
-		Short:   "Adopt an existing directory as a workitem",
-		Long: `Attach workitem metadata to an existing campaign directory without moving it.
+		Short:   "Adopt an existing directory or file as a workitem",
+		Long: `Attach workitem metadata to an existing campaign directory or markdown file.
 
-The target directory must already exist and must not already contain a
-.workitem file. The command writes that .workitem metadata file with the
-selected type, title, generated or supplied id, optional quest link, optional
-tags, and optional related projects. Use this when a workflow directory already
-exists and needs to become a tracked workitem.`,
-		Args: cobra.ExactArgs(1),
+With a directory argument, writes a .workitem marker (the directory must exist
+and must not already contain a .workitem). With --file <path.md>, stamps a
+kind: workitem frontmatter block onto an existing markdown file without ever
+rewriting its body: it prepends a block when the file has none, merges camp's
+keys into a foreign block (refusing an ambiguous foreign tags: key without
+--force), and updates tags/projects when the file is already a workitem. In all
+cases it sets the selected type, title, generated or supplied id, optional quest
+link, optional tags, and optional related projects.`,
+		Args: cobra.MaximumNArgs(1),
+		Annotations: map[string]string{
+			"agent_allowed": "false",
+			"agent_reason":  "Adopt mutates an existing directory or a file's frontmatter; requires a human decision",
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			if fileFlag != "" {
+				if len(args) > 0 {
+					return camperrors.NewValidation("args", "provide either a directory argument or --file, not both", nil)
+				}
+				return runAdoptFile(ctx, cmd, fileFlag, typeFlag, title, idOverride, questSelector, tags, projects, force)
+			}
+			if len(args) != 1 {
+				return camperrors.NewValidation("args", "adopt requires a directory argument or --file <path>", nil)
+			}
 			return runAdopt(ctx, cmd, args[0], typeFlag, title, idOverride, questSelector, tags, projects)
 		},
 	}
@@ -45,6 +62,8 @@ exists and needs to become a tracked workitem.`,
 	cmd.Flags().StringVar(&questSelector, "quest", "", questFlagHelp())
 	cmd.Flags().StringArrayVar(&tags, "tag", nil, "add a tag (repeatable, normalized to lowercase kebab-case)")
 	cmd.Flags().StringArrayVar(&projects, "project", nil, "add a related project path (repeatable, e.g. projects/camp)")
+	cmd.Flags().StringVar(&fileFlag, "file", "", "stamp kind: workitem frontmatter onto a markdown file instead of adopting a directory")
+	cmd.Flags().BoolVar(&force, "force", false, "with --file, take ownership of an existing foreign tags: key (union conforming values, drop and report non-conforming ones)")
 	return cmd
 }
 

--- a/internal/commands/workitem/adopt.go
+++ b/internal/commands/workitem/adopt.go
@@ -20,6 +20,7 @@ import (
 
 func newAdoptCommand() *cobra.Command {
 	var typeFlag, title, idOverride, questSelector string
+	var tags []string
 	cmd := &cobra.Command{
 		Use:     "adopt <dir>",
 		Aliases: []string{"init"},
@@ -28,25 +29,30 @@ func newAdoptCommand() *cobra.Command {
 
 The target directory must already exist and must not already contain a
 .workitem file. The command writes that .workitem metadata file with the
-selected type, title, generated or supplied id, and optional quest link. Use
-this when a workflow directory already exists and needs to become a tracked
-workitem.`,
+selected type, title, generated or supplied id, optional quest link, and
+optional tags. Use this when a workflow directory already exists and needs to
+become a tracked workitem.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			return runAdopt(ctx, cmd, args[0], typeFlag, title, idOverride, questSelector)
+			return runAdopt(ctx, cmd, args[0], typeFlag, title, idOverride, questSelector, tags)
 		},
 	}
 	cmd.Flags().StringVar(&typeFlag, "type", "feature", "workitem type (feature, bug, chore, or custom)")
 	cmd.Flags().StringVar(&title, "title", "", "human-readable title")
 	cmd.Flags().StringVar(&idOverride, "id", "", "override the generated id")
 	cmd.Flags().StringVar(&questSelector, "quest", "", questFlagHelp())
+	cmd.Flags().StringArrayVar(&tags, "tag", nil, "add a tag (repeatable, normalized to lowercase kebab-case)")
 	return cmd
 }
 
-func runAdopt(ctx context.Context, cmd *cobra.Command, dir, typeFlag, title, idOverride, questSelector string) error {
+func runAdopt(ctx context.Context, cmd *cobra.Command, dir, typeFlag, title, idOverride, questSelector string, tags []string) error {
 	if err := validateSlug(typeFlag); err != nil {
 		return camperrors.NewValidation("type", "invalid type slug: "+err.Error(), nil)
+	}
+	normalizedTags, err := normalizeTags(tags)
+	if err != nil {
+		return err
 	}
 
 	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
@@ -101,6 +107,7 @@ func runAdopt(ctx context.Context, cmd *cobra.Command, dir, typeFlag, title, idO
 		Title:   title,
 		Ref:     ref,
 		QuestID: questID,
+		Tags:    normalizedTags,
 	}
 	buf, err := yaml.Marshal(&meta)
 	if err != nil {

--- a/internal/commands/workitem/adopt.go
+++ b/internal/commands/workitem/adopt.go
@@ -21,6 +21,7 @@ import (
 func newAdoptCommand() *cobra.Command {
 	var typeFlag, title, idOverride, questSelector string
 	var tags []string
+	var projects []string
 	cmd := &cobra.Command{
 		Use:     "adopt <dir>",
 		Aliases: []string{"init"},
@@ -29,13 +30,13 @@ func newAdoptCommand() *cobra.Command {
 
 The target directory must already exist and must not already contain a
 .workitem file. The command writes that .workitem metadata file with the
-selected type, title, generated or supplied id, optional quest link, and
-optional tags. Use this when a workflow directory already exists and needs to
-become a tracked workitem.`,
+selected type, title, generated or supplied id, optional quest link, optional
+tags, and optional related projects. Use this when a workflow directory already
+exists and needs to become a tracked workitem.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			return runAdopt(ctx, cmd, args[0], typeFlag, title, idOverride, questSelector, tags)
+			return runAdopt(ctx, cmd, args[0], typeFlag, title, idOverride, questSelector, tags, projects)
 		},
 	}
 	cmd.Flags().StringVar(&typeFlag, "type", "feature", "workitem type (feature, bug, chore, or custom)")
@@ -43,15 +44,23 @@ become a tracked workitem.`,
 	cmd.Flags().StringVar(&idOverride, "id", "", "override the generated id")
 	cmd.Flags().StringVar(&questSelector, "quest", "", questFlagHelp())
 	cmd.Flags().StringArrayVar(&tags, "tag", nil, "add a tag (repeatable, normalized to lowercase kebab-case)")
+	cmd.Flags().StringArrayVar(&projects, "project", nil, "add a related project path (repeatable, e.g. projects/camp)")
 	return cmd
 }
 
-func runAdopt(ctx context.Context, cmd *cobra.Command, dir, typeFlag, title, idOverride, questSelector string, tags []string) error {
+func runAdopt(ctx context.Context, cmd *cobra.Command, dir, typeFlag, title, idOverride, questSelector string, tags, projects []string) error {
 	if err := validateSlug(typeFlag); err != nil {
 		return camperrors.NewValidation("type", "invalid type slug: "+err.Error(), nil)
 	}
 	normalizedTags, err := normalizeTags(tags)
 	if err != nil {
+		return err
+	}
+	normalizedProjects, err := normalizeProjects(projects)
+	if err != nil {
+		return err
+	}
+	if err := wkitem.ValidateProjectPaths(normalizedProjects); err != nil {
 		return err
 	}
 
@@ -100,14 +109,15 @@ func runAdopt(ctx context.Context, cmd *cobra.Command, dir, typeFlag, title, idO
 	questID := resolveQuestIDForCreate(ctx, cmd, campaignRoot, questSelector)
 
 	meta := wkitem.Metadata{
-		Version: wkitem.WorkitemSchemaVersion,
-		Kind:    "workitem",
-		ID:      id,
-		Type:    typeFlag,
-		Title:   title,
-		Ref:     ref,
-		QuestID: questID,
-		Tags:    normalizedTags,
+		Version:  wkitem.WorkitemSchemaVersion,
+		Kind:     "workitem",
+		ID:       id,
+		Type:     typeFlag,
+		Title:    title,
+		Ref:      ref,
+		QuestID:  questID,
+		Tags:     normalizedTags,
+		Projects: normalizedProjects,
 	}
 	buf, err := yaml.Marshal(&meta)
 	if err != nil {

--- a/internal/commands/workitem/adopt_file.go
+++ b/internal/commands/workitem/adopt_file.go
@@ -1,0 +1,305 @@
+package workitem
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+	"github.com/Obedience-Corp/camp/internal/ledger"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	wkaudit "github.com/Obedience-Corp/camp/internal/workitem/audit"
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
+)
+
+// runAdoptFile stamps kind: workitem frontmatter onto an existing markdown file
+// without ever rewriting the body. It has three branches: prepend a full block
+// when the file has no frontmatter, merge camp's keys into a foreign block, or
+// update tags/projects when the file is already a workitem.
+func runAdoptFile(ctx context.Context, cmd *cobra.Command, filePath, typeFlag, title, idOverride, questSelector string, tags, projects []string, force bool) error {
+	if err := validateSlug(typeFlag); err != nil {
+		return camperrors.NewValidation("type", "invalid type slug: "+err.Error(), nil)
+	}
+	normalizedTags, err := normalizeTags(tags)
+	if err != nil {
+		return err
+	}
+	normalizedProjects, err := normalizeProjects(projects)
+	if err != nil {
+		return err
+	}
+	if err := wkitem.ValidateProjectPaths(normalizedProjects); err != nil {
+		return err
+	}
+
+	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	rel := filePath
+	if filepath.IsAbs(filePath) {
+		rel, err = filepath.Rel(campaignRoot, filePath)
+		if err != nil {
+			return camperrors.Wrap(err, "resolve file relative to campaign root")
+		}
+	}
+	if err := validateParentPath(rel); err != nil {
+		return err
+	}
+	abs := filepath.Join(campaignRoot, rel)
+
+	info, err := os.Stat(abs)
+	if err != nil {
+		return camperrors.Wrap(err, "stat target file")
+	}
+	if info.IsDir() {
+		return camperrors.NewValidation("file",
+			"target is a directory; run `camp workitem adopt "+rel+"` without --file", nil)
+	}
+
+	content, err := os.ReadFile(abs)
+	if err != nil {
+		return camperrors.Wrapf(err, "read %s", rel)
+	}
+
+	// Already a workitem: update in place (identity is fixed; tags/projects merge).
+	existing, lerr := wkitem.LoadFrontmatterMetadata(abs)
+	if lerr != nil {
+		return camperrors.Wrapf(lerr, "existing frontmatter in %s is invalid", rel)
+	}
+	if existing != nil {
+		return updateAdoptedFile(ctx, cmd, campaignRoot, rel, abs, content, existing, idOverride, normalizedTags, normalizedProjects)
+	}
+
+	slug := strings.TrimSuffix(filepath.Base(rel), filepath.Ext(rel))
+	id, err := generateID(ctx, typeFlag, slug, idOverride, campaignRoot)
+	if err != nil {
+		return err
+	}
+	ref, err := deriveUniqueRef(ctx, campaignRoot, cfg, id)
+	if err != nil {
+		return err
+	}
+	questID := resolveQuestIDForCreate(ctx, cmd, campaignRoot, questSelector)
+
+	_, _, hasFrontmatter := wkitem.SplitFrontmatter(content)
+	if !hasFrontmatter {
+		meta := wkitem.Metadata{
+			Version:  wkitem.WorkitemSchemaVersion,
+			Kind:     "workitem",
+			ID:       id,
+			Type:     typeFlag,
+			Title:    title,
+			Ref:      ref,
+			QuestID:  questID,
+			Tags:     normalizedTags,
+			Projects: normalizedProjects,
+		}
+		fmBlock, err := wkitem.MarshalMetadataFrontmatter(&meta)
+		if err != nil {
+			return err
+		}
+		if err := prependFrontmatterLocked(ctx, abs, wkitem.FenceFrontmatter(fmBlock)); err != nil {
+			return err
+		}
+	} else {
+		tagsToStamp := normalizedTags
+		if wkitem.FrontmatterHasKey(content, "tags") {
+			if !force {
+				return camperrors.NewValidation("tags",
+					"file "+rel+" already has a foreign `tags:` frontmatter key; re-run with --force to take ownership (conforming values are kept, non-conforming ones dropped)", nil)
+			}
+			merged, dropped := mergeForeignTags(content, normalizedTags)
+			tagsToStamp = merged
+			if len(dropped) > 0 {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+					"note: dropped %d non-conforming foreign tag value(s) from %s: %s\n",
+					len(dropped), rel, strings.Join(dropped, ", "))
+			}
+		}
+		warnReflow(cmd, content)
+		hasTitle := wkitem.FrontmatterHasKey(content, "title")
+		if err := wkitem.StampFrontmatterFields(ctx, abs,
+			campStampFields(id, typeFlag, title, ref, questID, tagsToStamp, normalizedProjects, hasTitle)); err != nil {
+			return err
+		}
+	}
+
+	emitFileAdopt(ctx, cmd, campaignRoot, rel, id, ref, typeFlag, title, questID)
+	return nil
+}
+
+// updateAdoptedFile handles a file that already carries kind: workitem: refuse a
+// conflicting --id, otherwise union new tags/projects into the existing lists and
+// re-stamp only when something changed (keeping re-runs diff-clean).
+func updateAdoptedFile(ctx context.Context, cmd *cobra.Command, campaignRoot, rel, abs string, content []byte, existing *wkitem.Metadata, idOverride string, newTags, newProjects []string) error {
+	if idOverride != "" && idOverride != existing.ID {
+		return camperrors.NewValidation("id",
+			"file "+rel+" already declares id "+existing.ID+"; refusing to overwrite with --id "+idOverride, nil)
+	}
+
+	mergedTags := unionStrings(existing.Tags, newTags)
+	mergedProjects := unionStrings(existing.Projects, newProjects)
+
+	var fields []wkitem.FrontmatterField
+	if !equalStrings(existing.Tags, mergedTags) {
+		fields = append(fields, wkitem.FrontmatterField{After: "ref", Key: "tags", Values: mergedTags})
+	}
+	if !equalStrings(existing.Projects, mergedProjects) {
+		fields = append(fields, wkitem.FrontmatterField{After: "tags", Key: "projects", Values: mergedProjects})
+	}
+	if len(fields) > 0 {
+		warnReflow(cmd, content)
+		if err := wkitem.StampFrontmatterFields(ctx, abs, fields); err != nil {
+			return err
+		}
+	}
+	emitFileAdopt(ctx, cmd, campaignRoot, rel, existing.ID, existing.Ref, existing.Type, existing.Title, existing.QuestID)
+	return nil
+}
+
+// campStampFields lists camp's keys in stable order for a foreign-frontmatter
+// merge. version appends after the foreign keys (After ""), and each subsequent
+// key chains after the previous camp key so a skipped optional key never breaks
+// the chain. An existing foreign title is left untouched.
+func campStampFields(id, typeFlag, title, ref, questID string, tags, projects []string, hasTitle bool) []wkitem.FrontmatterField {
+	var fields []wkitem.FrontmatterField
+	prev := ""
+	add := func(key, value string, values []string) {
+		fields = append(fields, wkitem.FrontmatterField{After: prev, Key: key, Value: value, Values: values})
+		prev = key
+	}
+	add("version", wkitem.WorkitemSchemaVersion, nil)
+	add("kind", "workitem", nil)
+	add("id", id, nil)
+	add("type", typeFlag, nil)
+	if !hasTitle && title != "" {
+		add("title", title, nil)
+	}
+	add("ref", ref, nil)
+	if questID != "" {
+		add("quest_id", questID, nil)
+	}
+	if len(tags) > 0 {
+		add("tags", "", tags)
+	}
+	if len(projects) > 0 {
+		add("projects", "", projects)
+	}
+	return fields
+}
+
+func emitFileAdopt(ctx context.Context, cmd *cobra.Command, campaignRoot, rel, id, ref, typeFlag, title, questID string) {
+	invalidateNavigationCache(cmd, campaignRoot)
+	appendWorkitemAuditEvent(ctx, cmd, campaignRoot, wkaudit.Event{
+		Event: wkaudit.EventAdopt,
+		ID:    id,
+		Ref:   ref,
+		Type:  typeFlag,
+		Title: title,
+		To:    filepath.ToSlash(rel),
+	})
+	ledger.NewFromRoot(ctx, campaignRoot, ledger.WarnTo(cmd.ErrOrStderr())).
+		Emit(ctx, ledgerkit.KindCreated, ledgerkit.Scope{Workitem: ref, Quest: questID},
+			ledger.WithWhy(title),
+			ledger.WithPayload(map[string]any{"type": typeFlag, "title": title, "path": rel, "adopted": true, "file": true}))
+	questLine := ""
+	if questID != "" {
+		questLine = fmt.Sprintf("  quest: %s\n", questID)
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+		"adopted file %s\n  id: %s\n  ref: %s\n  type: %s\n%s",
+		rel, id, ref, typeFlag, questLine)
+}
+
+func writeFileLocked(ctx context.Context, abs string, content []byte) error {
+	release, err := fsutil.AcquireFileLock(ctx, abs+".lock")
+	if err != nil {
+		return err
+	}
+	defer release()
+	return fsutil.WriteFileAtomically(abs, content, 0o644)
+}
+
+// prependFrontmatterLocked prepends a fenced frontmatter block to a file under a
+// per-file lock held across the read and write, so a no-frontmatter adopt is a
+// consistent read-modify-write like the merge path.
+func prependFrontmatterLocked(ctx context.Context, abs string, fencedBlock []byte) error {
+	release, err := fsutil.AcquireFileLock(ctx, abs+".lock")
+	if err != nil {
+		return err
+	}
+	defer release()
+	content, err := os.ReadFile(abs)
+	if err != nil {
+		return camperrors.Wrapf(err, "read %s", abs)
+	}
+	return fsutil.WriteFileAtomically(abs, append(fencedBlock, content...), 0o644)
+}
+
+// mergeForeignTags takes ownership of a file's existing tags key: it normalizes
+// each conforming foreign value through the tag pipeline and unions those with
+// campTags, dropping (and returning) any value that is not a valid tag after
+// normalization or is a non-string scalar. This avoids silent data loss under
+// --force while keeping camp as the owner of the tags key.
+func mergeForeignTags(content []byte, campTags []string) (merged, dropped []string) {
+	foreignStrings, nonConforming := wkitem.FrontmatterSequenceStrings(content, "tags")
+	dropped = append(dropped, nonConforming...)
+	var conforming []string
+	for _, fv := range foreignStrings {
+		nv := normalizeTag(fv)
+		if wkitem.ValidTag(nv) {
+			conforming = append(conforming, nv)
+		} else {
+			dropped = append(dropped, fv)
+		}
+	}
+	return unionStrings(conforming, campTags), dropped
+}
+
+// warnReflow prints a one-line note when the existing frontmatter block uses a
+// non-2-space indent that a re-encode will reflow, so the byte-for-byte
+// deviation is never silent.
+func warnReflow(cmd *cobra.Command, content []byte) {
+	if w, ok := wkitem.FrontmatterMinIndent(content); ok && w != 2 {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+			"note: existing frontmatter used %d-space indentation; reformatted to 2-space\n", w)
+	}
+}
+
+func unionStrings(existing, add []string) []string {
+	seen := make(map[string]bool, len(existing)+len(add))
+	out := make([]string, 0, len(existing)+len(add))
+	for _, s := range existing {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	for _, s := range add {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/commands/workitem/audit_events_test.go
+++ b/internal/commands/workitem/audit_events_test.go
@@ -47,7 +47,7 @@ func TestRunCreate_AppendsCreateAuditEvent(t *testing.T) {
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
 
-	if err := runCreate(context.Background(), cmd, "atomic-marker", "design", "Atomic Marker", "design-atomic-marker-fixed", "", "", nil, false); err != nil {
+	if err := runCreate(context.Background(), cmd, "atomic-marker", "design", "Atomic Marker", "design-atomic-marker-fixed", "", "", nil, nil, false); err != nil {
 		t.Fatalf("runCreate() error = %v", err)
 	}
 
@@ -90,7 +90,7 @@ func TestRunAdopt_AppendsAdoptAuditEvent(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
-	if err := runAdopt(context.Background(), cmd, "workflow/design/legacy", "design", "Legacy", "design-legacy-fixed", "", nil); err != nil {
+	if err := runAdopt(context.Background(), cmd, "workflow/design/legacy", "design", "Legacy", "design-legacy-fixed", "", nil, nil); err != nil {
 		t.Fatalf("runAdopt() error = %v", err)
 	}
 

--- a/internal/commands/workitem/audit_events_test.go
+++ b/internal/commands/workitem/audit_events_test.go
@@ -47,7 +47,7 @@ func TestRunCreate_AppendsCreateAuditEvent(t *testing.T) {
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
 
-	if err := runCreate(context.Background(), cmd, "atomic-marker", "design", "Atomic Marker", "design-atomic-marker-fixed", "", "", false); err != nil {
+	if err := runCreate(context.Background(), cmd, "atomic-marker", "design", "Atomic Marker", "design-atomic-marker-fixed", "", "", nil, false); err != nil {
 		t.Fatalf("runCreate() error = %v", err)
 	}
 
@@ -90,7 +90,7 @@ func TestRunAdopt_AppendsAdoptAuditEvent(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
-	if err := runAdopt(context.Background(), cmd, "workflow/design/legacy", "design", "Legacy", "design-legacy-fixed", ""); err != nil {
+	if err := runAdopt(context.Background(), cmd, "workflow/design/legacy", "design", "Legacy", "design-legacy-fixed", "", nil); err != nil {
 		t.Fatalf("runAdopt() error = %v", err)
 	}
 

--- a/internal/commands/workitem/create.go
+++ b/internal/commands/workitem/create.go
@@ -27,7 +27,7 @@ import (
 )
 
 func newCreateCommand() *cobra.Command {
-	var typeFlag, title, idOverride, dirOverride, questSelector string
+	var typeFlag, title, idOverride, dirOverride, questSelector, fileFlag string
 	var jsonOut bool
 	var tags []string
 	var projects []string
@@ -54,13 +54,22 @@ populate campaign-governed content under the new directory as needed.
 Use "camp workitem adopt" to attach a marker to an existing directory.
 Use --json for machine-readable identity. next.command is set only for
 explore/design (recommended scaffold); otherwise it is empty/omitted.`,
-		Args: jsoncontract.Args(WorkitemCreateJSONVersion, func() bool { return jsonOut }, cobra.ExactArgs(1)),
+		Args: jsoncontract.Args(WorkitemCreateJSONVersion, func() bool { return jsonOut }, cobra.MaximumNArgs(1)),
 		Annotations: map[string]string{
 			"agent_allowed": "true",
 			"agent_reason":  "Creates workitems with --json output for automation",
 		},
 		RunE: jsoncontract.RunE(WorkitemCreateJSONVersion, func() bool { return jsonOut }, func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			if fileFlag != "" {
+				if len(args) > 0 {
+					return camperrors.NewValidation("args", "provide either a slug argument or --file, not both", nil)
+				}
+				return runCreateFile(ctx, cmd, fileFlag, typeFlag, title, idOverride, questSelector, tags, projects, jsonOut)
+			}
+			if len(args) != 1 {
+				return camperrors.NewValidation("args", "create requires a slug argument or --file <path>", nil)
+			}
 			return runCreate(ctx, cmd, args[0], typeFlag, title, idOverride, dirOverride, questSelector, tags, projects, jsonOut)
 		}),
 	}
@@ -73,7 +82,140 @@ explore/design (recommended scaffold); otherwise it is empty/omitted.`,
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a structured JSON result")
 	cmd.Flags().StringArrayVar(&tags, "tag", nil, "add a tag (repeatable, normalized to lowercase kebab-case)")
 	cmd.Flags().StringArrayVar(&projects, "project", nil, "add a related project path (repeatable, e.g. projects/camp)")
+	cmd.Flags().StringVar(&fileFlag, "file", "", "create a new markdown file with kind: workitem frontmatter instead of a directory workitem")
 	return cmd
+}
+
+// runCreateFile mints a new markdown file with a kind: workitem frontmatter
+// block and a minimal heading body, reusing the frontmatter construction of the
+// no-existing-frontmatter adopt branch.
+func runCreateFile(ctx context.Context, cmd *cobra.Command, filePath, typeFlag, title, idOverride, questSelector string, tags, projects []string, jsonOut bool) error {
+	if err := validateSlug(typeFlag); err != nil {
+		return camperrors.NewValidation("type", "invalid type slug: "+err.Error(), nil)
+	}
+	normalizedTags, err := normalizeTags(tags)
+	if err != nil {
+		return err
+	}
+	normalizedProjects, err := normalizeProjects(projects)
+	if err != nil {
+		return err
+	}
+	if err := wkitem.ValidateProjectPaths(normalizedProjects); err != nil {
+		return err
+	}
+
+	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	rel := filePath
+	if filepath.IsAbs(filePath) {
+		rel, err = filepath.Rel(campaignRoot, filePath)
+		if err != nil {
+			return camperrors.Wrap(err, "resolve file relative to campaign root")
+		}
+	}
+	if err := validateParentPath(rel); err != nil {
+		return err
+	}
+	if !strings.HasSuffix(rel, ".md") {
+		return camperrors.NewValidation("file", "create --file target must be a .md file, got "+rel, nil)
+	}
+	abs := filepath.Join(campaignRoot, rel)
+	if _, statErr := os.Stat(abs); statErr == nil {
+		return camperrors.NewValidation("path",
+			"target file already exists: "+rel+" — use `camp workitem adopt --file` to stamp an existing file", nil)
+	}
+
+	slug := strings.TrimSuffix(filepath.Base(rel), filepath.Ext(rel))
+	id, err := generateID(ctx, typeFlag, slug, idOverride, campaignRoot)
+	if err != nil {
+		return err
+	}
+	ref, err := deriveUniqueRef(ctx, campaignRoot, cfg, id)
+	if err != nil {
+		return err
+	}
+	questID := resolveQuestIDForCreate(ctx, cmd, campaignRoot, questSelector)
+
+	titleText := title
+	if titleText == "" {
+		titleText = slug
+	}
+	meta := wkitem.Metadata{
+		Version:  wkitem.WorkitemSchemaVersion,
+		Kind:     "workitem",
+		ID:       id,
+		Type:     typeFlag,
+		Title:    titleText,
+		Ref:      ref,
+		QuestID:  questID,
+		Tags:     normalizedTags,
+		Projects: normalizedProjects,
+	}
+	fmBlock, err := wkitem.MarshalMetadataFrontmatter(&meta)
+	if err != nil {
+		return err
+	}
+	content := append(wkitem.FenceFrontmatter(fmBlock), []byte("# "+titleText+"\n")...)
+
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		return camperrors.Wrap(err, "create parent directory")
+	}
+	if err := writeFileLocked(ctx, abs, content); err != nil {
+		return err
+	}
+
+	invalidateNavigationCache(cmd, campaignRoot)
+	appendWorkitemAuditEvent(ctx, cmd, campaignRoot, wkaudit.Event{
+		Event: wkaudit.EventCreate,
+		ID:    id,
+		Ref:   ref,
+		Type:  typeFlag,
+		Title: titleText,
+		To:    filepath.ToSlash(rel),
+	})
+	ledger.NewFromRoot(ctx, campaignRoot, ledger.WarnTo(cmd.ErrOrStderr())).
+		Emit(ctx, ledgerkit.KindCreated, ledgerkit.Scope{Workitem: ref, Quest: questID},
+			ledger.WithWhy(titleText),
+			ledger.WithPayload(map[string]any{"type": typeFlag, "title": titleText, "path": rel, "file": true}))
+
+	if jsonOut {
+		payload := struct {
+			SchemaVersion string    `json:"schema_version"`
+			GeneratedAt   time.Time `json:"generated_at"`
+			Workitem      struct {
+				ID            string `json:"id"`
+				Ref           string `json:"ref"`
+				Type          string `json:"type"`
+				Title         string `json:"title,omitempty"`
+				RelativePath  string `json:"relative_path"`
+				ItemKind      string `json:"item_kind"`
+				MarkerVersion string `json:"marker_version"`
+			} `json:"workitem"`
+		}{SchemaVersion: WorkitemCreateJSONVersion, GeneratedAt: time.Now().UTC()}
+		payload.Workitem.ID = id
+		payload.Workitem.Ref = ref
+		payload.Workitem.Type = typeFlag
+		payload.Workitem.Title = titleText
+		payload.Workitem.RelativePath = rel
+		payload.Workitem.ItemKind = "file"
+		payload.Workitem.MarkerVersion = wkitem.WorkitemSchemaVersion
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(payload)
+	}
+
+	questLine := ""
+	if questID != "" {
+		questLine = fmt.Sprintf("  quest: %s\n", questID)
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+		"created file %s\n  id: %s\n  ref: %s\n  type: %s\n%s",
+		rel, id, ref, typeFlag, questLine)
+	return nil
 }
 
 func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, idOverride, dirOverride, questSelector string, tags, projects []string, jsonOut bool) error {

--- a/internal/commands/workitem/create.go
+++ b/internal/commands/workitem/create.go
@@ -30,6 +30,7 @@ func newCreateCommand() *cobra.Command {
 	var typeFlag, title, idOverride, dirOverride, questSelector string
 	var jsonOut bool
 	var tags []string
+	var projects []string
 	cmd := &cobra.Command{
 		Use:   "create <slug>",
 		Short: "Create workitem tracking metadata",
@@ -39,7 +40,8 @@ This command does NOT create the substantive work scaffold (no design docs,
 explore notes, or festival structure). It only:
 
   1. Creates workflow/<type>/<slug>/ (or --dir/<slug>/)
-  2. Writes a .workitem marker (id, type, title, ref, optional quest, optional tags)
+  2. Writes a .workitem marker (id, type, title, ref, optional quest, optional
+     tags, optional related projects)
 
 Agents and humans must still add real content afterward. For explore/design
 types, the recommended structured-workflow scaffold is:
@@ -59,7 +61,7 @@ explore/design (recommended scaffold); otherwise it is empty/omitted.`,
 		},
 		RunE: jsoncontract.RunE(WorkitemCreateJSONVersion, func() bool { return jsonOut }, func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			return runCreate(ctx, cmd, args[0], typeFlag, title, idOverride, dirOverride, questSelector, tags, jsonOut)
+			return runCreate(ctx, cmd, args[0], typeFlag, title, idOverride, dirOverride, questSelector, tags, projects, jsonOut)
 		}),
 	}
 	cmd.SetFlagErrorFunc(jsoncontract.FlagErrorFunc(WorkitemCreateJSONVersion, func() bool { return jsonOut }))
@@ -70,10 +72,11 @@ explore/design (recommended scaffold); otherwise it is empty/omitted.`,
 	cmd.Flags().StringVar(&questSelector, "quest", "", questFlagHelp())
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a structured JSON result")
 	cmd.Flags().StringArrayVar(&tags, "tag", nil, "add a tag (repeatable, normalized to lowercase kebab-case)")
+	cmd.Flags().StringArrayVar(&projects, "project", nil, "add a related project path (repeatable, e.g. projects/camp)")
 	return cmd
 }
 
-func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, idOverride, dirOverride, questSelector string, tags []string, jsonOut bool) error {
+func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, idOverride, dirOverride, questSelector string, tags, projects []string, jsonOut bool) error {
 	if err := validateSlug(slug); err != nil {
 		return err
 	}
@@ -82,6 +85,13 @@ func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, i
 	}
 	normalizedTags, err := normalizeTags(tags)
 	if err != nil {
+		return err
+	}
+	normalizedProjects, err := normalizeProjects(projects)
+	if err != nil {
+		return err
+	}
+	if err := wkitem.ValidateProjectPaths(normalizedProjects); err != nil {
 		return err
 	}
 
@@ -127,14 +137,15 @@ func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, i
 	}()
 
 	meta := wkitem.Metadata{
-		Version: wkitem.WorkitemSchemaVersion,
-		Kind:    "workitem",
-		ID:      id,
-		Type:    typeFlag,
-		Title:   title,
-		Ref:     ref,
-		QuestID: questID,
-		Tags:    normalizedTags,
+		Version:  wkitem.WorkitemSchemaVersion,
+		Kind:     "workitem",
+		ID:       id,
+		Type:     typeFlag,
+		Title:    title,
+		Ref:      ref,
+		QuestID:  questID,
+		Tags:     normalizedTags,
+		Projects: normalizedProjects,
 	}
 	buf, err := yaml.Marshal(&meta)
 	if err != nil {

--- a/internal/commands/workitem/create.go
+++ b/internal/commands/workitem/create.go
@@ -29,6 +29,7 @@ import (
 func newCreateCommand() *cobra.Command {
 	var typeFlag, title, idOverride, dirOverride, questSelector string
 	var jsonOut bool
+	var tags []string
 	cmd := &cobra.Command{
 		Use:   "create <slug>",
 		Short: "Create workitem tracking metadata",
@@ -38,7 +39,7 @@ This command does NOT create the substantive work scaffold (no design docs,
 explore notes, or festival structure). It only:
 
   1. Creates workflow/<type>/<slug>/ (or --dir/<slug>/)
-  2. Writes a .workitem marker (id, type, title, ref, optional quest)
+  2. Writes a .workitem marker (id, type, title, ref, optional quest, optional tags)
 
 Agents and humans must still add real content afterward. For explore/design
 types, the recommended structured-workflow scaffold is:
@@ -58,7 +59,7 @@ explore/design (recommended scaffold); otherwise it is empty/omitted.`,
 		},
 		RunE: jsoncontract.RunE(WorkitemCreateJSONVersion, func() bool { return jsonOut }, func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			return runCreate(ctx, cmd, args[0], typeFlag, title, idOverride, dirOverride, questSelector, jsonOut)
+			return runCreate(ctx, cmd, args[0], typeFlag, title, idOverride, dirOverride, questSelector, tags, jsonOut)
 		}),
 	}
 	cmd.SetFlagErrorFunc(jsoncontract.FlagErrorFunc(WorkitemCreateJSONVersion, func() bool { return jsonOut }))
@@ -68,15 +69,20 @@ explore/design (recommended scaffold); otherwise it is empty/omitted.`,
 	cmd.Flags().StringVar(&dirOverride, "dir", "", "parent dir override (default: workflow/<type>)")
 	cmd.Flags().StringVar(&questSelector, "quest", "", questFlagHelp())
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a structured JSON result")
+	cmd.Flags().StringArrayVar(&tags, "tag", nil, "add a tag (repeatable, normalized to lowercase kebab-case)")
 	return cmd
 }
 
-func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, idOverride, dirOverride, questSelector string, jsonOut bool) error {
+func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, idOverride, dirOverride, questSelector string, tags []string, jsonOut bool) error {
 	if err := validateSlug(slug); err != nil {
 		return err
 	}
 	if err := validateSlug(typeFlag); err != nil {
 		return camperrors.NewValidation("type", "invalid type slug: "+err.Error(), nil)
+	}
+	normalizedTags, err := normalizeTags(tags)
+	if err != nil {
+		return err
 	}
 
 	cfg, campaignRoot, err := config.LoadCampaignConfigFromCwd(ctx)
@@ -128,6 +134,7 @@ func runCreate(ctx context.Context, cmd *cobra.Command, slug, typeFlag, title, i
 		Title:   title,
 		Ref:     ref,
 		QuestID: questID,
+		Tags:    normalizedTags,
 	}
 	buf, err := yaml.Marshal(&meta)
 	if err != nil {

--- a/internal/commands/workitem/create_test.go
+++ b/internal/commands/workitem/create_test.go
@@ -180,7 +180,7 @@ func TestRunCreateWritesWorkitemMarker(t *testing.T) {
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
 
-	if err := runCreate(context.Background(), cmd, "atomic-marker", "design", "Atomic Marker", "", "", "", false); err != nil {
+	if err := runCreate(context.Background(), cmd, "atomic-marker", "design", "Atomic Marker", "", "", "", nil, false); err != nil {
 		t.Fatalf("runCreate() error = %v", err)
 	}
 
@@ -209,7 +209,7 @@ func TestRunCreate_DeriveFailureLeavesNoTargetAndRetrySucceeds(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
-	err := runCreate(ctx, cmd, "retryable", "design", "Retryable", "design-retryable-id", "", "", false)
+	err := runCreate(ctx, cmd, "retryable", "design", "Retryable", "design-retryable-id", "", "", nil, false)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("runCreate canceled error = %v, want context.Canceled", err)
 	}
@@ -220,14 +220,14 @@ func TestRunCreate_DeriveFailureLeavesNoTargetAndRetrySucceeds(t *testing.T) {
 	cmd = &cobra.Command{}
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
-	if err := runCreate(context.Background(), cmd, "retryable", "design", "Retryable", "design-retryable-id", "", "", false); err != nil {
+	if err := runCreate(context.Background(), cmd, "retryable", "design", "Retryable", "design-retryable-id", "", "", nil, false); err != nil {
 		t.Fatalf("immediate retry runCreate() error = %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(target, ".workitem")); err != nil {
 		t.Fatalf("retry did not create marker: %v", err)
 	}
 
-	err = runCreate(context.Background(), cmd, "retryable", "design", "Retryable", "", "", "", false)
+	err = runCreate(context.Background(), cmd, "retryable", "design", "Retryable", "", "", "", nil, false)
 	if err == nil || !strings.Contains(err.Error(), "use `camp workitem adopt`") {
 		t.Fatalf("second create error = %v, want adopt guidance", err)
 	}
@@ -251,7 +251,7 @@ func TestRunCreate_PreExistingNonEmptyDirRequiresAdopt(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
-	err := runCreate(context.Background(), cmd, "legacy", "design", "Legacy", "", "", "", false)
+	err := runCreate(context.Background(), cmd, "legacy", "design", "Legacy", "", "", "", nil, false)
 	if err == nil || !strings.Contains(err.Error(), "use `camp workitem adopt`") {
 		t.Fatalf("runCreate existing dir error = %v, want adopt guidance", err)
 	}

--- a/internal/commands/workitem/create_test.go
+++ b/internal/commands/workitem/create_test.go
@@ -180,7 +180,7 @@ func TestRunCreateWritesWorkitemMarker(t *testing.T) {
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
 
-	if err := runCreate(context.Background(), cmd, "atomic-marker", "design", "Atomic Marker", "", "", "", nil, false); err != nil {
+	if err := runCreate(context.Background(), cmd, "atomic-marker", "design", "Atomic Marker", "", "", "", nil, nil, false); err != nil {
 		t.Fatalf("runCreate() error = %v", err)
 	}
 
@@ -209,7 +209,7 @@ func TestRunCreate_DeriveFailureLeavesNoTargetAndRetrySucceeds(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
-	err := runCreate(ctx, cmd, "retryable", "design", "Retryable", "design-retryable-id", "", "", nil, false)
+	err := runCreate(ctx, cmd, "retryable", "design", "Retryable", "design-retryable-id", "", "", nil, nil, false)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("runCreate canceled error = %v, want context.Canceled", err)
 	}
@@ -220,14 +220,14 @@ func TestRunCreate_DeriveFailureLeavesNoTargetAndRetrySucceeds(t *testing.T) {
 	cmd = &cobra.Command{}
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
-	if err := runCreate(context.Background(), cmd, "retryable", "design", "Retryable", "design-retryable-id", "", "", nil, false); err != nil {
+	if err := runCreate(context.Background(), cmd, "retryable", "design", "Retryable", "design-retryable-id", "", "", nil, nil, false); err != nil {
 		t.Fatalf("immediate retry runCreate() error = %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(target, ".workitem")); err != nil {
 		t.Fatalf("retry did not create marker: %v", err)
 	}
 
-	err = runCreate(context.Background(), cmd, "retryable", "design", "Retryable", "", "", "", nil, false)
+	err = runCreate(context.Background(), cmd, "retryable", "design", "Retryable", "", "", "", nil, nil, false)
 	if err == nil || !strings.Contains(err.Error(), "use `camp workitem adopt`") {
 		t.Fatalf("second create error = %v, want adopt guidance", err)
 	}
@@ -251,7 +251,7 @@ func TestRunCreate_PreExistingNonEmptyDirRequiresAdopt(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
-	err := runCreate(context.Background(), cmd, "legacy", "design", "Legacy", "", "", "", nil, false)
+	err := runCreate(context.Background(), cmd, "legacy", "design", "Legacy", "", "", "", nil, nil, false)
 	if err == nil || !strings.Contains(err.Error(), "use `camp workitem adopt`") {
 		t.Fatalf("runCreate existing dir error = %v, want adopt guidance", err)
 	}

--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -28,16 +28,18 @@ import (
 // Doctor finding codes (dotted-domain form). Stable strings; consumers
 // dispatch on them.
 const (
-	codeBrokenLink         = "workitem.link.broken"
-	codeBrokenScope        = "workitem.scope.broken"
-	codeOutOfBounds        = "workitem.scope.out-of-bounds"
-	codeScopeUnvalidatable = "workitem.scope.unvalidatable"
-	codeDuplicatePrimary   = "workitem.link.duplicate-primary"
-	codeSchemaViolation    = "workitem.schema.violation"
-	codeCurrentMissing     = "workitem.current.missing"
-	codeMissingRefField    = "workitem.ref.missing"
-	codeWorkitemScanFailed = "workitem.scan.failed"
-	codeRegistryParseError = "workitem.registry.parse-error"
+	codeBrokenLink           = "workitem.link.broken"
+	codeBrokenScope          = "workitem.scope.broken"
+	codeOutOfBounds          = "workitem.scope.out-of-bounds"
+	codeScopeUnvalidatable   = "workitem.scope.unvalidatable"
+	codeDuplicatePrimary     = "workitem.link.duplicate-primary"
+	codeSchemaViolation      = "workitem.schema.violation"
+	codeCurrentMissing       = "workitem.current.missing"
+	codeMissingRefField      = "workitem.ref.missing"
+	codeWorkitemScanFailed   = "workitem.scan.failed"
+	codeRegistryParseError   = "workitem.registry.parse-error"
+	codeProjectNotFound      = "workitem.project.not-found"
+	codeProjectUnvalidatable = "workitem.project.unvalidatable"
 )
 
 const (
@@ -99,7 +101,7 @@ func runDoctor(ctx context.Context, cmd *cobra.Command, jsonOut, fix bool) error
 	if err != nil {
 		return renderWorkitemDoctorError(cmd, jsonOut, camperrors.Wrap(err, "not in a campaign directory"))
 	}
-	knownIDs, err := workitemIDsOnDisk(ctx, root)
+	knownIDs, items, err := workitemIDsOnDisk(ctx, root)
 	if err != nil {
 		return renderWorkitemDoctorError(cmd, jsonOut, err)
 	}
@@ -120,7 +122,7 @@ func runDoctor(ctx context.Context, cmd *cobra.Command, jsonOut, fix bool) error
 			}
 		}
 		err = links.WithLock(ctx, root, func(registry *links.Links) error {
-			findings = collectWorkitemFindings(ctx, root, registry, knownIDs)
+			findings = collectWorkitemFindings(ctx, root, registry, knownIDs, items)
 			applied, fixErr := autoFixWorkitemFindings(ctx, root, registry, findings, cmd.ErrOrStderr())
 			if fixErr != nil {
 				return fixErr
@@ -128,14 +130,14 @@ func runDoctor(ctx context.Context, cmd *cobra.Command, jsonOut, fix bool) error
 			if applied == 0 {
 				return links.ErrSkipSave
 			}
-			knownIDs, _ = workitemIDsOnDisk(ctx, root)
-			findings = collectWorkitemFindings(ctx, root, registry, knownIDs)
+			knownIDs, items, _ = workitemIDsOnDisk(ctx, root)
+			findings = collectWorkitemFindings(ctx, root, registry, knownIDs, items)
 			return nil
 		})
 		if err != nil {
 			return renderWorkitemDoctorError(cmd, jsonOut, err)
 		}
-		knownIDs, err = workitemIDsOnDisk(ctx, root)
+		knownIDs, _, err = workitemIDsOnDisk(ctx, root)
 		if err != nil {
 			return renderWorkitemDoctorError(cmd, jsonOut, err)
 		}
@@ -166,7 +168,7 @@ func runDoctor(ctx context.Context, cmd *cobra.Command, jsonOut, fix bool) error
 			}
 			return camperrors.Wrap(loadErr, "load links registry")
 		}
-		findings = collectWorkitemFindings(ctx, root, registry, knownIDs)
+		findings = collectWorkitemFindings(ctx, root, registry, knownIDs, items)
 	}
 
 	if jsonOut {
@@ -210,7 +212,7 @@ func renderWorkitemDoctorError(cmd *cobra.Command, jsonOut bool, err error) erro
 	return jsoncontract.RenderError(cmd, WorkitemDoctorJSONVersion, err)
 }
 
-func collectWorkitemFindings(ctx context.Context, root string, registry *links.Links, knownIDs map[string]struct{}) []docFinding {
+func collectWorkitemFindings(ctx context.Context, root string, registry *links.Links, knownIDs map[string]struct{}, items []wkitem.WorkItem) []docFinding {
 	var findings []docFinding
 
 	// Schema-level validation.
@@ -314,6 +316,34 @@ func collectWorkitemFindings(ctx context.Context, root string, registry *links.L
 				FixHint:     "run camp workitem doctor --fix to backfill",
 				AutoFixable: true,
 			})
+		}
+	}
+
+	for _, item := range items {
+		for _, projectPath := range item.Projects {
+			_, statErr := os.Stat(filepath.Join(root, filepath.FromSlash(projectPath)))
+			switch {
+			case statErr == nil:
+				continue
+			case errors.Is(statErr, fs.ErrNotExist):
+				findings = append(findings, docFinding{
+					Code:        codeProjectNotFound,
+					Severity:    docSeverityWarning,
+					Target:      "workitem:" + item.RelativePath,
+					Message:     "projects entry " + projectPath + " does not exist",
+					FixHint:     "verify the project was renamed/removed intentionally; doctor --fix does not auto-remove this entry",
+					AutoFixable: false,
+				})
+			default:
+				findings = append(findings, docFinding{
+					Code:        codeProjectUnvalidatable,
+					Severity:    docSeverityWarning,
+					Target:      "workitem:" + item.RelativePath,
+					Message:     "projects entry " + projectPath + " could not be validated: " + statErr.Error(),
+					FixHint:     "resolve the filesystem error (for example a permissions issue) and re-run doctor",
+					AutoFixable: false,
+				})
+			}
 		}
 	}
 
@@ -422,15 +452,15 @@ func scopeTargetExists(root, scopePath string) bool {
 	return !errors.Is(err, fs.ErrNotExist)
 }
 
-func workitemIDsOnDisk(ctx context.Context, root string) (map[string]struct{}, error) {
+func workitemIDsOnDisk(ctx context.Context, root string) (map[string]struct{}, []wkitem.WorkItem, error) {
 	cfg, err := config.LoadCampaignConfig(ctx, root)
 	if err != nil {
-		return nil, camperrors.Wrap(err, "load campaign config")
+		return nil, nil, camperrors.Wrap(err, "load campaign config")
 	}
 	resolver := paths.NewResolverFromConfig(root, cfg)
 	items, err := wkitem.Discover(ctx, root, resolver)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	set := make(map[string]struct{}, len(items))
 	for _, item := range items {
@@ -447,7 +477,7 @@ func workitemIDsOnDisk(ctx context.Context, root string) (map[string]struct{}, e
 			set[item.SourceID] = struct{}{}
 		}
 	}
-	return set, nil
+	return set, items, nil
 }
 
 func hasErrorFinding(findings []docFinding) bool {

--- a/internal/commands/workitem/gather.go
+++ b/internal/commands/workitem/gather.go
@@ -143,7 +143,8 @@ func runWorkitemGather(cmd *cobra.Command, wfType string, args []string, opts ga
 	}
 	var typed []wkitem.WorkItem
 	for _, item := range items {
-		if item.WorkflowType == wkitem.WorkflowType(wfType) && item.ItemKind == wkitem.ItemKindDirectory {
+		if item.WorkflowType == wkitem.WorkflowType(wfType) &&
+			(item.ItemKind == wkitem.ItemKindDirectory || item.ItemKind == wkitem.ItemKindFile) {
 			typed = append(typed, item)
 		}
 	}
@@ -209,9 +210,18 @@ func runWorkitemGather(cmd *cobra.Command, wfType string, args []string, opts ga
 		} else if gatherBlockedByRun(run) {
 			blocked = append(blocked, filepath.Base(item.RelativePath))
 		}
-		meta, metaErr := wkitem.LoadMetadata(ctx, abs)
+		// A file workitem's identity lives in its own frontmatter, not a
+		// .workitem sibling (which for a file path could never exist), so load
+		// it through the frontmatter loader instead.
+		var meta *wkitem.Metadata
+		var metaErr error
+		if item.ItemKind == wkitem.ItemKindFile {
+			meta, metaErr = wkitem.LoadFrontmatterMetadata(abs)
+		} else {
+			meta, metaErr = wkitem.LoadMetadata(ctx, abs)
+		}
 		if metaErr != nil {
-			warnings = append(warnings, fmt.Sprintf(".workitem unreadable for %s: %v", filepath.Base(item.RelativePath), metaErr))
+			warnings = append(warnings, fmt.Sprintf("metadata unreadable for %s: %v", filepath.Base(item.RelativePath), metaErr))
 			meta = nil
 		}
 		sources = append(sources, gatherSource{Item: item, Meta: meta})

--- a/internal/commands/workitem/link.go
+++ b/internal/commands/workitem/link.go
@@ -134,7 +134,7 @@ func runLink(ctx context.Context, cmd *cobra.Command, opts linkOptions) error {
 
 	var knownIDs map[string]struct{}
 	if !opts.AllowMissing {
-		knownIDs, err = workitemIDsOnDisk(ctx, root)
+		knownIDs, _, err = workitemIDsOnDisk(ctx, root)
 		if err != nil {
 			return err
 		}

--- a/internal/commands/workitem/list.go
+++ b/internal/commands/workitem/list.go
@@ -20,13 +20,23 @@ type listOptions struct {
 	stages          []string
 	attentionStages []string
 	groups          []string
+	tags            []string
+	projects        []string
 	groupBy         string
 	showParked      bool
 	limit           int
 	query           string
 }
 
-func (o listOptions) filterOptions() wkitem.FilterOptions {
+func (o listOptions) filterOptions() (wkitem.FilterOptions, error) {
+	tags, err := normalizeTags(o.tags)
+	if err != nil {
+		return wkitem.FilterOptions{}, err
+	}
+	projects, err := normalizeProjects(o.projects)
+	if err != nil {
+		return wkitem.FilterOptions{}, err
+	}
 	return wkitem.FilterOptions{
 		Types:           o.types,
 		Categories:      o.categories,
@@ -34,9 +44,11 @@ func (o listOptions) filterOptions() wkitem.FilterOptions {
 		LifecycleStages: o.stages,
 		AttentionStages: o.attentionStages,
 		Groups:          o.groups,
+		Tags:            tags,
+		Projects:        projects,
 		Query:           o.query,
 		ShowParked:      o.showParked,
-	}
+	}, nil
 }
 
 func newListCommand() *cobra.Command {
@@ -57,6 +69,7 @@ Examples:
   camp workitem list intent
   camp workitem list active
   camp workitem list --category research --query auth
+  camp workitem list --tag public-launch --tag schema
   camp workitem list festival --status ready --json`,
 		Args: cobra.MaximumNArgs(1),
 		Annotations: map[string]string{
@@ -79,7 +92,10 @@ Examples:
 			if err := validateDisplayStatuses(opts.statuses); err != nil {
 				return err
 			}
-			filters := opts.filterOptions()
+			filters, err := opts.filterOptions()
+			if err != nil {
+				return err
+			}
 			if isInteractive() && !opts.json {
 				// --limit applies only to non-TTY / --json result size, not the TUI.
 				return runTUIWithFilters(cmd.Context(), state, filters, false, "")
@@ -112,6 +128,8 @@ Examples:
 	cmd.Flags().StringArrayVar(&opts.stages, "stage", nil, "Filter by lifecycle stage (repeat for OR)")
 	cmd.Flags().StringArrayVar(&opts.attentionStages, "attention-stage", nil, "Filter by attention stage (repeat for OR)")
 	cmd.Flags().StringArrayVar(&opts.groups, "group", nil, "Filter by workitem group (repeat for OR)")
+	cmd.Flags().StringArrayVar(&opts.tags, "tag", nil, "Filter by tag (repeat; item must have ALL given tags)")
+	cmd.Flags().StringArrayVar(&opts.projects, "project", nil, "Filter by related project (repeat for OR)")
 	cmd.Flags().StringVar(&opts.groupBy, "group-by", "", "Group output sections by attention_stage, group, type, or category")
 	cmd.Flags().BoolVar(&opts.showParked, "show-parked", false, "Include parked attention-stage workitems")
 	cmd.Flags().IntVar(&opts.limit, "limit", 0, "Maximum number of items to return (non-interactive / --json only)")

--- a/internal/commands/workitem/list_test.go
+++ b/internal/commands/workitem/list_test.go
@@ -1,0 +1,47 @@
+package workitem
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestListOptions_FilterOptionsNormalizesTagsAndProjects(t *testing.T) {
+	opts := listOptions{
+		tags:     []string{"Public Launch", "public-launch"},
+		projects: []string{"projects/camp/", "projects/./camp"},
+	}
+	fo, err := opts.filterOptions()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := []string{"public-launch"}; !reflect.DeepEqual(fo.Tags, want) {
+		t.Errorf("Tags = %#v, want %#v", fo.Tags, want)
+	}
+	if want := []string{"projects/camp"}; !reflect.DeepEqual(fo.Projects, want) {
+		t.Errorf("Projects = %#v, want %#v", fo.Projects, want)
+	}
+}
+
+func TestListOptions_FilterOptionsRejectsUnnormalizableTag(t *testing.T) {
+	opts := listOptions{tags: []string{"foo!bar"}}
+	if _, err := opts.filterOptions(); err == nil {
+		t.Fatal("expected error for a tag that is invalid after normalization")
+	}
+}
+
+func TestListOptions_FilterOptionsRejectsEmptyProject(t *testing.T) {
+	opts := listOptions{projects: []string{"/"}}
+	if _, err := opts.filterOptions(); err == nil {
+		t.Fatal("expected error for a project that is empty after normalization")
+	}
+}
+
+func TestListOptions_FilterOptionsEmptyIsNoError(t *testing.T) {
+	fo, err := listOptions{}.filterOptions()
+	if err != nil {
+		t.Fatalf("empty options should not error: %v", err)
+	}
+	if len(fo.Tags) != 0 || len(fo.Projects) != 0 {
+		t.Errorf("empty options should yield no tag/project filters, got tags=%v projects=%v", fo.Tags, fo.Projects)
+	}
+}

--- a/internal/commands/workitem/projects.go
+++ b/internal/commands/workitem/projects.go
@@ -1,0 +1,55 @@
+package workitem
+
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// normalizeProjects cleans each project path (filepath.Clean, forward slashes,
+// no trailing separator), rejects any that normalize to empty (naming the
+// original input), and deduplicates while preserving first-seen order.
+func normalizeProjects(raw []string) ([]string, error) {
+	seen := make(map[string]bool, len(raw))
+	out := make([]string, 0, len(raw))
+	for _, p := range raw {
+		norm := normalizeProject(p)
+		if norm == "" {
+			return nil, camperrors.NewValidation("project",
+				"project "+strconv.Quote(p)+" is empty after normalization", nil)
+		}
+		if seen[norm] {
+			continue
+		}
+		seen[norm] = true
+		out = append(out, norm)
+	}
+	return out, nil
+}
+
+func normalizeProject(s string) string {
+	return strings.TrimRight(filepath.ToSlash(filepath.Clean(s)), "/")
+}
+
+// normalizeExistingProjects normalizes and deduplicates projects already on a
+// marker. It returns the kept entries (normalized, deduped, first-occurrence
+// order) and the original entries that normalized to empty (genuine drops that
+// repair records distinctly as data removal). It never errors.
+func normalizeExistingProjects(projects []string) (kept, dropped []string) {
+	seen := make(map[string]bool, len(projects))
+	for _, p := range projects {
+		norm := normalizeProject(p)
+		if norm == "" {
+			dropped = append(dropped, p)
+			continue
+		}
+		if seen[norm] {
+			continue
+		}
+		seen[norm] = true
+		kept = append(kept, norm)
+	}
+	return kept, dropped
+}

--- a/internal/commands/workitem/projects_test.go
+++ b/internal/commands/workitem/projects_test.go
@@ -1,0 +1,65 @@
+package workitem
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+func TestNormalizeProjects(t *testing.T) {
+	t.Run("normalizes trailing slash and dedupes, first occurrence wins", func(t *testing.T) {
+		got, err := normalizeProjects([]string{"projects/camp/", "projects/./camp", "projects/fest"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{"projects/camp", "projects/fest"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("empty after normalization returns validation error naming original input", func(t *testing.T) {
+		_, err := normalizeProjects([]string{"/"})
+		if err == nil {
+			t.Fatal("expected error for a project that is empty after normalization")
+		}
+		var verr *camperrors.ValidationError
+		if !errors.As(err, &verr) {
+			t.Fatalf("expected ValidationError, got %T: %v", err, err)
+		}
+		if verr.Field != "project" {
+			t.Errorf("Field = %q, want project", verr.Field)
+		}
+		if !strings.Contains(err.Error(), `"/"`) {
+			t.Errorf("error must name the original input, got: %v", err)
+		}
+	})
+}
+
+func TestNormalizeExistingProjects(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          []string
+		wantKept    []string
+		wantDropped []string
+	}{
+		{"already clean, unchanged", []string{"projects/camp", "projects/fest"}, []string{"projects/camp", "projects/fest"}, nil},
+		{"normalizes and dedupes", []string{"projects/camp/", "projects/./camp", "projects/fest"}, []string{"projects/camp", "projects/fest"}, nil},
+		{"drops entries that normalize to empty", []string{"/", "projects/camp", "///"}, []string{"projects/camp"}, []string{"/", "///"}},
+		{"all dropped", []string{"/"}, nil, []string{"/"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kept, dropped := normalizeExistingProjects(tc.in)
+			if !reflect.DeepEqual(kept, tc.wantKept) {
+				t.Errorf("kept = %#v, want %#v", kept, tc.wantKept)
+			}
+			if !reflect.DeepEqual(dropped, tc.wantDropped) {
+				t.Errorf("dropped = %#v, want %#v", dropped, tc.wantDropped)
+			}
+		})
+	}
+}

--- a/internal/commands/workitem/promote.go
+++ b/internal/commands/workitem/promote.go
@@ -298,8 +298,13 @@ func doFestivalPromote(ctx context.Context, cmd *cobra.Command, opts runWorkitem
 		return nil, camperrors.New("festival creation failed: " + fr.CLIError)
 	}
 
-	ingestDir := filepath.Join(campaignRoot, "festivals", fr.Dest, fr.Dir, "001_INGEST", "input_specs", loc.Slug)
-	if err := promotepkg.CopyTree(loc.SourcePath, ingestDir); err != nil {
+	isFile, slug := promoteSourceShape(loc)
+	ingestDir := filepath.Join(campaignRoot, "festivals", fr.Dest, fr.Dir, "001_INGEST", "input_specs", slug)
+	copyDest := ingestDir
+	if isFile {
+		copyDest = filepath.Join(ingestDir, filepath.Base(loc.SourcePath))
+	}
+	if err := promotepkg.CopyTree(loc.SourcePath, copyDest); err != nil {
 		return nil, camperrors.Wrap(err, "copying workitem into festival ingest")
 	}
 	promotedTo := filepath.ToSlash(filepath.Join("festivals", fr.Dest, fr.Dir))
@@ -346,9 +351,10 @@ func doDocPromote(ctx context.Context, opts runWorkitemPromoteOptions, campaignR
 		return nil, camperrors.New("workitem doc is empty; use --force to promote anyway")
 	}
 
+	isFile, cleanSlug := promoteSourceShape(loc)
 	relDest := opts.Dest
 	if relDest == "" {
-		relDest = loc.Slug
+		relDest = cleanSlug
 	}
 	docsRoot := filepath.Join(campaignRoot, "docs")
 	if err := os.MkdirAll(docsRoot, 0o755); err != nil {
@@ -364,7 +370,11 @@ func doDocPromote(ctx context.Context, opts runWorkitemPromoteOptions, campaignR
 			return nil, camperrors.New("docs/" + relDest + " already exists and is not empty; use --force to overwrite")
 		}
 	}
-	if err := promotepkg.CopyTree(loc.SourcePath, destDir); err != nil {
+	copyDest := destDir
+	if isFile {
+		copyDest = filepath.Join(destDir, filepath.Base(loc.SourcePath))
+	}
+	if err := promotepkg.CopyTree(loc.SourcePath, copyDest); err != nil {
 		return nil, camperrors.Wrap(err, "copying workitem into docs")
 	}
 	promotedTo := filepath.ToSlash(filepath.Join("docs", relDest))
@@ -389,6 +399,16 @@ func doDocPromote(ctx context.Context, opts runWorkitemPromoteOptions, campaignR
 // marker), which has no stable-id links to migrate.
 func promotedWorkitemIdentity(ctx context.Context, campaignRoot string, loc *locate.Location, result *workitemPromoteResult) (id, key string) {
 	key = loc.Type + ":" + result.From
+	// A file source has no .workitem sibling; its identity is in its own
+	// frontmatter, so load it there (mirrors gather's ItemKind branch). Without
+	// this a file source yields an empty id and link migration can only match by
+	// key, never by stable ID.
+	if isFile, _ := promoteSourceShape(loc); isFile {
+		if meta, err := wkitem.LoadFrontmatterMetadata(loc.SourcePath); err == nil && meta != nil {
+			id = meta.ID
+		}
+		return id, key
+	}
 	if meta, err := wkitem.LoadMetadata(ctx, loc.SourcePath); err == nil && meta != nil {
 		id = meta.ID
 	}
@@ -474,8 +494,17 @@ func readFestivalID(campaignRoot, promotedTo string) string {
 }
 
 func recordPromotedTo(ctx context.Context, campaignRoot string, loc *locate.Location, promotedTo string) error {
-	if _, err := os.Stat(filepath.Join(loc.SourcePath, wkitem.MetadataFilename)); os.IsNotExist(err) {
+	info, statErr := os.Stat(loc.SourcePath)
+	if statErr != nil {
 		return nil
+	}
+	// A directory source needs a .workitem marker to stamp; a file source is
+	// itself the frontmatter target, so it always proceeds. wkitem.RecordPromotion
+	// picks the right surface by shape.
+	if info.IsDir() {
+		if _, err := os.Stat(filepath.Join(loc.SourcePath, wkitem.MetadataFilename)); os.IsNotExist(err) {
+			return nil
+		}
 	}
 	relPath := filepath.ToSlash(dungeoncmd.RelFromRoot(campaignRoot, loc.SourcePath))
 	if err := promotepkg.RecordPromotion(promotedTo, func(rec promotepkg.PromotionRecord) error {
@@ -518,12 +547,10 @@ type DungeonMove struct {
 // the shared dungeon plumbing. It is the single implementation behind both
 // camp workitem promote and the deprecated camp shelve alias.
 func MoveToDungeon(ctx context.Context, campaignRoot string, loc *locate.Location, status string) (DungeonMove, error) {
-	info, err := os.Stat(loc.SourcePath)
-	if err != nil {
+	// Directory and file workitems both move via the generic dungeon plumbing
+	// (statusmove + link rewriting); the shape does not matter here.
+	if _, err := os.Stat(loc.SourcePath); err != nil {
 		return DungeonMove{}, camperrors.Wrapf(err, "stat workitem %s", loc.SourcePath)
-	}
-	if !info.IsDir() {
-		return DungeonMove{}, camperrors.New(fmt.Sprintf("workitem %s is not a directory; only directory-style workitems can be moved to the dungeon", dungeoncmd.RelFromRoot(campaignRoot, loc.SourcePath)))
 	}
 
 	if loc.InDungeon && loc.Status == status {
@@ -550,7 +577,29 @@ func MoveToDungeon(ctx context.Context, campaignRoot string, loc *locate.Locatio
 	}, nil
 }
 
+// promoteSourceShape reports whether loc's source is a single file and returns a
+// container slug for it: the extension-stripped slug for a file (so a file lands
+// under <dest>/<slug>/<file>.md rather than <dest>/<file>.md/), or loc.Slug for a
+// directory.
+func promoteSourceShape(loc *locate.Location) (isFile bool, slug string) {
+	if info, err := os.Stat(loc.SourcePath); err == nil && !info.IsDir() {
+		return true, strings.TrimSuffix(loc.Slug, filepath.Ext(loc.Slug))
+	}
+	return false, loc.Slug
+}
+
+// primaryDocContent returns the promotable markdown for a source path. For a
+// file workitem the source is itself the doc; for a directory it is README.md or
+// the first top-level .md.
 func primaryDocContent(srcDir string) (string, error) {
+	if info, err := os.Stat(srcDir); err == nil && !info.IsDir() {
+		data, rerr := os.ReadFile(srcDir)
+		if rerr != nil {
+			return "", camperrors.Wrap(rerr, "reading workitem file")
+		}
+		return string(data), nil
+	}
+
 	if data, err := os.ReadFile(filepath.Join(srcDir, "README.md")); err == nil {
 		return string(data), nil
 	} else if !os.IsNotExist(err) {

--- a/internal/commands/workitem/promote_test.go
+++ b/internal/commands/workitem/promote_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/fest"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/locate"
 )
 
 func promoteCampaign(t *testing.T) string {
@@ -37,6 +38,23 @@ func writeFile(t *testing.T, path, content string) {
 	}
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+func TestPromotedWorkitemIdentity_FileSourceResolvesID(t *testing.T) {
+	dir := t.TempDir()
+	fpath := filepath.Join(dir, "note.md")
+	writeFile(t, fpath, "---\nversion: v1alpha8\nkind: workitem\nid: note-x-2026-07-19\ntype: design\ntitle: X\nref: WI-abc123\n---\n\n# X\n")
+
+	loc := &locate.Location{SourcePath: fpath, Type: "design"}
+	result := &workitemPromoteResult{From: "workflow/design/note.md"}
+	id, key := promotedWorkitemIdentity(context.Background(), dir, loc, result)
+
+	if id != "note-x-2026-07-19" {
+		t.Errorf("file source id = %q, want note-x-2026-07-19 (must resolve via frontmatter, not a .workitem sibling)", id)
+	}
+	if key != "design:workflow/design/note.md" {
+		t.Errorf("key = %q, want design:workflow/design/note.md", key)
 	}
 }
 

--- a/internal/commands/workitem/ref_quest_test.go
+++ b/internal/commands/workitem/ref_quest_test.go
@@ -51,7 +51,7 @@ func TestRunCreate_WritesRefAndOmitsQuestWhenNoneActive(t *testing.T) {
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
 
-	if err := runCreate(context.Background(), cmd, "alpha", "design", "Alpha", "", "", "", nil, false); err != nil {
+	if err := runCreate(context.Background(), cmd, "alpha", "design", "Alpha", "", "", "", nil, nil, false); err != nil {
 		t.Fatalf("runCreate: %v", err)
 	}
 	meta := loadMarker(t, filepath.Join(root, "workflow", "design", "alpha", ".workitem"))
@@ -86,7 +86,7 @@ func TestRunCreate_RefsAreUniqueAcrossWorkitems(t *testing.T) {
 	cmd.SetErr(os.Stderr)
 
 	for _, slug := range []string{"alpha", "beta", "gamma"} {
-		if err := runCreate(context.Background(), cmd, slug, "design", slug, "", "", "", nil, false); err != nil {
+		if err := runCreate(context.Background(), cmd, slug, "design", slug, "", "", "", nil, nil, false); err != nil {
 			t.Fatalf("runCreate %s: %v", slug, err)
 		}
 	}
@@ -114,7 +114,7 @@ func TestRunAdopt_WritesRef(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
-	if err := runAdopt(context.Background(), cmd, "workflow/design/legacy", "design", "Legacy", "", "", nil); err != nil {
+	if err := runAdopt(context.Background(), cmd, "workflow/design/legacy", "design", "Legacy", "", "", nil, nil); err != nil {
 		t.Fatalf("runAdopt: %v", err)
 	}
 	meta := loadMarker(t, filepath.Join(adoptDir, ".workitem"))

--- a/internal/commands/workitem/ref_quest_test.go
+++ b/internal/commands/workitem/ref_quest_test.go
@@ -51,7 +51,7 @@ func TestRunCreate_WritesRefAndOmitsQuestWhenNoneActive(t *testing.T) {
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
 
-	if err := runCreate(context.Background(), cmd, "alpha", "design", "Alpha", "", "", "", false); err != nil {
+	if err := runCreate(context.Background(), cmd, "alpha", "design", "Alpha", "", "", "", nil, false); err != nil {
 		t.Fatalf("runCreate: %v", err)
 	}
 	meta := loadMarker(t, filepath.Join(root, "workflow", "design", "alpha", ".workitem"))
@@ -86,7 +86,7 @@ func TestRunCreate_RefsAreUniqueAcrossWorkitems(t *testing.T) {
 	cmd.SetErr(os.Stderr)
 
 	for _, slug := range []string{"alpha", "beta", "gamma"} {
-		if err := runCreate(context.Background(), cmd, slug, "design", slug, "", "", "", false); err != nil {
+		if err := runCreate(context.Background(), cmd, slug, "design", slug, "", "", "", nil, false); err != nil {
 			t.Fatalf("runCreate %s: %v", slug, err)
 		}
 	}
@@ -114,7 +114,7 @@ func TestRunAdopt_WritesRef(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetOut(os.Stdout)
 	cmd.SetErr(os.Stderr)
-	if err := runAdopt(context.Background(), cmd, "workflow/design/legacy", "design", "Legacy", "", ""); err != nil {
+	if err := runAdopt(context.Background(), cmd, "workflow/design/legacy", "design", "Legacy", "", "", nil); err != nil {
 		t.Fatalf("runAdopt: %v", err)
 	}
 	meta := loadMarker(t, filepath.Join(adoptDir, ".workitem"))

--- a/internal/commands/workitem/repair.go
+++ b/internal/commands/workitem/repair.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -210,6 +211,22 @@ func computeRepair(
 			meta.Title = title
 			set("title", "", title)
 		}
+	}
+	if len(meta.Tags) > 0 {
+		kept, dropped := normalizeExistingTags(meta.Tags)
+		survivors := make([]string, 0, len(meta.Tags))
+		for _, t := range meta.Tags {
+			if normalizeTag(t) != "" {
+				survivors = append(survivors, t)
+			}
+		}
+		if len(dropped) > 0 {
+			changes = append(changes, repairChange{Field: "tags", Action: repairActionCleared, From: strings.Join(dropped, ",")})
+		}
+		if strings.Join(kept, ",") != strings.Join(survivors, ",") {
+			set("tags", strings.Join(survivors, ","), strings.Join(kept, ","))
+		}
+		meta.Tags = kept
 	}
 
 	return markerRepair{meta: meta, changes: changes, created: !exists}, nil

--- a/internal/commands/workitem/repair.go
+++ b/internal/commands/workitem/repair.go
@@ -228,6 +228,22 @@ func computeRepair(
 		}
 		meta.Tags = kept
 	}
+	if len(meta.Projects) > 0 {
+		kept, dropped := normalizeExistingProjects(meta.Projects)
+		survivors := make([]string, 0, len(meta.Projects))
+		for _, p := range meta.Projects {
+			if normalizeProject(p) != "" {
+				survivors = append(survivors, p)
+			}
+		}
+		if len(dropped) > 0 {
+			changes = append(changes, repairChange{Field: "projects", Action: repairActionCleared, From: strings.Join(dropped, ",")})
+		}
+		if strings.Join(kept, ",") != strings.Join(survivors, ",") {
+			set("projects", strings.Join(survivors, ","), strings.Join(kept, ","))
+		}
+		meta.Projects = kept
+	}
 
 	return markerRepair{meta: meta, changes: changes, created: !exists}, nil
 }

--- a/internal/commands/workitem/repair_test.go
+++ b/internal/commands/workitem/repair_test.go
@@ -137,6 +137,67 @@ func TestComputeRepair_DropsUnrecoverableTags(t *testing.T) {
 	}
 }
 
+func TestComputeRepair_NormalizesProjects(t *testing.T) {
+	genID, genRef, inferTitle := stubGenerators()
+	current := wkitem.Metadata{
+		Version:  wkitem.WorkitemSchemaVersion,
+		Kind:     "workitem",
+		ID:       "design-foo-2026-05-25",
+		Type:     "design",
+		Title:    "Kept",
+		Ref:      "WI-abc123",
+		Projects: []string{"projects/camp/", "projects/./camp", "projects/fest"},
+	}
+	plan, err := computeRepair(current, true, "design", genID, genRef, inferTitle)
+	if err != nil {
+		t.Fatalf("computeRepair: %v", err)
+	}
+	want := []string{"projects/camp", "projects/fest"}
+	if !reflect.DeepEqual(plan.meta.Projects, want) {
+		t.Errorf("projects = %#v, want %#v", plan.meta.Projects, want)
+	}
+	if _, ok := changeFields(plan.changes)["projects"]; !ok {
+		t.Error("expected a projects change to be recorded")
+	}
+}
+
+func TestComputeRepair_DropsUnrecoverableProjects(t *testing.T) {
+	genID, genRef, inferTitle := stubGenerators()
+	current := wkitem.Metadata{
+		Version:  wkitem.WorkitemSchemaVersion,
+		Kind:     "workitem",
+		ID:       "design-foo-2026-05-25",
+		Type:     "design",
+		Title:    "Kept",
+		Ref:      "WI-abc123",
+		Projects: []string{"/", "projects/camp"},
+	}
+	plan, err := computeRepair(current, true, "design", genID, genRef, inferTitle)
+	if err != nil {
+		t.Fatalf("computeRepair: %v", err)
+	}
+	if want := []string{"projects/camp"}; !reflect.DeepEqual(plan.meta.Projects, want) {
+		t.Errorf("projects = %#v, want %#v", plan.meta.Projects, want)
+	}
+	for _, p := range plan.meta.Projects {
+		if p == "" {
+			t.Fatal("repair must never write an empty projects entry")
+		}
+	}
+	var cleared *repairChange
+	for i := range plan.changes {
+		if plan.changes[i].Field == "projects" && plan.changes[i].Action == repairActionCleared {
+			cleared = &plan.changes[i]
+		}
+	}
+	if cleared == nil {
+		t.Fatal("a dropped project must be recorded distinctly as a cleared action, not folded into a reformatting change")
+	}
+	if !strings.Contains(cleared.From, "/") {
+		t.Errorf("cleared change should name the dropped project, got From=%q", cleared.From)
+	}
+}
+
 func TestComputeRepair_LegacyUpgradeAndMismatch(t *testing.T) {
 	genID, genRef, inferTitle := stubGenerators()
 	current := wkitem.Metadata{

--- a/internal/commands/workitem/repair_test.go
+++ b/internal/commands/workitem/repair_test.go
@@ -56,6 +56,29 @@ func TestComputeRepair_CreateFromMissing(t *testing.T) {
 	}
 }
 
+func TestComputeRepair_LegacyInputsUpgradeToCurrent(t *testing.T) {
+	genID, genRef, inferTitle := stubGenerators()
+	for _, version := range []string{"v1alpha4", "v1alpha5", "v1alpha6", "v1alpha7"} {
+		t.Run(version, func(t *testing.T) {
+			current := wkitem.Metadata{
+				Version: version,
+				Kind:    "workitem",
+				ID:      "design-foo-2026-05-25",
+				Type:    "design",
+				Title:   "Kept Title",
+				Ref:     "WI-abc123",
+			}
+			plan, err := computeRepair(current, true, "design", genID, genRef, inferTitle)
+			if err != nil {
+				t.Fatalf("computeRepair: %v", err)
+			}
+			if plan.meta.Version != wkitem.WorkitemSchemaVersion {
+				t.Errorf("version = %q, want %q (%s must upgrade to current)", plan.meta.Version, wkitem.WorkitemSchemaVersion, version)
+			}
+		})
+	}
+}
+
 func TestComputeRepair_LegacyUpgradeAndMismatch(t *testing.T) {
 	genID, genRef, inferTitle := stubGenerators()
 	current := wkitem.Metadata{

--- a/internal/commands/workitem/repair_test.go
+++ b/internal/commands/workitem/repair_test.go
@@ -1,6 +1,8 @@
 package workitem
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
@@ -76,6 +78,62 @@ func TestComputeRepair_LegacyInputsUpgradeToCurrent(t *testing.T) {
 				t.Errorf("version = %q, want %q (%s must upgrade to current)", plan.meta.Version, wkitem.WorkitemSchemaVersion, version)
 			}
 		})
+	}
+}
+
+func TestComputeRepair_NormalizesTags(t *testing.T) {
+	genID, genRef, inferTitle := stubGenerators()
+	current := wkitem.Metadata{
+		Version: wkitem.WorkitemSchemaVersion,
+		Kind:    "workitem",
+		ID:      "design-foo-2026-05-25",
+		Type:    "design",
+		Title:   "Kept",
+		Ref:     "WI-abc123",
+		Tags:    []string{"Public-Launch", "public launch", "schema"},
+	}
+	plan, err := computeRepair(current, true, "design", genID, genRef, inferTitle)
+	if err != nil {
+		t.Fatalf("computeRepair: %v", err)
+	}
+	want := []string{"public-launch", "schema"}
+	if !reflect.DeepEqual(plan.meta.Tags, want) {
+		t.Errorf("tags = %#v, want %#v", plan.meta.Tags, want)
+	}
+	if _, ok := changeFields(plan.changes)["tags"]; !ok {
+		t.Error("expected a tags change to be recorded")
+	}
+}
+
+func TestComputeRepair_DropsUnrecoverableTags(t *testing.T) {
+	genID, genRef, inferTitle := stubGenerators()
+	current := wkitem.Metadata{
+		Version: wkitem.WorkitemSchemaVersion,
+		Kind:    "workitem",
+		ID:      "design-foo-2026-05-25",
+		Type:    "design",
+		Title:   "Kept",
+		Ref:     "WI-abc123",
+		Tags:    []string{"---", "schema"},
+	}
+	plan, err := computeRepair(current, true, "design", genID, genRef, inferTitle)
+	if err != nil {
+		t.Fatalf("computeRepair: %v", err)
+	}
+	if want := []string{"schema"}; !reflect.DeepEqual(plan.meta.Tags, want) {
+		t.Errorf("tags = %#v, want %#v", plan.meta.Tags, want)
+	}
+	var cleared *repairChange
+	for i := range plan.changes {
+		if plan.changes[i].Field == "tags" && plan.changes[i].Action == repairActionCleared {
+			cleared = &plan.changes[i]
+		}
+	}
+	if cleared == nil {
+		t.Fatal("a dropped tag must be recorded distinctly as a cleared action, not folded into a reformatting change")
+	}
+	if !strings.Contains(cleared.From, "---") {
+		t.Errorf("cleared change should name the dropped tag, got From=%q", cleared.From)
 	}
 }
 

--- a/internal/commands/workitem/tags.go
+++ b/internal/commands/workitem/tags.go
@@ -1,0 +1,67 @@
+package workitem
+
+import (
+	"strconv"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+// normalizeTags lowercases and hyphenates each input tag, rejects any that
+// still fail validation after normalization, and deduplicates while preserving
+// first-seen order.
+func normalizeTags(raw []string) ([]string, error) {
+	seen := make(map[string]bool, len(raw))
+	out := make([]string, 0, len(raw))
+	for _, t := range raw {
+		norm := normalizeTag(t)
+		if !wkitem.ValidTag(norm) {
+			return nil, camperrors.NewValidation("tag",
+				"tag "+strconv.Quote(t)+" is not a valid tag after normalization (want lowercase kebab-case, got "+strconv.Quote(norm)+")", nil)
+		}
+		if seen[norm] {
+			continue
+		}
+		seen[norm] = true
+		out = append(out, norm)
+	}
+	return out, nil
+}
+
+func normalizeTag(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.Map(func(r rune) rune {
+		switch r {
+		case ' ', '_':
+			return '-'
+		default:
+			return r
+		}
+	}, s)
+	for strings.Contains(s, "--") {
+		s = strings.ReplaceAll(s, "--", "-")
+	}
+	return strings.Trim(s, "-")
+}
+
+// normalizeExistingTags normalizes and deduplicates tags already on a marker.
+// It returns the kept tags (normalized, deduped, first-occurrence order) and the
+// original entries that normalized to empty (genuine drops that repair records
+// distinctly as data removal). It never errors.
+func normalizeExistingTags(tags []string) (kept, dropped []string) {
+	seen := make(map[string]bool, len(tags))
+	for _, t := range tags {
+		norm := normalizeTag(t)
+		if norm == "" {
+			dropped = append(dropped, t)
+			continue
+		}
+		if seen[norm] {
+			continue
+		}
+		seen[norm] = true
+		kept = append(kept, norm)
+	}
+	return kept, dropped
+}

--- a/internal/commands/workitem/tags_test.go
+++ b/internal/commands/workitem/tags_test.go
@@ -1,0 +1,96 @@
+package workitem
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+func TestNormalizeTag(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"already normalized", "public-launch", "public-launch"},
+		{"uppercase", "Public-Launch", "public-launch"},
+		{"spaces", "public launch", "public-launch"},
+		{"underscores", "public_launch", "public-launch"},
+		{"repeated spaces collapse", "public   launch", "public-launch"},
+		{"repeated hyphens collapse", "public---launch", "public-launch"},
+		{"leading and trailing trimmed", "  -Public Launch-  ", "public-launch"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeTag(tc.in); got != tc.want {
+				t.Errorf("normalizeTag(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeTags(t *testing.T) {
+	t.Run("normalizes and dedupes order-preserving, first occurrence wins", func(t *testing.T) {
+		got, err := normalizeTags([]string{"Public-Launch", "public launch", "Schema", "schema"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{"public-launch", "schema"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("normalization still invalid returns validation error naming original input", func(t *testing.T) {
+		_, err := normalizeTags([]string{"screaming CASE 日本"})
+		if err == nil {
+			t.Fatal("expected error for a tag that is invalid after normalization")
+		}
+		var verr *camperrors.ValidationError
+		if !errors.As(err, &verr) {
+			t.Fatalf("expected ValidationError, got %T: %v", err, err)
+		}
+		if verr.Field != "tag" {
+			t.Errorf("Field = %q, want tag", verr.Field)
+		}
+		if !strings.Contains(err.Error(), "screaming CASE 日本") {
+			t.Errorf("error must name the original input, got: %v", err)
+		}
+	})
+
+	t.Run("boundary rejections", func(t *testing.T) {
+		for _, in := range []string{strings.Repeat("a", 65), "", "foo!bar"} {
+			if _, err := normalizeTags([]string{in}); err == nil {
+				t.Errorf("normalizeTags(%q) expected error, got nil", in)
+			}
+		}
+	})
+}
+
+func TestNormalizeExistingTags(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          []string
+		wantKept    []string
+		wantDropped []string
+	}{
+		{"already clean, unchanged", []string{"a", "b"}, []string{"a", "b"}, nil},
+		{"normalizes and dedupes", []string{"Public-Launch", "public launch", "schema"}, []string{"public-launch", "schema"}, nil},
+		{"drops entries that normalize to empty", []string{"---", "schema", "  "}, []string{"schema"}, []string{"---", "  "}},
+		{"all dropped", []string{"---"}, nil, []string{"---"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kept, dropped := normalizeExistingTags(tc.in)
+			if !reflect.DeepEqual(kept, tc.wantKept) {
+				t.Errorf("kept = %#v, want %#v", kept, tc.wantKept)
+			}
+			if !reflect.DeepEqual(dropped, tc.wantDropped) {
+				t.Errorf("dropped = %#v, want %#v", dropped, tc.wantDropped)
+			}
+		})
+	}
+}

--- a/internal/commands/workitem/validate.go
+++ b/internal/commands/workitem/validate.go
@@ -28,10 +28,13 @@ import (
 // Validate finding codes (dotted-domain form, stable). codeMissingRefField is
 // shared with `camp workitem doctor` so agents dispatch on one ref code.
 const (
-	codeMarkerMissing   = "workitem.marker.missing"
-	codeMarkerMalformed = "workitem.marker.malformed"
-	codeTypeMismatch    = "workitem.type.mismatch"
-	codeSchemaOutdated  = "workitem.schema.outdated"
+	codeMarkerMissing       = "workitem.marker.missing"
+	codeMarkerMalformed     = "workitem.marker.malformed"
+	codeTypeMismatch        = "workitem.type.mismatch"
+	codeSchemaOutdated      = "workitem.schema.outdated"
+	codeSchemaForwardCompat = "workitem.schema.forward-compat"
+	codeIdentityConflict    = "workitem.identity.conflict"
+	codeIdentityRefPending  = "workitem.identity.ref-pending"
 )
 
 type validateFinding struct {
@@ -118,6 +121,9 @@ func runValidate(ctx context.Context, cmd *cobra.Command, jsonOut bool, target s
 		}
 		findings = append(findings, classifyWorkflowDir(root, c.RelPath, c.PathType)...)
 	}
+	if target == "" {
+		findings = append(findings, frontmatterTypeMismatchFindings(root, resolver)...)
+	}
 	sort.SliceStable(findings, func(i, j int) bool {
 		if findings[i].Target != findings[j].Target {
 			return findings[i].Target < findings[j].Target
@@ -159,7 +165,119 @@ func classifyWorkflowDir(root, relPath, pathType string) []validateFinding {
 			Repairable:    false,
 		}}
 	}
-	return classifyMarker(relPath, pathType, true, raw)
+	findings := classifyMarker(relPath, pathType, true, raw)
+	findings = append(findings, frontmatterConflictFindings(root, relPath, raw)...)
+	return findings
+}
+
+// frontmatterConflictFindings enforces the identity-conflict rule: a document
+// frontmatter block anywhere in a marker directory's subtree that declares an
+// id/ref disagreeing with the directory .workitem is a hard error, never
+// silently resolved in either direction (doc 03).
+func frontmatterConflictFindings(root, relPath string, raw []byte) []validateFinding {
+	var dirMeta wkitem.Metadata
+	if err := yaml.Unmarshal(raw, &dirMeta); err != nil {
+		return nil // a malformed marker is already reported by classifyMarker
+	}
+	if dirMeta.ID == "" {
+		return nil // no directory identity to conflict with
+	}
+	dirAbs := filepath.Join(root, filepath.FromSlash(relPath))
+	conflicts, err := wkitem.FindFrontmatterConflicts(dirAbs, &dirMeta)
+	if err != nil {
+		return nil // best-effort; a walk error must not fail validate
+	}
+	var findings []validateFinding
+	for _, c := range conflicts {
+		fmRel := filepath.ToSlash(filepath.Join(relPath, c.RelPathFromDir))
+		switch c.Kind {
+		case wkitem.FrontmatterConflictRefPending:
+			findings = append(findings, validateFinding{
+				Code:     codeIdentityRefPending,
+				Severity: docSeverityWarning,
+				Target:   relPath,
+				Message: "frontmatter in " + fmRel + " shares the directory .workitem id but only one side declares a ref (dir ref: " +
+					refOrUnset(dirMeta.Ref) + ", frontmatter ref: " + refOrUnset(c.Ref) + "); the directory marker owns identity — reconcile by setting the directory ref to match or removing the frontmatter ref",
+				Repairable: false,
+			})
+		default:
+			findings = append(findings, validateFinding{
+				Code:     codeIdentityConflict,
+				Severity: docSeverityError,
+				Target:   relPath,
+				Message: "frontmatter in " + fmRel + " declares id/ref conflicting with the directory .workitem (dir: " +
+					dirMeta.ID + "/" + dirMeta.Ref + ", frontmatter: " + c.ID + "/" + c.Ref + ")",
+				Repairable: false,
+			})
+		}
+	}
+	return findings
+}
+
+func refOrUnset(ref string) string {
+	if ref == "" {
+		return "(unset)"
+	}
+	return ref
+}
+
+// frontmatterTypeMismatchFindings flags document frontmatter files under a
+// path-typed tree (design/explore) whose type: disagrees with the path. The
+// path decides the effective type (discovery forces it); validate surfaces the
+// disagreement rather than silently accepting either value. Files inside a
+// marker-bearing directory belong to that directory (collision rule) and are
+// skipped here; their identity is checked by the conflict rule instead.
+func frontmatterTypeMismatchFindings(root string, resolver *paths.Resolver) []validateFinding {
+	roots := []struct {
+		dir      string
+		pathType string
+	}{
+		{resolver.Design(), string(wkitem.WorkflowTypeDesign)},
+		{resolver.Explore(), string(wkitem.WorkflowTypeExplore)},
+	}
+	var findings []validateFinding
+	for _, r := range roots {
+		_ = filepath.WalkDir(r.dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if d.IsDir() {
+				if path == r.dir {
+					return nil
+				}
+				name := d.Name()
+				if name == "dungeon" || strings.HasPrefix(name, ".") {
+					return filepath.SkipDir
+				}
+				if _, statErr := os.Stat(filepath.Join(path, wkitem.MetadataFilename)); statErr == nil {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(d.Name(), ".md") {
+				return nil
+			}
+			md, ferr := wkitem.LoadFrontmatterMetadata(path)
+			if ferr != nil || md == nil {
+				return nil
+			}
+			if md.Type != "" && md.Type != r.pathType {
+				rel, relErr := filepath.Rel(root, path)
+				if relErr != nil {
+					return nil
+				}
+				findings = append(findings, validateFinding{
+					Code:       codeTypeMismatch,
+					Severity:   docSeverityError,
+					Target:     filepath.ToSlash(rel),
+					Message:    "frontmatter type " + strconv.Quote(md.Type) + " does not match path type " + strconv.Quote(r.pathType),
+					Repairable: false,
+				})
+			}
+			return nil
+		})
+	}
+	return findings
 }
 
 // classifyMarker is the pure structural check: given whether a marker is present
@@ -209,6 +327,15 @@ func classifyMarker(relPath, pathType string, present bool, raw []byte) []valida
 		})
 	}
 	switch {
+	case wkitem.IsForwardCompatVersion(meta.Version):
+		// Read-only: never suggest repair, which would downgrade a newer marker
+		// and drop fields this binary does not model.
+		findings = append(findings, validateFinding{
+			Code: codeSchemaForwardCompat, Severity: docSeverityWarning, Target: relPath,
+			Message: "marker schema version " + meta.Version + " is newer than this binary (current " + wkitem.WorkitemSchemaVersion +
+				"); loaded via forward-compat. Upgrade camp to a version that models " + meta.Version + " to edit this marker safely.",
+			Repairable: false,
+		})
 	case !wkitem.IsAcceptedVersion(meta.Version):
 		malformed("unsupported .workitem schema version " + strconv.Quote(meta.Version) + "; current is " + wkitem.WorkitemSchemaVersion)
 	case !wkitem.IsCurrentVersion(meta.Version):

--- a/internal/commands/workitem/validate_test.go
+++ b/internal/commands/workitem/validate_test.go
@@ -143,3 +143,24 @@ func TestClassifyMarker_MissingIsRepairable(t *testing.T) {
 		t.Errorf("want %s, got %v", codeMarkerMissing, findingCodes(findings))
 	}
 }
+
+func TestClassifyMarker_ForwardCompatIsWarningNoRepair(t *testing.T) {
+	raw := "version: v1alpha99\nkind: workitem\nid: design-foo-2026-05-25\ntype: design\ntitle: Foo\nref: WI-abc123\n"
+	findings := classifyMarker("workflow/design/foo", "design", true, []byte(raw))
+	if len(findings) != 1 {
+		t.Fatalf("findings = %d, want exactly 1: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.Code != codeSchemaForwardCompat {
+		t.Errorf("code = %q, want %q", f.Code, codeSchemaForwardCompat)
+	}
+	if f.Severity != docSeverityWarning {
+		t.Errorf("severity = %q, want %q", f.Severity, docSeverityWarning)
+	}
+	if f.RepairCommand != "" {
+		t.Errorf("forward-compat finding must not suggest repair, got %q", f.RepairCommand)
+	}
+	if f.Repairable {
+		t.Error("forward-compat finding must not be repairable")
+	}
+}

--- a/internal/commands/workitem/validate_test.go
+++ b/internal/commands/workitem/validate_test.go
@@ -41,19 +41,19 @@ func TestClassifyMarker(t *testing.T) {
 		{
 			name:      "unparseable marker",
 			present:   true,
-			raw:       "version: v1alpha7\n[not: yaml{{{\n",
+			raw:       "version: v1alpha8\n[not: yaml{{{\n",
 			wantCodes: []string{codeMarkerMalformed},
 		},
 		{
 			name:      "valid current marker",
 			present:   true,
-			raw:       "version: v1alpha7\nkind: workitem\nid: design-foo-2026-05-25\ntype: design\ntitle: Foo\nref: WI-abc123\n",
+			raw:       "version: v1alpha8\nkind: workitem\nid: design-foo-2026-05-25\ntype: design\ntitle: Foo\nref: WI-abc123\n",
 			wantCodes: nil,
 		},
 		{
 			name:      "missing ref only",
 			present:   true,
-			raw:       "version: v1alpha7\nkind: workitem\nid: design-foo-2026-05-25\ntype: design\ntitle: Foo\n",
+			raw:       "version: v1alpha8\nkind: workitem\nid: design-foo-2026-05-25\ntype: design\ntitle: Foo\n",
 			wantCodes: []string{codeMissingRefField},
 		},
 		{
@@ -65,7 +65,7 @@ func TestClassifyMarker(t *testing.T) {
 		{
 			name:      "type mismatch",
 			present:   true,
-			raw:       "version: v1alpha7\nkind: workitem\nid: design-foo-2026-05-25\ntype: feature\ntitle: Foo\nref: WI-abc123\n",
+			raw:       "version: v1alpha8\nkind: workitem\nid: design-foo-2026-05-25\ntype: feature\ntitle: Foo\nref: WI-abc123\n",
 			wantCodes: []string{codeTypeMismatch},
 		},
 		{
@@ -77,13 +77,13 @@ func TestClassifyMarker(t *testing.T) {
 		{
 			name:      "empty id and wrong kind are malformed",
 			present:   true,
-			raw:       "version: v1alpha7\nkind: note\ntype: design\nref: WI-abc123\n",
+			raw:       "version: v1alpha8\nkind: note\ntype: design\nref: WI-abc123\n",
 			wantCodes: []string{codeMarkerMalformed},
 		},
 		{
 			name:      "invalid ref shape is malformed",
 			present:   true,
-			raw:       "version: v1alpha7\nkind: workitem\nid: design-foo-2026-05-25\ntype: design\nref: nope\n",
+			raw:       "version: v1alpha8\nkind: workitem\nid: design-foo-2026-05-25\ntype: design\nref: nope\n",
 			wantCodes: []string{codeMarkerMalformed},
 		},
 		{

--- a/internal/workitem/discover.go
+++ b/internal/workitem/discover.go
@@ -52,6 +52,16 @@ func Discover(ctx context.Context, campaignRoot string, resolver *paths.Resolver
 		return nil, err
 	}
 
+	frontmatterDocs, err := discoverWorkflowFrontmatterDocs(ctx, campaignRoot, resolver)
+	if err != nil {
+		return nil, err
+	}
+	items = append(items, frontmatterDocs...)
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	festivals, err := discoverFestivals(ctx, campaignRoot, resolver)
 	if err != nil {
 		return nil, err

--- a/internal/workitem/discover_frontmatter.go
+++ b/internal/workitem/discover_frontmatter.go
@@ -1,0 +1,324 @@
+package workitem
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/paths"
+)
+
+// frontmatterMaxHead bounds the head-read for a document workitem's identity
+// block. Generous for a real frontmatter block while keeping the byte-zero
+// check cheap for the many markdown files that are not workitems.
+const frontmatterMaxHead = 4096
+
+// readFrontmatterBlock returns the raw YAML bytes between the opening and
+// closing "---" delimiters at the head of path, or (nil, false) if path does
+// not begin with "---" at byte zero or has no closing delimiter within maxHead
+// bytes. It never reads the full file when the leading delimiter is absent.
+func readFrontmatterBlock(path string, maxHead int) ([]byte, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, false
+	}
+	defer func() { _ = f.Close() }()
+
+	head := make([]byte, maxHead)
+	n, _ := io.ReadFull(f, head)
+	return parseFrontmatterHead(head[:n])
+}
+
+// parseFrontmatterHead extracts the YAML bytes between the opening and closing
+// "---" delimiters of a document head, or (nil, false) if head does not begin
+// with "---" at byte zero (LF or CRLF) or has no closing delimiter within it.
+// Split out from readFrontmatterBlock so the delimiter logic is unit-tested
+// without touching the filesystem.
+func parseFrontmatterHead(head []byte) ([]byte, bool) {
+	var openLen int
+	switch {
+	case bytes.HasPrefix(head, []byte("---\n")):
+		openLen = len("---\n")
+	case bytes.HasPrefix(head, []byte("---\r\n")):
+		openLen = len("---\r\n")
+	default:
+		return nil, false
+	}
+	body := head[openLen:]
+	idx := bytes.Index(body, []byte("\n---"))
+	if idx < 0 {
+		return nil, false
+	}
+	return body[:idx], true
+}
+
+// LoadFrontmatterMetadata reads and validates the kind:workitem frontmatter
+// block of the markdown file at path, returning (nil, nil) if the file has no
+// such block (mirrors LoadMetadata's "not found" contract for .workitem). The
+// gather (07_file_lifecycle_verbs) and links-migration doctor passes reuse this
+// to load a file source's Metadata without going through the directory-only
+// LoadMetadata.
+func LoadFrontmatterMetadata(path string) (*Metadata, error) {
+	block, ok := readFrontmatterBlock(path, frontmatterMaxHead)
+	if !ok || !bytes.Contains(block, []byte("kind: workitem")) {
+		return nil, nil
+	}
+	var md Metadata
+	if err := yaml.Unmarshal(block, &md); err != nil {
+		return nil, camperrors.Wrapf(err, "parsing frontmatter %s", path)
+	}
+	if err := validateMetadata(&md); err != nil {
+		return nil, camperrors.Wrapf(err, "validating frontmatter %s", path)
+	}
+	return &md, nil
+}
+
+// discoverWorkflowFrontmatterDocs scans workflow/** for markdown files whose
+// frontmatter declares kind: workitem and returns them as file workitems. The
+// dungeon and dotfile skips mirror the directory scanner so both detection
+// surfaces agree (doc 03). Malformed frontmatter is logged and skipped, not
+// fatal, matching buildWorkflowDirItem's log-and-skip on marker parse errors.
+func discoverWorkflowFrontmatterDocs(ctx context.Context, campaignRoot string, resolver *paths.Resolver) ([]WorkItem, error) {
+	root := resolver.Workflow()
+	var items []WorkItem
+	walkErr := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) && path == root {
+				return filepath.SkipAll
+			}
+			return err
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		name := d.Name()
+		if d.IsDir() {
+			if name == "dungeon" || strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(name, ".md") {
+			return nil
+		}
+		// Collision rule (doc 03): a directory .workitem owns the identity of
+		// everything under it, so a frontmatter file below a marker-bearing
+		// directory is never a second workitem. Cheaper than the head-check, so
+		// it runs first.
+		if hasMarkerAncestor(root, filepath.Dir(path)) {
+			return nil
+		}
+		item, ok := buildFrontmatterItem(ctx, campaignRoot, path, resolver)
+		if ok {
+			items = append(items, item)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	return items, nil
+}
+
+// buildFrontmatterItem constructs a file WorkItem from a markdown file's
+// kind:workitem frontmatter. It returns (item, false) when the file has no such
+// block or its frontmatter is invalid (logged and skipped, never fatal).
+func buildFrontmatterItem(ctx context.Context, campaignRoot, path string, resolver *paths.Resolver) (WorkItem, bool) {
+	md, err := LoadFrontmatterMetadata(path)
+	if err != nil {
+		slog.Default().Debug("workitem discovery skip",
+			"path", path, "reason", "frontmatter-invalid", "error", err.Error())
+		return WorkItem{}, false
+	}
+	if md == nil {
+		return WorkItem{}, false
+	}
+
+	relPath, err := filepath.Rel(campaignRoot, path)
+	if err != nil {
+		return WorkItem{}, false
+	}
+
+	// Type authority (doc 03): under a path-typed tree the path decides the
+	// type; the frontmatter's own type: is validated against it but never
+	// overrides it (mirrors buildWorkflowDirItem). Elsewhere frontmatter is
+	// authoritative.
+	wfType := WorkflowType(md.Type)
+	if forced, ok := frontmatterPathType(resolver, path); ok {
+		wfType = forced
+	}
+
+	created, updated := ScanFileTimestamps(ctx, path)
+	titleStem := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	item := WorkItem{
+		Key:            "file:" + relPath,
+		WorkflowType:   wfType,
+		LifecycleStage: LifecycleStageActive,
+		Title:          titleFromDoc(path, titleStem),
+		RelativePath:   relPath,
+		PrimaryDoc:     relPath,
+		ItemKind:       ItemKindFile,
+		CreatedAt:      created,
+		UpdatedAt:      updated,
+		Tags:           []string{},
+		Projects:       []string{},
+	}
+	item.SortTimestamp = DeriveSortTimestamp(item.UpdatedAt, item.CreatedAt)
+	item.Summary = extractSummaryFromFile(path, 200)
+
+	merged, err := ApplyMetadata(item, md)
+	if err != nil {
+		slog.Default().Debug("workitem discovery skip",
+			"path", path, "reason", "apply-metadata", "error", err.Error())
+		return WorkItem{}, false
+	}
+	return merged, true
+}
+
+// frontmatterPathType returns the workflow type a path-typed tree (design or
+// explore) forces on a document under it, and true; ("", false) when the path
+// has no type convention and the frontmatter's own type: is authoritative.
+func frontmatterPathType(resolver *paths.Resolver, path string) (WorkflowType, bool) {
+	switch {
+	case underRoot(path, resolver.Design()):
+		return WorkflowTypeDesign, true
+	case underRoot(path, resolver.Explore()):
+		return WorkflowTypeExplore, true
+	default:
+		return "", false
+	}
+}
+
+func underRoot(path, root string) bool {
+	return path == root || strings.HasPrefix(path, root+string(filepath.Separator))
+}
+
+// hasMarkerAncestor reports whether fileDir or any ancestor up to workflowRoot
+// (inclusive) carries a .workitem marker. Such a directory owns the identity of
+// everything beneath it, so a frontmatter file below it is never a second
+// workitem (doc 03 collision rule).
+func hasMarkerAncestor(workflowRoot, fileDir string) bool {
+	dir := fileDir
+	for {
+		if _, err := os.Stat(filepath.Join(dir, MetadataFilename)); err == nil {
+			return true
+		}
+		if dir == workflowRoot || len(dir) <= len(workflowRoot) {
+			return false
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+		dir = parent
+	}
+}
+
+// FrontmatterConflictKind distinguishes a hard identity conflict from a
+// recoverable pending-ref state between a directory marker and a document
+// frontmatter block that share the same id.
+type FrontmatterConflictKind int
+
+const (
+	// FrontmatterConflictIdentity is a hard conflict: the frontmatter declares a
+	// different id, or the same id with a different ref (both refs set).
+	FrontmatterConflictIdentity FrontmatterConflictKind = iota
+	// FrontmatterConflictRefPending is a warning: same id, but exactly one side
+	// declares a ref. Doctor's ref backfill is frontmatter-unaware and would
+	// later mint an unrelated dir ref, flipping this into a hard conflict, so it
+	// is surfaced for proactive reconciliation.
+	FrontmatterConflictRefPending
+)
+
+// FrontmatterConflict describes a document frontmatter block whose identity
+// disagrees with, or is only partially reconciled against, the directory
+// .workitem that owns its tree.
+type FrontmatterConflict struct {
+	RelPathFromDir string
+	ID             string
+	Ref            string
+	Kind           FrontmatterConflictKind
+}
+
+// FindFrontmatterConflicts walks dirAbs for markdown files whose kind:workitem
+// frontmatter identity disagrees with dirMeta (the directory's own .workitem). A
+// nested directory carrying its own .workitem owns its subtree and is skipped;
+// invalid or absent frontmatter is not a conflict. Validate uses this to enforce
+// the identity-conflict rule (doc 03).
+func FindFrontmatterConflicts(dirAbs string, dirMeta *Metadata) ([]FrontmatterConflict, error) {
+	var conflicts []FrontmatterConflict
+	err := filepath.WalkDir(dirAbs, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if path == dirAbs {
+				return nil
+			}
+			name := d.Name()
+			if name == "dungeon" || strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			if _, statErr := os.Stat(filepath.Join(path, MetadataFilename)); statErr == nil {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+		md, ferr := LoadFrontmatterMetadata(path)
+		if ferr != nil || md == nil {
+			return nil
+		}
+		kind, isFinding := classifyFrontmatterIdentity(md, dirMeta)
+		if !isFinding {
+			return nil
+		}
+		rel, relErr := filepath.Rel(dirAbs, path)
+		if relErr != nil {
+			return nil
+		}
+		conflicts = append(conflicts, FrontmatterConflict{
+			RelPathFromDir: filepath.ToSlash(rel),
+			ID:             md.ID,
+			Ref:            md.Ref,
+			Kind:           kind,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return conflicts, nil
+}
+
+// classifyFrontmatterIdentity compares a document frontmatter block against the
+// directory .workitem that owns its tree. It reports a hard identity conflict
+// when the id differs or both refs are set and differ, a pending-ref warning
+// when the ids match but exactly one side declares a ref, and no finding when
+// they agree or neither declares a ref.
+func classifyFrontmatterIdentity(md, dirMeta *Metadata) (FrontmatterConflictKind, bool) {
+	if md.ID != dirMeta.ID {
+		return FrontmatterConflictIdentity, true
+	}
+	dirHasRef := dirMeta.Ref != ""
+	fmHasRef := md.Ref != ""
+	switch {
+	case dirHasRef && fmHasRef && md.Ref != dirMeta.Ref:
+		return FrontmatterConflictIdentity, true
+	case dirHasRef != fmHasRef:
+		return FrontmatterConflictRefPending, true
+	default:
+		return FrontmatterConflictIdentity, false
+	}
+}

--- a/internal/workitem/discover_frontmatter_test.go
+++ b/internal/workitem/discover_frontmatter_test.go
@@ -1,0 +1,30 @@
+package workitem
+
+import "testing"
+
+func TestParseFrontmatterHead(t *testing.T) {
+	cases := []struct {
+		name     string
+		head     string
+		wantOK   bool
+		wantYAML string
+	}{
+		{"valid LF block", "---\nkind: workitem\nid: x\n---\n\n# Body", true, "kind: workitem\nid: x"},
+		{"valid CRLF block keeps interior bytes", "---\r\nkind: workitem\r\n---\r\n", true, "kind: workitem\r"},
+		{"no leading delimiter is not frontmatter", "kind: workitem\n---\n", false, ""},
+		{"leading delimiter with no closing delimiter", "---\nkind: workitem\nno close here\n", false, ""},
+		{"empty input", "", false, ""},
+		{"only the opening delimiter", "---\n", false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseFrontmatterHead([]byte(tc.head))
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && string(got) != tc.wantYAML {
+				t.Errorf("block = %q, want %q", got, tc.wantYAML)
+			}
+		})
+	}
+}

--- a/internal/workitem/filter.go
+++ b/internal/workitem/filter.go
@@ -15,12 +15,14 @@ type FilterOptions struct {
 	LifecycleStages []string
 	AttentionStages []string
 	Groups          []string
+	Tags            []string
+	Projects        []string
 	Query           string
 	ShowParked      bool
 }
 
 func FilterAdvanced(items []WorkItem, opts FilterOptions) []WorkItem {
-	if len(opts.Types) == 0 && len(opts.Categories) == 0 && len(opts.Statuses) == 0 && len(opts.LifecycleStages) == 0 && len(opts.AttentionStages) == 0 && len(opts.Groups) == 0 && opts.Query == "" && opts.ShowParked {
+	if len(opts.Types) == 0 && len(opts.Categories) == 0 && len(opts.Statuses) == 0 && len(opts.LifecycleStages) == 0 && len(opts.AttentionStages) == 0 && len(opts.Groups) == 0 && len(opts.Tags) == 0 && len(opts.Projects) == 0 && opts.Query == "" && opts.ShowParked {
 		return items
 	}
 
@@ -30,6 +32,7 @@ func FilterAdvanced(items []WorkItem, opts FilterOptions) []WorkItem {
 	stageSet := toSet(opts.LifecycleStages)
 	attentionSet := toSet(opts.AttentionStages)
 	groupSet := toSet(opts.Groups)
+	projectSet := toSet(opts.Projects)
 	query := strings.ToLower(opts.Query)
 
 	var result []WorkItem
@@ -54,6 +57,12 @@ func FilterAdvanced(items []WorkItem, opts FilterOptions) []WorkItem {
 			continue
 		}
 		if len(groupSet) > 0 && !groupSet[item.Group] {
+			continue
+		}
+		if !hasAllTags(item.Tags, opts.Tags) {
+			continue
+		}
+		if len(projectSet) > 0 && !anyMatches(item.Projects, projectSet) {
 			continue
 		}
 		if !opts.ShowParked && len(attentionSet) == 0 && len(statusSet) == 0 && item.AttentionStage == "parked" {
@@ -87,6 +96,33 @@ func toSet(vals []string) map[string]bool {
 		m[v] = true
 	}
 	return m
+}
+
+// hasAllTags reports whether item carries every tag in wanted (AND semantics,
+// deliberately different from every other filter dimension in this file, which
+// are OR-within-dimension). Returns true when wanted is empty.
+func hasAllTags(itemTags, wanted []string) bool {
+	if len(wanted) == 0 {
+		return true
+	}
+	set := toSet(itemTags)
+	for _, w := range wanted {
+		if !set[w] {
+			return false
+		}
+	}
+	return true
+}
+
+// anyMatches reports whether any of items intersects wantedSet (OR semantics,
+// matching the convention used by Types/Categories/etc in this file).
+func anyMatches(items []string, wantedSet map[string]bool) bool {
+	for _, v := range items {
+		if wantedSet[v] {
+			return true
+		}
+	}
+	return false
 }
 
 func matchesQuery(item WorkItem, query string) bool {

--- a/internal/workitem/filter_test.go
+++ b/internal/workitem/filter_test.go
@@ -180,3 +180,99 @@ func TestFilter_PreservesOrder(t *testing.T) {
 		t.Error("filter should preserve original order")
 	}
 }
+
+func TestHasAllTags(t *testing.T) {
+	cases := []struct {
+		name     string
+		itemTags []string
+		wanted   []string
+		want     bool
+	}{
+		{"empty wanted is always true", []string{"a"}, nil, true},
+		{"empty wanted with empty item is true", nil, nil, true},
+		{"single matching tag", []string{"a", "b"}, []string{"a"}, true},
+		{"single non-matching tag", []string{"a", "b"}, []string{"c"}, false},
+		{"all wanted present", []string{"a", "b", "c"}, []string{"a", "b"}, true},
+		{"one wanted missing is false, distinguishing AND from OR", []string{"a", "c"}, []string{"a", "b"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasAllTags(tc.itemTags, tc.wanted); got != tc.want {
+				t.Errorf("hasAllTags(%v, %v) = %v, want %v", tc.itemTags, tc.wanted, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAnyMatches(t *testing.T) {
+	cases := []struct {
+		name   string
+		items  []string
+		wanted []string
+		want   bool
+	}{
+		{"empty wanted set matches nothing; match-all lives in the FilterAdvanced guard", []string{"projects/camp"}, nil, false},
+		{"single matching entry", []string{"projects/camp"}, []string{"projects/camp"}, true},
+		{"one of several entries matches", []string{"projects/fest", "projects/camp"}, []string{"projects/camp"}, true},
+		{"no matching entries", []string{"projects/obey"}, []string{"projects/camp", "projects/fest"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := anyMatches(tc.items, toSet(tc.wanted)); got != tc.want {
+				t.Errorf("anyMatches(%v, toSet(%v)) = %v, want %v", tc.items, tc.wanted, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFilterAdvanced_TagsAreANDedProjectsAreORed(t *testing.T) {
+	items := []WorkItem{
+		{Title: "both-tags", Tags: []string{"a", "b"}},
+		{Title: "only-a", Tags: []string{"a"}},
+		{Title: "only-b", Tags: []string{"b"}},
+		{Title: "camp", Projects: []string{"projects/camp"}},
+		{Title: "fest", Projects: []string{"projects/fest"}},
+		{Title: "obey", Projects: []string{"projects/obey"}},
+	}
+
+	got := FilterAdvanced(items, FilterOptions{Tags: []string{"a", "b"}, ShowParked: true})
+	if len(got) != 1 || got[0].Title != "both-tags" {
+		t.Fatalf("Tags AND = %v, want only both-tags", got)
+	}
+
+	got = FilterAdvanced(items, FilterOptions{Projects: []string{"projects/camp", "projects/fest"}, ShowParked: true})
+	if len(got) != 2 || got[0].Title != "camp" || got[1].Title != "fest" {
+		t.Fatalf("Projects OR = %v, want camp and fest", got)
+	}
+}
+
+func TestFilterAdvanced_TagsProjectsCombineAcrossDimensions(t *testing.T) {
+	items := []WorkItem{
+		{Title: "match", WorkflowType: WorkflowTypeDesign, Tags: []string{"a", "b"}, Projects: []string{"projects/camp"}},
+		{Title: "wrong-type", WorkflowType: WorkflowTypeIntent, Tags: []string{"a", "b"}, Projects: []string{"projects/camp"}},
+		{Title: "missing-tag", WorkflowType: WorkflowTypeDesign, Tags: []string{"a"}, Projects: []string{"projects/camp"}},
+		{Title: "wrong-project", WorkflowType: WorkflowTypeDesign, Tags: []string{"a", "b"}, Projects: []string{"projects/obey"}},
+	}
+	got := FilterAdvanced(items, FilterOptions{
+		Types:      []string{"design"},
+		Tags:       []string{"a", "b"},
+		Projects:   []string{"projects/camp"},
+		ShowParked: true,
+	})
+	if len(got) != 1 || got[0].Title != "match" {
+		t.Fatalf("cross-dimension AND = %v, want only the item matching type, tags, and project", got)
+	}
+}
+
+func TestFilterAdvanced_NoFilterOptionsReturnsAllItems(t *testing.T) {
+	items := []WorkItem{
+		{Title: "a", Tags: []string{"x"}},
+		{Title: "b", Projects: []string{"projects/camp"}},
+	}
+	if got := FilterAdvanced(items, FilterOptions{}); len(got) != len(items) {
+		t.Fatalf("empty options should return all %d items, got %d", len(items), len(got))
+	}
+	if got := FilterAdvanced(items, FilterOptions{ShowParked: true}); len(got) != len(items) {
+		t.Fatalf("early-return guard should return all %d items, got %d", len(items), len(got))
+	}
+}

--- a/internal/workitem/frontmatter_stamp.go
+++ b/internal/workitem/frontmatter_stamp.go
@@ -1,0 +1,276 @@
+package workitem
+
+import (
+	"bytes"
+	"context"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+)
+
+// frontmatterIndent is the block indentation used for all frontmatter we write.
+// Two spaces is the near-universal markdown frontmatter convention (Hugo,
+// Obsidian, Jekyll), so encoding at this width preserves existing 2-space
+// foreign keys byte-for-byte through a yaml.Node round-trip; yaml's default of 4
+// would reflow them.
+const frontmatterIndent = 2
+
+// FrontmatterField is one camp-owned key to stamp into a document's frontmatter.
+// Exactly one of Value (scalar keys like id/type/ref) or Values (list keys like
+// tags/projects) is used; Values takes precedence when non-nil.
+type FrontmatterField struct {
+	After  string
+	Key    string
+	Value  string
+	Values []string
+}
+
+func (f FrontmatterField) node() *yaml.Node {
+	if f.Values != nil {
+		seq := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+		for _, v := range f.Values {
+			seq.Content = append(seq.Content, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: v})
+		}
+		return seq
+	}
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: f.Value}
+}
+
+// StampFrontmatterFields updates the kind:workitem-style frontmatter block of the
+// markdown file at path, inserting or replacing only the given camp-owned keys
+// and leaving the body and all foreign keys untouched. It holds a per-file lock
+// for the duration and writes atomically. The file must already have a
+// frontmatter block (--- at byte zero); callers prepend a block first for
+// no-frontmatter files.
+func StampFrontmatterFields(ctx context.Context, path string, fields []FrontmatterField) error {
+	release, err := fsutil.AcquireFileLock(ctx, path+".lock")
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return camperrors.Wrapf(err, "read %s", path)
+	}
+	block, body, ok := SplitFrontmatter(content)
+	if !ok {
+		return camperrors.NewValidation("frontmatter",
+			"no frontmatter block at the head of "+path, nil)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(block, &doc); err != nil {
+		return camperrors.Wrapf(err, "parse frontmatter %s", path)
+	}
+	for _, f := range fields {
+		if err := insertNodeAfter(&doc, f.After, f.Key, f.node()); err != nil {
+			return err
+		}
+	}
+	encoded, err := encodeFrontmatterNode(&doc)
+	if err != nil {
+		return camperrors.Wrapf(err, "encode frontmatter %s", path)
+	}
+	return fsutil.WriteFileAtomically(path, assembleFrontmatter(encoded, body), 0o644)
+}
+
+// MarshalMetadataFrontmatter renders meta as a frontmatter YAML block (no fences)
+// at the frontmatter indent width, for the no-existing-frontmatter and
+// create --file paths that prepend a full block.
+func MarshalMetadataFrontmatter(meta *Metadata) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(frontmatterIndent)
+	if err := enc.Encode(meta); err != nil {
+		return nil, camperrors.Wrap(err, "encode metadata frontmatter")
+	}
+	if err := enc.Close(); err != nil {
+		return nil, camperrors.Wrap(err, "close metadata frontmatter encoder")
+	}
+	return buf.Bytes(), nil
+}
+
+// FenceFrontmatter wraps an encoded frontmatter block in --- fences with a
+// trailing blank line, ready to prepend to a body.
+func FenceFrontmatter(block []byte) []byte {
+	out := make([]byte, 0, len(block)+len("---\n---\n\n"))
+	out = append(out, "---\n"...)
+	out = append(out, block...)
+	out = append(out, "---\n\n"...)
+	return out
+}
+
+// FrontmatterHasKey reports whether the frontmatter block of content declares a
+// top-level key. Used to decide the ambiguous tags-collision refusal and to
+// avoid clobbering a foreign title.
+func FrontmatterHasKey(content []byte, key string) bool {
+	block, _, ok := SplitFrontmatter(content)
+	if !ok {
+		return false
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(block, &doc); err != nil {
+		return false
+	}
+	root := mappingRoot(&doc)
+	if root == nil {
+		return false
+	}
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Kind == yaml.ScalarNode && root.Content[i].Value == key {
+			return true
+		}
+	}
+	return false
+}
+
+// FrontmatterSequenceStrings returns the string scalar values of a top-level
+// sequence key in content's frontmatter, plus the raw text of any entries that
+// are not plain string scalars (numbers, bools, nested nodes) and so cannot be
+// tags. A non-sequence value for the key is reported entirely as non-conforming.
+func FrontmatterSequenceStrings(content []byte, key string) (values, nonConforming []string) {
+	block, _, ok := SplitFrontmatter(content)
+	if !ok {
+		return nil, nil
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(block, &doc); err != nil {
+		return nil, nil
+	}
+	root := mappingRoot(&doc)
+	if root == nil {
+		return nil, nil
+	}
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Kind != yaml.ScalarNode || root.Content[i].Value != key {
+			continue
+		}
+		valNode := root.Content[i+1]
+		if valNode.Kind != yaml.SequenceNode {
+			if valNode.Value != "" {
+				nonConforming = append(nonConforming, valNode.Value)
+			}
+			return values, nonConforming
+		}
+		for _, e := range valNode.Content {
+			if e.Kind == yaml.ScalarNode && e.Tag == "!!str" {
+				values = append(values, e.Value)
+			} else if e.Value != "" {
+				nonConforming = append(nonConforming, e.Value)
+			}
+		}
+		return values, nonConforming
+	}
+	return nil, nil
+}
+
+// FrontmatterMinIndent returns the smallest positive leading-space indent among
+// the lines of content's frontmatter block, and whether any indented line
+// exists. A block whose nested content is not 2-space indented will be reflowed
+// to 2 spaces on re-encode, so callers warn when this is not 2.
+func FrontmatterMinIndent(content []byte) (width int, hasIndent bool) {
+	block, _, ok := SplitFrontmatter(content)
+	if !ok {
+		return 0, false
+	}
+	minIndent := -1
+	for _, line := range bytes.Split(block, []byte("\n")) {
+		trimmed := bytes.TrimLeft(line, " ")
+		if len(trimmed) == 0 {
+			continue
+		}
+		lead := len(line) - len(trimmed)
+		if lead == 0 {
+			continue
+		}
+		if minIndent < 0 || lead < minIndent {
+			minIndent = lead
+		}
+	}
+	if minIndent < 0 {
+		return 0, false
+	}
+	return minIndent, true
+}
+
+func encodeFrontmatterNode(node *yaml.Node) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(frontmatterIndent)
+	if err := enc.Encode(node); err != nil {
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func assembleFrontmatter(encodedBlock, body []byte) []byte {
+	out := make([]byte, 0, len(encodedBlock)+len(body)+len("---\n---\n"))
+	out = append(out, "---\n"...)
+	out = append(out, encodedBlock...)
+	out = append(out, "---\n"...)
+	out = append(out, body...)
+	return out
+}
+
+// SplitFrontmatter divides full file content into the raw YAML block and the
+// body that follows the closing delimiter line. ok is false when content does
+// not begin with --- at byte zero or has no closing delimiter.
+func SplitFrontmatter(content []byte) (block, body []byte, ok bool) {
+	var openLen int
+	switch {
+	case bytes.HasPrefix(content, []byte("---\n")):
+		openLen = len("---\n")
+	case bytes.HasPrefix(content, []byte("---\r\n")):
+		openLen = len("---\r\n")
+	default:
+		return nil, nil, false
+	}
+	rest := content[openLen:]
+	idx := bytes.Index(rest, []byte("\n---"))
+	if idx < 0 {
+		return nil, nil, false
+	}
+	block = rest[:idx]
+	closing := rest[idx+1:] // starts at the closing "---" line
+	if nl := bytes.IndexByte(closing, '\n'); nl >= 0 {
+		body = closing[nl+1:]
+	}
+	return block, body, true
+}
+
+// insertNodeAfter inserts {key: value} into the top-level mapping immediately
+// after the pair whose key equals `after`, or replaces the value in place when
+// key already exists, or appends when `after` is absent. Generalizes
+// insertScalarAfter (ref_backfill.go) to an arbitrary value node so list keys
+// (tags/projects) stamp the same way as scalars.
+func insertNodeAfter(doc *yaml.Node, after, key string, value *yaml.Node) error {
+	root := mappingRoot(doc)
+	if root == nil {
+		return camperrors.NewValidation("doc", "top-level YAML is not a mapping", nil)
+	}
+	insertAt := len(root.Content)
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		k := root.Content[i]
+		if k.Kind == yaml.ScalarNode && k.Value == key {
+			root.Content[i+1] = value
+			return nil
+		}
+		if k.Kind == yaml.ScalarNode && k.Value == after {
+			insertAt = i + 2
+		}
+	}
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
+	updated := make([]*yaml.Node, 0, len(root.Content)+2)
+	updated = append(updated, root.Content[:insertAt]...)
+	updated = append(updated, keyNode, value)
+	updated = append(updated, root.Content[insertAt:]...)
+	root.Content = updated
+	return nil
+}

--- a/internal/workitem/gather.go
+++ b/internal/workitem/gather.go
@@ -2,52 +2,17 @@ package workitem
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"time"
-
-	"gopkg.in/yaml.v3"
-
-	camperrors "github.com/Obedience-Corp/camp/internal/errors"
-	"github.com/Obedience-Corp/camp/internal/fsutil"
 )
 
-// RecordGather stamps gathered_into and gathered_at on the .workitem file of
-// a gathered source. relPath is the source's campaign-relative location after
-// the move into the gathered package. Existing keys are updated in place so
-// the operation is idempotent.
+// RecordGather stamps gathered_into and gathered_at on a gathered source: a
+// directory workitem's .workitem marker or a file workitem's frontmatter.
+// relPath is the source's campaign-relative location after the move into the
+// gathered package. Existing keys are updated in place so the operation is
+// idempotent.
 func RecordGather(ctx context.Context, root, relPath, gatheredInto string, at time.Time) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	abs := filepath.Join(root, filepath.FromSlash(relPath), MetadataFilename)
-
-	release, err := fsutil.AcquireFileLock(ctx, abs+".lock")
-	if err != nil {
-		return err
-	}
-	defer release()
-
-	raw, err := os.ReadFile(abs)
-	if err != nil {
-		return camperrors.Wrapf(err, "read %s", abs)
-	}
-
-	var doc yaml.Node
-	if err := yaml.Unmarshal(raw, &doc); err != nil {
-		return camperrors.Wrapf(err, "parse %s", abs)
-	}
-
-	if err := insertScalarAfter(&doc, "type", "gathered_into", gatheredInto); err != nil {
-		return err
-	}
-	if err := insertScalarAfter(&doc, "gathered_into", "gathered_at", at.UTC().Format(time.RFC3339)); err != nil {
-		return err
-	}
-
-	out, err := yaml.Marshal(&doc)
-	if err != nil {
-		return camperrors.Wrap(err, "marshal updated workitem")
-	}
-	return fsutil.WriteFileAtomically(abs, out, 0o644)
+	return recordLifecycleFields(ctx, root, relPath, []FrontmatterField{
+		{After: "type", Key: "gathered_into", Value: gatheredInto},
+		{After: "gathered_into", Key: "gathered_at", Value: at.UTC().Format(time.RFC3339)},
+	})
 }

--- a/internal/workitem/metadata.go
+++ b/internal/workitem/metadata.go
@@ -263,3 +263,10 @@ func ValidQuestID(s string) bool {
 func ValidTag(s string) bool {
 	return tagShape.MatchString(s)
 }
+
+// ValidateProjectPaths reports the first shape problem among project paths
+// (empty, absolute, escaping the campaign root, or duplicate), or nil. It is
+// the exported form of the loader's projects validation.
+func ValidateProjectPaths(paths []string) error {
+	return validateProjects(paths)
+}

--- a/internal/workitem/metadata.go
+++ b/internal/workitem/metadata.go
@@ -258,3 +258,8 @@ func ValidRef(s string) bool {
 func ValidQuestID(s string) bool {
 	return questIDShape.MatchString(s)
 }
+
+// ValidTag reports whether s is a well-formed tag (lowercase kebab-case).
+func ValidTag(s string) bool {
+	return tagShape.MatchString(s)
+}

--- a/internal/workitem/metadata.go
+++ b/internal/workitem/metadata.go
@@ -25,16 +25,15 @@ var (
 
 const MetadataFilename = ".workitem"
 
-const WorkitemSchemaVersion = "v1alpha7"
+const WorkitemSchemaVersion = "v1alpha8"
 
 const MetadataKind = "workitem"
 
 // acceptedWorkitemVersions are loadable .workitem schema versions. v1alpha4
-// through v1alpha6 are accepted for backward compatibility; v1alpha7 is the
-// current write version (GatheredInto/GatheredAt fields); v1alpha8 adds the
-// Tags and Projects fields and is loadable ahead of the writer release, per the
-// two-phase rollout. validateMetadata additionally accepts unknown future
-// v1alphaN via the forward-compat rule.
+// through v1alpha7 are accepted for backward compatibility (v1alpha7 added the
+// GatheredInto/GatheredAt fields); v1alpha8 is the current write version and
+// adds the Tags and Projects fields. validateMetadata additionally accepts
+// unknown future v1alphaN via the forward-compat rule.
 var acceptedWorkitemVersions = map[string]bool{
 	"v1alpha4": true,
 	"v1alpha5": true,

--- a/internal/workitem/metadata_test.go
+++ b/internal/workitem/metadata_test.go
@@ -386,6 +386,32 @@ func TestValidateMetadata_TagsProjects(t *testing.T) {
 	}
 }
 
+func TestValidateProjectPaths_DelegatesToLoaderCheck(t *testing.T) {
+	if err := ValidateProjectPaths([]string{"projects/camp", "projects/fest"}); err != nil {
+		t.Fatalf("well-formed project paths should be accepted: %v", err)
+	}
+	if err := ValidateProjectPaths(nil); err != nil {
+		t.Fatalf("empty list should be accepted: %v", err)
+	}
+	for _, bad := range [][]string{
+		{"../outside"},
+		{"/etc/passwd"},
+		{"projects/camp", "projects/camp"},
+	} {
+		err := ValidateProjectPaths(bad)
+		if err == nil {
+			t.Fatalf("ValidateProjectPaths(%v) should reject, got nil", bad)
+		}
+		var verr *camperrors.ValidationError
+		if !errors.As(err, &verr) {
+			t.Fatalf("expected ValidationError for %v, got %T: %v", bad, err, err)
+		}
+		if verr.Field != "projects" {
+			t.Errorf("Field = %q, want projects for %v", verr.Field, bad)
+		}
+	}
+}
+
 func TestLoadMetadata_V1Alpha7MarkerUnaffectedByReaderChanges(t *testing.T) {
 	body := `version: v1alpha7
 kind: workitem

--- a/internal/workitem/metadata_test.go
+++ b/internal/workitem/metadata_test.go
@@ -116,7 +116,7 @@ id: x
 type: design
 title: T
 `,
-			wantSubstr: "v1alpha7",
+			wantSubstr: WorkitemSchemaVersion,
 		},
 		{
 			name: "wrong kind",

--- a/internal/workitem/promotion.go
+++ b/internal/workitem/promotion.go
@@ -13,8 +13,30 @@ import (
 )
 
 func RecordPromotion(ctx context.Context, root, relPath, promotedTo string, at time.Time) error {
-	abs := filepath.Join(root, filepath.FromSlash(relPath), MetadataFilename)
+	return recordLifecycleFields(ctx, root, relPath, []FrontmatterField{
+		{After: "type", Key: "promoted_to", Value: promotedTo},
+		{After: "promoted_to", Key: "promoted_at", Value: at.UTC().Format(time.RFC3339)},
+	})
+}
 
+// recordLifecycleFields stamps scalar lifecycle keys onto a workitem, choosing
+// the right surface by shape: a directory workitem's .workitem marker, or a file
+// workitem's own frontmatter. Existing keys are updated in place so the
+// operation is idempotent. Both paths hold a per-file lock and write atomically.
+func recordLifecycleFields(ctx context.Context, root, relPath string, fields []FrontmatterField) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	target := filepath.Join(root, filepath.FromSlash(relPath))
+	info, err := os.Stat(target)
+	if err != nil {
+		return camperrors.Wrapf(err, "stat %s", relPath)
+	}
+	if !info.IsDir() {
+		return StampFrontmatterFields(ctx, target, fields)
+	}
+
+	abs := filepath.Join(target, MetadataFilename)
 	release, err := fsutil.AcquireFileLock(ctx, abs+".lock")
 	if err != nil {
 		return err
@@ -25,19 +47,15 @@ func RecordPromotion(ctx context.Context, root, relPath, promotedTo string, at t
 	if err != nil {
 		return camperrors.Wrapf(err, "read %s", abs)
 	}
-
 	var doc yaml.Node
 	if err := yaml.Unmarshal(raw, &doc); err != nil {
 		return camperrors.Wrapf(err, "parse %s", abs)
 	}
-
-	if err := insertScalarAfter(&doc, "type", "promoted_to", promotedTo); err != nil {
-		return err
+	for _, f := range fields {
+		if err := insertScalarAfter(&doc, f.After, f.Key, f.Value); err != nil {
+			return err
+		}
 	}
-	if err := insertScalarAfter(&doc, "promoted_to", "promoted_at", at.UTC().Format(time.RFC3339)); err != nil {
-		return err
-	}
-
 	out, err := yaml.Marshal(&doc)
 	if err != nil {
 		return camperrors.Wrap(err, "marshal updated workitem")

--- a/internal/workitem/testdata/workitem_full.yaml
+++ b/internal/workitem/testdata/workitem_full.yaml
@@ -1,4 +1,4 @@
-version: v1alpha7
+version: v1alpha8
 kind: workitem
 
 id: design-thin-start-workflow-ladder-2026-04-25

--- a/internal/workitem/timestamps.go
+++ b/internal/workitem/timestamps.go
@@ -47,6 +47,18 @@ func ScanDirTimestamps(ctx context.Context, dir string) (earliest, latest time.T
 	return earliest, latest
 }
 
+// ScanFileTimestamps returns a single file's mtime as both created and updated,
+// the file-shaped analog of ScanDirTimestamps for document workitems (a single
+// markdown file rather than a directory tree). Returns zero times if the file
+// cannot be stat'd.
+func ScanFileTimestamps(ctx context.Context, path string) (created, updated time.Time) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return time.Time{}, time.Time{}
+	}
+	return info.ModTime(), info.ModTime()
+}
+
 // listTrackedFiles returns tracked + untracked-but-not-ignored files under dir.
 // Falls back to filepath.WalkDir if git is unavailable.
 func listTrackedFiles(ctx context.Context, dir string) ([]string, error) {

--- a/tests/integration/adopt_file_test.go
+++ b/tests/integration/adopt_file_test.go
@@ -1,0 +1,168 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_AdoptFileNoFrontmatterPreservesBody(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/adopt-file-nofm"
+	_, err := tc.InitCampaign(dir, "adopt-file-nofm", "product")
+	require.NoError(t, err)
+
+	orig := "# My Notes\n\nSome body text.\nLine two.\n"
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/notes.md", orig))
+
+	_, err = tc.RunCampInDir(dir, "workitem", "adopt", "--file", "workflow/design/notes.md", "--type", "design", "--title", "My Notes")
+	require.NoError(t, err)
+
+	result, err := tc.ReadFile(dir + "/workflow/design/notes.md")
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(result, "---\nversion: v1alpha8\nkind: workitem\n"),
+		"a valid frontmatter block must be prepended:\n%s", result)
+	assert.True(t, strings.HasSuffix(result, orig),
+		"the original body must be preserved byte-for-byte at the tail:\n%s", result)
+}
+
+func TestIntegration_AdoptFilePreservesForeignKeys(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/adopt-file-foreign"
+	_, err := tc.InitCampaign(dir, "adopt-file-foreign", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/hugo.md",
+		"---\ntitle: Launch checklist\ndate: 2026-01-02\ndraft: true\naliases: [launch-todo]\n---\n\n- [ ] cut rc\n"))
+
+	_, err = tc.RunCampInDir(dir, "workitem", "adopt", "--file", "workflow/design/hugo.md", "--type", "design")
+	require.NoError(t, err)
+
+	result, err := tc.ReadFile(dir + "/workflow/design/hugo.md")
+	require.NoError(t, err)
+	assert.Contains(t, result, "title: Launch checklist", "foreign title preserved")
+	assert.Contains(t, result, "date: 2026-01-02", "foreign date preserved")
+	assert.Contains(t, result, "draft: true", "foreign bool preserved untyped")
+	assert.Contains(t, result, "aliases: [launch-todo]", "foreign flow sequence preserved")
+	assert.Contains(t, result, "kind: workitem", "camp keys merged in")
+	assert.True(t, strings.HasSuffix(result, "\n- [ ] cut rc\n"), "body preserved")
+}
+
+func TestIntegration_AdoptFileForeignTagsRefusesWithoutForce(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/adopt-file-tags"
+	_, err := tc.InitCampaign(dir, "adopt-file-tags", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/tagged.md",
+		"---\ntitle: Tagged\ntags: [personal, blog]\n---\n\nbody\n"))
+
+	out, err := tc.RunCampInDir(dir, "workitem", "adopt", "--file", "workflow/design/tagged.md", "--type", "design")
+	require.Error(t, err, "a foreign tags: key must refuse without --force: %s", out)
+	assert.Contains(t, out, "--force", "the error must tell the user how to proceed")
+
+	_, err = tc.RunCampInDir(dir, "workitem", "adopt", "--file", "workflow/design/tagged.md", "--type", "design", "--force", "--tag", "campy")
+	require.NoError(t, err, "--force must allow the stamp")
+	result, err := tc.ReadFile(dir + "/workflow/design/tagged.md")
+	require.NoError(t, err)
+	assert.Contains(t, result, "kind: workitem", "camp keys added with --force")
+	assert.Contains(t, result, "personal", "--force unions conforming foreign tags (no silent data loss)")
+	assert.Contains(t, result, "blog", "--force unions conforming foreign tags (no silent data loss)")
+	assert.Contains(t, result, "campy", "--force adds the new --tag values to the union")
+}
+
+func TestIntegration_AdoptFileForeignTagsDropsNonConforming(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/adopt-file-tags-nc"
+	_, err := tc.InitCampaign(dir, "adopt-file-tags-nc", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/mixed.md",
+		"---\ntitle: Mixed\ntags: [personal, 42]\n---\n\nbody\n"))
+
+	out, err := tc.RunCampInDir(dir, "workitem", "adopt", "--file", "workflow/design/mixed.md", "--type", "design", "--force")
+	require.NoError(t, err, "--force must succeed: %s", out)
+	assert.Contains(t, out, "42", "a non-conforming foreign tag value must be reported as dropped")
+	assert.Contains(t, out, "dropped", "the drop notice must be explicit")
+
+	result, err := tc.ReadFile(dir + "/workflow/design/mixed.md")
+	require.NoError(t, err)
+	assert.Contains(t, result, "personal", "a conforming foreign tag survives")
+	assert.NotContains(t, result, "- 42", "a non-conforming int must not be written as a tag")
+}
+
+func TestIntegration_AdoptFileReflowWarning(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/adopt-file-reflow"
+	_, err := tc.InitCampaign(dir, "adopt-file-reflow", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/four.md",
+		"---\ntitle: Four\nnested:\n    a: 1\n    b: 2\n---\n\nbody\n"))
+	out, err := tc.RunCampInDir(dir, "workitem", "adopt", "--file", "workflow/design/four.md", "--type", "design")
+	require.NoError(t, err, "%s", out)
+	assert.Contains(t, out, "4-space indentation", "a non-2-space block must warn about the reflow")
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/two.md",
+		"---\ntitle: Two\nnested:\n  a: 1\n---\n\nbody\n"))
+	out, err = tc.RunCampInDir(dir, "workitem", "adopt", "--file", "workflow/design/two.md", "--type", "design")
+	require.NoError(t, err, "%s", out)
+	assert.NotContains(t, out, "indentation", "a 2-space block must not warn")
+}
+
+func TestIntegration_AdoptFileIdentityConflict(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/adopt-file-conflict"
+	_, err := tc.InitCampaign(dir, "adopt-file-conflict", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/wi.md",
+		"---\nversion: v1alpha8\nkind: workitem\nid: design-wi-2026-07-19\ntype: design\ntitle: WI\nref: WI-abc123\n---\n\n# WI\n"))
+
+	out, err := tc.RunCampInDir(dir, "workitem", "adopt", "--file", "workflow/design/wi.md", "--type", "design", "--id", "design-other-2026-07-19")
+	require.Error(t, err, "a conflicting --id must refuse: %s", out)
+	assert.Contains(t, out, "design-wi-2026-07-19", "the error must name the existing id")
+
+	_, err = tc.RunCampInDir(dir, "workitem", "adopt", "--file", "workflow/design/wi.md", "--type", "design")
+	require.NoError(t, err, "re-adopting with no --id override must succeed as an update")
+}
+
+func TestIntegration_AdoptFileDeterministic(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/adopt-file-determ"
+	_, err := tc.InitCampaign(dir, "adopt-file-determ", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/det.md",
+		"---\ntitle: Det\ndraft: false\n---\n\nbody line\n"))
+
+	_, err = tc.RunCampInDir(dir, "workitem", "adopt", "--file", "workflow/design/det.md", "--type", "design", "--tag", "a", "--tag", "b")
+	require.NoError(t, err)
+	run1, err := tc.ReadFile(dir + "/workflow/design/det.md")
+	require.NoError(t, err)
+
+	_, err = tc.RunCampInDir(dir, "workitem", "adopt", "--file", "workflow/design/det.md", "--type", "design", "--tag", "a", "--tag", "b")
+	require.NoError(t, err)
+	run2, err := tc.ReadFile(dir + "/workflow/design/det.md")
+	require.NoError(t, err)
+
+	assert.Equal(t, run1, run2, "re-running adopt --file with identical flags must be byte-identical (diff-clean)")
+}
+
+func TestIntegration_CreateFileRefusesExisting(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/create-file-exists"
+	_, err := tc.InitCampaign(dir, "create-file-exists", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/taken.md", "# already here\n"))
+
+	out, err := tc.RunCampInDir(dir, "workitem", "create", "--file", "workflow/design/taken.md", "--type", "design", "--title", "Taken")
+	require.Error(t, err, "create --file on an existing path must refuse: %s", out)
+	assert.Contains(t, out, "already exists", "the error must explain the existing-target guard")
+}

--- a/tests/integration/file_lifecycle_test.go
+++ b/tests/integration/file_lifecycle_test.go
@@ -1,0 +1,151 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createFileWorkitem(t *testing.T, tc *TestContainer, campaign, wfType, slug, id, ref string) {
+	t.Helper()
+	content := "---\nversion: v1alpha8\nkind: workitem\nid: " + id +
+		"\ntype: " + wfType + "\ntitle: " + slug +
+		"\nref: " + ref + "\n---\n\n# " + slug + "\n\nBody paragraph so promote is not empty.\n"
+	require.NoError(t, tc.WriteFile(campaign+"/workflow/"+wfType+"/"+slug+".md", content))
+}
+
+func findOneFile(tc *TestContainer, root, name string) (string, bool) {
+	out, _, _ := tc.ExecCommand("find", root, "-name", name, "-type", "f", "-print", "-quit")
+	p := strings.TrimSpace(out)
+	return p, p != ""
+}
+
+func TestIntegration_FileDungeonStatuses(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaign := setupDungeonCampaign(t, tc, "file-dungeon")
+
+	statuses := []string{"completed", "archived", "someday"}
+	refs := map[string]string{"completed": "WI-c00001", "archived": "WI-a00002", "someday": "WI-500003"}
+	for _, status := range statuses {
+		id := "note-" + status + "file-2026-07-19"
+		createFileWorkitem(t, tc, campaign, "design", status+"file", id, refs[status])
+	}
+	tc.GitOutput(t, campaign, "add", "-A")
+	tc.GitOutput(t, campaign, "commit", "-m", "seed file workitems")
+
+	for _, status := range statuses {
+		id := "note-" + status + "file-2026-07-19"
+		out, err := tc.RunCampInDir(campaign, "workitem", "promote", id, "--target", status)
+		require.NoError(t, err, "promote %s to %s: %s", id, status, out)
+
+		stillActive, err := tc.CheckFileExists(campaign + "/workflow/design/" + status + "file.md")
+		require.NoError(t, err)
+		assert.False(t, stillActive, "%sfile.md must leave the active location", status)
+
+		found, err := checkDatedDungeonStatusItemExists(tc, campaign+"/workflow/design/dungeon/"+status, status+"file.md")
+		require.NoError(t, err)
+		assert.True(t, found, "%sfile.md must land under dungeon/%s by the dated convention", status, status)
+	}
+
+	// Dungeoned files are excluded from active discovery.
+	listOut, err := tc.RunCampInDir(campaign, "workitem", "list", "--json")
+	require.NoError(t, err)
+	for _, status := range statuses {
+		assert.NotContains(t, listOut, "note-"+status+"file-2026-07-19",
+			"a dungeoned file must be excluded from active discovery")
+	}
+}
+
+func TestIntegration_FilePromoteToDoc(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaign := setupDungeonCampaign(t, tc, "file-promote-doc")
+
+	createFileWorkitem(t, tc, campaign, "design", "docme", "note-docme-2026-07-19", "WI-dc0001")
+	tc.GitOutput(t, campaign, "add", "-A")
+	tc.GitOutput(t, campaign, "commit", "-m", "seed file workitem")
+
+	out, err := tc.RunCampInDir(campaign, "workitem", "promote", "note-docme-2026-07-19", "--target", "doc")
+	require.NoError(t, err, "promote to doc: %s", out)
+
+	// Copied to docs/<slug>/<file>.md, not an empty docs/<slug>/ directory.
+	copied, err := tc.CheckFileExists(campaign + "/docs/docme/docme.md")
+	require.NoError(t, err)
+	assert.True(t, copied, "the file must be copied to docs/docme/docme.md")
+
+	// Source left the active location (shelved to dungeon/completed).
+	stillActive, err := tc.CheckFileExists(campaign + "/workflow/design/docme.md")
+	require.NoError(t, err)
+	assert.False(t, stillActive, "the source must be shelved out of the active location")
+
+	// The shelved source carries the promotion stamp with its body intact.
+	shelved, ok := findOneFile(tc, campaign+"/workflow/design/dungeon/completed", "docme.md")
+	require.True(t, ok, "the shelved source file must exist under dungeon/completed")
+	content, err := tc.ReadFile(shelved)
+	require.NoError(t, err)
+	assert.Contains(t, content, "promoted_to: docs/docme", "promoted_to must be stamped in frontmatter")
+	assert.Contains(t, content, "promoted_at:", "promoted_at must be stamped in frontmatter")
+	assert.Contains(t, content, "Body paragraph", "the body must be preserved")
+}
+
+func TestIntegration_FilePromoteToFestival(t *testing.T) {
+	if !festAvailable {
+		t.Skip("fest CLI not available in container")
+	}
+	tc := GetSharedContainer(t)
+	campaign := setupDungeonCampaign(t, tc, "file-promote-festival")
+	_, _, err := tc.ExecCommand("sh", "-c",
+		"mkdir -p "+campaign+"/festivals/.festival/templates "+campaign+"/festivals/.festival/.state "+campaign+"/festivals/planning")
+	require.NoError(t, err)
+
+	createFileWorkitem(t, tc, campaign, "design", "festme", "note-festme-2026-07-19", "WI-fe0001")
+	tc.GitOutput(t, campaign, "add", "-A")
+	tc.GitOutput(t, campaign, "commit", "-m", "seed file workitem")
+
+	out, err := tc.RunCampInDir(campaign, "workitem", "promote", "note-festme-2026-07-19", "--target", "festival")
+	require.NoError(t, err, "promote to festival: %s", out)
+
+	// The festival ingest receives just the file (input_specs/<slug>/<file>.md),
+	// not an empty directory tree.
+	ingested, ok := findOneFile(tc, campaign+"/festivals", "festme.md")
+	require.True(t, ok, "the file must be copied into the festival ingest")
+	assert.Contains(t, ingested, "input_specs", "the copy must land under 001_INGEST/input_specs")
+}
+
+func TestIntegration_GatherMixedDirAndFile(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campaign := "/campaigns/gather-mixed"
+	_, err := tc.InitCampaign(campaign, "gather-mixed", "product")
+	require.NoError(t, err)
+
+	// One directory-shaped source and one file-shaped source.
+	createDesignWorkitem(t, tc, campaign, "dir-src", "Dir Src", "# Dir Src\n\nA directory design.\n")
+	createFileWorkitem(t, tc, campaign, "design", "file-src", "note-file-src-2026-07-19", "WI-fa0001")
+	tc.GitOutput(t, campaign, "add", "-A")
+	tc.GitOutput(t, campaign, "commit", "-m", "seed mixed sources")
+
+	out, err := tc.RunCampInDir(campaign, "gather", "design", "dir-src", "note-file-src-2026-07-19", "--title", "Mixed Pkg")
+	require.NoError(t, err, "gather mixed: %s", out)
+
+	// The file source's frontmatter is stamped with gathered_into, like a
+	// directory source's .workitem marker.
+	movedFile, ok := findOneFile(tc, campaign+"/workflow/design/mixed-pkg", "file-src.md")
+	require.True(t, ok, "the file source must move into the gathered package")
+	fileContent, err := tc.ReadFile(movedFile)
+	require.NoError(t, err)
+	assert.Contains(t, fileContent, "gathered_into: ", "the file source frontmatter must be stamped")
+	assert.Contains(t, fileContent, "gathered_at:", "the file source frontmatter must be stamped")
+
+	dirMarker, err := tc.ReadFile(campaign + "/workflow/design/mixed-pkg/dir-src/.workitem")
+	require.NoError(t, err)
+	assert.Contains(t, dirMarker, "gathered_into: ", "the directory source marker must be stamped identically")
+
+	readme, err := tc.ReadFile(campaign + "/workflow/design/mixed-pkg/README.md")
+	require.NoError(t, err)
+	assert.Contains(t, readme, "Dir Src", "the README must reference the directory source")
+	assert.Contains(t, readme, "file-src", "the README must reference the file source")
+}

--- a/tests/integration/frontmatter_discovery_test.go
+++ b/tests/integration/frontmatter_discovery_test.go
@@ -1,0 +1,205 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fmListItem struct {
+	ItemKind     string `json:"item_kind"`
+	WorkflowType string `json:"workflow_type"`
+	RelativePath string `json:"relative_path"`
+	StableID     string `json:"stable_id"`
+}
+
+func fmListItems(t *testing.T, tc *TestContainer, dir string) []fmListItem {
+	t.Helper()
+	out, err := tc.RunCampInDir(dir, "workitem", "list", "--json")
+	require.NoError(t, err, "list --json: %s", out)
+	start := strings.Index(out, "{")
+	require.GreaterOrEqual(t, start, 0, "no JSON in: %s", out)
+	var payload struct {
+		Items []fmListItem `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out[start:]), &payload))
+	return payload.Items
+}
+
+func fmItemByPath(items []fmListItem, relPath string) (fmListItem, bool) {
+	for _, i := range items {
+		if i.RelativePath == relPath {
+			return i, true
+		}
+	}
+	return fmListItem{}, false
+}
+
+func fmDoc(id, typ, title, ref string) string {
+	return "---\nversion: v1alpha8\nkind: workitem\nid: " + id +
+		"\ntype: " + typ + "\ntitle: " + title + "\nref: " + ref + "\n---\n\n# " + title + "\n"
+}
+
+func fmMarker(id, typ, ref string) string {
+	return "version: v1alpha8\nkind: workitem\nid: " + id + "\ntype: " + typ + "\ntitle: " + id + "\nref: " + ref + "\n"
+}
+
+func fmValidateFindings(t *testing.T, tc *TestContainer, dir string) (codes map[string]string, nonZero bool) {
+	t.Helper()
+	out, err := tc.RunCampInDir(dir, "workitem", "validate", "--json")
+	nonZero = err != nil
+	start := strings.Index(out, "{")
+	require.GreaterOrEqual(t, start, 0, "no JSON in validate output: %s", out)
+	var payload struct {
+		Findings []struct {
+			Code     string `json:"code"`
+			Severity string `json:"severity"`
+			Target   string `json:"target"`
+		} `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out[start:]), &payload))
+	codes = make(map[string]string)
+	for _, f := range payload.Findings {
+		codes[f.Code+"|"+f.Target] = f.Severity
+	}
+	return codes, nonZero
+}
+
+func TestIntegration_FrontmatterDiscoveryAndCollision(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/fm-collision"
+	_, err := tc.InitCampaign(dir, "fm-collision", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/notes/doc.md", fmDoc("note-doc-2026-07-19", "chore", "Doc", "WI-aaaaaa")))
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/pkg/.workitem", fmMarker("design-pkg-2026-07-19", "design", "WI-bbbbbb")))
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/pkg/child.md", fmDoc("note-child-2026-07-19", "design", "Child", "WI-cccccc")))
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/pkg/sub/deep.md", fmDoc("note-deep-2026-07-19", "design", "Deep", "WI-dddddd")))
+	// sibling of the marker dir, no marker of its own: hasMarkerAncestor ascends
+	// only, so this file must still be discovered.
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/other/note.md", fmDoc("note-sibling-2026-07-19", "design", "Sibling", "WI-eeeeee")))
+
+	items := fmListItems(t, tc, dir)
+
+	doc, ok := fmItemByPath(items, "workflow/notes/doc.md")
+	require.True(t, ok, "standalone frontmatter doc must be discovered")
+	assert.Equal(t, "file", doc.ItemKind)
+
+	_, childFound := fmItemByPath(items, "workflow/design/pkg/child.md")
+	assert.False(t, childFound, "collision: immediate child of a marker dir must not be discovered")
+
+	_, deepFound := fmItemByPath(items, "workflow/design/pkg/sub/deep.md")
+	assert.False(t, deepFound, "collision: a file two levels below a marker-bearing ancestor must not be discovered")
+
+	sib, sibFound := fmItemByPath(items, "workflow/design/other/note.md")
+	assert.True(t, sibFound, "a file in a sibling directory of a marker dir must still be discovered (ascent-only)")
+	assert.Equal(t, "file", sib.ItemKind)
+}
+
+func TestIntegration_ForwardCompatMarkerIsWarningExitZero(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/fm-forward-compat"
+	_, err := tc.InitCampaign(dir, "fm-forward-compat", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/future/.workitem",
+		"version: v1alpha99\nkind: workitem\nid: design-future-2026-07-19\ntype: design\ntitle: Future\nref: WI-dddddd\n"))
+
+	codes, nonZero := fmValidateFindings(t, tc, dir)
+	assert.False(t, nonZero, "a forward-compat marker alone must not fail validate")
+	assert.Equal(t, "warning", codes["workitem.schema.forward-compat|workflow/design/future"],
+		"forward-compat marker must produce a warning, not a malformed error")
+	assert.NotContains(t, codes, "workitem.marker.malformed|workflow/design/future",
+		"forward-compat marker must not be reported as malformed")
+}
+
+func TestIntegration_FrontmatterRefPending(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/fm-ref-pending"
+	_, err := tc.InitCampaign(dir, "fm-ref-pending", "product")
+	require.NoError(t, err)
+
+	// directory marker with no ref; nested frontmatter shares the id and adds a ref
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/refpend/.workitem",
+		"version: v1alpha8\nkind: workitem\nid: design-refpend-2026-07-19\ntype: design\ntitle: RefPend\n"))
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/refpend/sub/note.md",
+		fmDoc("design-refpend-2026-07-19", "design", "Note", "WI-aaaaaa")))
+
+	codes, nonZero := fmValidateFindings(t, tc, dir)
+	assert.False(t, nonZero, "a pending ref alone must not fail validate")
+	assert.Equal(t, "warning", codes["workitem.identity.ref-pending|workflow/design/refpend"],
+		"same id with only one side's ref set must warn, not hard-conflict")
+	assert.NotContains(t, codes, "workitem.identity.conflict|workflow/design/refpend",
+		"a pending ref must not be reported as a hard conflict")
+}
+
+func TestIntegration_FrontmatterTypeAuthority(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/fm-type-authority"
+	_, err := tc.InitCampaign(dir, "fm-type-authority", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/forced.md", fmDoc("note-forced-2026-07-19", "feature", "Forced", "WI-aaaaaa")))
+	require.NoError(t, tc.WriteFile(dir+"/workflow/feature/free.md", fmDoc("note-free-2026-07-19", "feature", "Free", "WI-bbbbbb")))
+
+	items := fmListItems(t, tc, dir)
+
+	forced, ok := fmItemByPath(items, "workflow/design/forced.md")
+	require.True(t, ok, "frontmatter doc under design/ must be discovered")
+	assert.Equal(t, "design", forced.WorkflowType, "path type forces design over the frontmatter's feature type")
+
+	free, ok := fmItemByPath(items, "workflow/feature/free.md")
+	require.True(t, ok, "frontmatter doc outside path-typed trees must be discovered")
+	assert.Equal(t, "feature", free.WorkflowType, "outside path-typed trees the frontmatter type is authoritative")
+}
+
+func TestIntegration_FrontmatterShortCircuit(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/fm-shortcircuit"
+	_, err := tc.InitCampaign(dir, "fm-shortcircuit", "product")
+	require.NoError(t, err)
+
+	// Leading --- but the block is invalid YAML and lacks kind: workitem, so the
+	// kind pre-check short-circuits before yaml.Unmarshal: list succeeds and the
+	// file is not discovered.
+	require.NoError(t, tc.WriteFile(dir+"/workflow/notes/bad.md", "---\nnot: [valid: yaml\ntitle: whatever\n---\n\n# Bad\n"))
+
+	items := fmListItems(t, tc, dir)
+	_, found := fmItemByPath(items, "workflow/notes/bad.md")
+	assert.False(t, found, "a file without kind: workitem frontmatter must not be discovered")
+}
+
+func TestIntegration_FrontmatterIdentityConflict(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/fm-conflict"
+	_, err := tc.InitCampaign(dir, "fm-conflict", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/dir/.workitem", fmMarker("design-dir-2026-07-19", "design", "WI-aaaaaa")))
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/dir/sub/nested.md", fmDoc("note-other-2026-07-19", "design", "Nested", "WI-bbbbbb")))
+
+	codes, nonZero := fmValidateFindings(t, tc, dir)
+	assert.True(t, nonZero, "validate must exit non-zero on an identity conflict")
+	assert.Equal(t, "error", codes["workitem.identity.conflict|workflow/design/dir"],
+		"expected an error-severity identity conflict on the directory")
+}
+
+func TestIntegration_FrontmatterTypeMismatchValidate(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/fm-type-mismatch"
+	_, err := tc.InitCampaign(dir, "fm-type-mismatch", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/mismatch.md", fmDoc("note-mm-2026-07-19", "feature", "Mismatch", "WI-aaaaaa")))
+
+	codes, nonZero := fmValidateFindings(t, tc, dir)
+	assert.True(t, nonZero, "validate must exit non-zero on a frontmatter type mismatch")
+	assert.Equal(t, "error", codes["workitem.type.mismatch|workflow/design/mismatch.md"],
+		"expected a type mismatch on the frontmatter file under a path-typed tree")
+}

--- a/tests/integration/gather_explore_test.go
+++ b/tests/integration/gather_explore_test.go
@@ -74,7 +74,7 @@ func TestGatherExplore_MovesSourcesIntoGatheredPackage(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, marker, "gathered_into: "+result.Gathered.ID)
 	assert.Contains(t, marker, "gathered_at:")
-	assert.Contains(t, marker, "version: v1alpha7")
+	assert.Contains(t, marker, "version: v1alpha8")
 
 	listOutput, err := tc.RunCampInDir(campaign, "workitem", "--json", "--type", "explore")
 	require.NoError(t, err)

--- a/tests/integration/gather_workitem_test.go
+++ b/tests/integration/gather_workitem_test.go
@@ -89,6 +89,11 @@ func TestGatherDesign_MovesSourcesIntoGatheredPackage(t *testing.T) {
 	assert.Contains(t, marker, "gathered_into: "+result.Gathered.ID)
 	assert.Contains(t, marker, "gathered_at:")
 
+	// The gathered package's own marker is stamped with the current schema version.
+	pkgMarker, err := tc.ReadFile(campaign + "/workflow/design/unified-auth/.workitem")
+	require.NoError(t, err)
+	assert.Contains(t, pkgMarker, "version: v1alpha8")
+
 	// Discovery lists the gathered package but not the moved sources.
 	listOutput, err := tc.RunCampInDir(campaign, "workitem", "--json", "--type", "design")
 	require.NoError(t, err)

--- a/tests/integration/workitem_create_test.go
+++ b/tests/integration/workitem_create_test.go
@@ -65,7 +65,7 @@ func TestIntegration_WorkitemCreateAndAdopt(t *testing.T) {
 
 		manifest, err := tc.ReadFile(campaignDir + "/workflow/feature/demo-feature/.workitem")
 		require.NoError(t, err)
-		assert.Contains(t, manifest, "version: v1alpha7")
+		assert.Contains(t, manifest, "version: v1alpha8")
 		assert.Contains(t, manifest, "kind: workitem")
 		assert.Contains(t, manifest, "type: feature")
 		assert.Contains(t, manifest, "title: Demo")
@@ -97,6 +97,7 @@ func TestIntegration_WorkitemCreateAndAdopt(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, manifest, "type: incident")
 		assert.Contains(t, manifest, "title: P99 spike")
+		assert.Contains(t, manifest, "version: v1alpha8")
 	})
 
 	t.Run("AdoptRefusesAlreadyAdopted", func(t *testing.T) {
@@ -223,7 +224,7 @@ func TestIntegration_WorkitemCreateJSON(t *testing.T) {
 	assert.Equal(t, "Agent JSON", payload.Workitem.Title)
 	assert.Empty(t, payload.Workitem.QuestID)
 	assert.Equal(t, "workflow/feature/agent-json", payload.Workitem.RelativePath)
-	assert.Equal(t, "v1alpha7", payload.Workitem.MarkerVersion)
+	assert.Equal(t, "v1alpha8", payload.Workitem.MarkerVersion)
 	// feature/bug/chore: no agent-executable scaffold command
 	assert.Empty(t, payload.Next.Command,
 		"non-explore/design types must not ship unconditional fest create workflow")

--- a/tests/integration/workitem_list_filter_test.go
+++ b/tests/integration/workitem_list_filter_test.go
@@ -50,3 +50,47 @@ func TestIntegration_WorkitemListFiltersNonTTYAndJSON(t *testing.T) {
 	require.NoError(t, err, "legacy --list: %s", legacy)
 	assert.Contains(t, legacy, "Auth Design")
 }
+
+func TestIntegration_WorkitemListTagAndProjectFilters(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/workitem-list-tag-project"
+	_, err := tc.InitCampaign(dir, "workitem-list-tag-project", "product")
+	require.NoError(t, err)
+
+	_, err = tc.RunCampInDir(dir, "workitem", "create", "tagboth", "--type", "design",
+		"--title", "TagBoth", "--tag", "public-launch", "--tag", "schema")
+	require.NoError(t, err)
+	_, err = tc.RunCampInDir(dir, "workitem", "create", "tagone", "--type", "design",
+		"--title", "TagOne", "--tag", "public-launch")
+	require.NoError(t, err)
+	_, err = tc.RunCampInDir(dir, "workitem", "create", "projcamp", "--type", "design",
+		"--title", "ProjCamp", "--project", "projects/camp")
+	require.NoError(t, err)
+	_, err = tc.RunCampInDir(dir, "workitem", "create", "projfest", "--type", "design",
+		"--title", "ProjFest", "--project", "projects/fest")
+	require.NoError(t, err)
+
+	andText, err := tc.RunCampInDir(dir, "workitem", "list", "--tag", "public-launch", "--tag", "schema")
+	require.NoError(t, err, "tag AND list: %s", andText)
+	assert.Contains(t, andText, "TagBoth", "item carrying both tags must be listed")
+	assert.NotContains(t, andText, "TagOne", "--tag is AND: an item missing one named tag must be excluded")
+	assert.NotContains(t, andText, "ProjCamp", "an untagged item must be excluded by a tag filter")
+
+	orText, err := tc.RunCampInDir(dir, "workitem", "list", "--project", "projects/camp", "--project", "projects/fest")
+	require.NoError(t, err, "project OR list: %s", orText)
+	assert.Contains(t, orText, "ProjCamp", "--project is OR: an item touching either project must be listed")
+	assert.Contains(t, orText, "ProjFest", "--project is OR: an item touching either project must be listed")
+	assert.NotContains(t, orText, "TagBoth", "an item touching neither project must be excluded")
+
+	parityTag, err := tc.RunCampInDir(dir, "workitem", "list", "--tag", "Public-Launch")
+	require.NoError(t, err, "unnormalized --tag list: %s", parityTag)
+	assert.Contains(t, parityTag, "TagBoth", "--tag Public-Launch must normalize and match stored public-launch")
+	assert.Contains(t, parityTag, "TagOne", "--tag Public-Launch must normalize and match stored public-launch")
+
+	parityProject, err := tc.RunCampInDir(dir, "workitem", "list", "--project", "projects/camp/")
+	require.NoError(t, err, "trailing-slash --project list: %s", parityProject)
+	assert.Contains(t, parityProject, "ProjCamp", "--project projects/camp/ must normalize and match stored projects/camp")
+
+	emptyProject, err := tc.RunCampInDir(dir, "workitem", "list", "--project", "/")
+	require.Error(t, err, "--project / must fail as empty after normalization: %s", emptyProject)
+}

--- a/tests/integration/workitem_projects_test.go
+++ b/tests/integration/workitem_projects_test.go
@@ -1,0 +1,93 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_WorkitemProjects(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	const campaignDir = "/test/workitem-projects"
+	_, err := tc.RunCamp(
+		"init", campaignDir,
+		"--name", "Workitem Projects Test",
+		"--type", "product",
+		"-d", "Projects integration",
+		"-m", "Verify --project normalization, dedupe, and validation",
+		"--force",
+		"--no-register",
+		"--no-git",
+	)
+	require.NoError(t, err, "camp init should succeed")
+
+	t.Run("CreateDedupesProjects", func(t *testing.T) {
+		out, err := tc.RunCampInDir(campaignDir, "workitem", "create", "dedup-item",
+			"--type", "feature", "--title", "Dedup",
+			"--project", "projects/camp", "--project", "projects/camp")
+		require.NoError(t, err, "create --project: %s", out)
+
+		marker, err := tc.ReadFile(campaignDir + "/workflow/feature/dedup-item/.workitem")
+		require.NoError(t, err)
+		assert.Contains(t, marker, "projects:")
+		assert.Equal(t, 1, strings.Count(marker, "projects/camp"),
+			"duplicate project paths must collapse to one entry")
+	})
+
+	t.Run("CreateNormalizesTrailingSlashAndDedupes", func(t *testing.T) {
+		out, err := tc.RunCampInDir(campaignDir, "workitem", "create", "slash-item",
+			"--type", "feature", "--title", "Slash",
+			"--project", "projects/camp", "--project", "projects/camp/")
+		require.NoError(t, err, "create --project: %s", out)
+
+		marker, err := tc.ReadFile(campaignDir + "/workflow/feature/slash-item/.workitem")
+		require.NoError(t, err)
+		assert.NotContains(t, marker, "projects/camp/", "trailing slash must be normalized away")
+		assert.Equal(t, 1, strings.Count(marker, "projects/camp"),
+			"trailing-slash variant must normalize then dedupe to a single entry")
+	})
+
+	t.Run("CreateRejectsEscapingProjectAndCreatesNoDir", func(t *testing.T) {
+		out, err := tc.RunCampInDir(campaignDir, "workitem", "create", "escaping-item",
+			"--type", "feature", "--title", "Escaping", "--project", "../outside")
+		require.Error(t, err, "create with an escaping --project must fail: %s", out)
+
+		_, exitCode, execErr := tc.ExecCommand("test", "-d", campaignDir+"/workflow/feature/escaping-item")
+		require.NoError(t, execErr, "directory-absence check should execute")
+		require.NotEqual(t, 0, exitCode, "no directory should be created when validation fails")
+	})
+}
+
+func TestIntegration_WorkitemProjectsDoctorWarning(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	const campaignDir = "/test/workitem-projects-doctor"
+	_, err := tc.RunCamp(
+		"init", campaignDir,
+		"--name", "Workitem Projects Doctor Test",
+		"--type", "product",
+		"-d", "Projects doctor integration",
+		"-m", "Verify doctor warns on a missing project path and still exits 0",
+		"--force",
+		"--no-register",
+		"--no-git",
+	)
+	require.NoError(t, err, "camp init should succeed")
+
+	out, err := tc.RunCampInDir(campaignDir, "workitem", "create", "doc-item",
+		"--type", "feature", "--title", "DocItem", "--project", "projects/nonexistent")
+	require.NoError(t, err, "create --project: %s", out)
+
+	dout, derr := tc.RunCampInDir(campaignDir, "workitem", "doctor")
+	require.NoError(t, derr, "doctor must exit 0 when the only issue is a missing project path:\n%s", dout)
+	assert.Equal(t, 1, strings.Count(dout, "workitem.project.not-found"),
+		"expected exactly one missing-project finding:\n%s", dout)
+	assert.Contains(t, dout, "[warning] workitem.project.not-found",
+		"a missing project path must be a warning, never an error")
+}

--- a/tests/integration/workitem_tags_test.go
+++ b/tests/integration/workitem_tags_test.go
@@ -1,0 +1,58 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_WorkitemTags(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	const campaignDir = "/test/workitem-tags"
+	_, err := tc.RunCamp(
+		"init", campaignDir,
+		"--name", "Workitem Tags Test",
+		"--type", "product",
+		"-d", "Tags integration",
+		"-m", "Verify --tag normalization and dedupe",
+		"--force",
+		"--no-register",
+		"--no-git",
+	)
+	require.NoError(t, err, "camp init should succeed")
+
+	t.Run("CreateNormalizesAndDedupesTags", func(t *testing.T) {
+		out, err := tc.RunCampInDir(campaignDir, "workitem", "create", "tagged-item",
+			"--type", "feature", "--title", "Tagged", "--tag", "A", "--tag", "a")
+		require.NoError(t, err, "create --tag: %s", out)
+
+		marker, err := tc.ReadFile(campaignDir + "/workflow/feature/tagged-item/.workitem")
+		require.NoError(t, err)
+		assert.Contains(t, marker, "tags:")
+		assert.Contains(t, marker, "- a")
+		assert.NotContains(t, marker, "- A", "tags must normalize to lowercase")
+		assert.Equal(t, 1, strings.Count(marker, "- a"), "duplicate tags must collapse to one entry")
+	})
+
+	t.Run("AdoptNormalizesTags", func(t *testing.T) {
+		_, _, err := tc.ExecCommand("mkdir", "-p", campaignDir+"/workflow/feature/adopt-tagged")
+		require.NoError(t, err)
+
+		out, err := tc.RunCampInDir(campaignDir, "workitem", "adopt", "workflow/feature/adopt-tagged",
+			"--type", "feature", "--title", "Adopted", "--tag", "Foo", "--tag", "foo")
+		require.NoError(t, err, "adopt --tag: %s", out)
+
+		marker, err := tc.ReadFile(campaignDir + "/workflow/feature/adopt-tagged/.workitem")
+		require.NoError(t, err)
+		assert.Contains(t, marker, "tags:")
+		assert.Contains(t, marker, "- foo")
+		assert.NotContains(t, marker, "- Foo", "tags must normalize to lowercase")
+		assert.Equal(t, 1, strings.Count(marker, "- foo"), "duplicate tags must collapse to one entry")
+	})
+}

--- a/tests/integration/workitem_validate_repair_test.go
+++ b/tests/integration/workitem_validate_repair_test.go
@@ -156,11 +156,11 @@ func TestIntegration_WorkitemRepair_CreatesMarkerFromH1(t *testing.T) {
 	assert.Equal(t, "design", rep.Workitem.Type)
 	assert.Equal(t, "Legacy Design Title", rep.Workitem.Title, "title must come from the README H1")
 	assert.Regexp(t, `^WI-[0-9a-f]{6}$`, rep.Workitem.Ref)
-	assert.Equal(t, "v1alpha7", rep.Workitem.MarkerVersion)
+	assert.Equal(t, "v1alpha8", rep.Workitem.MarkerVersion)
 
 	marker, err := tc.ReadFile(dir + "/" + target + "/.workitem")
 	require.NoError(t, err)
-	assert.Contains(t, marker, "version: v1alpha7")
+	assert.Contains(t, marker, "version: v1alpha8")
 	assert.Contains(t, marker, "type: design")
 	assert.Contains(t, marker, "title: Legacy Design Title")
 
@@ -183,7 +183,7 @@ func TestIntegration_WorkitemRepair_UpgradesLegacyMarkerIdempotently(t *testing.
 
 	marker, err := tc.ReadFile(dir + "/" + target + "/.workitem")
 	require.NoError(t, err)
-	assert.Contains(t, marker, "version: v1alpha7", "schema upgraded")
+	assert.Contains(t, marker, "version: v1alpha8", "schema upgraded")
 	assert.Contains(t, marker, "type: design", "type aligned to path")
 	assert.Contains(t, marker, "id: design-legacy-marker-2026-05-25", "existing id preserved")
 	assert.Regexp(t, `ref: WI-[0-9a-f]{6}`, marker, "ref backfilled")


### PR DESCRIPTION
## Summary

The writer half of the two-phase v1alpha8 workitem schema rollout. The reader half shipped in #464 and reached the installed rc channel as camp v0.3.0-rc.3 (pinned by festival PR #109) before any commit here landed, per the rollout contract: every binary on the rc channel can already read what these writers produce.

Seven sequences, one commit each:

- `e1e0bca5` write-path flip: WorkitemSchemaVersion stamps v1alpha8 on create/adopt/repair/gather; all legacy versions still load.
- `62dca6e5` tags: repeatable `--tag` on create/adopt with lowercase-kebab write normalization (canonical regex exported as `wkitem.ValidTag`); repair normalizes and dedupes existing tags, recording genuine drops distinctly from reformats.
- `23832e77` projects: repeatable `--project` with path normalization (Clean + trailing-slash trim, empty-after-normalize rejected naming the input), exported `ValidateProjectPaths`, doctor warning `workitem.project.not-found` (plus `workitem.project.unvalidatable` for stat errors), consolidated doctor discovery scans.
- `32a1b710` list filters: `--tag` (AND semantics, deliberately diverging from the OR-within-dimension convention per the design) and `--project` (OR), with filter-input normalization matching the write side.
- `b69035ff` frontmatter discovery: `workflow/**` markdown files with `kind: workitem` frontmatter discovered as `item_kind: file`; collision rule (directory marker owns identity), conflict rule (`workitem.identity.conflict` hard error), one-sided ref state surfaced as `workitem.identity.ref-pending` warning, type-authority (path wins), and the forward-compat validate finding `workitem.schema.forward-compat` (warning, exit 0, no repair hint since repair would downgrade).
- `cc8ccd51` adopt/create `--file`: frontmatter stamping that never touches the body, preserves foreign keys byte-for-byte (2-space indent; non-2-space input reflows with a printed notice), refuses conflicting identity unconditionally, unions foreign tags under `--force` with a printed notice for non-conforming drops, deterministic output, explicit `agent_allowed: false` on adopt.
- `98c1b672` file lifecycle: dungeon/promote/gather parity for file workitems, including two latent impossible-path bugs fixed (gather and promote identity both loaded `<file>.md/.workitem` for file sources).

## Scope note

`link.go` carries exactly one mechanical line (`knownIDs, _, err = workitemIDsOnDisk(...)`) adapting to the doctor-consolidation helper's widened return. No links.yaml migration logic rides in this PR; that is phase 004 (next, independent of this merge beyond the `projects:` field existing).

## Verification

Every sequence passed an independent adversarial review before its commit (findings fixed pre-commit, including an empirically proven foreign-tags data-loss bug in the first `--force` implementation). Final branch gates, run at merge time: `go build` clean, whole-module unit suite green, `just lint` 0 issues (both ratchets clean), containerized integration suite 496/496.

Full context: `obey-campaign` festival `festivals/active/workitem-schema-tags-and-projects-WS0001` (design package `workflow/design/workitem-schema-tags-and-projects/`, docs 01-09).