### PR TITLE
fix: handle large dungeon migration commits

### DIFF
--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -286,7 +287,12 @@ func ResetIndexToHead(ctx context.Context, repoPath string, paths []string) erro
 		// thousands of files (a dungeon migration is one example). Passing all
 		// of those paths to one git process can exceed the platform's argument
 		// size limit even though each individual path is valid.
-		for _, batch := range splitPathspecsForExec(paths) {
+		//
+		// Batches are applied sequentially. A mid-loop non-lock failure can
+		// leave earlier batches already reset; re-running is safe because
+		// `git reset HEAD -- <paths>` is idempotent for this cleanup.
+		limit := resetPathspecPayloadLimit(repoPath)
+		for _, batch := range splitPathspecsForExec(paths, limit) {
 			args := []string{"-C", repoPath, "reset", "-q", "HEAD", "--"}
 			args = append(args, batch...)
 			cmd := exec.CommandContext(ctx, "git", args...)
@@ -303,19 +309,58 @@ func ResetIndexToHead(ctx context.Context, repoPath string, paths []string) erro
 	})
 }
 
-// Keep reset invocations comfortably below common Unix ARG_MAX values. The
-// paths are already expanded before this point, so a single migration can
-// otherwise create a multi-megabyte argv.
-const resetPathspecArgLimit = 32 * 1024
+// platformCommandLineBudget is the max bytes we will put on a single git
+// process command line (executable + args). Unix ARG_MAX is typically
+// 256KiB–1MiB; Windows CreateProcess is 32,767 characters for the whole line.
+// We keep Unix large so huge migrations need few batches (performance), and
+// Windows conservative so fixed argv overhead cannot reintroduce the failure.
+func platformCommandLineBudget() int {
+	if runtime.GOOS == "windows" {
+		return 32767
+	}
+	// Large enough that multi-megabyte path lists become a handful of batches,
+	// not thousands of git invocations. Still far below typical ARG_MAX.
+	return 128 * 1024
+}
 
