### PR TITLE
fix(remote): surface Tailscale SSH check URLs instead of bare timeouts

### DIFF
--- a/cmd/camp/machine_tui.go
+++ b/cmd/camp/machine_tui.go
@@ -420,11 +420,19 @@ func parseRemoteVersion(out string) string {
 // screen already implies; what matters is ssh's own line, or camp's hint when
 // the binary is missing on the far side.
 //
+// Tailscale SSH check mode is special: the host is reachable, but BatchMode
+// cannot complete the browser approval. Prefer the extracted check URL over a
+// generic "timed out" / "unreachable" line so the operator knows what to do.
+//
 // Exit 127 is special: RunCampCommand wraps it with login-shell PATH context
 // and CAMP_REMOTE_CAMP_PATH guidance. Digging past that wrap to the bare
 // "command not found" stderr line is exactly the failure mode the health
 // check exists to surface, so preserve the outer message instead.
 func connectionFailureDetail(err error) string {
+	if detail := remote.TailscaleCheckDetail(err); detail != "" {
+		return detail
+	}
+
 	var cmdErr *camperrors.CommandError
 	if errors.As(err, &cmdErr) && cmdErr.ExitCode == 127 {
 		return firstLine(err.Error())
@@ -436,7 +444,16 @@ func connectionFailureDetail(err error) string {
 			message = detail
 		}
 	}
-	return strings.TrimPrefix(strings.TrimSpace(message), "ssh: ")
+	// Drop a trailing ": context deadline exceeded" from wrapped timeouts so
+	// the pane leads with the real cause when stderr was preserved.
+	message = strings.TrimSpace(message)
+	if before, found := strings.CutSuffix(message, ": context deadline exceeded"); found {
+		message = strings.TrimSpace(before)
+	}
+	if before, found := strings.CutSuffix(message, ": context canceled"); found {
+		message = strings.TrimSpace(before)
+	}
+	return strings.TrimPrefix(message, "ssh: ")
 }
 
 func firstLine(s string) string {

--- a/cmd/camp/machine_tui_test.go
+++ b/cmd/camp/machine_tui_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -468,6 +469,31 @@ func TestParseRemoteVersionAndFailureDetail(t *testing.T) {
 	err := camperrors.New(`command "ssh ci@10.0.0.12" exited with code 255: ssh: connect to host 10.0.0.12 port 22: Operation timed out`)
 	if got := connectionFailureDetail(err); got != "connect to host 10.0.0.12 port 22: Operation timed out" {
 		t.Errorf("connectionFailureDetail = %q", got)
+	}
+}
+
+func TestConnectionFailureDetailSurfacesTailscaleCheck(t *testing.T) {
+	stderr := "# Tailscale SSH requires an additional check.\n# To authenticate, visit: https://login.tailscale.com/a/testhash\n"
+	err := camperrors.NewCommand("ssh lance@archdtop", 255, stderr, nil)
+	// Even raw CommandError stderr (pre-annotation path) should surface the URL.
+	got := connectionFailureDetail(err)
+	if !strings.Contains(got, "https://login.tailscale.com/a/testhash") {
+		t.Errorf("connectionFailureDetail missing check URL: %q", got)
+	}
+	if !strings.Contains(got, "browser check") {
+		t.Errorf("connectionFailureDetail missing guidance: %q", got)
+	}
+
+	// Timeout wrap path: context deadline must not hide the URL.
+	timeoutErr := camperrors.Wrapf(context.DeadlineExceeded,
+		"%s (while connecting to lance@archdtop)",
+		"Tailscale SSH requires a one-time browser check — open https://login.tailscale.com/a/testhash, approve, then retry (camp cannot complete this interactively)")
+	got = connectionFailureDetail(timeoutErr)
+	if !strings.Contains(got, "https://login.tailscale.com/a/testhash") {
+		t.Errorf("timeout wrap detail missing URL: %q", got)
+	}
+	if strings.Contains(got, "context deadline exceeded") {
+		t.Errorf("detail should strip deadline noise: %q", got)
 	}
 }
 

--- a/cmd/camp/machine_tui_test.go
+++ b/cmd/camp/machine_tui_test.go
@@ -472,6 +472,49 @@ func TestParseRemoteVersionAndFailureDetail(t *testing.T) {
 	}
 }
 
+func TestHealthDetailLinesWrapsTailscaleURL(t *testing.T) {
+	detail := "Tailscale SSH requires a one-time browser check — open https://login.tailscale.com/a/testhashlongtoken, approve, then retry"
+	lines := healthDetailLines(detail, 40, true)
+	if len(lines) < 2 {
+		t.Fatalf("expected wrap into multiple lines, got %v", lines)
+	}
+	joined := strings.Join(lines, "")
+	if !strings.Contains(joined, "https://login.tailscale.com/a/testhashlongtoken") {
+		t.Errorf("wrapped lines lost URL: %v", lines)
+	}
+	for _, line := range lines {
+		if len(line) > 40 {
+			t.Errorf("line longer than width: %q (len=%d)", line, len(line))
+		}
+	}
+	// Non-URL details still truncate to one line.
+	got := healthDetailLines("operation timed out waiting for peer", 20, false)
+	if len(got) != 1 || len(got[0]) > 20 {
+		t.Errorf("truncate path = %v", got)
+	}
+}
+
+func TestHealthSectionTailscaleCheckHeadline(t *testing.T) {
+	m := newMachineTUIModel(t.Context(), fleetFile())
+	m.health["devbox"] = machineHealth{
+		State:  healthUnreachable,
+		Detail: "Tailscale SSH requires a one-time browser check — open https://login.tailscale.com/a/x, approve, then retry",
+	}
+	// healthSection for unreachable with tailscale detail
+	// Find devbox id index - fleet has devbox first remote; health map is by id
+	lines := m.healthSection("devbox", 36)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "Needs Tailscale SSH check") {
+		t.Errorf("headline missing check framing: %q", joined)
+	}
+	if strings.Contains(joined, "Could not reach it") {
+		t.Errorf("still uses network-unreachable headline: %q", joined)
+	}
+	if !strings.Contains(joined, "login.tailscale.com") {
+		t.Errorf("URL missing from pane: %q", joined)
+	}
+}
+
 func TestConnectionFailureDetailSurfacesTailscaleCheck(t *testing.T) {
 	stderr := "# Tailscale SSH requires an additional check.\n# To authenticate, visit: https://login.tailscale.com/a/testhash\n"
 	err := camperrors.NewCommand("ssh lance@archdtop", 255, stderr, nil)

--- a/cmd/camp/machine_tui_test.go
+++ b/cmd/camp/machine_tui_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
@@ -473,6 +474,8 @@ func TestParseRemoteVersionAndFailureDetail(t *testing.T) {
 }
 
 func TestHealthDetailLinesWrapsTailscaleURL(t *testing.T) {
+	// Em dash is multi-byte; wrapping must stay on rune boundaries and honor
+	// display width (not raw byte length).
 	detail := "Tailscale SSH requires a one-time browser check — open https://login.tailscale.com/a/testhashlongtoken, approve, then retry"
 	lines := healthDetailLines(detail, 40, true)
 	if len(lines) < 2 {
@@ -482,14 +485,20 @@ func TestHealthDetailLinesWrapsTailscaleURL(t *testing.T) {
 	if !strings.Contains(joined, "https://login.tailscale.com/a/testhashlongtoken") {
 		t.Errorf("wrapped lines lost URL: %v", lines)
 	}
+	if !strings.Contains(joined, "—") {
+		t.Errorf("em dash corrupted by wrap: %v", lines)
+	}
 	for _, line := range lines {
-		if len(line) > 40 {
-			t.Errorf("line longer than width: %q (len=%d)", line, len(line))
+		if !utf8.ValidString(line) {
+			t.Errorf("invalid UTF-8 line: %q", line)
+		}
+		if w := lipgloss.Width(line); w > 40 {
+			t.Errorf("line display width %d > 40: %q", w, line)
 		}
 	}
 	// Non-URL details still truncate to one line.
 	got := healthDetailLines("operation timed out waiting for peer", 20, false)
-	if len(got) != 1 || len(got[0]) > 20 {
+	if len(got) != 1 || lipgloss.Width(got[0]) > 20 {
 		t.Errorf("truncate path = %v", got)
 	}
 }

--- a/cmd/camp/machine_tui_view.go
+++ b/cmd/camp/machine_tui_view.go
@@ -255,11 +255,22 @@ func (m *machineTUIModel) healthSection(id string, width int) []string {
 	case healthTesting:
 		return []string{style.Render(m.spin.View() + " Testing the connection...")}
 	case healthUnreachable:
-		return []string{
-			style.Render(glyph + " Could not reach it"),
-			machineMuted.Render("  " + ui.Truncate(health.Detail, max(width-4, 20))),
-			machineMuted.Render("  e edits it · t tries again"),
+		// Tailscale check URLs are long; prefer wrapping the actionable detail
+		// over hard-truncating the only thing the operator needs to open.
+		detail := health.Detail
+		if !strings.Contains(detail, "login.tailscale.com") {
+			detail = ui.Truncate(detail, max(width-4, 20))
 		}
+		lines := []string{
+			style.Render(glyph + " Could not reach it"),
+			machineMuted.Render("  " + detail),
+		}
+		if strings.Contains(health.Detail, "login.tailscale.com") {
+			lines = append(lines, machineMuted.Render("  Approve in the browser, then press t to try again."))
+		} else {
+			lines = append(lines, machineMuted.Render("  e edits it · t tries again"))
+		}
+		return lines
 	case healthUnsupported:
 		return []string{
 			style.Render(glyph + " Cannot be used yet"),

--- a/cmd/camp/machine_tui_view.go
+++ b/cmd/camp/machine_tui_view.go
@@ -255,17 +255,21 @@ func (m *machineTUIModel) healthSection(id string, width int) []string {
 	case healthTesting:
 		return []string{style.Render(m.spin.View() + " Testing the connection...")}
 	case healthUnreachable:
-		// Tailscale check URLs are long; prefer wrapping the actionable detail
-		// over hard-truncating the only thing the operator needs to open.
-		detail := health.Detail
-		if !strings.Contains(detail, "login.tailscale.com") {
-			detail = ui.Truncate(detail, max(width-4, 20))
+		tailscaleCheck := strings.Contains(health.Detail, "login.tailscale.com")
+		headline := "Could not reach it"
+		if tailscaleCheck {
+			// Check-mode is auth policy, not network failure — do not frame it
+			// as unreachable or operators chase connectivity.
+			headline = "Needs Tailscale SSH check"
 		}
-		lines := []string{
-			style.Render(glyph + " Could not reach it"),
-			machineMuted.Render("  " + detail),
+		lines := []string{style.Render(glyph + " " + headline)}
+		// Width-aware detail: wrap long check URLs so the actionable token
+		// stays visible in a narrow pane instead of clipping off-screen.
+		detailWidth := max(width-4, 20)
+		for _, line := range healthDetailLines(health.Detail, detailWidth, tailscaleCheck) {
+			lines = append(lines, machineMuted.Render("  "+line))
 		}
-		if strings.Contains(health.Detail, "login.tailscale.com") {
+		if tailscaleCheck {
 			lines = append(lines, machineMuted.Render("  Approve in the browser, then press t to try again."))
 		} else {
 			lines = append(lines, machineMuted.Render("  e edits it · t tries again"))
@@ -283,6 +287,36 @@ func (m *machineTUIModel) healthSection(id string, width int) []string {
 			machineMuted.Render("  t checks whether camp can reach it."),
 		}
 	}
+}
+
+// healthDetailLines formats a connection-failure detail for the detail pane.
+// Tailscale check messages keep the full URL, hard-wrapped at maxWidth so a
+// narrow pane still shows the whole token. Other details still truncate.
+func healthDetailLines(detail string, maxWidth int, keepFullURL bool) []string {
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return nil
+	}
+	if maxWidth < 8 {
+		maxWidth = 8
+	}
+	if !keepFullURL {
+		return []string{ui.Truncate(detail, maxWidth)}
+	}
+	// Prefer breaking after path separators so "https://…/a/…" remains readable.
+	var lines []string
+	for len(detail) > maxWidth {
+		cut := maxWidth
+		if i := strings.LastIndexAny(detail[:maxWidth], "/ ?&="); i > maxWidth/3 {
+			cut = i + 1
+		}
+		lines = append(lines, detail[:cut])
+		detail = detail[cut:]
+	}
+	if detail != "" {
+		lines = append(lines, detail)
+	}
+	return lines
 }
 
 // reuseSection explains the ControlMaster socket in terms of what it does for

--- a/cmd/camp/machine_tui_view.go
+++ b/cmd/camp/machine_tui_view.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/lipgloss"
 
@@ -292,6 +293,10 @@ func (m *machineTUIModel) healthSection(id string, width int) []string {
 // healthDetailLines formats a connection-failure detail for the detail pane.
 // Tailscale check messages keep the full URL, hard-wrapped at maxWidth so a
 // narrow pane still shows the whole token. Other details still truncate.
+//
+// maxWidth is a terminal-column budget (lipgloss/display width), not raw
+// bytes, so multi-byte runes (e.g. the em dash in Tailscale guidance) are
+// not split into invalid UTF-8.
 func healthDetailLines(detail string, maxWidth int, keepFullURL bool) []string {
 	detail = strings.TrimSpace(detail)
 	if detail == "" {
@@ -305,10 +310,14 @@ func healthDetailLines(detail string, maxWidth int, keepFullURL bool) []string {
 	}
 	// Prefer breaking after path separators so "https://…/a/…" remains readable.
 	var lines []string
-	for len(detail) > maxWidth {
-		cut := maxWidth
-		if i := strings.LastIndexAny(detail[:maxWidth], "/ ?&="); i > maxWidth/3 {
-			cut = i + 1
+	for lipgloss.Width(detail) > maxWidth {
+		cut := cutDisplayWidth(detail, maxWidth)
+		if cut <= 0 {
+			_, size := utf8.DecodeRuneInString(detail)
+			cut = size
+		} else if soft := strings.LastIndexAny(detail[:cut], "/ ?&="); soft > cut/3 {
+			// soft is a byte index of a break char; advance past it.
+			cut = soft + 1
 		}
 		lines = append(lines, detail[:cut])
 		detail = detail[cut:]
@@ -317,6 +326,32 @@ func healthDetailLines(detail string, maxWidth int, keepFullURL bool) []string {
 		lines = append(lines, detail)
 	}
 	return lines
+}
+
+// cutDisplayWidth returns a byte index into s such that s[:i] fits in at most
+// maxCols display columns and ends on a rune boundary.
+func cutDisplayWidth(s string, maxCols int) int {
+	if maxCols <= 0 || s == "" {
+		return 0
+	}
+	width := 0
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		rw := lipgloss.Width(string(r))
+		if rw < 1 {
+			rw = 1
+		}
+		if width+rw > maxCols {
+			if i == 0 {
+				// Single rune wider than budget — still emit it.
+				return size
+			}
+			return i
+		}
+		width += rw
+		i += size
+	}
+	return len(s)
 }
 
 // reuseSection explains the ControlMaster socket in terms of what it does for

--- a/internal/remote/ssh.go
+++ b/internal/remote/ssh.go
@@ -201,9 +201,11 @@ func ShellQuote(s string) string {
 
 // Run execs `ssh <opts> <target> <remoteCmd>` and returns stdout. The call is
 // bounded by ctx (and DefaultTimeout if ctx has no earlier deadline). A
-// timeout is a wrapped context error; a non-zero exit is a *camperrors.
-// CommandError carrying the exit code and trimmed remote stderr, so callers
-// can distinguish failure shapes (e.g. RunCampCommand's "binary not found"
+// timeout is a wrapped context error that still carries any captured stderr
+// (so a Tailscale SSH check URL is not discarded when the hop times out
+// waiting for browser approval); a non-zero exit is a *camperrors.CommandError
+// carrying the exit code and trimmed remote stderr, so callers can
+// distinguish failure shapes (e.g. RunCampCommand's "binary not found"
 // detection) without re-parsing the error string.
 func Run(ctx context.Context, target string, opts []string, remoteCmd string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, DefaultTimeout)
@@ -215,17 +217,138 @@ func Run(ctx context.Context, target string, opts []string, remoteCmd string) ([
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		trimmed := strings.TrimSpace(stderr.String())
 		if ctx.Err() != nil {
-			return nil, camperrors.Wrapf(ctx.Err(), "ssh to %s timed out", target)
+			return nil, sshTimeoutError(target, trimmed, ctx.Err())
 		}
 		exitCode := 0
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			exitCode = exitErr.ExitCode()
 		}
-		return nil, camperrors.NewCommand("ssh "+target, exitCode, strings.TrimSpace(stderr.String()), err)
+		return nil, sshExitError(target, exitCode, trimmed, err)
 	}
 	return stdout.Bytes(), nil
+}
+
+// tailscaleCheckMarker is the distinctive first line Tailscale SSH prints when
+// check mode requires a human browser approval before the hop can proceed.
+const tailscaleCheckMarker = "Tailscale SSH requires an additional check"
+
+// ParseTailscaleCheckURL extracts the login.tailscale.com check URL from ssh
+// stderr (or any text that embeds it). Returns false when the marker or URL is
+// absent. Tailscale prints:
+//
+//	# Tailscale SSH requires an additional check.
+//	# To authenticate, visit: https://login.tailscale.com/a/...
+//
+// camp runs with BatchMode=yes and cannot complete that browser step; callers
+// surface the URL so the operator can approve once and retry. Also accepts
+// camp's own annotated wording so re-parsing a already-classified error still
+// yields the URL.
+func ParseTailscaleCheckURL(text string) (string, bool) {
+	if text == "" {
+		return "", false
+	}
+	hasMarker := strings.Contains(text, tailscaleCheckMarker) ||
+		strings.Contains(text, "Tailscale SSH requires a one-time browser check")
+	if !hasMarker {
+		return "", false
+	}
+	const prefix = "https://login.tailscale.com/"
+	idx := strings.Index(text, prefix)
+	if idx < 0 {
+		return "", false
+	}
+	rest := text[idx:]
+	end := strings.IndexAny(rest, " \t\r\n\"'")
+	if end < 0 {
+		return rest, true
+	}
+	if end == 0 {
+		return "", false
+	}
+	return rest[:end], true
+}
+
+// TailscaleCheckDetail returns a single-line, actionable explanation when err
+// (or its chain) is a Tailscale SSH check-mode failure. Empty string means the
+// failure is something else and callers should use their generic formatting.
+func TailscaleCheckDetail(err error) string {
+	if err == nil {
+		return ""
+	}
+	var cmdErr *camperrors.CommandError
+	if errors.As(err, &cmdErr) {
+		if url, ok := ParseTailscaleCheckURL(cmdErr.Stderr); ok {
+			return formatTailscaleCheckDetail(url)
+		}
+	}
+	if url, ok := ParseTailscaleCheckURL(err.Error()); ok {
+		return formatTailscaleCheckDetail(url)
+	}
+	return ""
+}
+
+func formatTailscaleCheckDetail(url string) string {
+	return "Tailscale SSH requires a one-time browser check — open " + url +
+		", approve, then retry (camp cannot complete this interactively)"
+}
+
+// sshTimeoutError keeps stderr on the timeout path. The previous behaviour
+// returned only "ssh to X timed out", which hid the Tailscale check URL that
+// ssh had already printed while waiting for browser approval.
+func sshTimeoutError(target, stderr string, err error) error {
+	if url, ok := ParseTailscaleCheckURL(stderr); ok {
+		// Wrap preserves errors.Is(err, context.DeadlineExceeded) while
+		// putting the check URL first so connectionFailureDetail / %v show it.
+		return camperrors.Wrapf(err, "%s (while connecting to %s)", formatTailscaleCheckDetail(url), target)
+	}
+	if stderr != "" {
+		return camperrors.Wrapf(err, "ssh to %s timed out: %s", target, compactSSHStderr(stderr))
+	}
+	return camperrors.Wrapf(err, "ssh to %s timed out", target)
+}
+
+// sshExitError annotates non-zero ssh exits. Tailscale check mode sometimes
+// exits (instead of hanging until our deadline) with the same marker+URL in
+// stderr; prefer that over the raw multi-line banner.
+func sshExitError(target string, exitCode int, stderr string, err error) error {
+	if url, ok := ParseTailscaleCheckURL(stderr); ok {
+		return camperrors.NewCommand("ssh "+target, exitCode, formatTailscaleCheckDetail(url), err)
+	}
+	return camperrors.NewCommand("ssh "+target, exitCode, stderr, err)
+}
+
+// compactSSHStderr collapses multi-line ssh noise into one short detail for
+// timeout messages. Skips empty and #-comment lines (Tailscale banners use
+// those) so the first real failure line wins when present.
+func compactSSHStderr(stderr string) string {
+	stderr = strings.TrimSpace(stderr)
+	if stderr == "" {
+		return ""
+	}
+	if !strings.Contains(stderr, "\n") {
+		return stderr
+	}
+	var firstComment string
+	for _, line := range strings.Split(stderr, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "#") {
+			if firstComment == "" {
+				firstComment = strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(line, "# "), "#"))
+			}
+			continue
+		}
+		return line
+	}
+	if firstComment != "" {
+		return firstComment
+	}
+	return strings.ReplaceAll(stderr, "\n", " ")
 }
 
 // RemoteCampPathEnv, when set, is the exact camp invocation used on the far

--- a/internal/remote/ssh_test.go
+++ b/internal/remote/ssh_test.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -340,5 +341,96 @@ func TestCampNotFoundHintPassesThroughNonCommandErrors(t *testing.T) {
 	got := campNotFoundHint(original, m, "camp")
 	if got != original {
 		t.Errorf("campNotFoundHint changed a non-CommandError: got %v, want unchanged %v", got, original)
+	}
+}
+
+func TestParseTailscaleCheckURL(t *testing.T) {
+	stderr := "# Tailscale SSH requires an additional check.\n# To authenticate, visit: https://login.tailscale.com/a/l623187f3a1372\n"
+	url, ok := ParseTailscaleCheckURL(stderr)
+	if !ok {
+		t.Fatal("ParseTailscaleCheckURL returned false, want true")
+	}
+	if url != "https://login.tailscale.com/a/l623187f3a1372" {
+		t.Errorf("url = %q", url)
+	}
+
+	if _, ok := ParseTailscaleCheckURL("ssh: connect to host timed out"); ok {
+		t.Error("plain timeout should not parse as Tailscale check")
+	}
+	if _, ok := ParseTailscaleCheckURL(""); ok {
+		t.Error("empty stderr should not parse")
+	}
+	// Marker without a URL is not actionable enough to claim success.
+	if _, ok := ParseTailscaleCheckURL("Tailscale SSH requires an additional check."); ok {
+		t.Error("marker without URL should return false")
+	}
+}
+
+func TestSSHTimeoutErrorPreservesTailscaleCheckURL(t *testing.T) {
+	stderr := "# Tailscale SSH requires an additional check.\n# To authenticate, visit: https://login.tailscale.com/a/abc123\n"
+	err := sshTimeoutError("lance@archdtop.ts.net", stderr, context.DeadlineExceeded)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("should still match context.DeadlineExceeded: %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "https://login.tailscale.com/a/abc123") {
+		t.Errorf("timeout error dropped Tailscale check URL: %v", err)
+	}
+	if !strings.Contains(msg, "browser check") {
+		t.Errorf("timeout error missing actionable check guidance: %v", err)
+	}
+	// Must not look like a bare "timed out" with no cause.
+	if strings.HasPrefix(msg, "ssh to lance@archdtop.ts.net timed out") && !strings.Contains(msg, "login.tailscale.com") {
+		t.Errorf("regressed to stderr-less timeout: %v", err)
+	}
+}
+
+func TestSSHTimeoutErrorPreservesGenericStderr(t *testing.T) {
+	err := sshTimeoutError("box", "kex_exchange_identification: Connection closed", context.DeadlineExceeded)
+	if !strings.Contains(err.Error(), "kex_exchange_identification") {
+		t.Errorf("generic stderr not preserved on timeout: %v", err)
+	}
+}
+
+func TestSSHTimeoutErrorWithoutStderr(t *testing.T) {
+	err := sshTimeoutError("box", "", context.DeadlineExceeded)
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("plain timeout message = %v", err)
+	}
+}
+
+func TestSSHExitErrorAnnotatesTailscaleCheck(t *testing.T) {
+	stderr := "# Tailscale SSH requires an additional check.\n# To authenticate, visit: https://login.tailscale.com/a/xyz\n"
+	err := sshExitError("lance@box", 255, stderr, nil)
+	var cmdErr *camperrors.CommandError
+	if !errors.As(err, &cmdErr) {
+		t.Fatalf("want CommandError, got %T: %v", err, err)
+	}
+	if !strings.Contains(cmdErr.Stderr, "https://login.tailscale.com/a/xyz") {
+		t.Errorf("CommandError.Stderr = %q", cmdErr.Stderr)
+	}
+	if detail := TailscaleCheckDetail(err); detail == "" || !strings.Contains(detail, "login.tailscale.com/a/xyz") {
+		t.Errorf("TailscaleCheckDetail = %q", detail)
+	}
+}
+
+func TestTailscaleCheckDetailFromWrappedTimeout(t *testing.T) {
+	stderr := "# Tailscale SSH requires an additional check.\n# To authenticate, visit: https://login.tailscale.com/a/wrap1\n"
+	err := sshTimeoutError("host", stderr, context.DeadlineExceeded)
+	detail := TailscaleCheckDetail(err)
+	if !strings.Contains(detail, "https://login.tailscale.com/a/wrap1") {
+		t.Errorf("TailscaleCheckDetail from timeout wrap = %q", detail)
+	}
+}
+
+func TestCompactSSHStderr(t *testing.T) {
+	if got := compactSSHStderr("# ignore\nreal problem here\n"); got != "real problem here" {
+		t.Errorf("compactSSHStderr = %q", got)
+	}
+	if got := compactSSHStderr("single line"); got != "single line" {
+		t.Errorf("single line = %q", got)
 	}
 }


### PR DESCRIPTION
## Summary

- Preserve SSH stderr when a remote hop times out so Tailscale check-mode URLs are not discarded.
- Detect Tailscale SSH check-mode failures (`Tailscale SSH requires an additional check` + `login.tailscale.com` URL) and return actionable errors while still wrapping `context.DeadlineExceeded`.
- Surface that guidance in `camp machine` health (detail + “approve in browser, then t”) instead of a generic “unreachable / timed out” message.

Camp still correctly uses `BatchMode=yes` for agent/script hops and cannot complete browser approval itself. This fixes the diagnosis path so operators see what to do next.

## Test plan

- [x] `go test ./internal/remote/ ./cmd/camp/`
- [ ] Manually: with Tailscale SSH check pending, run `camp machine` and press `t` on a `tailscale-ssh` machine — pane should show the `login.tailscale.com` URL, not only “timed out”
- [ ] Approve the check in a browser, press `t` again — machine should report reachable
- [ ] Confirm plain timeout/network failures still report useful stderr (non-Tailscale)