### PR TITLE
feat(workitem): add camp workitem rename verb

### DIFF
--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -94,6 +94,7 @@ var manifestAgentAllowedReasons = map[string]string{
 	"workitem group":             "Non-interactive group update with explicit selector",
 	"workitem priority":          "Non-interactive priority update with explicit selector",
 	"workitem promote":           "Non-interactive promote fully specified by --target and flags",
+	"workitem rename":            "Non-interactive rename fully specified by positional args and flags",
 	"workitem repair":            "Idempotent, non-destructive marker repair with --json and --dry-run",
 	"workitem resolve":           "Read-only workitem context resolution",
 	"workitem stage":             "Non-interactive attention-stage update with explicit selector",

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -7567,6 +7567,47 @@ camp workitem promote [id] --target <target> [flags]
 ```
 ---
 
+## camp workitem rename
+
+Rename a workitem and repair references
+
+### Synopsis
+
+Rename the workitem matched by <selector> so its directory (or file)
+basename becomes <new-name>. Identity is preserved: the stable id, ref, title,
+type, and lifecycle status do not change; only the path basename moves.
+
+References are repaired in the same commit as the move:
+  - relative markdown links pointing at the workitem are rewritten
+  - the workitem link registry (links.yaml) key and any scope paths under the
+    renamed directory are updated
+  - manual priority and attention-stage entries are re-keyed on disk
+  - the current-workitem pointer is updated when it referenced the old path key
+
+Festivals and intents are managed by their own tooling and cannot be renamed
+here. For file workitems, pass the full new filename; the original extension is
+kept when omitted.
+
+```
+camp workitem rename <selector> <new-name> [flags]
+```
+
+### Options
+
+```
+      --dry-run     Print the planned rename, change nothing
+  -h, --help        help for rename
+      --json        Output result as a single JSON object
+      --no-commit   Skip the auto-commit
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
 ## camp workitem repair
 
 Repair a workflow directory into a workitem

--- a/docs/cli-reference/camp_workitem.md
+++ b/docs/cli-reference/camp_workitem.md
@@ -59,6 +59,7 @@ camp workitem [flags]
 * [camp workitem list](camp_workitem_list.md)	 - List or browse filtered workitems
 * [camp workitem priority](camp_workitem_priority.md)	 - Set or clear the manual priority
 * [camp workitem promote](camp_workitem_promote.md)	 - Promote a workitem to a festival, doc, or dungeon
+* [camp workitem rename](camp_workitem_rename.md)	 - Rename a workitem and repair references
 * [camp workitem repair](camp_workitem_repair.md)	 - Repair a workflow directory into a workitem
 * [camp workitem resolve](camp_workitem_resolve.md)	 - Print the workitem for the current context
 * [camp workitem stage](camp_workitem_stage.md)	 - Set or clear the attention stage

--- a/docs/cli-reference/camp_workitem_rename.md
+++ b/docs/cli-reference/camp_workitem_rename.md
@@ -1,0 +1,43 @@
+## camp workitem rename
+
+Rename a workitem and repair references
+
+### Synopsis
+
+Rename the workitem matched by <selector> so its directory (or file)
+basename becomes <new-name>. Identity is preserved: the stable id, ref, title,
+type, and lifecycle status do not change; only the path basename moves.
+
+References are repaired in the same commit as the move:
+  - relative markdown links pointing at the workitem are rewritten
+  - the workitem link registry (links.yaml) key and any scope paths under the
+    renamed directory are updated
+  - manual priority and attention-stage entries are re-keyed on disk
+  - the current-workitem pointer is updated when it referenced the old path key
+
+Festivals and intents are managed by their own tooling and cannot be renamed
+here. For file workitems, pass the full new filename; the original extension is
+kept when omitted.
+
+```
+camp workitem rename <selector> <new-name> [flags]
+```
+
+### Options
+
+```
+      --dry-run     Print the planned rename, change nothing
+  -h, --help        help for rename
+      --json        Output result as a single JSON object
+      --no-commit   Skip the auto-commit
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/internal/commands/workitem/json_contract.go
+++ b/internal/commands/workitem/json_contract.go
@@ -25,4 +25,6 @@ const (
 	WorkitemRepairJSONVersion = "workitem-repair/v1alpha1"
 	// WorkitemGatherJSONVersion is the schema version of camp gather <type> --json.
 	WorkitemGatherJSONVersion = "workitem-gather/v1alpha1"
+	// WorkitemRenameJSONVersion is the schema version of camp workitem rename --json.
+	WorkitemRenameJSONVersion = "workitem-rename/v1alpha1"
 )

--- a/internal/commands/workitem/rename.go
+++ b/internal/commands/workitem/rename.go
@@ -1,0 +1,259 @@
+package workitem
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/jsoncontract"
+	"github.com/Obedience-Corp/camp/internal/pathutil"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+type runWorkitemRenameOptions struct {
+	Selector string
+	NewName  string
+	DryRun   bool
+	NoCommit bool
+	JSON     bool
+}
+
+type workitemRenameResult struct {
+	ID             string   `json:"id"`
+	Key            string   `json:"key"`
+	Type           string   `json:"type"`
+	ItemKind       string   `json:"item_kind"`
+	From           string   `json:"from"`
+	To             string   `json:"to"`
+	Committed      bool     `json:"committed"`
+	CommitMessage  string   `json:"commit_message,omitempty"`
+	LinksUpdated   bool     `json:"links_updated"`
+	PriorityMoved  bool     `json:"priority_migrated"`
+	CurrentUpdated bool     `json:"current_updated"`
+	RewrittenFiles []string `json:"rewritten_files,omitempty"`
+	Warnings       []string `json:"warnings,omitempty"`
+}
+
+// renamePlan is the validated, side-effect-free description of a rename,
+// computed before any filesystem mutation runs.
+type renamePlan struct {
+	item    *wkitem.WorkItem
+	srcPath string
+	dstPath string
+	oldRel  string
+	newRel  string
+	oldKey  string
+	newKey  string
+	isFile  bool
+}
+
+func newRenameCommand() *cobra.Command {
+	var (
+		dryRun   bool
+		noCommit bool
+		jsonOut  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "rename <selector> <new-name>",
+		Short: "Rename a workitem and repair references",
+		Long: `Rename the workitem matched by <selector> so its directory (or file)
+basename becomes <new-name>. Identity is preserved: the stable id, ref, title,
+type, and lifecycle status do not change; only the path basename moves.
+
+References are repaired in the same commit as the move:
+  - relative markdown links pointing at the workitem are rewritten
+  - the workitem link registry (links.yaml) key and any scope paths under the
+    renamed directory are updated
+  - manual priority and attention-stage entries are re-keyed on disk
+  - the current-workitem pointer is updated when it referenced the old path key
+
+Festivals and intents are managed by their own tooling and cannot be renamed
+here. For file workitems, pass the full new filename; the original extension is
+kept when omitted.`,
+		Args: jsoncontract.Args(WorkitemRenameJSONVersion, func() bool { return jsonOut }, cobra.ExactArgs(2)),
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Fully specified by positional args and flags; no interactive prompts",
+		},
+		RunE: jsoncontract.RunE(WorkitemRenameJSONVersion, func() bool { return jsonOut }, func(cmd *cobra.Command, args []string) error {
+			return runWorkitemRename(cmd, runWorkitemRenameOptions{
+				Selector: args[0],
+				NewName:  args[1],
+				DryRun:   dryRun,
+				NoCommit: noCommit,
+				JSON:     jsonOut,
+			})
+		}),
+	}
+	cmd.SetFlagErrorFunc(jsoncontract.FlagErrorFunc(WorkitemRenameJSONVersion, func() bool { return jsonOut }))
+
+	f := cmd.Flags()
+	f.BoolVar(&dryRun, "dry-run", false, "Print the planned rename, change nothing")
+	f.BoolVar(&noCommit, "no-commit", false, "Skip the auto-commit")
+	f.BoolVar(&jsonOut, "json", false, "Output result as a single JSON object")
+	return cmd
+}
+
+func runWorkitemRename(cmd *cobra.Command, opts runWorkitemRenameOptions) error {
+	ctx := cmd.Context()
+
+	cfg, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	plan, err := planRename(ctx, root, opts)
+	if err != nil {
+		return err
+	}
+
+	result := workitemRenameResult{
+		ID:       plan.item.StableID,
+		Key:      plan.newKey,
+		Type:     string(plan.item.WorkflowType),
+		ItemKind: string(plan.item.ItemKind),
+		From:     filepath.ToSlash(plan.oldRel),
+		To:       filepath.ToSlash(plan.newRel),
+	}
+
+	if opts.DryRun {
+		if opts.JSON {
+			return emitRenameJSON(cmd.OutOrStdout(), result)
+		}
+		_, err := fmt.Fprintf(cmd.OutOrStdout(),
+			"dry-run: would rename workitem %s (%s) to %s\n",
+			filepath.Base(plan.oldRel), plan.item.ItemKind, filepath.ToSlash(plan.newRel))
+		return err
+	}
+
+	return applyRename(ctx, cmd, cfg, root, plan, opts, result)
+}
+
+// planRename resolves the selector, validates the new name, and computes the
+// source/destination paths and keys without touching the filesystem.
+func planRename(ctx context.Context, root string, opts runWorkitemRenameOptions) (*renamePlan, error) {
+	if err := pathutil.ValidateSegment("new-name", opts.NewName); err != nil {
+		return nil, err
+	}
+
+	item, err := resolveSelector(ctx, root, opts.Selector, false)
+	if err != nil {
+		return nil, err
+	}
+	if item.RelativePath == "" {
+		return nil, camperrors.New("resolved workitem has no path on disk")
+	}
+	if err := ensureRenamable(item); err != nil {
+		return nil, err
+	}
+
+	oldRel := filepath.Clean(item.RelativePath)
+	isFile := item.ItemKind == wkitem.ItemKindFile
+	newBase, err := renameBasename(opts.NewName, oldRel, isFile)
+	if err != nil {
+		return nil, err
+	}
+	newRel := filepath.Join(filepath.Dir(oldRel), newBase)
+	if newRel == oldRel {
+		return nil, camperrors.NewValidation("new-name",
+			"new name is identical to the current name: "+newBase, nil)
+	}
+
+	newKey, err := renameKey(item.Key, oldRel, newRel)
+	if err != nil {
+		return nil, err
+	}
+
+	srcPath := filepath.Join(root, oldRel)
+	dstPath := filepath.Join(root, newRel)
+	if _, statErr := os.Lstat(dstPath); statErr == nil {
+		return nil, camperrors.Wrap(camperrors.ErrAlreadyExists,
+			"a sibling named "+newBase+" already exists at "+filepath.ToSlash(newRel))
+	} else if !os.IsNotExist(statErr) {
+		return nil, camperrors.Wrapf(statErr, "checking destination %s", newRel)
+	}
+
+	return &renamePlan{
+		item:    item,
+		srcPath: srcPath,
+		dstPath: dstPath,
+		oldRel:  oldRel,
+		newRel:  newRel,
+		oldKey:  item.Key,
+		newKey:  newKey,
+		isFile:  isFile,
+	}, nil
+}
+
+// ensureRenamable rejects workitem kinds whose identity is owned by other
+// tooling. Festivals are managed by the fest CLI and intents carry their own
+// title-based rename; renaming their directories here would desync that state.
+func ensureRenamable(item *wkitem.WorkItem) error {
+	switch item.WorkflowType {
+	case wkitem.WorkflowTypeFestival:
+		return camperrors.New("cannot rename a festival with camp workitem rename; festival identity is managed by the fest CLI")
+	case wkitem.WorkflowTypeIntent:
+		return camperrors.New("cannot rename an intent with camp workitem rename; intents are renamed by title through the intent tooling")
+	default:
+		return nil
+	}
+}
+
+// renameBasename returns the destination basename. For a directory the new name
+// is used verbatim; for a file the original extension is preserved (appended
+// when the new name omits it) and a conflicting extension is rejected.
+func renameBasename(newName, oldRel string, isFile bool) (string, error) {
+	if !isFile {
+		return newName, nil
+	}
+	origExt := filepath.Ext(oldRel)
+	if origExt == "" {
+		return newName, nil
+	}
+	switch filepath.Ext(newName) {
+	case "":
+		return newName + origExt, nil
+	case origExt:
+		return newName, nil
+	default:
+		return "", camperrors.NewValidation("new-name",
+			"file workitem extension must stay "+origExt+"; rename to a name ending in "+origExt, nil)
+	}
+}
+
+// renameKey rebuilds the path-derived workitem key for the new location. The
+// key is always "<prefix>:" + RelativePath, so swapping the trailing path
+// yields the key discovery will produce after the move.
+func renameKey(oldKey, oldRel, newRel string) (string, error) {
+	if !strings.HasSuffix(oldKey, oldRel) {
+		return "", camperrors.New("cannot derive new key: workitem key " + oldKey + " does not end with its path " + oldRel)
+	}
+	return oldKey[:len(oldKey)-len(oldRel)] + newRel, nil
+}
+
+func emitRenameJSON(w io.Writer, result workitemRenameResult) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(struct {
+		SchemaVersion string               `json:"schema_version"`
+		GeneratedAt   time.Time            `json:"generated_at"`
+		Workitem      workitemRenameResult `json:"workitem"`
+	}{
+		SchemaVersion: WorkitemRenameJSONVersion,
+		GeneratedAt:   time.Now().UTC(),
+		Workitem:      result,
+	}); err != nil {
+		return camperrors.Wrap(err, "encoding JSON output")
+	}
+	return nil
+}

--- a/internal/commands/workitem/rename_apply.go
+++ b/internal/commands/workitem/rename_apply.go
@@ -1,0 +1,227 @@
+package workitem
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	dungeoncmd "github.com/Obedience-Corp/camp/cmd/camp/dungeon"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/mdlinks"
+	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
+	"github.com/Obedience-Corp/camp/internal/statusmove"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	wkaudit "github.com/Obedience-Corp/camp/internal/workitem/audit"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
+)
+
+// applyRename performs the on-disk rename, repairs every reference, and commits
+// the result. The physical move runs first; bookkeeping that fails afterward is
+// surfaced as a warning rather than stranding the already-moved workitem.
+func applyRename(ctx context.Context, cmd *cobra.Command, cfg *config.CampaignConfig, root string, plan *renamePlan, opts runWorkitemRenameOptions, result workitemRenameResult) error {
+	warn := func(format string, args ...any) {
+		msg := fmt.Sprintf(format, args...)
+		result.Warnings = append(result.Warnings, msg)
+		if !opts.JSON {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s %s\n", ui.WarningIcon(), msg)
+		}
+	}
+
+	rewritten, err := renameMove(ctx, root, plan)
+	if err != nil {
+		return err
+	}
+	result.RewrittenFiles = rewritten
+
+	destPaths := []string{plan.dstPath}
+	if p, ok := stageAuditEvent(ctx, cmd, root, plan); ok {
+		destPaths = append(destPaths, p)
+	}
+
+	linksChanged := migrateRenameReferences(ctx, root, plan, &result, warn)
+	if linksChanged {
+		destPaths = append(destPaths, links.LinksPath(root))
+	}
+
+	if navErr := navindex.Delete(root); navErr != nil {
+		warn("failed to invalidate navigation cache: %v", navErr)
+	}
+
+	if !opts.NoCommit {
+		if err := commitRename(ctx, cmd, cfg, root, plan, opts, destPaths, rewritten, &result); err != nil {
+			return err
+		}
+	}
+
+	return emitRenameOutcome(cmd, opts, result)
+}
+
+// renameMove applies the physical basename change and rewrites the markdown
+// links that referenced the moved path.
+func renameMove(ctx context.Context, root string, plan *renamePlan) ([]string, error) {
+	if _, err := statusmove.Move(ctx, plan.srcPath, plan.dstPath, statusmove.MoveOptions{BoundaryRoot: root}); err != nil {
+		if errors.Is(err, statusmove.ErrAlreadyExists) {
+			return nil, camperrors.Wrapf(camperrors.ErrAlreadyExists,
+				"cannot rename %s: destination %s already exists",
+				filepath.Base(plan.oldRel), filepath.ToSlash(plan.newRel))
+		}
+		return nil, camperrors.Wrapf(err, "renaming %s to %s", filepath.ToSlash(plan.oldRel), filepath.ToSlash(plan.newRel))
+	}
+	rewritten, err := mdlinks.RewriteForMove(ctx, root, plan.srcPath, plan.dstPath)
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "rewriting markdown links after renaming %s (move applied; recover with git status)", filepath.Base(plan.oldRel))
+	}
+	return rewritten, nil
+}
+
+// migrateRenameReferences repairs the priority store, link registry, and
+// current-workitem pointer for the new path. It returns whether links.yaml
+// changed so the caller can stage it. Each store is best-effort: a failure is
+// recorded as a warning without failing the already-applied move.
+func migrateRenameReferences(ctx context.Context, root string, plan *renamePlan, result *workitemRenameResult, warn func(string, ...any)) bool {
+	if moved, err := migrateRenamePriority(ctx, root, plan.oldKey, plan.newKey); err != nil {
+		warn("migrate priority entries: %v", err)
+	} else {
+		result.PriorityMoved = moved
+	}
+
+	linksChanged, err := migrateRenameLinks(ctx, root, plan.oldKey, plan.newKey, plan.oldRel, plan.newRel)
+	if err != nil {
+		warn("re-home workitem links: %v", err)
+	}
+	result.LinksUpdated = linksChanged
+
+	if updated, err := migrateRenameCurrent(ctx, root, plan.oldKey, plan.newKey); err != nil {
+		warn("update current workitem selection: %v", err)
+	} else {
+		result.CurrentUpdated = updated
+	}
+	return linksChanged
+}
+
+// migrateRenamePriority re-keys the manual priority and attention entries. The
+// store at .campaign/settings/workitems.json is gitignored per-machine state,
+// so it is migrated on disk and never staged into the rename commit (matching
+// gather's treatment of the same file).
+func migrateRenamePriority(ctx context.Context, root, oldKey, newKey string) (bool, error) {
+	path := priority.StorePath(root)
+	store, err := priority.Load(path)
+	if err != nil {
+		return false, err
+	}
+	if _, ok := store.ManualPriorities[oldKey]; !ok {
+		if _, ok := store.Attention[oldKey]; !ok {
+			return false, nil
+		}
+	}
+	changed := false
+	if err := priority.WithLock(ctx, path, func(s *priority.Store) error {
+		changed = rekeyRenamePriorities(s, oldKey, newKey)
+		return nil
+	}); err != nil {
+		return false, err
+	}
+	return changed, nil
+}
+
+// migrateRenameLinks rewrites the shared link registry under lock. links.yaml is
+// tracked, so a change is reported for staging.
+func migrateRenameLinks(ctx context.Context, root, oldKey, newKey, oldRel, newRel string) (bool, error) {
+	changed := false
+	if err := links.WithLock(ctx, root, func(reg *links.Links) error {
+		if !rehomeRenameLinks(reg, oldKey, newKey, oldRel, newRel) {
+			return links.ErrSkipSave
+		}
+		changed = true
+		return nil
+	}); err != nil {
+		return false, err
+	}
+	return changed, nil
+}
+
+// migrateRenameCurrent updates current.yaml only when it referenced the old
+// path key. A pointer stored as a stable id needs no change because the rename
+// preserves the id; current.yaml is gitignored and is not staged.
+func migrateRenameCurrent(ctx context.Context, root, oldKey, newKey string) (bool, error) {
+	cur, err := links.LoadCurrent(ctx, root)
+	if err != nil {
+		return false, err
+	}
+	if cur == nil || cur.WorkitemID != oldKey {
+		return false, nil
+	}
+	cur.WorkitemID = newKey
+	if err := links.SaveCurrent(ctx, root, cur); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// stageAuditEvent appends the workitem-level move event and returns the ledger
+// path when it exists on disk, so the caller stages it into the same commit.
+// git add hard-fails on a never-created path, so an unwritten ledger is skipped.
+func stageAuditEvent(ctx context.Context, cmd *cobra.Command, root string, plan *renamePlan) (string, bool) {
+	eventID := plan.item.StableID
+	if eventID == "" {
+		eventID = filepath.Base(plan.newRel)
+	}
+	appendWorkitemAuditEvent(ctx, cmd, root, wkaudit.Event{
+		Event: wkaudit.EventMove,
+		ID:    eventID,
+		Ref:   refFromItem(plan),
+		Type:  string(plan.item.WorkflowType),
+		Title: plan.item.Title,
+		From:  filepath.ToSlash(plan.oldRel),
+		To:    filepath.ToSlash(plan.newRel),
+	})
+	path := filepath.Join(root, ".campaign", "workitems", wkaudit.AuditFile)
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		return path, true
+	}
+	return "", false
+}
+
+func refFromItem(plan *renamePlan) string {
+	if plan.item.SourceMetadata == nil {
+		return ""
+	}
+	if ref, ok := plan.item.SourceMetadata["ref"].(string); ok {
+		return ref
+	}
+	return ""
+}
+
+// commitRename stages the move (recording the source deletion as a rename) and
+// auto-commits it alongside every repaired reference.
+func commitRename(ctx context.Context, cmd *cobra.Command, cfg *config.CampaignConfig, root string, plan *renamePlan, opts runWorkitemRenameOptions, destPaths, rewritten []string, result *workitemRenameResult) error {
+	outcome := dungeoncmd.StageAndCommitDungeonMove(ctx, &dungeoncmd.DungeonMoveCommit{
+		Config:           cfg,
+		CampaignRoot:     root,
+		Description:      fmt.Sprintf("Rename workitem %s to %s", filepath.Base(plan.oldRel), filepath.Base(plan.newRel)),
+		SourcePaths:      []string{plan.srcPath},
+		DestinationPaths: destPaths,
+		RewrittenFiles:   rewritten,
+	})
+	if !opts.JSON {
+		dungeoncmd.PrintDungeonMoveOutcome(cmd.OutOrStdout(), outcome)
+	}
+	result.Committed = outcome.Committed
+	result.CommitMessage = outcome.Message
+	return outcome.Err()
+}
+
+func emitRenameOutcome(cmd *cobra.Command, opts runWorkitemRenameOptions, result workitemRenameResult) error {
+	if opts.JSON {
+		return emitRenameJSON(cmd.OutOrStdout(), result)
+	}
+	_, err := fmt.Fprintf(cmd.OutOrStdout(), "%s Renamed workitem %s to %s\n",
+		ui.SuccessIcon(), result.From, result.To)
+	return err
+}

--- a/internal/commands/workitem/rename_migrate.go
+++ b/internal/commands/workitem/rename_migrate.go
@@ -1,0 +1,73 @@
+package workitem
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
+)
+
+// rekeyRenamePriorities moves the manual-priority and attention entries from
+// oldKey to newKey, preserving each entry verbatim. Returns true when the store
+// changed. Unlike gather's N:1 collapse this is a 1:1 remap, so the item keeps
+// its stage and group across the rename.
+func rekeyRenamePriorities(store *priority.Store, oldKey, newKey string) bool {
+	if oldKey == newKey {
+		return false
+	}
+	changed := false
+	if entry, ok := store.ManualPriorities[oldKey]; ok {
+		delete(store.ManualPriorities, oldKey)
+		store.ManualPriorities[newKey] = entry
+		changed = true
+	}
+	if entry, ok := store.Attention[oldKey]; ok {
+		delete(store.Attention, oldKey)
+		store.Attention[newKey] = entry
+		changed = true
+	}
+	return changed
+}
+
+// rehomeRenameLinks repoints registry links from the renamed workitem's old
+// path onto its new path. Two kinds of reference move:
+//   - links whose subject is this workitem: WorkitemKey oldKey -> newKey. The
+//     WorkitemID (stable id) is unchanged by a rename and is left untouched.
+//   - scope paths that target the renamed directory, exactly or as a subtree:
+//     rewritten from oldRel to newRel.
+//
+// Returns true when the registry changed.
+func rehomeRenameLinks(reg *links.Links, oldKey, newKey, oldRel, newRel string) bool {
+	oldRelSlash := filepath.ToSlash(oldRel)
+	newRelSlash := filepath.ToSlash(newRel)
+	changed := false
+	for i := range reg.Links {
+		l := &reg.Links[i]
+		if oldKey != newKey && l.WorkitemKey == oldKey {
+			l.WorkitemKey = newKey
+			changed = true
+		}
+		if np, ok := rewriteScopePath(l.Scope.Path, oldRelSlash, newRelSlash); ok {
+			l.Scope.Path = np
+			changed = true
+		}
+	}
+	return changed
+}
+
+// rewriteScopePath rewrites a link scope path that points at the renamed item.
+// It matches the directory itself and any path beneath it, leaving unrelated
+// scopes untouched.
+func rewriteScopePath(p, oldRel, newRel string) (string, bool) {
+	if oldRel == newRel {
+		return p, false
+	}
+	if p == oldRel {
+		return newRel, true
+	}
+	if strings.HasPrefix(p, oldRel+"/") {
+		return newRel + strings.TrimPrefix(p, oldRel), true
+	}
+	return p, false
+}

--- a/internal/commands/workitem/rename_test.go
+++ b/internal/commands/workitem/rename_test.go
@@ -1,0 +1,218 @@
+package workitem
+
+import (
+	"testing"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
+)
+
+func TestRenameBasename(t *testing.T) {
+	cases := []struct {
+		name    string
+		newName string
+		oldRel  string
+		isFile  bool
+		want    string
+		wantErr bool
+	}{
+		{"file wrong extension rejected", "foo.txt", "workflow/explore/n.md", true, "", true},
+		{"directory verbatim", "release-timeline", "workflow/design/timeline", false, "release-timeline", false},
+		{"directory keeps dotted name", "v1.2", "workflow/design/timeline", false, "v1.2", false},
+		{"file appends original extension", "weekly", "workflow/explore/note.md", true, "weekly.md", false},
+		{"file keeps matching extension", "weekly.md", "workflow/explore/note.md", true, "weekly.md", false},
+		{"file without original extension is verbatim", "readme2", "workflow/explore/README", true, "readme2", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := renameBasename(c.newName, c.oldRel, c.isFile)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("renameBasename(%q,%q,%v) = %q, want error", c.newName, c.oldRel, c.isFile, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("renameBasename(%q,%q,%v) unexpected error: %v", c.newName, c.oldRel, c.isFile, err)
+			}
+			if got != c.want {
+				t.Fatalf("renameBasename(%q,%q,%v) = %q, want %q", c.newName, c.oldRel, c.isFile, got, c.want)
+			}
+		})
+	}
+}
+
+func TestRenameKey(t *testing.T) {
+	cases := []struct {
+		name    string
+		oldKey  string
+		oldRel  string
+		newRel  string
+		want    string
+		wantErr bool
+	}{
+		{"key must end with path", "design:workflow/design/other", "workflow/design/timeline", "workflow/design/release", "", true},
+		{"design key rederived", "design:workflow/design/timeline", "workflow/design/timeline", "workflow/design/release", "design:workflow/design/release", false},
+		{"file key rederived", "file:workflow/explore/note.md", "workflow/explore/note.md", "workflow/explore/weekly.md", "file:workflow/explore/weekly.md", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := renameKey(c.oldKey, c.oldRel, c.newRel)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("renameKey(%q,%q,%q) = %q, want error", c.oldKey, c.oldRel, c.newRel, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("renameKey unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Fatalf("renameKey = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestEnsureRenamable(t *testing.T) {
+	cases := []struct {
+		name    string
+		wfType  wkitem.WorkflowType
+		wantErr bool
+	}{
+		{"festival rejected", wkitem.WorkflowTypeFestival, true},
+		{"intent rejected", wkitem.WorkflowTypeIntent, true},
+		{"design allowed", wkitem.WorkflowTypeDesign, false},
+		{"explore allowed", wkitem.WorkflowTypeExplore, false},
+		{"custom type allowed", wkitem.WorkflowType("feature"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ensureRenamable(&wkitem.WorkItem{WorkflowType: c.wfType})
+			if c.wantErr != (err != nil) {
+				t.Fatalf("ensureRenamable(%q) err=%v, wantErr=%v", c.wfType, err, c.wantErr)
+			}
+		})
+	}
+}
+
+func TestRewriteScopePath(t *testing.T) {
+	const oldRel, newRel = "workflow/design/alpha", "workflow/design/beta"
+	cases := []struct {
+		name   string
+		path   string
+		want   string
+		wantOK bool
+	}{
+		{"unrelated path untouched", "projects/camp", "projects/camp", false},
+		{"prefix-but-not-segment untouched", "workflow/design/alpha-notes", "workflow/design/alpha-notes", false},
+		{"exact directory match", "workflow/design/alpha", "workflow/design/beta", true},
+		{"subtree match", "workflow/design/alpha/sub/x", "workflow/design/beta/sub/x", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := rewriteScopePath(c.path, oldRel, newRel)
+			if ok != c.wantOK || got != c.want {
+				t.Fatalf("rewriteScopePath(%q) = (%q,%v), want (%q,%v)", c.path, got, ok, c.want, c.wantOK)
+			}
+		})
+	}
+}
+
+func TestRekeyRenamePriorities(t *testing.T) {
+	const oldKey, newKey = "design:workflow/design/alpha", "design:workflow/design/beta"
+
+	t.Run("same key no change", func(t *testing.T) {
+		store := priority.NewStore()
+		priority.Set(store, oldKey, priority.High)
+		if rekeyRenamePriorities(store, oldKey, oldKey) {
+			t.Fatal("expected no change when keys are identical")
+		}
+	})
+
+	t.Run("no entry no change", func(t *testing.T) {
+		store := priority.NewStore()
+		if rekeyRenamePriorities(store, oldKey, newKey) {
+			t.Fatal("expected no change for absent key")
+		}
+	})
+
+	t.Run("manual priority moves", func(t *testing.T) {
+		store := priority.NewStore()
+		priority.Set(store, oldKey, priority.High)
+		if !rekeyRenamePriorities(store, oldKey, newKey) {
+			t.Fatal("expected change")
+		}
+		if _, ok := store.ManualPriorities[oldKey]; ok {
+			t.Fatal("old key should be cleared")
+		}
+		if store.ManualPriorities[newKey].Priority != priority.High {
+			t.Fatalf("new key priority = %q, want high", store.ManualPriorities[newKey].Priority)
+		}
+	})
+
+	t.Run("attention stage and group carry", func(t *testing.T) {
+		store := priority.NewStore()
+		priority.SetAttentionStage(store, oldKey, priority.AttentionCurrent)
+		priority.SetGroup(store, oldKey, "auth")
+		if !rekeyRenamePriorities(store, oldKey, newKey) {
+			t.Fatal("expected change")
+		}
+		if _, ok := store.Attention[oldKey]; ok {
+			t.Fatal("old key attention should be cleared")
+		}
+		entry := store.Attention[newKey]
+		if entry.Stage != priority.AttentionCurrent || entry.Group != "auth" {
+			t.Fatalf("new key attention = %+v, want stage=current group=auth", entry)
+		}
+	})
+}
+
+func TestRehomeRenameLinks(t *testing.T) {
+	const (
+		oldKey = "design:workflow/design/alpha"
+		newKey = "design:workflow/design/beta"
+		oldRel = "workflow/design/alpha"
+		newRel = "workflow/design/beta"
+	)
+
+	t.Run("no matching references returns false", func(t *testing.T) {
+		reg := &links.Links{Links: []links.Link{{
+			ID: "l1", WorkitemID: "id", WorkitemKey: "design:workflow/design/other",
+			Scope: links.LinkScope{Kind: links.ScopeProject, Path: "projects/camp"},
+		}}}
+		if rehomeRenameLinks(reg, oldKey, newKey, oldRel, newRel) {
+			t.Fatal("expected no change")
+		}
+	})
+
+	t.Run("subject key migrates, stable id preserved", func(t *testing.T) {
+		reg := &links.Links{Links: []links.Link{{
+			ID: "l1", WorkitemID: "design-alpha-fixed", WorkitemKey: oldKey,
+			Scope: links.LinkScope{Kind: links.ScopeProject, Path: "projects/camp"},
+		}}}
+		if !rehomeRenameLinks(reg, oldKey, newKey, oldRel, newRel) {
+			t.Fatal("expected change")
+		}
+		if reg.Links[0].WorkitemKey != newKey {
+			t.Fatalf("workitem_key = %q, want %q", reg.Links[0].WorkitemKey, newKey)
+		}
+		if reg.Links[0].WorkitemID != "design-alpha-fixed" {
+			t.Fatal("stable id must not change on rename")
+		}
+	})
+
+	t.Run("scope path under renamed dir migrates", func(t *testing.T) {
+		reg := &links.Links{Links: []links.Link{{
+			ID: "l1", WorkitemID: "design-alpha-fixed", WorkitemKey: "design:workflow/design/other",
+			Scope: links.LinkScope{Kind: links.ScopeCampaignPath, Path: "workflow/design/alpha/sub"},
+		}}}
+		if !rehomeRenameLinks(reg, oldKey, newKey, oldRel, newRel) {
+			t.Fatal("expected change")
+		}
+		if reg.Links[0].Scope.Path != "workflow/design/beta/sub" {
+			t.Fatalf("scope path = %q, want workflow/design/beta/sub", reg.Links[0].Scope.Path)
+		}
+	})
+}

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -150,6 +150,7 @@ Examples:
 	cmd.AddCommand(newStageCommand())
 	cmd.AddCommand(newGroupCommand())
 	cmd.AddCommand(newPromoteCommand())
+	cmd.AddCommand(newRenameCommand())
 	cmd.AddCommand(newDoctorCommand())
 	cmd.AddCommand(newValidateCommand())
 	cmd.AddCommand(newRepairCommand())

--- a/internal/commands/workitem/workitem_test.go
+++ b/internal/commands/workitem/workitem_test.go
@@ -461,8 +461,8 @@ func TestWorkitemSubcommandsStayRegisteredAndVisible(t *testing.T) {
 
 	want := []string{
 		"adopt", "commit", "commits", "create", "current", "doctor", "group",
-		"link", "links", "list", "priority", "promote", "repair", "resolve",
-		"stage", "unlink", "validate", "worktree",
+		"link", "links", "list", "priority", "promote", "rename", "repair",
+		"resolve", "stage", "unlink", "validate", "worktree",
 	}
 
 	for _, name := range want {

--- a/tests/integration/workitem_rename_test.go
+++ b/tests/integration/workitem_rename_test.go
@@ -1,0 +1,212 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupRenameWorkitem creates a campaign with one directory workitem of the
+// given type and slug, committed, and returns the campaign path.
+func setupRenameWorkitem(t *testing.T, tc *TestContainer, name, wkType, slug string) string {
+	t.Helper()
+	path := "/campaigns/" + name
+	_, err := tc.InitCampaign(path, name, "product")
+	require.NoError(t, err)
+
+	output, err := tc.RunCampInDir(path,
+		"workitem", "create", slug,
+		"--type", wkType,
+		"--title", slug,
+		"--id", wkType+"-"+slug+"-fixed",
+	)
+	require.NoError(t, err, "workitem create should succeed: %s", output)
+
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+path+" && git add . && git commit -m 'add workitem'")
+	require.NoError(t, err, "initial commit should succeed")
+	return path
+}
+
+func TestWorkitemRename_RepairsReferences(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRenameWorkitem(t, tc, "wi-rename-refs", "design", "timeline")
+
+	// An external doc that links at the workitem, plus a manual priority.
+	require.NoError(t, tc.WriteFile(path+"/docs/note.md",
+		"# Doc\n\nSee [timeline](../workflow/design/timeline/README.md).\n"))
+	require.NoError(t, tc.WriteFile(path+"/workflow/design/timeline/README.md", "# Timeline\n"))
+	_, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git add . && git commit -m 'seed doc'")
+	require.NoError(t, err)
+
+	_, err = tc.RunCampInDir(path, "workitem", "priority", "timeline", "high")
+	require.NoError(t, err)
+
+	output, err := tc.RunCampInDir(path, "workitem", "rename", "timeline", "release-timeline")
+	require.NoError(t, err, "rename should succeed: %s", output)
+	assert.Contains(t, output, "Renamed workitem")
+
+	// Directory moved.
+	exists, err := tc.CheckDirExists(path + "/workflow/design/release-timeline")
+	require.NoError(t, err)
+	assert.True(t, exists, "renamed directory should exist")
+	exists, err = tc.CheckDirExists(path + "/workflow/design/timeline")
+	require.NoError(t, err)
+	assert.False(t, exists, "old directory should be gone")
+
+	// External markdown link rewritten.
+	note, err := tc.ReadFile(path + "/docs/note.md")
+	require.NoError(t, err)
+	assert.Contains(t, note, "../workflow/design/release-timeline/README.md")
+	assert.NotContains(t, note, "design/timeline/README.md")
+
+	// Priority store re-keyed on disk (gitignored, not committed).
+	store, err := tc.ReadFile(path + "/.campaign/settings/workitems.json")
+	require.NoError(t, err)
+	assert.Contains(t, store, "design:workflow/design/release-timeline")
+	assert.NotContains(t, store, "design:workflow/design/timeline\"")
+
+	// Auto-commit landed and the tree is clean.
+	body := tc.GitOutput(t, path, "log", "-1", "--pretty=%B")
+	assert.Contains(t, body, "Rename workitem timeline to release-timeline")
+	status, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git status --porcelain")
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(status), "git tree should be clean after rename")
+}
+
+func TestWorkitemRename_LinksRegistryRepaired(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRenameWorkitem(t, tc, "wi-rename-links", "design", "alpha")
+
+	require.NoError(t, tc.WriteFile(path+"/workflow/design/alpha/sub/notes.md", "# Notes\n"))
+	_, err := tc.RunCampInDir(path, "workitem", "link", "alpha", "workflow/design/alpha/sub")
+	require.NoError(t, err)
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+path+" && git add . && git commit -m 'seed link'")
+	require.NoError(t, err)
+
+	_, err = tc.RunCampInDir(path, "workitem", "rename", "alpha", "beta")
+	require.NoError(t, err)
+
+	registry, err := tc.ReadFile(path + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, registry, "workitem_key: design:workflow/design/beta")
+	assert.Contains(t, registry, "path: workflow/design/beta/sub")
+	assert.Contains(t, registry, "workitem_id: design-alpha-fixed", "stable id must be preserved")
+	assert.NotContains(t, registry, "design/alpha")
+}
+
+func TestWorkitemRename_JSON(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRenameWorkitem(t, tc, "wi-rename-json", "design", "widget")
+
+	output, err := tc.RunCampInDir(path, "workitem", "rename", "widget", "gadget", "--json")
+	require.NoError(t, err, "rename --json should succeed: %s", output)
+
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		Workitem      struct {
+			ID            string `json:"id"`
+			Key           string `json:"key"`
+			Type          string `json:"type"`
+			ItemKind      string `json:"item_kind"`
+			From          string `json:"from"`
+			To            string `json:"to"`
+			Committed     bool   `json:"committed"`
+			PriorityMoved bool   `json:"priority_migrated"`
+		} `json:"workitem"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &payload), "output must be one JSON object: %s", output)
+	assert.Equal(t, "workitem-rename/v1alpha1", payload.SchemaVersion)
+	assert.Equal(t, "design-widget-fixed", payload.Workitem.ID)
+	assert.Equal(t, "design:workflow/design/gadget", payload.Workitem.Key)
+	assert.Equal(t, "directory", payload.Workitem.ItemKind)
+	assert.Equal(t, "workflow/design/widget", payload.Workitem.From)
+	assert.Equal(t, "workflow/design/gadget", payload.Workitem.To)
+	assert.True(t, payload.Workitem.Committed)
+}
+
+func TestWorkitemRename_DryRun(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRenameWorkitem(t, tc, "wi-rename-dry", "design", "sprocket")
+
+	head := strings.TrimSpace(tc.GitOutput(t, path, "rev-parse", "HEAD"))
+	output, err := tc.RunCampInDir(path, "workitem", "rename", "sprocket", "cog", "--dry-run")
+	require.NoError(t, err)
+	assert.Contains(t, output, "dry-run")
+
+	exists, err := tc.CheckDirExists(path + "/workflow/design/sprocket")
+	require.NoError(t, err)
+	assert.True(t, exists, "dry-run must not move the workitem")
+	assert.Equal(t, head, strings.TrimSpace(tc.GitOutput(t, path, "rev-parse", "HEAD")), "dry-run must not commit")
+}
+
+func TestWorkitemRename_NoCommit(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRenameWorkitem(t, tc, "wi-rename-nocommit", "design", "lever")
+
+	head := strings.TrimSpace(tc.GitOutput(t, path, "rev-parse", "HEAD"))
+	output, err := tc.RunCampInDir(path, "workitem", "rename", "lever", "handle", "--no-commit")
+	require.NoError(t, err, "rename --no-commit should succeed: %s", output)
+
+	exists, err := tc.CheckDirExists(path + "/workflow/design/handle")
+	require.NoError(t, err)
+	assert.True(t, exists, "workitem should be moved on disk")
+	assert.Equal(t, head, strings.TrimSpace(tc.GitOutput(t, path, "rev-parse", "HEAD")), "no new commit with --no-commit")
+
+	status, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git status --porcelain")
+	require.NoError(t, err)
+	assert.NotEmpty(t, strings.TrimSpace(status), "move should be visible in git status")
+}
+
+func TestWorkitemRename_SiblingCollision(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRenameWorkitem(t, tc, "wi-rename-collision", "design", "one")
+
+	_, err := tc.RunCampInDir(path, "workitem", "create", "two", "--type", "design", "--title", "two", "--id", "design-two-fixed")
+	require.NoError(t, err)
+
+	output, err := tc.RunCampInDir(path, "workitem", "rename", "one", "two")
+	require.Error(t, err, "rename onto an existing sibling should fail")
+	assert.Contains(t, output, "already exists")
+
+	exists, err := tc.CheckDirExists(path + "/workflow/design/one")
+	require.NoError(t, err)
+	assert.True(t, exists, "source must be untouched after a rejected rename")
+}
+
+func TestWorkitemRename_FileWorkitem(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := "/campaigns/wi-rename-file"
+	_, err := tc.InitCampaign(path, "wi-rename-file", "product")
+	require.NoError(t, err)
+
+	_, err = tc.RunCampInDir(path, "workitem", "create", "--file", "workflow/explore/note.md", "--type", "explore", "--title", "Note")
+	require.NoError(t, err)
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+path+" && git add . && git commit -m 'add file workitem'")
+	require.NoError(t, err)
+
+	// Selector by full basename; the original .md extension is preserved.
+	output, err := tc.RunCampInDir(path, "workitem", "rename", "note.md", "weekly-note", "--json")
+	require.NoError(t, err, "file rename should succeed: %s", output)
+
+	var payload struct {
+		Workitem struct {
+			Key      string `json:"key"`
+			ItemKind string `json:"item_kind"`
+			To       string `json:"to"`
+		} `json:"workitem"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &payload))
+	assert.Equal(t, "file", payload.Workitem.ItemKind)
+	assert.Equal(t, "workflow/explore/weekly-note.md", payload.Workitem.To)
+	assert.Equal(t, "file:workflow/explore/weekly-note.md", payload.Workitem.Key)
+
+	exists, err := tc.CheckFileExists(path + "/workflow/explore/weekly-note.md")
+	require.NoError(t, err)
+	assert.True(t, exists, "renamed file should exist with preserved extension")
+}


### PR DESCRIPTION
## What this adds

`camp workitem rename <selector> <new-name>` renames a workitem's directory or
file basename while keeping its identity coherent. Only the path basename
changes: the stable id, ref, title, workflow type, and lifecycle status are
untouched. Every path-derived reference is repaired in the same commit as the
move.

Flags: `--dry-run`, `--json`, `--no-commit`. The command carries
`agent_allowed: "true"` annotations (matching `promote.go`) because it is fully
specified by positional args and flags with no interactive prompt.

Motivation: workitems could not be renamed without a manual `mv` plus by-hand
fixups of every reference, because the workitem `Key` is path-derived and
several stores key off that path.

## Design principle

Rename is a move within the same parent, so its fixup surface must equal the
fixup surface of a physical move. Rather than reimplement, the command reuses
the exact primitives `promote` and `camp dungeon move` already use:
`statusmove.Move` for the physical relocation and `mdlinks.RewriteForMove` for
markdown link rewriting, then re-keys the path-derived stores the way `gather`
does when it relocates workitems.

## Enumerated fixup surface (each verified against source)

1. **Physical move** via `statusmove.Move` with `BoundaryRoot` set
   (`internal/statusmove/move.go`). No dated bucket. `noReplaceMove` gives
   collision safety at the OS level; the command also pre-checks the
   destination and returns a clean "already exists" error. Handles both files
   and directories.
2. **Markdown links** via `mdlinks.RewriteForMove`
   (`internal/mdlinks/rewrite.go`): rewrites both the moved subtree's own
   relative links and other campaign files that pointed at the moved item, and
   returns the campaign-relative modified files to stage. A pure sibling rename
   leaves same-depth relative links unchanged (correct) and rewrites external
   references into the renamed item.
3. **Priority + attention store** `.campaign/settings/workitems.json`, keyed by
   `WorkItem.Key` (`internal/workitem/priority/store.go`): the old key's manual
   priority and attention (stage + group) entries are re-keyed 1:1 to the new
   key (`rekeyRenamePriorities`, `rename_migrate.go`). This file is gitignored
   per-machine state (`internal/scaffold/init.go` writes `settings/workitems.json`
   into `.campaign/.gitignore`), so it is migrated on disk and never staged,
   matching how `gather` treats the same file.
4. **Link registry** `.campaign/workitems/links.yaml`
   (`internal/workitem/links/`): `rehomeRenameLinks` migrates the subject
   links' `workitem_key` (old key -> new key; `workitem_id`/stable id is left
   unchanged) and rewrites any `scope.path` that targets the renamed directory
   exactly or as a subtree. links.yaml is tracked, so a change is staged into
   the commit.
5. **Current-workitem pointer** `.campaign/workitems/current.yaml`
   (`internal/commands/workitem/current.go`): `current.yaml` stores the stable
   id when the item has one, otherwise the path `Key`. The rename preserves the
   stable id, so only the key-fallback case (unadopted item) needs migration;
   `migrateRenameCurrent` updates it. current.yaml is also gitignored per-machine
   and is not staged.
6. **Workitem audit ledger** `.campaign/workitems/.workitems.jsonl`: an
   `EventMove` record is appended (`stageAuditEvent`), the same event type
   `camp dungeon move` uses for relocations
   (`internal/workitem/audit/audit.go` doc for `EventMove`). It is staged only
   when the file exists on disk, because `git add` hard-fails on a
   never-created pathspec (same guard as `cmd/camp/dungeon/workitem_ledger.go`).
7. **Navigation index**: `navindex.Delete(root)` invalidates the nav cache, as
   promote does.
8. **Auto-commit** via `dungeoncmd.StageAndCommitDungeonMove` (the same helper
   promote uses): pre-stages the source deletion so git records a rename, and
   commits the destination, rewritten markdown, links.yaml, and the audit log
   together. `--no-commit` skips it.

`WorkItem.Key` is always `"<prefix>:" + RelativePath` across every discover path
(`discover_workflow_docs.go`, `discover_frontmatter.go`, `discover_intents.go`,
`discover_festivals.go`), so the new key is derived by swapping the trailing
path segment (`renameKey`); the derivation errors out rather than guessing if
that invariant ever fails to hold.

## Design decisions and rationale

- **Festivals and intents are rejected** (`ensureRenamable`). A festival's
  identity is owned by the fest CLI and an intent has its own title-based
  rename (`internal/intent/rename.go`); relocating their directories through a
  generic mover would desync that state. Every other workflow type
  (design, explore, custom) and file workitems are supported.
- **File workitems are supported** because the shared machinery already handles
  files cheaply (`statusmove` Lstat's any source, `mdlinks` handles a single
  `.md`, the `file:` key re-keys like any other). The original extension is
  preserved: a new name with no extension gets the original appended, a
  matching extension is kept, and a conflicting extension is rejected
  (`renameBasename`). Note: because the selector's slug matcher compares against
  the full basename, a file workitem is selected by its full filename
  (e.g. `note.md`), its stable id, ref, key, or path, not by an
  extension-stripped stem. This is pre-existing selector behavior, unchanged
  here.
- **Dungeon items are allowed.** Renaming an item already inside a dungeon falls
  out of the machinery naturally (statusmove + mdlinks + key migration all work
  on the dungeon path), so it is permitted rather than special-cased.
- **Quest links are intentionally NOT handled.** I verified that promote, the
  dungeon move path, gather, and mdlinks never touch quest link paths
  (`internal/quest/types.go` `Link.Path`); a workitem relocation already leaves
  quest links stale today. This is a pre-existing gap across all move flows, not
  something rename introduces, so rename matches the existing behavior and does
  not add divergent quest handling.
- **The `.workitem` marker / frontmatter is not restamped.** No stamped field is
  re-derived from the slug (`internal/workitem/metadata.go`): the id is minted at
  creation and frozen, the title is independent. Preserving stable_id therefore
  means simply not touching the marker.
- **No ledgerkit event is emitted.** A rename is a relocation, not a lifecycle
  transition, and there is no `KindRenamed` in `pkg/ledgerkit`; misusing
  `KindTransitioned` or adding a new kind (which ripples into camp-graph
  consumers) is unwarranted. The workitem audit log's purpose-built `EventMove`
  is the correct surface, matching `camp dungeon move`.
- **JSON contract** uses the `jsoncontract` envelope with schema version
  `workitem-rename/v1alpha1`, matching the newer subcommands (create, current,
  priority, stage) rather than promote's bare object, so agent callers get a
  stable, versioned error envelope.

## Tradeoffs and deferred

- Git branches and worktrees previously derived from the old workitem name are
  intentionally not renamed; existing branches keep their names.
- The priority store and current.yaml are migrated on disk but not committed,
  because they are gitignored per-machine state. In a campaign that force-tracks
  them (against the generated `.gitignore`), a rename would leave those files
  dirty. This matches gather's existing treatment and is the correct behavior
  for the standard gitignored layout.
- Quest link staleness on move is left as the documented pre-existing gap above.

## Test coverage

Unit tests (`internal/commands/workitem/rename_test.go`), table-driven, error
cases first: `renameBasename` (extension handling), `renameKey` (key
derivation invariant), `ensureRenamable` (festival/intent rejection),
`rewriteScopePath`, `rekeyRenamePriorities` (the priority migration proof,
including attention stage + group), and `rehomeRenameLinks` (key migration with
stable-id preserved, scope-path subtree rewrite).

Integration tests, containerized with the `integration` build tag
(`tests/integration/workitem_rename_test.go`): end-to-end reference repair
(directory move + external markdown link + priority store re-key + clean git
tree + rename commit), links.yaml repair (key + scope path, stable id
preserved), `--json` shape, `--dry-run` (no change, no commit), `--no-commit`
(moved on disk, HEAD unchanged), sibling collision rejection, and file-workitem
rename with extension preservation.

Gates run from the worktree, all passing: `just build` (stable + dev),
`go vet ./...` (stable, dev, integration), `just lint` (stable + dev; golangci
`--new-from-merge-base`, the fmt.Errorf ratchet, and the host-fs-tests ratchet
all clean), `just test unit` (3643/3643 stable, 3675/3675 dev), the 7 rename
integration tests, and `just docs` (regenerated; the only doc changes are the
new `camp_workitem_rename.md` and the rename entries in `camp_workitem.md` and
`camp-reference.md`, no unrelated drift).

## Real CLI output

Dry run (human):

```
dry-run: would rename workitem timeline (directory) to workflow/design/release-timeline
```

Dry run (`--json`):

```json
{
  "schema_version": "workitem-rename/v1alpha1",
  "generated_at": "2026-07-23T22:50:39.084564Z",
  "workitem": {
    "id": "design-timeline-fixed",
    "key": "design:workflow/design/release-timeline",
    "type": "design",
    "item_kind": "directory",
    "from": "workflow/design/timeline",
    "to": "workflow/design/release-timeline",
    "committed": false,
    "links_updated": false,
    "priority_migrated": false,
    "current_updated": false
  }
}
```

Real rename with a link present (`--json`):

```json
{
  "schema_version": "workitem-rename/v1alpha1",
  "generated_at": "2026-07-23T22:51:31.678282Z",
  "workitem": {
    "id": "design-alpha-fixed",
    "key": "design:workflow/design/alpha-renamed",
    "type": "design",
    "item_kind": "directory",
    "from": "workflow/design/alpha",
    "to": "workflow/design/alpha-renamed",
    "committed": true,
    "commit_message": "Committed changes to git",
    "links_updated": true,
    "priority_migrated": false,
    "current_updated": false
  }
}
```

links.yaml before and after that rename (subject key and scope path migrated,
stable id preserved):

```yaml
# before
  - id: lnk_20260723_1ef657
    workitem_id: design-alpha-fixed
    workitem_key: design:workflow/design/alpha
    scope:
      kind: campaign_path
      path: workflow/design/alpha/sub
    role: primary
# after
  - id: lnk_20260723_1ef657
    workitem_id: design-alpha-fixed
    workitem_key: design:workflow/design/alpha-renamed
    scope:
      kind: campaign_path
      path: workflow/design/alpha-renamed/sub
    role: primary
```

Rename commit (git records the directory move as a rename and stages the
repaired references together):

```
 .campaign/workitems/.workitems.jsonl                     | 1 +
 docs/note.md                                             | 2 +-
 workflow/design/{timeline => release-timeline}/.workitem | 0
 workflow/design/{timeline => release-timeline}/README.md | 0
 workflow/design/{timeline => release-timeline}/sub/x.md  | 0
```
