### PR TITLE
feat(quest): optional workitem binding in quest create

### DIFF
--- a/cmd/camp/quest/create.go
+++ b/cmd/camp/quest/create.go
@@ -3,6 +3,7 @@
 package quest
 
 import (
+	"context"
 	"fmt"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -30,12 +31,20 @@ CAPTURE MODES:
   Non-interactive       Provide --no-editor or --description for agent use
   Deep (--edit)         Full YAML template in $EDITOR
 
+A quest may optionally be bound to a workitem at creation time. Pass
+--workitem <selector> to bind non-interactively (the selector accepts a
+workitem ref, stable id, key, path, directory slug, or festival id), or pick
+one from the optional binding step in the interactive TUI. The binding is
+stored exactly as "camp quest link" would store it, so it renders through
+"camp quest show" and "camp quest links" with no extra steps.
+
 Examples:
   camp quest create                                    Interactive TUI
   camp quest create q2-reliability                     TUI with name pre-filled
   camp quest create q2-reliability --no-editor --purpose "harden platform"
   camp quest create data-pipeline --description "..."  Non-interactive
-  camp quest create -e customer-onboarding             Deep capture with $EDITOR`,
+  camp quest create -e customer-onboarding             Deep capture with $EDITOR
+  camp quest create launch --no-editor --workitem SC0001  Bind a festival workitem`,
 	Args: cobra.MaximumNArgs(1),
 	Annotations: map[string]string{
 		"agent_allowed": "true",
@@ -54,6 +63,8 @@ func init() {
 	flags.Bool("no-editor", false, "Skip editor and create directly from flags")
 	flags.BoolP("edit", "e", false, "Open in $EDITOR for deep capture")
 	flags.Bool("no-commit", false, "Don't create a git commit")
+	flags.String("workitem", "", "Bind a workitem by selector (ref, id, key, path, slug, or festival id)")
+	_ = questCreateCmd.RegisterFlagCompletionFunc("workitem", completeWorkitemSelector)
 }
 
 func runQuestCreate(cmd *cobra.Command, args []string) error {
@@ -69,18 +80,30 @@ func runQuestCreate(cmd *cobra.Command, args []string) error {
 	noEditor, _ := cmd.Flags().GetBool("no-editor")
 	useEditor, _ := cmd.Flags().GetBool("edit")
 	noCommit, _ := cmd.Flags().GetBool("no-commit")
+	workitemSel, _ := cmd.Flags().GetString("workitem")
+
+	// Resolve the --workitem binding up-front so a bad selector fails before we
+	// open the TUI or create anything.
+	var boundPath string
+	if workitemSel != "" {
+		resolved, err := resolveWorkitemPath(ctx, workitemSel)
+		if err != nil {
+			return err
+		}
+		boundPath = resolved
+	}
 
 	// Non-interactive path: flags provide all data
 	if noEditor || description != "" {
 		if name == "" {
 			return camperrors.New("quest name is required in non-interactive mode (provide a name argument or run interactively)")
 		}
-		return createQuestDirect(cmd, name, purpose, description, tags, noCommit)
+		return createQuestDirect(cmd, name, purpose, description, tags, noCommit, boundPath)
 	}
 
 	// Deep capture: open $EDITOR on YAML template
 	if useEditor {
-		return createQuestWithEditor(cmd, name, purpose, description, tags, noCommit)
+		return createQuestWithEditor(cmd, name, purpose, description, tags, noCommit, boundPath)
 	}
 
 	// Interactive TUI path
@@ -88,10 +111,21 @@ func runQuestCreate(cmd *cobra.Command, args []string) error {
 		return camperrors.New("quest name is required in non-interactive mode (provide a name argument or run interactively)")
 	}
 
+	// Only offer the picker when the binding was not already fixed by the flag.
+	var choices []questtui.WorkitemChoice
+	if boundPath == "" {
+		if gathered, err := gatherWorkitemChoices(ctx); err == nil {
+			choices = gathered
+		} else {
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: workitem picker unavailable: %v\n", err)
+		}
+	}
+
 	model := questtui.NewQuestCreateModel(ctx, questtui.CreateOptions{
 		DefaultName:    name,
 		DefaultPurpose: purpose,
 		DefaultTags:    tags,
+		Choices:        choices,
 	})
 
 	p := tea.NewProgram(model, tea.WithAltScreen())
@@ -114,10 +148,13 @@ func runQuestCreate(cmd *cobra.Command, args []string) error {
 		return camperrors.New("quest creation cancelled")
 	}
 
-	return createQuestDirect(cmd, result.Name, result.Purpose, result.Description, result.Tags, noCommit)
+	if boundPath == "" {
+		boundPath = result.WorkitemPath
+	}
+	return createQuestDirect(cmd, result.Name, result.Purpose, result.Description, result.Tags, noCommit, boundPath)
 }
 
-func createQuestDirect(cmd *cobra.Command, name, purpose, description, tags string, noCommit bool) error {
+func createQuestDirect(cmd *cobra.Command, name, purpose, description, tags string, noCommit bool, boundPath string) error {
 	qctx, err := loadQuestCommandContext(cmd.Context(), true)
 	if err != nil {
 		return err
@@ -128,11 +165,13 @@ func createQuestDirect(cmd *cobra.Command, name, purpose, description, tags stri
 		return err
 	}
 
-	ledger.NewFromRoot(cmd.Context(), qctx.campaignRoot, ledger.WarnTo(cmd.ErrOrStderr())).
-		Emit(cmd.Context(), ledgerkit.KindCreated, ledgerkit.Scope{Quest: result.Quest.ID}, ledger.WithWhy(result.Quest.Name))
+	result, err = bindWorkitem(cmd.Context(), qctx, result, boundPath)
+	if err != nil {
+		return err
+	}
 
-	fmt.Printf("✓ Quest created: %s (%s)\n", result.Quest.Name, result.Quest.ID)
-	fmt.Printf("  %s\n", quest.RelativePath(qctx.campaignRoot, result.Quest.Path))
+	emitQuestCreated(cmd, qctx, result)
+	printQuestCreated(qctx, result, boundPath)
 
 	if !noCommit {
 		if err := autoCommitQuest(cmd.Context(), qctx, commit.QuestCreate, result, "Created quest"); err != nil {
@@ -142,7 +181,7 @@ func createQuestDirect(cmd *cobra.Command, name, purpose, description, tags stri
 	return nil
 }
 
-func createQuestWithEditor(cmd *cobra.Command, name, purpose, description, tags string, noCommit bool) error {
+func createQuestWithEditor(cmd *cobra.Command, name, purpose, description, tags string, noCommit bool, boundPath string) error {
 	if name == "" {
 		return camperrors.New("quest name is required for --edit mode (provide a name argument)")
 	}
@@ -157,11 +196,13 @@ func createQuestWithEditor(cmd *cobra.Command, name, purpose, description, tags 
 		return err
 	}
 
-	ledger.NewFromRoot(cmd.Context(), qctx.campaignRoot, ledger.WarnTo(cmd.ErrOrStderr())).
-		Emit(cmd.Context(), ledgerkit.KindCreated, ledgerkit.Scope{Quest: result.Quest.ID}, ledger.WithWhy(result.Quest.Name))
+	result, err = bindWorkitem(cmd.Context(), qctx, result, boundPath)
+	if err != nil {
+		return err
+	}
 
-	fmt.Printf("✓ Quest created: %s (%s)\n", result.Quest.Name, result.Quest.ID)
-	fmt.Printf("  %s\n", quest.RelativePath(qctx.campaignRoot, result.Quest.Path))
+	emitQuestCreated(cmd, qctx, result)
+	printQuestCreated(qctx, result, boundPath)
 
 	if !noCommit {
 		if err := autoCommitQuest(cmd.Context(), qctx, commit.QuestCreate, result, "Created quest"); err != nil {
@@ -169,4 +210,32 @@ func createQuestWithEditor(cmd *cobra.Command, name, purpose, description, tags 
 		}
 	}
 	return nil
+}
+
+// bindWorkitem links a resolved workitem path to a freshly created quest through
+// the same service path `camp quest link` uses (auto-detecting the link type).
+// It returns the post-link MutationResult so the binding lands in the same
+// create commit. A no-op when boundPath is empty.
+func bindWorkitem(ctx context.Context, qctx *questCommandContext, result *quest.MutationResult, boundPath string) (*quest.MutationResult, error) {
+	if boundPath == "" {
+		return result, nil
+	}
+	linked, err := qctx.service.Link(ctx, result.Quest.ID, boundPath, "")
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "quest created, but workitem binding failed for %s", boundPath)
+	}
+	return linked, nil
+}
+
+func emitQuestCreated(cmd *cobra.Command, qctx *questCommandContext, result *quest.MutationResult) {
+	ledger.NewFromRoot(cmd.Context(), qctx.campaignRoot, ledger.WarnTo(cmd.ErrOrStderr())).
+		Emit(cmd.Context(), ledgerkit.KindCreated, ledgerkit.Scope{Quest: result.Quest.ID}, ledger.WithWhy(result.Quest.Name))
+}
+
+func printQuestCreated(qctx *questCommandContext, result *quest.MutationResult, boundPath string) {
+	fmt.Printf("✓ Quest created: %s (%s)\n", result.Quest.Name, result.Quest.ID)
+	fmt.Printf("  %s\n", quest.RelativePath(qctx.campaignRoot, result.Quest.Path))
+	if boundPath != "" {
+		fmt.Printf("  bound workitem: %s\n", boundPath)
+	}
 }

--- a/cmd/camp/quest/workitem_binding.go
+++ b/cmd/camp/quest/workitem_binding.go
@@ -1,0 +1,110 @@
+//go:build dev
+
+package quest
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	"github.com/Obedience-Corp/camp/internal/pathutil"
+	questtui "github.com/Obedience-Corp/camp/internal/quest/tui"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/selector"
+)
+
+// resolveWorkitemPath resolves a --workitem selector to a campaign-relative
+// path using the same resolver family the workitem commands use (ref, stable
+// id, key, path, directory slug, festival id). It is called before any quest is
+// created so a bad selector fails fast without leaving an orphan quest.
+func resolveWorkitemPath(ctx context.Context, sel string) (string, error) {
+	_, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return "", camperrors.Wrap(err, "not in a campaign directory")
+	}
+	root, err = pathutil.ResolveRoot(root)
+	if err != nil {
+		return "", camperrors.Wrap(err, "resolving campaign root")
+	}
+	item, err := selector.Resolve(ctx, root, sel, selector.ResolveOptions{})
+	if err != nil {
+		return "", err
+	}
+	return item.RelativePath, nil
+}
+
+// gatherWorkitemChoices enumerates the workitems offered by the interactive
+// binding picker: the same active, non-dungeon set that `camp workitem` serves
+// (discovery never scans dungeon/completed directories), including festivals.
+func gatherWorkitemChoices(ctx context.Context) ([]questtui.WorkitemChoice, error) {
+	cfg, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "not in a campaign directory")
+	}
+	root, err = pathutil.ResolveRoot(root)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "resolving campaign root")
+	}
+
+	resolver := paths.NewResolverFromConfig(root, cfg)
+	items, err := wkitem.Discover(ctx, root, resolver)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "discovering workitems")
+	}
+	wkitem.Sort(items)
+
+	choices := make([]questtui.WorkitemChoice, 0, len(items))
+	for _, item := range items {
+		choices = append(choices, questtui.WorkitemChoice{
+			Path:  item.RelativePath,
+			Title: workitemChoiceTitle(item),
+			Ref:   workitemChoiceRef(item),
+			Type:  string(item.WorkflowType),
+		})
+	}
+	return choices, nil
+}
+
+func workitemChoiceTitle(item wkitem.WorkItem) string {
+	if item.Title != "" {
+		return item.Title
+	}
+	return filepath.Base(item.RelativePath)
+}
+
+func workitemChoiceRef(item wkitem.WorkItem) string {
+	if ref, ok := item.SourceMetadata["ref"].(string); ok && ref != "" {
+		return ref
+	}
+	return item.SourceID
+}
+
+// completeWorkitemSelector offers workitem refs, stable ids, directory slugs,
+// and festival ids as shell completions for the --workitem flag.
+func completeWorkitemSelector(cmd *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	choices, err := gatherWorkitemChoices(cmd.Context())
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	prefix := strings.ToLower(toComplete)
+	seen := map[string]struct{}{}
+	var matches []string
+	for _, choice := range choices {
+		for _, candidate := range []string{choice.Ref, filepath.Base(choice.Path)} {
+			if candidate == "" || !strings.HasPrefix(strings.ToLower(candidate), prefix) {
+				continue
+			}
+			if _, ok := seen[candidate]; ok {
+				continue
+			}
+			seen[candidate] = struct{}{}
+			matches = append(matches, candidate)
+		}
+	}
+	return matches, cobra.ShellCompDirectiveNoFileComp
+}

