### PR TITLE
fix: restore Camp integration suite consistency

### DIFF
--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -293,6 +293,13 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 			BaseRef:       syncState.baseRef,
 			RefreshRemote: true,
 		}
+		// Reclaiming the default branch detaches its former worktree. Preserve
+		// that exact worktree during this prune pass: fresh created the detached
+		// state as a safe branch handoff, so it must not immediately classify
+		// the worktree as merged and remove it.
+		if syncState.reclaimed && syncState.worktreePath != "" {
+			pruneOpts.PreserveDetachedWorktrees = []string{syncState.worktreePath}
+		}
 		pr := prune.Execute(ctx, name, path, pruneOpts)
 		if pr.Error != "" {
 			return camperrors.Wrapf(errors.New(pr.Error), "prune merged branches")

--- a/internal/prune/prune.go
+++ b/internal/prune/prune.go
@@ -56,6 +56,12 @@ type Options struct {
 
 	// Remote name used when RefreshRemote is true. Empty means "origin".
 	RemoteName string
+
+	// PreserveDetachedWorktrees lists detached worktree paths that this prune
+	// pass must retain even when their commits are merged into BaseRef. This is
+	// used when a caller detached a worktree as part of the surrounding
+	// operation and must not immediately undo that work by deleting it.
+	PreserveDetachedWorktrees []string
 }
 
 // Result holds the outcome for a single branch.
@@ -279,6 +285,11 @@ func deleteDetachedWorktrees(ctx context.Context, path, baseRef string, opts Opt
 	}
 	if gitDir, err := git.Output(ctx, path, "rev-parse", "--absolute-git-dir"); err == nil {
 		skipPaths[filepath.Clean(gitDir)] = struct{}{}
+	}
+	for _, preserved := range opts.PreserveDetachedWorktrees {
+		if preserved = strings.TrimSpace(preserved); preserved != "" {
+			skipPaths[filepath.Clean(preserved)] = struct{}{}
+		}
 	}
 
 	removedAny := false

--- a/tests/integration/fresh_test.go
+++ b/tests/integration/fresh_test.go
@@ -530,8 +530,10 @@ git -C %[1]s worktree add %[2]s main
 	branchOnStuck := tc.GitOutput(t, stuckWT, "rev-parse", "--abbrev-ref", "HEAD")
 	require.Equal(t, "main", branchOnStuck, "precondition: stuck worktree should hold main")
 
-	// --no-prune so the reclaimed worktree is not removed after detach
-	// (prune deletes clean detached worktrees that match merged history).
+	// --no-prune keeps this test focused on the reclaim handoff itself. The
+	// reclaim-then-prune preservation contract (the detached worktree surviving
+	// the same run's prune pass) is locked by
+	// TestFresh_ReclaimedWorktreePreservedDuringPrune.
 	output, err := tc.RunCampInDir(projectDir, "fresh", "--no-branch", "--no-push", "--no-follow-up", "--no-prune")
 	require.NoError(t, err, "camp fresh should reclaim main:\n%s", output)
 	assert.Contains(t, output, "Free", "fresh should report freeing the default branch")
@@ -544,4 +546,62 @@ git -C %[1]s worktree add %[2]s main
 	// Occupying worktree was detached so main is free for the primary path.
 	stuck := tc.GitOutput(t, stuckWT, "rev-parse", "--abbrev-ref", "HEAD")
 	assert.Equal(t, "HEAD", stuck, "occupying worktree should be detached, got %s", stuck)
+}
+
+// TestFresh_ReclaimedWorktreePreservedDuringPrune locks the reclaim-then-prune
+// contract. Reclaiming the default branch detaches its former worktree at merged
+// history, so the same run's prune pass would immediately delete it unless fresh
+// preserves that exact path (PreserveDetachedWorktrees in fresh.go). With prune
+// ENABLED, the reclaimed worktree must survive while an unrelated merged detached
+// worktree is still removed. This fails without the preserve wiring.
+func TestFresh_ReclaimedWorktreePreservedDuringPrune(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-reclaim-prune"
+	_, projectDir, _ := setupFreshCampaignWithSubmodule(t, tc, name)
+
+	// Primary starts on a feature branch; main is held by a finished worktree.
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+git -C %[1]s checkout -b feature-active
+printf 'work\n' > %[1]s/feature.txt
+git -C %[1]s add .
+git -C %[1]s commit -m 'feature work'
+`, projectDir))
+
+	stuckWT := worktreePath(name, "stuck-main")
+	// A separate clean, merged, detached worktree that a normal prune removes.
+	// It is not the reclaimed path, so it must NOT be preserved.
+	mergedWT := worktreePath(name, "merged-detached")
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+git -C %[1]s worktree add %[2]s main
+git -C %[1]s worktree add --detach %[3]s main
+`, projectDir, stuckWT, mergedWT))
+
+	require.Equal(t, "main", tc.GitOutput(t, stuckWT, "rev-parse", "--abbrev-ref", "HEAD"),
+		"precondition: stuck worktree should hold main")
+	require.Equal(t, "HEAD", tc.GitOutput(t, mergedWT, "rev-parse", "--abbrev-ref", "HEAD"),
+		"precondition: sibling worktree should be detached")
+
+	// Prune ENABLED (no --no-prune): this is the exact path the fix protects.
+	output, err := tc.RunCampInDir(projectDir, "fresh", "--no-branch", "--no-push", "--no-follow-up")
+	require.NoError(t, err, "camp fresh should reclaim main with prune enabled:\n%s", output)
+
+	// Primary reclaimed main.
+	assert.Equal(t, "main", tc.GitOutput(t, projectDir, "rev-parse", "--abbrev-ref", "HEAD"),
+		"primary project path should hold main after fresh")
+
+	// The reclaimed (now detached) worktree must survive the prune pass.
+	stuckExists, err := tc.CheckDirExists(stuckWT)
+	require.NoError(t, err)
+	require.True(t, stuckExists, "reclaimed worktree must be preserved during prune, not deleted")
+	assert.Equal(t, "HEAD", tc.GitOutput(t, stuckWT, "rev-parse", "--abbrev-ref", "HEAD"),
+		"reclaimed worktree should remain detached after fresh")
+
+	// The unrelated merged detached worktree must still be pruned, proving the
+	// preserve list is scoped to the reclaimed path and does not disable prune.
+	mergedExists, err := tc.CheckDirExists(mergedWT)
+	require.NoError(t, err)
+	assert.False(t, mergedExists, "unrelated merged detached worktree should still be removed by prune")
 }