-func splitPathspecsForExec(paths []string) [][]string {
+// resetPathspecPayloadLimit is the max bytes of path arguments (+ NULs) per
+// git reset process after reserving space for fixed args
+// (`git -C <repo> reset -q HEAD --`) and a small safety margin.
+func resetPathspecPayloadLimit(repoPath string) int {
+	// Fixed argv: git, -C, repoPath, reset, -q, HEAD, --  (each +1 for separator/NUL).
+	fixed := len("git") + 1 +
+		len("-C") + 1 +
+		len(repoPath) + 1 +
+		len("reset") + 1 +
+		len("-q") + 1 +
+		len("HEAD") + 1 +
+		len("--") + 1
+	margin := 1024
+	if runtime.GOOS == "windows" {
+		// Extra headroom for quoting / CreateProcess encoding.
+		margin = 2048
+	}
+	payload := platformCommandLineBudget() - fixed - margin
+	if payload < minResetPathspecPayload {
+		return minResetPathspecPayload
+	}
+	return payload
+}
+
+// splitPathspecsForExec partitions paths so each batch's path payload
+// (bytes + one NUL per arg) stays within limit. A single path larger than
+// limit still forms its own batch (cannot split further).
+func splitPathspecsForExec(paths []string, limit int) [][]string {
+	if limit <= 0 {
+		limit = minResetPathspecPayload
+	}
 	var batches [][]string
 	var batch []string
 	batchBytes := 0
 
 	for _, path := range paths {
 		pathBytes := len(path) + 1 // include the argument's NUL terminator
-		if len(batch) > 0 && batchBytes+pathBytes > resetPathspecArgLimit {
+		if len(batch) > 0 && batchBytes+pathBytes > limit {
 			batches = append(batches, batch)
 			batch = nil
 			batchBytes = 0
@@ -328,6 +373,10 @@ func splitPathspecsForExec(paths []string) [][]string {
 	}
 	return batches
 }
+
+// minResetPathspecPayload is the floor for path payload after fixed-argv
+// reservation, so pathological repo paths cannot collapse the budget to zero.
+const minResetPathspecPayload = 4 * 1024
 
 // isLockError checks if an error is a lock-related error.
 func isLockError(err error) bool {

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -316,7 +316,13 @@ func ResetIndexToHead(ctx context.Context, repoPath string, paths []string) erro
 // Windows conservative so fixed argv overhead cannot reintroduce the failure.
 func platformCommandLineBudget() int {
 	if runtime.GOOS == "windows" {
-		return 32767
+		// Well below CreateProcess's 32,767-character ceiling. Go os/exec
+		// serializes argv into one command line and may quote/escape paths
+		// with spaces or special characters; the real git executable path
+		// is also longer than the literal "git" token.
+		// Unix keeps a large budget (below) so this does not affect macOS/Linux
+		// batch performance.
+		return 16 * 1024
 	}
 	// Large enough that multi-megabyte path lists become a handful of batches,
 	// not thousands of git invocations. Still far below typical ARG_MAX.
@@ -327,8 +333,14 @@ func platformCommandLineBudget() int {
 // git reset process after reserving space for fixed args
 // (`git -C <repo> reset -q HEAD --`) and a small safety margin.
 func resetPathspecPayloadLimit(repoPath string) int {
-	// Fixed argv: git, -C, repoPath, reset, -q, HEAD, --  (each +1 for separator/NUL).
-	fixed := len("git") + 1 +
+	// Fixed argv: executable, -C, repoPath, reset, -q, HEAD, --.
+	// On Windows use a conservative stand-in for a long install path so we
+	// do not under-count the way the bare "git" token would.
+	gitToken := "git"
+	if runtime.GOOS == "windows" {
+		gitToken = `C:\Program Files\Git\cmd\git.exe`
+	}
+	fixed := len(gitToken) + 1 +
 		len("-C") + 1 +
 		len(repoPath) + 1 +
 		len("reset") + 1 +
@@ -337,8 +349,9 @@ func resetPathspecPayloadLimit(repoPath string) int {
 		len("--") + 1
 	margin := 1024
 	if runtime.GOOS == "windows" {
-		// Extra headroom for quoting / CreateProcess encoding.
-		margin = 2048
+		// Quoting can add two quotes per path plus escapes; keep a wide
+		// fixed margin instead of shrinking the Unix budget.
+		margin = 4 * 1024
 	}
 	payload := platformCommandLineBudget() - fixed - margin
 	if payload < minResetPathspecPayload {

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -282,19 +282,51 @@ func ResetIndexToHead(ctx context.Context, repoPath string, paths []string) erro
 	cfg := DefaultRetryConfig()
 	cfg.OperationName = "reset-index"
 	return WithLockRetry(ctx, repoPath, cfg, func() error {
-		args := []string{"-C", repoPath, "reset", "-q", "HEAD", "--"}
-		args = append(args, paths...)
-		cmd := exec.CommandContext(ctx, "git", args...)
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			errType := ClassifyGitError(string(out), cmd.ProcessState.ExitCode())
-			if errType == GitErrorLock {
-				return &LockError{Path: "index.lock", Err: err}
+		// Scoped commits may expand a directory pathspec into tens of
+		// thousands of files (a dungeon migration is one example). Passing all
+		// of those paths to one git process can exceed the platform's argument
+		// size limit even though each individual path is valid.
+		for _, batch := range splitPathspecsForExec(paths) {
+			args := []string{"-C", repoPath, "reset", "-q", "HEAD", "--"}
+			args = append(args, batch...)
+			cmd := exec.CommandContext(ctx, "git", args...)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				errType := ClassifyGitError(string(out), cmd.ProcessState.ExitCode())
+				if errType == GitErrorLock {
+					return &LockError{Path: "index.lock", Err: err}
+				}
+				return camperrors.NewGit("reset", "", errType.String(), strings.TrimSpace(string(out)), err)
 			}
-			return camperrors.NewGit("reset", "", errType.String(), strings.TrimSpace(string(out)), err)
 		}
 		return nil
 	})
+}
+
+// Keep reset invocations comfortably below common Unix ARG_MAX values. The
+// paths are already expanded before this point, so a single migration can
+// otherwise create a multi-megabyte argv.
+const resetPathspecArgLimit = 32 * 1024
+
+func splitPathspecsForExec(paths []string) [][]string {
+	var batches [][]string
+	var batch []string
+	batchBytes := 0
+
+	for _, path := range paths {
+		pathBytes := len(path) + 1 // include the argument's NUL terminator
+		if len(batch) > 0 && batchBytes+pathBytes > resetPathspecArgLimit {
+			batches = append(batches, batch)
+			batch = nil
+			batchBytes = 0
+		}
+		batch = append(batch, path)
+		batchBytes += pathBytes
+	}
+	if len(batch) > 0 {
+		batches = append(batches, batch)
+	}
+	return batches
 }
 
 // isLockError checks if an error is a lock-related error.

--- a/internal/git/commit_test.go
+++ b/internal/git/commit_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1054,12 +1055,13 @@ func TestStage_ReturnsRemovalFailureForStaleLock(t *testing.T) {
 }
 
 func TestSplitPathspecsForExecKeepsBatchesBelowArgLimit(t *testing.T) {
+	const limit = 32 * 1024
 	paths := make([]string, 100)
 	for i := range paths {
 		paths[i] = strings.Repeat("p", 1000)
 	}
 
-	batches := splitPathspecsForExec(paths)
+	batches := splitPathspecsForExec(paths, limit)
 	if len(batches) < 2 {
 		t.Fatalf("splitPathspecsForExec() returned %d batch(es), want multiple", len(batches))
 	}
@@ -1070,8 +1072,8 @@ func TestSplitPathspecsForExecKeepsBatchesBelowArgLimit(t *testing.T) {
 		for _, path := range batch {
 			bytes += len(path) + 1
 		}
-		if bytes > resetPathspecArgLimit {
-			t.Errorf("batch %d is %d bytes, want at most %d", i, bytes, resetPathspecArgLimit)
+		if bytes > limit {
+			t.Errorf("batch %d is %d bytes, want at most %d", i, bytes, limit)
 		}
 		flattened = append(flattened, batch...)
 	}
@@ -1083,5 +1085,41 @@ func TestSplitPathspecsForExecKeepsBatchesBelowArgLimit(t *testing.T) {
 		if flattened[i] != paths[i] {
 			t.Fatalf("path %d = %q, want %q", i, flattened[i], paths[i])
 		}
+	}
+}
+
+func TestSplitPathspecsForExecEmpty(t *testing.T) {
+	if got := splitPathspecsForExec(nil, 1024); len(got) != 0 {
+		t.Fatalf("nil paths = %v, want empty", got)
+	}
+	if got := splitPathspecsForExec([]string{}, 1024); len(got) != 0 {
+		t.Fatalf("empty paths = %v, want empty", got)
+	}
+}
+
+func TestResetPathspecPayloadLimitReservesFixedArgv(t *testing.T) {
+	shortRepo := "/r"
+	longRepo := "/" + strings.Repeat("x", 2000)
+	shortLimit := resetPathspecPayloadLimit(shortRepo)
+	longLimit := resetPathspecPayloadLimit(longRepo)
+	if longLimit >= shortLimit {
+		t.Fatalf("longer repoPath should reduce payload budget: short=%d long=%d", shortLimit, longLimit)
+	}
+	// Fixed argv for long repo must still leave a usable path budget.
+	if longLimit < minResetPathspecPayload {
+		t.Fatalf("payload limit %d below floor %d", longLimit, minResetPathspecPayload)
+	}
+	// Unix budget stays large so multi-MB path lists need few batches.
+	if runtime.GOOS != "windows" {
+		if platformCommandLineBudget() < 64*1024 {
+			t.Fatalf("unix command-line budget %d is too small for performance", platformCommandLineBudget())
+		}
+		if shortLimit < 64*1024 {
+			t.Fatalf("unix path payload for short repo %d, want generous batches", shortLimit)
+		}
+	}
+	// Windows total line budget stays at CreateProcess ceiling.
+	if runtime.GOOS == "windows" && platformCommandLineBudget() != 32767 {
+		t.Fatalf("windows budget = %d, want 32767", platformCommandLineBudget())
 	}
 }

--- a/internal/git/commit_test.go
+++ b/internal/git/commit_test.go
@@ -1052,3 +1052,36 @@ func TestStage_ReturnsRemovalFailureForStaleLock(t *testing.T) {
 		t.Fatalf("StageAll() error = %v, did not want ErrLockActive", err)
 	}
 }
+
+func TestSplitPathspecsForExecKeepsBatchesBelowArgLimit(t *testing.T) {
+	paths := make([]string, 100)
+	for i := range paths {
+		paths[i] = strings.Repeat("p", 1000)
+	}
+
+	batches := splitPathspecsForExec(paths)
+	if len(batches) < 2 {
+		t.Fatalf("splitPathspecsForExec() returned %d batch(es), want multiple", len(batches))
+	}
+
+	var flattened []string
+	for i, batch := range batches {
+		bytes := 0
+		for _, path := range batch {
+			bytes += len(path) + 1
+		}
+		if bytes > resetPathspecArgLimit {
+			t.Errorf("batch %d is %d bytes, want at most %d", i, bytes, resetPathspecArgLimit)
+		}
+		flattened = append(flattened, batch...)
+	}
+
+	if len(flattened) != len(paths) {
+		t.Fatalf("splitPathspecsForExec() returned %d paths, want %d", len(flattened), len(paths))
+	}
+	for i := range paths {
+		if flattened[i] != paths[i] {
+			t.Fatalf("path %d = %q, want %q", i, flattened[i], paths[i])
+		}
+	}
+}

--- a/internal/git/commit_test.go
+++ b/internal/git/commit_test.go
@@ -1118,8 +1118,9 @@ func TestResetPathspecPayloadLimitReservesFixedArgv(t *testing.T) {
 			t.Fatalf("unix path payload for short repo %d, want generous batches", shortLimit)
 		}
 	}
-	// Windows total line budget stays at CreateProcess ceiling.
-	if runtime.GOOS == "windows" && platformCommandLineBudget() != 32767 {
-		t.Fatalf("windows budget = %d, want 32767", platformCommandLineBudget())
+	// Windows leaves substantial room below the CreateProcess ceiling for
+	// os/exec command-line quoting and escaping.
+	if runtime.GOOS == "windows" && platformCommandLineBudget() != 16*1024 {
+		t.Fatalf("windows budget = %d, want %d", platformCommandLineBudget(), 16*1024)
 	}
 }


### PR DESCRIPTION
## Summary

- batch large path lists when resetting the real Git index after scoped commits
- prevent `camp dungeon migrate` from failing during cleanup on large campaigns
- add regression coverage for argument-size-safe batching

## Root cause

Dungeon migration expands affected directory pathspecs into every tracked file. On the reported campaign this produced roughly 4.9 MB of reset arguments, exceeding macOS's process argument limit. The migration commit could be created, but index cleanup failed and the command reported the commit as failed.

## Validation

- `just test unit` — 3,586/3,586 tests passed
- dungeon migration integration tests passed
- stable/dev builds and `go vet` passed
- `just gate-fast` reached lint; its only failure was the pre-existing unused `renderStatusBar` finding in `internal/intent/tui/explorer/render.go`
