### PR TITLE
feat(skills): project campaign skills into project worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,8 @@ __debug_bin*
 .envrc
 CLAUDE.md
 .claude/
+# Local agent harness skill projections (worktree projection / camp skills link)
+.agents/
+.grok/
 dist/
 projects/worktrees/

--- a/cmd/camp/project/worktree/add.go
+++ b/cmd/camp/project/worktree/add.go
@@ -177,10 +177,11 @@ func runProjectWorktreeAdd(cmd *cobra.Command, args []string) error {
 	// Project campaign skills into the worktree so Grok/Claude sessions whose
 	// git root is the worktree still discover .campaign/skills. Failure here
 	// must not undo a successful worktree create.
-	if err := intskills.ProjectIntoWorktreeBestEffort(campRoot, result.Path); err != nil {
+	projected, err := intskills.ProjectIntoWorktreeBestEffort(campRoot, result.Path)
+	if err != nil {
 		fmt.Println(ui.Warning(fmt.Sprintf("  Skills: could not project into worktree: %v", err)))
 		fmt.Println(ui.Dim("  Fix later with: camp skills link --worktrees-only"))
-	} else {
+	} else if projected {
 		fmt.Println(ui.Dim("  Skills: projected campaign skill bundles into worktree (.agents/.claude/.grok)"))
 	}
 

--- a/cmd/camp/project/worktree/add.go
+++ b/cmd/camp/project/worktree/add.go
@@ -12,6 +12,7 @@ import (
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/project"
+	intskills "github.com/Obedience-Corp/camp/internal/skills"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
@@ -171,6 +172,16 @@ func runProjectWorktreeAdd(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Printf("  Workitem: %s (%s)\n", ui.Value(link.WorkitemID), ui.Dim(link.WorkitemKey))
 		fmt.Println(ui.Dim("  camp p commit in this worktree will include WI-* in the campaign tag"))
+	}
+
+	// Project campaign skills into the worktree so Grok/Claude sessions whose
+	// git root is the worktree still discover .campaign/skills. Failure here
+	// must not undo a successful worktree create.
+	if err := intskills.ProjectIntoWorktreeBestEffort(campRoot, result.Path); err != nil {
+		fmt.Println(ui.Warning(fmt.Sprintf("  Skills: could not project into worktree: %v", err)))
+		fmt.Println(ui.Dim("  Fix later with: camp skills link --worktrees-only"))
+	} else {
+		fmt.Println(ui.Dim("  Skills: projected campaign skill bundles into worktree (.agents/.claude/.grok)"))
 	}
 
 	fmt.Println()

--- a/cmd/camp/project/worktree/add.go
+++ b/cmd/camp/project/worktree/add.go
@@ -177,7 +177,7 @@ func runProjectWorktreeAdd(cmd *cobra.Command, args []string) error {
 	// Project campaign skills into the worktree so Grok/Claude sessions whose
 	// git root is the worktree still discover .campaign/skills. Failure here
 	// must not undo a successful worktree create.
-	projected, err := intskills.ProjectIntoWorktreeBestEffort(campRoot, result.Path)
+	projected, err := intskills.ProjectIntoWorktreeBestEffort(ctx, campRoot, result.Path)
 	if err != nil {
 		fmt.Println(ui.Warning(fmt.Sprintf("  Skills: could not project into worktree: %v", err)))
 		fmt.Println(ui.Dim("  Fix later with: camp skills link --worktrees-only"))

--- a/cmd/camp/skills/link.go
+++ b/cmd/camp/skills/link.go
@@ -21,9 +21,15 @@ This command creates one symlink per skill bundle. It does not replace entire
 provider skills directories, so existing user skills remain intact.
 
 With neither --tool nor --path, skills are projected into every registered tool.
+Pass --worktrees with no --tool/--path to also project into every
+projects/worktrees/<project>/<name> checkout (so Grok/Claude sessions opened
+inside a worktree still see campaign skills). Use --worktrees-only to project
+into worktrees without touching campaign-root tool directories.
 
 Examples:
   camp skills link                     Project skills into all registered tools
+  camp skills link --worktrees         Project into tools and every project worktree
+  camp skills link --worktrees-only    Project into every project worktree only
   camp skills link --tool claude       Project skills into .claude/skills/
   camp skills link --tool agents       Project skills into .agents/skills/
   camp skills link --path custom/dir   Project skills into custom/dir
@@ -45,6 +51,8 @@ func init() {
 	flags.StringP("path", "p", "", "Custom destination directory")
 	flags.BoolP("force", "f", false, "Replace conflicting symlink entries (never files/directories)")
 	flags.BoolP("dry-run", "n", false, "Show what would happen without making changes")
+	flags.Bool("worktrees", false, "Also project into every projects/worktrees/*/* worktree")
+	flags.Bool("worktrees-only", false, "Project only into project worktrees (skip campaign tool dirs)")
 }
 
 func runSkillsLink(cmd *cobra.Command, _ []string) error {
@@ -56,9 +64,20 @@ func runSkillsLink(cmd *cobra.Command, _ []string) error {
 	destPath, _ := cmd.Flags().GetString("path")
 	force, _ := cmd.Flags().GetBool("force")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	withWorktrees, _ := cmd.Flags().GetBool("worktrees")
+	worktreesOnly, _ := cmd.Flags().GetBool("worktrees-only")
 
 	if tool != "" && destPath != "" {
 		return camperrors.Newf("--tool and --path are mutually exclusive; use one or the other")
+	}
+	if worktreesOnly && (tool != "" || destPath != "") {
+		return camperrors.Newf("--worktrees-only cannot be combined with --tool or --path")
+	}
+	if worktreesOnly && withWorktrees {
+		return camperrors.Newf("--worktrees and --worktrees-only are mutually exclusive; use one")
+	}
+	if withWorktrees && (tool != "" || destPath != "") {
+		return camperrors.Newf("--worktrees cannot be combined with --tool or --path; use --worktrees-only for worktrees alone, or omit --tool/--path")
 	}
 
 	skillsDir, err := intskills.FindSkillsDir(ctx)
@@ -71,9 +90,20 @@ func runSkillsLink(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// Worktrees-only: skip campaign tool directories.
+	if worktreesOnly {
+		return linkAllWorktrees(out, errOut, root, skillsDir, force, dryRun)
+	}
+
 	// With neither --tool nor --path, project into every registered tool.
 	if tool == "" && destPath == "" {
-		return linkAllTools(out, errOut, root, skillsDir, force, dryRun)
+		if err := linkAllTools(out, errOut, root, skillsDir, force, dryRun); err != nil {
+			return err
+		}
+		if withWorktrees {
+			return linkAllWorktrees(out, errOut, root, skillsDir, force, dryRun)
+		}
+		return nil
 	}
 
 	dest, err := resolveSkillsDestination(root, tool, destPath)

--- a/cmd/camp/skills/link.go
+++ b/cmd/camp/skills/link.go
@@ -22,9 +22,14 @@ provider skills directories, so existing user skills remain intact.
 
 With neither --tool nor --path, skills are projected into every registered tool.
 Pass --worktrees with no --tool/--path to also project into every
-projects/worktrees/<project>/<name> checkout (so Grok/Claude sessions opened
-inside a worktree still see campaign skills). Use --worktrees-only to project
-into worktrees without touching campaign-root tool directories.
+projects/worktrees/<project>/<name> git checkout (so Grok/Claude sessions
+opened inside a worktree still see campaign skills). Use --worktrees-only to
+project into worktrees without touching campaign-root tool directories.
+
+Worktree discovery only includes directories with a .git file/dir. The normal
+layout is projects/worktrees/<project>/<name>/. A loose git root at
+projects/worktrees/<name>/ is also accepted; nested dirs under that root are
+not scanned as separate worktrees.
 
 Examples:
   camp skills link                     Project skills into all registered tools
@@ -92,7 +97,7 @@ func runSkillsLink(cmd *cobra.Command, _ []string) error {
 
 	// Worktrees-only: skip campaign tool directories.
 	if worktreesOnly {
-		return linkAllWorktrees(out, errOut, root, skillsDir, force, dryRun)
+		return linkAllWorktrees(ctx, out, errOut, root, skillsDir, force, dryRun)
 	}
 
 	// With neither --tool nor --path, project into every registered tool.
@@ -101,7 +106,7 @@ func runSkillsLink(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 		if withWorktrees {
-			return linkAllWorktrees(out, errOut, root, skillsDir, force, dryRun)
+			return linkAllWorktrees(ctx, out, errOut, root, skillsDir, force, dryRun)
 		}
 		return nil
 	}

--- a/cmd/camp/skills/root.go
+++ b/cmd/camp/skills/root.go
@@ -10,8 +10,13 @@ var Cmd = &cobra.Command{
 	Long: `Manage campaign skill bundle projection for tool interoperability.
 
 Skills are centralized in .campaign/skills/ and projected into tool ecosystems
-(Claude, agents, etc.) as per-bundle symlinks. This keeps a single source of
-truth while preserving existing provider-native skills directories.
+(Claude, agents, Grok, etc.) as per-bundle symlinks. This keeps a single source
+of truth while preserving existing provider-native skills directories.
+
+Project worktrees under projects/worktrees/<project>/<name>/ are also supported:
+'camp project worktree add' projects skills into each new worktree automatically,
+and 'camp skills link --worktrees' repairs all of them. That way harnesses whose
+git root is the worktree (not the campaign root) still discover campaign skills.
 
 Commands:
   link     Project per-skill symlinks into a tool-specific skills directory
@@ -21,6 +26,8 @@ Commands:
 Examples:
   camp skills link --tool claude    Project skills into .claude/skills/
   camp skills link --tool agents    Project skills into .agents/skills/
+  camp skills link --worktrees      Project into tools and every project worktree
+  camp skills link --worktrees-only Project into project worktrees only
   camp skills status                Show all skill projection states
   camp skills unlink --tool claude  Remove projected symlinks from .claude/skills/`,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/camp/skills/root.go
+++ b/cmd/camp/skills/root.go
@@ -17,6 +17,8 @@ Project worktrees under projects/worktrees/<project>/<name>/ are also supported:
 'camp project worktree add' projects skills into each new worktree automatically,
 and 'camp skills link --worktrees' repairs all of them. That way harnesses whose
 git root is the worktree (not the campaign root) still discover campaign skills.
+Only git checkouts are projected (directory must contain .git). A loose git root
+at projects/worktrees/<name>/ is accepted; package subdirs under it are not.
 
 Commands:
   link     Project per-skill symlinks into a tool-specific skills directory

--- a/cmd/camp/skills/status.go
+++ b/cmd/camp/skills/status.go
@@ -1,14 +1,17 @@
 package skills
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
+	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/jsoncontract"
+	"github.com/Obedience-Corp/camp/internal/paths"
 	intskills "github.com/Obedience-Corp/camp/internal/skills"
 	"github.com/spf13/cobra"
 )
@@ -86,10 +89,10 @@ func runSkillsStatus(cmd *cobra.Command, _ []string) error {
 	hasAttention := false
 
 	toolNames := intskills.ToolNames()
-	paths := intskills.ToolPaths()
+	toolPaths := intskills.ToolPaths()
 
 	for _, tool := range toolNames {
-		relPath := paths[tool]
+		relPath := toolPaths[tool]
 		destPath := filepath.Join(root, relPath)
 
 		pathType, err := intskills.CheckPathType(destPath)
@@ -145,6 +148,16 @@ func runSkillsStatus(cmd *cobra.Command, _ []string) error {
 		entries = append(entries, entry)
 	}
 
+	// Project status for each project worktree (.agents/skills primary).
+	wtEntries, wtAttention, err := worktreeSkillStatusEntries(root, skillsDir, slugs)
+	if err != nil {
+		return err
+	}
+	entries = append(entries, wtEntries...)
+	if wtAttention {
+		hasAttention = true
+	}
+
 	if skillsStatusJSON {
 		data, err := json.MarshalIndent(entries, "", "  ")
 		if err != nil {
@@ -154,10 +167,10 @@ func runSkillsStatus(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 	} else {
-		if _, err := fmt.Fprintf(out, "%-10s %-20s %s\n", "Tool", "Path", "Status"); err != nil {
+		if _, err := fmt.Fprintf(out, "%-10s %-52s %s\n", "Tool", "Path", "Status"); err != nil {
 			return err
 		}
-		if _, err := fmt.Fprintf(out, "%-10s %-20s %s\n", "----", "----", "------"); err != nil {
+		if _, err := fmt.Fprintf(out, "%-10s %-52s %s\n", "----", "----", "------"); err != nil {
 			return err
 		}
 
@@ -166,7 +179,7 @@ func runSkillsStatus(cmd *cobra.Command, _ []string) error {
 			if e.Target != "" {
 				status = fmt.Sprintf("%s -> %s", status, e.Target)
 			}
-			if _, err := fmt.Fprintf(out, "%-10s %-20s %s\n", e.Tool, e.Path, status); err != nil {
+			if _, err := fmt.Fprintf(out, "%-10s %-52s %s\n", e.Tool, e.Path, status); err != nil {
 				return err
 			}
 		}
@@ -194,4 +207,59 @@ func runSkillsStatus(cmd *cobra.Command, _ []string) error {
 	}
 
 	return nil
+}
+
+// worktreeSkillStatusEntries builds status rows for each project worktree.
+func worktreeSkillStatusEntries(root, skillsDir string, slugs []string) ([]skillStatusEntry, bool, error) {
+	cfg, err := config.LoadCampaignConfig(context.Background(), root)
+	if err != nil {
+		cfg = &config.CampaignConfig{}
+	}
+	resolver := paths.NewResolver(root, cfg.Paths())
+	wtRoot := resolver.Worktrees()
+	roots, err := intskills.ListWorktreeRoots(wtRoot)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var entries []skillStatusEntry
+	hasAttention := false
+	for _, wtPath := range roots {
+		rel, err := filepath.Rel(root, wtPath)
+		if err != nil {
+			rel = wtPath
+		}
+		entry := skillStatusEntry{
+			Tool: "worktree",
+			Path: filepath.ToSlash(rel),
+		}
+		projState, err := intskills.InspectWorktreeProjection(wtPath, skillsDir, slugs)
+		if err != nil {
+			return nil, false, camperrors.Wrapf(err, "inspect worktree %s", rel)
+		}
+		switch {
+		case projState.Conflicts > 0:
+			entry.State = fmt.Sprintf("blocked (%d conflict)", projState.Conflicts)
+			entry.Suggestion = fmt.Sprintf("resolve conflicting entries in %s/.agents/skills then rerun link --worktrees-only", rel)
+			hasAttention = true
+		case projState.Broken > 0:
+			entry.State = fmt.Sprintf("broken (%d)", projState.Broken)
+			entry.Suggestion = "run 'camp skills link --worktrees-only --force' to repair worktree skill links"
+			hasAttention = true
+		case projState.Mismatched > 0:
+			entry.State = fmt.Sprintf("mismatched (%d)", projState.Mismatched)
+			entry.Suggestion = "run 'camp skills link --worktrees-only --force' to update worktree skill links"
+			hasAttention = true
+		case projState.Linked == 0:
+			entry.State = "not linked"
+			entry.Suggestion = "run 'camp skills link --worktrees-only' to project skills into worktrees"
+		case projState.Linked < projState.TotalSkills:
+			entry.State = fmt.Sprintf("partial (%d/%d)", projState.Linked, projState.TotalSkills)
+			entry.Suggestion = "run 'camp skills link --worktrees-only' to sync missing worktree skill links"
+		default:
+			entry.State = fmt.Sprintf("linked (%d/%d)", projState.Linked, projState.TotalSkills)
+		}
+		entries = append(entries, entry)
+	}
+	return entries, hasAttention, nil
 }

--- a/cmd/camp/skills/status.go
+++ b/cmd/camp/skills/status.go
@@ -149,7 +149,7 @@ func runSkillsStatus(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Project status for each project worktree (.agents/skills primary).
-	wtEntries, wtAttention, err := worktreeSkillStatusEntries(root, skillsDir, slugs)
+	wtEntries, wtAttention, err := worktreeSkillStatusEntries(ctx, root, skillsDir, slugs)
 	if err != nil {
 		return err
 	}
@@ -210,8 +210,11 @@ func runSkillsStatus(cmd *cobra.Command, _ []string) error {
 }
 
 // worktreeSkillStatusEntries builds status rows for each project worktree.
-func worktreeSkillStatusEntries(root, skillsDir string, slugs []string) ([]skillStatusEntry, bool, error) {
-	cfg, err := config.LoadCampaignConfig(context.Background(), root)
+func worktreeSkillStatusEntries(ctx context.Context, root, skillsDir string, slugs []string) ([]skillStatusEntry, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	cfg, err := config.LoadCampaignConfig(ctx, root)
 	if err != nil {
 		cfg = &config.CampaignConfig{}
 	}

--- a/cmd/camp/skills/worktree_project.go
+++ b/cmd/camp/skills/worktree_project.go
@@ -1,0 +1,67 @@
+package skills
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	intskills "github.com/Obedience-Corp/camp/internal/skills"
+)
+
+// linkAllWorktrees projects skill bundles into every projects/worktrees/*/*
+// checkout under the campaign.
+func linkAllWorktrees(out, errOut io.Writer, root, skillsDir string, force, dryRun bool) error {
+	cfg, err := config.LoadCampaignConfig(context.Background(), root)
+	if err != nil {
+		// Paths defaults still work when campaign config is missing/unloadable.
+		cfg = &config.CampaignConfig{}
+	}
+	resolver := paths.NewResolver(root, cfg.Paths())
+	wtRoot := resolver.Worktrees()
+
+	results, err := intskills.LinkAllWorktrees(root, wtRoot, skillsDir, dryRun, force, errOut)
+	if err != nil {
+		return err
+	}
+	if len(results) == 0 {
+		if _, err := fmt.Fprintf(out, "no project worktrees under %s\n", wtRoot); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	verb := "projected"
+	if dryRun {
+		verb = "would project"
+	}
+	var conflicts int
+	var conflictNames []string
+	var hardErrs int
+	for _, res := range results {
+		if res.Err != nil {
+			hardErrs++
+			if _, err := fmt.Fprintf(errOut, "worktree %s: %v\n", res.RelPath, res.Err); err != nil {
+				return err
+			}
+			continue
+		}
+		s := res.Agents
+		if _, err := fmt.Fprintf(out, "%s %d skill bundle(s) into worktree %s (created=%d replaced=%d unchanged=%d)\n",
+			verb, s.Created+s.Replaced+s.AlreadyLinked, res.RelPath, s.Created, s.Replaced, s.AlreadyLinked); err != nil {
+			return err
+		}
+		conflicts += s.Conflicts + res.Claude.Conflicts
+		conflictNames = append(conflictNames, s.ConflictNames...)
+		conflictNames = append(conflictNames, res.Claude.ConflictNames...)
+	}
+	if hardErrs > 0 {
+		return camperrors.Newf("worktree skill projection failed for %d worktree(s)", hardErrs)
+	}
+	if conflicts > 0 {
+		return camperrors.Newf("worktree projection incomplete: %d conflicting skill path(s): %v", conflicts, conflictNames)
+	}
+	return nil
+}

--- a/cmd/camp/skills/worktree_project.go
+++ b/cmd/camp/skills/worktree_project.go
@@ -26,7 +26,7 @@ func linkAllWorktrees(ctx context.Context, out, errOut io.Writer, root, skillsDi
 	resolver := paths.NewResolver(root, cfg.Paths())
 	wtRoot := resolver.Worktrees()
 
-	results, err := intskills.LinkAllWorktrees(root, wtRoot, skillsDir, dryRun, force, errOut)
+	results, err := intskills.LinkAllWorktrees(ctx, root, wtRoot, skillsDir, dryRun, force, errOut)
 	if err != nil {
 		return err
 	}

--- a/cmd/camp/skills/worktree_project.go
+++ b/cmd/camp/skills/worktree_project.go
@@ -12,9 +12,13 @@ import (
 )
 
 // linkAllWorktrees projects skill bundles into every projects/worktrees/*/*
-// checkout under the campaign.
-func linkAllWorktrees(out, errOut io.Writer, root, skillsDir string, force, dryRun bool) error {
-	cfg, err := config.LoadCampaignConfig(context.Background(), root)
+// checkout under the campaign. ctx is used for campaign config load so
+// cancellation from the CLI propagates.
+func linkAllWorktrees(ctx context.Context, out, errOut io.Writer, root, skillsDir string, force, dryRun bool) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	cfg, err := config.LoadCampaignConfig(ctx, root)
 	if err != nil {
 		// Paths defaults still work when campaign config is missing/unloadable.
 		cfg = &config.CampaignConfig{}

--- a/cmd/camp/worktrees/create.go
+++ b/cmd/camp/worktrees/create.go
@@ -178,7 +178,7 @@ func runWorktreesCreate(cmd *cobra.Command, args []string) error {
 		fmt.Println(ui.Dim("  camp p commit in this worktree will include WI-* in the campaign tag"))
 	}
 
-	projected, err := intskills.ProjectIntoWorktreeBestEffort(campRoot, result.Path)
+	projected, err := intskills.ProjectIntoWorktreeBestEffort(ctx, campRoot, result.Path)
 	if err != nil {
 		fmt.Println(ui.Warning(fmt.Sprintf("  Skills: could not project into worktree: %v", err)))
 		fmt.Println(ui.Dim("  Fix later with: camp skills link --worktrees-only"))

--- a/cmd/camp/worktrees/create.go
+++ b/cmd/camp/worktrees/create.go
@@ -178,10 +178,11 @@ func runWorktreesCreate(cmd *cobra.Command, args []string) error {
 		fmt.Println(ui.Dim("  camp p commit in this worktree will include WI-* in the campaign tag"))
 	}
 
-	if err := intskills.ProjectIntoWorktreeBestEffort(campRoot, result.Path); err != nil {
+	projected, err := intskills.ProjectIntoWorktreeBestEffort(campRoot, result.Path)
+	if err != nil {
 		fmt.Println(ui.Warning(fmt.Sprintf("  Skills: could not project into worktree: %v", err)))
 		fmt.Println(ui.Dim("  Fix later with: camp skills link --worktrees-only"))
-	} else {
+	} else if projected {
 		fmt.Println(ui.Dim("  Skills: projected campaign skill bundles into worktree (.agents/.claude/.grok)"))
 	}
 

--- a/cmd/camp/worktrees/create.go
+++ b/cmd/camp/worktrees/create.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/project"
+	intskills "github.com/Obedience-Corp/camp/internal/skills"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
@@ -175,6 +176,13 @@ func runWorktreesCreate(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Printf("  Workitem: %s (%s)\n", ui.Value(link.WorkitemID), ui.Dim(link.WorkitemKey))
 		fmt.Println(ui.Dim("  camp p commit in this worktree will include WI-* in the campaign tag"))
+	}
+
+	if err := intskills.ProjectIntoWorktreeBestEffort(campRoot, result.Path); err != nil {
+		fmt.Println(ui.Warning(fmt.Sprintf("  Skills: could not project into worktree: %v", err)))
+		fmt.Println(ui.Dim("  Fix later with: camp skills link --worktrees-only"))
+	} else {
+		fmt.Println(ui.Dim("  Skills: projected campaign skill bundles into worktree (.agents/.claude/.grok)"))
 	}
 
 	fmt.Println()

--- a/internal/skills/worktree.go
+++ b/internal/skills/worktree.go
@@ -1,0 +1,262 @@
+package skills
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// WorktreeSkillDestRels are the tool skill directories projected into each
+// campaign project worktree. Harnesses such as Grok stop skill discovery at
+// the worktree git root; projecting here makes campaign skills visible without
+// requiring the session CWD to be the campaign root.
+var WorktreeSkillDestRels = []string{
+	".agents/skills",
+	".claude/skills",
+}
+
+// GrokSkillsRel is the Grok-preferred skills path inside a worktree. It is a
+// symlink to .agents/skills (same pattern as campaign-root .grok/skills).
+const GrokSkillsRel = ".grok/skills"
+
+// WorktreeProjection is one worktree destination after projection.
+type WorktreeProjection struct {
+	// Path is the absolute worktree root.
+	Path string
+	// RelPath is Path relative to campaignRoot when provided; otherwise Path.
+	RelPath string
+	// Agents is the projection summary for .agents/skills (primary status).
+	Agents ProjectionSummary
+	// Claude is the projection summary for .claude/skills.
+	Claude ProjectionSummary
+	// Err is a hard failure projecting into this worktree (skipped otherwise).
+	Err error
+}
+
+// ListWorktreeRoots returns absolute paths of project worktrees under
+// worktreesRoot, which uses the campaign layout:
+//
+//	worktreesRoot/<project>/<name>/
+//
+// Only directories that look like git checkouts (have a .git file or
+// directory) are returned, so ordinary project subdirs (src, bin,
+// node_modules, …) under a mis-nested tree are ignored. Missing
+// worktreesRoot yields an empty list, not an error.
+func ListWorktreeRoots(worktreesRoot string) ([]string, error) {
+	entries, err := os.ReadDir(worktreesRoot)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, camperrors.Wrap(err, "list worktrees root")
+	}
+
+	var roots []string
+	for _, projectEntry := range entries {
+		if !projectEntry.IsDir() || strings.HasPrefix(projectEntry.Name(), ".") {
+			continue
+		}
+		projectDir := filepath.Join(worktreesRoot, projectEntry.Name())
+		// Some checkouts land directly under worktreesRoot/<name> (no project
+		// nesting). Accept those when they are git roots.
+		if isGitCheckoutRoot(projectDir) {
+			roots = append(roots, projectDir)
+			continue
+		}
+		wtEntries, err := os.ReadDir(projectDir)
+		if err != nil {
+			return nil, camperrors.Wrapf(err, "list worktrees for project %s", projectEntry.Name())
+		}
+		for _, wtEntry := range wtEntries {
+			if !wtEntry.IsDir() || strings.HasPrefix(wtEntry.Name(), ".") {
+				continue
+			}
+			wtPath := filepath.Join(projectDir, wtEntry.Name())
+			if !isGitCheckoutRoot(wtPath) {
+				continue
+			}
+			roots = append(roots, wtPath)
+		}
+	}
+	sort.Strings(roots)
+	return roots, nil
+}
+
+// isGitCheckoutRoot reports whether path is a git working tree (main repo or
+// linked worktree). Linked worktrees use a .git file; main repos use a .git
+// directory.
+func isGitCheckoutRoot(path string) bool {
+	_, err := os.Lstat(filepath.Join(path, ".git"))
+	return err == nil
+}
+
+// ProjectIntoWorktree projects skill bundles from skillsDir into a single
+// worktree root (.agents/skills and .claude/skills), then ensures
+// .grok/skills → .agents/skills so Grok discovers the same set.
+//
+// campaignRoot is used only for ValidateDestination; it must contain the
+// worktree. An empty slugs list is a successful no-op.
+func ProjectIntoWorktree(worktreeRoot, campaignRoot, skillsDir string, slugs []string, dryRun, force bool, errOut io.Writer) (WorktreeProjection, error) {
+	out := WorktreeProjection{Path: worktreeRoot}
+	if rel, err := filepath.Rel(campaignRoot, worktreeRoot); err == nil && !strings.HasPrefix(rel, "..") {
+		out.RelPath = rel
+	} else {
+		out.RelPath = worktreeRoot
+	}
+
+	if len(slugs) == 0 {
+		return out, nil
+	}
+
+	for _, rel := range WorktreeSkillDestRels {
+		dest := filepath.Join(worktreeRoot, rel)
+		if err := ValidateDestination(dest, campaignRoot); err != nil {
+			out.Err = err
+			return out, err
+		}
+		if err := EnsureProjectionDirectory(dest, dryRun, errOut); err != nil {
+			out.Err = err
+			return out, err
+		}
+		summary, err := ProjectSkillEntries(dest, skillsDir, slugs, dryRun, force)
+		if err != nil {
+			out.Err = err
+			return out, err
+		}
+		switch rel {
+		case ".agents/skills":
+			out.Agents = summary
+		case ".claude/skills":
+			out.Claude = summary
+		}
+	}
+
+	if err := EnsureGrokSkillsAlias(worktreeRoot, dryRun); err != nil {
+		out.Err = err
+		return out, err
+	}
+	return out, nil
+}
+
+// EnsureGrokSkillsAlias creates worktreeRoot/.grok/skills as a symlink to
+// ../.agents/skills when missing or incorrect. It never overwrites a real
+// directory or a non-managed symlink that points elsewhere without force
+// semantics — here a foreign real directory is left alone and reported as an error
+// only when it blocks a clean alias; a correct existing link is a no-op.
+func EnsureGrokSkillsAlias(worktreeRoot string, dryRun bool) error {
+	linkPath := filepath.Join(worktreeRoot, GrokSkillsRel)
+	// Target relative to the symlink's parent (.grok/): ../.agents/skills
+	const relTarget = "../.agents/skills"
+	wantAbs := filepath.Clean(filepath.Join(filepath.Dir(linkPath), relTarget))
+
+	info, err := os.Lstat(linkPath)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink == 0 {
+			if info.IsDir() {
+				// Real directory: leave it; Grok can still scan it if populated.
+				return nil
+			}
+			return camperrors.Newf("refusing to replace non-symlink at %s", linkPath)
+		}
+		raw, readErr := os.Readlink(linkPath)
+		if readErr != nil {
+			return camperrors.Wrap(readErr, "read grok skills alias")
+		}
+		gotAbs := resolveSymlinkTargetAbs(linkPath, raw)
+		if filepath.Clean(gotAbs) == wantAbs {
+			return nil
+		}
+		// Wrong target: replace when not dry-run.
+		if dryRun {
+			return nil
+		}
+		if err := os.Remove(linkPath); err != nil {
+			return camperrors.Wrap(err, "remove stale grok skills alias")
+		}
+	} else if !os.IsNotExist(err) {
+		return camperrors.Wrap(err, "stat grok skills alias")
+	}
+
+	if dryRun {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+		return camperrors.Wrap(err, "create .grok directory")
+	}
+	if err := os.Symlink(relTarget, linkPath); err != nil {
+		return camperrors.Wrap(err, "create grok skills alias")
+	}
+	return nil
+}
+
+// LinkAllWorktrees projects skill bundles into every worktree under
+// worktreesRoot. Per-worktree errors are recorded on WorktreeProjection.Err;
+// a top-level error is returned only when the worktree list or skill discovery
+// cannot be read.
+func LinkAllWorktrees(campaignRoot, worktreesRoot, skillsDir string, dryRun, force bool, errOut io.Writer) ([]WorktreeProjection, error) {
+	slugs, err := DiscoverSkillSlugs(skillsDir)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "discover skill bundles")
+	}
+	roots, err := ListWorktreeRoots(worktreesRoot)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]WorktreeProjection, 0, len(roots))
+	for _, root := range roots {
+		proj, projErr := ProjectIntoWorktree(root, campaignRoot, skillsDir, slugs, dryRun, force, errOut)
+		if projErr != nil && proj.Err == nil {
+			proj.Err = projErr
+		}
+		results = append(results, proj)
+	}
+	return results, nil
+}
+
+// ProjectIntoWorktreeBestEffort projects campaign skills into a newly created
+// worktree. Missing .campaign/skills or an empty skills dir is a silent
+// success (no-op). Other errors are returned so callers can warn without
+// failing worktree creation.
+func ProjectIntoWorktreeBestEffort(campaignRoot, worktreePath string) error {
+	skillsDir := filepath.Join(campaignRoot, campaign.CampaignDir, SkillsSubdir)
+	if _, err := os.Stat(skillsDir); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return camperrors.Wrap(err, "stat campaign skills")
+	}
+	slugs, err := DiscoverSkillSlugs(skillsDir)
+	if err != nil {
+		return err
+	}
+	if len(slugs) == 0 {
+		return nil
+	}
+	_, err = ProjectIntoWorktree(worktreePath, campaignRoot, skillsDir, slugs, false, false, io.Discard)
+	return err
+}
+
+// InspectWorktreeProjection reports projection state for a worktree's
+// .agents/skills directory (primary harness path).
+func InspectWorktreeProjection(worktreeRoot, skillsDir string, slugs []string) (ProjectionState, error) {
+	dest := filepath.Join(worktreeRoot, ".agents/skills")
+	pathType, err := CheckPathType(dest)
+	if err != nil {
+		return ProjectionState{}, err
+	}
+	switch pathType {
+	case TypeMissing:
+		return ProjectionState{TotalSkills: len(slugs)}, nil
+	case TypeFile, TypeSymlink:
+		return ProjectionState{TotalSkills: len(slugs), Conflicts: 1}, nil
+	case TypeDirectory:
+		return InspectSkillProjection(dest, skillsDir, slugs)
+	default:
+		return ProjectionState{TotalSkills: len(slugs)}, nil
+	}
+}

--- a/internal/skills/worktree.go
+++ b/internal/skills/worktree.go
@@ -1,6 +1,8 @@
 package skills
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -9,6 +11,7 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git"
 )
 
 // WorktreeSkillDestRels are the tool skill directories projected into each
@@ -23,6 +26,15 @@ var WorktreeSkillDestRels = []string{
 // GrokSkillsRel is the Grok-preferred skills path inside a worktree. It is a
 // symlink to .agents/skills (same pattern as campaign-root .grok/skills).
 const GrokSkillsRel = ".grok/skills"
+
+// worktreeSkillExcludePatterns are installed into the target worktree's
+// .git/info/exclude (local, not committed) so projected harness dirs do not
+// show up as untracked files in fest/festival/obey/etc. checkouts.
+var worktreeSkillExcludePatterns = []string{
+	".agents/",
+	".claude/",
+	".grok/",
+}
 
 // WorktreeProjection is one worktree destination after projection.
 type WorktreeProjection struct {
@@ -104,11 +116,13 @@ func isGitCheckoutRoot(path string) bool {
 
 // ProjectIntoWorktree projects skill bundles from skillsDir into a single
 // worktree root (.agents/skills and .claude/skills), then ensures
-// .grok/skills → .agents/skills so Grok discovers the same set.
+// .grok/skills → .agents/skills so Grok discovers the same set. It also
+// installs local .git/info/exclude patterns so projected dirs are not
+// untracked noise in the target project checkout.
 //
 // campaignRoot is used only for ValidateDestination; it must contain the
 // worktree. An empty slugs list is a successful no-op.
-func ProjectIntoWorktree(worktreeRoot, campaignRoot, skillsDir string, slugs []string, dryRun, force bool, errOut io.Writer) (WorktreeProjection, error) {
+func ProjectIntoWorktree(ctx context.Context, worktreeRoot, campaignRoot, skillsDir string, slugs []string, dryRun, force bool, errOut io.Writer) (WorktreeProjection, error) {
 	out := WorktreeProjection{Path: worktreeRoot}
 	if rel, err := filepath.Rel(campaignRoot, worktreeRoot); err == nil && !strings.HasPrefix(rel, "..") {
 		out.RelPath = rel
@@ -118,6 +132,10 @@ func ProjectIntoWorktree(worktreeRoot, campaignRoot, skillsDir string, slugs []s
 
 	if len(slugs) == 0 {
 		return out, nil
+	}
+	if err := ctx.Err(); err != nil {
+		out.Err = err
+		return out, err
 	}
 
 	for _, rel := range WorktreeSkillDestRels {
@@ -155,7 +173,30 @@ func ProjectIntoWorktree(worktreeRoot, campaignRoot, skillsDir string, slugs []s
 	out.Agents.Created += grokSummary.Created
 	out.Agents.Replaced += grokSummary.Replaced
 	out.Agents.AlreadyLinked += grokSummary.AlreadyLinked
+
+	if !dryRun {
+		if err := ensureWorktreeSkillExcludes(ctx, worktreeRoot, errOut); err != nil {
+			// Projection still succeeded; exclude is hygiene for the target repo.
+			if errOut != nil {
+				fmt.Fprintf(errOut, "warning: could not update local git excludes in %s: %v\n", worktreeRoot, err)
+			}
+		}
+	}
 	return out, nil
+}
+
+// ensureWorktreeSkillExcludes adds local (non-committed) exclude patterns for
+// projected harness directories via .git/info/exclude.
+func ensureWorktreeSkillExcludes(ctx context.Context, worktreeRoot string, errOut io.Writer) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	for _, pattern := range worktreeSkillExcludePatterns {
+		if _, err := git.EnsureInfoExclude(ctx, worktreeRoot, pattern); err != nil {
+			return camperrors.Wrapf(err, "ensure info/exclude %q", pattern)
+		}
+	}
+	return nil
 }
 
 // grokAliasRelTarget is the symlink target for .grok/skills relative to .grok/.
@@ -255,7 +296,7 @@ func EnsureGrokSkillsAlias(worktreeRoot string, dryRun bool) error {
 // worktreesRoot. Per-worktree errors are recorded on WorktreeProjection.Err;
 // a top-level error is returned only when the worktree list or skill discovery
 // cannot be read.
-func LinkAllWorktrees(campaignRoot, worktreesRoot, skillsDir string, dryRun, force bool, errOut io.Writer) ([]WorktreeProjection, error) {
+func LinkAllWorktrees(ctx context.Context, campaignRoot, worktreesRoot, skillsDir string, dryRun, force bool, errOut io.Writer) ([]WorktreeProjection, error) {
 	slugs, err := DiscoverSkillSlugs(skillsDir)
 	if err != nil {
 		return nil, camperrors.Wrap(err, "discover skill bundles")
@@ -266,7 +307,10 @@ func LinkAllWorktrees(campaignRoot, worktreesRoot, skillsDir string, dryRun, for
 	}
 	results := make([]WorktreeProjection, 0, len(roots))
 	for _, root := range roots {
-		proj, projErr := ProjectIntoWorktree(root, campaignRoot, skillsDir, slugs, dryRun, force, errOut)
+		if err := ctx.Err(); err != nil {
+			return results, err
+		}
+		proj, projErr := ProjectIntoWorktree(ctx, root, campaignRoot, skillsDir, slugs, dryRun, force, errOut)
 		if projErr != nil && proj.Err == nil {
 			proj.Err = projErr
 		}
@@ -281,7 +325,7 @@ func LinkAllWorktrees(campaignRoot, worktreesRoot, skillsDir string, dryRun, for
 // false "projected" success message). Missing .campaign/skills or an empty
 // skills dir is a silent no-op (projected=false, err=nil). Other errors are
 // returned so callers can warn without failing worktree creation.
-func ProjectIntoWorktreeBestEffort(campaignRoot, worktreePath string) (projected bool, err error) {
+func ProjectIntoWorktreeBestEffort(ctx context.Context, campaignRoot, worktreePath string) (projected bool, err error) {
 	skillsDir := filepath.Join(campaignRoot, campaign.CampaignDir, SkillsSubdir)
 	if _, err := os.Stat(skillsDir); err != nil {
 		if os.IsNotExist(err) {
@@ -296,7 +340,7 @@ func ProjectIntoWorktreeBestEffort(campaignRoot, worktreePath string) (projected
 	if len(slugs) == 0 {
 		return false, nil
 	}
-	proj, err := ProjectIntoWorktree(worktreePath, campaignRoot, skillsDir, slugs, false, false, io.Discard)
+	proj, err := ProjectIntoWorktree(ctx, worktreePath, campaignRoot, skillsDir, slugs, false, false, io.Discard)
 	if err != nil {
 		return false, err
 	}
@@ -304,10 +348,26 @@ func ProjectIntoWorktreeBestEffort(campaignRoot, worktreePath string) (projected
 	return n > 0, nil
 }
 
-// InspectWorktreeProjection reports projection state for a worktree's
-// .agents/skills directory (primary harness path).
+// InspectWorktreeProjection reports aggregate projection state across all
+// managed worktree harness surfaces: .agents/skills, .claude/skills, and
+// .grok/skills. A worktree is fully linked only when every surface is healthy.
 func InspectWorktreeProjection(worktreeRoot, skillsDir string, slugs []string) (ProjectionState, error) {
-	dest := filepath.Join(worktreeRoot, ".agents/skills")
+	agents, err := inspectToolSkillDest(filepath.Join(worktreeRoot, ".agents/skills"), skillsDir, slugs)
+	if err != nil {
+		return ProjectionState{}, err
+	}
+	claude, err := inspectToolSkillDest(filepath.Join(worktreeRoot, ".claude/skills"), skillsDir, slugs)
+	if err != nil {
+		return ProjectionState{}, err
+	}
+	grok, err := inspectGrokSkillDest(worktreeRoot, skillsDir, slugs)
+	if err != nil {
+		return ProjectionState{}, err
+	}
+	return mergeWorktreeProjectionStates(agents, claude, grok), nil
+}
+
+func inspectToolSkillDest(dest, skillsDir string, slugs []string) (ProjectionState, error) {
 	pathType, err := CheckPathType(dest)
 	if err != nil {
 		return ProjectionState{}, err
@@ -322,4 +382,61 @@ func InspectWorktreeProjection(worktreeRoot, skillsDir string, slugs []string) (
 	default:
 		return ProjectionState{TotalSkills: len(slugs)}, nil
 	}
+}
+
+func inspectGrokSkillDest(worktreeRoot, skillsDir string, slugs []string) (ProjectionState, error) {
+	linkPath := filepath.Join(worktreeRoot, GrokSkillsRel)
+	wantAbs := filepath.Clean(filepath.Join(filepath.Dir(linkPath), grokAliasRelTarget))
+	pathType, err := CheckPathType(linkPath)
+	if err != nil {
+		return ProjectionState{}, err
+	}
+	switch pathType {
+	case TypeMissing:
+		return ProjectionState{TotalSkills: len(slugs)}, nil
+	case TypeFile:
+		return ProjectionState{TotalSkills: len(slugs), Conflicts: 1}, nil
+	case TypeSymlink:
+		raw, readErr := os.Readlink(linkPath)
+		if readErr != nil {
+			return ProjectionState{}, camperrors.Wrap(readErr, "read grok skills alias")
+		}
+		gotAbs := resolveSymlinkTargetAbs(linkPath, raw)
+		if filepath.Clean(gotAbs) == wantAbs {
+			// Correct alias: treat as fully linked for this surface.
+			return ProjectionState{TotalSkills: len(slugs), Linked: len(slugs)}, nil
+		}
+		return ProjectionState{TotalSkills: len(slugs), Conflicts: 1}, nil
+	case TypeDirectory:
+		return InspectSkillProjection(linkPath, skillsDir, slugs)
+	default:
+		return ProjectionState{TotalSkills: len(slugs)}, nil
+	}
+}
+
+// mergeWorktreeProjectionStates combines per-surface states. Linked is the
+// minimum across surfaces (all must be healthy); Broken/Mismatched/Conflicts sum.
+func mergeWorktreeProjectionStates(states ...ProjectionState) ProjectionState {
+	if len(states) == 0 {
+		return ProjectionState{}
+	}
+	out := ProjectionState{TotalSkills: states[0].TotalSkills, Linked: states[0].Linked}
+	for i, s := range states {
+		if i == 0 {
+			out.Broken = s.Broken
+			out.Mismatched = s.Mismatched
+			out.Conflicts = s.Conflicts
+			continue
+		}
+		if s.Linked < out.Linked {
+			out.Linked = s.Linked
+		}
+		out.Broken += s.Broken
+		out.Mismatched += s.Mismatched
+		out.Conflicts += s.Conflicts
+		if s.TotalSkills > out.TotalSkills {
+			out.TotalSkills = s.TotalSkills
+		}
+	}
+	return out
 }

--- a/internal/skills/worktree.go
+++ b/internal/skills/worktree.go
@@ -39,14 +39,20 @@ type WorktreeProjection struct {
 }
 
 // ListWorktreeRoots returns absolute paths of project worktrees under
-// worktreesRoot, which uses the campaign layout:
+// worktreesRoot.
 //
-//	worktreesRoot/<project>/<name>/
+// Expected campaign layout (what camp project worktree add creates):
+//
+//	worktreesRoot/<project>/<name>/   # git worktree root
 //
 // Only directories that look like git checkouts (have a .git file or
 // directory) are returned, so ordinary project subdirs (src, bin,
-// node_modules, …) under a mis-nested tree are ignored. Missing
-// worktreesRoot yields an empty list, not an error.
+// node_modules, …) under a mis-nested tree are ignored.
+//
+// If worktreesRoot/<project> is itself a git root (a loose checkout without
+// the <name> level), that directory is projected and its children are not
+// scanned — nested worktrees under a git-root project dir are out of scope.
+// Missing worktreesRoot yields an empty list, not an error.
 func ListWorktreeRoots(worktreesRoot string) ([]string, error) {
 	entries, err := os.ReadDir(worktreesRoot)
 	if os.IsNotExist(err) {
@@ -62,8 +68,9 @@ func ListWorktreeRoots(worktreesRoot string) ([]string, error) {
 			continue
 		}
 		projectDir := filepath.Join(worktreesRoot, projectEntry.Name())
-		// Some checkouts land directly under worktreesRoot/<name> (no project
-		// nesting). Accept those when they are git roots.
+		// Loose checkout: worktreesRoot/<name> is itself the git root (no
+		// project nesting). Project it and do not descend — children are
+		// package dirs, not nested worktrees under this layout contract.
 		if isGitCheckoutRoot(projectDir) {
 			roots = append(roots, projectDir)
 			continue
@@ -219,26 +226,32 @@ func LinkAllWorktrees(campaignRoot, worktreesRoot, skillsDir string, dryRun, for
 }
 
 // ProjectIntoWorktreeBestEffort projects campaign skills into a newly created
-// worktree. Missing .campaign/skills or an empty skills dir is a silent
-// success (no-op). Other errors are returned so callers can warn without
-// failing worktree creation.
-func ProjectIntoWorktreeBestEffort(campaignRoot, worktreePath string) error {
+// worktree. projected is true when at least one skill bundle was created or
+// already linked under the worktree's .agents/skills (so callers can avoid a
+// false "projected" success message). Missing .campaign/skills or an empty
+// skills dir is a silent no-op (projected=false, err=nil). Other errors are
+// returned so callers can warn without failing worktree creation.
+func ProjectIntoWorktreeBestEffort(campaignRoot, worktreePath string) (projected bool, err error) {
 	skillsDir := filepath.Join(campaignRoot, campaign.CampaignDir, SkillsSubdir)
 	if _, err := os.Stat(skillsDir); err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return false, nil
 		}
-		return camperrors.Wrap(err, "stat campaign skills")
+		return false, camperrors.Wrap(err, "stat campaign skills")
 	}
 	slugs, err := DiscoverSkillSlugs(skillsDir)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if len(slugs) == 0 {
-		return nil
+		return false, nil
 	}
-	_, err = ProjectIntoWorktree(worktreePath, campaignRoot, skillsDir, slugs, false, false, io.Discard)
-	return err
+	proj, err := ProjectIntoWorktree(worktreePath, campaignRoot, skillsDir, slugs, false, false, io.Discard)
+	if err != nil {
+		return false, err
+	}
+	n := proj.Agents.Created + proj.Agents.Replaced + proj.Agents.AlreadyLinked
+	return n > 0, nil
 }
 
 // InspectWorktreeProjection reports projection state for a worktree's

--- a/internal/skills/worktree.go
+++ b/internal/skills/worktree.go
@@ -143,62 +143,112 @@ func ProjectIntoWorktree(worktreeRoot, campaignRoot, skillsDir string, slugs []s
 		}
 	}
 
-	if err := EnsureGrokSkillsAlias(worktreeRoot, dryRun); err != nil {
+	grokSummary, err := ensureWorktreeGrokSkills(worktreeRoot, skillsDir, slugs, dryRun, force, errOut)
+	if err != nil {
 		out.Err = err
 		return out, err
 	}
+	// Surface grok conflicts on the agents summary so link/status aggregation
+	// already counts them (same ConflictNames path as tool dirs).
+	out.Agents.Conflicts += grokSummary.Conflicts
+	out.Agents.ConflictNames = append(out.Agents.ConflictNames, grokSummary.ConflictNames...)
+	out.Agents.Created += grokSummary.Created
+	out.Agents.Replaced += grokSummary.Replaced
+	out.Agents.AlreadyLinked += grokSummary.AlreadyLinked
 	return out, nil
 }
 
-// EnsureGrokSkillsAlias creates worktreeRoot/.grok/skills as a symlink to
-// ../.agents/skills when missing or incorrect. It never overwrites a real
-// directory or a non-managed symlink that points elsewhere without force
-// semantics — here a foreign real directory is left alone and reported as an error
-// only when it blocks a clean alias; a correct existing link is a no-op.
-func EnsureGrokSkillsAlias(worktreeRoot string, dryRun bool) error {
-	linkPath := filepath.Join(worktreeRoot, GrokSkillsRel)
-	// Target relative to the symlink's parent (.grok/): ../.agents/skills
-	const relTarget = "../.agents/skills"
-	wantAbs := filepath.Clean(filepath.Join(filepath.Dir(linkPath), relTarget))
+// grokAliasRelTarget is the symlink target for .grok/skills relative to .grok/.
+const grokAliasRelTarget = "../.agents/skills"
 
-	info, err := os.Lstat(linkPath)
-	if err == nil {
-		if info.Mode()&os.ModeSymlink == 0 {
-			if info.IsDir() {
-				// Real directory: leave it; Grok can still scan it if populated.
-				return nil
-			}
-			return camperrors.Newf("refusing to replace non-symlink at %s", linkPath)
-		}
+// ensureWorktreeGrokSkills makes Grok discover the same campaign skills as
+// .agents/skills:
+//
+//   - missing path → symlink .grok/skills → ../.agents/skills
+//   - correct symlink → no-op
+//   - wrong symlink → conflict unless force (then replace), matching ProjectSkillEntries
+//   - real directory → project per-bundle managed links into it (do not replace the dir)
+//   - plain file → conflict
+func ensureWorktreeGrokSkills(worktreeRoot, skillsDir string, slugs []string, dryRun, force bool, errOut io.Writer) (ProjectionSummary, error) {
+	linkPath := filepath.Join(worktreeRoot, GrokSkillsRel)
+	wantAbs := filepath.Clean(filepath.Join(filepath.Dir(linkPath), grokAliasRelTarget))
+
+	pathType, err := CheckPathType(linkPath)
+	if err != nil {
+		return ProjectionSummary{}, err
+	}
+
+	switch pathType {
+	case TypeDirectory:
+		// Real directory: Grok will scan it, so project managed bundles into it.
+		return ProjectSkillEntries(linkPath, skillsDir, slugs, dryRun, force)
+
+	case TypeFile:
+		return ProjectionSummary{
+			Conflicts:     1,
+			ConflictNames: []string{GrokSkillsRel},
+		}, nil
+
+	case TypeSymlink:
 		raw, readErr := os.Readlink(linkPath)
 		if readErr != nil {
-			return camperrors.Wrap(readErr, "read grok skills alias")
+			return ProjectionSummary{}, camperrors.Wrap(readErr, "read grok skills alias")
 		}
 		gotAbs := resolveSymlinkTargetAbs(linkPath, raw)
 		if filepath.Clean(gotAbs) == wantAbs {
-			return nil
+			return ProjectionSummary{AlreadyLinked: 1}, nil
 		}
-		// Wrong target: replace when not dry-run.
+		// Foreign / wrong-target symlink: require force, same as ProjectSkillEntries.
+		if !force {
+			return ProjectionSummary{
+				Conflicts:     1,
+				ConflictNames: []string{GrokSkillsRel},
+			}, nil
+		}
 		if dryRun {
-			return nil
+			return ProjectionSummary{Replaced: 1}, nil
 		}
 		if err := os.Remove(linkPath); err != nil {
-			return camperrors.Wrap(err, "remove stale grok skills alias")
+			return ProjectionSummary{}, camperrors.Wrap(err, "remove foreign grok skills alias")
 		}
-	} else if !os.IsNotExist(err) {
-		return camperrors.Wrap(err, "stat grok skills alias")
-	}
+		if err := createGrokSkillsAlias(worktreeRoot, dryRun); err != nil {
+			return ProjectionSummary{}, err
+		}
+		return ProjectionSummary{Replaced: 1}, nil
 
+	case TypeMissing:
+		if err := createGrokSkillsAlias(worktreeRoot, dryRun); err != nil {
+			return ProjectionSummary{}, err
+		}
+		return ProjectionSummary{Created: 1}, nil
+
+	default:
+		return ProjectionSummary{}, camperrors.Newf("unsupported path type for %s", linkPath)
+	}
+}
+
+// createGrokSkillsAlias writes worktreeRoot/.grok/skills → ../.agents/skills.
+func createGrokSkillsAlias(worktreeRoot string, dryRun bool) error {
+	linkPath := filepath.Join(worktreeRoot, GrokSkillsRel)
 	if dryRun {
 		return nil
 	}
 	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
 		return camperrors.Wrap(err, "create .grok directory")
 	}
-	if err := os.Symlink(relTarget, linkPath); err != nil {
+	if err := os.Symlink(grokAliasRelTarget, linkPath); err != nil {
 		return camperrors.Wrap(err, "create grok skills alias")
 	}
 	return nil
+}
+
+// EnsureGrokSkillsAlias creates worktreeRoot/.grok/skills as a symlink to
+// ../.agents/skills when missing. Prefer ensureWorktreeGrokSkills from
+// ProjectIntoWorktree (handles force, directory projection, and conflicts).
+// Kept for tests and callers that only need the default alias path with force.
+func EnsureGrokSkillsAlias(worktreeRoot string, dryRun bool) error {
+	_, err := ensureWorktreeGrokSkills(worktreeRoot, "", nil, dryRun, true, io.Discard)
+	return err
 }
 
 // LinkAllWorktrees projects skill bundles into every worktree under

--- a/internal/skills/worktree_test.go
+++ b/internal/skills/worktree_test.go
@@ -1,372 +1,47 @@
 package skills
 
 import (
-	"io"
-	"os"
-	"path/filepath"
 	"testing"
 )
 
-func writeSkillBundle(t *testing.T, skillsDir, slug string) {
-	t.Helper()
-	dir := filepath.Join(skillsDir, slug)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("mkdir skill: %v", err)
+// Pure-logic tests only. Filesystem-mutating worktree projection coverage
+// lives in tests/integration/skills_worktree_test.go (container harness).
+
+func TestMergeWorktreeProjectionStates(t *testing.T) {
+	agents := ProjectionState{TotalSkills: 3, Linked: 3}
+	claude := ProjectionState{TotalSkills: 3, Linked: 1, Mismatched: 1}
+	grok := ProjectionState{TotalSkills: 3, Linked: 3, Conflicts: 1}
+
+	got := mergeWorktreeProjectionStates(agents, claude, grok)
+	if got.Linked != 1 {
+		t.Errorf("Linked = %d, want min surface = 1", got.Linked)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: "+slug+"\n---\n"), 0o644); err != nil {
-		t.Fatalf("write SKILL.md: %v", err)
+	if got.Mismatched != 1 {
+		t.Errorf("Mismatched = %d, want 1", got.Mismatched)
+	}
+	if got.Conflicts != 1 {
+		t.Errorf("Conflicts = %d, want 1", got.Conflicts)
+	}
+	if got.TotalSkills != 3 {
+		t.Errorf("TotalSkills = %d, want 3", got.TotalSkills)
 	}
 }
 
-func TestListWorktreeRoots(t *testing.T) {
-	tmp := t.TempDir()
-	// Layout: worktrees/camp/feat-a, worktrees/fest/pr-1 — only dirs with .git count.
-	for _, p := range []string{
-		filepath.Join(tmp, "camp", "feat-a"),
-		filepath.Join(tmp, "camp", "feat-b"),
-		filepath.Join(tmp, "fest", "pr-1"),
-	} {
-		if err := os.MkdirAll(p, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(p, ".git"), []byte("gitdir: /tmp/fake\n"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := os.MkdirAll(filepath.Join(tmp, "camp", "not-a-worktree", "src"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(tmp, "camp", ".hidden"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(tmp, "camp", "notadir"), []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := ListWorktreeRoots(tmp)
-	if err != nil {
-		t.Fatalf("ListWorktreeRoots: %v", err)
-	}
-	if len(got) != 3 {
-		t.Fatalf("got %d roots %v, want 3", len(got), got)
-	}
-	if got[0] != filepath.Join(tmp, "camp", "feat-a") {
-		t.Errorf("first = %q", got[0])
+func TestMergeWorktreeProjectionStatesEmpty(t *testing.T) {
+	got := mergeWorktreeProjectionStates()
+	if got.TotalSkills != 0 || got.Linked != 0 {
+		t.Errorf("empty merge = %+v", got)
 	}
 }
 
-func TestListWorktreeRootsSkipsNonGitChildren(t *testing.T) {
-	tmp := t.TempDir()
-	// Mis-nested: project dir is itself a git checkout; children are src/bin.
-	proj := filepath.Join(tmp, "fest-gif")
-	if err := os.MkdirAll(filepath.Join(proj, "src"), 0o755); err != nil {
-		t.Fatal(err)
+func TestWorktreeSkillExcludePatterns(t *testing.T) {
+	want := map[string]bool{".agents/": true, ".claude/": true, ".grok/": true}
+	if len(worktreeSkillExcludePatterns) != len(want) {
+		t.Fatalf("patterns = %v, want %d entries", worktreeSkillExcludePatterns, len(want))
 	}
-	if err := os.WriteFile(filepath.Join(proj, ".git"), []byte("gitdir: /tmp/fake\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	got, err := ListWorktreeRoots(tmp)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(got) != 1 || got[0] != proj {
-		t.Fatalf("got %v, want only the git root %s", got, proj)
-	}
-}
-
-func TestListWorktreeRootsMissing(t *testing.T) {
-	got, err := ListWorktreeRoots(filepath.Join(t.TempDir(), "nope"))
-	if err != nil {
-		t.Fatalf("missing root should not error: %v", err)
-	}
-	if len(got) != 0 {
-		t.Errorf("got %v, want empty", got)
-	}
-}
-
-func TestProjectIntoWorktree(t *testing.T) {
-	campaignRoot := t.TempDir()
-	skillsDir := filepath.Join(campaignRoot, ".campaign", "skills")
-	writeSkillBundle(t, skillsDir, "camp-navigation")
-	writeSkillBundle(t, skillsDir, "fest-execution")
-
-	wt := filepath.Join(campaignRoot, "projects", "worktrees", "camp", "feature-x")
-	if err := os.MkdirAll(wt, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	slugs, err := DiscoverSkillSlugs(skillsDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	proj, err := ProjectIntoWorktree(wt, campaignRoot, skillsDir, slugs, false, false, io.Discard)
-	if err != nil {
-		t.Fatalf("ProjectIntoWorktree: %v", err)
-	}
-	// 2 skill bundles under .agents + 1 for creating .grok/skills alias.
-	if proj.Agents.Created != 3 {
-		t.Errorf("agents created = %d, want 3 (2 skills + grok alias)", proj.Agents.Created)
-	}
-	if proj.Claude.Created != 2 {
-		t.Errorf("claude created = %d, want 2", proj.Claude.Created)
-	}
-
-	for _, rel := range []string{
-		".agents/skills/camp-navigation",
-		".agents/skills/fest-execution",
-		".claude/skills/camp-navigation",
-	} {
-		p := filepath.Join(wt, rel)
-		info, err := os.Lstat(p)
-		if err != nil {
-			t.Fatalf("missing %s: %v", rel, err)
+	for _, p := range worktreeSkillExcludePatterns {
+		if !want[p] {
+			t.Errorf("unexpected exclude pattern %q", p)
 		}
-		if info.Mode()&os.ModeSymlink == 0 {
-			t.Errorf("%s is not a symlink", rel)
-		}
-		target, err := os.Readlink(p)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !filepath.IsAbs(target) {
-			// relative targets should still resolve into .campaign/skills
-			abs := resolveSymlinkTargetAbs(p, target)
-			if _, err := os.Stat(abs); err != nil {
-				t.Errorf("%s -> %s does not resolve: %v", rel, target, err)
-			}
-		}
-	}
-
-	// Grok alias
-	grokLink := filepath.Join(wt, GrokSkillsRel)
-	info, err := os.Lstat(grokLink)
-	if err != nil {
-		t.Fatalf("grok skills alias missing: %v", err)
-	}
-	if info.Mode()&os.ModeSymlink == 0 {
-		t.Fatal("grok skills alias is not a symlink")
-	}
-	raw, err := os.Readlink(grokLink)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if raw != "../.agents/skills" {
-		t.Errorf("grok alias target = %q, want ../.agents/skills", raw)
-	}
-
-	// Idempotent second run
-	proj2, err := ProjectIntoWorktree(wt, campaignRoot, skillsDir, slugs, false, false, io.Discard)
-	if err != nil {
-		t.Fatalf("second ProjectIntoWorktree: %v", err)
-	}
-	// 2 skill links already linked + grok alias already linked.
-	if proj2.Agents.AlreadyLinked != 3 || proj2.Agents.Created != 0 {
-		t.Errorf("second run agents: created=%d linked=%d, want created=0 linked=3",
-			proj2.Agents.Created, proj2.Agents.AlreadyLinked)
-	}
-}
-
-func TestLinkAllWorktrees(t *testing.T) {
-	campaignRoot := t.TempDir()
-	skillsDir := filepath.Join(campaignRoot, ".campaign", "skills")
-	writeSkillBundle(t, skillsDir, "alpha")
-
-	wtRoot := filepath.Join(campaignRoot, "projects", "worktrees")
-	for _, p := range []string{
-		filepath.Join(wtRoot, "camp", "a"),
-		filepath.Join(wtRoot, "fest", "b"),
-	} {
-		if err := os.MkdirAll(p, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(p, ".git"), []byte("gitdir: /tmp/fake\n"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	results, err := LinkAllWorktrees(campaignRoot, wtRoot, skillsDir, false, false, io.Discard)
-	if err != nil {
-		t.Fatalf("LinkAllWorktrees: %v", err)
-	}
-	if len(results) != 2 {
-		t.Fatalf("results = %d, want 2", len(results))
-	}
-	for _, r := range results {
-		if r.Err != nil {
-			t.Errorf("worktree %s: %v", r.Path, r.Err)
-		}
-		// 1 skill bundle + 1 grok alias create.
-		if r.Agents.Created != 2 {
-			t.Errorf("%s agents created = %d, want 2", r.RelPath, r.Agents.Created)
-		}
-		if _, err := os.Lstat(filepath.Join(r.Path, ".agents/skills", "alpha")); err != nil {
-			t.Errorf("missing projection in %s: %v", r.Path, err)
-		}
-	}
-}
-
-func TestInspectWorktreeProjection(t *testing.T) {
-	campaignRoot := t.TempDir()
-	skillsDir := filepath.Join(campaignRoot, ".campaign", "skills")
-	writeSkillBundle(t, skillsDir, "alpha")
-	slugs, _ := DiscoverSkillSlugs(skillsDir)
-
-	wt := filepath.Join(campaignRoot, "projects", "worktrees", "camp", "x")
-	if err := os.MkdirAll(wt, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	st, err := InspectWorktreeProjection(wt, skillsDir, slugs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if st.Linked != 0 || st.TotalSkills != 1 {
-		t.Errorf("before project: linked=%d total=%d", st.Linked, st.TotalSkills)
-	}
-
-	if _, err := ProjectIntoWorktree(wt, campaignRoot, skillsDir, slugs, false, false, io.Discard); err != nil {
-		t.Fatal(err)
-	}
-	st, err = InspectWorktreeProjection(wt, skillsDir, slugs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if st.Linked != 1 {
-		t.Errorf("after project: linked=%d, want 1", st.Linked)
-	}
-}
-
-func TestEnsureGrokSkillsAliasIdempotent(t *testing.T) {
-	wt := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(wt, ".agents", "skills"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := EnsureGrokSkillsAlias(wt, false); err != nil {
-		t.Fatal(err)
-	}
-	if err := EnsureGrokSkillsAlias(wt, false); err != nil {
-		t.Fatalf("second ensure: %v", err)
-	}
-}
-
-func TestEnsureWorktreeGrokSkillsForeignSymlinkRequiresForce(t *testing.T) {
-	wt := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(wt, ".grok"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	linkPath := filepath.Join(wt, GrokSkillsRel)
-	if err := os.Symlink("/somewhere/else", linkPath); err != nil {
-		t.Fatal(err)
-	}
-
-	summary, err := ensureWorktreeGrokSkills(wt, "", nil, false, false, io.Discard)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if summary.Conflicts != 1 {
-		t.Fatalf("conflicts = %d, want 1", summary.Conflicts)
-	}
-	// Link must still point at foreign target.
-	raw, _ := os.Readlink(linkPath)
-	if raw != "/somewhere/else" {
-		t.Errorf("foreign symlink was modified without force: %q", raw)
-	}
-
-	summary, err = ensureWorktreeGrokSkills(wt, "", nil, false, true, io.Discard)
-	if err != nil {
-		t.Fatalf("force replace: %v", err)
-	}
-	if summary.Replaced != 1 {
-		t.Errorf("replaced = %d, want 1", summary.Replaced)
-	}
-	raw, err = os.Readlink(linkPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if raw != grokAliasRelTarget {
-		t.Errorf("after force target = %q, want %q", raw, grokAliasRelTarget)
-	}
-}
-
-func TestEnsureWorktreeGrokSkillsProjectsIntoRealDirectory(t *testing.T) {
-	campaignRoot := t.TempDir()
-	skillsDir := filepath.Join(campaignRoot, ".campaign", "skills")
-	writeSkillBundle(t, skillsDir, "camp-navigation")
-	slugs, _ := DiscoverSkillSlugs(skillsDir)
-
-	wt := filepath.Join(campaignRoot, "projects", "worktrees", "camp", "dir-grok")
-	grokSkills := filepath.Join(wt, GrokSkillsRel)
-	if err := os.MkdirAll(grokSkills, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	summary, err := ensureWorktreeGrokSkills(wt, skillsDir, slugs, false, false, io.Discard)
-	if err != nil {
-		t.Fatalf("project into dir: %v", err)
-	}
-	if summary.Created != 1 {
-		t.Errorf("created = %d, want 1", summary.Created)
-	}
-	if _, err := os.Lstat(filepath.Join(grokSkills, "camp-navigation")); err != nil {
-		t.Errorf("managed link missing in .grok/skills dir: %v", err)
-	}
-	// Directory must remain a directory, not be replaced by a symlink.
-	info, err := os.Lstat(grokSkills)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
-		t.Error(".grok/skills should remain a real directory")
-	}
-}
-
-func TestProjectIntoWorktreeBestEffort(t *testing.T) {
-	campaignRoot := t.TempDir()
-	wt := filepath.Join(campaignRoot, "projects", "worktrees", "camp", "x")
-	if err := os.MkdirAll(wt, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	// No skills dir: no-op, not projected.
-	projected, err := ProjectIntoWorktreeBestEffort(campaignRoot, wt)
-	if err != nil {
-		t.Fatalf("missing skills dir: %v", err)
-	}
-	if projected {
-		t.Error("projected=true with no skills dir")
-	}
-
-	skillsDir := filepath.Join(campaignRoot, ".campaign", "skills")
-	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	// Empty skills dir: no-op.
-	projected, err = ProjectIntoWorktreeBestEffort(campaignRoot, wt)
-	if err != nil {
-		t.Fatalf("empty skills dir: %v", err)
-	}
-	if projected {
-		t.Error("projected=true with empty skills dir")
-	}
-
-	writeSkillBundle(t, skillsDir, "camp-navigation")
-	projected, err = ProjectIntoWorktreeBestEffort(campaignRoot, wt)
-	if err != nil {
-		t.Fatalf("with skills: %v", err)
-	}
-	if !projected {
-		t.Error("projected=false after successful projection")
-	}
-	if _, err := os.Lstat(filepath.Join(wt, ".agents", "skills", "camp-navigation")); err != nil {
-		t.Errorf("link missing: %v", err)
-	}
-
-	// Second call still projected (already-linked counts).
-	projected, err = ProjectIntoWorktreeBestEffort(campaignRoot, wt)
-	if err != nil {
-		t.Fatalf("idempotent: %v", err)
-	}
-	if !projected {
-		t.Error("projected=false when already linked")
 	}
 }

--- a/internal/skills/worktree_test.go
+++ b/internal/skills/worktree_test.go
@@ -103,8 +103,9 @@ func TestProjectIntoWorktree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProjectIntoWorktree: %v", err)
 	}
-	if proj.Agents.Created != 2 {
-		t.Errorf("agents created = %d, want 2", proj.Agents.Created)
+	// 2 skill bundles under .agents + 1 for creating .grok/skills alias.
+	if proj.Agents.Created != 3 {
+		t.Errorf("agents created = %d, want 3 (2 skills + grok alias)", proj.Agents.Created)
 	}
 	if proj.Claude.Created != 2 {
 		t.Errorf("claude created = %d, want 2", proj.Claude.Created)
@@ -158,8 +159,9 @@ func TestProjectIntoWorktree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second ProjectIntoWorktree: %v", err)
 	}
-	if proj2.Agents.AlreadyLinked != 2 || proj2.Agents.Created != 0 {
-		t.Errorf("second run agents: created=%d linked=%d, want created=0 linked=2",
+	// 2 skill links already linked + grok alias already linked.
+	if proj2.Agents.AlreadyLinked != 3 || proj2.Agents.Created != 0 {
+		t.Errorf("second run agents: created=%d linked=%d, want created=0 linked=3",
 			proj2.Agents.Created, proj2.Agents.AlreadyLinked)
 	}
 }
@@ -193,8 +195,9 @@ func TestLinkAllWorktrees(t *testing.T) {
 		if r.Err != nil {
 			t.Errorf("worktree %s: %v", r.Path, r.Err)
 		}
-		if r.Agents.Created != 1 {
-			t.Errorf("%s agents created = %d", r.RelPath, r.Agents.Created)
+		// 1 skill bundle + 1 grok alias create.
+		if r.Agents.Created != 2 {
+			t.Errorf("%s agents created = %d, want 2", r.RelPath, r.Agents.Created)
 		}
 		if _, err := os.Lstat(filepath.Join(r.Path, ".agents/skills", "alpha")); err != nil {
 			t.Errorf("missing projection in %s: %v", r.Path, err)
@@ -243,6 +246,77 @@ func TestEnsureGrokSkillsAliasIdempotent(t *testing.T) {
 	}
 	if err := EnsureGrokSkillsAlias(wt, false); err != nil {
 		t.Fatalf("second ensure: %v", err)
+	}
+}
+
+func TestEnsureWorktreeGrokSkillsForeignSymlinkRequiresForce(t *testing.T) {
+	wt := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(wt, ".grok"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkPath := filepath.Join(wt, GrokSkillsRel)
+	if err := os.Symlink("/somewhere/else", linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	summary, err := ensureWorktreeGrokSkills(wt, "", nil, false, false, io.Discard)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if summary.Conflicts != 1 {
+		t.Fatalf("conflicts = %d, want 1", summary.Conflicts)
+	}
+	// Link must still point at foreign target.
+	raw, _ := os.Readlink(linkPath)
+	if raw != "/somewhere/else" {
+		t.Errorf("foreign symlink was modified without force: %q", raw)
+	}
+
+	summary, err = ensureWorktreeGrokSkills(wt, "", nil, false, true, io.Discard)
+	if err != nil {
+		t.Fatalf("force replace: %v", err)
+	}
+	if summary.Replaced != 1 {
+		t.Errorf("replaced = %d, want 1", summary.Replaced)
+	}
+	raw, err = os.Readlink(linkPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw != grokAliasRelTarget {
+		t.Errorf("after force target = %q, want %q", raw, grokAliasRelTarget)
+	}
+}
+
+func TestEnsureWorktreeGrokSkillsProjectsIntoRealDirectory(t *testing.T) {
+	campaignRoot := t.TempDir()
+	skillsDir := filepath.Join(campaignRoot, ".campaign", "skills")
+	writeSkillBundle(t, skillsDir, "camp-navigation")
+	slugs, _ := DiscoverSkillSlugs(skillsDir)
+
+	wt := filepath.Join(campaignRoot, "projects", "worktrees", "camp", "dir-grok")
+	grokSkills := filepath.Join(wt, GrokSkillsRel)
+	if err := os.MkdirAll(grokSkills, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	summary, err := ensureWorktreeGrokSkills(wt, skillsDir, slugs, false, false, io.Discard)
+	if err != nil {
+		t.Fatalf("project into dir: %v", err)
+	}
+	if summary.Created != 1 {
+		t.Errorf("created = %d, want 1", summary.Created)
+	}
+	if _, err := os.Lstat(filepath.Join(grokSkills, "camp-navigation")); err != nil {
+		t.Errorf("managed link missing in .grok/skills dir: %v", err)
+	}
+	// Directory must remain a directory, not be replaced by a symlink.
+	info, err := os.Lstat(grokSkills)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		t.Error(".grok/skills should remain a real directory")
 	}
 }
 

--- a/internal/skills/worktree_test.go
+++ b/internal/skills/worktree_test.go
@@ -245,3 +245,54 @@ func TestEnsureGrokSkillsAliasIdempotent(t *testing.T) {
 		t.Fatalf("second ensure: %v", err)
 	}
 }
+
+func TestProjectIntoWorktreeBestEffort(t *testing.T) {
+	campaignRoot := t.TempDir()
+	wt := filepath.Join(campaignRoot, "projects", "worktrees", "camp", "x")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// No skills dir: no-op, not projected.
+	projected, err := ProjectIntoWorktreeBestEffort(campaignRoot, wt)
+	if err != nil {
+		t.Fatalf("missing skills dir: %v", err)
+	}
+	if projected {
+		t.Error("projected=true with no skills dir")
+	}
+
+	skillsDir := filepath.Join(campaignRoot, ".campaign", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Empty skills dir: no-op.
+	projected, err = ProjectIntoWorktreeBestEffort(campaignRoot, wt)
+	if err != nil {
+		t.Fatalf("empty skills dir: %v", err)
+	}
+	if projected {
+		t.Error("projected=true with empty skills dir")
+	}
+
+	writeSkillBundle(t, skillsDir, "camp-navigation")
+	projected, err = ProjectIntoWorktreeBestEffort(campaignRoot, wt)
+	if err != nil {
+		t.Fatalf("with skills: %v", err)
+	}
+	if !projected {
+		t.Error("projected=false after successful projection")
+	}
+	if _, err := os.Lstat(filepath.Join(wt, ".agents", "skills", "camp-navigation")); err != nil {
+		t.Errorf("link missing: %v", err)
+	}
+
+	// Second call still projected (already-linked counts).
+	projected, err = ProjectIntoWorktreeBestEffort(campaignRoot, wt)
+	if err != nil {
+		t.Fatalf("idempotent: %v", err)
+	}
+	if !projected {
+		t.Error("projected=false when already linked")
+	}
+}

--- a/internal/skills/worktree_test.go
+++ b/internal/skills/worktree_test.go
@@ -1,0 +1,247 @@
+package skills
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeSkillBundle(t *testing.T, skillsDir, slug string) {
+	t.Helper()
+	dir := filepath.Join(skillsDir, slug)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: "+slug+"\n---\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+}
+
+func TestListWorktreeRoots(t *testing.T) {
+	tmp := t.TempDir()
+	// Layout: worktrees/camp/feat-a, worktrees/fest/pr-1 — only dirs with .git count.
+	for _, p := range []string{
+		filepath.Join(tmp, "camp", "feat-a"),
+		filepath.Join(tmp, "camp", "feat-b"),
+		filepath.Join(tmp, "fest", "pr-1"),
+	} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(p, ".git"), []byte("gitdir: /tmp/fake\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, "camp", "not-a-worktree", "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmp, "camp", ".hidden"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "camp", "notadir"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ListWorktreeRoots(tmp)
+	if err != nil {
+		t.Fatalf("ListWorktreeRoots: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d roots %v, want 3", len(got), got)
+	}
+	if got[0] != filepath.Join(tmp, "camp", "feat-a") {
+		t.Errorf("first = %q", got[0])
+	}
+}
+
+func TestListWorktreeRootsSkipsNonGitChildren(t *testing.T) {
+	tmp := t.TempDir()
+	// Mis-nested: project dir is itself a git checkout; children are src/bin.
+	proj := filepath.Join(tmp, "fest-gif")
+	if err := os.MkdirAll(filepath.Join(proj, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(proj, ".git"), []byte("gitdir: /tmp/fake\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ListWorktreeRoots(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != proj {
+		t.Fatalf("got %v, want only the git root %s", got, proj)
+	}
+}
+
+func TestListWorktreeRootsMissing(t *testing.T) {
+	got, err := ListWorktreeRoots(filepath.Join(t.TempDir(), "nope"))
+	if err != nil {
+		t.Fatalf("missing root should not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}
+
+func TestProjectIntoWorktree(t *testing.T) {
+	campaignRoot := t.TempDir()
+	skillsDir := filepath.Join(campaignRoot, ".campaign", "skills")
+	writeSkillBundle(t, skillsDir, "camp-navigation")
+	writeSkillBundle(t, skillsDir, "fest-execution")
+
+	wt := filepath.Join(campaignRoot, "projects", "worktrees", "camp", "feature-x")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	slugs, err := DiscoverSkillSlugs(skillsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proj, err := ProjectIntoWorktree(wt, campaignRoot, skillsDir, slugs, false, false, io.Discard)
+	if err != nil {
+		t.Fatalf("ProjectIntoWorktree: %v", err)
+	}
+	if proj.Agents.Created != 2 {
+		t.Errorf("agents created = %d, want 2", proj.Agents.Created)
+	}
+	if proj.Claude.Created != 2 {
+		t.Errorf("claude created = %d, want 2", proj.Claude.Created)
+	}
+
+	for _, rel := range []string{
+		".agents/skills/camp-navigation",
+		".agents/skills/fest-execution",
+		".claude/skills/camp-navigation",
+	} {
+		p := filepath.Join(wt, rel)
+		info, err := os.Lstat(p)
+		if err != nil {
+			t.Fatalf("missing %s: %v", rel, err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Errorf("%s is not a symlink", rel)
+		}
+		target, err := os.Readlink(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !filepath.IsAbs(target) {
+			// relative targets should still resolve into .campaign/skills
+			abs := resolveSymlinkTargetAbs(p, target)
+			if _, err := os.Stat(abs); err != nil {
+				t.Errorf("%s -> %s does not resolve: %v", rel, target, err)
+			}
+		}
+	}
+
+	// Grok alias
+	grokLink := filepath.Join(wt, GrokSkillsRel)
+	info, err := os.Lstat(grokLink)
+	if err != nil {
+		t.Fatalf("grok skills alias missing: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("grok skills alias is not a symlink")
+	}
+	raw, err := os.Readlink(grokLink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw != "../.agents/skills" {
+		t.Errorf("grok alias target = %q, want ../.agents/skills", raw)
+	}
+
+	// Idempotent second run
+	proj2, err := ProjectIntoWorktree(wt, campaignRoot, skillsDir, slugs, false, false, io.Discard)
+	if err != nil {
+		t.Fatalf("second ProjectIntoWorktree: %v", err)
+	}
+	if proj2.Agents.AlreadyLinked != 2 || proj2.Agents.Created != 0 {
+		t.Errorf("second run agents: created=%d linked=%d, want created=0 linked=2",
+			proj2.Agents.Created, proj2.Agents.AlreadyLinked)
+	}
+}
+
+func TestLinkAllWorktrees(t *testing.T) {
+	campaignRoot := t.TempDir()
+	skillsDir := filepath.Join(campaignRoot, ".campaign", "skills")
+	writeSkillBundle(t, skillsDir, "alpha")
+
+	wtRoot := filepath.Join(campaignRoot, "projects", "worktrees")
+	for _, p := range []string{
+		filepath.Join(wtRoot, "camp", "a"),
+		filepath.Join(wtRoot, "fest", "b"),
+	} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(p, ".git"), []byte("gitdir: /tmp/fake\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	results, err := LinkAllWorktrees(campaignRoot, wtRoot, skillsDir, false, false, io.Discard)
+	if err != nil {
+		t.Fatalf("LinkAllWorktrees: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	for _, r := range results {
+		if r.Err != nil {
+			t.Errorf("worktree %s: %v", r.Path, r.Err)
+		}
+		if r.Agents.Created != 1 {
+			t.Errorf("%s agents created = %d", r.RelPath, r.Agents.Created)
+		}
+		if _, err := os.Lstat(filepath.Join(r.Path, ".agents/skills", "alpha")); err != nil {
+			t.Errorf("missing projection in %s: %v", r.Path, err)
+		}
+	}
+}
+
+func TestInspectWorktreeProjection(t *testing.T) {
+	campaignRoot := t.TempDir()
+	skillsDir := filepath.Join(campaignRoot, ".campaign", "skills")
+	writeSkillBundle(t, skillsDir, "alpha")
+	slugs, _ := DiscoverSkillSlugs(skillsDir)
+
+	wt := filepath.Join(campaignRoot, "projects", "worktrees", "camp", "x")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := InspectWorktreeProjection(wt, skillsDir, slugs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Linked != 0 || st.TotalSkills != 1 {
+		t.Errorf("before project: linked=%d total=%d", st.Linked, st.TotalSkills)
+	}
+
+	if _, err := ProjectIntoWorktree(wt, campaignRoot, skillsDir, slugs, false, false, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	st, err = InspectWorktreeProjection(wt, skillsDir, slugs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Linked != 1 {
+		t.Errorf("after project: linked=%d, want 1", st.Linked)
+	}
+}
+
+func TestEnsureGrokSkillsAliasIdempotent(t *testing.T) {
+	wt := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(wt, ".agents", "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureGrokSkillsAlias(wt, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureGrokSkillsAlias(wt, false); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+}

--- a/tests/integration/skills_worktree_test.go
+++ b/tests/integration/skills_worktree_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSkills_LinkWorktreesOnlyProjectsGitWorktree covers the containerized
+// path for worktree skill projection (camp skills link --worktrees-only).
+// Unit tests exercise the pure link helpers on host temp dirs; this test
+// drives the real CLI against a fake worktree layout inside the harness.
+func TestSkills_LinkWorktreesOnlyProjectsGitWorktree(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupSkillsCampaign(t, tc, "skills-worktree-proj")
+
+	// Layout matches camp project worktree add: projects/worktrees/<proj>/<name>/
+	// with a .git marker so ListWorktreeRoots accepts it.
+	wt := path + "/projects/worktrees/demo/feature-x"
+	tc.Shell(t, fmt.Sprintf(
+		"mkdir -p %s && printf 'gitdir: /tmp/fake\\n' > %s/.git",
+		wt, wt,
+	))
+
+	output, err := tc.RunCampInDir(path, "skills", "link", "--worktrees-only")
+	require.NoError(t, err, "output: %s", output)
+	assert.Contains(t, output, "feature-x")
+
+	// Projected skill symlink under the worktree.
+	link := wt + "/.agents/skills/" + testSkillSlug
+	_, exitCode, err := tc.ExecCommand("test", "-L", link)
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode, "expected projected skill link at %s; output: %s", link, output)
+
+	// Grok alias points at .agents/skills.
+	_, exitCode, err = tc.ExecCommand("test", "-L", wt+"/.grok/skills")
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode, "expected .grok/skills alias")
+
+	target, exitCode, err := tc.ExecCommand("readlink", wt+"/.grok/skills")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	assert.Contains(t, target, ".agents/skills")
+
+	// Status lists the worktree as linked.
+	status, err := tc.RunCampInDir(path, "skills", "status")
+	require.NoError(t, err)
+	assert.Contains(t, status, "worktree")
+	assert.Contains(t, status, "feature-x")
+	assert.Contains(t, status, "linked")
+}

--- a/tests/integration/skills_worktree_test.go
+++ b/tests/integration/skills_worktree_test.go
@@ -5,27 +5,41 @@ package integration
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// realWorktree creates a real git worktree checkout under the campaign's
+// projects/worktrees layout so ListWorktreeRoots + info/exclude work.
+func realWorktree(t *testing.T, tc *TestContainer, campaignPath, project, name string) string {
+	t.Helper()
+	// Source repo for the worktree (a minimal git repo).
+	src := campaignPath + "/projects/" + project
+	tc.Shell(t, fmt.Sprintf(`
+		mkdir -p %[1]s && cd %[1]s &&
+		git init -q &&
+		git config user.email test@example.com &&
+		git config user.name test &&
+		echo ok > README && git add README && git commit -q -m init
+	`, src))
+
+	wt := campaignPath + "/projects/worktrees/" + project + "/" + name
+	tc.Shell(t, fmt.Sprintf(
+		"mkdir -p %s && git -C %s worktree add -q %s -b %s",
+		campaignPath+"/projects/worktrees/"+project, src, wt, name,
+	))
+	return wt
+}
+
 // TestSkills_LinkWorktreesOnlyProjectsGitWorktree covers the containerized
 // path for worktree skill projection (camp skills link --worktrees-only).
-// Unit tests exercise the pure link helpers on host temp dirs; this test
-// drives the real CLI against a fake worktree layout inside the harness.
 func TestSkills_LinkWorktreesOnlyProjectsGitWorktree(t *testing.T) {
 	tc := GetSharedContainer(t)
 	path := setupSkillsCampaign(t, tc, "skills-worktree-proj")
-
-	// Layout matches camp project worktree add: projects/worktrees/<proj>/<name>/
-	// with a .git marker so ListWorktreeRoots accepts it.
-	wt := path + "/projects/worktrees/demo/feature-x"
-	tc.Shell(t, fmt.Sprintf(
-		"mkdir -p %s && printf 'gitdir: /tmp/fake\\n' > %s/.git",
-		wt, wt,
-	))
+	wt := realWorktree(t, tc, path, "demo", "feature-x")
 
 	output, err := tc.RunCampInDir(path, "skills", "link", "--worktrees-only")
 	require.NoError(t, err, "output: %s", output)
@@ -37,6 +51,11 @@ func TestSkills_LinkWorktreesOnlyProjectsGitWorktree(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, exitCode, "expected projected skill link at %s; output: %s", link, output)
 
+	// Claude surface too.
+	_, exitCode, err = tc.ExecCommand("test", "-L", wt+"/.claude/skills/"+testSkillSlug)
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode, "expected .claude projected skill link")
+
 	// Grok alias points at .agents/skills.
 	_, exitCode, err = tc.ExecCommand("test", "-L", wt+"/.grok/skills")
 	require.NoError(t, err)
@@ -47,10 +66,116 @@ func TestSkills_LinkWorktreesOnlyProjectsGitWorktree(t *testing.T) {
 	require.Equal(t, 0, exitCode)
 	assert.Contains(t, target, ".agents/skills")
 
+	// Local excludes so projections are not untracked in the target repo.
+	exclude, exitCode, err := tc.ExecCommand("sh", "-c",
+		"git -C "+wt+" rev-parse --git-path info/exclude | xargs cat")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "read info/exclude: %s", exclude)
+	for _, pattern := range []string{".agents/", ".claude/", ".grok/"} {
+		assert.Contains(t, exclude, pattern, "info/exclude missing %s", pattern)
+	}
+	// Untracked list should not show harness dirs.
+	untracked, exitCode, err := tc.ExecCommand("git", "-C", wt, "status", "--porcelain")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	assert.NotContains(t, untracked, ".agents/")
+	assert.NotContains(t, untracked, ".claude/")
+	assert.NotContains(t, untracked, ".grok/")
+
 	// Status lists the worktree as linked.
 	status, err := tc.RunCampInDir(path, "skills", "status")
 	require.NoError(t, err)
 	assert.Contains(t, status, "worktree")
 	assert.Contains(t, status, "feature-x")
 	assert.Contains(t, status, "linked")
+}
+
+// TestSkills_WorktreeGrokForeignSymlinkRequiresForce ensures a user-owned
+// .grok/skills symlink is not silently replaced without --force.
+func TestSkills_WorktreeGrokForeignSymlinkRequiresForce(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupSkillsCampaign(t, tc, "skills-worktree-force")
+	wt := realWorktree(t, tc, path, "demo2", "feature-y")
+
+	// Pre-create foreign grok alias.
+	tc.Shell(t, fmt.Sprintf(
+		"mkdir -p %s/.grok && ln -s /tmp/user-skills %s/.grok/skills",
+		wt, wt,
+	))
+
+	output, err := tc.RunCampInDir(path, "skills", "link", "--worktrees-only")
+	// Conflict should surface as a non-zero exit or explicit incomplete message.
+	if err == nil {
+		// Some paths report conflicts as exit 0 with message — require conflict wording.
+		require.True(t,
+			strings.Contains(output, "conflict") || strings.Contains(output, "incomplete"),
+			"expected conflict report without --force; output: %s", output)
+	}
+
+	// Foreign target preserved.
+	target, exitCode, err := tc.ExecCommand("readlink", wt+"/.grok/skills")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	assert.Contains(t, target, "/tmp/user-skills")
+
+	// Force replaces.
+	output, err = tc.RunCampInDir(path, "skills", "link", "--worktrees-only", "--force")
+	require.NoError(t, err, "force link: %s", output)
+	target, exitCode, err = tc.ExecCommand("readlink", wt+"/.grok/skills")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	assert.Contains(t, target, ".agents/skills")
+}
+
+// TestSkills_WorktreeGrokDirectoryGetsProjectedBundles covers a real
+// .grok/skills directory (not a symlink): campaign bundles must be linked into it.
+func TestSkills_WorktreeGrokDirectoryGetsProjectedBundles(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupSkillsCampaign(t, tc, "skills-worktree-grokdir")
+	wt := realWorktree(t, tc, path, "demo3", "feature-z")
+
+	tc.Shell(t, fmt.Sprintf("mkdir -p %s/.grok/skills", wt))
+
+	output, err := tc.RunCampInDir(path, "skills", "link", "--worktrees-only")
+	require.NoError(t, err, "output: %s", output)
+
+	// Directory remains a directory.
+	_, exitCode, err := tc.ExecCommand("test", "-d", wt+"/.grok/skills")
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+	_, exitCode, err = tc.ExecCommand("test", "!", "-L", wt+"/.grok/skills")
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode)
+
+	// Managed bundle inside the directory.
+	_, exitCode, err = tc.ExecCommand("test", "-L", wt+"/.grok/skills/"+testSkillSlug)
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode, "expected managed skill link inside .grok/skills dir")
+}
+
+// TestSkills_WorktreeStatusAggregatesSurfaces: broken claude while agents ok
+// must not report fully linked.
+func TestSkills_WorktreeStatusAggregatesSurfaces(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupSkillsCampaign(t, tc, "skills-worktree-status")
+	wt := realWorktree(t, tc, path, "demo4", "feature-s")
+
+	_, err := tc.RunCampInDir(path, "skills", "link", "--worktrees-only")
+	require.NoError(t, err)
+
+	// Break claude surface: replace skills dir with a file.
+	tc.Shell(t, fmt.Sprintf("rm -rf %s/.claude/skills && mkdir -p %s/.claude && echo x > %s/.claude/skills", wt, wt, wt))
+
+	status, err := tc.RunCampInDir(path, "skills", "status")
+	require.NoError(t, err)
+	assert.Contains(t, status, "feature-s")
+	// Must not claim fully linked when a surface is blocked.
+	assert.NotContains(t, status, fmt.Sprintf("feature-s%slinked", strings.Repeat(" ", 10)))
+	// Expect blocked/partial/conflict wording somewhere for the worktree row.
+	assert.True(t,
+		strings.Contains(status, "blocked") ||
+			strings.Contains(status, "partial") ||
+			strings.Contains(status, "conflict") ||
+			strings.Contains(status, "not linked"),
+		"status should not look fully healthy; got:\n%s", status)
 }


### PR DESCRIPTION
## Summary

- Project campaign skill bundles into each project worktree (`.agents/skills`, `.claude/skills`, and `.grok/skills → .agents/skills`) so Grok/Claude sessions whose git root is the worktree still discover `.campaign/skills`.
- Run projection automatically on `camp project worktree add` (and the deprecated `camp worktrees create`), best-effort so create still succeeds if projection fails.
- Add `camp skills link --worktrees` (tools + all worktrees) and `--worktrees-only` (worktrees only) for repair/sync.
- Extend `camp skills status` with a `worktree` row per git worktree under `projects/worktrees/`.
- Enumerate only directories that look like git checkouts (have `.git`), so nested `src`/`bin`/`node_modules` are not treated as worktrees.
- Gitignore local `.agents/` and `.grok/` harness dirs in the camp project checkout.

## Motivation

Grok skill discovery walks CWD → **git root**. Nested worktrees under `projects/worktrees/<project>/<name>/` are their own git roots, so campaign skills at the campaign root never load. Projection mirrors the existing per-bundle symlink model into each worktree.

## Test plan

- [x] `go test ./internal/skills/`
- [x] `go build ./cmd/camp`
- [x] Dry-run: `camp skills link --worktrees-only -n` lists real git worktrees only
- [ ] `camp project worktree add smoke-skills --start-point main` shows “Skills: projected…”
- [ ] From that worktree: `grok inspect` lists campaign skills as `project`
- [ ] `camp skills link --worktrees-only` repairs existing worktrees
- [ ] `camp skills status` shows linked worktree rows