### PR TITLE
fix(register): camp register created campaigns with no festivals/ directory

### DIFF
--- a/cmd/camp/init/command.go
+++ b/cmd/camp/init/command.go
@@ -312,7 +312,7 @@ func RunFlow(ctx context.Context, p Params, w Writers, isInteractive bool) error
 	var festInitialized bool
 	if !p.DryRun {
 		var festErr error
-		festInitialized, festErr = initializeFestivals(ctx, result.CampaignRoot, w)
+		festInitialized, festErr = InitializeFestivals(ctx, result.CampaignRoot, w)
 		if festErr != nil && !errors.Is(festErr, fest.ErrFestNotFound) {
 			return festErr
 		}

--- a/cmd/camp/init/fest.go
+++ b/cmd/camp/init/fest.go
@@ -10,9 +10,15 @@ import (
 	"github.com/Obedience-Corp/camp/internal/ui"
 )
 
-// initializeFestivals runs fest init in the campaign directory.
+// InitializeFestivals runs fest init in the campaign directory.
 // Returns true if successful, false with guidance if fest is unavailable.
-func initializeFestivals(ctx context.Context, campaignRoot string, w Writers) (bool, error) {
+//
+// Exported because `camp register` initializes campaigns too, when the user
+// accepts its offer to set one up. Both commands have to reach the same
+// implementation: the previous arrangement gave scaffold its own copy of this
+// logic, and the copies drifted until register's silently created campaigns
+// with no festivals/ directory at all.
+func InitializeFestivals(ctx context.Context, campaignRoot string, w Writers) (bool, error) {
 	if fest.IsInitialized(campaignRoot) {
 		writeLine(w.HumanOut, ui.Success("Festival Methodology already initialized"))
 		return true, nil

--- a/cmd/camp/register.go
+++ b/cmd/camp/register.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	initcmd "github.com/Obedience-Corp/camp/cmd/camp/init"
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fest"
 	"github.com/Obedience-Corp/camp/internal/scaffold"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/spf13/cobra"
@@ -84,6 +87,15 @@ func runRegister(cmd *cobra.Command, args []string) error {
 			result, err := scaffold.Init(ctx, absPath, opts)
 			if err != nil {
 				return err
+			}
+			// Scaffolding alone leaves a campaign without festivals/, which is
+			// the same campaign `camp init` would have set up completely. A
+			// missing fest CLI is reported by InitializeFestivals and is not
+			// fatal, matching how init treats it.
+			if _, festErr := initcmd.InitializeFestivals(ctx, result.CampaignRoot, initcmd.Writers{HumanOut: os.Stdout}); festErr != nil {
+				if !errors.Is(festErr, fest.ErrFestNotFound) {
+					return festErr
+				}
 			}
 			fmt.Printf("%s Initialized and registered campaign at %s\n", ui.SuccessIcon(), ui.Value(result.CampaignRoot))
 			return nil

--- a/internal/scaffold/init.go
+++ b/internal/scaffold/init.go
@@ -2,7 +2,6 @@ package scaffold
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -24,9 +23,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/lancekrogers/guild-scaffold/pkg/scaffold"
 )
-
-// ErrFestNotInstalled indicates that the fest CLI is unavailable during init.
-var ErrFestNotInstalled = errors.New("fest not installed")
 
 // InitOptions configures the campaign initialization.
 type InitOptions struct {
@@ -416,23 +412,10 @@ workitems/current.yaml
 		}
 	}
 
-	// Initialize festivals directory via fest CLI if it doesn't exist
-	if !opts.DryRun {
-		if err := initFestivalsIfNeeded(ctx, absDir); err != nil {
-			if errors.Is(err, ErrFestNotInstalled) {
-				result.Skipped = append(result.Skipped, "festivals/ (fest not installed; run 'fest init' after installing)")
-			} else {
-				fmt.Fprintf(os.Stderr, "Warning: fest init failed: %v\n", err)
-				result.Skipped = append(result.Skipped, "festivals/ (fest init failed - run manually)")
-			}
-		} else {
-			// Check if festivals was created
-			festivalsPath := filepath.Join(absDir, "festivals")
-			if _, err := os.Stat(festivalsPath); err == nil {
-				result.DirsCreated = append(result.DirsCreated, festivalsPath)
-			}
-		}
-	}
+	// Festival Methodology setup is intentionally not done here. Scaffolding
+	// owns the campaign's own directories and files; running the fest CLI is a
+	// command-level concern, handled once by each command that initializes a
+	// campaign (see initcmd.InitializeFestivals).
 
 	// Initialize git repository if not already in one and not skipped
 	if !opts.SkipGitInit && !opts.DryRun {
@@ -540,32 +523,3 @@ func (o *InitOptions) Validate() error {
 	return nil
 }
 
-// initFestivalsIfNeeded runs `fest init` if the festivals directory doesn't exist.
-// This delegates festival scaffolding to the fest CLI for proper structure.
-func initFestivalsIfNeeded(ctx context.Context, dir string) error {
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
-
-	festivalsPath := filepath.Join(dir, "festivals")
-	if _, err := os.Stat(festivalsPath); err == nil {
-		// festivals/ already exists, skip
-		return nil
-	}
-
-	// Check if fest is available
-	festPath, err := exec.LookPath("fest")
-	if err != nil {
-		return ErrFestNotInstalled
-	}
-
-	cmd := exec.CommandContext(ctx, festPath, "init", "--path", dir)
-	cmd.Dir = dir
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		// Don't fail the whole init if fest init fails - user can run it manually
-		return camperrors.Wrapf(err, "fest init failed (run manually with 'fest init') (output: %s)", string(output))
-	}
-
-	return nil
-}

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -256,6 +257,44 @@ func buildCampBinaryShared() (string, error) {
 // buildFestBinaryShared builds the fest binary from the sibling fest project.
 // Returns ("", error) if the fest source is not found or build fails — callers
 // should treat this as non-fatal since fest is optional for most integration tests.
+// locateFestSource finds the fest checkout to build the container's fest binary
+// from, starting at the camp project root.
+//
+// fest normally sits beside camp as a sibling submodule (projects/camp,
+// projects/fest), but camp is routinely developed from a worktree under
+// projects/worktrees/camp/<branch>, where the sibling lookup lands on
+// projects/worktrees/camp/fest and misses. Every fest-gated test then skipped,
+// silently, and a green run meant nothing for that coverage. Walking the
+// ancestors finds projects/fest from either layout.
+//
+// CAMP_TEST_FEST_SRC overrides the search for checkouts that live elsewhere.
+func locateFestSource(projectRoot string) (string, error) {
+	if override := os.Getenv("CAMP_TEST_FEST_SRC"); override != "" {
+		abs, err := filepath.Abs(override)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve CAMP_TEST_FEST_SRC: %w", err)
+		}
+		if _, err := os.Stat(filepath.Join(abs, "cmd", "fest")); err != nil {
+			return "", fmt.Errorf("CAMP_TEST_FEST_SRC=%s has no cmd/fest: %w", abs, err)
+		}
+		return abs, nil
+	}
+
+	searched := []string{}
+	for dir := projectRoot; ; dir = filepath.Dir(dir) {
+		candidate := filepath.Join(dir, "fest")
+		searched = append(searched, candidate)
+		if _, err := os.Stat(filepath.Join(candidate, "cmd", "fest")); err == nil {
+			return candidate, nil
+		}
+		if parent := filepath.Dir(dir); parent == dir {
+			break
+		}
+	}
+	return "", fmt.Errorf("fest source not found; searched %s (set CAMP_TEST_FEST_SRC to override)",
+		strings.Join(searched, ", "))
+}
+
 func buildFestBinaryShared() (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -269,16 +308,9 @@ func buildFestBinaryShared() (string, error) {
 		return "", fmt.Errorf("failed to get absolute path: %w", err)
 	}
 
-	// fest lives alongside camp as a sibling submodule under projects/
-	festRoot := filepath.Join(projectRoot, "..", "fest")
-	festRoot, err = filepath.Abs(festRoot)
+	festRoot, err := locateFestSource(projectRoot)
 	if err != nil {
-		return "", fmt.Errorf("failed to get fest absolute path: %w", err)
-	}
-
-	// Verify fest source exists
-	if _, err := os.Stat(filepath.Join(festRoot, "cmd", "fest")); err != nil {
-		return "", fmt.Errorf("fest source not found at %s: %w", festRoot, err)
+		return "", err
 	}
 
 	binDir, err := os.MkdirTemp("", "fest-integration-bin-*")

--- a/tests/integration/register_festivals_test.go
+++ b/tests/integration/register_festivals_test.go
@@ -1,0 +1,98 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegister_InitializesFestivals covers the campaign `camp register` builds
+// when it offers to initialize a directory that is not yet a campaign.
+//
+// That path delegates to the scaffolder, which used to carry its own copy of
+// the fest invocation and passed a --path flag the fest CLI has never accepted.
+// The call failed on every run, the failure was non-fatal by design, and
+// register still printed its success line, so the command reported having set
+// up a campaign that had no festivals/ directory in it.
+//
+// Nothing executed camp's fest invocation anywhere in the suite, which is why
+// the mismatch survived. The assertion here is deliberately on the outcome
+// rather than on the argv: it has to keep holding no matter which code path
+// ends up owning the call.
+func TestRegister_InitializesFestivals(t *testing.T) {
+	if !festAvailable {
+		t.Skip("fest binary not available in container; skipping festival-present test")
+	}
+
+	tc := GetSharedContainer(t)
+	path := "/campaigns/register-bare-dir"
+	tc.Shell(t, fmt.Sprintf("rm -rf %s && mkdir -p %s", path, path))
+
+	// register prompts before initializing, so the confirmation is piped in.
+	output := tc.Shell(t, fmt.Sprintf("printf 'y\\n' | /camp register %s --name register-bare-dir 2>&1", path))
+
+	require.Contains(t, output, "Initialized and registered campaign",
+		"register should report initializing the campaign; output: %s", output)
+
+	exists, err := tc.CheckDirExists(path + "/festivals")
+	require.NoError(t, err)
+	assert.True(t, exists,
+		"festivals/ should exist after register initializes a campaign; output: %s", output)
+
+	// A festivals/ directory that fest did not populate would pass a bare
+	// existence check while still being unusable, so require a fest marker.
+	markers := []string{".festival", "fest.yaml", ".fest"}
+	found := 0
+	for _, marker := range markers {
+		if ok, checkErr := tc.CheckDirExists(path + "/festivals/" + marker); checkErr == nil && ok {
+			found++
+			continue
+		}
+		if ok, checkErr := tc.CheckFileExists(path + "/festivals/" + marker); checkErr == nil && ok {
+			found++
+		}
+	}
+	assert.NotZero(t, found,
+		"festivals/ should carry a fest marker (%s), meaning fest init actually ran",
+		strings.Join(markers, ", "))
+}
+
+// TestInit_NoFestWarningOnStderr pins the second symptom of the same defect.
+//
+// `camp init` called fest twice: the scaffolder's broken invocation ran first
+// and printed "Warning: fest init failed", then the command-level call ran and
+// quietly succeeded. festivals/ was created either way, so the only evidence
+// was a warning on stderr contradicted by the success line on stdout. Users
+// reasonably read that as noise, which is the other reason this went unnoticed.
+func TestInit_NoFestWarningOnStderr(t *testing.T) {
+	if !festAvailable {
+		t.Skip("fest binary not available in container; skipping festival-present test")
+	}
+
+	tc := GetSharedContainer(t)
+	path := "/campaigns/init-clean-stderr"
+
+	stdout, stderr, exitCode, err := tc.RunCampSplit("init", path,
+		"--name", "init-clean-stderr",
+		"-d", "desc",
+		"-m", "mission",
+		"--no-git",
+	)
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "camp init should succeed; stdout: %s stderr: %s", stdout, stderr)
+
+	assert.NotContains(t, stderr, "fest init failed",
+		"camp init should not report a fest failure it then silently recovers from")
+	assert.NotContains(t, stdout, "fest init failed - run manually",
+		"camp init should not list festivals/ as skipped when it creates it")
+
+	exists, checkErr := tc.CheckDirExists(path + "/festivals")
+	require.NoError(t, checkErr)
+	assert.True(t, exists, "festivals/ should exist when fest is available")
+}


### PR DESCRIPTION
## Problem

`camp register` offers to initialize a directory that isn't yet a campaign. Answer `y` and it creates a campaign **with no `festivals/` directory** — then prints a success line saying it initialized one.

```
⚠ No campaign found at /tmp/probe/bare
Would you like to initialize one? [y/N] Warning: fest init failed: ... unknown flag: --path
✓ Initialized and registered campaign at /tmp/probe/bare

festivals/: MISSING
```

## Cause

`scaffold.Init` carried its own copy of the fest invocation, passing a `--path` flag **the fest CLI has never accepted** — `fest init` takes a positional path (`Use: "init [path]"`). It failed on every run, and was non-fatal by design, so nothing surfaced.

`camp init` was unaffected *in outcome* because it calls fest a second time via `initializeFestivals`, which uses the positional form and succeeds. That second call is also why this survived six months (the `--path` line dates to `617916bd`, 2026-01-21): the only symptom on the common path was a stderr warning immediately contradicted by `Festivals: initialized` on stdout, which reads as noise.

## Fix

Give `register` the same call `init` makes, and drop scaffold's copy entirely:

```
scaffold.Init          → dirs, files, symlinks. No fest.
cmd/camp/init          → InitializeFestivals()   ← already there
cmd/camp/register (y)  → InitializeFestivals()   ← added
```

Scaffolding owns the campaign's own files; running the fest CLI is a command-level concern. Each command that initializes a campaign now makes exactly one call to one implementation.

Fixing the flag in place would also have worked, but leaves two copies of "shell out to fest init" — which is *why* one drifted unnoticed — and would leave `camp init` calling fest twice, the second call reporting *"Festival Methodology already initialized"* on a brand-new campaign.

`register` also picks up what the duplicate never had: the **30s timeout** in `fest.RunInit` (a wedged fest could previously hang the command indefinitely), plus the install/manual-init guidance `init` already showed.

After:

```
Would you like to initialize one? [y/N] Initializing Festival Methodology...
Festival Methodology initialized
✓ Initialized and registered campaign at /tmp/probe/reg
festivals/: PRESENT (9 entries)
```

`camp init`'s stderr is now empty, and the bogus `festivals/ (fest init failed - run manually)` skip entry is gone.

## Why it wasn't caught, and the harness bug that hid it

Nothing in the suite executed camp's fest invocation. A wrong argv inside `exec.Command` is invisible to unit tests and to `go vet`.

Adding integration coverage surfaced a **second problem**: the container's fest binary was built from `projectRoot/../fest`, which resolves to `projects/fest` only when camp sits at `projects/camp`. Camp is routinely developed from `projects/worktrees/camp/<branch>`, where that expression lands on `projects/worktrees/camp/fest` and misses. `festAvailable` went false and **all 9 fest-gated tests skipped** — the suite still reported `ok`, so a green integration run from a worktree carried no signal for that coverage at all. First commit walks the ancestors instead (works from either layout) and adds `CAMP_TEST_FEST_SRC`.

Full integration suite passes with the un-skipped tests now actually running (423s), so nothing was hiding behind them.

## Verification

Both new tests assert on **outcome, not argv**, so they keep holding regardless of which path owns the call. Confirmed they actually catch the bug:

```
# against the unfixed binary
--- FAIL: TestRegister_InitializesFestivals
    festivals/ should carry a fest marker (.festival, fest.yaml, .fest)
--- FAIL: TestInit_NoFestWarningOnStderr
    "Warning: fest init failed ... unknown flag: --path" should not contain "fest init failed"

# against the fixed binary
--- PASS: TestRegister_InitializesFestivals (3.36s)
--- PASS: TestInit_NoFestWarningOnStderr (3.15s)
```

`just gate`: 3614/3614 pass, lint clean. Full integration suite: pass.

## One caveat on how far this protects

`just gate` only *vets* the integration build tag — it does not run those tests (`just test` does), and GitHub CI is paused. So this catches the class **on demand, not automatically**. Making it automatic means having the gate run integration, which is a separate call with a real runtime cost (~7 min).

Also worth knowing: these tests shell out to a binary built at run time, so Go's test cache can't see source changes behind them. `-count=1` is required when using them to check a behavior change — without it I got a cached PASS against deliberately broken source.
