### PR TITLE
test+docs: acceptance criteria + CLI reference regen for workitem-schema festival

### DIFF
--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -7048,30 +7048,37 @@ camp workitem [flags]
 
 ## camp workitem adopt
 
-Adopt an existing directory as a workitem
+Adopt an existing directory or file as a workitem
 
 ### Synopsis
 
-Attach workitem metadata to an existing campaign directory without moving it.
+Attach workitem metadata to an existing campaign directory or markdown file.
 
-The target directory must already exist and must not already contain a
-.workitem file. The command writes that .workitem metadata file with the
-selected type, title, generated or supplied id, and optional quest link. Use
-this when a workflow directory already exists and needs to become a tracked
-workitem.
+With a directory argument, writes a .workitem marker (the directory must exist
+and must not already contain a .workitem). With --file <path.md>, stamps a
+kind: workitem frontmatter block onto an existing markdown file without ever
+rewriting its body: it prepends a block when the file has none, merges camp's
+keys into a foreign block (refusing an ambiguous foreign tags: key without
+--force), and updates tags/projects when the file is already a workitem. In all
+cases it sets the selected type, title, generated or supplied id, optional quest
+link, optional tags, and optional related projects.
 
 ```
-camp workitem adopt <dir> [flags]
+camp workitem adopt [dir] [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help           help for adopt
-      --id string      override the generated id
-      --quest string   quest ID to associate (requires dev-profile camp; forward-compatible flag)
-      --title string   human-readable title
-      --type string    workitem type (feature, bug, chore, or custom) (default "feature")
+      --file string           stamp kind: workitem frontmatter onto a markdown file instead of adopting a directory
+      --force                 with --file, take ownership of an existing foreign tags: key (union conforming values, drop and report non-conforming ones)
+  -h, --help                  help for adopt
+      --id string             override the generated id
+      --project stringArray   add a related project path (repeatable, e.g. projects/camp)
+      --quest string          quest ID to associate (requires dev-profile camp; forward-compatible flag)
+      --tag stringArray       add a tag (repeatable, normalized to lowercase kebab-case)
+      --title string          human-readable title
+      --type string           workitem type (feature, bug, chore, or custom) (default "feature")
 ```
 
 ### Options inherited from parent commands
@@ -7168,17 +7175,30 @@ camp workitem commits [selector] [flags]
 
 ## camp workitem create
 
-Create a workitem
+Create workitem tracking metadata
 
 ### Synopsis
 
-Create a new workitem directory with minimal v1 metadata.
+Create tracking metadata for a new workitem (directory + .workitem marker).
 
-The workitem is created under workflow/<type>/<slug>/ unless --dir supplies a
-different campaign-relative parent directory. A .workitem file is written with
-the id, type, title, ref, creation metadata, and optional quest link. Use --json
-for machine-readable output containing the new workitem identity and next-step
-location.
+This command does NOT create the substantive work scaffold (no design docs,
+explore notes, or festival structure). It only:
+
+  1. Creates workflow/<type>/<slug>/ (or --dir/<slug>/)
+  2. Writes a .workitem marker (id, type, title, ref, optional quest, optional
+     tags, optional related projects)
+
+Agents and humans must still add real content afterward. For explore/design
+types, the recommended structured-workflow scaffold is:
+
+  cd workflow/<type>/<slug> && fest create workflow <slug>
+
+For other types (feature, bug, chore, …), no festival scaffold is implied;
+populate campaign-governed content under the new directory as needed.
+
+Use "camp workitem adopt" to attach a marker to an existing directory.
+Use --json for machine-readable identity. next.command is set only for
+explore/design (recommended scaffold); otherwise it is empty/omitted.
 
 ```
 camp workitem create <slug> [flags]
@@ -7187,13 +7207,16 @@ camp workitem create <slug> [flags]
 ### Options
 
 ```