--- a/internal/quest/tui/create_model.go
+++ b/internal/quest/tui/create_model.go
@@ -22,6 +22,7 @@ const (
 	createStepPurpose
 	createStepDescription
 	createStepTags
+	createStepWorkitem
 	createStepDone
 )
 
@@ -30,6 +31,9 @@ type CreateOptions struct {
 	DefaultName    string
 	DefaultPurpose string
 	DefaultTags    string
+	// Choices are the workitems offered by the optional binding picker. When
+	// empty, the picker step is skipped entirely and the flow ends at tags.
+	Choices []WorkitemChoice
 }
 
 // CreateResult contains the collected quest data.
@@ -38,6 +42,9 @@ type CreateResult struct {
 	Purpose     string
 	Description string
 	Tags        string
+	// WorkitemPath is the campaign-relative path of the workitem the user chose
+	// to bind, or empty when the binding step was skipped.
+	WorkitemPath string
 }
 
 // editorFinishedMsg is sent when the external editor closes.
@@ -57,6 +64,7 @@ type QuestCreateModel struct {
 	purposeInput textinput.Model
 	tagsInput    textinput.Model
 	vimEditor    *vim.Editor
+	picker       workitemPicker
 
 	result    *CreateResult
 	cancelled bool
@@ -104,6 +112,7 @@ func NewQuestCreateModel(ctx context.Context, opts CreateOptions) QuestCreateMod
 		purposeInput: pi,
 		tagsInput:    ti,
 		vimEditor:    vimEd,
+		picker:       newWorkitemPicker(opts.Choices),
 	}
 }
 
