### PR TITLE
feat(workitem): add camp workitem id verb

### DIFF
--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -88,6 +88,7 @@ var manifestAgentAllowedReasons = map[string]string{
 	"workitem create":            "Non-interactive workitem creation with explicit slug",
 	"workitem current":           "Non-interactive current-workitem selection and query",
 	"workitem doctor":            "Read path (--json) is safe; never pass --fix from an agent",
+	"workitem id":                "Read-only identifier lookup with a bare-id stdout contract and --json for automation",
 	"workitem link":              "Non-interactive workitem link operation",
 	"workitem links":             "Read-only workitem link listing",
 	"workitem list":              "Read-only filtered listing with non-interactive compact and JSON output",

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -7353,6 +7353,52 @@ camp workitem group <selector> <group|clear> [flags]
 ```
 ---
 
+## camp workitem id
+
+Print the identifier of a workitem
+
+### Synopsis
+
+Print the stable identifier of a workitem.
+
+With no argument, the workitem is detected from the current context using the
+same tiered resolution as `camp workitem resolve` (explicit selector, cwd
+ancestor, linked scope, festival, current-workitem pointer). With an argument,
+the workitem is resolved through the shared selector family: workitem ref,
+stable id, key, campaign-relative path, directory slug, or festival id. A
+filesystem path (absolute or relative to the current directory) is accepted and
+translated to the campaign-relative form the selector expects.
+
+The bare stable id is written to stdout for shell scripting; it is the id sibling
+of `camp workitem --print`, which prints a path. Use --key for the
+path-derived key instead, or --json for a structured object.
+
+Examples:
+  camp workitem id                       # id of the workitem for the cwd
+  camp workitem id design-x-2026-05-24   # echoes back the stable id
+  camp workitem id ./workflow/design/x   # resolves a filesystem path
+  camp workitem id --key                 # print the <type>:<path> key form
+  camp workitem id --json SC0001         # structured object for a festival
+
+```
+camp workitem id [selector-or-path] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for id
+      --json   emit a structured JSON result
+      --key    print the path-derived key instead of the stable id
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
 ## camp workitem link
 
 Create a workitem link

--- a/docs/cli-reference/camp_workitem.md
+++ b/docs/cli-reference/camp_workitem.md
@@ -54,6 +54,7 @@ camp workitem [flags]
 * [camp workitem current](camp_workitem_current.md)	 - Get, set, or clear the current workitem
 * [camp workitem doctor](camp_workitem_doctor.md)	 - Report link-registry health issues
 * [camp workitem group](camp_workitem_group.md)	 - Set or clear the group
+* [camp workitem id](camp_workitem_id.md)	 - Print the identifier of a workitem
 * [camp workitem link](camp_workitem_link.md)	 - Create a workitem link
 * [camp workitem links](camp_workitem_links.md)	 - List workitem links
 * [camp workitem list](camp_workitem_list.md)	 - List or browse filtered workitems

--- a/docs/cli-reference/camp_workitem_id.md
+++ b/docs/cli-reference/camp_workitem_id.md
@@ -1,0 +1,48 @@
+## camp workitem id
+
+Print the identifier of a workitem
+
+### Synopsis
+
+Print the stable identifier of a workitem.
+
+With no argument, the workitem is detected from the current context using the
+same tiered resolution as `camp workitem resolve` (explicit selector, cwd
+ancestor, linked scope, festival, current-workitem pointer). With an argument,
+the workitem is resolved through the shared selector family: workitem ref,
+stable id, key, campaign-relative path, directory slug, or festival id. A
+filesystem path (absolute or relative to the current directory) is accepted and
+translated to the campaign-relative form the selector expects.
+
+The bare stable id is written to stdout for shell scripting; it is the id sibling
+of `camp workitem --print`, which prints a path. Use --key for the
+path-derived key instead, or --json for a structured object.
+
+Examples:
+  camp workitem id                       # id of the workitem for the cwd
+  camp workitem id design-x-2026-05-24   # echoes back the stable id
+  camp workitem id ./workflow/design/x   # resolves a filesystem path
+  camp workitem id --key                 # print the <type>:<path> key form
+  camp workitem id --json SC0001         # structured object for a festival
+
+```
+camp workitem id [selector-or-path] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for id
+      --json   emit a structured JSON result
+      --key    print the path-derived key instead of the stable id
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/internal/commands/workitem/id.go
+++ b/internal/commands/workitem/id.go
@@ -1,0 +1,238 @@
+package workitem
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/jsoncontract"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/resolver"
+)
+
+// selectorCompleteTimeout bounds workitem discovery on the shell completion
+// path so a large campaign cannot stall a keystroke.
+const selectorCompleteTimeout = 200 * time.Millisecond
+
+type idOptions struct {
+	JSON bool
+	Key  bool
+}
+
+func newIDCommand() *cobra.Command {
+	var opts idOptions
+	cmd := &cobra.Command{
+		Use:   "id [selector-or-path]",
+		Short: "Print the identifier of a workitem",
+		Long: `Print the stable identifier of a workitem.
+
+With no argument, the workitem is detected from the current context using the
+same tiered resolution as ` + "`camp workitem resolve`" + ` (explicit selector, cwd
+ancestor, linked scope, festival, current-workitem pointer). With an argument,
+the workitem is resolved through the shared selector family: workitem ref,
+stable id, key, campaign-relative path, directory slug, or festival id. A
+filesystem path (absolute or relative to the current directory) is accepted and
+translated to the campaign-relative form the selector expects.
+
+The bare stable id is written to stdout for shell scripting; it is the id sibling
+of ` + "`camp workitem --print`" + `, which prints a path. Use --key for the
+path-derived key instead, or --json for a structured object.
+
+Examples:
+  camp workitem id                       # id of the workitem for the cwd
+  camp workitem id design-x-2026-05-24   # echoes back the stable id
+  camp workitem id ./workflow/design/x   # resolves a filesystem path
+  camp workitem id --key                 # print the <type>:<path> key form
+  camp workitem id --json SC0001         # structured object for a festival`,
+		Args:              jsoncontract.Args(WorkitemIDJSONVersion, func() bool { return opts.JSON }, cobra.MaximumNArgs(1)),
+		ValidArgsFunction: completeWorkitemSelector,
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Read-only identifier lookup with a bare-id stdout contract and --json for automation",
+		},
+		RunE: jsoncontract.RunE(WorkitemIDJSONVersion, func() bool { return opts.JSON }, func(cmd *cobra.Command, args []string) error {
+			return runID(cmd.Context(), cmd, args, opts)
+		}),
+	}
+	cmd.SetFlagErrorFunc(jsoncontract.FlagErrorFunc(WorkitemIDJSONVersion, func() bool { return opts.JSON }))
+	cmd.Flags().BoolVar(&opts.JSON, "json", false, "emit a structured JSON result")
+	cmd.Flags().BoolVar(&opts.Key, "key", false, "print the path-derived key instead of the stable id")
+	return cmd
+}
+
+func runID(ctx context.Context, cmd *cobra.Command, args []string, opts idOptions) error {
+	_, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+	resolveOpts := resolver.Options{}
+	if len(args) == 1 {
+		selectorArg, serr := selectorFromArg(root, args[0])
+		if serr != nil {
+			return serr
+		}
+		resolveOpts.Explicit = selectorArg
+	}
+	res, err := resolver.Resolve(ctx, root, resolveOpts)
+	if err != nil {
+		return err
+	}
+	if res.Workitem == nil {
+		return camperrors.NewValidation("workitem",
+			"no workitem in the current context; pass a selector or run inside a workitem directory", nil)
+	}
+	id, kind := durableID(res.Workitem)
+	if opts.JSON {
+		return emitIDJSON(cmd.OutOrStdout(), res, id, kind)
+	}
+	out := id
+	if opts.Key {
+		out = res.Workitem.Key
+	}
+	_, err = fmt.Fprintln(cmd.OutOrStdout(), out)
+	return err
+}
+
+// idKind records which identifier form durableID selected, so --json can flag
+// when an item without a stable id falls back to its key.
+type idKind string
+
+const (
+	idKindStable   idKind = "stable"
+	idKindFestival idKind = "festival"
+	idKindKey      idKind = "key"
+)
+
+// durableID returns the single-segment identifier the selector can resolve back
+// to wi, plus which form it is. The value is delegated to LinkWorkitemID so the
+// id printed here and the id stored on a link cannot drift; the kind is derived
+// from the same precedence (stable .workitem id, then a festival's fest.yaml id,
+// then the path-derived key fallback).
+func durableID(wi *wkitem.WorkItem) (string, idKind) {
+	id := wkitem.LinkWorkitemID(wi)
+	switch {
+	case wi.StableID != "" && id == wi.StableID:
+		return id, idKindStable
+	case wi.WorkflowType == wkitem.WorkflowTypeFestival && wi.SourceID != "" && id == wi.SourceID:
+		return id, idKindFestival
+	default:
+		return id, idKindKey
+	}
+}
+
+// selectorFromArg translates a positional argument into a selector string. An
+// argument that names an existing filesystem path (absolute or relative to the
+// cwd) is rewritten to the campaign-relative form the selector's path matcher
+// expects; anything else is passed through unchanged as an id/key/slug/festival
+// selector. Both sides are canonicalized the same way resolver.Resolve
+// canonicalizes its root so a symlinked campaign resolves consistently.
+func selectorFromArg(root, arg string) (string, error) {
+	trimmed := strings.TrimSpace(arg)
+	if trimmed == "" {
+		return "", camperrors.NewValidation("selector", "selector must not be empty", nil)
+	}
+	abs := trimmed
+	if !filepath.IsAbs(abs) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", camperrors.Wrap(err, "get cwd")
+		}
+		abs = filepath.Join(cwd, abs)
+	}
+	if _, err := os.Stat(abs); err != nil {
+		return trimmed, nil
+	}
+	rel, err := filepath.Rel(canonicalPath(root), canonicalPath(abs))
+	if err != nil || escapesRoot(rel) {
+		return trimmed, nil
+	}
+	return filepath.ToSlash(strings.TrimRight(rel, "/")), nil
+}
+
+func canonicalPath(p string) string {
+	if abs, err := filepath.Abs(p); err == nil {
+		p = abs
+	}
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	return p
+}
+
+func escapesRoot(rel string) bool {
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel)
+}
+
+func emitIDJSON(w io.Writer, res *resolver.Resolution, id string, kind idKind) error {
+	wi := res.Workitem
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(struct {
+		SchemaVersion string          `json:"schema_version"`
+		GeneratedAt   time.Time       `json:"generated_at"`
+		ID            string          `json:"id"`
+		IDKind        idKind          `json:"id_kind"`
+		Key           string          `json:"key"`
+		StableID      string          `json:"stable_id,omitempty"`
+		Source        resolver.Source `json:"source"`
+		RelativePath  string          `json:"relative_path"`
+	}{
+		SchemaVersion: WorkitemIDJSONVersion,
+		GeneratedAt:   time.Now().UTC(),
+		ID:            id,
+		IDKind:        kind,
+		Key:           wi.Key,
+		StableID:      wi.StableID,
+		Source:        res.Source,
+		RelativePath:  wi.RelativePath,
+	})
+}
+
+func completeWorkitemSelector(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	ctx, cancel := context.WithTimeout(cmd.Context(), selectorCompleteTimeout)
+	defer cancel()
+	state, err := discoverWorkitems(ctx)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return workitemSelectorCandidates(state.items, toComplete), cobra.ShellCompDirectiveNoFileComp
+}
+
+// workitemSelectorCandidates builds the completion list from the same gather
+// that serves `camp workitem --json`: one durable id per item (which covers
+// festival ids), prefix-filtered, deduplicated, sorted, and annotated with the
+// item title as a cobra completion description.
+func workitemSelectorCandidates(items []wkitem.WorkItem, toComplete string) []string {
+	seen := make(map[string]bool, len(items))
+	out := make([]string, 0, len(items))
+	for i := range items {
+		id, _ := durableID(&items[i])
+		if id == "" || seen[id] {
+			continue
+		}
+		if toComplete != "" && !strings.HasPrefix(id, toComplete) {
+			continue
+		}
+		seen[id] = true
+		if title := strings.TrimSpace(items[i].Title); title != "" {
+			out = append(out, id+"\t"+title)
+			continue
+		}
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/commands/workitem/id_test.go
+++ b/internal/commands/workitem/id_test.go
@@ -1,0 +1,395 @@
+package workitem
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+func runIDCmd(t *testing.T, ctx context.Context, args []string, opts idOptions) (string, error) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	err := runID(ctx, cmd, args, opts)
+	return stdout.String(), err
+}
+
+// writeWorkitemDir seeds a directory workitem with a stable .workitem id.
+func writeWorkitemDir(t *testing.T, root, relDir, wtype, id string) {
+	t.Helper()
+	dir := filepath.Join(root, filepath.FromSlash(relDir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := "version: v1alpha5\nkind: workitem\nid: " + id + "\ntype: " + wtype + "\ntitle: " + id + "\n"
+	if err := os.WriteFile(filepath.Join(dir, wkitem.MetadataFilename), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeFestival seeds a festival directory with a fest.yaml metadata id.
+func writeFestival(t *testing.T, root, stage, name, id string) {
+	t.Helper()
+	dir := filepath.Join(root, "festivals", stage, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "version: v1alpha1\nmetadata:\n  id: " + id + "\n  name: " + id + "\n  festival_type: standard\n"
+	if err := os.WriteFile(filepath.Join(dir, "fest.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestID_NoContextIsError(t *testing.T) {
+	root := linkTestCampaign(t)
+	other := filepath.Join(root, "docs")
+	if err := os.MkdirAll(other, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	restore := chdir(t, other)
+	defer restore()
+
+	if _, err := runIDCmd(t, context.Background(), nil, idOptions{}); err == nil {
+		t.Fatal("expected an error when no workitem is in context and no selector is given")
+	}
+}
+
+func TestID_NonexistentSelectorIsError(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	if _, err := runIDCmd(t, context.Background(), []string{"does-not-exist"}, idOptions{}); err == nil {
+		t.Fatal("expected an error for a selector that matches nothing")
+	}
+}
+
+func TestID_NonexistentPathIsError(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	// A path-looking argument that is not on disk is treated as a selector and
+	// must fail loudly rather than silently succeed.
+	if _, err := runIDCmd(t, context.Background(), []string{"workflow/design/missing"}, idOptions{}); err == nil {
+		t.Fatal("expected an error for a nonexistent campaign-relative path")
+	}
+}
+
+func TestID_AmbiguousSelectorIsError(t *testing.T) {
+	root := linkTestCampaign(t)
+	writeWorkitemDir(t, root, "workflow/design/dup", "design", "design-dup-a")
+	writeWorkitemDir(t, root, "workflow/explore/dup", "explore", "explore-dup-b")
+	restore := chdir(t, root)
+	defer restore()
+
+	// "dup" matches the directory-slug tier against two workitems.
+	if _, err := runIDCmd(t, context.Background(), []string{"dup"}, idOptions{}); err == nil {
+		t.Fatal("expected an ambiguity error when a slug matches multiple workitems")
+	}
+}
+
+func TestID_StableIDIsDefault(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	out, err := runIDCmd(t, context.Background(), []string{testWorkitemID}, idOptions{})
+	if err != nil {
+		t.Fatalf("runID: %v", err)
+	}
+	if strings.TrimSpace(out) != testWorkitemID {
+		t.Fatalf("id = %q, want %q", strings.TrimSpace(out), testWorkitemID)
+	}
+}
+
+func TestID_KeyFlagPrintsKey(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	out, err := runIDCmd(t, context.Background(), []string{testWorkitemID}, idOptions{Key: true})
+	if err != nil {
+		t.Fatalf("runID --key: %v", err)
+	}
+	if strings.TrimSpace(out) != testWorkitemKey {
+		t.Fatalf("key = %q, want %q", strings.TrimSpace(out), testWorkitemKey)
+	}
+}
+
+func TestID_CwdInsideWorkitemResolvesViaAncestor(t *testing.T) {
+	root := linkTestCampaign(t)
+	cwd := filepath.Join(root, "workflow", "design", "example")
+	restore := chdir(t, cwd)
+	defer restore()
+
+	out, err := runIDCmd(t, context.Background(), nil, idOptions{})
+	if err != nil {
+		t.Fatalf("runID: %v", err)
+	}
+	if strings.TrimSpace(out) != testWorkitemID {
+		t.Fatalf("id = %q, want %q", strings.TrimSpace(out), testWorkitemID)
+	}
+}
+
+func TestID_ExplicitSelectorBeatsCwd(t *testing.T) {
+	root := linkTestCampaign(t)
+	writeWorkitemDir(t, root, "workflow/design/other", "design", "design-other-2026-05-24")
+	// cwd is inside the "example" workitem, but an explicit selector for
+	// "other" must win (explicit tier precedes the cwd-ancestor tier).
+	cwd := filepath.Join(root, "workflow", "design", "example")
+	restore := chdir(t, cwd)
+	defer restore()
+
+	out, err := runIDCmd(t, context.Background(), []string{"design-other-2026-05-24"}, idOptions{})
+	if err != nil {
+		t.Fatalf("runID: %v", err)
+	}
+	if strings.TrimSpace(out) != "design-other-2026-05-24" {
+		t.Fatalf("id = %q, want design-other-2026-05-24", strings.TrimSpace(out))
+	}
+}
+
+func TestID_CampaignRelativePathResolves(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	out, err := runIDCmd(t, context.Background(), []string{"workflow/design/example"}, idOptions{})
+	if err != nil {
+		t.Fatalf("runID path: %v", err)
+	}
+	if strings.TrimSpace(out) != testWorkitemID {
+		t.Fatalf("id = %q, want %q", strings.TrimSpace(out), testWorkitemID)
+	}
+}
+
+func TestID_AbsoluteFilesystemPathResolves(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	abs := filepath.Join(root, "workflow", "design", "example")
+	out, err := runIDCmd(t, context.Background(), []string{abs}, idOptions{})
+	if err != nil {
+		t.Fatalf("runID abs path: %v", err)
+	}
+	if strings.TrimSpace(out) != testWorkitemID {
+		t.Fatalf("id = %q, want %q", strings.TrimSpace(out), testWorkitemID)
+	}
+}
+
+func TestID_FestivalDurableIDIsFestivalMetadataID(t *testing.T) {
+	root := linkTestCampaign(t)
+	writeFestival(t, root, "active", "social-SC0001", "SC0001")
+	restore := chdir(t, root)
+	defer restore()
+
+	out, err := runIDCmd(t, context.Background(), []string{"SC0001"}, idOptions{})
+	if err != nil {
+		t.Fatalf("runID festival: %v", err)
+	}
+	if strings.TrimSpace(out) != "SC0001" {
+		t.Fatalf("id = %q, want SC0001", strings.TrimSpace(out))
+	}
+}
+
+func TestID_JSONShape(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	out, err := runIDCmd(t, context.Background(), []string{testWorkitemID}, idOptions{JSON: true})
+	if err != nil {
+		t.Fatalf("runID --json: %v", err)
+	}
+	var payload struct {
+		SchemaVersion string `json:"schema_version"`
+		ID            string `json:"id"`
+		IDKind        string `json:"id_kind"`
+		Key           string `json:"key"`
+		StableID      string `json:"stable_id"`
+		Source        string `json:"source"`
+		RelativePath  string `json:"relative_path"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\nraw=%s", err, out)
+	}
+	if payload.SchemaVersion != WorkitemIDJSONVersion {
+		t.Fatalf("schema_version = %q, want %q", payload.SchemaVersion, WorkitemIDJSONVersion)
+	}
+	if payload.ID != testWorkitemID || payload.IDKind != string(idKindStable) {
+		t.Fatalf("id/id_kind = %q/%q", payload.ID, payload.IDKind)
+	}
+	if payload.Key != testWorkitemKey || payload.StableID != testWorkitemID {
+		t.Fatalf("key/stable_id = %q/%q", payload.Key, payload.StableID)
+	}
+	if payload.Source != "explicit" || payload.RelativePath != "workflow/design/example" {
+		t.Fatalf("source/relative_path = %q/%q", payload.Source, payload.RelativePath)
+	}
+}
+
+func TestID_JSONKeyFallbackForItemWithoutStableID(t *testing.T) {
+	root := linkTestCampaign(t)
+	plain := filepath.Join(root, "workflow", "design", "plain")
+	if err := os.MkdirAll(plain, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(plain, "README.md"), []byte("# Plain\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	restore := chdir(t, root)
+	defer restore()
+
+	out, err := runIDCmd(t, context.Background(), []string{"workflow/design/plain"}, idOptions{JSON: true})
+	if err != nil {
+		t.Fatalf("runID --json: %v", err)
+	}
+	var payload struct {
+		ID       string `json:"id"`
+		IDKind   string `json:"id_kind"`
+		Key      string `json:"key"`
+		StableID string `json:"stable_id"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\nraw=%s", err, out)
+	}
+	if payload.IDKind != string(idKindKey) {
+		t.Fatalf("id_kind = %q, want key", payload.IDKind)
+	}
+	if payload.ID != payload.Key || payload.Key != "design:workflow/design/plain" {
+		t.Fatalf("id/key = %q/%q, want both design:workflow/design/plain", payload.ID, payload.Key)
+	}
+	if payload.StableID != "" {
+		t.Fatalf("stable_id = %q, want empty for a key-fallback item", payload.StableID)
+	}
+}
+
+func TestDurableID_MatchesLinkTarget(t *testing.T) {
+	cases := []struct {
+		name string
+		wi   wkitem.WorkItem
+		want idKind
+	}{
+		{"stable", wkitem.WorkItem{StableID: "design-x-2026-05-24", Key: "design:workflow/design/x"}, idKindStable},
+		{"festival", wkitem.WorkItem{WorkflowType: wkitem.WorkflowTypeFestival, SourceID: "SC0001", Key: "festival:festivals/active/x"}, idKindFestival},
+		{"key_only", wkitem.WorkItem{Key: "design:workflow/design/plain"}, idKindKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, kind := durableID(&tc.wi)
+			if want := wkitem.LinkWorkitemID(&tc.wi); id != want {
+				t.Fatalf("durableID value = %q, want LinkWorkitemID %q (must not drift)", id, want)
+			}
+			if kind != tc.want {
+				t.Fatalf("id_kind = %q, want %q", kind, tc.want)
+			}
+		})
+	}
+}
+
+func TestWorkitemSelectorCandidates(t *testing.T) {
+	items := []wkitem.WorkItem{
+		{StableID: "design-a", Key: "design:workflow/design/a", Title: "Alpha"},
+		{StableID: "design-b", Key: "design:workflow/design/b", Title: "Bravo"},
+		{WorkflowType: wkitem.WorkflowTypeFestival, SourceID: "SC0001", Key: "festival:festivals/active/x", Title: "Camp"},
+		{Key: "design:workflow/design/plain", Title: "Plain"}, // key fallback
+	}
+
+	tests := []struct {
+		name       string
+		toComplete string
+		want       []string
+	}{
+		{
+			name:       "all with titles",
+			toComplete: "",
+			want: []string{
+				"SC0001\tCamp",
+				"design-a\tAlpha",
+				"design-b\tBravo",
+				"design:workflow/design/plain\tPlain",
+			},
+		},
+		{
+			name:       "prefix filters",
+			toComplete: "design-",
+			want:       []string{"design-a\tAlpha", "design-b\tBravo"},
+		},
+		{
+			name:       "festival prefix",
+			toComplete: "SC",
+			want:       []string{"SC0001\tCamp"},
+		},
+		{
+			name:       "no match",
+			toComplete: "zzz",
+			want:       []string{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := workitemSelectorCandidates(items, tc.toComplete)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Fatalf("candidate[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestWorkitemSelectorCandidates_Dedup(t *testing.T) {
+	items := []wkitem.WorkItem{
+		{StableID: "design-a", Key: "design:workflow/design/a", Title: "Alpha"},
+		{StableID: "design-a", Key: "design:workflow/design/a", Title: "Alpha copy"},
+	}
+	got := workitemSelectorCandidates(items, "")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 deduplicated candidate, got %v", got)
+	}
+}
+
+func TestCompleteWorkitemSelector_Wired(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	got, directive := completeWorkitemSelector(cmd, nil, "design")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("directive = %v, want NoFileComp", directive)
+	}
+	found := false
+	for _, c := range got {
+		if strings.HasPrefix(c, testWorkitemID) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected completion to include %q, got %v", testWorkitemID, got)
+	}
+}
+
+func TestCompleteWorkitemSelector_NoCompletionAfterFirstArg(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	got, directive := completeWorkitemSelector(cmd, []string{"already"}, "")
+	if got != nil || directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("expected no candidates after the first positional arg, got %v (%v)", got, directive)
+	}
+}

--- a/internal/commands/workitem/json_contract.go
+++ b/internal/commands/workitem/json_contract.go
@@ -5,6 +5,8 @@ const (
 	WorkitemCreateJSONVersion = "workitem-create/v1alpha1"
 	// WorkitemResolveJSONVersion is the schema version of camp workitem resolve --json.
 	WorkitemResolveJSONVersion = "workitem-resolve/v1alpha1"
+	// WorkitemIDJSONVersion is the schema version of camp workitem id --json.
+	WorkitemIDJSONVersion = "workitem-id/v1alpha1"
 	// WorkitemPriorityJSONVersion is the schema version of camp workitem priority --json.
 	WorkitemPriorityJSONVersion = "workitem-priority/v1alpha1"
 	// WorkitemStageJSONVersion is the schema version of camp workitem stage --json.

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -146,6 +146,7 @@ Examples:
 	cmd.AddCommand(newWorktreeCommand())
 	cmd.AddCommand(newCurrentCommand())
 	cmd.AddCommand(newResolveCommand())
+	cmd.AddCommand(newIDCommand())
 	cmd.AddCommand(newPriorityCommand())
 	cmd.AddCommand(newStageCommand())
 	cmd.AddCommand(newGroupCommand())

--- a/internal/commands/workitem/workitem_test.go
+++ b/internal/commands/workitem/workitem_test.go
@@ -461,7 +461,7 @@ func TestWorkitemSubcommandsStayRegisteredAndVisible(t *testing.T) {
 
 	want := []string{
 		"adopt", "commit", "commits", "create", "current", "doctor", "group",
-		"link", "links", "list", "priority", "promote", "rename", "repair",
+		"id", "link", "links", "list", "priority", "promote", "rename", "repair",
 		"resolve", "stage", "unlink", "validate", "worktree",
 	}
 


### PR DESCRIPTION
## Summary

Adds `camp workitem id [selector-or-path]`, a read-only command that prints a workitem's durable identifier. It is the identifier sibling of the existing `camp workitem --print` (which prints a path): the bare id goes to stdout so scripts and agents can capture it.

## Output contract

- **Default (bare id):** the durable stable id on stdout, nothing else, exit 0.
- **`--key`:** the path-derived `<type>:<path>` key form instead.
- **`--json`:** a small structured object aligned with the existing WorkItem / resolve vocabulary.

Real captured output (from a throwaway fixture campaign):

```
$ camp workitem id design-example-2026-05-24
design-example-2026-05-24

$ camp workitem id --key design-example-2026-05-24
design:workflow/design/example

$ camp workitem id --json design-example-2026-05-24
{
  "schema_version": "workitem-id/v1alpha1",
  "generated_at": "2026-07-23T23:11:02.326311Z",
  "id": "design-example-2026-05-24",
  "id_kind": "stable",
  "key": "design:workflow/design/example",
  "stable_id": "design-example-2026-05-24",
  "source": "explicit",
  "relative_path": "workflow/design/example"
}
```

## Which identifier is the default (stable id vs key)

There are two identifier forms in the codebase: the durable stable id and the path-derived key (`WorkItem.Key`, always `<type>:<path>`). The stable id is not one uniform thing across all workitem types, so "stable id" here means the single-segment identifier the selector can resolve back to the item, delegated to `internal/workitem/link_target.go:LinkWorkitemID`:

1. an adopted workitem's stable `.workitem` id (`WorkItem.StableID`), when present;
2. a festival's `fest.yaml` metadata id (`WorkItem.SourceID`, e.g. `SC0001`) for festivals, which have no `StableID`;
3. otherwise the path-derived key as a documented fallback.

`id.go:durableID` takes its value from `LinkWorkitemID` so the id printed here cannot drift from what a link stores, and derives an `id_kind` (`stable` / `festival` / `key`) so `--json` consumers can see when an item without a real stable id fell back to its key. `stable_id` is `omitempty`, so its absence is the machine-readable fallback signal too.

Festival and key-fallback `--json` (real output):

```
$ camp workitem id --json SC0001
{ "id": "SC0001", "id_kind": "festival", "key": "festival:festivals/active/social-campaign-SC0001", "source": "explicit", "relative_path": "festivals/active/social-campaign-SC0001", ... }

$ camp workitem id --json workflow/design/plain
{ "id": "design:workflow/design/plain", "id_kind": "key", "key": "design:workflow/design/plain", "source": "explicit", "relative_path": "workflow/design/plain", ... }
```

## How resolution is shared with `resolve`

`id` is a thin veneer over the same resolver machinery `camp workitem resolve` uses; it writes no second resolution path and differs only in output shape, positional-argument handling, and completion registration.

- No argument: `internal/commands/workitem/id.go:runID` calls `internal/workitem/resolver.Resolve` with empty options, so context detection runs the identical tiered pipeline as `resolve` (explicit, cwd ancestor, link, festival, current-workitem pointer). See `internal/workitem/resolver/resolver.go:63`.
- With an argument: `runID` sets `resolver.Options.Explicit`, so the argument flows through the resolver's explicit tier into `internal/workitem/selector.Resolve` (`resolver.go:164`), the same selector family every other workitem command uses (`ref` / `stable id` / `key` / `path` / `slug` / `festival id`).
- Output shape differs deliberately: `resolve` prints `no workitem context` and exits 0; `id` treats "no context and no selector" as an error (nonzero exit) because it is a scripting primitive.

`TestDurableID_MatchesLinkTarget` asserts `durableID`'s value equals `LinkWorkitemID` for stable / festival / key-only items, guarding against drift between the two.

## Filesystem path argument

`id.go:selectorFromArg` translates a positional argument that names an existing on-disk path (absolute or relative to the cwd) into the campaign-relative form the selector's path matcher expects; anything else passes through unchanged as an id/key/slug/festival selector. Both sides are canonicalized with `EvalSymlinks` the same way `resolver.Resolve` canonicalizes its root, so a symlinked campaign resolves consistently. A path that does not exist on disk is treated as a selector and fails loudly rather than silently succeeding.

## Completion wiring

Dynamic shell completion for the positional argument is registered as the command's cobra `ValidArgsFunction` (`completeWorkitemSelector`), reachable through camp's existing `__complete` machinery (verified: `camp __complete workitem id design` returns candidates). It gathers candidates from `discoverWorkitems` (the same gather that serves `camp workitem --json`) and, via the pure, unit-tested `workitemSelectorCandidates`, offers one durable id per item (which covers festival ids), prefix-filtered, deduplicated, sorted, and annotated with the item title as a cobra description. Discovery is bounded by a 200ms timeout so a large campaign cannot stall a keystroke. This adds no shell-template changes, so the `internal/shell` wrapper-transparency tests are unaffected.

## Error behavior

- No context and no argument: clear message on stderr, nonzero exit, never a hang or interactive prompt.

  ```
  $ camp workitem id
  Error: validation error on workitem: no workitem in the current context; pass a selector or run inside a workitem directory
  exit=1
  ```
- Unknown selector / nonexistent path: the resolver's explicit tier fails loudly (selector not found), nonzero exit.
- Ambiguous selector (e.g. a slug matching two items): surfaced as an ambiguity error from the shared selector.
- With `--json`, all of the above render through the existing `jsoncontract` error envelope with `schema_version: workitem-id/v1alpha1`.

## Cobra annotations

`agent_allowed: "true"` with a reason on the command, plus the matching entry in `cmd/camp/zz_manifest_annotations.go` (the hand-maintained allowlist the manifest guard test enforces).

## Test coverage

New tests in `internal/commands/workitem/id_test.go` (host-side fixture trees via the existing `linkTestCampaign` + `chdir` helpers, matching the `resolve`/`selector` test convention; this command is read-only), error cases first:

- no context + no argument is an error; nonexistent selector is an error; nonexistent path is an error; ambiguous slug is an error;
- stable id is the default; `--key` prints the key; cwd inside a workitem resolves via the ancestor tier; an explicit selector beats cwd;
- campaign-relative path resolves; absolute filesystem path resolves; festival durable id is the `fest.yaml` id;
- `--json` shape (all fields) and the key-fallback `--json` case;
- `durableID` matches `LinkWorkitemID` (drift guard);
- `workitemSelectorCandidates` (dedup, prefix filter, sort, title annotation) and the wired `completeWorkitemSelector` (directive + candidates, and no completion after the first positional arg).

Updated the two guard tests a new subcommand is expected to touch: `internal/commands/workitem/workitem_test.go` (registered-subcommand list/count) and the manifest allowlist above.

## Gates

Run from the worktree, all green:

- `just build-camp` (stable) and dev-profile build via `just gate`
- `just gate`: stable + dev build, `go vet` stable/dev/integration, `just lint` stable + dev (0 issues each), unit tests dev (3687 passed) and stable (3655 passed)
- `just docs` regenerated the CLI reference (committed separately as generated output)

No pre-existing failures encountered.

## Tradeoffs and deferred items

- **No interactive picker/TUI.** Completion is the interactive surface. A reusable fuzzy picker is being built concurrently elsewhere; unifying `id` with it can happen later.
- **Read-only.** The command mutates no campaign state; the only writes it could trigger are whatever `discoverWorkitems` already does on read for `camp workitem --json` (it does not write).
- **Interactive shell-wrapper `--path-output`.** The `camp` shell function intercepts `camp workitem ...` on a TTY and appends `--path-output` unless a passthrough flag (`--help`/`--json`/`--print`) is present. This is a pre-existing interaction that affects every workitem subcommand equally (verified: `camp workitem resolve --path-output` already exits 2 today), not something this PR introduces. `id`'s primary consumers are scripts/agents that call the binary directly or pass `--json` (which passes through cleanly), so it is left as-is; making the wrapper pass through recognized subcommands is a separate, broader change.
