### PR TITLE
feat: deprecate links.yaml related-project rows: CLI rejection, doctor migration, merged JSON view

### DIFF
--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -28,18 +28,19 @@ import (
 // Doctor finding codes (dotted-domain form). Stable strings; consumers
 // dispatch on them.
 const (
-	codeBrokenLink           = "workitem.link.broken"
-	codeBrokenScope          = "workitem.scope.broken"
-	codeOutOfBounds          = "workitem.scope.out-of-bounds"
-	codeScopeUnvalidatable   = "workitem.scope.unvalidatable"
-	codeDuplicatePrimary     = "workitem.link.duplicate-primary"
-	codeSchemaViolation      = "workitem.schema.violation"
-	codeCurrentMissing       = "workitem.current.missing"
-	codeMissingRefField      = "workitem.ref.missing"
-	codeWorkitemScanFailed   = "workitem.scan.failed"
-	codeRegistryParseError   = "workitem.registry.parse-error"
-	codeProjectNotFound      = "workitem.project.not-found"
-	codeProjectUnvalidatable = "workitem.project.unvalidatable"
+	codeBrokenLink               = "workitem.link.broken"
+	codeBrokenScope              = "workitem.scope.broken"
+	codeOutOfBounds              = "workitem.scope.out-of-bounds"
+	codeScopeUnvalidatable       = "workitem.scope.unvalidatable"
+	codeDuplicatePrimary         = "workitem.link.duplicate-primary"
+	codeSchemaViolation          = "workitem.schema.violation"
+	codeCurrentMissing           = "workitem.current.missing"
+	codeMissingRefField          = "workitem.ref.missing"
+	codeWorkitemScanFailed       = "workitem.scan.failed"
+	codeRegistryParseError       = "workitem.registry.parse-error"
+	codeProjectNotFound          = "workitem.project.not-found"
+	codeProjectUnvalidatable     = "workitem.project.unvalidatable"
+	codeDeprecatedRelatedProject = "workitem.link.related-project-deprecated"
 )
 
 const (
@@ -231,7 +232,14 @@ func collectWorkitemFindings(ctx context.Context, root string, registry *links.L
 	promotedTargets := promotedFestivalTargets(ctx, root)
 	primarySeen := make(map[string]string)
 	for _, link := range registry.Links {
-		if _, known := knownIDs[link.WorkitemID]; !known {
+		// A deprecated related-project link (doc 04 D005) is handled solely by
+		// the migration below: --fix moves it into the workitem's projects: and
+		// removes the row, and a row whose workitem cannot be resolved is left in
+		// place and reported. It is never removed as a broken link/scope, so no
+		// data is lost.
+		deprecatedRelatedProject := link.Role == links.RoleRelated && link.Scope.Kind == links.ScopeProject
+
+		if _, known := knownIDs[link.WorkitemID]; !known && !deprecatedRelatedProject {
 			finding := docFinding{
 				Code:        codeBrokenLink,
 				Severity:    docSeverityError,
@@ -252,7 +260,7 @@ func collectWorkitemFindings(ctx context.Context, root string, registry *links.L
 			findings = append(findings, finding)
 		}
 		scopeMissing := !scopeTargetExists(root, link.Scope.Path)
-		if scopeMissing {
+		if scopeMissing && !deprecatedRelatedProject {
 			findings = append(findings, docFinding{
 				Code:        codeBrokenScope,
 				Severity:    docSeverityError,
@@ -292,6 +300,16 @@ func collectWorkitemFindings(ctx context.Context, root string, registry *links.L
 			} else {
 				primarySeen[key] = link.ID
 			}
+		}
+		if deprecatedRelatedProject {
+			findings = append(findings, docFinding{
+				Code:        codeDeprecatedRelatedProject,
+				Severity:    docSeverityWarning,
+				Target:      "link:" + link.ID,
+				Message:     "workitem " + link.WorkitemID + " has a deprecated related-project link to " + link.Scope.Path,
+				FixHint:     "run `camp workitem doctor --fix` to migrate it into the workitem's projects: field",
+				AutoFixable: true,
+			})
 		}
 	}
 
@@ -413,6 +431,21 @@ func autoFixWorkitemFindings(ctx context.Context, root string, registry *links.L
 			}
 		case codeMissingRefField:
 			needsRefBackfill = true
+		case codeDeprecatedRelatedProject:
+			linkID := strings.TrimPrefix(f.Target, "link:")
+			link, ok := registry.FindByID(linkID)
+			if !ok {
+				continue
+			}
+			if err := migrateRelatedProjectLink(ctx, root, *link); err != nil {
+				// Unmigratable (e.g. the workitem no longer resolves): report and
+				// leave the row in place. Never delete the data.
+				if _, writeErr := fmt.Fprintf(errw, "warning: cannot migrate related-project link %s: %v\n", linkID, err); writeErr != nil {
+					return applied, writeErr
+				}
+			} else if registry.RemoveLinkByID(linkID) {
+				applied++
+			}
 		}
 	}
 	if needsRefBackfill {

--- a/internal/commands/workitem/doctor_project_migration.go
+++ b/internal/commands/workitem/doctor_project_migration.go
@@ -1,0 +1,93 @@
+package workitem
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+// migrateRelatedProjectLink appends link.Scope.Path to the projects: list of the
+// workitem identified by link.WorkitemID, writing to its .workitem marker
+// (directory) or its frontmatter (file). It is idempotent: when the path is
+// already listed it returns nil without writing, so the caller (doctor --fix)
+// only removes the row. It never removes the link row itself — the caller does
+// that, and only after this succeeds, so an unresolvable workitem preserves its
+// data.
+func migrateRelatedProjectLink(ctx context.Context, root string, link links.Link) error {
+	wi, err := resolveSelector(ctx, root, link.WorkitemID, false)
+	if err != nil {
+		return camperrors.Wrapf(err, "resolving workitem %s for project migration", link.WorkitemID)
+	}
+
+	if wi.ItemKind == wkitem.ItemKindDirectory {
+		absMarker := filepath.Join(root, filepath.FromSlash(wi.RelativePath), wkitem.MetadataFilename)
+		raw, err := os.ReadFile(absMarker)
+		if err != nil {
+			return camperrors.Wrapf(err, "reading %s", absMarker)
+		}
+		var meta wkitem.Metadata
+		if err := yaml.Unmarshal(raw, &meta); err != nil {
+			return camperrors.Wrapf(err, "parsing %s", absMarker)
+		}
+		for _, p := range meta.Projects {
+			if p == link.Scope.Path {
+				return nil // already migrated, idempotent no-op
+			}
+		}
+		meta.Projects = append(meta.Projects, link.Scope.Path)
+		// A directory .workitem holds only camp-owned keys, so a full-struct
+		// remarshal is safe (no foreign keys to preserve, unlike frontmatter).
+		out, err := yaml.Marshal(&meta)
+		if err != nil {
+			return camperrors.Wrap(err, "marshal updated .workitem")
+		}
+		return fsutil.WriteFileAtomically(absMarker, out, 0o644)
+	}
+
+	// File (frontmatter) workitem: stamp through the AST-preserving helper so the
+	// body and unrelated frontmatter keys are never touched.
+	absFile := filepath.Join(root, filepath.FromSlash(wi.RelativePath))
+	existing, err := wkitem.LoadFrontmatterMetadata(absFile)
+	if err != nil {
+		return camperrors.Wrapf(err, "reading frontmatter %s", absFile)
+	}
+	if existing == nil {
+		return camperrors.NewValidation("frontmatter",
+			"no kind: workitem frontmatter to migrate into at "+absFile, nil)
+	}
+	for _, p := range existing.Projects {
+		if p == link.Scope.Path {
+			return nil
+		}
+	}
+	newProjects := append(append([]string{}, existing.Projects...), link.Scope.Path)
+	return wkitem.StampFrontmatterFields(ctx, absFile,
+		[]wkitem.FrontmatterField{{After: frontmatterProjectsAnchor(existing), Key: "projects", Values: newProjects}})
+}
+
+// frontmatterProjectsAnchor returns the key a freshly stamped projects: list
+// should follow so a doctor-migrated file lands projects: exactly where
+// create/adopt would (campStampFields, adopt_file.go): chained after the last
+// camp key present before it. type is always present, so the anchor never falls
+// through to insertNodeAfter's append-at-end path.
+func frontmatterProjectsAnchor(meta *wkitem.Metadata) string {
+	switch {
+	case len(meta.Tags) > 0:
+		return "tags"
+	case meta.QuestID != "":
+		return "quest_id"
+	case meta.Ref != "":
+		return "ref"
+	case meta.Title != "":
+		return "title"
+	default:
+		return "type"
+	}
+}

--- a/internal/commands/workitem/link.go
+++ b/internal/commands/workitem/link.go
@@ -46,6 +46,11 @@ A primary worktree link is how design/explore workitems under workflow/ get
 into camp p commit tags: when you commit from that worktree, the resolver
 matches the link and stamps WI-<ref> on the subject.
 
+Note: role:related links to a project scope are no longer accepted; a workitem's
+related projects live in its own projects: field. Use "camp workitem
+create/adopt --project <path>" (or edit the .workitem/frontmatter) instead of
+"--role related --project".
+
 Examples:
   camp workitem link WI-2a7950 --worktree fest/fest-list-watch
   camp workitem link workflow/design/fest-list-watch --worktree projects/worktrees/fest/fest-list-watch
@@ -124,6 +129,17 @@ func runLink(ctx context.Context, cmd *cobra.Command, opts linkOptions) error {
 	scope, err := resolveLinkScope(root, opts)
 	if err != nil {
 		return err
+	}
+
+	// role:related + scope.kind:project is the deprecated overlap (doc 04): that
+	// fact now lives only in the workitem's projects: field, so reject new such
+	// rows at the command layer. AddLink stays a pure registry primitive the
+	// doctor migration can still call to remove existing rows.
+	if role == links.RoleRelated && scope.Kind == links.ScopeProject {
+		return camperrors.NewValidation("role",
+			"role:related + scope.kind:project links are deprecated; use the workitem's own "+
+				"`projects:` field instead (e.g. `camp workitem create/adopt --project "+
+				scope.Path+"`, or edit the .workitem/frontmatter directly)", nil)
 	}
 
 	if !opts.AllowMissing {

--- a/internal/commands/workitem/list.go
+++ b/internal/commands/workitem/list.go
@@ -114,7 +114,7 @@ Examples:
 				}
 			}
 			if opts.json {
-				return outputJSON(state.campaignRoot, state.cfg, items, groupBy)
+				return outputJSON(cmd.Context(), state.campaignRoot, state.cfg, items, groupBy)
 			}
 			return outputList(cmd.OutOrStdout(), items, groupBy)
 		}),

--- a/internal/commands/workitem/merged_projects.go
+++ b/internal/commands/workitem/merged_projects.go
@@ -1,0 +1,25 @@
+package workitem
+
+import (
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+// mergeProjectRefs builds one workitem's merged projects view: every path in its
+// semantic projects: list, annotated with whether that project is also the
+// workitem-scope primary link in links.yaml (registry.PrimaryForScope). The base
+// is the projects: list exactly (a primary link to a project not listed there is
+// a separate consistency concern, not surfaced here). It always returns a
+// non-nil slice so the JSON projects field encodes as [] rather than null when
+// the list is empty.
+func mergeProjectRefs(projects []string, registry *links.Links) []wkitem.ProjectRef {
+	refs := make([]wkitem.ProjectRef, 0, len(projects))
+	for _, path := range projects {
+		primary := false
+		if registry != nil {
+			_, primary = registry.PrimaryForScope(links.ScopeProject, path)
+		}
+		refs = append(refs, wkitem.ProjectRef{Path: path, Primary: primary})
+	}
+	return refs
+}

--- a/internal/commands/workitem/merged_projects_test.go
+++ b/internal/commands/workitem/merged_projects_test.go
@@ -1,0 +1,39 @@
+package workitem
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+func TestMergeProjectRefs(t *testing.T) {
+	registry := &links.Links{Links: []links.Link{
+		{ID: "lnk_20260719_000001", Role: links.RolePrimary, Scope: links.LinkScope{Kind: links.ScopeProject, Path: "projects/camp"}},
+		// A related (non-primary) link to fest must not count as primary, and a
+		// primary link on a different scope kind must not match a project path.
+		{ID: "lnk_20260719_000002", Role: links.RoleRelated, Scope: links.LinkScope{Kind: links.ScopeProject, Path: "projects/fest"}},
+	}}
+
+	t.Run("empty projects returns non-nil empty slice", func(t *testing.T) {
+		refs := mergeProjectRefs(nil, registry)
+		assert.NotNil(t, refs, "must be [] not nil so JSON encodes [] not null")
+		assert.Len(t, refs, 0)
+	})
+
+	t.Run("primary and non-primary annotated independently in order", func(t *testing.T) {
+		refs := mergeProjectRefs([]string{"projects/camp", "projects/fest", "projects/other"}, registry)
+		assert.Equal(t, []wkitem.ProjectRef{
+			{Path: "projects/camp", Primary: true},
+			{Path: "projects/fest", Primary: false},
+			{Path: "projects/other", Primary: false},
+		}, refs)
+	})
+
+	t.Run("nil registry yields all non-primary", func(t *testing.T) {
+		refs := mergeProjectRefs([]string{"projects/camp"}, nil)
+		assert.Equal(t, []wkitem.ProjectRef{{Path: "projects/camp", Primary: false}}, refs)
+	})
+}

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/pathutil"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
 	"github.com/Obedience-Corp/camp/internal/workitem/priority"
 	wktui "github.com/Obedience-Corp/camp/internal/workitem/tui"
 )
@@ -109,7 +110,7 @@ Examples:
 			case flagList:
 				return outputList(cmd.OutOrStdout(), items, displayGroupBy)
 			case flagJSON:
-				return outputJSON(state.campaignRoot, state.cfg, items, displayGroupBy)
+				return outputJSON(ctx, state.campaignRoot, state.cfg, items, displayGroupBy)
 			default:
 				// Non-interactive --print/--path-output: output first item path directly.
 				if len(items) == 0 {
@@ -345,7 +346,22 @@ func validateDisplayStatuses(statuses []string) error {
 	return nil
 }
 
-func outputJSON(campaignRoot string, cfg *config.CampaignConfig, items []wkitem.WorkItem, groupBy string) error {
+func outputJSON(ctx context.Context, campaignRoot string, cfg *config.CampaignConfig, items []wkitem.WorkItem, groupBy string) error {
+	// Annotate each item's projects: with its primary designation from links.yaml
+	// so the JSON projects field is the merged view. Both --json call sites
+	// (list.go, workitem.go) route through here. A malformed registry must not
+	// hard-fail this read-only listing (it was registry-independent before the
+	// merged view): fall back to no annotation and warn, mirroring doctor's
+	// continue posture. mergeProjectRefs treats a nil registry as no primaries.
+	registry, err := links.Load(ctx, campaignRoot)
+	if err != nil {
+		registry = nil
+		_, _ = fmt.Fprintf(os.Stderr,
+			"warning: could not read links.yaml (%v); showing projects without primary annotation; run `camp workitem doctor --fix`\n", err)
+	}
+	for i := range items {
+		items[i].ProjectRefs = mergeProjectRefs(items[i].Projects, registry)
+	}
 	payload := wkitem.NewPayloadWithGrouping(campaignRoot, items, groupBy)
 	payload.CategoryVocabulary = categoryVocabulary(cfg)
 	enc := json.NewEncoder(os.Stdout)

--- a/internal/workitem/json.go
+++ b/internal/workitem/json.go
@@ -26,9 +26,12 @@ import (
 //     attention/group vocabularies, grouping metadata, and reusable section rows.
 //   - v1alpha8: add config-derived workflow_category per item, category_vocabulary,
 //     category_counts, and category in available_group_by and section rows.
-//   - v1alpha9: add tags and projects fields (free-form topic labels and
-//     campaign-relative related-project paths, both non-nil empty slices
-//     when absent). See internal/workitem/metadata.go for the marker-level
+//   - v1alpha9: add tags and projects fields. tags is a non-nil slice of
+//     free-form topic labels ([] not null when absent). projects is the merged
+//     view: a non-nil slice of {path, primary} objects ([] not null when
+//     absent), where path is a campaign-relative project path and primary
+//     reflects whether that project is the workitem-scope primary link in
+//     links.yaml. See internal/workitem/metadata.go for the marker-level
 //     v1alpha8 schema these are sourced from.
 const SchemaVersion = "workitems/v1alpha9"
 

--- a/internal/workitem/json_test.go
+++ b/internal/workitem/json_test.go
@@ -276,15 +276,18 @@ func TestWorkItem_PopulatedTagsProjectsRoundTrip(t *testing.T) {
 	if !strings.Contains(got, `"tags":["ux","public-launch"]`) {
 		t.Errorf("tags not preserved in order: %s", got)
 	}
-	if !strings.Contains(got, `"projects":["projects/camp","projects/fest"]`) {
-		t.Errorf("projects not preserved in order: %s", got)
+	// projects is the merged view: ApplyMetadata builds the base (primary=false,
+	// since the links registry is not available here); the output layer sets
+	// primary. Order is preserved.
+	if !strings.Contains(got, `"projects":[{"path":"projects/camp","primary":false},{"path":"projects/fest","primary":false}]`) {
+		t.Errorf("projects not preserved as merged view in order: %s", got)
 	}
 }
 
 func TestNewPayload_TagsProjectsSerialization(t *testing.T) {
 	items := []WorkItem{
-		{Key: "a", Title: "A", WorkflowType: WorkflowTypeDesign, Tags: []string{"ux"}, Projects: []string{"projects/camp"}},
-		{Key: "b", Title: "B", WorkflowType: WorkflowTypeIntent, Tags: []string{}, Projects: []string{}},
+		{Key: "a", Title: "A", WorkflowType: WorkflowTypeDesign, Tags: []string{"ux"}, Projects: []string{"projects/camp"}, ProjectRefs: []ProjectRef{{Path: "projects/camp"}}},
+		{Key: "b", Title: "B", WorkflowType: WorkflowTypeIntent, Tags: []string{}, Projects: []string{}, ProjectRefs: []ProjectRef{}},
 	}
 	got := string(mustMarshal(t, NewPayloadWithGrouping("/tmp", items, "type")))
 	if !strings.Contains(got, `"tags":["ux"]`) {
@@ -292,6 +295,12 @@ func TestNewPayload_TagsProjectsSerialization(t *testing.T) {
 	}
 	if !strings.Contains(got, `"tags":[]`) {
 		t.Errorf("empty tags should serialize as [] in payload: %s", got)
+	}
+	if !strings.Contains(got, `"projects":[{"path":"projects/camp","primary":false}]`) {
+		t.Errorf("populated projects missing merged view from payload: %s", got)
+	}
+	if !strings.Contains(got, `"projects":[]`) {
+		t.Errorf("empty projects should serialize as [] in payload: %s", got)
 	}
 	if strings.Contains(got, `"tags":null`) || strings.Contains(got, `"projects":null`) {
 		t.Errorf("payload must never contain null tags or projects: %s", got)

--- a/internal/workitem/merge.go
+++ b/internal/workitem/merge.go
@@ -33,6 +33,10 @@ func ApplyMetadata(item WorkItem, md *Metadata) (WorkItem, error) {
 	}
 	item.Tags = nonNilStrings(md.Tags)
 	item.Projects = nonNilStrings(md.Projects)
+	// Build the non-nil base merged view here so ProjectRefs is [] not null even
+	// on a WorkItem that never reaches the output layer. outputJSON re-derives it
+	// with the primary annotation from links.yaml (which is unavailable here).
+	item.ProjectRefs = projectRefsBase(item.Projects)
 	return item, nil
 }
 
@@ -41,4 +45,15 @@ func nonNilStrings(s []string) []string {
 		return []string{}
 	}
 	return s
+}
+
+// projectRefsBase renders projects: as the merged view without the links-derived
+// primary annotation (every entry primary=false). It always returns a non-nil
+// slice so the JSON projects field encodes as [] rather than null.
+func projectRefsBase(projects []string) []ProjectRef {
+	refs := make([]ProjectRef, 0, len(projects))
+	for _, p := range projects {
+		refs = append(refs, ProjectRef{Path: p})
+	}
+	return refs
 }

--- a/internal/workitem/model.go
+++ b/internal/workitem/model.go
@@ -54,7 +54,19 @@ type WorkItem struct {
 	StableID     string            `json:"stable_id,omitempty"`
 	WorkflowMeta *WorkItemWorkflow `json:"workflow,omitempty"`
 	Tags         []string          `json:"tags"`
-	Projects     []string          `json:"projects"`
+	Projects     []string          `json:"-"`
+	ProjectRefs  []ProjectRef      `json:"projects"`
+}
+
+// ProjectRef is one entry in a workitem's merged projects view: a
+// campaign-relative project path from the workitem's projects: list, annotated
+// with whether that project is also the workitem-scope primary link in
+// links.yaml. It is the JSON shape of the "projects" field (workitems/v1alpha9);
+// the plain []string Projects field stays the internal semantic base that
+// ApplyMetadata populates and the merged view is derived from at output time.
+type ProjectRef struct {
+	Path    string `json:"path"`
+	Primary bool   `json:"primary"`
 }
 
 // WorkItemWorkflow carries local runtime progress when .workflow/ is present

--- a/tests/integration/doctor_project_migration_test.go
+++ b/tests/integration/doctor_project_migration_test.go
@@ -1,0 +1,214 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedDesignWorkitemWithID(t *testing.T, tc *TestContainer, dir, slug, id string) {
+	t.Helper()
+	out, err := tc.RunCampInDir(dir, "workitem", "create", slug, "--type", "design", "--title", slug, "--id", id)
+	require.NoError(t, err, "create %s: %s", slug, out)
+}
+
+func writeRelatedProjectLinks(t *testing.T, tc *TestContainer, dir string, entries [][3]string) {
+	t.Helper()
+	var sb strings.Builder
+	sb.WriteString("version: workitem-links/v1alpha1\nlinks:\n")
+	for _, e := range entries {
+		fmt.Fprintf(&sb,
+			"  - {id: %s, workitem_id: %s, scope: {kind: project, path: %s}, role: related, created_at: 2026-07-19T10:00:00-06:00, created_by: test}\n",
+			e[0], e[1], e[2])
+	}
+	require.NoError(t, tc.WriteFile(dir+"/.campaign/workitems/links.yaml", sb.String()))
+}
+
+func doctorFindings(t *testing.T, out string) []doctorFinding {
+	t.Helper()
+	start := strings.Index(out, "{")
+	require.GreaterOrEqual(t, start, 0, "no JSON in doctor output: %s", out)
+	var report doctorReport
+	require.NoError(t, json.NewDecoder(strings.NewReader(out[start:])).Decode(&report), "doctor --json parse: %s", out)
+	return report.Findings
+}
+
+func setupRelatedProjectMigration(t *testing.T, tc *TestContainer, dir string) {
+	t.Helper()
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "pa")
+	seedProject(t, tc, dir, "pb")
+	seedDesignWorkitemWithID(t, tc, dir, "wa", "design-wa-2026-07-19")
+	seedDesignWorkitemWithID(t, tc, dir, "wb", "design-wb-2026-07-19")
+	writeRelatedProjectLinks(t, tc, dir, [][3]string{
+		{"lnk_20260719_000001", "design-wa-2026-07-19", "projects/pa"},
+		{"lnk_20260719_000002", "design-wb-2026-07-19", "projects/pb"},
+	})
+}
+
+func TestIntegration_DoctorReportsRelatedProjectDeprecated(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/doctor-migrate-report"
+	setupRelatedProjectMigration(t, tc, dir)
+
+	out, err := tc.RunCampInDir(dir, "workitem", "doctor", "--json")
+	require.NoError(t, err, "report mode with warnings only must exit 0: %s", out)
+
+	n := 0
+	for _, f := range doctorFindings(t, out) {
+		if f.Code == "workitem.link.related-project-deprecated" {
+			assert.Equal(t, "warning", f.Severity)
+			n++
+		}
+	}
+	assert.Equal(t, 2, n, "expected exactly one deprecated finding per related-project row")
+}
+
+func TestIntegration_DoctorFixMigratesRelatedProject(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/doctor-migrate-fix"
+	setupRelatedProjectMigration(t, tc, dir)
+
+	out, err := tc.RunCampInDir(dir, "workitem", "doctor", "--fix")
+	require.NoError(t, err, "--fix: %s", out)
+
+	linksYAML, err := tc.ReadFile(dir + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.NotContains(t, linksYAML, "role: related", "zero related+project rows remain after --fix")
+
+	wa, err := tc.ReadFile(dir + "/workflow/design/wa/.workitem")
+	require.NoError(t, err)
+	assert.Contains(t, wa, "projects/pa", "the project path is migrated into the marker")
+	wb, err := tc.ReadFile(dir + "/workflow/design/wb/.workitem")
+	require.NoError(t, err)
+	assert.Contains(t, wb, "projects/pb")
+}
+
+func TestIntegration_DoctorFixIdempotent(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/doctor-migrate-idempotent"
+	setupRelatedProjectMigration(t, tc, dir)
+
+	_, err := tc.RunCampInDir(dir, "workitem", "doctor", "--fix")
+	require.NoError(t, err)
+	out, err := tc.RunCampInDir(dir, "workitem", "doctor", "--fix")
+	require.NoError(t, err, "second --fix must be a clean no-op: %s", out)
+
+	jout, err := tc.RunCampInDir(dir, "workitem", "doctor", "--json")
+	require.NoError(t, err)
+	for _, f := range doctorFindings(t, jout) {
+		assert.NotEqual(t, "workitem.link.related-project-deprecated", f.Code, "no deprecated findings remain")
+	}
+	wa, err := tc.ReadFile(dir + "/workflow/design/wa/.workitem")
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(wa, "projects/pa"), "no duplicate projects entry after a second --fix")
+}
+
+func TestIntegration_DoctorFixPreExistingOverlap(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/doctor-migrate-overlap"
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "pa")
+	// The workitem already lists projects/pa before migration.
+	out, err := tc.RunCampInDir(dir, "workitem", "create", "wa", "--type", "design", "--title", "wa",
+		"--id", "design-wa-2026-07-19", "--project", "projects/pa")
+	require.NoError(t, err, "create with --project: %s", out)
+	writeRelatedProjectLinks(t, tc, dir, [][3]string{{"lnk_20260719_000001", "design-wa-2026-07-19", "projects/pa"}})
+
+	_, err = tc.RunCampInDir(dir, "workitem", "doctor", "--fix")
+	require.NoError(t, err)
+
+	wa, err := tc.ReadFile(dir + "/workflow/design/wa/.workitem")
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(wa, "projects/pa"), "a pre-existing project must not be duplicated")
+	linksYAML, err := tc.ReadFile(dir + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.NotContains(t, linksYAML, "role: related", "the now-redundant row is still removed")
+}
+
+func TestIntegration_DoctorFixFileFrontmatterTarget(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/doctor-migrate-file"
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "pa")
+	require.NoError(t, tc.WriteFile(dir+"/workflow/notes/doc.md",
+		"---\nversion: v1alpha8\nkind: workitem\nid: note-doc-2026-07-19\ntype: chore\ntitle: Doc\nref: WI-fa0001\ndraft: true\n---\n\n# Doc\n\nBody text.\n"))
+	writeRelatedProjectLinks(t, tc, dir, [][3]string{{"lnk_20260719_000001", "note-doc-2026-07-19", "projects/pa"}})
+
+	_, err := tc.RunCampInDir(dir, "workitem", "doctor", "--fix")
+	require.NoError(t, err)
+
+	doc, err := tc.ReadFile(dir + "/workflow/notes/doc.md")
+	require.NoError(t, err)
+	assert.Contains(t, doc, "projects/pa", "migrated into the file frontmatter")
+	assert.Contains(t, doc, "draft: true", "a foreign frontmatter key is preserved")
+	assert.Contains(t, doc, "Body text.", "the body is preserved")
+	linksYAML, err := tc.ReadFile(dir + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.NotContains(t, linksYAML, "role: related")
+}
+
+func TestIntegration_DoctorFixFileFrontmatterProjectsAfterTags(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/doctor-migrate-after-tags"
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "pa")
+	// A file workitem that already carries tags: but no projects:. create/adopt
+	// chain projects: after tags:, so doctor's migration must land it there too.
+	require.NoError(t, tc.WriteFile(dir+"/workflow/notes/tagged.md",
+		"---\nversion: v1alpha8\nkind: workitem\nid: note-tagged-2026-07-19\ntype: chore\ntitle: Tagged\nref: WI-fb0001\ntags:\n  - foo\n  - bar\ndraft: true\n---\n\n# Tagged\n\nBody.\n"))
+	writeRelatedProjectLinks(t, tc, dir, [][3]string{{"lnk_20260719_000001", "note-tagged-2026-07-19", "projects/pa"}})
+
+	_, err := tc.RunCampInDir(dir, "workitem", "doctor", "--fix")
+	require.NoError(t, err)
+
+	doc, err := tc.ReadFile(dir + "/workflow/notes/tagged.md")
+	require.NoError(t, err)
+	assert.Contains(t, doc, "projects/pa", "migrated into the frontmatter")
+	assert.Contains(t, doc, "foo", "existing tags preserved")
+	assert.Contains(t, doc, "bar")
+	tagsAt := strings.Index(doc, "\ntags:")
+	projectsAt := strings.Index(doc, "\nprojects:")
+	draftAt := strings.Index(doc, "\ndraft:")
+	require.Positive(t, projectsAt, "projects: key present")
+	assert.Less(t, tagsAt, projectsAt, "projects: is stamped after tags:, matching create/adopt")
+	assert.Less(t, projectsAt, draftAt, "projects: lands right after the tags block, before the trailing foreign key")
+}
+
+func TestIntegration_DoctorMissingWorkitemRowPreserved(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/doctor-migrate-missing"
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "pa")
+	writeRelatedProjectLinks(t, tc, dir, [][3]string{{"lnk_20260719_000001", "gone-2026-07-19", "projects/pa"}})
+
+	out, err := tc.RunCampInDir(dir, "workitem", "doctor", "--json")
+	require.NoError(t, err, "report exits 0: %s", out)
+	hasDeprecated := false
+	for _, f := range doctorFindings(t, out) {
+		if f.Target == "link:lnk_20260719_000001" {
+			assert.NotEqual(t, "workitem.link.broken", f.Code,
+				"a deprecated related-project row is not also flagged broken (it is handled solely by the migration)")
+			if f.Code == "workitem.link.related-project-deprecated" {
+				hasDeprecated = true
+			}
+		}
+	}
+	assert.True(t, hasDeprecated, "the row is reported as deprecated")
+
+	_, err = tc.RunCampInDir(dir, "workitem", "doctor", "--fix")
+	require.NoError(t, err, "--fix with only an unmigratable row still exits 0")
+	linksYAML, err := tc.ReadFile(dir + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, linksYAML, "lnk_20260719_000001", "an unmigratable row is preserved, never deleted")
+	exists, err := tc.CheckDirExists(dir + "/workflow/design/gone")
+	require.NoError(t, err)
+	assert.False(t, exists, "no phantom workitem is created for a missing target")
+}

--- a/tests/integration/doctor_project_migration_test.go
+++ b/tests/integration/doctor_project_migration_test.go
@@ -138,14 +138,14 @@ func TestIntegration_DoctorFixFileFrontmatterTarget(t *testing.T) {
 	dir := "/test/doctor-migrate-file"
 	initLinksCampaign(t, tc, dir)
 	seedProject(t, tc, dir, "pa")
-	require.NoError(t, tc.WriteFile(dir+"/workflow/notes/doc.md",
-		"---\nversion: v1alpha8\nkind: workitem\nid: note-doc-2026-07-19\ntype: chore\ntitle: Doc\nref: WI-fa0001\ndraft: true\n---\n\n# Doc\n\nBody text.\n"))
-	writeRelatedProjectLinks(t, tc, dir, [][3]string{{"lnk_20260719_000001", "note-doc-2026-07-19", "projects/pa"}})
+	require.NoError(t, tc.WriteFile(dir+"/workflow/notes/migdoc.md",
+		"---\nversion: v1alpha8\nkind: workitem\nid: note-migdoc-2026-07-19\ntype: chore\ntitle: Doc\nref: WI-fa0001\ndraft: true\n---\n\n# Doc\n\nBody text.\n"))
+	writeRelatedProjectLinks(t, tc, dir, [][3]string{{"lnk_20260719_000001", "note-migdoc-2026-07-19", "projects/pa"}})
 
 	_, err := tc.RunCampInDir(dir, "workitem", "doctor", "--fix")
 	require.NoError(t, err)
 
-	doc, err := tc.ReadFile(dir + "/workflow/notes/doc.md")
+	doc, err := tc.ReadFile(dir + "/workflow/notes/migdoc.md")
 	require.NoError(t, err)
 	assert.Contains(t, doc, "projects/pa", "migrated into the file frontmatter")
 	assert.Contains(t, doc, "draft: true", "a foreign frontmatter key is preserved")

--- a/tests/integration/merged_projects_view_test.go
+++ b/tests/integration/merged_projects_view_test.go
@@ -1,0 +1,124 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mergedViewProjectRef struct {
+	Path    string `json:"path"`
+	Primary bool   `json:"primary"`
+}
+
+type mergedViewItem struct {
+	RelativePath string                 `json:"relative_path"`
+	Projects     []mergedViewProjectRef `json:"projects"`
+}
+
+// mergedViewItems runs a camp workitem JSON command and returns the parsed
+// items. args is the full camp invocation (e.g. "workitem", "list", "--json"),
+// letting one helper cover both --json call sites (list.go and workitem.go).
+func mergedViewItems(t *testing.T, tc *TestContainer, dir string, args ...string) (items []mergedViewItem, raw string) {
+	t.Helper()
+	out, err := tc.RunCampInDir(dir, args...)
+	require.NoError(t, err, "%v: %s", args, out)
+	start := strings.Index(out, "{")
+	require.GreaterOrEqual(t, start, 0, "no JSON in: %s", out)
+	var payload struct {
+		Items []mergedViewItem `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out[start:]), &payload), "raw=%s", out)
+	return payload.Items, out
+}
+
+func mergedViewByPath(items []mergedViewItem, relPath string) (mergedViewItem, bool) {
+	for _, it := range items {
+		if it.RelativePath == relPath {
+			return it, true
+		}
+	}
+	return mergedViewItem{}, false
+}
+
+func TestIntegration_MergedProjectsViewPrimaryAnnotation(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/merged-view-primary"
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "camp")
+	seedProject(t, tc, dir, "fest")
+
+	// Base projects: list on the marker.
+	out, err := tc.RunCampInDir(dir, "workitem", "create", "wa", "--type", "design", "--title", "wa",
+		"--project", "projects/camp", "--project", "projects/fest")
+	require.NoError(t, err, "create: %s", out)
+	// Primary link for projects/camp only. The link command's --project takes a
+	// bare project name (it prefixes projects/), unlike create's full path.
+	out, err = tc.RunCampInDir(dir, "workitem", "link", "wa", "--project", "camp")
+	require.NoError(t, err, "link primary: %s", out)
+
+	// Both --json call sites must produce the same merged, primary-annotated view.
+	for _, cmd := range [][]string{
+		{"workitem", "list", "--json"},
+		{"workitem", "--json"},
+	} {
+		items, _ := mergedViewItems(t, tc, dir, cmd...)
+		item, ok := mergedViewByPath(items, "workflow/design/wa")
+		require.True(t, ok, "%v: item not found in %+v", cmd, items)
+		assert.Equal(t, []mergedViewProjectRef{
+			{Path: "projects/camp", Primary: true},
+			{Path: "projects/fest", Primary: false},
+		}, item.Projects, "%v: merged view must annotate the primary project", cmd)
+	}
+}
+
+func TestIntegration_MergedProjectsViewMalformedRegistryFallback(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/merged-view-malformed"
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "camp")
+	out, err := tc.RunCampInDir(dir, "workitem", "create", "wa", "--type", "design", "--title", "wa",
+		"--project", "projects/camp")
+	require.NoError(t, err, "create: %s", out)
+	// A links.yaml with no version field is rejected by links.Load. The read-only
+	// listing must not hard-fail on it: it degrades to no primary annotation and
+	// warns, rather than returning an error envelope.
+	require.NoError(t, tc.WriteFile(dir+"/.campaign/workitems/links.yaml", "links: []\n"))
+
+	// Both --json call sites must degrade gracefully.
+	for _, cmd := range [][]string{
+		{"workitem", "list", "--json"},
+		{"workitem", "--json"},
+	} {
+		items, raw := mergedViewItems(t, tc, dir, cmd...)
+		assert.Contains(t, raw, "camp workitem doctor --fix",
+			"%v: the fallback warning must name the fix command", cmd)
+		item, ok := mergedViewByPath(items, "workflow/design/wa")
+		require.True(t, ok, "%v: item not found in %+v", cmd, items)
+		require.Len(t, item.Projects, 1, "%v: projects must still be present", cmd)
+		assert.Equal(t, "projects/camp", item.Projects[0].Path)
+		assert.False(t, item.Projects[0].Primary,
+			"%v: no primary annotation is available when the registry is unreadable", cmd)
+	}
+}
+
+func TestIntegration_MergedProjectsViewEmptyNeverNull(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/merged-view-empty"
+	initLinksCampaign(t, tc, dir)
+	seedDesignWorkitem(t, tc, dir, "noproj")
+
+	items, raw := mergedViewItems(t, tc, dir, "workitem", "list", "--json")
+	item, ok := mergedViewByPath(items, "workflow/design/noproj")
+	require.True(t, ok, "item not found in %+v", items)
+	require.NotNil(t, item.Projects, "projects must be [] not null when there are none")
+	assert.Len(t, item.Projects, 0)
+	// Guard against a null literal slipping through the encoder for this item.
+	assert.NotContains(t, raw, `"projects": null`, "the merged view must never serialize null")
+}

--- a/tests/integration/workitem_link_concurrent_test.go
+++ b/tests/integration/workitem_link_concurrent_test.go
@@ -38,8 +38,10 @@ func TestIntegration_LinkConcurrentNoLoss(t *testing.T) {
 	var script strings.Builder
 	script.WriteString("set -e; cd " + dir + "; pids=\"\"; ")
 	for i := 0; i < n; i++ {
+		// blocked_by (not the deprecated related+project) exercises the same
+		// concurrent many-row append path this test guards.
 		fmt.Fprintf(&script,
-			"/camp workitem link shared --project proj-%02d --role related >/tmp/link-%02d.out 2>&1 & pids=\"$pids $!\"; ",
+			"/camp workitem link shared --project proj-%02d --role blocked_by >/tmp/link-%02d.out 2>&1 & pids=\"$pids $!\"; ",
 			i, i)
 	}
 	script.WriteString("for p in $pids; do wait $p || exit $?; done")

--- a/tests/integration/workitem_link_reject_test.go
+++ b/tests/integration/workitem_link_reject_test.go
@@ -1,0 +1,94 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_LinkRejectsRelatedProjectNoMutation(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/link-reject-related-project"
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "someproj")
+	seedDesignWorkitem(t, tc, dir, "wi")
+
+	// Establish a baseline link so links.yaml exists and has known content.
+	_, err := tc.RunCampInDir(dir, "workitem", "link", "wi", "--project", "someproj")
+	require.NoError(t, err)
+	before, err := tc.ReadFile(dir + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+
+	out, err := tc.RunCampInDir(dir, "workitem", "link", "wi", "--project", "someproj", "--role", "related")
+	require.Error(t, err, "related+project must be rejected: %s", out)
+	assert.Contains(t, out, "--project", "the error must name --project on create/adopt as the alternative")
+	assert.Contains(t, out, "deprecated", "the error must explain the deprecation")
+
+	after, err := tc.ReadFile(dir + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, before, after, "a rejected link must not mutate links.yaml at all")
+}
+
+func TestIntegration_LinkPrimaryProjectStillWorks(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/link-primary-project"
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "someproj")
+	seedDesignWorkitem(t, tc, dir, "wi")
+
+	out, err := tc.RunCampInDir(dir, "workitem", "link", "wi", "--project", "someproj")
+	require.NoError(t, err, "primary+project (default role) must still work: %s", out)
+	assert.Contains(t, out, "linked")
+
+	linksYAML, err := tc.ReadFile(dir + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, linksYAML, "projects/someproj")
+	assert.Contains(t, linksYAML, "role: primary")
+}
+
+func TestIntegration_LinkRelatedNonProjectStillWorks(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/link-related-nonproject"
+	initLinksCampaign(t, tc, dir)
+	seedDesignWorkitem(t, tc, dir, "wi")
+
+	// related + a non-project scope: the rejection is project-scoped, so this is
+	// allowed. --allow-missing skips scope-existence validation so the row writes.
+	out, err := tc.RunCampInDir(dir, "workitem", "link", "wi", "--festival", "somefest", "--role", "related", "--allow-missing")
+	require.NoError(t, err, "related + non-project scope must still succeed: %s", out)
+	assert.Contains(t, out, "linked")
+
+	linksYAML, err := tc.ReadFile(dir + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, linksYAML, "role: related")
+}
+
+func TestIntegration_LinkNonRelatedProjectStillWorks(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/link-nonrelated-project"
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "someproj")
+	seedDesignWorkitem(t, tc, dir, "wi")
+
+	for _, role := range []string{"blocked_by", "supersedes"} {
+		out, err := tc.RunCampInDir(dir, "workitem", "link", "wi", "--project", "someproj", "--role", role)
+		require.NoError(t, err, "%s+project must still work (only related is blocked): %s", role, out)
+		assert.Contains(t, out, "linked")
+	}
+}
+
+func TestIntegration_LinkAllowMissingDoesNotBypassRejection(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/link-reject-allowmissing"
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "someproj")
+	seedDesignWorkitem(t, tc, dir, "wi")
+
+	out, err := tc.RunCampInDir(dir, "workitem", "link", "wi", "--project", "someproj", "--role", "related", "--allow-missing")
+	require.Error(t, err, "--allow-missing must not bypass the related+project rejection: %s", out)
+	assert.Contains(t, out, "--project", "the rejection error still names the alternative")
+}


### PR DESCRIPTION
## Summary

Phase three of the v1alpha8 workitem schema rollout (after reader #464 and writer #468): the `links.yaml` `role: related` + `scope.kind: project` overlap is deprecated. Semantic project membership now has exactly one writable store, the workitem's own `projects:` field, and one merged read view.

- `e10458d7` CLI rejection: `camp workitem link --role related --project <name>` is rejected at the command layer with an error naming the replacement (`create`/`adopt --project`). Registry primitives (`AddLink`) are untouched, so doctor keeps its ability to manage rows. `--allow-missing` deliberately does not bypass. All other role and scope combinations behave exactly as before.
- `58e1b5e4` doctor migration: a new auto-fixable warning `workitem.link.related-project-deprecated` per legacy row; `--fix` writes the project into the workitem's identity document (marker or frontmatter, placement matching the create/adopt key convention), idempotent set semantics, then removes the row via `RemoveLinkByID`, both inside one locked pass. A row whose workitem cannot be resolved is reported as unmigratable and preserved, never deleted as a broken-link side effect (data preservation over cleanup, recorded in the festival).
- `4290dbf4` merged JSON view: the `--json` `projects` field becomes `[{path, primary}]`, the semantic set annotated with primary from `PrimaryForScope`, always `[]` when empty, at both output call sites. A malformed `links.yaml` degrades gracefully (nil-registry fallback, stderr warning pointing at `doctor --fix`) instead of failing read-only listing.

## JSON shape decision

Doc 04 left the merged-entry encoding (plain string vs object) open. Decision: object encoding `{path, primary}` in place, within `workitems/v1alpha9`, no version bump. Rationale: doc 04's binding constraint is one array that IS the merged view (an additive second field would re-introduce the split-view problem this phase removes); no released binary has ever emitted a populated `projects` array (the field shipped empty-only in v0.3.0-rc.3 and the writer release is unreleased); festival-app does not model the field but does pin `schema_version`, so bumping is the riskier move. The originally scaffolded `project_refs`/v1alpha10 sketch is superseded; the v1alpha9 changelog entry documents the object shape.

## Dependencies and verification

Depends on #468 (the `projects:` field must exist), already merged. Every sequence passed an independent adversarial review before its commit; findings fixed pre-merge included the malformed-registry regression above and a frontmatter key-placement divergence. Gates at PR time: build clean, whole-module unit green, lint 0 issues, containerized integration 511/511.

Full context: `obey-campaign` festival `festivals/active/workitem-schema-tags-and-projects-WS0001` (design doc `workflow/design/workitem-schema-tags-and-projects/04-projects-and-links.md`).