@@ -127,6 +136,7 @@ func (m QuestCreateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.nameInput.Width = min(msg.Width-10, 80)
 		m.purposeInput.Width = min(msg.Width-10, 80)
 		m.tagsInput.Width = min(msg.Width-10, 80)
+		m.picker.setWidth(msg.Width)
 		w, h := m.calculateDescriptionSize()
 		m.vimEditor.SetSize(w, h)
 		return m, nil
@@ -152,6 +162,8 @@ func (m QuestCreateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateDescription(msg)
 		case createStepTags:
 			return m.updateTags(msg)
+		case createStepWorkitem:
+			return m.updateWorkitem(msg)
 		}
 	}
 
@@ -269,6 +281,11 @@ func (m QuestCreateModel) finish() (QuestCreateModel, tea.Cmd) {
 		Description: strings.TrimSpace(m.vimEditor.Content()),
 		Tags:        strings.TrimSpace(m.tagsInput.Value()),
 	}
+	if m.picker.active() {
+		m.step = createStepWorkitem
+		m.tagsInput.Blur()
+		return m, m.picker.filter.Focus()
+	}
 	m.step = createStepDone
 	return m, tea.Quit
 }
@@ -335,6 +352,8 @@ func (m QuestCreateModel) View() string {
 		b.WriteString(m.viewDescriptionStep())
 	case createStepTags:
 		b.WriteString(m.viewTagsStep())
+	case createStepWorkitem:
+		b.WriteString(m.picker.view())
 	}
 
 	return b.String()

--- a/internal/quest/tui/create_model_test.go
+++ b/internal/quest/tui/create_model_test.go
@@ -322,6 +322,88 @@ func TestQuestCreateModel_ResultIsNilWhenCancelled(t *testing.T) {
 	}
 }
 