-      --dir string     parent dir override (default: workflow/<type>)
-  -h, --help           help for create
-      --id string      override the generated id
-      --json           emit a structured JSON result
-      --quest string   quest ID to associate (requires dev-profile camp; forward-compatible flag)
-      --title string   human-readable title
-      --type string    workitem type (feature, bug, chore, or custom) (default "feature")
+      --dir string            parent dir override (default: workflow/<type>)
+      --file string           create a new markdown file with kind: workitem frontmatter instead of a directory workitem
+  -h, --help                  help for create
+      --id string             override the generated id
+      --json                  emit a structured JSON result
+      --project stringArray   add a related project path (repeatable, e.g. projects/camp)
+      --quest string          quest ID to associate (requires dev-profile camp; forward-compatible flag)
+      --tag stringArray       add a tag (repeatable, normalized to lowercase kebab-case)
+      --title string          human-readable title
+      --type string           workitem type (feature, bug, chore, or custom) (default "feature")
 ```
 
 ### Options inherited from parent commands
@@ -7306,6 +7329,11 @@ A primary worktree link is how design/explore workitems under workflow/ get
 into camp p commit tags: when you commit from that worktree, the resolver
 matches the link and stamps WI-<ref> on the subject.
 
+Note: role:related links to a project scope are no longer accepted; a workitem's
+related projects live in its own projects: field. Use "camp workitem
+create/adopt --project <path>" (or edit the .workitem/frontmatter) instead of
+"--role related --project".
+
 Examples:
   camp workitem link WI-2a7950 --worktree fest/fest-list-watch
   camp workitem link workflow/design/fest-list-watch --worktree projects/worktrees/fest/fest-list-watch
@@ -7388,6 +7416,7 @@ Examples:
   camp workitem list intent
   camp workitem list active
   camp workitem list --category research --query auth
+  camp workitem list --tag public-launch --tag schema
   camp workitem list festival --status ready --json
 
 ```
@@ -7404,10 +7433,12 @@ camp workitem list [type|status|category] [flags]
   -h, --help                          help for list
       --json                          Output as JSON
       --limit int                     Maximum number of items to return (non-interactive / --json only)
+      --project stringArray           Filter by related project (repeat for OR)
       --query string                  Search query to filter items
       --show-parked                   Include parked attention-stage workitems
       --stage stringArray             Filter by lifecycle stage (repeat for OR)
       --status stringArray            Filter by displayed status: current, next, active, parked, inbox, ready, plan, ritual, chains, none (repeat for OR)
+      --tag stringArray               Filter by tag (repeat; item must have ALL given tags)
       --type stringArray              Filter by workflow type (repeat for OR)
 ```
 

--- a/docs/cli-reference/camp_workitem.md
+++ b/docs/cli-reference/camp_workitem.md
@@ -47,10 +47,10 @@ camp workitem [flags]
 ### SEE ALSO
 
 * [camp](camp.md)	 - Campaign management CLI for multi-project AI workspaces
-* [camp workitem adopt](camp_workitem_adopt.md)	 - Adopt an existing directory as a workitem
+* [camp workitem adopt](camp_workitem_adopt.md)	 - Adopt an existing directory or file as a workitem
 * [camp workitem commit](camp_workitem_commit.md)	 - Commit changes scoped to a workitem
 * [camp workitem commits](camp_workitem_commits.md)	 - List commits referencing a workitem
-* [camp workitem create](camp_workitem_create.md)	 - Create a workitem
+* [camp workitem create](camp_workitem_create.md)	 - Create workitem tracking metadata
 * [camp workitem current](camp_workitem_current.md)	 - Get, set, or clear the current workitem
 * [camp workitem doctor](camp_workitem_doctor.md)	 - Report link-registry health issues
 * [camp workitem group](camp_workitem_group.md)	 - Set or clear the group

--- a/docs/cli-reference/camp_workitem_adopt.md
+++ b/docs/cli-reference/camp_workitem_adopt.md
@@ -1,29 +1,36 @@
 ## camp workitem adopt
 
-Adopt an existing directory as a workitem
+Adopt an existing directory or file as a workitem
 
 ### Synopsis
 
-Attach workitem metadata to an existing campaign directory without moving it.
+Attach workitem metadata to an existing campaign directory or markdown file.
 
-The target directory must already exist and must not already contain a
-.workitem file. The command writes that .workitem metadata file with the
-selected type, title, generated or supplied id, and optional quest link. Use
-this when a workflow directory already exists and needs to become a tracked
-workitem.
+With a directory argument, writes a .workitem marker (the directory must exist
+and must not already contain a .workitem). With --file <path.md>, stamps a
+kind: workitem frontmatter block onto an existing markdown file without ever
+rewriting its body: it prepends a block when the file has none, merges camp's
+keys into a foreign block (refusing an ambiguous foreign tags: key without
+--force), and updates tags/projects when the file is already a workitem. In all
+cases it sets the selected type, title, generated or supplied id, optional quest
+link, optional tags, and optional related projects.
 
 ```