--- a/tests/integration/machine_discover_test.go
+++ b/tests/integration/machine_discover_test.go
@@ -52,7 +52,7 @@ exit 1
 
 // TestMachineAddDiscoverYes proves --discover --yes runs fully non-interactively
 // (no TTY in the container) by taking the first (sorted) discovered device and
-// writing it through machines.Save with auth_method=tailscale-ssh.
+// writing it through machines.Save with the OpenSSH default.
 func TestMachineAddDiscoverYes(t *testing.T) {
 	tc := GetSharedContainer(t)
 	installStubTailscale(t, tc)
@@ -64,20 +64,20 @@ func TestMachineAddDiscoverYes(t *testing.T) {
 	row, ok := findMachine(payload.Machines, "devbox")
 	require.True(t, ok, "devbox missing from list --json: %+v", payload.Machines)
 	require.Equal(t, "devbox.example-net.ts.net", row.Host)
-	require.Equal(t, "tailscale-ssh", row.AuthMethod)
-	require.Empty(t, row.SSHUser, "tailscale-ssh needs no ssh_user")
-	require.Empty(t, row.IdentityFile, "tailscale-ssh needs no identity_file")
+	require.Equal(t, "ssh-agent", row.AuthMethod)
+	require.Empty(t, row.SSHUser, "default OpenSSH discovery needs no ssh_user")
+	require.Empty(t, row.IdentityFile, "default OpenSSH discovery needs no identity_file")
 }
 
 // TestMachineAddDiscoverByID proves the positional-id selection path (picking a
-// discovered device by its derived id without the interactive picker) and that
-// re-running --discover against the same device updates in place rather than
-// duplicating — the same Upsert idempotency manual `add` gets.
+// discovered device by its derived id without the interactive picker), honors
+// an explicit auth override, and updates in place rather than duplicating on a
+// repeat run — the same Upsert idempotency manual `add` gets.
 func TestMachineAddDiscoverByID(t *testing.T) {
 	tc := GetSharedContainer(t)
 	installStubTailscale(t, tc)
 
-	out, err := tc.RunCamp("machine", "add", "--discover", "devbox")
+	out, err := tc.RunCamp("machine", "add", "--discover", "devbox", "--auth", "tailscale-ssh")
 	require.NoError(t, err, "machine add --discover devbox failed: %s", out)
 
 	payload := machineListJSON(t, tc)
@@ -85,7 +85,7 @@ func TestMachineAddDiscoverByID(t *testing.T) {
 	require.True(t, ok, "devbox missing from list --json: %+v", payload.Machines)
 	require.Equal(t, "tailscale-ssh", row.AuthMethod)
 
-	out, err = tc.RunCamp("machine", "add", "--discover", "devbox")
+	out, err = tc.RunCamp("machine", "add", "--discover", "devbox", "--auth", "tailscale-ssh")
 	require.NoError(t, err, "second machine add --discover devbox failed: %s", out)
 	payload = machineListJSON(t, tc)
 	count := 0


### PR DESCRIPTION
## Summary

- align machine-discovery integration expectations with the intentional `ssh-agent` default while retaining explicit `tailscale-ssh` coverage
- preserve the exact worktree `camp fresh` detaches while reclaiming the default branch
- continue pruning unrelated merged detached worktrees

## Root cause

The dual-auth change updated the CLI contract and unit coverage but left two older integration assertions expecting `tailscale-ssh`. Separately, the Fresh reclaim flow detached the worktree holding the default branch, after which the same run immediately classified that new detached worktree as merged and removed it.

## Validation

- original three failing integration tests pass
- adjacent machine-discovery and Fresh worktree-pruning regression cases pass
- `just gate-fast` passes, including stable/dev builds, vet, lint, and 3,669 unit tests
- full container integration suite passes: 537/537 tests in 449.86s
- `git diff --check` passes