+// advanceToTagsEnter walks name -> purpose -> description(skip) -> tags and
+// presses Enter at the tags step.
+func advanceToTagsEnter(m QuestCreateModel) QuestCreateModel {
+	m = typeText(m, "bound-quest")
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyEnter})     // purpose (empty)
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyCtrlS})     // skip description
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyEnter})     // tags Enter
+	return m
+}
+
+func TestQuestCreateModel_NoChoices_TagsEnterFinishesFast(t *testing.T) {
+	m := NewQuestCreateModel(context.Background(), CreateOptions{})
+	m = advanceToTagsEnter(m)
+
+	if m.step != createStepDone {
+		t.Fatalf("with no choices, tags Enter must finish; step = %v", m.step)
+	}
+	if r := m.Result(); r == nil || r.WorkitemPath != "" {
+		t.Fatalf("fast path must produce a result with no binding, got %+v", r)
+	}
+}
+
+func TestQuestCreateModel_WithChoices_TagsEnterOpensPicker(t *testing.T) {
+	m := NewQuestCreateModel(context.Background(), CreateOptions{Choices: sampleChoices()})
+	m = advanceToTagsEnter(m)
+
+	if m.step != createStepWorkitem {
+		t.Fatalf("with choices, tags Enter must open the picker; step = %v", m.step)
+	}
+	if m.Done() {
+		t.Fatal("model must not be done while the picker is open")
+	}
+}
+
+func TestQuestCreateModel_Picker_EscSkipsBinding(t *testing.T) {
+	m := NewQuestCreateModel(context.Background(), CreateOptions{Choices: sampleChoices()})
+	m = advanceToTagsEnter(m)
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyEsc})
+
+	if !m.Done() || m.Cancelled() {
+		t.Fatalf("Esc at picker must finish without cancel (done=%v cancelled=%v)", m.Done(), m.Cancelled())
+	}
+	r := m.Result()
+	if r == nil || r.WorkitemPath != "" {
+		t.Fatalf("Esc at picker must skip binding, got %+v", r)
+	}
+	if r.Name != "bound-quest" {
+		t.Fatalf("captured quest data must survive the skip, name = %q", r.Name)
+	}
+}
+
+func TestQuestCreateModel_Picker_CtrlCCancels(t *testing.T) {
+	m := NewQuestCreateModel(context.Background(), CreateOptions{Choices: sampleChoices()})
+	m = advanceToTagsEnter(m)
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyCtrlC})
+
+	if !m.Cancelled() {
+		t.Fatal("Ctrl+C at picker must cancel")
+	}
+	if m.Result() != nil {
+		t.Fatal("cancel must clear the result")
+	}
+}
+
+func TestQuestCreateModel_Picker_SelectBindsWorkitem(t *testing.T) {
+	m := NewQuestCreateModel(context.Background(), CreateOptions{Choices: sampleChoices()})
+	m = advanceToTagsEnter(m)
+
+	// Filter to a single match, then Enter selects it.
+	m = typeText(m, "billing")
+	m = sendKey(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if !m.Done() {
+		t.Fatal("selecting a workitem must finish the flow")
+	}
+	r := m.Result()
+	if r == nil || r.WorkitemPath != "workflow/design/billing-revamp" {
+		t.Fatalf("expected billing binding, got %+v", r)
+	}
+}
+
 func TestQuestCreateModel_FullFlow(t *testing.T) {
 	m := NewQuestCreateModel(context.Background(), CreateOptions{})
 

--- a/internal/quest/tui/styles.go
+++ b/internal/quest/tui/styles.go
@@ -25,4 +25,8 @@ var (
 
 	FieldValueStyle = lipgloss.NewStyle().
 			Foreground(pal.TextPrimary)
+
+	SelectedStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(pal.Accent)
 )

--- a/internal/quest/tui/workitem_picker.go
+++ b/internal/quest/tui/workitem_picker.go
@@ -214,7 +214,7 @@ func (p workitemPicker) view() string {
 	return b.String()
 }
 
-const noneRowLabel = "(none — skip binding)"
+const noneRowLabel = "(none - skip binding)"
 
 func (p workitemPicker) renderRow(cursorIndex int, text string) string {
 	if p.cursor == cursorIndex {

--- a/internal/quest/tui/workitem_picker.go
+++ b/internal/quest/tui/workitem_picker.go
@@ -1,0 +1,273 @@
+//go:build dev
+
+package tui
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Obedience-Corp/camp/internal/nav/fuzzy"
+)
+
+// maxPickerRows bounds how many workitem rows render at once. The "none" row is
+// always shown; matches beyond the window scroll into view around the cursor.
+const maxPickerRows = 8
+
+// WorkitemChoice is one selectable workitem in the create-flow picker. Path is
+// the campaign-relative value written to the quest as a Link (identical to what
+// `camp quest link` stores), so the binding renders through the existing
+// quest show / quest links surfaces unchanged.
+type WorkitemChoice struct {
+	Path  string
+	Title string
+	Ref   string
+	Type  string
+}
+
+func (c WorkitemChoice) label() string {
+	title := strings.TrimSpace(c.Title)
+	if title == "" {
+		title = c.Path
+	}
+	var b strings.Builder
+	b.WriteString(title)
+	if c.Ref != "" {
+		b.WriteString(" (")
+		b.WriteString(c.Ref)
+		b.WriteString(")")
+	}
+	if c.Type != "" {
+		b.WriteString(" [")
+		b.WriteString(c.Type)
+		b.WriteString("]")
+	}
+	return b.String()
+}
+
+func (c WorkitemChoice) searchText() string {
+	return c.Title + " " + c.Ref + " " + c.Type + " " + c.Path
+}
+
+// workitemPicker is a filterable list step for optionally binding a workitem at
+// quest-create time. Row 0 is always a "none / skip" row so the fast path is a
+// single Enter; typing narrows the list with fuzzy matching.
+type workitemPicker struct {
+	choices []WorkitemChoice
+	filter  textinput.Model
+
+	// visible holds indices into choices after the current filter, ordered by
+	// fuzzy score. cursor 0 is the skip row; cursor 1..len(visible) selects
+	// choices[visible[cursor-1]].
+	visible []int
+	cursor  int
+
+	done     bool
+	selected string
+}
+
+// updateWorkitem drives the optional binding step. Esc skips (finish with no
+// binding); Ctrl+C cancels the whole flow; everything else is the picker's own
+// filter/navigation/select handling. The result struct is already populated by
+// finish(), so this only records the chosen path.
+func (m QuestCreateModel) updateWorkitem(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		m.cancelled = true
+		m.result = nil
+		m.step = createStepDone
+		return m, tea.Quit
+	case "esc":
+		m.result.WorkitemPath = ""
+		m.step = createStepDone
+		return m, tea.Quit
+	}
+
+	var cmd tea.Cmd
+	m.picker, cmd = m.picker.update(msg)
+	if m.picker.done {
+		m.result.WorkitemPath = m.picker.selected
+		m.step = createStepDone
+		return m, tea.Quit
+	}
+	return m, cmd
+}
+
+func newWorkitemPicker(choices []WorkitemChoice) workitemPicker {
+	fi := textinput.New()
+	fi.Placeholder = "Type to filter by name, id, or festival"
+	fi.CharLimit = 120
+	fi.Width = 50
+	fi.Focus()
+
+	p := workitemPicker{choices: choices, filter: fi}
+	p.recompute()
+	return p
+}
+
+// active reports whether the picker has any candidates to offer.
+func (p workitemPicker) active() bool {
+	return len(p.choices) > 0
+}
+
+func (p *workitemPicker) setWidth(width int) {
+	p.filter.Width = min(max(width-10, 20), 80)
+}
+
+// update handles filter/navigation keys. Enter, Esc, and Ctrl+C are owned by the
+// parent model (select vs. skip vs. cancel), so they are not handled here.
+func (p workitemPicker) update(msg tea.KeyMsg) (workitemPicker, tea.Cmd) {
+	switch msg.String() {
+	case "enter":
+		p.done = true
+		if p.cursor > 0 && p.cursor-1 < len(p.visible) {
+			p.selected = p.choices[p.visible[p.cursor-1]].Path
+		} else {
+			p.selected = ""
+		}
+		return p, nil
+	case "up", "ctrl+p":
+		if p.cursor > 0 {
+			p.cursor--
+		}
+		return p, nil
+	case "down", "ctrl+n":
+		if p.cursor < len(p.visible) {
+			p.cursor++
+		}
+		return p, nil
+	}
+
+	prevQuery := p.filter.Value()
+	var cmd tea.Cmd
+	p.filter, cmd = p.filter.Update(msg)
+	if p.filter.Value() != prevQuery {
+		p.recompute()
+	}
+	return p, cmd
+}
+
+// recompute refilters the candidate list against the current query. When the
+// query is non-empty and produces matches, the cursor lands on the top match so
+// a single Enter selects it; an empty query keeps the cursor on the skip row.
+func (p *workitemPicker) recompute() {
+	query := strings.TrimSpace(p.filter.Value())
+	if query == "" {
+		p.visible = allIndices(len(p.choices))
+		p.cursor = 0
+		return
+	}
+
+	type scored struct {
+		idx   int
+		score int
+	}
+	var matches []scored
+	for i, choice := range p.choices {
+		if score, ok := fuzzyScore(query, choice.searchText()); ok {
+			matches = append(matches, scored{idx: i, score: score})
+		}
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		return matches[i].score > matches[j].score
+	})
+
+	p.visible = make([]int, len(matches))
+	for i, m := range matches {
+		p.visible[i] = m.idx
+	}
+	if len(p.visible) > 0 {
+		p.cursor = 1
+	} else {
+		p.cursor = 0
+	}
+}
+
+func (p workitemPicker) view() string {
+	var b strings.Builder
+	b.WriteString(FieldLabelStyle.Render("Bind a workitem (optional):"))
+	b.WriteString("\n")
+	b.WriteString(p.filter.View())
+	b.WriteString("\n\n")
+
+	b.WriteString(p.renderRow(0, noneRowLabel))
+	b.WriteString("\n")
+
+	start, end := windowBounds(p.cursor, len(p.visible), maxPickerRows)
+	if start > 0 {
+		b.WriteString(HelpStyle.Render("  ↑ more"))
+		b.WriteString("\n")
+	}
+	for i := start; i < end; i++ {
+		b.WriteString(p.renderRow(i+1, p.choices[p.visible[i]].label()))
+		b.WriteString("\n")
+	}
+	if end < len(p.visible) {
+		b.WriteString(HelpStyle.Render("  ↓ more"))
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(HelpStyle.Render("Type: filter • ↑↓: move • Enter: select • Esc: skip"))
+	return b.String()
+}
+
+const noneRowLabel = "(none — skip binding)"
+
+func (p workitemPicker) renderRow(cursorIndex int, text string) string {
+	if p.cursor == cursorIndex {
+		return SelectedStyle.Render("> " + text)
+	}
+	return FieldValueStyle.Render("  " + text)
+}
+
+func allIndices(n int) []int {
+	out := make([]int, n)
+	for i := range out {
+		out[i] = i
+	}
+	return out
+}
+
+// fuzzyScore requires every whitespace-separated term to match as a subsequence
+// of the target, summing per-term scores. Returns (0,false) when any term misses.
+func fuzzyScore(query, target string) (int, bool) {
+	terms := strings.Fields(query)
+	if len(terms) == 0 {
+		return 0, true
+	}
+	total := 0
+	for _, term := range terms {
+		score, _ := fuzzy.Score(term, target)
+		if score <= 0 {
+			return 0, false
+		}
+		total += score
+	}
+	return total, true
+}
+
+// windowBounds returns the [start,end) slice of a list of length n that keeps
+// the row at cursor (1-based over the list, 0 = skip row) visible within size.
+func windowBounds(cursor, n, size int) (int, int) {
+	if n <= size {
+		return 0, n
+	}
+	// cursor is 1-based over the visible list; convert to 0-based list index.
+	idx := cursor - 1
+	if idx < 0 {
+		idx = 0
+	}
+	start := idx - size/2
+	if start < 0 {
+		start = 0
+	}
+	end := start + size
+	if end > n {
+		end = n
+		start = end - size
+	}
+	return start, end
+}

--- a/internal/quest/tui/workitem_picker_test.go
+++ b/internal/quest/tui/workitem_picker_test.go
@@ -1,0 +1,144 @@
+//go:build dev
+
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func sampleChoices() []WorkitemChoice {
+	return []WorkitemChoice{
+		{Path: "festivals/planning/sync-clone-SC0001", Title: "Sync clone transport", Ref: "SC0001", Type: "festival"},
+		{Path: "workflow/design/billing-revamp", Title: "Billing revamp", Ref: "WI-abc123", Type: "design"},
+		{Path: ".campaign/intents/active/telemetry", Title: "Telemetry intent", Ref: "WI-def456", Type: "intent"},
+	}
+}
+
+func typePicker(p workitemPicker, text string) workitemPicker {
+	for _, r := range text {
+		p, _ = p.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	return p
+}
+
+func TestWorkitemPicker_NoChoicesIsInactive(t *testing.T) {
+	p := newWorkitemPicker(nil)
+	if p.active() {
+		t.Fatal("picker with no choices must be inactive")
+	}
+}
+
+func TestWorkitemPicker_NoMatchKeepsSkipRow(t *testing.T) {
+	p := newWorkitemPicker(sampleChoices())
+	p = typePicker(p, "zzznomatch")
+	if len(p.visible) != 0 {
+		t.Fatalf("expected no matches, got %d", len(p.visible))
+	}
+	if p.cursor != 0 {
+		t.Fatalf("cursor must rest on skip row with no matches, got %d", p.cursor)
+	}
+
+	p, _ = p.update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !p.done {
+		t.Fatal("enter should finish the picker")
+	}
+	if p.selected != "" {
+		t.Fatalf("no-match enter must skip, got %q", p.selected)
+	}
+}
+
+func TestWorkitemPicker_FilterNarrowsAndSelectsTopMatch(t *testing.T) {
+	p := newWorkitemPicker(sampleChoices())
+	p = typePicker(p, "billing")
+
+	if len(p.visible) != 1 {
+		t.Fatalf("expected 1 match for 'billing', got %d", len(p.visible))
+	}
+	if p.cursor != 1 {
+		t.Fatalf("non-empty query with matches should land cursor on first match, got %d", p.cursor)
+	}
+
+	p, _ = p.update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !p.done || p.selected != "workflow/design/billing-revamp" {
+		t.Fatalf("selected = %q (done=%v), want billing path", p.selected, p.done)
+	}
+}
+
+func TestWorkitemPicker_FiltersByFestivalID(t *testing.T) {
+	p := newWorkitemPicker(sampleChoices())
+	p = typePicker(p, "SC0001")
+	if len(p.visible) != 1 {
+		t.Fatalf("expected 1 match for festival id, got %d", len(p.visible))
+	}
+	p, _ = p.update(tea.KeyMsg{Type: tea.KeyEnter})
+	if p.selected != "festivals/planning/sync-clone-SC0001" {
+		t.Fatalf("selected = %q, want festival path", p.selected)
+	}
+}
+
+func TestWorkitemPicker_EmptyQueryDefaultsToSkip(t *testing.T) {
+	p := newWorkitemPicker(sampleChoices())
+	if p.cursor != 0 {
+		t.Fatalf("empty query must default cursor to skip row, got %d", p.cursor)
+	}
+	if len(p.visible) != 3 {
+		t.Fatalf("empty query shows all choices, got %d", len(p.visible))
+	}
+
+	p, _ = p.update(tea.KeyMsg{Type: tea.KeyEnter})
+	if p.selected != "" {
+		t.Fatalf("enter on default skip row must skip, got %q", p.selected)
+	}
+}
+
+func TestWorkitemPicker_NavigationClampsToBounds(t *testing.T) {
+	p := newWorkitemPicker(sampleChoices())
+	// Up from the skip row stays at 0.
+	p, _ = p.update(tea.KeyMsg{Type: tea.KeyUp})
+	if p.cursor != 0 {
+		t.Fatalf("up from skip row must clamp to 0, got %d", p.cursor)
+	}
+	// Down past the last row clamps at len(visible).
+	for i := 0; i < 10; i++ {
+		p, _ = p.update(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if p.cursor != len(p.visible) {
+		t.Fatalf("cursor must clamp to %d, got %d", len(p.visible), p.cursor)
+	}
+}
+
+func TestWorkitemPicker_ViewShowsSkipRowAndHelp(t *testing.T) {
+	p := newWorkitemPicker(sampleChoices())
+	view := p.view()
+	if !strings.Contains(view, noneRowLabel) {
+		t.Error("view must render the skip row")
+	}
+	if !strings.Contains(view, "Esc: skip") {
+		t.Error("view must document the skip action")
+	}
+}
+
+func TestWindowBounds(t *testing.T) {
+	tests := []struct {
+		name              string
+		cursor, n, size   int
+		wantStart, wantEnd int
+	}{
+		{"fits", 0, 3, 8, 0, 3},
+		{"top", 1, 20, 8, 0, 8},
+		{"middle", 10, 20, 8, 5, 13},
+		{"bottom", 20, 20, 8, 12, 20},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end := windowBounds(tt.cursor, tt.n, tt.size)
+			if start != tt.wantStart || end != tt.wantEnd {
+				t.Fatalf("windowBounds(%d,%d,%d) = (%d,%d), want (%d,%d)",
+					tt.cursor, tt.n, tt.size, start, end, tt.wantStart, tt.wantEnd)
+			}
+		})
+	}
+}

--- a/tests/integration/quest_create_workitem_test.go
+++ b/tests/integration/quest_create_workitem_test.go
@@ -1,0 +1,131 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// questShowResult mirrors the quest show --json payload enough to read the
+// bound workitem link back out.
+type questShowResult struct {
+	Quest struct {
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Links []struct {
+			Path string `json:"path"`
+			Type string `json:"type"`
+		} `json:"links"`
+	} `json:"quest"`
+}
+
+func setupBindingCampaign(t *testing.T, path string) *TestContainer {
+	t.Helper()
+	tc := GetSharedContainer(t)
+	_, err := tc.InitCampaign(path, "quest-binding", "product")
+	require.NoError(t, err)
+	return tc
+}
+
+// TestQuestCreate_WorkitemBinding_BadSelectorFailsFast asserts a bad --workitem
+// selector errors before any quest is written (no orphan quest).
+func TestQuestCreate_WorkitemBinding_BadSelectorFailsFast(t *testing.T) {
+	path := "/campaigns/quest-bind-badsel"
+	tc := setupBindingCampaign(t, path)
+
+	out, err := tc.RunCampInDir(path, "quest", "create", "orphan",
+		"--no-editor", "--workitem", "does-not-exist", "--no-commit")
+	require.Error(t, err, "bad selector must fail: %s", out)
+	assert.Contains(t, out, "does-not-exist")
+
+	// The quest must not have been created.
+	showOut, showErr := tc.RunCampInDir(path, "quest", "show", "orphan", "--json")
+	require.Error(t, showErr, "orphan quest must not exist: %s", showOut)
+}
+
+// TestQuestCreate_WorkitemBinding_BySlug binds a workitem selected by directory
+// slug and verifies it renders through quest show/links with no extra steps.
+func TestQuestCreate_WorkitemBinding_BySlug(t *testing.T) {
+	path := "/campaigns/quest-bind-slug"
+	tc := setupBindingCampaign(t, path)
+
+	wcOut, err := tc.RunCampInDir(path, "workitem", "create", "billing-redesign",
+		"--type", "design", "--title", "Billing redesign")
+	require.NoError(t, err, wcOut)
+
+	createOut, err := tc.RunCampInDir(path, "quest", "create", "launch",
+		"--no-editor", "--purpose", "Q3 launch", "--workitem", "billing-redesign", "--no-commit")
+	require.NoError(t, err, createOut)
+	assert.Contains(t, createOut, "bound workitem:")
+	assert.Contains(t, createOut, "workflow/design/billing-redesign")
+
+	showOut, err := tc.RunCampInDir(path, "quest", "show", "launch", "--json")
+	require.NoError(t, err, showOut)
+
+	var show questShowResult
+	require.NoError(t, json.Unmarshal([]byte(showOut), &show), "show --json: %s", showOut)
+	require.Len(t, show.Quest.Links, 1, "expected exactly one bound link: %s", showOut)
+	assert.Contains(t, show.Quest.Links[0].Path, "workflow/design/billing-redesign")
+	assert.Equal(t, "design", show.Quest.Links[0].Type, "auto-detected link type for a design workitem")
+
+	// quest links renders the same binding.
+	linksOut, err := tc.RunCampInDir(path, "quest", "links", "launch", "--json")
+	require.NoError(t, err, linksOut)
+	assert.Contains(t, linksOut, "workflow/design/billing-redesign")
+}
+
+// TestQuestCreate_WorkitemBinding_ByPath binds a workitem selected by its
+// campaign-relative path, the same resolver family the workitem commands use.
+func TestQuestCreate_WorkitemBinding_ByPath(t *testing.T) {
+	path := "/campaigns/quest-bind-path"
+	tc := setupBindingCampaign(t, path)
+
+	wcOut, err := tc.RunCampInDir(path, "workitem", "create", "search-index",
+		"--type", "feature", "--title", "Search index")
+	require.NoError(t, err, wcOut)
+
+	createOut, err := tc.RunCampInDir(path, "quest", "create", "indexing",
+		"--no-editor", "--workitem", "workflow/feature/search-index", "--no-commit")
+	require.NoError(t, err, createOut)
+
+	showOut, err := tc.RunCampInDir(path, "quest", "show", "indexing", "--json")
+	require.NoError(t, err, showOut)
+	var show questShowResult
+	require.NoError(t, json.Unmarshal([]byte(showOut), &show), "show --json: %s", showOut)
+	require.Len(t, show.Quest.Links, 1, "expected one bound link: %s", showOut)
+	assert.Contains(t, show.Quest.Links[0].Path, "workflow/feature/search-index")
+}
+
+// TestQuestCreate_WorkitemBinding_CommittedInCreateCommit asserts the binding is
+// written into the same create commit and leaves no dirty quest file behind.
+func TestQuestCreate_WorkitemBinding_CommittedInCreateCommit(t *testing.T) {
+	path := "/campaigns/quest-bind-commit"
+	tc := setupBindingCampaign(t, path)
+
+	wcOut, err := tc.RunCampInDir(path, "workitem", "create", "telemetry",
+		"--type", "design", "--title", "Telemetry")
+	require.NoError(t, err, wcOut)
+
+	createOut, err := tc.RunCampInDir(path, "quest", "create", "observability",
+		"--no-editor", "--workitem", "telemetry")
+	require.NoError(t, err, createOut)
+
+	// The binding is present (proves the link was saved).
+	showOut, err := tc.RunCampInDir(path, "quest", "show", "observability", "--json")
+	require.NoError(t, err, showOut)
+	var show questShowResult
+	require.NoError(t, json.Unmarshal([]byte(showOut), &show), "show --json: %s", showOut)
+	require.Len(t, show.Quest.Links, 1, "expected one bound link: %s", showOut)
+
+	// No quest.yaml remains uncommitted: the link landed in the create commit.
+	statusOut, exitCode, err := tc.ExecCommand("sh", "-c",
+		"cd "+path+" && git status --porcelain")
+	require.NoError(t, err)
+	require.Zero(t, exitCode, statusOut)
+	assert.NotContains(t, statusOut, ".campaign/quests",
+		"quest binding must be committed, not left dirty: %q", statusOut)
+}


### PR DESCRIPTION
## Summary

`camp quest create` gains an optional workitem binding at creation time, on both
surfaces:

- **Non-interactive:** a new `--workitem <selector>` flag.
- **Interactive TUI:** an optional final picker step where you fuzzy-search
  workitems and bind one, or skip.

A quest can now be created for a workitem, making the binding an optional part of
the quest lifecycle. This is dev-profile only (all `quest` commands are
`//go:build dev`); the stable command surface is unchanged.

## The flow

**Flag path.** `--workitem <selector>` resolves through the exact same resolver
family the workitem commands use (`internal/workitem/selector.Resolve`): workitem
ref (`WI-<hex>`), stable `.workitem` id, key, campaign-relative path, directory
slug, and festival id. The selector is resolved up-front in `runQuestCreate`
before any quest is written, so a bad selector fails fast and never leaves an
orphan quest.

**Picker path.** When no `--workitem` flag is supplied and stdout is a TTY, the
interactive create flow (name -> purpose -> description -> tags) gains one more
optional step. The command layer discovers candidates and injects them into the
model, so the model stays pure and testable. The picker fuzzy-filters on title,
ref, workflow type, and path using the house `internal/nav/fuzzy` scorer, and
renders with the existing quest TUI styles.

## Storage shape (reuses the existing representation exactly)

The binding is written through the same service path `camp quest link` uses:
`quest.Service.Link(ctx, questID, path, "")` (`internal/quest/service.go:387`),
which appends a `Link{Path, Type, AddedAt}` (`internal/quest/types.go:37`) with
the type auto-detected from the path (`quest.DetectLinkType`,
`internal/quest/link.go:18`). The bound path is the workitem's campaign-relative
`RelativePath` (`internal/workitem/model.go:40`).

Because it is the identical `Link` representation, `camp quest show` and
`camp quest links` render the binding with **zero changes** (verified below). I
deliberately did not introduce a second quest-workitem representation. Note there
are two other, unrelated conventions in the codebase that I did **not** use here:
the workitem-side `quest_id` capture (`internal/commands/workitem/ref_quest.go`)
and the checklist-item `link-workitem` stored-id join
(`cmd/camp/quest` checklist commands). Neither is rendered by `quest show` /
`quest links`, and the task called for the quest-level `quest link`
representation, so that is what this uses.

The link goes into the **same create commit**: after `service.Create`, the
binding is applied with `service.Link` and the post-link `MutationResult` (which
carries the updated `quest.yaml` in its `Files`) is what the existing
`autoCommitQuest` commits.

## Which workitems the picker offers, and why

The picker offers the same set `camp workitem` / `camp wi` serves:
`workitem.Discover(ctx, root, resolver)` sorted by `workitem.Sort`. Discovery
only scans the active surfaces (intents inbox/active/ready, design/explore
active, festivals planning/ready/active/ritual/chains); it never scans
dungeon/completed directories, so the candidate set is inherently active and
non-dungeon, and it includes festivals. Every discovered item is offered; the
fuzzy filter narrows from there. This keeps the picker consistent with what the
rest of the CLI already treats as "current work" rather than inventing a separate
filter.

## Skip / no-friction behavior

Per the standing no-init-friction constraint:

- The picker only appears when candidate workitems exist. A campaign with none
  keeps the exact prior four-step flow.
- The `--no-editor` / flags-only fast path never enters the TUI, so it is exactly
  as fast as before.
- The picker's first row is always `(none - skip binding)` and is the default
  cursor position on an empty filter, so a single **Enter** skips. **Esc** also
  skips. Only when you type a query do results appear and the cursor lands on the
  top match, so **Enter** then selects it. `Ctrl+C` cancels the whole flow.

## PTY verification

Green unit tests do not verify a TUI, so I drove the real dev binary in a pty
(pyte VT100 emulator, `pty.fork()`, `TIOCSWINSZ` set so bubbletea pads frames)
against a throwaway fixture campaign under a fake `HOME` with three seeded
workitems. Both render and write were verified.

Picker opened (cursor defaults to the skip row):

```
Bind a workitem (optional):
> Type to filter by name, id, or festival

> (none - skip binding)
  Telemetry pipeline (WI-438437) [design]
  Search index revamp (WI-b96176) [feature]
  Billing redesign (WI-870fe7) [design]

Type: filter | up/down: move | Enter: select | Esc: skip
```

After typing `billing` (list narrows to one match, cursor moves to it):

```
Bind a workitem (optional):
> billing

  (none - skip binding)
> Billing redesign (WI-870fe7) [design]
```

After Enter (write confirmation):

```
Quest created: pty-final (qst_20260723_u3489z)
  .campaign/quests/20260723-pty-final/quest.yaml
  bound workitem: workflow/design/billing-redesign
```

Write verified separately by reading the created `quest.yaml` and via
`quest show --json` (same shape a non-interactive create produces):

```yaml
links:
    - path: workflow/design/billing-redesign
      type: design
      added_at: 2026-07-23T22:53:52.469928Z
```

```json
"links": [
  { "path": "workflow/design/billing-redesign", "type": "design", "added_at": "..." }
]
```

Skip via Enter on the none row and skip via Esc both produced a quest with
`links: None` (no binding). A bad `--workitem` selector produced
`Error: no workitem matched selector nope-nothing` (exit 1) and the quest was
absent from `quest list`, confirming fail-fast with no orphan.

## Real CLI output (non-interactive)

```
$ camp quest create ni-slug --no-editor --purpose "Q3 launch" --workitem billing-redesign --no-commit
Quest created: ni-slug (qst_20260723_3bdvfs)
  .campaign/quests/20260723-ni-slug/quest.yaml
  bound workitem: workflow/design/billing-redesign

$ camp quest create ni-orphan --no-editor --workitem nope-nothing --no-commit
Error: no workitem matched selector nope-nothing: validation error on selector: not found
```

## Test coverage

- `internal/quest/tui/workitem_picker_test.go` (new): picker logic - inactive
  with no choices, empty query defaults to skip, filter narrows and selects the
  top match, filter by festival id, no-match keeps the skip row, navigation
  clamps to bounds, view renders skip row + help, `windowBounds` scrolling.
- `internal/quest/tui/create_model_test.go` (extended): fast path finishes at
  tags when there are no choices; tags Enter opens the picker when choices exist;
  Esc skips (binding empty, captured quest data preserved); Ctrl+C cancels
  (result cleared); selecting a workitem sets `WorkitemPath`.
- `tests/integration/quest_create_workitem_test.go` (new, `//go:build
  integration`): bind by slug (asserts one `design` link via `quest show --json`
  and via `quest links --json`), bind by path, bad-selector fail-fast (no orphan
  quest), and binding committed in the create commit (clean `git status`, nothing
  dirty under `.campaign/quests`). Error cases first, table-driven where it fits.

## Gates

- `just test unit`: 3637/3637 passed (standard gate; runs without the `dev` tag
  so dev-gated packages are covered separately below).
- `go test -tags dev ./...`: all pass (covers `internal/quest/tui` and
  `cmd/camp/quest`).
- `just lint`: `0 issues` (ratchet vs origin/main); no `fmt.Errorf` regressions;
  no host-fs test violators. My new files add zero lint findings.
- `go build ./...` (stable) and `go build -tags dev ./...` both clean.
- `just test integration-run TestQuestCreate_WorkitemBinding`: 4/4 passed.

## Where reality differed from the task description

- `internal/workitem/selector/festival.go` does **not** exist. Festival
  resolution is folded into `selector.go` as the `festival_id` matcher (matches
  `fest.yaml` metadata id via `WorkItem.SourceID`); there is a
  `selector/festival_test.go` but no `festival.go`. Festival selectors resolve by
  **id** (e.g. `SC0001`); festival name resolution is not a distinct matcher
  today. The picker still lets you fuzzy-search by festival name because it
  filters on the workitem title.
- `camp quest create` does not support `--json`, so there is no create JSON
  contract to capture; the binding surfaces in `quest show --json` /
  `quest links --json`, whose real output is shown above.

## Tradeoffs and deferred

- **Path-based binding.** Like every other quest `Link`, the binding stores a
  campaign-relative path, so it goes stale if the workitem is later moved or
  renamed. Storing a stable workitem id instead would survive moves, but that is
  a different representation that `quest show` / `quest links` do not render, and
  the task called for reusing the `quest link` shape unchanged. Left as a
  possible future enhancement.
- **Link type for custom workflow types.** `DetectLinkType` recognizes intent /
  design / explore / festival / project and falls back to `document` for anything
  else (for example a `feature` workitem under `workflow/feature/`). This matches
  exactly what `camp quest link <path>` does today; I did not diverge the type
  vocabulary. Called out so it is a deliberate choice, not an oversight.
- The picker filter uses subsequence fuzzy scoring per whitespace-separated term
  (all terms must match). Deliberately simple and predictable; no ranking config
  exposed.