-camp workitem adopt <dir> [flags]
+camp workitem adopt [dir] [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help           help for adopt
-      --id string      override the generated id
-      --quest string   quest ID to associate (requires dev-profile camp; forward-compatible flag)
-      --title string   human-readable title
-      --type string    workitem type (feature, bug, chore, or custom) (default "feature")
+      --file string           stamp kind: workitem frontmatter onto a markdown file instead of adopting a directory
+      --force                 with --file, take ownership of an existing foreign tags: key (union conforming values, drop and report non-conforming ones)
+  -h, --help                  help for adopt
+      --id string             override the generated id
+      --project stringArray   add a related project path (repeatable, e.g. projects/camp)
+      --quest string          quest ID to associate (requires dev-profile camp; forward-compatible flag)
+      --tag stringArray       add a tag (repeatable, normalized to lowercase kebab-case)
+      --title string          human-readable title
+      --type string           workitem type (feature, bug, chore, or custom) (default "feature")
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_workitem_create.md
+++ b/docs/cli-reference/camp_workitem_create.md
@@ -1,16 +1,29 @@
 ## camp workitem create
 
-Create a workitem
+Create workitem tracking metadata
 
 ### Synopsis
 
-Create a new workitem directory with minimal v1 metadata.
+Create tracking metadata for a new workitem (directory + .workitem marker).
 
-The workitem is created under workflow/<type>/<slug>/ unless --dir supplies a
-different campaign-relative parent directory. A .workitem file is written with
-the id, type, title, ref, creation metadata, and optional quest link. Use --json
-for machine-readable output containing the new workitem identity and next-step
-location.
+This command does NOT create the substantive work scaffold (no design docs,
+explore notes, or festival structure). It only:
+
+  1. Creates workflow/<type>/<slug>/ (or --dir/<slug>/)
+  2. Writes a .workitem marker (id, type, title, ref, optional quest, optional
+     tags, optional related projects)
+
+Agents and humans must still add real content afterward. For explore/design
+types, the recommended structured-workflow scaffold is:
+
+  cd workflow/<type>/<slug> && fest create workflow <slug>
+
+For other types (feature, bug, chore, …), no festival scaffold is implied;
+populate campaign-governed content under the new directory as needed.
+
+Use "camp workitem adopt" to attach a marker to an existing directory.
+Use --json for machine-readable identity. next.command is set only for
+explore/design (recommended scaffold); otherwise it is empty/omitted.
 
 ```
 camp workitem create <slug> [flags]
@@ -19,13 +32,16 @@ camp workitem create <slug> [flags]
 ### Options
 
 ```
-      --dir string     parent dir override (default: workflow/<type>)
-  -h, --help           help for create
-      --id string      override the generated id
-      --json           emit a structured JSON result
-      --quest string   quest ID to associate (requires dev-profile camp; forward-compatible flag)
-      --title string   human-readable title
-      --type string    workitem type (feature, bug, chore, or custom) (default "feature")
+      --dir string            parent dir override (default: workflow/<type>)
+      --file string           create a new markdown file with kind: workitem frontmatter instead of a directory workitem
+  -h, --help                  help for create
+      --id string             override the generated id
+      --json                  emit a structured JSON result
+      --project stringArray   add a related project path (repeatable, e.g. projects/camp)
+      --quest string          quest ID to associate (requires dev-profile camp; forward-compatible flag)
+      --tag stringArray       add a tag (repeatable, normalized to lowercase kebab-case)
+      --title string          human-readable title
+      --type string           workitem type (feature, bug, chore, or custom) (default "feature")
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli-reference/camp_workitem_link.md
+++ b/docs/cli-reference/camp_workitem_link.md
@@ -15,6 +15,11 @@ A primary worktree link is how design/explore workitems under workflow/ get
 into camp p commit tags: when you commit from that worktree, the resolver
 matches the link and stamps WI-<ref> on the subject.
 
+Note: role:related links to a project scope are no longer accepted; a workitem's
+related projects live in its own projects: field. Use "camp workitem
+create/adopt --project <path>" (or edit the .workitem/frontmatter) instead of
+"--role related --project".
+
 Examples:
   camp workitem link WI-2a7950 --worktree fest/fest-list-watch
   camp workitem link workflow/design/fest-list-watch --worktree projects/worktrees/fest/fest-list-watch

--- a/docs/cli-reference/camp_workitem_list.md
+++ b/docs/cli-reference/camp_workitem_list.md
@@ -17,6 +17,7 @@ Examples:
   camp workitem list intent
   camp workitem list active
   camp workitem list --category research --query auth
+  camp workitem list --tag public-launch --tag schema
   camp workitem list festival --status ready --json
 
 ```
@@ -33,10 +34,12 @@ camp workitem list [type|status|category] [flags]
   -h, --help                          help for list
       --json                          Output as JSON
       --limit int                     Maximum number of items to return (non-interactive / --json only)
+      --project stringArray           Filter by related project (repeat for OR)
       --query string                  Search query to filter items
       --show-parked                   Include parked attention-stage workitems
       --stage stringArray             Filter by lifecycle stage (repeat for OR)
       --status stringArray            Filter by displayed status: current, next, active, parked, inbox, ready, plan, ritual, chains, none (repeat for OR)
+      --tag stringArray               Filter by tag (repeat; item must have ALL given tags)
       --type stringArray              Filter by workflow type (repeat for OR)
 ```
 

--- a/tests/integration/acceptance_criteria_test.go
+++ b/tests/integration/acceptance_criteria_test.go
@@ -1,0 +1,173 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// accItem parses the workitem --json item shape needed by the seq-01 acceptance
+// gap-closing tests: tags and the merged {path, primary} projects view.
+type accItem struct {
+	Key          string   `json:"key"`
+	RelativePath string   `json:"relative_path"`
+	ItemKind     string   `json:"item_kind"`
+	Tags         []string `json:"tags"`
+	Projects     []struct {
+		Path    string `json:"path"`
+		Primary bool   `json:"primary"`
+	} `json:"projects"`
+}
+
+func accItems(t *testing.T, tc *TestContainer, dir string, args ...string) []accItem {
+	t.Helper()
+	out, err := tc.RunCampInDir(dir, args...)
+	require.NoError(t, err, "%v: %s", args, out)
+	start := strings.Index(out, "{")
+	require.GreaterOrEqual(t, start, 0, "no JSON in: %s", out)
+	var payload struct {
+		Items []accItem `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out[start:]), &payload), "raw=%s", out)
+	return payload.Items
+}
+
+func accItemByPath(items []accItem, rel string) (accItem, bool) {
+	for _, it := range items {
+		if it.RelativePath == rel {
+			return it, true
+		}
+	}
+	return accItem{}, false
+}
+
+// doc 08 criterion 1: a directory marker with tags and a multi-entry projects
+// list validates and appears in camp workitem --json with both fields populated.
+func TestIntegration_Crit01_JSONShowsTagsAndMultiProject(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/acc-crit01"
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "camp")
+	seedProject(t, tc, dir, "fest")
+	out, err := tc.RunCampInDir(dir, "workitem", "create", "feat", "--type", "design", "--title", "Feat",
+		"--tag", "ux", "--tag", "public-launch",
+		"--project", "projects/camp", "--project", "projects/fest")
+	require.NoError(t, err, "create: %s", out)
+
+	items := accItems(t, tc, dir, "workitem", "list", "--json")
+	item, ok := accItemByPath(items, "workflow/design/feat")
+	require.True(t, ok, "item not found in %+v", items)
+	assert.Equal(t, []string{"ux", "public-launch"}, item.Tags, "both tags populated in order")
+	require.Len(t, item.Projects, 2, "multi-entry projects populated")
+	assert.Equal(t, "projects/camp", item.Projects[0].Path)
+	assert.Equal(t, "projects/fest", item.Projects[1].Path)
+}
+
+// doc 08 criterion 13: a workitem whose marker fails schema validation is not
+// silently included in a filtered result, and the validation failure surfaces
+// (via validate) rather than being swallowed. Pinned behavior: the invalid
+// marker discovers as a bare item (empty tags), so a tag filter excludes it,
+// and validate reports it as an error finding.
+func TestIntegration_Crit13_InvalidMarkerExcludedFromFilterAndSurfaced(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/acc-crit13"
+	initLinksCampaign(t, tc, dir)
+	seedProject(t, tc, dir, "target")
+	// A valid workitem carrying both the filter tag and the filter project.
+	out, err := tc.RunCampInDir(dir, "workitem", "create", "good", "--type", "design", "--title", "Good",
+		"--tag", "target", "--project", "projects/target")
+	require.NoError(t, err, "create good: %s", out)
+	// A directory marker with an invalid version (fails schema load) that also
+	// claims tag "target" and project projects/target: if it loaded, it would
+	// match both filters.
+	require.NoError(t, tc.WriteFile(dir+"/workflow/design/bad/.workitem",
+		"version: v1alpha7x\nkind: workitem\nid: design-bad-2026-07-19\ntype: design\ntitle: Bad\nref: WI-bad001\ntags:\n  - target\nprojects:\n  - projects/target\n"))
+
+	// The tag filter must not silently include the invalid marker.
+	tagItems := accItems(t, tc, dir, "workitem", "list", "--tag", "target", "--json")
+	_, goodInTag := accItemByPath(tagItems, "workflow/design/good")
+	_, badInTag := accItemByPath(tagItems, "workflow/design/bad")
+	assert.True(t, goodInTag, "the valid tagged item is present in the --tag result")
+	assert.False(t, badInTag, "the invalid marker's tag claim does not leak into the --tag filter")
+
+	// Symmetry: the project filter must not silently include it either.
+	projItems := accItems(t, tc, dir, "workitem", "list", "--project", "projects/target", "--json")
+	_, goodInProj := accItemByPath(projItems, "workflow/design/good")
+	_, badInProj := accItemByPath(projItems, "workflow/design/bad")
+	assert.True(t, goodInProj, "the valid item is present in the --project result")
+	assert.False(t, badInProj, "the invalid marker's project claim does not leak into the --project filter")
+
+	// The boundary is "excluded from filters", not "hidden": the invalid marker
+	// still appears in an unfiltered list as a bare item, because its tags and
+	// projects never loaded from the failed marker.
+	allItems := accItems(t, tc, dir, "workitem", "list", "--json")
+	bad, badPresent := accItemByPath(allItems, "workflow/design/bad")
+	require.True(t, badPresent, "the invalid marker appears as a bare item in the unfiltered list")
+	assert.Empty(t, bad.Tags, "the bare item exposes no loaded tags")
+	assert.Empty(t, bad.Projects, "the bare item exposes no loaded projects")
+
+	// The validation failure must surface via validate (non-zero exit + the path).
+	vout, verr := tc.RunCampInDir(dir, "workitem", "validate", "--json")
+	assert.Error(t, verr, "validate exits non-zero when a marker is malformed: %s", vout)
+	assert.Contains(t, vout, "workflow/design/bad", "validate surfaces the invalid marker rather than swallowing it")
+}
+
+// doc 08 criterion 17 (the load-bearing one): a shipped pre-reader binary
+// (v0.3.0-rc.2, commit 1f06e423, allowlist stops at v1alpha6, no forward-compat
+// rule) hard-fails to load a v1alpha8 marker written by the current binary, with
+// a non-zero exit and a versions error naming its supported list. This proves the
+// staged reader-before-writer rollout was necessary.
+func TestIntegration_Crit17_PreReaderBinaryRejectsV1Alpha8(t *testing.T) {
+	if legacyCampSkip != "" {
+		t.Skip(legacyCampSkip)
+	}
+	tc := GetSharedContainer(t)
+	dir := "/test/acc-crit17"
+	initLinksCampaign(t, tc, dir)
+
+	// The CURRENT binary writes a v1alpha8 marker.
+	out, err := tc.RunCampInDir(dir, "workitem", "create", "feat", "--type", "design", "--title", "Feat")
+	require.NoError(t, err, "current create: %s", out)
+	marker, err := tc.ReadFile(dir + "/workflow/design/feat/.workitem")
+	require.NoError(t, err)
+	require.Contains(t, marker, "version: v1alpha8", "the current binary writes a v1alpha8 marker")
+
+	// The pre-reader binary must hard-fail on that campaign rather than silently
+	// accept the marker: non-zero exit, versions error naming its supported list.
+	lout, lerr := tc.RunLegacyCampInDir(dir, "workitem", "validate")
+	require.Error(t, lerr, "pre-reader binary must exit non-zero on a v1alpha8 marker: %s", lout)
+	assert.Contains(t, lout, "v1alpha8", "the error names the unsupported version it read")
+	assert.Contains(t, lout, "v1alpha6", "the error names the pre-reader supported list (which stops at v1alpha6)")
+}
+
+// doc 08 criterion 9: an intent under .campaign/intents/<stage>/*.md is discovered
+// only by the intents path, never a second time as a kind: workitem frontmatter
+// document, because the document scanner does not descend into .campaign/.
+func TestIntegration_Crit09_IntentNotDoubleDiscoveredAsFrontmatter(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/acc-crit09"
+	initLinksCampaign(t, tc, dir)
+	// The adversarial case: an intent file that also carries a kind: workitem
+	// frontmatter block. If the document scanner descended into .campaign/, this
+	// would be discovered a second time as a file workitem.
+	require.NoError(t, tc.WriteFile(dir+"/.campaign/intents/active/01-idea.md",
+		"---\nid: int_01\nstatus: active\nkind: workitem\ntype: design\nref: WI-aaaaaa\ntitle: Idea\n---\n\nbody\n"))
+
+	items := accItems(t, tc, dir, "workitem", "list", "--json")
+	rel := ".campaign/intents/active/01-idea.md"
+	var matches []accItem
+	for _, it := range items {
+		if it.RelativePath == rel {
+			matches = append(matches, it)
+		}
+	}
+	require.Len(t, matches, 1, "the intent is discovered exactly once, never doubled as a frontmatter workitem: %+v", matches)
+	assert.True(t, strings.HasPrefix(matches[0].Key, "intent:"),
+		"the single discovery is via the intents path (key %q), not a frontmatter workitem", matches[0].Key)
+}

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -59,9 +59,10 @@ type TestContainer struct {
 // sharedBinaries holds host paths to the test binaries built once in TestMain
 // and copied into every pooled container.
 type sharedBinaries struct {
-	camp string
-	fest string // "" when fest is unavailable
-	scc  string // "" when scc is unavailable
+	camp       string
+	fest       string // "" when fest is unavailable
+	scc        string // "" when scc is unavailable
+	campLegacy string // "" when the pinned pre-reader binary is unavailable
 }
 
 // buildSharedBinaries builds the camp/fest/scc binaries on the host exactly once.
@@ -105,7 +106,77 @@ func buildSharedBinaries() (sharedBinaries, func(), error) {
 		sccAvailable = true
 	}
 
+	// Pinned pre-reader binary for the criterion-17 rollout-contract test. Cached
+	// across runs in TempDir (so not added to dirs for cleanup); a skip reason is
+	// recorded instead of a hard failure when the pinned commit is unavailable.
+	if legacyBin, skip := buildLegacyCampBinaryShared(); skip != "" {
+		fmt.Fprintf(os.Stderr, "WARN: %s\n", skip)
+		legacyCampSkip = skip
+	} else {
+		bins.campLegacy = legacyBin
+	}
+
 	return bins, cleanup, nil
+}
+
+// legacyCampCommit pins the pre-reader camp binary for the criterion-17 rollout
+// contract test: commit 1f06e423 is release v0.3.0-rc.2, the newest shipped
+// binary whose allowlist stops at v1alpha6 with no forward-compat rule.
+const legacyCampCommit = "1f06e423"
+
+// buildLegacyCampBinaryShared builds the pinned pre-reader camp binary once and
+// caches it across runs at a stable TempDir path keyed by commit and arch. It
+// returns a non-empty skip reason (and empty path) when the pinned commit is not
+// present in this clone (e.g. a shallow CI checkout) or the build fails, so the
+// criterion-17 test skips with a clear message rather than a cryptic failure that
+// blocks the whole suite. It stays entirely inside the integration harness: no
+// host unit test depends on git history.
+func buildLegacyCampBinaryShared() (path string, skip string) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Sprintf("pre-reader binary unavailable: %v", err)
+	}
+	projectRoot, err := filepath.Abs(filepath.Join(cwd, "../.."))
+	if err != nil {
+		return "", fmt.Sprintf("pre-reader binary unavailable: %v", err)
+	}
+
+	cached := filepath.Join(os.TempDir(), fmt.Sprintf("camp-legacy-%s-%s", legacyCampCommit, runtime.GOARCH))
+	if _, statErr := os.Stat(cached); statErr == nil {
+		return cached, ""
+	}
+
+	// cat-file -e fails on a shallow clone that lacks the pinned commit.
+	if err := runCommand(fmt.Sprintf("git -C %s cat-file -e %s^{commit}", projectRoot, legacyCampCommit)); err != nil {
+		return "", fmt.Sprintf("pre-reader binary skipped: commit %s (v0.3.0-rc.2) not in this clone (shallow?)", legacyCampCommit)
+	}
+
+	srcDir, err := os.MkdirTemp("", "camp-legacy-src-*")
+	if err != nil {
+		return "", fmt.Sprintf("pre-reader binary skipped: %v", err)
+	}
+	defer os.RemoveAll(srcDir)
+	// git archive extracts the source tree at the pinned commit with no worktree
+	// or .git entry to clean up afterward.
+	if err := runCommand(fmt.Sprintf("git -C %s archive %s | tar -x -C %s", projectRoot, legacyCampCommit, srcDir)); err != nil {
+		return "", fmt.Sprintf("pre-reader binary skipped: extract %s failed: %v", legacyCampCommit, err)
+	}
+
+	// Build to a pid-suffixed temp path then rename into the cache, so an
+	// interrupted or racing build never leaves a partial binary at the cached
+	// path. GOTOOLCHAIN=auto lets go fetch whatever toolchain the rc.2 go.mod pins.
+	tmpBin := fmt.Sprintf("%s.tmp.%d", cached, os.Getpid())
+	build := fmt.Sprintf("cd %s && GOTOOLCHAIN=auto GOOS=linux GOARCH=%s go build -tags=dev -o %s ./cmd/camp",
+		srcDir, runtime.GOARCH, tmpBin)
+	if err := runCommand(build); err != nil {
+		_ = os.Remove(tmpBin)
+		return "", fmt.Sprintf("pre-reader binary skipped: build %s failed: %v", legacyCampCommit, err)
+	}
+	if err := os.Rename(tmpBin, cached); err != nil {
+		_ = os.Remove(tmpBin)
+		return "", fmt.Sprintf("pre-reader binary skipped: cache %s failed: %v", legacyCampCommit, err)
+	}
+	return cached, ""
 }
 
 // newPooledContainer starts one container and provisions it identically to every
@@ -162,6 +233,12 @@ func newPooledContainer(ctx context.Context, bins sharedBinaries) (*TestContaine
 		if err := container.CopyFileToContainer(ctx, bins.scc, "/usr/local/bin/scc", 0o755); err != nil {
 			container.Terminate(ctx)
 			return nil, fmt.Errorf("failed to copy scc binary into container: %w", err)
+		}
+	}
+	if bins.campLegacy != "" {
+		if err := container.CopyFileToContainer(ctx, bins.campLegacy, "/camp-legacy", 0o755); err != nil {
+			container.Terminate(ctx)
+			return nil, fmt.Errorf("failed to copy legacy camp binary into container: %w", err)
 		}
 	}
 

--- a/tests/integration/helpers_container.go
+++ b/tests/integration/helpers_container.go
@@ -107,6 +107,32 @@ func (tc *TestContainer) RunCampInDir(dir string, args ...string) (string, error
 	return string(output), nil
 }
 
+// RunLegacyCampInDir runs the pinned pre-reader camp binary (/camp-legacy) from
+// dir. Used only by the criterion-17 rollout-contract test to prove a pre-reader
+// binary hard-fails on a v1alpha8 marker. Mirrors RunCampInDir: the returned
+// error is non-nil on a non-zero exit, with the merged stdout/stderr as output.
+func (tc *TestContainer) RunLegacyCampInDir(dir string, args ...string) (string, error) {
+	quotedArgs := make([]string, len(args))
+	for i, arg := range args {
+		escaped := strings.ReplaceAll(arg, "'", "'\"'\"'")
+		quotedArgs[i] = "'" + escaped + "'"
+	}
+	cmdStr := fmt.Sprintf("cd %s && /camp-legacy %s 2>&1", dir, strings.Join(quotedArgs, " "))
+	exitCode, reader, err := tc.container.Exec(tc.ctx, []string{"sh", "-c", cmdStr})
+	if err != nil {
+		return "", fmt.Errorf("failed to execute legacy camp: %w", err)
+	}
+	rawOutput, err := io.ReadAll(reader)
+	if err != nil {
+		return "", fmt.Errorf("failed to read output: %w", err)
+	}
+	output := demuxDockerOutput(rawOutput)
+	if exitCode != 0 {
+		return string(output), fmt.Errorf("legacy camp exited with code %d: %s", exitCode, output)
+	}
+	return string(output), nil
+}
+
 // InitCampaign creates a new campaign via camp init and initializes it as a git repo
 func (tc *TestContainer) InitCampaign(path, name, campType string) (string, error) {
 	args := []string{"init", path, "--name", name, "-d", "Test campaign", "-m", "Test mission"}

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -30,6 +30,11 @@ var festAvailable bool
 // skip if false.
 var sccAvailable bool
 
+// legacyCampSkip is set to a non-empty reason when the pinned pre-reader camp
+// binary (/camp-legacy) could not be built (e.g. its commit is absent in a
+// shallow clone). The criterion-17 rollout-contract test skips with this reason.
+var legacyCampSkip string
+
 // TestMain builds a pool of identical containers once and shares them across all
 // integration tests. Reusing containers avoids per-test create/destroy cost; a
 // pool (rather than a single container) lets tests run concurrently via


### PR DESCRIPTION
## Overview

Final hardening for the workitem-schema-tags-and-projects festival (v1alpha8 tags/projects, document-only file workitems, co-located multi-project links, JSON contract v1alpha9). Two commits, no production code change: seq 01 exercises existing behavior, seq 02 is generated docs.

- `b1fadc1a` test: containerized acceptance-criteria tests closing the doc 08 gaps.
- `d64d8128` docs: regenerated `docs/cli-reference` for the new workitem surface (generated output only, isolated per the regen-separately rule).

## Acceptance criteria to tests (doc 08, 24 criteria)

New / tightened in this PR:
- Crit 1 (tags + multi-entry projects both populated in `--json`): `TestIntegration_Crit01_JSONShowsTagsAndMultiProject`
- Crit 9 (an intent under `.campaign/intents/` is never double-discovered as a frontmatter workitem): `TestIntegration_Crit09_IntentNotDoubleDiscoveredAsFrontmatter`
- Crit 13 (a schema-invalid marker is excluded from `--tag` and `--project` filters and surfaced by `validate`, yet still visible as a bare item unfiltered): `TestIntegration_Crit13_InvalidMarkerExcludedFromFilterAndSurfaced`
- Crit 17 (load-bearing rollout contract, real pre-reader binary): `TestIntegration_Crit17_PreReaderBinaryRejectsV1Alpha8`

Already covered by phases 002-004:
- Crit 2: `TestApplyMetadata_EmptyTagsProjectsNeverNull`, `TestNewPayload_TagsProjectsSerialization`
- Crit 3, 4: `TestValidateMetadata_TagsProjects`
- Crit 5, 6: `TestIntegration_FrontmatterDiscoveryAndCollision`
- Crit 7: `TestIntegration_FrontmatterIdentityConflict`
- Crit 8: `TestIntegration_FrontmatterTypeAuthority`, `TestIntegration_FrontmatterTypeMismatchValidate`
- Crit 10: `TestIntegration_FileDungeonStatuses`
- Crit 11, 12: `TestFilterAdvanced_TagsAreANDedProjectsAreORed`, `TestIntegration_WorkitemListTagAndProjectFilters`
- Crit 14: `TestLoadMetadata_V1Alpha7MarkerUnaffectedByReaderChanges`, `TestValidateMetadata_VersionAcceptance`
- Crit 15: `TestComputeRepair_LegacyInputsUpgradeToCurrent`, `TestClassifyMarker`
- Crit 16: `TestClassifyMarker_ForwardCompatIsWarningNoRepair`, `TestIntegration_ForwardCompatMarkerIsWarningExitZero`
- Crit 18: `TestIntegration_LinkRejectsRelatedProjectNoMutation`
- Crit 19: `TestIntegration_DoctorFixMigratesRelatedProject` (plus the doctor migration suite)
- Crit 20: `TestIntegration_MergedProjectsViewPrimaryAnnotation` / `EmptyNeverNull` / `MalformedRegistryFallback`, `TestMergeProjectRefs`
- Crit 21: `TestIntegration_AdoptFilePreservesForeignKeys`, `TestIntegration_AdoptFileDeterministic`
- Crit 22: `TestIntegration_AdoptFileIdentityConflict`
- Crit 23: `TestIntegration_FilePromoteToDoc`, `TestIntegration_FilePromoteToFestival`, `TestIntegration_GatherMixedDirAndFile`

Doc-only:
- Crit 24: doc 05 `05-tags-model.md` "Label tags vs lineage edges (D006)" section (verified).

## Criterion 17 harness (the load-bearing test)

A real shipped pre-reader binary is built once at TestMain from the pinned commit `1f06e423` (release v0.3.0-rc.2, allowlist stops at v1alpha6, no forward-compat rule) via `git archive | tar -x` plus `GOTOOLCHAIN=auto go build`, cached across runs with an atomic rename, injected as `/camp-legacy` into every pool container (matching the existing camp/fest/scc provisioning), and skipped cleanly when the pinned commit is absent (for example a shallow clone). The test proves the pre-reader binary hard-fails on a v1alpha8 marker written by the current binary, with the versions error naming its supported list. This is the evidence that the rollout had to ship the reader before any writer.

## Testing

Full serial integration suite: 0 failures, all four new tests pass (crit-17 exercises the real legacy binary, no skip). `just build`, `just lint` (0 issues), and the unit suite are green.
