### PR TITLE
fix(fresh): reclaim default branch from clean worktrees

### DIFF
--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -176,8 +176,16 @@ type freshSyncState struct {
 	defaultBranch string
 	baseRef       string
 	displayRef    string
-	detached      bool
-	worktreePath  string
+	// detached is true when this path must sync via origin/<default> rather
+	// than checking out the local default branch (another worktree holds it
+	// and could not be reclaimed).
+	detached bool
+	// worktreePath is the other worktree that held (or still holds) the
+	// default branch, when known.
+	worktreePath string
+	// reclaimed is true when fresh detached that other worktree so the
+	// default branch can be checked out here normally.
+	reclaimed bool
 }
 
 func executeFresh(ctx context.Context, name, path string, opts freshOptions) error {
@@ -205,6 +213,56 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 		return camperrors.Wrap(err, "prepare fresh sync state")
 	}
 
+	// When another worktree holds the default branch, free it if that tree is
+	// clean so this project path can check out main/master normally. Leaving
+	// main stuck on a finished feature worktree is the failure mode after
+	// camp project worktree add --start-point main.
+	if syncState.worktreePath != "" {
+		if opts.dryRun {
+			// Dry-run still inspects dirtiness (status is non-mutating) so the
+			// plan matches what a real run would do.
+			reclaimed, reclaimErr := canReclaimDefaultBranchWorktree(ctx, syncState.worktreePath)
+			if reclaimErr != nil {
+				return reclaimErr
+			}
+			if reclaimed {
+				syncState.reclaimed = true
+				syncState.detached = false
+				syncState.baseRef = defaultBranch
+				syncState.displayRef = defaultBranch
+				fmt.Printf("%s── Would free %-23s %s\n", prefix, defaultBranch,
+					freshStepDim.Render(fmt.Sprintf("(detach clean worktree %s)", filepath.Base(syncState.worktreePath))))
+			} else {
+				fmt.Printf("%s── Would free %-23s %s\n", prefix, defaultBranch,
+					freshStepDim.Render(fmt.Sprintf(
+						"skipped · %s has uncommitted changes; would sync detached",
+						filepath.Base(syncState.worktreePath))))
+			}
+		} else {
+			reclaimed, reclaimErr := reclaimDefaultBranchWorktree(ctx, syncState.worktreePath)
+			if reclaimErr != nil {
+				return reclaimErr
+			}
+			if reclaimed {
+				syncState.reclaimed = true
+				syncState.detached = false
+				syncState.baseRef = defaultBranch
+				syncState.displayRef = defaultBranch
+				fmt.Printf("%s── Free %-28s %s\n", prefix, defaultBranch,
+					freshStepGreen.Render("done")+" "+freshStepDim.Render(
+						fmt.Sprintf("(detached %s so %s is free here)",
+							filepath.Base(syncState.worktreePath), defaultBranch)))
+			} else {
+				// Dirty worktree: keep detached-sync fallback, but make the
+				// reason obvious instead of a raw git checkout error later.
+				fmt.Printf("%s── Free %-28s %s\n", prefix, defaultBranch,
+					freshStepDim.Render(fmt.Sprintf(
+						"skipped · %s has uncommitted changes; syncing detached",
+						filepath.Base(syncState.worktreePath))))
+			}
+		}
+	}
+
 	if syncState.detached {
 		note := freshSyncWorktreeNote(syncState)
 		if opts.dryRun {
@@ -224,13 +282,20 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 			fmt.Printf("%s── Checkout %-25s %s\n", prefix, syncState.displayRef,
 				freshStepGreen.Render("done")+" "+freshStepDim.Render(note))
 		}
-	} else if currentBranch == defaultBranch {
+	} else if currentBranch == defaultBranch && !syncState.reclaimed {
 		fmt.Printf("%s── Checkout %-24s %s\n", prefix, defaultBranch, freshStepDim.Render("already on it"))
 	} else if opts.dryRun {
 		fmt.Printf("%s── Would checkout %-19s %s\n", prefix, defaultBranch,
-			freshStepDim.Render(fmt.Sprintf("(currently on %s)", currentBranch)))
+			freshStepDim.Render(fmt.Sprintf("(currently on %s)", emptyBranchLabel(currentBranch))))
 	} else {
 		if err := git.Checkout(ctx, path, defaultBranch); err != nil {
+			// Surface a clearer message than git's raw "already used by worktree".
+			if isBranchInUseByWorktree(err) {
+				return camperrors.Wrapf(err,
+					"checkout %s: another worktree holds this branch; "+
+						"detach it with `git -C <worktree> checkout --detach` then re-run camp fresh",
+					defaultBranch)
+			}
 			return camperrors.Wrapf(err, "checkout %s", defaultBranch)
 		}
 		fmt.Printf("%s── Checkout %-24s %s\n", prefix, defaultBranch, freshStepGreen.Render("done"))
@@ -374,7 +439,10 @@ func resolveFreshSyncState(ctx context.Context, path, currentBranch, defaultBran
 		displayRef:    defaultBranch,
 	}
 
-	entry, err := findBranchInOtherWorktree(ctx, path, currentBranch, defaultBranch)
+	// Always scan for another worktree holding the default branch — even when
+	// this path is already on it is impossible, but when this path is detached
+	// or on a feature branch, main often sits stuck on a finished worktree.
+	entry, err := findBranchInOtherWorktree(ctx, path, defaultBranch)
 	if err != nil {
 		return state, err
 	}
@@ -382,6 +450,8 @@ func resolveFreshSyncState(ctx context.Context, path, currentBranch, defaultBran
 		return state, nil
 	}
 
+	// Prefer reclaim + normal checkout; until reclaim succeeds, plan for a
+	// detached origin/<default> sync so fresh does not hard-fail.
 	state.baseRef = "origin/" + defaultBranch
 	state.displayRef = state.baseRef + " (detached)"
 	state.detached = true
@@ -390,18 +460,22 @@ func resolveFreshSyncState(ctx context.Context, path, currentBranch, defaultBran
 	return state, nil
 }
 
-func findBranchInOtherWorktree(ctx context.Context, path, currentBranch, branch string) (*worktree.GitWorktreeEntry, error) {
-	if currentBranch == branch {
-		return nil, nil
-	}
-
+// findBranchInOtherWorktree returns the first worktree (other than path) that
+// has branch checked out. path is the project working tree being freshened.
+func findBranchInOtherWorktree(ctx context.Context, path, branch string) (*worktree.GitWorktreeEntry, error) {
 	entries, err := worktree.NewGitWorktree(path).List(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	self := worktreeToplevel(ctx, path)
 	for _, entry := range entries {
 		if entry.Branch != branch {
+			continue
+		}
+		// Skip the worktree that is path itself (path form can differ for
+		// submodules: projects/camp vs .git/modules/projects/camp).
+		if sameWorktreePath(self, worktreeToplevel(ctx, entry.Path)) {
 			continue
 		}
 		entryCopy := entry
@@ -411,11 +485,83 @@ func findBranchInOtherWorktree(ctx context.Context, path, currentBranch, branch 
 	return nil, nil
 }
 
+// canReclaimDefaultBranchWorktree reports whether occupyingPath is clean
+// enough to detach without losing work (used by dry-run planning).
+func canReclaimDefaultBranchWorktree(ctx context.Context, occupyingPath string) (bool, error) {
+	dirty, err := git.HasNonSubmoduleChanges(ctx, occupyingPath)
+	if err != nil {
+		return false, camperrors.Wrapf(err, "check worktree %s for uncommitted changes", occupyingPath)
+	}
+	return !dirty, nil
+}
+
+// reclaimDefaultBranchWorktree detaches a clean worktree so its branch ref
+// can be checked out elsewhere. Returns (false, nil) when the worktree has
+// uncommitted changes and must not be touched; (true, nil) after a successful
+// detach.
+func reclaimDefaultBranchWorktree(ctx context.Context, occupyingPath string) (bool, error) {
+	ok, err := canReclaimDefaultBranchWorktree(ctx, occupyingPath)
+	if err != nil || !ok {
+		return ok, err
+	}
+	// Detach at HEAD: keeps the same commit checked out, frees the branch name.
+	if err := git.CheckoutDetached(ctx, occupyingPath, "HEAD"); err != nil {
+		return false, camperrors.Wrapf(err, "detach worktree %s to free its branch", occupyingPath)
+	}
+	return true, nil
+}
+
+func worktreeToplevel(ctx context.Context, path string) string {
+	out, err := git.Output(ctx, path, "rev-parse", "--show-toplevel")
+	if err != nil || strings.TrimSpace(out) == "" {
+		abs, absErr := filepath.Abs(path)
+		if absErr != nil {
+			return filepath.Clean(path)
+		}
+		return abs
+	}
+	return filepath.Clean(strings.TrimSpace(out))
+}
+
+func sameWorktreePath(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	a = filepath.Clean(a)
+	b = filepath.Clean(b)
+	if a == b {
+		return true
+	}
+	// Resolve symlinks when possible (submodule / worktree path forms).
+	ra, errA := filepath.EvalSymlinks(a)
+	rb, errB := filepath.EvalSymlinks(b)
+	if errA == nil && errB == nil {
+		return ra == rb
+	}
+	return false
+}
+
+func emptyBranchLabel(branch string) string {
+	if branch == "" {
+		return "detached HEAD"
+	}
+	return branch
+}
+
+func isBranchInUseByWorktree(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "already used by worktree") ||
+		strings.Contains(msg, "is already checked out at")
+}
+
 func freshSyncWorktreeNote(state freshSyncState) string {
 	if state.worktreePath == "" {
 		return ""
 	}
-	return fmt.Sprintf("(%s in %s)", state.defaultBranch, filepath.Base(state.worktreePath))
+	return fmt.Sprintf("(%s still in %s)", state.defaultBranch, filepath.Base(state.worktreePath))
 }
 
 func pruneResultNames(results []prune.Result, statuses ...prune.Status) []string {

--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -208,7 +208,7 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 	}
 
 	currentBranch := git.CurrentBranch(ctx, path)
-	syncState, err := resolveFreshSyncState(ctx, path, currentBranch, defaultBranch)
+	syncState, err := resolveFreshSyncState(ctx, path, defaultBranch)
 	if err != nil {
 		return camperrors.Wrap(err, "prepare fresh sync state")
 	}
@@ -217,50 +217,8 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 	// clean so this project path can check out main/master normally. Leaving
 	// main stuck on a finished feature worktree is the failure mode after
 	// camp project worktree add --start-point main.
-	if syncState.worktreePath != "" {
-		if opts.dryRun {
-			// Dry-run still inspects dirtiness (status is non-mutating) so the
-			// plan matches what a real run would do.
-			reclaimed, reclaimErr := canReclaimDefaultBranchWorktree(ctx, syncState.worktreePath)
-			if reclaimErr != nil {
-				return reclaimErr
-			}
-			if reclaimed {
-				syncState.reclaimed = true
-				syncState.detached = false
-				syncState.baseRef = defaultBranch
-				syncState.displayRef = defaultBranch
-				fmt.Printf("%s── Would free %-23s %s\n", prefix, defaultBranch,
-					freshStepDim.Render(fmt.Sprintf("(detach clean worktree %s)", filepath.Base(syncState.worktreePath))))
-			} else {
-				fmt.Printf("%s── Would free %-23s %s\n", prefix, defaultBranch,
-					freshStepDim.Render(fmt.Sprintf(
-						"skipped · %s has uncommitted changes; would sync detached",
-						filepath.Base(syncState.worktreePath))))
-			}
-		} else {
-			reclaimed, reclaimErr := reclaimDefaultBranchWorktree(ctx, syncState.worktreePath)
-			if reclaimErr != nil {
-				return reclaimErr
-			}
-			if reclaimed {
-				syncState.reclaimed = true
-				syncState.detached = false
-				syncState.baseRef = defaultBranch
-				syncState.displayRef = defaultBranch
-				fmt.Printf("%s── Free %-28s %s\n", prefix, defaultBranch,
-					freshStepGreen.Render("done")+" "+freshStepDim.Render(
-						fmt.Sprintf("(detached %s so %s is free here)",
-							filepath.Base(syncState.worktreePath), defaultBranch)))
-			} else {
-				// Dirty worktree: keep detached-sync fallback, but make the
-				// reason obvious instead of a raw git checkout error later.
-				fmt.Printf("%s── Free %-28s %s\n", prefix, defaultBranch,
-					freshStepDim.Render(fmt.Sprintf(
-						"skipped · %s has uncommitted changes; syncing detached",
-						filepath.Base(syncState.worktreePath))))
-			}
-		}
+	if err := maybeReclaimDefaultBranch(ctx, &syncState, opts.dryRun, prefix); err != nil {
+		return err
 	}
 
 	if syncState.detached {
@@ -432,16 +390,16 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 	return nil
 }
 
-func resolveFreshSyncState(ctx context.Context, path, currentBranch, defaultBranch string) (freshSyncState, error) {
+func resolveFreshSyncState(ctx context.Context, path, defaultBranch string) (freshSyncState, error) {
 	state := freshSyncState{
 		defaultBranch: defaultBranch,
 		baseRef:       defaultBranch,
 		displayRef:    defaultBranch,
 	}
 
-	// Always scan for another worktree holding the default branch — even when
-	// this path is already on it is impossible, but when this path is detached
-	// or on a feature branch, main often sits stuck on a finished worktree.
+	// Scan for another worktree holding the default branch. When this path is
+	// detached or on a feature branch, main often sits stuck on a finished
+	// worktree left over from camp project worktree add --start-point main.
 	entry, err := findBranchInOtherWorktree(ctx, path, defaultBranch)
 	if err != nil {
 		return state, err
@@ -458,6 +416,84 @@ func resolveFreshSyncState(ctx context.Context, path, currentBranch, defaultBran
 	state.worktreePath = entry.Path
 
 	return state, nil
+}
+
+// maybeReclaimDefaultBranch frees the default branch from another clean
+// worktree when possible. Dry-run still inspects dirtiness (status is
+// non-mutating) so the printed plan matches a real run. On success, mutates
+// state so the primary path checks out the real default branch; on dirty
+// skip, leaves the detached-origin fallback in place.
+func maybeReclaimDefaultBranch(ctx context.Context, state *freshSyncState, dryRun bool, prefix string) error {
+	if state == nil || state.worktreePath == "" {
+		return nil
+	}
+
+	var (
+		reclaimed bool
+		err       error
+	)
+	if dryRun {
+		reclaimed, err = canReclaimDefaultBranchWorktree(ctx, state.worktreePath)
+	} else {
+		reclaimed, err = reclaimDefaultBranchWorktree(ctx, state.worktreePath)
+	}
+	if err != nil {
+		return err
+	}
+	if reclaimed {
+		applyReclaimDecision(state)
+	}
+	printReclaimStep(prefix, *state, reclaimed, dryRun)
+	return nil
+}
+
+// applyReclaimDecision flips a detached-fallback plan to a normal default-branch
+// checkout after the occupying worktree has been (or would be) freed.
+func applyReclaimDecision(state *freshSyncState) {
+	if state == nil {
+		return
+	}
+	state.reclaimed = true
+	state.detached = false
+	state.baseRef = state.defaultBranch
+	state.displayRef = state.defaultBranch
+}
+
+// reclaimStepDetail returns the step label and dim detail for a free/reclaim
+// line. Pure so dry-run and real paths cannot drift and unit tests can lock copy.
+func reclaimStepDetail(branch, worktreePath string, reclaimed, dryRun bool) (label, detail string) {
+	base := filepath.Base(worktreePath)
+	if dryRun {
+		label = fmt.Sprintf("Would free %-23s", branch)
+		if reclaimed {
+			detail = fmt.Sprintf("(detach clean worktree %s)", base)
+		} else {
+			detail = fmt.Sprintf("skipped · %s has uncommitted changes; would sync detached", base)
+		}
+		return label, detail
+	}
+	label = fmt.Sprintf("Free %-28s", branch)
+	if reclaimed {
+		detail = fmt.Sprintf("(detached %s so %s is free here)", base, branch)
+	} else {
+		detail = fmt.Sprintf("skipped · %s has uncommitted changes; syncing detached", base)
+	}
+	return label, detail
+}
+
+func printReclaimStep(prefix string, state freshSyncState, reclaimed, dryRun bool) {
+	label, detail := reclaimStepDetail(state.defaultBranch, state.worktreePath, reclaimed, dryRun)
+	if dryRun {
+		fmt.Printf("%s── %s %s\n", prefix, label, freshStepDim.Render(detail))
+		return
+	}
+	if reclaimed {
+		fmt.Printf("%s── %s %s\n", prefix, label,
+			freshStepGreen.Render("done")+" "+freshStepDim.Render(detail))
+		return
+	}
+	// Dirty worktree: keep detached-sync fallback, but make the reason obvious.
+	fmt.Printf("%s── %s %s\n", prefix, label, freshStepDim.Render(detail))
 }
 
 // findBranchInOtherWorktree returns the first worktree (other than path) that

--- a/internal/commands/fresh/sync_state_test.go
+++ b/internal/commands/fresh/sync_state_test.go
@@ -1,0 +1,62 @@
+package fresh
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestSameWorktreePath(t *testing.T) {
+	if !sameWorktreePath("/a/b", "/a/b") {
+		t.Error("identical paths should match")
+	}
+	if !sameWorktreePath("/a/b/", "/a/b") {
+		t.Error("trailing slash should not matter")
+	}
+	if sameWorktreePath("/a/b", "/a/c") {
+		t.Error("different paths should not match")
+	}
+	if sameWorktreePath("", "/a") || sameWorktreePath("/a", "") {
+		t.Error("empty path should not match")
+	}
+}
+
+func TestEmptyBranchLabel(t *testing.T) {
+	if got := emptyBranchLabel(""); got != "detached HEAD" {
+		t.Errorf("empty = %q", got)
+	}
+	if got := emptyBranchLabel("main"); got != "main" {
+		t.Errorf("main = %q", got)
+	}
+}
+
+func TestIsBranchInUseByWorktree(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{errors.New("fatal: 'main' is already used by worktree at '/tmp/x'"), true},
+		{errors.New("'main' is already checked out at '/tmp/x'"), true},
+		{errors.New("conflict: path is unmerged"), false},
+	}
+	for _, tc := range cases {
+		if got := isBranchInUseByWorktree(tc.err); got != tc.want {
+			t.Errorf("isBranchInUseByWorktree(%v) = %v, want %v", tc.err, got, tc.want)
+		}
+	}
+}
+
+func TestFreshSyncWorktreeNote(t *testing.T) {
+	if got := freshSyncWorktreeNote(freshSyncState{}); got != "" {
+		t.Errorf("empty = %q", got)
+	}
+	got := freshSyncWorktreeNote(freshSyncState{
+		defaultBranch: "main",
+		worktreePath:  "/campaign/projects/worktrees/camp/old-feature",
+	})
+	want := "(main still in " + filepath.Base("/campaign/projects/worktrees/camp/old-feature") + ")"
+	if got != want {
+		t.Errorf("note = %q, want %q", got, want)
+	}
+}

--- a/internal/commands/fresh/sync_state_test.go
+++ b/internal/commands/fresh/sync_state_test.go
@@ -60,3 +60,144 @@ func TestFreshSyncWorktreeNote(t *testing.T) {
 		t.Errorf("note = %q, want %q", got, want)
 	}
 }
+
+func TestApplyReclaimDecision(t *testing.T) {
+	// Starting state mirrors resolveFreshSyncState when another worktree holds main.
+	state := freshSyncState{
+		defaultBranch: "main",
+		baseRef:       "origin/main",
+		displayRef:    "origin/main (detached)",
+		detached:      true,
+		worktreePath:  "/campaign/projects/worktrees/camp/stuck-main",
+	}
+
+	applyReclaimDecision(&state)
+
+	if !state.reclaimed {
+		t.Error("reclaimed should be true")
+	}
+	if state.detached {
+		t.Error("detached should be false after reclaim")
+	}
+	if state.baseRef != "main" {
+		t.Errorf("baseRef = %q, want main", state.baseRef)
+	}
+	if state.displayRef != "main" {
+		t.Errorf("displayRef = %q, want main", state.displayRef)
+	}
+	// Occupying path is retained for messaging until the step finishes.
+	if state.worktreePath != "/campaign/projects/worktrees/camp/stuck-main" {
+		t.Errorf("worktreePath should be preserved, got %q", state.worktreePath)
+	}
+
+	// Nil must not panic.
+	applyReclaimDecision(nil)
+}
+
+func TestReclaimStepDetail(t *testing.T) {
+	const branch = "main"
+	const path = "/campaign/projects/worktrees/camp/stuck-main"
+	base := filepath.Base(path)
+
+	cases := []struct {
+		name      string
+		reclaimed bool
+		dryRun    bool
+		wantLabel string
+		wantDet   string
+	}{
+		{
+			name:      "real reclaim success",
+			reclaimed: true,
+			dryRun:    false,
+			wantLabel: "Free main                        ",
+			wantDet:   "(detached " + base + " so main is free here)",
+		},
+		{
+			name:      "real reclaim dirty skip",
+			reclaimed: false,
+			dryRun:    false,
+			wantLabel: "Free main                        ",
+			wantDet:   "skipped · " + base + " has uncommitted changes; syncing detached",
+		},
+		{
+			name:      "dry-run would reclaim",
+			reclaimed: true,
+			dryRun:    true,
+			wantLabel: "Would free main                   ",
+			wantDet:   "(detach clean worktree " + base + ")",
+		},
+		{
+			name:      "dry-run dirty skip",
+			reclaimed: false,
+			dryRun:    true,
+			wantLabel: "Would free main                   ",
+			wantDet:   "skipped · " + base + " has uncommitted changes; would sync detached",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			label, detail := reclaimStepDetail(branch, path, tc.reclaimed, tc.dryRun)
+			if label != tc.wantLabel {
+				t.Errorf("label = %q, want %q", label, tc.wantLabel)
+			}
+			if detail != tc.wantDet {
+				t.Errorf("detail = %q, want %q", detail, tc.wantDet)
+			}
+		})
+	}
+}
+
+// TestReclaimDecisionMatrix locks the resolve → reclaim state transitions that
+// executeFresh relies on, without git.
+func TestReclaimDecisionMatrix(t *testing.T) {
+	occupied := func() freshSyncState {
+		return freshSyncState{
+			defaultBranch: "main",
+			baseRef:       "origin/main",
+			displayRef:    "origin/main (detached)",
+			detached:      true,
+			worktreePath:  "/tmp/other",
+		}
+	}
+
+	t.Run("clean reclaim enables normal checkout", func(t *testing.T) {
+		state := occupied()
+		// Simulate maybeReclaimDefaultBranch after can/reclaim returned true.
+		applyReclaimDecision(&state)
+		if state.detached || !state.reclaimed {
+			t.Fatalf("want reclaimed normal checkout, got detached=%v reclaimed=%v", state.detached, state.reclaimed)
+		}
+		if state.baseRef != "main" || state.displayRef != "main" {
+			t.Fatalf("refs = %q / %q, want main", state.baseRef, state.displayRef)
+		}
+	})
+
+	t.Run("dirty skip keeps detached fallback", func(t *testing.T) {
+		state := occupied()
+		// maybeReclaimDefaultBranch does not call applyReclaimDecision when dirty.
+		if !state.detached || state.reclaimed {
+			t.Fatalf("precondition failed: detached=%v reclaimed=%v", state.detached, state.reclaimed)
+		}
+		if state.baseRef != "origin/main" {
+			t.Fatalf("baseRef = %q, want origin/main", state.baseRef)
+		}
+		note := freshSyncWorktreeNote(state)
+		if note == "" {
+			t.Fatal("expected worktree note for dirty fallback messaging")
+		}
+	})
+
+	t.Run("no occupying worktree is a no-op", func(t *testing.T) {
+		state := freshSyncState{
+			defaultBranch: "main",
+			baseRef:       "main",
+			displayRef:    "main",
+		}
+		// maybeReclaimDefaultBranch returns immediately when worktreePath is empty.
+		if state.worktreePath != "" || state.detached || state.reclaimed {
+			t.Fatalf("unexpected occupied state: %+v", state)
+		}
+	})
+}

--- a/internal/commands/fresh/workflow.go
+++ b/internal/commands/fresh/workflow.go
@@ -103,7 +103,7 @@ func buildFreshWorkflow(cfg *config.FreshConfig, projectName string) []freshWork
 
 	steps := []freshWorkflowStep{
 		{Title: "Safety checks", Detail: "no merge/rebase in progress; worktree is clean", Enabled: true},
-		{Title: "Checkout default branch", Detail: "use the repository's default branch (or a safe detached ref)", Enabled: true},
+		{Title: "Checkout default branch", Detail: "reclaim default branch from a clean worktree if needed, then check it out (detached origin/ fallback when dirty)", Enabled: true},
 		{Title: "Pull", Detail: "fast-forward only", Enabled: true},
 	}
 

--- a/tests/integration/fresh_test.go
+++ b/tests/integration/fresh_test.go
@@ -499,3 +499,49 @@ git -C %[2]s push origin main
 	remoteHeads := tc.GitOutput(t, bareDir, "show-ref", "--verify", "refs/heads/feature-remote")
 	assert.Contains(t, remoteHeads, "refs/heads/feature-remote")
 }
+
+// TestFresh_ReclaimsDefaultBranchFromOtherWorktree proves that when main is
+// checked out in a clean feature worktree (the common leftover after
+// worktree add --start-point main), camp fresh detaches that worktree and
+// checks out main on the primary project path instead of failing with
+// "already used by worktree" or leaving the primary on detached origin/main.
+func TestFresh_ReclaimsDefaultBranchFromOtherWorktree(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-reclaim-main"
+	_, projectDir, _ := setupFreshCampaignWithSubmodule(t, tc, name)
+
+	// Primary starts on a feature branch; main is held by a finished worktree.
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+git -C %[1]s checkout -b feature-active
+printf 'work\n' > %[1]s/feature.txt
+git -C %[1]s add .
+git -C %[1]s commit -m 'feature work'
+`, projectDir))
+
+	stuckWT := worktreePath(name, "stuck-main")
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+git -C %[1]s worktree add %[2]s main
+`, projectDir, stuckWT))
+
+	// Confirm main is locked before fresh.
+	branchOnStuck := tc.GitOutput(t, stuckWT, "rev-parse", "--abbrev-ref", "HEAD")
+	require.Equal(t, "main", branchOnStuck, "precondition: stuck worktree should hold main")
+
+	// --no-prune so the reclaimed worktree is not removed after detach
+	// (prune deletes clean detached worktrees that match merged history).
+	output, err := tc.RunCampInDir(projectDir, "fresh", "--no-branch", "--no-push", "--no-follow-up", "--no-prune")
+	require.NoError(t, err, "camp fresh should reclaim main:\n%s", output)
+	assert.Contains(t, output, "Free", "fresh should report freeing the default branch")
+	assert.Contains(t, output, "stuck-main", "fresh should name the occupying worktree")
+
+	// Primary is on main (not detached origin/main).
+	primary := tc.GitOutput(t, projectDir, "rev-parse", "--abbrev-ref", "HEAD")
+	assert.Equal(t, "main", primary, "primary project path should hold main after fresh")
+
+	// Occupying worktree was detached so main is free for the primary path.
+	stuck := tc.GitOutput(t, stuckWT, "rev-parse", "--abbrev-ref", "HEAD")
+	assert.Equal(t, "HEAD", stuck, "occupying worktree should be detached, got %s", stuck)
+}


### PR DESCRIPTION
## Summary

`camp fresh` could leave you unable to use `main` on the primary project path because a finished worktree still had `main` checked out. Git then fails with:

```text
fatal: 'main' is already used by worktree at '.../worktrees/camp/...'
```

Previously fresh worked around this by syncing **detached** `origin/main` on the primary path, which left `main` stuck forever on a random worktree and made a later `git checkout main` fail.

## Fix

When another worktree holds the default branch:

1. If that worktree is **clean**, detach it (`checkout --detach HEAD`) to free the branch name
2. Check out the real default branch on the primary project path
3. Pull / prune as usual

If the occupying worktree is **dirty**, keep the detached `origin/<default>` fallback and print why free was skipped (instead of a raw git error).

## Example

```text
  camp
  ── Free main                         done (detached workitem-schema-… so main is free here)
  ── Checkout main                     done
  ── Pull (ff-only)                  updated
  Fresh! Synced to main.
```

## Test plan

- [x] `go test ./internal/commands/fresh/`
- [x] `go test -tags=integration -run TestFresh_ReclaimsDefaultBranchFromOtherWorktree ./tests/integration/`
- [x] Smoke: real camp tree with main stuck on a worktree — free + checkout main + pull