### PR TITLE
fix(leverage): correct personal --author leverage (no multi-count actual PM)

### DIFF
--- a/cmd/camp/leverage/dir.go
+++ b/cmd/camp/leverage/dir.go
@@ -127,6 +127,10 @@ func runLeverageDir(cmd *cobra.Command, targetDir string) error {
 	authorFilter, _ := cmd.Flags().GetString("author")
 	byAuthor, _ := cmd.Flags().GetBool("by-author")
 
+	if authorFilter != "" && byAuthor {
+		return camperrors.New("--author and --by-author are mutually exclusive: use --by-author for the full per-author breakdown, or --author for personal leverage")
+	}
+
 	gitRoot := detectGitRoot(ctx, targetDir)
 
 	setup, err := initDirectorySetup(ctx, targetDir, gitRoot)
@@ -209,8 +213,11 @@ func runLeverageDir(cmd *cobra.Command, targetDir string) error {
 	agg := intleverage.AggregateScores(scores, effectivePeople, elapsed)
 
 	if authorFilter != "" {
-		authorPM, pmErr := intleverage.AuthorActualPersonMonths(ctx, scoredProjects, authorMatch)
-		if pmErr == nil && authorPM > 0 {
+		authorPM, pmErr := intleverage.AuthorActualPersonMonths(ctx, scoredProjects, authorMatch, setup.Resolver)
+		if pmErr != nil {
+			return camperrors.Wrap(pmErr, "computing personal actual person-months")
+		}
+		if authorPM > 0 {
 			estPM := agg.EstimatedPeople * agg.EstimatedMonths
 			agg.ActualPersonMonths = authorPM
 			agg.ActualPeople = 1

--- a/cmd/camp/leverage/dir.go
+++ b/cmd/camp/leverage/dir.go
@@ -142,7 +142,8 @@ func runLeverageDir(cmd *cobra.Command, targetDir string) error {
 	if peopleOverride > 0 {
 		cfg.ActualPeople = peopleOverride
 	}
-	if authorFilter == "" && cfg.AuthorEmail != "" {
+	// Suppress configured AuthorEmail when --by-author is requested (same as campaign path).
+	if authorFilter == "" && !byAuthor && cfg.AuthorEmail != "" {
 		authorFilter = cfg.AuthorEmail
 	}
 
@@ -163,7 +164,10 @@ func runLeverageDir(cmd *cobra.Command, targetDir string) error {
 	authorMatch := intleverage.ExpandAuthorFilter(setup.Resolver, authorFilter)
 	if authorFilter != "" {
 		hasCommits, gitErr := intleverage.AuthorHasCommitsMatch(ctx, proj.GitDir, authorMatch)
-		if gitErr != nil || !hasCommits {
+		if gitErr != nil {
+			return camperrors.Wrapf(gitErr, "checking author commits in %s", proj.Name)
+		}
+		if !hasCommits {
 			return camperrors.New(fmt.Sprintf("no commits for author %q in %s", authorFilter, proj.Name))
 		}
 	}

--- a/cmd/camp/leverage/dir.go
+++ b/cmd/camp/leverage/dir.go
@@ -156,8 +156,9 @@ func runLeverageDir(cmd *cobra.Command, targetDir string) error {
 	}
 	proj = resolved[0]
 
+	authorMatch := intleverage.ExpandAuthorFilter(setup.Resolver, authorFilter)
 	if authorFilter != "" {
-		hasCommits, gitErr := intleverage.AuthorHasCommits(ctx, proj.GitDir, authorFilter)
+		hasCommits, gitErr := intleverage.AuthorHasCommitsMatch(ctx, proj.GitDir, authorMatch)
 		if gitErr != nil || !hasCommits {
 			return camperrors.New(fmt.Sprintf("no commits for author %q in %s", authorFilter, proj.Name))
 		}
@@ -188,13 +189,18 @@ func runLeverageDir(cmd *cobra.Command, targetDir string) error {
 
 	score := intleverage.ComputeProjectScore(ctx, proj, result, intleverage.ProjectScoreParams{
 		AuthorFilter:    authorFilter,
+		AuthorMatch:     authorMatch,
+		Resolver:        setup.Resolver,
 		PeopleOverride:  peopleOverride,
 		FallbackElapsed: elapsed,
 	})
 	scores := []*intleverage.LeverageScore{score}
+	scoredProjects := []intleverage.ResolvedProject{proj}
 
 	effectivePeople := cfg.ActualPeople
-	if effectivePeople == 0 {
+	if authorFilter != "" {
+		effectivePeople = 1
+	} else if effectivePeople == 0 {
 		effectivePeople = proj.AuthorCount
 		if effectivePeople == 0 {
 			effectivePeople = 1
@@ -202,7 +208,16 @@ func runLeverageDir(cmd *cobra.Command, targetDir string) error {
 	}
 	agg := intleverage.AggregateScores(scores, effectivePeople, elapsed)
 
-	if score.ActualPersonMonths > 0 {
+	if authorFilter != "" {
+		authorPM, pmErr := intleverage.AuthorActualPersonMonths(ctx, scoredProjects, authorMatch)
+		if pmErr == nil && authorPM > 0 {
+			estPM := agg.EstimatedPeople * agg.EstimatedMonths
+			agg.ActualPersonMonths = authorPM
+			agg.ActualPeople = 1
+			agg.FullLeverage = estPM / authorPM
+			agg.SimpleLeverage = agg.EstimatedPeople
+		}
+	} else if score.ActualPersonMonths > 0 {
 		estPM := agg.EstimatedPeople * agg.EstimatedMonths
 		agg.ActualPersonMonths = score.ActualPersonMonths
 		agg.FullLeverage = estPM / score.ActualPersonMonths
@@ -218,7 +233,7 @@ func runLeverageDir(cmd *cobra.Command, targetDir string) error {
 		return leverageOutputJSON(cmd, agg, scores)
 	}
 	if byAuthor {
-		return leverageOutputByAuthor(cmd, agg, resolved, setup.Resolver, opts)
+		return leverageOutputByAuthor(cmd, ctx, agg, scores, scoredProjects, setup.Resolver, opts)
 	}
 
 	return leverageOutputTable(cmd, agg, scores, cfg, setup.AutoDetected, recentLeverage{}, opts)

--- a/cmd/camp/leverage/helpers.go
+++ b/cmd/camp/leverage/helpers.go
@@ -199,9 +199,10 @@ func resolveAndPopulateProjects(ctx context.Context, root string, cfg *intlevera
 
 	var authorExcluded int
 	if authorFilter != "" {
+		match := intleverage.ExpandAuthorFilter(resolver, authorFilter)
 		var filtered []intleverage.ResolvedProject
 		for _, proj := range resolved {
-			hasCommits, gitErr := intleverage.AuthorHasCommits(ctx, proj.GitDir, authorFilter)
+			hasCommits, gitErr := intleverage.AuthorHasCommitsMatch(ctx, proj.GitDir, match)
 			if gitErr == nil && hasCommits {
 				filtered = append(filtered, proj)
 			} else {

--- a/cmd/camp/leverage/helpers.go
+++ b/cmd/camp/leverage/helpers.go
@@ -203,7 +203,10 @@ func resolveAndPopulateProjects(ctx context.Context, root string, cfg *intlevera
 		var filtered []intleverage.ResolvedProject
 		for _, proj := range resolved {
 			hasCommits, gitErr := intleverage.AuthorHasCommitsMatch(ctx, proj.GitDir, match)
-			if gitErr == nil && hasCommits {
+			if gitErr != nil {
+				return nil, 0, camperrors.Wrapf(gitErr, "checking author commits in %s", proj.Name)
+			}
+			if hasCommits {
 				filtered = append(filtered, proj)
 			} else {
 				authorExcluded++

--- a/cmd/camp/leverage/main_command.go
+++ b/cmd/camp/leverage/main_command.go
@@ -53,6 +53,10 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 	authorFilter, _ := cmd.Flags().GetString("author")
 	byAuthor, _ := cmd.Flags().GetBool("by-author")
 
+	if authorFilter != "" && byAuthor {
+		return camperrors.New("--author and --by-author are mutually exclusive: use --by-author for the full per-author breakdown, or --author for personal leverage")
+	}
+
 	setup, err := initLeverageSetup(ctx)
 	if err != nil {
 		return err
@@ -148,8 +152,11 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 	if authorFilter != "" {
 		// Personal headline: union author calendar across unique git dirs
 		// (never sum per-project spans) with already ownership-scaled estimates.
-		authorPM, pmErr := intleverage.AuthorActualPersonMonths(ctx, scoredProjects, authorMatch)
-		if pmErr == nil && authorPM > 0 {
+		authorPM, pmErr := intleverage.AuthorActualPersonMonths(ctx, scoredProjects, authorMatch, setup.Resolver)
+		if pmErr != nil {
+			return camperrors.Wrap(pmErr, "computing personal actual person-months")
+		}
+		if authorPM > 0 {
 			estPM := agg.EstimatedPeople * agg.EstimatedMonths
 			agg.ActualPersonMonths = authorPM
 			agg.ActualPeople = 1

--- a/cmd/camp/leverage/main_command.go
+++ b/cmd/camp/leverage/main_command.go
@@ -87,8 +87,12 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 	now := time.Now()
 	elapsed := intleverage.ElapsedMonths(cfg.ProjectStart, now)
 
+	authorMatch := intleverage.ExpandAuthorFilter(setup.Resolver, authorFilter)
+
 	var scores []*intleverage.LeverageScore
 	var snapshotInputs []intleverage.CurrentSnapshotInput
+	// Keep projects aligned with scores for personal aggregate rewrite.
+	var scoredProjects []intleverage.ResolvedProject
 	for _, proj := range resolved {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -106,10 +110,13 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 
 		score := intleverage.ComputeProjectScore(ctx, proj, result, intleverage.ProjectScoreParams{
 			AuthorFilter:    authorFilter,
+			AuthorMatch:     authorMatch,
+			Resolver:        setup.Resolver,
 			PeopleOverride:  peopleOverride,
 			FallbackElapsed: elapsed,
 		})
 		scores = append(scores, score)
+		scoredProjects = append(scoredProjects, proj)
 		snapshotInputs = append(snapshotInputs, intleverage.CurrentSnapshotInput{
 			Project: proj,
 			Result:  result,
@@ -122,7 +129,10 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 	}
 
 	effectivePeople := cfg.ActualPeople
-	if effectivePeople == 0 {
+	if authorFilter != "" {
+		// Personal mode is always one effective person for simple leverage.
+		effectivePeople = 1
+	} else if effectivePeople == 0 {
 		for _, s := range scores {
 			if s.AuthorCount > effectivePeople {
 				effectivePeople = s.AuthorCount
@@ -135,7 +145,20 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 
 	agg := intleverage.AggregateScores(scores, effectivePeople, elapsed)
 
-	if authorFilter == "" && peopleOverride == 0 {
+	if authorFilter != "" {
+		// Personal headline: union author calendar across unique git dirs
+		// (never sum per-project spans) with already ownership-scaled estimates.
+		authorPM, pmErr := intleverage.AuthorActualPersonMonths(ctx, scoredProjects, authorMatch)
+		if pmErr == nil && authorPM > 0 {
+			estPM := agg.EstimatedPeople * agg.EstimatedMonths
+			agg.ActualPersonMonths = authorPM
+			agg.ActualPeople = 1
+			agg.FullLeverage = estPM / authorPM
+			if effectivePeople > 0 {
+				agg.SimpleLeverage = agg.EstimatedPeople / float64(effectivePeople)
+			}
+		}
+	} else if peopleOverride == 0 {
 		campaignPM, pmErr := intleverage.CampaignActualPersonMonths(ctx, resolved, setup.Resolver)
 		if pmErr == nil && campaignPM > 0 {
 			estPM := agg.EstimatedPeople * agg.EstimatedMonths
@@ -170,7 +193,7 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 	}
 
 	if byAuthor {
-		return leverageOutputByAuthor(cmd, agg, resolved, setup.Resolver, opts)
+		return leverageOutputByAuthor(cmd, ctx, agg, scores, scoredProjects, setup.Resolver, opts)
 	}
 
 	return leverageOutputTable(cmd, agg, scores, cfg, setup.AutoDetected, recent, opts)

--- a/cmd/camp/leverage/main_command.go
+++ b/cmd/camp/leverage/main_command.go
@@ -53,6 +53,9 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 	authorFilter, _ := cmd.Flags().GetString("author")
 	byAuthor, _ := cmd.Flags().GetBool("by-author")
 
+	// Explicit CLI conflict only. Config AuthorEmail is applied after setup and
+	// is suppressed when --by-author is requested so the breakdown still works
+	// in campaigns that set a personal default.
 	if authorFilter != "" && byAuthor {
 		return camperrors.New("--author and --by-author are mutually exclusive: use --by-author for the full per-author breakdown, or --author for personal leverage")
 	}
@@ -70,7 +73,8 @@ func runLeverage(cmd *cobra.Command, args []string) error {
 		cfg.ActualPeople = peopleOverride
 	}
 
-	if authorFilter == "" && cfg.AuthorEmail != "" {
+	// Apply configured personal default only when not doing a by-author breakdown.
+	if authorFilter == "" && !byAuthor && cfg.AuthorEmail != "" {
 		authorFilter = cfg.AuthorEmail
 	}
 

--- a/cmd/camp/leverage/output.go
+++ b/cmd/camp/leverage/output.go
@@ -216,28 +216,21 @@ func leverageOutputByAuthor(cmd *cobra.Command, ctx context.Context, agg *intlev
 		}
 	}
 
-	// Personal actual PM: union of commit spans across unique git dirs (not sum).
+	// One git pass per unique GitDir for all authors (not authors×repos×emails).
+	spans, spanErr := intleverage.CollectMergedAuthorSpans(ctx, resolved, resolver)
+	if spanErr != nil {
+		return camperrors.Wrap(spanErr, "collecting author date spans")
+	}
+
 	// Drop authors under 1% of campaign blamed lines (same threshold as effort calc).
 	authors := make([]*authorAgg, 0, len(byID))
 	for authorID, entry := range byID {
 		if campaignLines > 0 && float64(entry.lines)/float64(campaignLines)*100 < 1.0 {
 			continue
 		}
-		match := intleverage.AuthorMatch{
-			Filter:    authorID,
-			AuthorIDs: map[string]bool{authorID: true},
-			Emails:    authorEmailsForID(resolver, authorID),
-		}
-		if len(match.Emails) == 0 {
-			match.Emails = []string{authorID}
-		}
-		actualPM, err := intleverage.AuthorActualPersonMonths(ctx, resolved, match)
-		if err != nil || actualPM <= 0 {
-			actualPM = 0.1
-		}
-		entry.actualPM = actualPM
-		if actualPM > 0 {
-			entry.leverage = entry.estPM / actualPM
+		entry.actualPM = spans.PersonMonths(authorID)
+		if entry.actualPM > 0 {
+			entry.leverage = entry.estPM / entry.actualPM
 		}
 		authors = append(authors, entry)
 	}
@@ -290,27 +283,8 @@ func leverageOutputByAuthor(cmd *cobra.Command, ctx context.Context, agg *intlev
 	fmt.Fprintln(out, ui.Dim("Est PM = project COCOMO person-months × author LOC share (per project, summed)"))
 	fmt.Fprintln(out, ui.Dim("Actual PM = union of author's commit span across unique git repos (not summed per project)"))
 	fmt.Fprintln(out, ui.Dim("Leverage = Est PM / Actual PM"))
+	fmt.Fprintln(out, ui.Dim("--author and --by-author are mutually exclusive"))
 	return nil
-}
-
-// authorEmailsForID returns configured emails for a canonical author ID.
-func authorEmailsForID(resolver *intleverage.AuthorResolver, authorID string) []string {
-	if resolver == nil {
-		return nil
-	}
-	// ExpandAuthorFilter with the ID as filter reuses group matching.
-	match := intleverage.ExpandAuthorFilter(resolver, authorID)
-	var emails []string
-	for _, e := range match.Emails {
-		if e != authorID {
-			emails = append(emails, e)
-		}
-	}
-	// Prefer configured emails only; fall back to ID if nothing else.
-	if len(emails) == 0 {
-		return []string{authorID}
-	}
-	return emails
 }
 
 func fmtInt(n int) string {

--- a/cmd/camp/leverage/output.go
+++ b/cmd/camp/leverage/output.go
@@ -1,6 +1,7 @@
 package leverage
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -160,7 +161,7 @@ func leverageOutputTable(cmd *cobra.Command, agg *intleverage.LeverageScore, sco
 	return nil
 }
 
-func leverageOutputByAuthor(cmd *cobra.Command, agg *intleverage.LeverageScore, resolved []intleverage.ResolvedProject, resolver *intleverage.AuthorResolver, opts leverageOutputOpts) error {
+func leverageOutputByAuthor(cmd *cobra.Command, ctx context.Context, agg *intleverage.LeverageScore, scores []*intleverage.LeverageScore, resolved []intleverage.ResolvedProject, resolver *intleverage.AuthorResolver, opts leverageOutputOpts) error {
 	out := cmd.OutOrStdout()
 	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(ui.CategoryColor)
 
@@ -168,48 +169,92 @@ func leverageOutputByAuthor(cmd *cobra.Command, agg *intleverage.LeverageScore, 
 		displayName string
 		authorID    string
 		lines       int
-		weightedPM  float64
+		estPM       float64
+		actualPM    float64
+		leverage    float64
 	}
 
+	// Map authorID → lines owned + ownership-weighted estimated PM.
 	byID := make(map[string]*authorAgg)
-	for _, proj := range resolved {
+	var campaignLines int
+	for i, proj := range resolved {
+		var score *intleverage.LeverageScore
+		if i < len(scores) {
+			score = scores[i]
+		}
+		projEstPM := 0.0
+		if score != nil {
+			// When --by-author is used without --author, scores are full-tree.
+			// Recompute from unscaled people×months.
+			projEstPM = score.EstimatedPeople * score.EstimatedMonths
+		}
+
+		// Sum lines once for ownership fractions within this project.
+		totalLines := 0
 		for _, a := range proj.Authors {
-			authorID := resolver.Resolve(a.Email)
-			if existing, ok := byID[authorID]; ok {
-				existing.lines += a.Lines
-				existing.weightedPM += a.WeightedPM
+			totalLines += a.Lines
+		}
+
+		for _, a := range proj.Authors {
+			if resolver.IsExcluded(a.Email) {
 				continue
 			}
-			byID[authorID] = &authorAgg{
-				displayName: resolver.DisplayName(authorID),
-				authorID:    authorID,
-				lines:       a.Lines,
-				weightedPM:  a.WeightedPM,
+			authorID := resolver.Resolve(a.Email)
+			entry, ok := byID[authorID]
+			if !ok {
+				entry = &authorAgg{
+					displayName: resolver.DisplayName(authorID),
+					authorID:    authorID,
+				}
+				byID[authorID] = entry
+			}
+			entry.lines += a.Lines
+			campaignLines += a.Lines
+			if totalLines > 0 && projEstPM > 0 {
+				entry.estPM += projEstPM * (float64(a.Lines) / float64(totalLines))
 			}
 		}
 	}
 
+	// Personal actual PM: union of commit spans across unique git dirs (not sum).
+	// Drop authors under 1% of campaign blamed lines (same threshold as effort calc).
 	authors := make([]*authorAgg, 0, len(byID))
-	for _, a := range byID {
-		authors = append(authors, a)
+	for authorID, entry := range byID {
+		if campaignLines > 0 && float64(entry.lines)/float64(campaignLines)*100 < 1.0 {
+			continue
+		}
+		match := intleverage.AuthorMatch{
+			Filter:    authorID,
+			AuthorIDs: map[string]bool{authorID: true},
+			Emails:    authorEmailsForID(resolver, authorID),
+		}
+		if len(match.Emails) == 0 {
+			match.Emails = []string{authorID}
+		}
+		actualPM, err := intleverage.AuthorActualPersonMonths(ctx, resolved, match)
+		if err != nil || actualPM <= 0 {
+			actualPM = 0.1
+		}
+		entry.actualPM = actualPM
+		if actualPM > 0 {
+			entry.leverage = entry.estPM / actualPM
+		}
+		authors = append(authors, entry)
 	}
 	sort.Slice(authors, func(i, j int) bool {
-		return authors[i].weightedPM > authors[j].weightedPM
+		return authors[i].leverage > authors[j].leverage
 	})
 
-	headers := []string{"AUTHOR", "ID", "LINES OWNED", "WEIGHTED PM", "LEVERAGE SHARE"}
+	headers := []string{"AUTHOR", "ID", "LINES OWNED", "EST PM", "ACTUAL PM", "LEVERAGE"}
 	var rows [][]string
 	for _, a := range authors {
-		levShare := 0.0
-		if agg.ActualPersonMonths > 0 {
-			levShare = (a.weightedPM / agg.ActualPersonMonths) * agg.FullLeverage
-		}
 		rows = append(rows, []string{
 			a.displayName,
 			a.authorID,
 			fmtInt(a.lines),
-			fmt.Sprintf("%.2f", a.weightedPM),
-			fmtScore(levShare) + "x",
+			fmt.Sprintf("%.1f", a.estPM),
+			fmt.Sprintf("%.1f", a.actualPM),
+			fmtScore(a.leverage) + "x",
 		})
 	}
 
@@ -233,7 +278,7 @@ func leverageOutputByAuthor(cmd *cobra.Command, agg *intleverage.LeverageScore, 
 			switch col {
 			case 0:
 				return lipgloss.NewStyle().Foreground(ui.AccentColor)
-			case 4:
+			case 5:
 				return lipgloss.NewStyle().Foreground(ui.SuccessColor)
 			default:
 				return lipgloss.NewStyle()
@@ -242,9 +287,30 @@ func leverageOutputByAuthor(cmd *cobra.Command, agg *intleverage.LeverageScore, 
 
 	fmt.Fprintln(out, t)
 	fmt.Fprintln(out)
-	fmt.Fprintln(out, ui.Dim("Weighted PM = author's date span × (author's LOC / total LOC)"))
-	fmt.Fprintln(out, ui.Dim("Leverage Share = (author's weighted PM / total actual PM) × campaign leverage"))
+	fmt.Fprintln(out, ui.Dim("Est PM = project COCOMO person-months × author LOC share (per project, summed)"))
+	fmt.Fprintln(out, ui.Dim("Actual PM = union of author's commit span across unique git repos (not summed per project)"))
+	fmt.Fprintln(out, ui.Dim("Leverage = Est PM / Actual PM"))
 	return nil
+}
+
+// authorEmailsForID returns configured emails for a canonical author ID.
+func authorEmailsForID(resolver *intleverage.AuthorResolver, authorID string) []string {
+	if resolver == nil {
+		return nil
+	}
+	// ExpandAuthorFilter with the ID as filter reuses group matching.
+	match := intleverage.ExpandAuthorFilter(resolver, authorID)
+	var emails []string
+	for _, e := range match.Emails {
+		if e != authorID {
+			emails = append(emails, e)
+		}
+	}
+	// Prefer configured emails only; fall back to ID if nothing else.
+	if len(emails) == 0 {
+		return []string{authorID}
+	}
+	return emails
 }
 
 func fmtInt(n int) string {

--- a/docs/leverage-score.md
+++ b/docs/leverage-score.md
@@ -54,10 +54,16 @@ Important details:
 - Project table rows may still show per-repo spans; the **campaign footer** uses the
   union actual above.
 - Standing-tree COCOMO is scaled by **blame ownership**, not by “any commit in repo.”
-- `--author` and `--by-author` are **mutually exclusive**. Use `--by-author` alone
-  for the full per-author table; use `--author` alone for personal leverage.
-- Operational git failures and cancellation are returned; only the expected
-  “no commits for this author” outcome is suppressed per email/repo.
+- `--author` and `--by-author` are **mutually exclusive** when both are passed on
+  the CLI. A configured `author_email` default is **not** applied when
+  `--by-author` is used, so the breakdown still works in personal-default campaigns.
+- Full display names match exactly (e.g. `Alice Smith`); single-token display
+  words also match (`Alice` → `Alice Smith`).
+- Ad-hoc / partial filters (e.g. `alice@co`) use git `--author` substring search
+  and do **not** invent a canonical author ID (avoids false 0.1 PM floors).
+- Operational git failures and cancellation are returned from author presence
+  and date-range queries; only the expected “no commits for this author”
+  outcome is treated as a soft miss.
 
 ### Simple Leverage (headcount-based)
 

--- a/docs/leverage-score.md
+++ b/docs/leverage-score.md
@@ -32,6 +32,26 @@ FullLeverage = ─────────────────────�
 Measures estimated person-months delivered per actual person-month. This is the
 primary metric — it accounts for both team size and time elapsed.
 
+### Personal leverage (`--author`)
+
+Personal mode answers “how productive was this author?” and must **not** multi-count
+calendar time across repositories:
+
+```
+personalEstPM    = Σ (projectEstPM × authorLOC_share_in_project)
+personalActualPM = months(union of author's first→last commit across unique git dirs)
+personalLeverage = personalEstPM / personalActualPM
+```
+
+Important details:
+
+- `--author` expands through `.campaign/leverage/authors.json` so all emails in a
+  matched identity group are included (e.g. work + personal addresses).
+- Monorepo subprojects that share a `GitDir` contribute **once** to actual effort.
+- Project table rows may still show per-repo spans; the **campaign footer** uses the
+  union actual above.
+- Standing-tree COCOMO is scaled by **blame ownership**, not by “any commit in repo.”
+
 ### Simple Leverage (headcount-based)
 
 ```

--- a/docs/leverage-score.md
+++ b/docs/leverage-score.md
@@ -47,10 +47,17 @@ Important details:
 
 - `--author` expands through `.campaign/leverage/authors.json` so all emails in a
   matched identity group are included (e.g. work + personal addresses).
+- Configured identity matching is **exact** on author ID / email local-part (and
+  word-wise on display name). A filter of `alice` does **not** match `malice`.
+  After a configured match, the raw filter is **not** retained as a git substring.
 - Monorepo subprojects that share a `GitDir` contribute **once** to actual effort.
 - Project table rows may still show per-repo spans; the **campaign footer** uses the
   union actual above.
 - Standing-tree COCOMO is scaled by **blame ownership**, not by “any commit in repo.”
+- `--author` and `--by-author` are **mutually exclusive**. Use `--by-author` alone
+  for the full per-author table; use `--author` alone for personal leverage.
+- Operational git failures and cancellation are returned; only the expected
+  “no commits for this author” outcome is suppressed per email/repo.
 
 ### Simple Leverage (headcount-based)
 

--- a/internal/leverage/author_filter.go
+++ b/internal/leverage/author_filter.go
@@ -1,0 +1,275 @@
+package leverage
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// AuthorMatch is the result of expanding an --author filter against authors.json
+// and free-form email/name substrings.
+type AuthorMatch struct {
+	// Filter is the original user-provided filter string.
+	Filter string
+
+	// AuthorIDs are canonical resolver IDs matched by the filter.
+	// Empty when the filter only matches as a raw git --author substring
+	// (no authors.json group).
+	AuthorIDs map[string]bool
+
+	// Emails are concrete addresses to query with git log --author=
+	// (group emails plus the raw filter when useful).
+	Emails []string
+}
+
+// ExpandAuthorFilter resolves an --author flag against the author config.
+//
+// Matching is case-insensitive substring against author ID, display name, and
+// configured emails. When a configured identity matches, all of its emails are
+// included so personal mode does not miss alternate commit addresses.
+//
+// When nothing in the config matches, the raw filter is still used as a single
+// git author substring (preserving prior behavior for ad-hoc emails).
+func ExpandAuthorFilter(resolver *AuthorResolver, filter string) AuthorMatch {
+	filter = strings.TrimSpace(filter)
+	m := AuthorMatch{
+		Filter:    filter,
+		AuthorIDs: make(map[string]bool),
+	}
+	if filter == "" {
+		return m
+	}
+
+	lower := strings.ToLower(filter)
+	seenEmail := make(map[string]bool)
+
+	addEmail := func(email string) {
+		email = strings.TrimSpace(email)
+		if email == "" {
+			return
+		}
+		key := strings.ToLower(email)
+		if seenEmail[key] {
+			return
+		}
+		seenEmail[key] = true
+		m.Emails = append(m.Emails, email)
+	}
+
+	if resolver != nil && resolver.config != nil {
+		for id, identity := range resolver.config.Authors {
+			if identity.Exclude {
+				continue
+			}
+			matched := strings.Contains(strings.ToLower(id), lower) ||
+				strings.Contains(strings.ToLower(identity.DisplayName), lower)
+			if !matched {
+				for _, email := range identity.Emails {
+					if strings.Contains(strings.ToLower(email), lower) {
+						matched = true
+						break
+					}
+				}
+			}
+			if !matched {
+				continue
+			}
+			m.AuthorIDs[id] = true
+			for _, email := range identity.Emails {
+				addEmail(email)
+			}
+		}
+	}
+
+	// Always keep the raw filter for git substring match (covers unlisted emails
+	// and partial strings like "lancekrogers").
+	addEmail(filter)
+
+	// If we only matched via raw filter, seed AuthorIDs from resolver so ownership
+	// lookups work when the filter is an exact configured email. Skip excluded
+	// identities (bots/test accounts) so they do not become "personal" targets.
+	if len(m.AuthorIDs) == 0 && resolver != nil && !resolver.IsExcluded(filter) {
+		id := resolver.Resolve(filter)
+		// Resolve falls back to lowercase email for unknowns — still useful as a key.
+		if id != "" {
+			m.AuthorIDs[id] = true
+		}
+	}
+
+	return m
+}
+
+// MatchesAuthor reports whether email belongs to the matched personal filter set.
+func (m AuthorMatch) MatchesAuthor(resolver *AuthorResolver, email string) bool {
+	if m.Filter == "" {
+		return false
+	}
+	if resolver != nil && len(m.AuthorIDs) > 0 {
+		if m.AuthorIDs[resolver.Resolve(email)] {
+			return true
+		}
+	}
+	lowerEmail := strings.ToLower(strings.TrimSpace(email))
+	lowerFilter := strings.ToLower(m.Filter)
+	if strings.Contains(lowerEmail, lowerFilter) {
+		return true
+	}
+	for _, e := range m.Emails {
+		if strings.EqualFold(e, email) || strings.Contains(lowerEmail, strings.ToLower(e)) {
+			return true
+		}
+	}
+	return false
+}
+
+// AuthorHasCommitsMatch reports whether any matched identity has commits in gitDir.
+func AuthorHasCommitsMatch(ctx context.Context, gitDir string, match AuthorMatch) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	// Prefer distinct email queries so alternate addresses are found.
+	// Fall back to raw filter substring (single git call) when emails empty.
+	queries := match.Emails
+	if len(queries) == 0 && match.Filter != "" {
+		queries = []string{match.Filter}
+	}
+	for _, q := range queries {
+		ok, err := AuthorHasCommits(ctx, gitDir, q)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// AuthorDateRangeMatch returns the earliest and latest commit dates across all
+// matched author emails in gitDir.
+func AuthorDateRangeMatch(ctx context.Context, gitDir string, match AuthorMatch) (first, last time.Time, err error) {
+	if err := ctx.Err(); err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+
+	queries := match.Emails
+	if len(queries) == 0 && match.Filter != "" {
+		queries = []string{match.Filter}
+	}
+
+	var found bool
+	for _, q := range queries {
+		f, l, qErr := AuthorDateRange(ctx, gitDir, q)
+		if qErr != nil {
+			continue
+		}
+		found = true
+		if first.IsZero() || f.Before(first) {
+			first = f
+		}
+		if last.IsZero() || l.After(last) {
+			last = l
+		}
+	}
+	if !found {
+		return time.Time{}, time.Time{}, camperrors.Newf("no commits matching author filter %q in %s", match.Filter, gitDir)
+	}
+	return first, last, nil
+}
+
+// AuthorOwnershipFraction returns the fraction of blamed lines in proj owned by
+// the matched author set. When blame data is missing, returns 1.0 so projects
+// the author committed to are not zeroed out.
+func AuthorOwnershipFraction(proj ResolvedProject, match AuthorMatch, resolver *AuthorResolver) float64 {
+	if match.Filter == "" {
+		return 1.0
+	}
+	if len(proj.Authors) == 0 {
+		return 1.0
+	}
+
+	var authorLines, totalLines int
+	for _, c := range proj.Authors {
+		totalLines += c.Lines
+		if match.MatchesAuthor(resolver, c.Email) {
+			authorLines += c.Lines
+		}
+	}
+	if totalLines == 0 {
+		return 1.0
+	}
+	return float64(authorLines) / float64(totalLines)
+}
+
+// AuthorActualPersonMonths computes personal actual effort as the union of the
+// matched author's commit date spans across unique git directories.
+//
+// This intentionally does NOT sum per-project spans (which multi-counts parallel
+// multi-repo work and monorepo subprojects that share a GitDir).
+func AuthorActualPersonMonths(ctx context.Context, projects []ResolvedProject, match AuthorMatch) (float64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if match.Filter == "" {
+		return minAuthorMonths, nil
+	}
+
+	uniqueGitDirs := make(map[string]struct{})
+	for _, p := range projects {
+		if p.GitDir != "" {
+			uniqueGitDirs[p.GitDir] = struct{}{}
+		}
+	}
+
+	var merged authorDateSpan
+	var any bool
+	for gitDir := range uniqueGitDirs {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		first, last, err := AuthorDateRangeMatch(ctx, gitDir, match)
+		if err != nil {
+			continue
+		}
+		any = true
+		merged.merge(&authorDateSpan{earliest: first, latest: last})
+	}
+
+	if !any || merged.earliest.IsZero() {
+		return minAuthorMonths, nil
+	}
+
+	months := ElapsedMonths(merged.earliest, merged.latest)
+	if months < minAuthorMonths {
+		months = minAuthorMonths
+	}
+	return months, nil
+}
+
+// ScaleScoreForAuthor multiplies estimated effort fields by ownership fraction.
+// EstimatedMonths is left unchanged so EstimatedPeople * EstimatedMonths scales
+// with ownership. ActualPersonMonths and FullLeverage are recomputed by the caller.
+func ScaleScoreForAuthor(score *LeverageScore, ownership float64) {
+	if score == nil {
+		return
+	}
+	if ownership < 0 {
+		ownership = 0
+	}
+	if ownership > 1 {
+		ownership = 1
+	}
+	score.EstimatedPeople *= ownership
+	score.EstimatedCost *= ownership
+	// Keep TotalCode/TotalLines as full-tree inventory for transparency, but scale
+	// is applied on cost/people which drive leverage.
+	if score.ActualPeople > 0 {
+		score.SimpleLeverage = score.EstimatedPeople / score.ActualPeople
+	}
+	if score.ActualPersonMonths > 0 {
+		estPM := score.EstimatedPeople * score.EstimatedMonths
+		score.FullLeverage = estPM / score.ActualPersonMonths
+	}
+}

--- a/internal/leverage/author_filter.go
+++ b/internal/leverage/author_filter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"time"
+	"unicode"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
@@ -15,23 +16,28 @@ type AuthorMatch struct {
 	Filter string
 
 	// AuthorIDs are canonical resolver IDs matched by the filter.
-	// Empty when the filter only matches as a raw git --author substring
-	// (no authors.json group).
+	// When non-empty, matching is identity-group exclusive (no raw substring).
 	AuthorIDs map[string]bool
 
-	// Emails are concrete addresses to query with git log --author=
-	// (group emails plus the raw filter when useful).
+	// Emails are concrete addresses for git log --author= queries.
+	// Populated from configured identity groups, or the raw filter when no
+	// configured identity matched.
 	Emails []string
+
+	// Configured is true when at least one authors.json identity matched.
+	// When true, the raw filter is not used as a git substring (avoids
+	// collisions like "alice" matching "malice").
+	Configured bool
 }
 
 // ExpandAuthorFilter resolves an --author flag against the author config.
 //
 // Matching is case-insensitive substring against author ID, display name, and
 // configured emails. When a configured identity matches, all of its emails are
-// included so personal mode does not miss alternate commit addresses.
+// included and the raw filter is NOT retained as a git substring.
 //
-// When nothing in the config matches, the raw filter is still used as a single
-// git author substring (preserving prior behavior for ad-hoc emails).
+// When nothing in the config matches, the raw filter is used as a single git
+// author substring (ad-hoc email / name search).
 func ExpandAuthorFilter(resolver *AuthorResolver, filter string) AuthorMatch {
 	filter = strings.TrimSpace(filter)
 	m := AuthorMatch{
@@ -63,19 +69,13 @@ func ExpandAuthorFilter(resolver *AuthorResolver, filter string) AuthorMatch {
 			if identity.Exclude {
 				continue
 			}
-			matched := strings.Contains(strings.ToLower(id), lower) ||
-				strings.Contains(strings.ToLower(identity.DisplayName), lower)
-			if !matched {
-				for _, email := range identity.Emails {
-					if strings.Contains(strings.ToLower(email), lower) {
-						matched = true
-						break
-					}
-				}
-			}
-			if !matched {
+			// Avoid naive substring matching on IDs/emails (e.g. "alice" must
+			// not select "malice"). Use exact ID/email/local-part and word-wise
+			// display-name matching instead.
+			if !identityMatchesFilter(id, identity, lower) {
 				continue
 			}
+			m.Configured = true
 			m.AuthorIDs[id] = true
 			for _, email := range identity.Emails {
 				addEmail(email)
@@ -83,16 +83,19 @@ func ExpandAuthorFilter(resolver *AuthorResolver, filter string) AuthorMatch {
 		}
 	}
 
-	// Always keep the raw filter for git substring match (covers unlisted emails
-	// and partial strings like "lancekrogers").
+	if m.Configured {
+		// Identity-group match: use only group emails / IDs. Do not append the
+		// raw filter as a git substring (would include "malice" for "alice").
+		return m
+	}
+
+	// No configured identity: raw filter is the sole git author query.
 	addEmail(filter)
 
-	// If we only matched via raw filter, seed AuthorIDs from resolver so ownership
-	// lookups work when the filter is an exact configured email. Skip excluded
-	// identities (bots/test accounts) so they do not become "personal" targets.
-	if len(m.AuthorIDs) == 0 && resolver != nil && !resolver.IsExcluded(filter) {
+	// Seed AuthorIDs from resolver so ownership lookups work for exact emails
+	// that are not grouped. Skip excluded identities.
+	if resolver != nil && !resolver.IsExcluded(filter) {
 		id := resolver.Resolve(filter)
-		// Resolve falls back to lowercase email for unknowns — still useful as a key.
 		if id != "" {
 			m.AuthorIDs[id] = true
 		}
@@ -101,27 +104,78 @@ func ExpandAuthorFilter(resolver *AuthorResolver, filter string) AuthorMatch {
 	return m
 }
 
-// MatchesAuthor reports whether email belongs to the matched personal filter set.
-func (m AuthorMatch) MatchesAuthor(resolver *AuthorResolver, email string) bool {
-	if m.Filter == "" {
+// identityMatchesFilter reports whether a configured identity matches filter
+// (already lowercased). Matching is intentionally stricter than raw git
+// --author substring so short filters do not collide across identities.
+func identityMatchesFilter(id string, identity AuthorIdentity, filterLower string) bool {
+	if filterLower == "" {
 		return false
 	}
-	if resolver != nil && len(m.AuthorIDs) > 0 {
-		if m.AuthorIDs[resolver.Resolve(email)] {
-			return true
-		}
-	}
-	lowerEmail := strings.ToLower(strings.TrimSpace(email))
-	lowerFilter := strings.ToLower(m.Filter)
-	if strings.Contains(lowerEmail, lowerFilter) {
+	if strings.ToLower(id) == filterLower {
 		return true
 	}
-	for _, e := range m.Emails {
-		if strings.EqualFold(e, email) || strings.Contains(lowerEmail, strings.ToLower(e)) {
+	if containsWord(strings.ToLower(identity.DisplayName), filterLower) {
+		return true
+	}
+	for _, email := range identity.Emails {
+		el := strings.ToLower(strings.TrimSpace(email))
+		if el == filterLower {
+			return true
+		}
+		// Local-part exact: "alice" matches alice@example.com, not malice@…
+		if at := strings.IndexByte(el, '@'); at > 0 {
+			local := el[:at]
+			if local == filterLower {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// containsWord reports whether word appears as a whole alphanumeric token in text.
+func containsWord(text, word string) bool {
+	if text == "" || word == "" {
+		return false
+	}
+	fields := strings.FieldsFunc(text, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
+	})
+	for _, f := range fields {
+		if f == word {
 			return true
 		}
 	}
 	return false
+}
+
+// MatchesAuthor reports whether email belongs to the matched personal filter set.
+//
+// When a configured identity matched (or AuthorIDs is non-empty from resolve),
+// membership is by canonical author ID only — never by raw substring on the
+// filter string.
+func (m AuthorMatch) MatchesAuthor(resolver *AuthorResolver, email string) bool {
+	if m.Filter == "" {
+		return false
+	}
+
+	if len(m.AuthorIDs) > 0 {
+		if resolver != nil {
+			return m.AuthorIDs[resolver.Resolve(email)]
+		}
+		// No resolver: exact email match against the expanded email list.
+		for _, e := range m.Emails {
+			if strings.EqualFold(e, email) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Ad-hoc filter with no IDs: substring match on email (legacy git behavior).
+	lowerEmail := strings.ToLower(strings.TrimSpace(email))
+	lowerFilter := strings.ToLower(m.Filter)
+	return strings.Contains(lowerEmail, lowerFilter)
 }
 
 // AuthorHasCommitsMatch reports whether any matched identity has commits in gitDir.
@@ -129,8 +183,6 @@ func AuthorHasCommitsMatch(ctx context.Context, gitDir string, match AuthorMatch
 	if err := ctx.Err(); err != nil {
 		return false, err
 	}
-	// Prefer distinct email queries so alternate addresses are found.
-	// Fall back to raw filter substring (single git call) when emails empty.
 	queries := match.Emails
 	if len(queries) == 0 && match.Filter != "" {
 		queries = []string{match.Filter}
@@ -147,8 +199,24 @@ func AuthorHasCommitsMatch(ctx context.Context, gitDir string, match AuthorMatch
 	return false, nil
 }
 
+// isNoAuthorCommits reports whether err is the expected "no commits for author"
+// outcome (as opposed to cancellation or git operational failure).
+func isNoAuthorCommits(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "no commits by ") ||
+		strings.Contains(msg, "no commits matching author filter") ||
+		strings.Contains(msg, "no valid commit dates by ")
+}
+
 // AuthorDateRangeMatch returns the earliest and latest commit dates across all
 // matched author emails in gitDir.
+//
+// "No commits for this author" on an individual email is skipped so alternate
+// addresses can still contribute. Context cancellation and operational git
+// failures are returned immediately.
 func AuthorDateRangeMatch(ctx context.Context, gitDir string, match AuthorMatch) (first, last time.Time, err error) {
 	if err := ctx.Err(); err != nil {
 		return time.Time{}, time.Time{}, err
@@ -161,9 +229,19 @@ func AuthorDateRangeMatch(ctx context.Context, gitDir string, match AuthorMatch)
 
 	var found bool
 	for _, q := range queries {
+		if err := ctx.Err(); err != nil {
+			return time.Time{}, time.Time{}, err
+		}
 		f, l, qErr := AuthorDateRange(ctx, gitDir, q)
 		if qErr != nil {
-			continue
+			if ctx.Err() != nil {
+				return time.Time{}, time.Time{}, ctx.Err()
+			}
+			if isNoAuthorCommits(qErr) {
+				continue
+			}
+			// Operational failure (repo missing, git broken, etc.).
+			return time.Time{}, time.Time{}, qErr
 		}
 		found = true
 		if first.IsZero() || f.Before(first) {
@@ -203,12 +281,79 @@ func AuthorOwnershipFraction(proj ResolvedProject, match AuthorMatch, resolver *
 	return float64(authorLines) / float64(totalLines)
 }
 
+// MergedAuthorSpans maps canonical author ID → commit date span merged across
+// unique git directories. Built with one git log pass per git dir.
+type MergedAuthorSpans map[string]*authorDateSpan
+
+// CollectMergedAuthorSpans computes per-author date spans across projects with
+// one gitDirAuthors call per unique GitDir (not per author × email).
+func CollectMergedAuthorSpans(ctx context.Context, projects []ResolvedProject, resolver *AuthorResolver) (MergedAuthorSpans, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if resolver == nil {
+		resolver = NewAuthorResolver(nil)
+	}
+
+	uniqueGitDirs := make(map[string]struct{})
+	for _, p := range projects {
+		if p.GitDir != "" {
+			uniqueGitDirs[p.GitDir] = struct{}{}
+		}
+	}
+
+	merged := make(MergedAuthorSpans)
+	for gitDir := range uniqueGitDirs {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		byID, err := gitDirAuthors(ctx, gitDir, resolver)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			return nil, err
+		}
+		for authorID, span := range byID {
+			if span == nil {
+				continue
+			}
+			existing, ok := merged[authorID]
+			if !ok {
+				cp := *span
+				merged[authorID] = &cp
+				continue
+			}
+			existing.merge(span)
+		}
+	}
+	return merged, nil
+}
+
+// PersonMonths returns elapsed months for authorID, floored at minAuthorMonths.
+// Missing authors return minAuthorMonths.
+func (s MergedAuthorSpans) PersonMonths(authorID string) float64 {
+	span, ok := s[authorID]
+	if !ok || span == nil || span.earliest.IsZero() {
+		return minAuthorMonths
+	}
+	months := ElapsedMonths(span.earliest, span.latest)
+	if months < minAuthorMonths {
+		return minAuthorMonths
+	}
+	return months
+}
+
 // AuthorActualPersonMonths computes personal actual effort as the union of the
 // matched author's commit date spans across unique git directories.
 //
-// This intentionally does NOT sum per-project spans (which multi-counts parallel
-// multi-repo work and monorepo subprojects that share a GitDir).
-func AuthorActualPersonMonths(ctx context.Context, projects []ResolvedProject, match AuthorMatch) (float64, error) {
+// When match.AuthorIDs is non-empty and resolver is non-nil, spans are taken from
+// CollectMergedAuthorSpans (one git pass per repo). Otherwise falls back to
+// per-email AuthorDateRangeMatch for ad-hoc filters.
+//
+// Operational git errors and cancellation are returned. A true "no commits in
+// any repo" outcome yields minAuthorMonths (not an error).
+func AuthorActualPersonMonths(ctx context.Context, projects []ResolvedProject, match AuthorMatch, resolver *AuthorResolver) (float64, error) {
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
@@ -216,6 +361,33 @@ func AuthorActualPersonMonths(ctx context.Context, projects []ResolvedProject, m
 		return minAuthorMonths, nil
 	}
 
+	// Fast path: configured / resolved author IDs → single pass per git dir.
+	if resolver != nil && len(match.AuthorIDs) > 0 {
+		spans, err := CollectMergedAuthorSpans(ctx, projects, resolver)
+		if err != nil {
+			return 0, err
+		}
+		var merged authorDateSpan
+		var any bool
+		for id := range match.AuthorIDs {
+			span, ok := spans[id]
+			if !ok || span == nil || span.earliest.IsZero() {
+				continue
+			}
+			any = true
+			merged.merge(span)
+		}
+		if !any {
+			return minAuthorMonths, nil
+		}
+		months := ElapsedMonths(merged.earliest, merged.latest)
+		if months < minAuthorMonths {
+			months = minAuthorMonths
+		}
+		return months, nil
+	}
+
+	// Ad-hoc filter: query unique git dirs with the expanded email/filter list.
 	uniqueGitDirs := make(map[string]struct{})
 	for _, p := range projects {
 		if p.GitDir != "" {
@@ -231,7 +403,10 @@ func AuthorActualPersonMonths(ctx context.Context, projects []ResolvedProject, m
 		}
 		first, last, err := AuthorDateRangeMatch(ctx, gitDir, match)
 		if err != nil {
-			continue
+			if isNoAuthorCommits(err) {
+				continue
+			}
+			return 0, err
 		}
 		any = true
 		merged.merge(&authorDateSpan{earliest: first, latest: last})
@@ -263,8 +438,6 @@ func ScaleScoreForAuthor(score *LeverageScore, ownership float64) {
 	}
 	score.EstimatedPeople *= ownership
 	score.EstimatedCost *= ownership
-	// Keep TotalCode/TotalLines as full-tree inventory for transparency, but scale
-	// is applied on cost/people which drive leverage.
 	if score.ActualPeople > 0 {
 		score.SimpleLeverage = score.EstimatedPeople / score.ActualPeople
 	}

--- a/internal/leverage/author_filter.go
+++ b/internal/leverage/author_filter.go
@@ -32,12 +32,13 @@ type AuthorMatch struct {
 
 // ExpandAuthorFilter resolves an --author flag against the author config.
 //
-// Matching is case-insensitive substring against author ID, display name, and
-// configured emails. When a configured identity matches, all of its emails are
-// included and the raw filter is NOT retained as a git substring.
+// When a configured identity matches, all of its emails are included and the
+// raw filter is NOT retained as a git substring.
 //
 // When nothing in the config matches, the raw filter is used as a single git
-// author substring (ad-hoc email / name search).
+// author substring (ad-hoc search). AuthorIDs stays empty in that case so
+// actual-PM uses the ad-hoc git path (partial filters like "alice@co" keep
+// working). Only configured identity matches populate AuthorIDs.
 func ExpandAuthorFilter(resolver *AuthorResolver, filter string) AuthorMatch {
 	filter = strings.TrimSpace(filter)
 	m := AuthorMatch{
@@ -70,8 +71,8 @@ func ExpandAuthorFilter(resolver *AuthorResolver, filter string) AuthorMatch {
 				continue
 			}
 			// Avoid naive substring matching on IDs/emails (e.g. "alice" must
-			// not select "malice"). Use exact ID/email/local-part and word-wise
-			// display-name matching instead.
+			// not select "malice"). Use exact ID/email/local-part and
+			// full/word display-name matching instead.
 			if !identityMatchesFilter(id, identity, lower) {
 				continue
 			}
@@ -90,17 +91,10 @@ func ExpandAuthorFilter(resolver *AuthorResolver, filter string) AuthorMatch {
 	}
 
 	// No configured identity: raw filter is the sole git author query.
+	// Leave AuthorIDs empty so AuthorActualPersonMonths uses AuthorDateRangeMatch
+	// (git --author substring) instead of CollectMergedAuthorSpans keyed by
+	// full canonical emails — partial filters like "alice@co" must still work.
 	addEmail(filter)
-
-	// Seed AuthorIDs from resolver so ownership lookups work for exact emails
-	// that are not grouped. Skip excluded identities.
-	if resolver != nil && !resolver.IsExcluded(filter) {
-		id := resolver.Resolve(filter)
-		if id != "" {
-			m.AuthorIDs[id] = true
-		}
-	}
-
 	return m
 }
 
@@ -114,7 +108,13 @@ func identityMatchesFilter(id string, identity AuthorIdentity, filterLower strin
 	if strings.ToLower(id) == filterLower {
 		return true
 	}
-	if containsWord(strings.ToLower(identity.DisplayName), filterLower) {
+	displayLower := strings.ToLower(strings.TrimSpace(identity.DisplayName))
+	// Exact full display name (supports "Alice Smith").
+	if normalizeSpace(displayLower) == normalizeSpace(filterLower) {
+		return true
+	}
+	// Single-token display match ("Alice" matches display "Alice Smith").
+	if containsWord(displayLower, filterLower) {
 		return true
 	}
 	for _, email := range identity.Emails {
@@ -131,6 +131,11 @@ func identityMatchesFilter(id string, identity AuthorIdentity, filterLower strin
 		}
 	}
 	return false
+}
+
+// normalizeSpace lowercases is already applied; collapse internal whitespace.
+func normalizeSpace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }
 
 // containsWord reports whether word appears as a whole alphanumeric token in text.
@@ -151,9 +156,9 @@ func containsWord(text, word string) bool {
 
 // MatchesAuthor reports whether email belongs to the matched personal filter set.
 //
-// When a configured identity matched (or AuthorIDs is non-empty from resolve),
-// membership is by canonical author ID only — never by raw substring on the
-// filter string.
+// When AuthorIDs is non-empty (configured identity match only), membership is by
+// canonical author ID. Ad-hoc filters leave AuthorIDs empty and use substring
+// match on the email (same as git --author).
 func (m AuthorMatch) MatchesAuthor(resolver *AuthorResolver, email string) bool {
 	if m.Filter == "" {
 		return false

--- a/internal/leverage/author_filter_test.go
+++ b/internal/leverage/author_filter_test.go
@@ -2,20 +2,71 @@ package leverage
 
 import (
 	"context"
+	"errors"
 	"math"
+	"strings"
 	"testing"
+	"time"
 )
 
-func TestExpandAuthorFilter_GroupEmails(t *testing.T) {
+func TestExpandAuthorFilter_GroupEmailsNoRawSubstring(t *testing.T) {
 	cfg := &AuthorConfig{
 		Authors: map[string]AuthorIdentity{
-			"lancekrogers": {
-				DisplayName: "lancekrogers",
-				Emails: []string{
-					"lancekrogers@gmail.com",
-					"lance@blockhead.consulting",
-				},
+			"alice": {
+				DisplayName: "Alice",
+				Emails:      []string{"alice@example.com", "alice@work.com"},
 			},
+			"malice": {
+				DisplayName: "Malice",
+				Emails:      []string{"malice@example.com"},
+			},
+		},
+	}
+	resolver := NewAuthorResolver(cfg)
+
+	// Substring "alice" must match only the alice group — not malice, and must
+	// not retain raw filter "alice" as a git substring query.
+	match := ExpandAuthorFilter(resolver, "alice")
+	if !match.Configured {
+		t.Fatal("expected configured identity match")
+	}
+	if !match.AuthorIDs["alice"] {
+		t.Fatalf("expected alice ID: %+v", match.AuthorIDs)
+	}
+	if match.AuthorIDs["malice"] {
+		t.Fatal("alice filter must not match malice identity")
+	}
+	for _, e := range match.Emails {
+		if e == "alice" || strings.EqualFold(e, "alice") {
+			t.Fatalf("raw filter must not be retained after configured match: %v", match.Emails)
+		}
+		if strings.Contains(strings.ToLower(e), "malice") {
+			t.Fatalf("malice email must not be included: %v", match.Emails)
+		}
+	}
+	// Full group emails present.
+	want := map[string]bool{"alice@example.com": true, "alice@work.com": true}
+	for _, e := range match.Emails {
+		delete(want, strings.ToLower(e))
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing group emails, leftover want: %v; got %v", want, match.Emails)
+	}
+}
+
+func TestExpandAuthorFilter_AdHocKeepsRawFilter(t *testing.T) {
+	match := ExpandAuthorFilter(NewAuthorResolver(nil), "someone@unlisted.dev")
+	if match.Configured {
+		t.Fatal("ad-hoc filter should not be configured")
+	}
+	if len(match.Emails) != 1 || match.Emails[0] != "someone@unlisted.dev" {
+		t.Fatalf("ad-hoc emails = %v", match.Emails)
+	}
+}
+
+func TestExpandAuthorFilter_ExcludedNotConfigured(t *testing.T) {
+	cfg := &AuthorConfig{
+		Authors: map[string]AuthorIdentity{
 			"bot": {
 				DisplayName: "Bot",
 				Emails:      []string{"bot@example.com"},
@@ -23,41 +74,27 @@ func TestExpandAuthorFilter_GroupEmails(t *testing.T) {
 			},
 		},
 	}
-	resolver := NewAuthorResolver(cfg)
-
-	match := ExpandAuthorFilter(resolver, "lancekrogers@gmail.com")
-	if !match.AuthorIDs["lancekrogers"] {
-		t.Fatalf("expected lancekrogers ID matched: %+v", match.AuthorIDs)
-	}
-	hasBlockhead := false
-	for _, e := range match.Emails {
-		if e == "lance@blockhead.consulting" {
-			hasBlockhead = true
-		}
-	}
-	if !hasBlockhead {
-		t.Fatalf("expected alternate email in match: %v", match.Emails)
-	}
-
-	// Excluded identities must not match by email alone via expand of their id.
-	botMatch := ExpandAuthorFilter(resolver, "bot@example.com")
-	if botMatch.AuthorIDs["bot"] {
-		t.Fatal("excluded author should not be added via group match")
+	match := ExpandAuthorFilter(NewAuthorResolver(cfg), "bot@example.com")
+	if match.AuthorIDs["bot"] {
+		t.Fatal("excluded author should not be added as configured identity")
 	}
 }
 
-func TestExpandAuthorFilter_ByDisplayName(t *testing.T) {
+func TestMatchesAuthor_ConfiguredIsIDExclusive(t *testing.T) {
 	cfg := &AuthorConfig{
 		Authors: map[string]AuthorIdentity{
-			"alice-smith": {
-				DisplayName: "Alice Smith",
-				Emails:      []string{"alice@work.com", "alice@personal.com"},
-			},
+			"alice":  {DisplayName: "Alice", Emails: []string{"alice@example.com"}},
+			"malice": {DisplayName: "Malice", Emails: []string{"malice@example.com"}},
 		},
 	}
-	match := ExpandAuthorFilter(NewAuthorResolver(cfg), "Alice")
-	if !match.AuthorIDs["alice-smith"] {
-		t.Fatalf("display name substring should match: %+v", match.AuthorIDs)
+	resolver := NewAuthorResolver(cfg)
+	match := ExpandAuthorFilter(resolver, "alice")
+
+	if !match.MatchesAuthor(resolver, "alice@example.com") {
+		t.Error("alice email should match")
+	}
+	if match.MatchesAuthor(resolver, "malice@example.com") {
+		t.Error("malice email must not match alice filter (no raw substring)")
 	}
 }
 
@@ -73,81 +110,19 @@ func TestAuthorOwnershipFraction(t *testing.T) {
 		Authors: []AuthorContribution{
 			{Email: "alice@example.com", Lines: 75},
 			{Email: "bob@example.com", Lines: 25},
+			// Would match raw substring "alice" but must not with configured match.
+			{Email: "malice@example.com", Lines: 50},
 		},
 	}
 	got := AuthorOwnershipFraction(proj, match, resolver)
-	if math.Abs(got-0.75) > 0.001 {
-		t.Errorf("ownership = %f, want 0.75", got)
+	// 75 / (75+25+50) = 0.5
+	if math.Abs(got-0.5) > 0.001 {
+		t.Errorf("ownership = %f, want 0.5 (malice excluded)", got)
 	}
 
-	// Missing blame → full ownership so committed projects are not zeroed.
 	empty := ResolvedProject{}
 	if AuthorOwnershipFraction(empty, match, resolver) != 1.0 {
 		t.Error("empty authors should default ownership to 1.0")
-	}
-}
-
-func TestAuthorActualPersonMonths_DeduplicatesAcrossRepos(t *testing.T) {
-	ctx := context.Background()
-
-	repo1 := initGitRepo(t)
-	repo2 := initGitRepo(t)
-
-	// Alice active Jan–Sep in repo1 (~8 months) and Mar–Jul in repo2 (overlap).
-	commitFileWithDate(t, repo1, "a.go", "package a\n", "Alice", "alice@example.com", "2025-01-01T12:00:00+00:00")
-	commitFileWithDate(t, repo1, "b.go", "package a\nvar x = 1\n", "Alice", "alice@example.com", "2025-09-01T12:00:00+00:00")
-	commitFileWithDate(t, repo2, "c.go", "package b\n", "Alice", "alice@example.com", "2025-03-01T12:00:00+00:00")
-	commitFileWithDate(t, repo2, "d.go", "package b\nvar y = 1\n", "Alice", "alice@example.com", "2025-07-01T12:00:00+00:00")
-
-	projects := []ResolvedProject{
-		{Name: "p1", GitDir: repo1, SCCDir: repo1},
-		{Name: "p2", GitDir: repo2, SCCDir: repo2},
-	}
-	match := ExpandAuthorFilter(NewAuthorResolver(nil), "alice@example.com")
-
-	pm, err := AuthorActualPersonMonths(ctx, projects, match)
-	if err != nil {
-		t.Fatalf("AuthorActualPersonMonths: %v", err)
-	}
-	// Union span is ~8 months, not 8+4.
-	if pm < 7.5 || pm > 9.0 {
-		t.Errorf("author PM = %.2f, want ~8.0 (union across repos)", pm)
-	}
-
-	// Naive sum of per-repo spans must be larger.
-	first1, last1, err := AuthorDateRange(ctx, repo1, "alice@example.com")
-	if err != nil {
-		t.Fatal(err)
-	}
-	first2, last2, err := AuthorDateRange(ctx, repo2, "alice@example.com")
-	if err != nil {
-		t.Fatal(err)
-	}
-	naive := ElapsedMonths(first1, last1) + ElapsedMonths(first2, last2)
-	if pm >= naive-0.01 {
-		t.Errorf("union PM (%.2f) should be less than naive sum (%.2f)", pm, naive)
-	}
-}
-
-func TestAuthorActualPersonMonths_DeduplicatesMonorepoGitDir(t *testing.T) {
-	ctx := context.Background()
-	repo := initGitRepo(t)
-	commitFileWithDate(t, repo, "a.go", "package a\n", "Alice", "alice@example.com", "2025-01-01T12:00:00+00:00")
-	commitFileWithDate(t, repo, "b.go", "package a\nvar x = 1\n", "Alice", "alice@example.com", "2025-07-01T12:00:00+00:00")
-
-	projects := []ResolvedProject{
-		{Name: "root", GitDir: repo, SCCDir: repo},
-		{Name: "sub1", GitDir: repo, SCCDir: repo + "/sub1", InMonorepo: true},
-		{Name: "sub2", GitDir: repo, SCCDir: repo + "/sub2", InMonorepo: true},
-	}
-	match := ExpandAuthorFilter(NewAuthorResolver(nil), "alice@example.com")
-	pm, err := AuthorActualPersonMonths(ctx, projects, match)
-	if err != nil {
-		t.Fatalf("AuthorActualPersonMonths: %v", err)
-	}
-	// ~6 months once, not 3×.
-	if pm < 5.5 || pm > 7.0 {
-		t.Errorf("author PM = %.2f, want ~6.0 for monorepo shared GitDir", pm)
 	}
 }
 
@@ -166,23 +141,70 @@ func TestScaleScoreForAuthor(t *testing.T) {
 	if score.EstimatedCost != 500 {
 		t.Errorf("EstimatedCost = %v, want 500", score.EstimatedCost)
 	}
-	// Full leverage recomputed: (5*5)/2 = 12.5
 	if math.Abs(score.FullLeverage-12.5) > 0.01 {
 		t.Errorf("FullLeverage = %v, want 12.5", score.FullLeverage)
 	}
 }
 
-func TestComputeProjectScore_AuthorScalesEstimate(t *testing.T) {
-	ctx := context.Background()
-	repo := initGitRepo(t)
-	commitFileWithDate(t, repo, "a.go", "package a\n", "Alice", "alice@example.com", "2025-01-01T12:00:00+00:00")
-	commitFileWithDate(t, repo, "b.go", "package a\nvar x = 1\n", "Alice", "alice@example.com", "2025-07-01T12:00:00+00:00")
-	// Bob owns more lines in blame if we only set Authors manually.
+func TestIsNoAuthorCommits(t *testing.T) {
+	if !isNoAuthorCommits(errors.New("no commits by alice@x in /tmp/r")) {
+		t.Error("expected no-commits detection")
+	}
+	if !isNoAuthorCommits(errors.New(`no commits matching author filter "alice" in /tmp/r`)) {
+		t.Error("expected filter no-commits detection")
+	}
+	if isNoAuthorCommits(errors.New("git log: exit status 128")) {
+		t.Error("operational git error must not be treated as no-commits")
+	}
+	if isNoAuthorCommits(context.Canceled) {
+		t.Error("cancellation must not be treated as no-commits")
+	}
+}
 
+func TestAuthorDateRangeMatch_PropagatesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	match := AuthorMatch{Filter: "alice@example.com", Emails: []string{"alice@example.com"}}
+	_, _, err := AuthorDateRangeMatch(ctx, "/nonexistent", match)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}
+
+func TestAuthorActualPersonMonths_PropagatesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	match := ExpandAuthorFilter(NewAuthorResolver(nil), "alice@example.com")
+	_, err := AuthorActualPersonMonths(ctx, []ResolvedProject{{GitDir: "/tmp/x"}}, match, NewAuthorResolver(nil))
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}
+
+func TestMergedAuthorSpans_PersonMonths(t *testing.T) {
+	spans := MergedAuthorSpans{
+		"alice": {
+			earliest: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			latest:   time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	pm := spans.PersonMonths("alice")
+	if pm < 7.5 || pm > 9.0 {
+		t.Errorf("PersonMonths = %f, want ~8", pm)
+	}
+	if spans.PersonMonths("missing") != minAuthorMonths {
+		t.Errorf("missing author should floor at %v", minAuthorMonths)
+	}
+}
+
+func TestComputeProjectScore_AuthorScalesEstimateNoGit(t *testing.T) {
+	// Pure unit path: Authors pre-populated; AuthorDateRangeMatch will fail for
+	// missing git dir and fall back to minAuthorMonths elapsed.
+	ctx := context.Background()
 	proj := ResolvedProject{
 		Name:   "p",
-		GitDir: repo,
-		SCCDir: repo,
+		GitDir: "/nonexistent-git-dir-for-unit-test",
+		SCCDir: "/nonexistent",
 		Authors: []AuthorContribution{
 			{Email: "alice@example.com", Lines: 25, Percentage: 25},
 			{Email: "bob@example.com", Lines: 75, Percentage: 75},
@@ -202,79 +224,14 @@ func TestComputeProjectScore_AuthorScalesEstimate(t *testing.T) {
 		Resolver:    resolver,
 	})
 
-	// Ownership 25% → estimated people scaled.
 	if math.Abs(score.EstimatedPeople-2.0) > 0.01 {
 		t.Errorf("EstimatedPeople = %v, want 2.0 (25%% of 8)", score.EstimatedPeople)
 	}
 	if math.Abs(score.EstimatedCost-20000) > 0.01 {
 		t.Errorf("EstimatedCost = %v, want 20000", score.EstimatedCost)
 	}
-	if score.ActualPeople != 1 {
-		t.Errorf("ActualPeople = %v, want 1", score.ActualPeople)
-	}
-}
-
-func TestPersonalAggregate_NoMultiCount(t *testing.T) {
-	// Simulates main_command personal rewrite: ownership-scaled project est
-	// summed, actual from AuthorActualPersonMonths (union).
-	ctx := context.Background()
-	repo1 := initGitRepo(t)
-	repo2 := initGitRepo(t)
-
-	commitFileWithDate(t, repo1, "a.go", "package a\n", "Alice", "alice@example.com", "2025-01-01T12:00:00+00:00")
-	commitFileWithDate(t, repo1, "b.go", "package a\nvar x = 1\n", "Alice", "alice@example.com", "2025-09-01T12:00:00+00:00")
-	commitFileWithDate(t, repo2, "c.go", "package b\n", "Alice", "alice@example.com", "2025-03-01T12:00:00+00:00")
-	commitFileWithDate(t, repo2, "d.go", "package b\nvar y = 1\n", "Alice", "alice@example.com", "2025-07-01T12:00:00+00:00")
-
-	resolver := NewAuthorResolver(nil)
-	match := ExpandAuthorFilter(resolver, "alice@example.com")
-
-	projects := []ResolvedProject{
-		{
-			Name: "p1", GitDir: repo1, SCCDir: repo1,
-			Authors: []AuthorContribution{{Email: "alice@example.com", Lines: 100, Percentage: 100}},
-		},
-		{
-			Name: "p2", GitDir: repo2, SCCDir: repo2,
-			Authors: []AuthorContribution{{Email: "alice@example.com", Lines: 100, Percentage: 100}},
-		},
-	}
-	results := []*SCCResult{
-		{EstimatedPeople: 10, EstimatedScheduleMonths: 5, EstimatedCost: 1, LanguageSummary: []LanguageEntry{{Lines: 10, Code: 8}}},
-		{EstimatedPeople: 10, EstimatedScheduleMonths: 5, EstimatedCost: 1, LanguageSummary: []LanguageEntry{{Lines: 10, Code: 8}}},
-	}
-
-	var scores []*LeverageScore
-	for i, p := range projects {
-		scores = append(scores, ComputeProjectScore(ctx, p, results[i], ProjectScoreParams{
-			AuthorMatch: match,
-			Resolver:    resolver,
-		}))
-	}
-
-	// Broken path: sum of project actuals ~ 8+4 = 12
-	var sumActual float64
-	var sumEst float64
-	for _, s := range scores {
-		sumActual += s.ActualPersonMonths
-		sumEst += s.EstimatedPeople * s.EstimatedMonths
-	}
-
-	unionActual, err := AuthorActualPersonMonths(ctx, projects, match)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if unionActual >= sumActual-0.01 {
-		t.Fatalf("union actual %.2f should be < sum actual %.2f", unionActual, sumActual)
-	}
-
-	brokenLev := sumEst / sumActual
-	fixedLev := sumEst / unionActual
-	if fixedLev <= brokenLev {
-		t.Fatalf("fixed leverage %.2f should exceed broken %.2f", fixedLev, brokenLev)
-	}
-	// Est is 50+50=100, union actual ~8 → leverage ~12.5; broken ~100/12 ~ 8.3
-	if fixedLev < 10 || fixedLev > 15 {
-		t.Errorf("fixed leverage = %.2f, want ~12.5", fixedLev)
+	// Elapsed falls back to min when git dir is missing / no commits.
+	if score.ActualPersonMonths != minAuthorMonths {
+		t.Errorf("ActualPersonMonths = %v, want min floor %v", score.ActualPersonMonths, minAuthorMonths)
 	}
 }

--- a/internal/leverage/author_filter_test.go
+++ b/internal/leverage/author_filter_test.go
@@ -62,6 +62,40 @@ func TestExpandAuthorFilter_AdHocKeepsRawFilter(t *testing.T) {
 	if len(match.Emails) != 1 || match.Emails[0] != "someone@unlisted.dev" {
 		t.Fatalf("ad-hoc emails = %v", match.Emails)
 	}
+	if len(match.AuthorIDs) != 0 {
+		t.Fatalf("ad-hoc filter must leave AuthorIDs empty (got %v) so partial filters use git substring path", match.AuthorIDs)
+	}
+}
+
+func TestExpandAuthorFilter_PartialAdHocNoCanonicalID(t *testing.T) {
+	// Documented partial form: alice@co must not invent AuthorIDs["alice@co"].
+	cfg := &AuthorConfig{
+		Authors: map[string]AuthorIdentity{
+			"bob": {DisplayName: "Bob", Emails: []string{"bob@example.com"}},
+		},
+	}
+	match := ExpandAuthorFilter(NewAuthorResolver(cfg), "alice@co")
+	if match.Configured {
+		t.Fatal("partial unlisted filter should not be configured")
+	}
+	if len(match.AuthorIDs) != 0 {
+		t.Fatalf("AuthorIDs must stay empty for ad-hoc partial filters, got %v", match.AuthorIDs)
+	}
+}
+
+func TestExpandAuthorFilter_FullDisplayName(t *testing.T) {
+	cfg := &AuthorConfig{
+		Authors: map[string]AuthorIdentity{
+			"alice-smith": {
+				DisplayName: "Alice Smith",
+				Emails:      []string{"alice@example.com"},
+			},
+		},
+	}
+	match := ExpandAuthorFilter(NewAuthorResolver(cfg), "Alice Smith")
+	if !match.Configured || !match.AuthorIDs["alice-smith"] {
+		t.Fatalf("full display name should match: configured=%v ids=%v", match.Configured, match.AuthorIDs)
+	}
 }
 
 func TestExpandAuthorFilter_ExcludedNotConfigured(t *testing.T) {

--- a/internal/leverage/author_filter_test.go
+++ b/internal/leverage/author_filter_test.go
@@ -1,0 +1,280 @@
+package leverage
+
+import (
+	"context"
+	"math"
+	"testing"
+)
+
+func TestExpandAuthorFilter_GroupEmails(t *testing.T) {
+	cfg := &AuthorConfig{
+		Authors: map[string]AuthorIdentity{
+			"lancekrogers": {
+				DisplayName: "lancekrogers",
+				Emails: []string{
+					"lancekrogers@gmail.com",
+					"lance@blockhead.consulting",
+				},
+			},
+			"bot": {
+				DisplayName: "Bot",
+				Emails:      []string{"bot@example.com"},
+				Exclude:     true,
+			},
+		},
+	}
+	resolver := NewAuthorResolver(cfg)
+
+	match := ExpandAuthorFilter(resolver, "lancekrogers@gmail.com")
+	if !match.AuthorIDs["lancekrogers"] {
+		t.Fatalf("expected lancekrogers ID matched: %+v", match.AuthorIDs)
+	}
+	hasBlockhead := false
+	for _, e := range match.Emails {
+		if e == "lance@blockhead.consulting" {
+			hasBlockhead = true
+		}
+	}
+	if !hasBlockhead {
+		t.Fatalf("expected alternate email in match: %v", match.Emails)
+	}
+
+	// Excluded identities must not match by email alone via expand of their id.
+	botMatch := ExpandAuthorFilter(resolver, "bot@example.com")
+	if botMatch.AuthorIDs["bot"] {
+		t.Fatal("excluded author should not be added via group match")
+	}
+}
+
+func TestExpandAuthorFilter_ByDisplayName(t *testing.T) {
+	cfg := &AuthorConfig{
+		Authors: map[string]AuthorIdentity{
+			"alice-smith": {
+				DisplayName: "Alice Smith",
+				Emails:      []string{"alice@work.com", "alice@personal.com"},
+			},
+		},
+	}
+	match := ExpandAuthorFilter(NewAuthorResolver(cfg), "Alice")
+	if !match.AuthorIDs["alice-smith"] {
+		t.Fatalf("display name substring should match: %+v", match.AuthorIDs)
+	}
+}
+
+func TestAuthorOwnershipFraction(t *testing.T) {
+	resolver := NewAuthorResolver(&AuthorConfig{
+		Authors: map[string]AuthorIdentity{
+			"alice": {DisplayName: "Alice", Emails: []string{"alice@example.com"}},
+		},
+	})
+	match := ExpandAuthorFilter(resolver, "alice@example.com")
+
+	proj := ResolvedProject{
+		Authors: []AuthorContribution{
+			{Email: "alice@example.com", Lines: 75},
+			{Email: "bob@example.com", Lines: 25},
+		},
+	}
+	got := AuthorOwnershipFraction(proj, match, resolver)
+	if math.Abs(got-0.75) > 0.001 {
+		t.Errorf("ownership = %f, want 0.75", got)
+	}
+
+	// Missing blame → full ownership so committed projects are not zeroed.
+	empty := ResolvedProject{}
+	if AuthorOwnershipFraction(empty, match, resolver) != 1.0 {
+		t.Error("empty authors should default ownership to 1.0")
+	}
+}
+
+func TestAuthorActualPersonMonths_DeduplicatesAcrossRepos(t *testing.T) {
+	ctx := context.Background()
+
+	repo1 := initGitRepo(t)
+	repo2 := initGitRepo(t)
+
+	// Alice active Jan–Sep in repo1 (~8 months) and Mar–Jul in repo2 (overlap).
+	commitFileWithDate(t, repo1, "a.go", "package a\n", "Alice", "alice@example.com", "2025-01-01T12:00:00+00:00")
+	commitFileWithDate(t, repo1, "b.go", "package a\nvar x = 1\n", "Alice", "alice@example.com", "2025-09-01T12:00:00+00:00")
+	commitFileWithDate(t, repo2, "c.go", "package b\n", "Alice", "alice@example.com", "2025-03-01T12:00:00+00:00")
+	commitFileWithDate(t, repo2, "d.go", "package b\nvar y = 1\n", "Alice", "alice@example.com", "2025-07-01T12:00:00+00:00")
+
+	projects := []ResolvedProject{
+		{Name: "p1", GitDir: repo1, SCCDir: repo1},
+		{Name: "p2", GitDir: repo2, SCCDir: repo2},
+	}
+	match := ExpandAuthorFilter(NewAuthorResolver(nil), "alice@example.com")
+
+	pm, err := AuthorActualPersonMonths(ctx, projects, match)
+	if err != nil {
+		t.Fatalf("AuthorActualPersonMonths: %v", err)
+	}
+	// Union span is ~8 months, not 8+4.
+	if pm < 7.5 || pm > 9.0 {
+		t.Errorf("author PM = %.2f, want ~8.0 (union across repos)", pm)
+	}
+
+	// Naive sum of per-repo spans must be larger.
+	first1, last1, err := AuthorDateRange(ctx, repo1, "alice@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	first2, last2, err := AuthorDateRange(ctx, repo2, "alice@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	naive := ElapsedMonths(first1, last1) + ElapsedMonths(first2, last2)
+	if pm >= naive-0.01 {
+		t.Errorf("union PM (%.2f) should be less than naive sum (%.2f)", pm, naive)
+	}
+}
+
+func TestAuthorActualPersonMonths_DeduplicatesMonorepoGitDir(t *testing.T) {
+	ctx := context.Background()
+	repo := initGitRepo(t)
+	commitFileWithDate(t, repo, "a.go", "package a\n", "Alice", "alice@example.com", "2025-01-01T12:00:00+00:00")
+	commitFileWithDate(t, repo, "b.go", "package a\nvar x = 1\n", "Alice", "alice@example.com", "2025-07-01T12:00:00+00:00")
+
+	projects := []ResolvedProject{
+		{Name: "root", GitDir: repo, SCCDir: repo},
+		{Name: "sub1", GitDir: repo, SCCDir: repo + "/sub1", InMonorepo: true},
+		{Name: "sub2", GitDir: repo, SCCDir: repo + "/sub2", InMonorepo: true},
+	}
+	match := ExpandAuthorFilter(NewAuthorResolver(nil), "alice@example.com")
+	pm, err := AuthorActualPersonMonths(ctx, projects, match)
+	if err != nil {
+		t.Fatalf("AuthorActualPersonMonths: %v", err)
+	}
+	// ~6 months once, not 3×.
+	if pm < 5.5 || pm > 7.0 {
+		t.Errorf("author PM = %.2f, want ~6.0 for monorepo shared GitDir", pm)
+	}
+}
+
+func TestScaleScoreForAuthor(t *testing.T) {
+	score := &LeverageScore{
+		EstimatedPeople:    10,
+		EstimatedMonths:    5,
+		EstimatedCost:      1000,
+		ActualPeople:       1,
+		ActualPersonMonths: 2,
+	}
+	ScaleScoreForAuthor(score, 0.5)
+	if score.EstimatedPeople != 5 {
+		t.Errorf("EstimatedPeople = %v, want 5", score.EstimatedPeople)
+	}
+	if score.EstimatedCost != 500 {
+		t.Errorf("EstimatedCost = %v, want 500", score.EstimatedCost)
+	}
+	// Full leverage recomputed: (5*5)/2 = 12.5
+	if math.Abs(score.FullLeverage-12.5) > 0.01 {
+		t.Errorf("FullLeverage = %v, want 12.5", score.FullLeverage)
+	}
+}
+
+func TestComputeProjectScore_AuthorScalesEstimate(t *testing.T) {
+	ctx := context.Background()
+	repo := initGitRepo(t)
+	commitFileWithDate(t, repo, "a.go", "package a\n", "Alice", "alice@example.com", "2025-01-01T12:00:00+00:00")
+	commitFileWithDate(t, repo, "b.go", "package a\nvar x = 1\n", "Alice", "alice@example.com", "2025-07-01T12:00:00+00:00")
+	// Bob owns more lines in blame if we only set Authors manually.
+
+	proj := ResolvedProject{
+		Name:   "p",
+		GitDir: repo,
+		SCCDir: repo,
+		Authors: []AuthorContribution{
+			{Email: "alice@example.com", Lines: 25, Percentage: 25},
+			{Email: "bob@example.com", Lines: 75, Percentage: 75},
+		},
+	}
+	result := &SCCResult{
+		EstimatedPeople:         8,
+		EstimatedScheduleMonths: 10,
+		EstimatedCost:           80000,
+		LanguageSummary:         []LanguageEntry{{Lines: 100, Code: 80}},
+	}
+	resolver := NewAuthorResolver(nil)
+	match := ExpandAuthorFilter(resolver, "alice@example.com")
+
+	score := ComputeProjectScore(ctx, proj, result, ProjectScoreParams{
+		AuthorMatch: match,
+		Resolver:    resolver,
+	})
+
+	// Ownership 25% → estimated people scaled.
+	if math.Abs(score.EstimatedPeople-2.0) > 0.01 {
+		t.Errorf("EstimatedPeople = %v, want 2.0 (25%% of 8)", score.EstimatedPeople)
+	}
+	if math.Abs(score.EstimatedCost-20000) > 0.01 {
+		t.Errorf("EstimatedCost = %v, want 20000", score.EstimatedCost)
+	}
+	if score.ActualPeople != 1 {
+		t.Errorf("ActualPeople = %v, want 1", score.ActualPeople)
+	}
+}
+
+func TestPersonalAggregate_NoMultiCount(t *testing.T) {
+	// Simulates main_command personal rewrite: ownership-scaled project est
+	// summed, actual from AuthorActualPersonMonths (union).
+	ctx := context.Background()
+	repo1 := initGitRepo(t)
+	repo2 := initGitRepo(t)
+
+	commitFileWithDate(t, repo1, "a.go", "package a\n", "Alice", "alice@example.com", "2025-01-01T12:00:00+00:00")
+	commitFileWithDate(t, repo1, "b.go", "package a\nvar x = 1\n", "Alice", "alice@example.com", "2025-09-01T12:00:00+00:00")
+	commitFileWithDate(t, repo2, "c.go", "package b\n", "Alice", "alice@example.com", "2025-03-01T12:00:00+00:00")
+	commitFileWithDate(t, repo2, "d.go", "package b\nvar y = 1\n", "Alice", "alice@example.com", "2025-07-01T12:00:00+00:00")
+
+	resolver := NewAuthorResolver(nil)
+	match := ExpandAuthorFilter(resolver, "alice@example.com")
+
+	projects := []ResolvedProject{
+		{
+			Name: "p1", GitDir: repo1, SCCDir: repo1,
+			Authors: []AuthorContribution{{Email: "alice@example.com", Lines: 100, Percentage: 100}},
+		},
+		{
+			Name: "p2", GitDir: repo2, SCCDir: repo2,
+			Authors: []AuthorContribution{{Email: "alice@example.com", Lines: 100, Percentage: 100}},
+		},
+	}
+	results := []*SCCResult{
+		{EstimatedPeople: 10, EstimatedScheduleMonths: 5, EstimatedCost: 1, LanguageSummary: []LanguageEntry{{Lines: 10, Code: 8}}},
+		{EstimatedPeople: 10, EstimatedScheduleMonths: 5, EstimatedCost: 1, LanguageSummary: []LanguageEntry{{Lines: 10, Code: 8}}},
+	}
+
+	var scores []*LeverageScore
+	for i, p := range projects {
+		scores = append(scores, ComputeProjectScore(ctx, p, results[i], ProjectScoreParams{
+			AuthorMatch: match,
+			Resolver:    resolver,
+		}))
+	}
+
+	// Broken path: sum of project actuals ~ 8+4 = 12
+	var sumActual float64
+	var sumEst float64
+	for _, s := range scores {
+		sumActual += s.ActualPersonMonths
+		sumEst += s.EstimatedPeople * s.EstimatedMonths
+	}
+
+	unionActual, err := AuthorActualPersonMonths(ctx, projects, match)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unionActual >= sumActual-0.01 {
+		t.Fatalf("union actual %.2f should be < sum actual %.2f", unionActual, sumActual)
+	}
+
+	brokenLev := sumEst / sumActual
+	fixedLev := sumEst / unionActual
+	if fixedLev <= brokenLev {
+		t.Fatalf("fixed leverage %.2f should exceed broken %.2f", fixedLev, brokenLev)
+	}
+	// Est is 50+50=100, union actual ~8 → leverage ~12.5; broken ~100/12 ~ 8.3
+	if fixedLev < 10 || fixedLev > 15 {
+		t.Errorf("fixed leverage = %.2f, want ~12.5", fixedLev)
+	}
+}

--- a/internal/leverage/authors.go
+++ b/internal/leverage/authors.go
@@ -292,6 +292,11 @@ func CountAuthors(ctx context.Context, gitDir string, resolver *AuthorResolver) 
 }
 
 // AuthorHasCommits returns true if the given author email has commits in the repo.
+//
+// A successful git log with empty output means the author has no commits
+// (false, nil). Context cancellation and operational git failures (bad repo,
+// permission errors, etc.) are returned as errors — callers must not treat
+// them as "no commits".
 func AuthorHasCommits(ctx context.Context, gitDir, authorEmail string) (bool, error) {
 	if err := ctx.Err(); err != nil {
 		return false, err
@@ -301,7 +306,13 @@ func AuthorHasCommits(ctx context.Context, gitDir, authorEmail string) (bool, er
 		"--author="+authorEmail, "--oneline", "-1")
 	out, err := cmd.Output()
 	if err != nil {
-		return false, nil
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+		if ee, ok := err.(*exec.ExitError); ok {
+			return false, camperrors.Newf("git log --author in %s: %w\nstderr: %s", gitDir, err, ee.Stderr)
+		}
+		return false, camperrors.Wrapf(err, "git log --author in %s", gitDir)
 	}
 	return strings.TrimSpace(string(out)) != "", nil
 }

--- a/internal/leverage/authors_test.go
+++ b/internal/leverage/authors_test.go
@@ -348,6 +348,23 @@ func TestAuthorHasCommits(t *testing.T) {
 	}
 }
 
+func TestAuthorHasCommits_PropagatesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := AuthorHasCommits(ctx, "/tmp", "alice@example.com")
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}
+
+func TestAuthorHasCommits_OperationalFailure(t *testing.T) {
+	// Non-repo path must surface as an error, not (false, nil).
+	_, err := AuthorHasCommits(context.Background(), "/nonexistent-not-a-git-repo", "alice@example.com")
+	if err == nil {
+		t.Fatal("expected operational git error for non-repo path")
+	}
+}
+
 func TestAuthorDateRange(t *testing.T) {
 	dir := initGitRepo(t)
 	commitFile(t, dir, "a.go", "package a\n", "Alice", "alice@example.com")

--- a/internal/leverage/score.go
+++ b/internal/leverage/score.go
@@ -67,27 +67,58 @@ func ComputeScore(result *SCCResult, actualPeople int, elapsedMonths float64) *L
 
 // ProjectScoreParams configures project-level score policy.
 type ProjectScoreParams struct {
-	AuthorFilter    string
-	PeopleOverride  int
+	// AuthorFilter is the raw --author string (kept for diagnostics).
+	AuthorFilter string
+	// AuthorMatch is the expanded personal filter (emails + author IDs).
+	// When Filter is non-empty, personal scoring is applied.
+	AuthorMatch AuthorMatch
+	// Resolver maps emails to canonical author IDs for ownership.
+	Resolver *AuthorResolver
+	// PeopleOverride forces team size when > 0.
+	PeopleOverride int
+	// FallbackElapsed is used when git date range is unavailable.
 	FallbackElapsed float64
 }
 
 // ComputeProjectScore computes the leverage score for one resolved project.
+//
+// Personal mode (AuthorMatch.Filter set):
+//   - Actual effort is the author's commit span in this project's GitDir only
+//     (project row). Campaign aggregation must union spans across unique git
+//     dirs — never sum these project actuals for the personal headline.
+//   - Estimated effort is scaled by blame ownership fraction for the author.
 func ComputeProjectScore(ctx context.Context, proj ResolvedProject, result *SCCResult, params ProjectScoreParams) *LeverageScore {
 	var projActualPM float64
 	var projPeople int
 	var projElapsed float64
 
-	if params.AuthorFilter != "" {
+	if params.AuthorMatch.Filter != "" || params.AuthorFilter != "" {
+		match := params.AuthorMatch
+		if match.Filter == "" {
+			match = ExpandAuthorFilter(params.Resolver, params.AuthorFilter)
+		}
 		projPeople = 1
-		first, last, gitErr := AuthorDateRange(ctx, proj.GitDir, params.AuthorFilter)
+		first, last, gitErr := AuthorDateRangeMatch(ctx, proj.GitDir, match)
 		if gitErr == nil {
 			projElapsed = ElapsedMonths(first, last)
 		}
 		if projElapsed <= 0 {
-			projElapsed = 0.1
+			projElapsed = minAuthorMonths
 		}
 		projActualPM = projElapsed
+
+		score := ComputeScore(result, projPeople, projElapsed)
+		score.ProjectName = proj.Name
+		score.AuthorCount = proj.AuthorCount
+		score.ActualPersonMonths = projActualPM
+
+		ownership := AuthorOwnershipFraction(proj, match, params.Resolver)
+		ScaleScoreForAuthor(score, ownership)
+		if score.ActualPersonMonths > 0 {
+			estPM := score.EstimatedPeople * score.EstimatedMonths
+			score.FullLeverage = estPM / score.ActualPersonMonths
+		}
+		return score
 	} else if params.PeopleOverride > 0 {
 		projPeople = params.PeopleOverride
 		first, last, gitErr := GitDateRange(ctx, proj.GitDir)

--- a/tests/integration/leverage_test.go
+++ b/tests/integration/leverage_test.go
@@ -252,3 +252,110 @@ func TestLeverage_ConfigValidationCOCOMO(t *testing.T) {
 	require.Error(t, err, "expected rejection: %s", output)
 	assert.Contains(t, output, "invalid COCOMO type", output)
 }
+
+// setupMultiRepoAuthorCampaign builds two projects with overlapping commit
+// history from the same author so personal --author mode can prove actual PM
+// is unioned across git dirs (not summed).
+func setupMultiRepoAuthorCampaign(t *testing.T, tc *TestContainer, name string) string {
+	t.Helper()
+
+	root := "/campaigns/" + name
+	_, err := tc.InitCampaign(root, name, "")
+	require.NoError(t, err, "camp init should succeed")
+
+	// Project alpha: commits spanning ~8 months (Jan → Sep).
+	// Project beta: commits spanning overlapping Mar → Jul.
+	// Naive sum ≈ 12 months; union ≈ 8 months.
+	tc.Shell(t, fmt.Sprintf(`
+		set -e
+		for project in alpha beta; do
+			mkdir -p %s/projects/$project
+		done
+
+		# alpha: Jan and Sep
+		cd %s/projects/alpha
+		git init -q
+		git config user.email alice@example.com
+		git config user.name Alice
+		echo 'package alpha' > main.go
+		git add main.go
+		GIT_AUTHOR_DATE='2025-01-01T12:00:00 +0000' GIT_COMMITTER_DATE='2025-01-01T12:00:00 +0000' \
+			git commit -q -m "alpha start"
+		echo 'package alpha // mid' > main.go
+		git add main.go
+		GIT_AUTHOR_DATE='2025-09-01T12:00:00 +0000' GIT_COMMITTER_DATE='2025-09-01T12:00:00 +0000' \
+			git commit -q -m "alpha end"
+
+		# beta: Mar and Jul (subset of alpha span)
+		cd %s/projects/beta
+		git init -q
+		git config user.email alice@example.com
+		git config user.name Alice
+		echo 'package beta' > main.go
+		git add main.go
+		GIT_AUTHOR_DATE='2025-03-01T12:00:00 +0000' GIT_COMMITTER_DATE='2025-03-01T12:00:00 +0000' \
+			git commit -q -m "beta start"
+		echo 'package beta // mid' > main.go
+		git add main.go
+		GIT_AUTHOR_DATE='2025-07-01T12:00:00 +0000' GIT_COMMITTER_DATE='2025-07-01T12:00:00 +0000' \
+			git commit -q -m "beta end"
+	`, root, root, root))
+
+	return root
+}
+
+// TestLeverage_AuthorFilterUnionsActualPM verifies --author does not multi-count
+// calendar time across repositories (the core personal-mode regression).
+func TestLeverage_AuthorFilterUnionsActualPM(t *testing.T) {
+	if !sccAvailable {
+		t.Fatal("scc binary failed to build at container init time")
+	}
+
+	tc := GetSharedContainer(t)
+	root := setupMultiRepoAuthorCampaign(t, tc, "leverage-author-union")
+
+	output, err := tc.RunCampInDir(root, "leverage", "--author", "alice@example.com", "--json")
+	require.NoError(t, err, "camp leverage --author should succeed: %s", output)
+
+	jsonStart := strings.Index(output, "{")
+	require.GreaterOrEqual(t, jsonStart, 0, "no JSON in output: %s", output)
+
+	var result struct {
+		Campaign struct {
+			ActualPersonMonths float64 `json:"actual_person_months"`
+			FullLeverage       float64 `json:"full_leverage"`
+		} `json:"campaign"`
+		Projects []struct {
+			ActualPersonMonths float64 `json:"actual_person_months"`
+		} `json:"projects"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(output[jsonStart:]), &result), output)
+
+	// Union of Jan–Sep ≈ 8 months. Sum of project spans ≈ 8+4 = 12.
+	// Accept a band around 8; must stay well below naive sum.
+	assert.Greater(t, result.Campaign.ActualPersonMonths, 7.0, "actual PM too small: %+v", result.Campaign)
+	assert.Less(t, result.Campaign.ActualPersonMonths, 9.5, "actual PM multi-counted (want ~8, got %.2f)", result.Campaign.ActualPersonMonths)
+
+	var sumProjectActual float64
+	for _, p := range result.Projects {
+		sumProjectActual += p.ActualPersonMonths
+	}
+	assert.Less(t, result.Campaign.ActualPersonMonths, sumProjectActual-0.5,
+		"campaign actual (%.2f) should be less than sum of project actuals (%.2f)",
+		result.Campaign.ActualPersonMonths, sumProjectActual)
+}
+
+// TestLeverage_AuthorAndByAuthorMutuallyExclusive guards the flag combination
+// that would otherwise re-apportion ownership-scaled estimates.
+func TestLeverage_AuthorAndByAuthorMutuallyExclusive(t *testing.T) {
+	if !sccAvailable {
+		t.Fatal("scc binary failed to build at container init time")
+	}
+
+	tc := GetSharedContainer(t)
+	root := setupLeverageCampaign(t, tc, "leverage-author-by-author")
+
+	output, err := tc.RunCampInDir(root, "leverage", "--author", "test@test.com", "--by-author")
+	require.Error(t, err, "expected mutual exclusion error: %s", output)
+	assert.Contains(t, output, "mutually exclusive", output)
+}


### PR DESCRIPTION
## Summary

`--author` was **overcounting actual effort** (summing each repo’s first→last commit span), which made personal leverage look artificially low (e.g. ~37x vs ~334x campaign) while COCOMO/LOC totals stayed identical.

### Root cause
- Personal actual PM = Σ(author span per project), including monorepo subprojects that share one `GitDir`
- Campaign aggregate skipped the deduped `CampaignActualPersonMonths` path whenever `--author` was set
- Estimated effort was not scaled by blame ownership

### Fix
- **Actual PM**: union of the author’s commit span across **unique git dirs** (not summed per project)
- **Estimated PM**: scale each project’s COCOMO by blame ownership fraction
- **`--author` expansion**: match `authors.json` identity groups (all emails)
- **`--by-author`**: report `est PM / union actual PM` per author (drops the old `weightedPM/campaignActual × campaignLeverage` formula)
- Docs + unit tests for multi-repo and monorepo dedupe

### Verified on obey-campaign (obey-chat-2 excluded)
| Mode | Actual PM | Full leverage |
|------|-----------|---------------|
| Default | ~14.4 | ~334x |
| `--author lance…` (before) | ~128 | ~37x |
| `--author lance…` (after) | ~14.7 | ~318x |

Personal leverage now tracks campaign leverage when the author owns nearly all remaining code.

Related explore: `workflow/explore/camp-leverage-scoring-audit-2026-07-21` (WI-a61e82)

## Test plan
- [x] `go test ./internal/leverage/ ./cmd/camp/leverage/`
- [x] Smoke: `camp leverage --json` vs `camp leverage --author <you> --json` on a multi-project campaign
- [x] Confirm personal `actual_person_months` ≈ campaign actual (not ~N×)
- [x] Confirm personal full leverage within ~band of campaign when sole majority author
- [ ] CI green on this PR