### PR TITLE
feat(list,switch): surface remote machines in picker and list browser

### DIFF
--- a/cmd/camp/list.go
+++ b/cmd/camp/list.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/machines"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 type campaignEntry struct {
@@ -33,6 +34,10 @@ type campaignEntry struct {
 	Machine string `json:"machine,omitempty"`
 }
 
+// stderrIsTTY is overridden in tests so the R2 machines hint can be asserted
+// without a real terminal.
+var stderrIsTTY = func() bool { return term.IsTerminal(int(os.Stderr.Fd())) }
+
 var listCmd = &cobra.Command{
 	Use:   "list [org]",
 	Short: "List all registered campaigns",
@@ -43,9 +48,15 @@ with 'camp register'. The registry lives at ~/.obey/campaign/registry.json.
 
 In a terminal, 'camp list' (with no flags) opens an interactive browser where you
 can deactivate/reactivate campaigns (cycle lifecycle status), reassign their org,
-and copy paths. Pass an org as a positional argument to open the browser filtered
-to that org. Piped, with --json/--count, or with any filter/sort flag it prints
-the table instead. Home paths display as '~'.
+and copy paths. When machines are configured in ~/.obey/machines.yaml, press 'r'
+to load remote campaigns into the browser (not on open). Pass an org as a
+positional argument to open the browser filtered to that org. Piped, with
+--json/--count, or with any filter/sort flag it prints the table instead. Home
+paths display as '~'.
+
+Shell integration (recommended for go/hop from the browser):
+  eval "$(camp shell-init zsh)"   # or bash / fish
+  camp list                       # interactive browser; g hops remote rows
 
 Output formats:
   table   - Aligned columns with headers (default)
@@ -72,7 +83,10 @@ Examples:
 --remote runs each machine's own 'camp list --json' through a login shell
 (sh -lc) so PATH entries a login profile exports (~/.profile, etc.) are
 picked up. If camp still can't be found on a machine, set
-CAMP_REMOTE_CAMP_PATH to its exact path there.`,
+CAMP_REMOTE_CAMP_PATH to its exact path there.
+
+For interactive hop to a remote campaign from the picker, use csw after
+shell-init (see 'camp switch --help').`,
 	Aliases: []string{"ls"},
 	Args:    cobra.MaximumNArgs(1),
 	RunE:    runList,
@@ -184,18 +198,12 @@ func renderListTable(cmd *cobra.Command, positionalOrg string) error {
 		for i := range campaigns {
 			campaigns[i].Machine = machines.LocalMachineID
 		}
-		mf, err := machines.Load()
+		remoteRows, results, err := loadRemoteCampaigns(ctx, filter)
 		if err != nil {
 			return err
 		}
-		remoteResults = fanOutRemote(ctx, mf.Machines, enumerateRemoteFor(filter))
-		for _, r := range remoteResults {
-			if r.err == nil {
-				campaigns = append(campaigns, r.rows...)
-			}
-			// A failed result becomes a labeled muted row in the human render
-			// (task 2); it never contaminates the local/reachable rows here.
-		}
+		remoteResults = results
+		campaigns = append(campaigns, remoteRows...)
 		// Correctness backstop: a version-skewed or looser remote may return rows
 		// outside the requested --org/--tag/--status, so re-apply the local filter
 		// to the combined set. Idempotent for the already-filtered local rows.
@@ -226,6 +234,8 @@ func renderListTable(cmd *cobra.Command, positionalOrg string) error {
 	if listRemote {
 		return outputRemoteList(os.Stdout, cmd.ErrOrStderr(), campaigns, remoteResults, formatStr)
 	}
+	// R2: human table only, when machines exist and stderr is a TTY.
+	maybeEmitMachinesHint(cmd.ErrOrStderr(), formatStr)
 	if formatStr == "json" {
 		return outputCampaigns(os.Stdout, campaigns, formatStr)
 	}
@@ -233,6 +243,24 @@ func renderListTable(cmd *cobra.Command, positionalOrg string) error {
 		return outputGrouped(campaigns, formatStr, reg.FallbackOrg())
 	}
 	return outputCampaigns(os.Stdout, campaigns, formatStr)
+}
+
+// maybeEmitMachinesHint prints one muted stderr line when the human table path
+// runs without --remote and machines.yaml has at least one machine. JSON/simple/
+// count and non-TTY stderr stay silent (R2). Best-effort: load failure skips hint.
+func maybeEmitMachinesHint(stderr io.Writer, format string) {
+	if format != "table" {
+		return
+	}
+	if !stderrIsTTY() {
+		return
+	}
+	mf, err := machines.Load()
+	if err != nil || len(mf.Machines) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(stderr, ui.Dim(fmt.Sprintf(
+		"%d machine(s) configured — camp list --remote", len(mf.Machines))))
 }
 
 func loadVerifiedListRegistry(ctx context.Context) (*config.Registry, *config.VerificationReport, error) {

--- a/cmd/camp/list_machines_hint_test.go
+++ b/cmd/camp/list_machines_hint_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setupMachinesFile(t *testing.T, n int) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "machines.yaml")
+	var b strings.Builder
+	b.WriteString("version: 1\nmachines:\n")
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "  - id: m%d\n    host: m%d.ts.net\n    auth_method: tailscale-ssh\n", i, i)
+	}
+	if n == 0 {
+		b.Reset()
+		b.WriteString("version: 1\nmachines: []\n")
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CAMP_MACHINES_PATH", path)
+}
+
+func TestMaybeEmitMachinesHint(t *testing.T) {
+	origTTY := stderrIsTTY
+	t.Cleanup(func() { stderrIsTTY = origTTY })
+
+	t.Run("suppresses when stderr not tty", func(t *testing.T) {
+		stderrIsTTY = func() bool { return false }
+		setupMachinesFile(t, 2)
+		var buf bytes.Buffer
+		maybeEmitMachinesHint(&buf, "table")
+		if buf.Len() != 0 {
+			t.Errorf("expected no hint for non-TTY stderr, got %q", buf.String())
+		}
+	})
+
+	t.Run("suppresses for json format", func(t *testing.T) {
+		stderrIsTTY = func() bool { return true }
+		setupMachinesFile(t, 1)
+		var buf bytes.Buffer
+		maybeEmitMachinesHint(&buf, "json")
+		if buf.Len() != 0 {
+			t.Errorf("expected no hint for json, got %q", buf.String())
+		}
+	})
+
+	t.Run("emits when tty and machines present", func(t *testing.T) {
+		stderrIsTTY = func() bool { return true }
+		setupMachinesFile(t, 2)
+		var buf bytes.Buffer
+		maybeEmitMachinesHint(&buf, "table")
+		if !strings.Contains(buf.String(), "2 machine(s) configured") {
+			t.Errorf("hint missing count: %q", buf.String())
+		}
+		if !strings.Contains(buf.String(), "camp list --remote") {
+			t.Errorf("hint missing --remote guidance: %q", buf.String())
+		}
+	})
+
+	t.Run("silent when no machines", func(t *testing.T) {
+		stderrIsTTY = func() bool { return true }
+		setupMachinesFile(t, 0)
+		var buf bytes.Buffer
+		maybeEmitMachinesHint(&buf, "table")
+		if buf.Len() != 0 {
+			t.Errorf("expected no hint with empty fleet, got %q", buf.String())
+		}
+	})
+}

--- a/cmd/camp/list_remote.go
+++ b/cmd/camp/list_remote.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"text/tabwriter"
 
+	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/machines"
 	"github.com/Obedience-Corp/camp/internal/remote"
@@ -102,6 +103,39 @@ func enumerateRemoteFor(f listFilter) enumerateFunc {
 		// keystroke path ever doing a live ssh.
 		writeMachineCacheCampaigns(m.ID, names)
 		return rows, nil
+	}
+}
+
+// loadRemoteCampaigns is the shared live fan-out used by list --remote, the list
+// TUI remote toggle, and the switch picker. It loads machines.yaml, enumerates
+// every machine, and returns successful rows plus the full result set (including
+// per-machine errors). A missing/empty fleet returns empty slices, not an error.
+// Callers re-filter as needed; this does not re-apply the local filter backstop.
+func loadRemoteCampaigns(ctx context.Context, filter listFilter) ([]campaignEntry, []remoteResult, error) {
+	mf, err := machines.Load()
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(mf.Machines) == 0 {
+		return nil, nil, nil
+	}
+	results := fanOutRemote(ctx, mf.Machines, enumerateRemoteFor(filter))
+	var rows []campaignEntry
+	for _, r := range results {
+		if r.err == nil {
+			rows = append(rows, r.rows...)
+		}
+	}
+	return rows, results, nil
+}
+
+// listFilterFromScope maps a switch CampaignScope onto the list filter used for
+// remote enumerate (active-only by default; --all / --status / --org forwarded).
+func listFilterFromScope(scope cmdutil.CampaignScope) listFilter {
+	return listFilter{
+		org:    scope.Org,
+		status: scope.Status,
+		all:    scope.All,
 	}
 }
 

--- a/cmd/camp/list_tui.go
+++ b/cmd/camp/list_tui.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/machines"
 	"github.com/Obedience-Corp/camp/internal/pathutil"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/spf13/cobra"
@@ -37,6 +38,12 @@ type listTUIModel struct {
 	cursor     int
 	activeOnly bool
 
+	// Remote toggle (R1): default local-only; key r loads/strips remote rows.
+	remoteOn           bool
+	remoteLoading      bool
+	machinesConfigured bool
+	localCount         int // length of m.all before remote rows were appended
+
 	overlay listOverlay
 	input   textinput.Model
 
@@ -49,6 +56,13 @@ type listTUIModel struct {
 	width    int
 	height   int
 	quitting bool
+}
+
+// remoteLoadedMsg is delivered when the async fan-out for key r completes.
+type remoteLoadedMsg struct {
+	rows    []campaignEntry
+	results []remoteResult
+	err     error
 }
 
 // listTUIRequested decides whether bare `camp list` opens the browser. Machine or
@@ -100,8 +114,8 @@ func runListTUI(cmd *cobra.Command, positionalOrg string) error {
 }
 
 // writeGotoSelection persists the campaign the user chose to go to, for the
-// shell function to cd into. No-op unless a path-output file was supplied and a
-// selection was made.
+// shell function to cd into (local absolute path) or hop (ssh-hop: marker).
+// No-op unless a path-output file was supplied and a selection was made.
 func writeGotoSelection(final tea.Model, pathOutput string) error {
 	m, ok := final.(listTUIModel)
 	if !ok || pathOutput == "" || m.gotoPath == "" {
@@ -110,17 +124,47 @@ func writeGotoSelection(final tea.Model, pathOutput string) error {
 	return os.WriteFile(pathOutput, []byte(m.gotoPath), 0o600)
 }
 
+// gotoSelectionFor returns the path-output payload for a list row: absolute path
+// for local campaigns, ssh-hop:<machine>:<name> for remote rows.
+func gotoSelectionFor(e campaignEntry) string {
+	if e.Machine != "" && e.Machine != machines.LocalMachineID {
+		return "ssh-hop:" + e.Machine + ":" + e.Name
+	}
+	return e.Path
+}
+
+// isRemoteListEntry reports whether a row came from a remote machine fan-out.
+func isRemoteListEntry(e campaignEntry) bool {
+	return e.Machine != "" && e.Machine != machines.LocalMachineID
+}
+
 func newListTUIModel(ctx context.Context, reg *config.Registry, orgFilter string) listTUIModel {
 	ti := textinput.New()
 	ti.Prompt = "> "
 	m := listTUIModel{ctx: ctx, input: ti, orgFilter: orgFilter}
+	if mf, err := machines.Load(); err == nil && len(mf.Machines) > 0 {
+		m.machinesConfigured = true
+	}
 	m.loadFromRegistry(reg)
 	return m
 }
 
 func (m *listTUIModel) loadFromRegistry(reg *config.Registry) {
 	m.fallback = reg.FallbackOrg()
+	// Preserve remote rows across registry reload after local mutate.
+	var remotes []campaignEntry
+	if m.remoteOn {
+		for _, e := range m.all {
+			if isRemoteListEntry(e) {
+				remotes = append(remotes, e)
+			}
+		}
+	}
 	m.all = sortCampaigns(reg.Campaigns, "org", m.fallback)
+	m.localCount = len(m.all)
+	if m.remoteOn {
+		m.all = append(m.all, remotes...)
+	}
 	m.rebuildVisible()
 }
 

--- a/cmd/camp/list_tui_test.go
+++ b/cmd/camp/list_tui_test.go
@@ -405,3 +405,109 @@ func TestWriteGotoSelection(t *testing.T) {
 		t.Errorf("no path-output should be a no-op, got %v", err)
 	}
 }
+
+func TestGotoSelectionFor(t *testing.T) {
+	local := campaignEntry{Name: "x", Path: "/abs/x", Machine: ""}
+	if got := gotoSelectionFor(local); got != "/abs/x" {
+		t.Errorf("local = %q", got)
+	}
+	localTagged := campaignEntry{Name: "x", Path: "/abs/x", Machine: "local"}
+	if got := gotoSelectionFor(localTagged); got != "/abs/x" {
+		t.Errorf("local machine tag = %q", got)
+	}
+	remote := campaignEntry{Name: "lance-arch", Path: "/remote/p", Machine: "archdtop"}
+	if got := gotoSelectionFor(remote); got != "ssh-hop:archdtop:lance-arch" {
+		t.Errorf("remote = %q", got)
+	}
+}
+
+func TestListTUI_RemoteToggleMergeAndStrip(t *testing.T) {
+	m := newTestListModel(t)
+	m.machinesConfigured = true
+	localN := len(m.all)
+
+	// Simulate async load result.
+	next, _ := m.Update(remoteLoadedMsg{
+		rows: []campaignEntry{
+			{ID: "r1", Name: "lance-arch", Org: "obey", Status: config.StatusActive, Machine: "archdtop", Path: "/r"},
+		},
+		results: []remoteResult{{machineID: "archdtop"}},
+	})
+	m = next.(listTUIModel)
+	if !m.remoteOn {
+		t.Fatal("remoteOn should be true after load")
+	}
+	if len(m.all) != localN+1 {
+		t.Fatalf("all len = %d, want %d", len(m.all), localN+1)
+	}
+	// Toggle off via key r.
+	m = lkey(m, "r")
+	if m.remoteOn {
+		t.Error("remoteOn should be false after toggle off")
+	}
+	for _, e := range m.all {
+		if isRemoteListEntry(e) {
+			t.Errorf("remote row still present after toggle off: %+v", e)
+		}
+	}
+	if len(m.all) != localN {
+		t.Errorf("local count after strip = %d, want %d", len(m.all), localN)
+	}
+}
+
+func TestListTUI_RemoteMutateGuarded(t *testing.T) {
+	m := newTestListModel(t)
+	m.machinesConfigured = true
+	next, _ := m.Update(remoteLoadedMsg{
+		rows: []campaignEntry{
+			{ID: "r1", Name: "remote-camp", Org: "obey", Status: config.StatusActive, Machine: "archdtop", Path: "/r"},
+		},
+	})
+	m = next.(listTUIModel)
+	// Move cursor to last (remote) row.
+	m.cursor = len(m.visible) - 1
+	if !isRemoteListEntry(m.visible[m.cursor]) {
+		t.Fatal("expected cursor on remote row")
+	}
+	m = lkey(m, "s")
+	if !m.statusErr || !strings.Contains(m.status, "read-only") {
+		t.Errorf("status cycle on remote should refuse, got %q (err=%v)", m.status, m.statusErr)
+	}
+	m = lkey(m, "m")
+	if m.overlay != listOverlayNone {
+		t.Error("move overlay must not open on remote row")
+	}
+	if !m.statusErr || !strings.Contains(m.status, "read-only") {
+		t.Errorf("org move on remote should refuse, got %q", m.status)
+	}
+}
+
+func TestListTUI_Go_RemoteWritesSSHHop(t *testing.T) {
+	m := newTestListModel(t)
+	m.gotoEnabled = true
+	m.machinesConfigured = true
+	next, _ := m.Update(remoteLoadedMsg{
+		rows: []campaignEntry{
+			{ID: "r1", Name: "lance-arch", Org: "obey", Status: config.StatusActive, Machine: "archdtop", Path: "/remote/p"},
+		},
+	})
+	m = next.(listTUIModel)
+	m.cursor = len(m.visible) - 1
+	m = lkey(m, "g")
+	if !m.quitting {
+		t.Fatal("g should quit")
+	}
+	if m.gotoPath != "ssh-hop:archdtop:lance-arch" {
+		t.Errorf("gotoPath = %q, want ssh-hop marker", m.gotoPath)
+	}
+}
+
+func TestListTUI_FooterMentionsRemotesWhenConfigured(t *testing.T) {
+	m := newTestListModel(t)
+	m.machinesConfigured = true
+	m.width, m.height = 120, 30
+	out := m.View()
+	if !strings.Contains(out, "r: remotes") && !strings.Contains(out, "r remotes") {
+		t.Errorf("footer should mention r remotes when machines configured:\n%s", out)
+	}
+}

--- a/cmd/camp/list_tui_update.go
+++ b/cmd/camp/list_tui_update.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -14,11 +16,44 @@ func (m listTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.input.Width = max(msg.Width-8, 4)
 		}
 		return m, nil
+	case remoteLoadedMsg:
+		return m.applyRemoteLoaded(msg)
 	case tea.KeyMsg:
 		if m.overlay != listOverlayNone {
 			return m.updateOverlay(msg)
 		}
 		return m.updateBrowse(msg)
+	}
+	return m, nil
+}
+
+func (m listTUIModel) applyRemoteLoaded(msg remoteLoadedMsg) (tea.Model, tea.Cmd) {
+	m.remoteLoading = false
+	if msg.err != nil {
+		m.setStatus("remote load failed: "+msg.err.Error(), true)
+		return m, nil
+	}
+	// Drop any prior remote rows, then append the fresh fan-out.
+	locals := make([]campaignEntry, 0, m.localCount)
+	for _, e := range m.all {
+		if !isRemoteListEntry(e) {
+			locals = append(locals, e)
+		}
+	}
+	m.all = append(locals, msg.rows...)
+	m.remoteOn = true
+	m.rebuildVisible()
+
+	var unreach []string
+	for _, r := range msg.results {
+		if r.err != nil {
+			unreach = append(unreach, r.machineID)
+		}
+	}
+	if len(unreach) > 0 {
+		m.setStatus(fmt.Sprintf("loaded remotes (%d unreachable: %s)", len(unreach), strings.Join(unreach, ", ")), false)
+	} else {
+		m.setStatus(fmt.Sprintf("loaded %d remote campaign(s)", len(msg.rows)), false)
 	}
 	return m, nil
 }
@@ -37,7 +72,7 @@ func (m listTUIModel) updateBrowse(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.setStatus("go needs shell integration: run eval \"$(camp shell-init <shell>)\"", true)
 			return m, nil
 		}
-		m.gotoPath = m.visible[m.cursor].Path
+		m.gotoPath = gotoSelectionFor(m.visible[m.cursor])
 		m.quitting = true
 		return m, tea.Quit
 	case "down", "j":
@@ -52,6 +87,10 @@ func (m listTUIModel) updateBrowse(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "s":
 		if len(m.visible) > 0 {
+			if isRemoteListEntry(m.visible[m.cursor]) {
+				m.setStatus("remote campaigns are read-only here", true)
+				return m, nil
+			}
 			if err := m.cycleStatus(); err != nil {
 				m.setError(err)
 			}
@@ -59,6 +98,10 @@ func (m listTUIModel) updateBrowse(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "m":
 		if len(m.visible) > 0 {
+			if isRemoteListEntry(m.visible[m.cursor]) {
+				m.setStatus("remote campaigns are read-only here", true)
+				return m, nil
+			}
 			m.overlay = listOverlayMove
 			m.input.SetValue("")
 			m.input.Placeholder = "target org"
@@ -78,8 +121,46 @@ func (m listTUIModel) updateBrowse(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.activeOnly = !m.activeOnly
 		m.rebuildVisible()
 		return m, nil
+	case "r":
+		if !m.machinesConfigured {
+			m.setStatus("no machines configured (~/.obey/machines.yaml)", true)
+			return m, nil
+		}
+		if m.remoteLoading {
+			return m, nil
+		}
+		if m.remoteOn {
+			// Toggle off: strip remote rows.
+			locals := make([]campaignEntry, 0, m.localCount)
+			for _, e := range m.all {
+				if !isRemoteListEntry(e) {
+					locals = append(locals, e)
+				}
+			}
+			m.all = locals
+			m.remoteOn = false
+			m.rebuildVisible()
+			m.setStatus("showing local campaigns", false)
+			return m, nil
+		}
+		m.remoteLoading = true
+		m.setStatus("loading remotes…", false)
+		filter := listFilter{org: m.orgFilter}
+		if !m.activeOnly {
+			filter.all = true
+		}
+		return m, loadRemoteCampaignsCmd(m.ctx, filter)
 	}
 	return m, nil
+}
+
+// loadRemoteCampaignsCmd runs the shared fan-out off the UI thread so the
+// "loading remotes…" status line can paint (required; never block Update).
+func loadRemoteCampaignsCmd(ctx context.Context, filter listFilter) tea.Cmd {
+	return func() tea.Msg {
+		rows, results, err := loadRemoteCampaigns(ctx, filter)
+		return remoteLoadedMsg{rows: rows, results: results, err: err}
+	}
 }
 
 func (m listTUIModel) updateOverlay(key tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -95,7 +176,9 @@ func (m listTUIModel) updateOverlay(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		value := strings.TrimSpace(m.input.Value())
 		if value != "" && len(m.visible) > 0 {
 			e := m.visible[m.cursor]
-			if err := m.assignOrg(e.ID, e.Name, value); err != nil {
+			if isRemoteListEntry(e) {
+				m.setStatus("remote campaigns are read-only here", true)
+			} else if err := m.assignOrg(e.ID, e.Name, value); err != nil {
 				m.setError(err)
 			}
 		}

--- a/cmd/camp/list_tui_view.go
+++ b/cmd/camp/list_tui_view.go
@@ -179,8 +179,12 @@ func (m listTUIModel) renderRange(start, end int, headers bool, cw int) []string
 
 func (m listTUIModel) rowLine(e campaignEntry, selected bool, cw int) string {
 	prefix := "  " + ui.CursorGlyph(selected)
+	displayName := e.Name
+	if isRemoteListEntry(e) {
+		displayName = e.Machine + " · " + e.Name
+	}
 	if cw <= 0 {
-		name := styleName(fmt.Sprintf("%-*s", listNameMax, e.Name), selected)
+		name := styleName(fmt.Sprintf("%-*s", listNameMax, displayName), selected)
 		return prefix + name + "  " + listStatusCell(e.Status) + "  " +
 			listMutedStyle.Render(pathutil.AbbreviateHome(e.Path))
 	}
@@ -191,7 +195,7 @@ func (m listTUIModel) rowLine(e campaignEntry, selected bool, cw int) string {
 	}
 
 	nameW, statusOn, pathW := listColumns(rem)
-	row := prefix + styleName(fmt.Sprintf("%-*s", nameW, ui.Truncate(e.Name, nameW)), selected)
+	row := prefix + styleName(fmt.Sprintf("%-*s", nameW, ui.Truncate(displayName, nameW)), selected)
 	if statusOn {
 		row += "  " + listStatusCell(e.Status)
 	}
@@ -229,16 +233,23 @@ func (m listTUIModel) topBar() string {
 	if m.activeOnly {
 		mode = "active only"
 	}
+	if m.remoteOn {
+		mode += " + remotes"
+	} else if m.remoteLoading {
+		mode += " · loading remotes…"
+	}
 	return listTitleStyle.Render("Campaigns") + "  " +
 		listMutedStyle.Render(fmt.Sprintf("%s  .  showing: %s", ui.CountLabel(len(m.all), "campaign", "campaigns"), mode))
 }
 
 func (m listTUIModel) footer(cw int) string {
-	help := ui.CollapseHelp(cw,
-		"g: go . j/k: move . s: status . m: org . y: copy . f: filter . q: quit",
-		"j/k move . g go . f filter . q quit",
-		"q quit",
-	)
+	long := "g: go . j/k: move . s: status . m: org . y: copy . f: filter . q: quit"
+	mid := "j/k move . g go . f filter . q quit"
+	if m.machinesConfigured {
+		long = "g: go . j/k: move . s: status . m: org . y: copy . f: filter . r: remotes . q: quit"
+		mid = "j/k move . g go . r remotes . q quit"
+	}
+	help := ui.CollapseHelp(cw, long, mid, "q quit")
 	return listHelpStyle.Render(help)
 }
 

--- a/cmd/camp/switch.go
+++ b/cmd/camp/switch.go
@@ -30,13 +30,15 @@ Without arguments, opens an interactive picker to select a campaign.
 With an argument, looks up the campaign by name or ID prefix.
 Use --org or org/campaign to resolve inside one organization.
 
-Use with the cgo shell function for instant navigation:
-  cgo switch                 # Interactive campaign picker
-  cgo switch my-campaign     # Switch by name
-  cgo switch a1b2             # Switch by ID prefix
-  cgo switch obey/platform    # Switch by org-scoped selector
+Use with the shell-init wrappers for instant navigation (recommended):
+  eval "$(camp shell-init zsh)"   # or bash / fish — once per shell
+  csw                            # Interactive picker (local + remote machines)
+  csw my-campaign                # Switch by name
+  csw a1b2                       # Switch by ID prefix
+  csw obey/platform              # Switch by org-scoped selector
+  csw archdtop:lance-arch        # Hop to a remote campaign over ssh
 
-The --print flag outputs just the path for shell integration:
+The --print flag outputs just the path for shell integration (local only):
   cd "$(camp switch --print)"
 
 Use campaign@tab to navigate to a specific location in the target campaign:
@@ -44,19 +46,23 @@ Use campaign@tab to navigate to a specific location in the target campaign:
   camp switch obey/platform@f    # Switch inside org and navigate to festivals/
 
 Use machine:campaign to resolve a campaign on a machine registered in
-~/.obey/machines.yaml (via the csw shell wrapper, which hops there over ssh):
-  csw devbox:obey-campaign       # Resolve and hop to obey-campaign on devbox
+~/.obey/machines.yaml. The interactive picker also lists remote campaigns when
+machines are configured (locals open instantly; remotes append as they load).
+Bare 'command camp switch machine:…' resolves without hopping — use the csw
+shell wrapper (or --shell-connect under shell-init) to hop.
 
 Remote resolution runs the far machine's own 'camp switch' through a login
 shell (sh -lc) so PATH entries a login profile exports (~/.profile, etc.) are
 picked up. If camp still can't be found there, set CAMP_REMOTE_CAMP_PATH to
 its exact path on that machine.`,
-	Example: `  camp switch                        # Interactive picker
-  camp switch obey-campaign          # Switch by name
+	Example: `  eval "$(camp shell-init zsh)"
+  csw                                # Interactive picker (local + remotes)
+  csw obey-campaign                  # Switch by name
+  csw archdtop:lance-arch            # Hop to remote campaign
   camp switch --org obey platform    # Switch by name within an org
   camp switch obey/platform          # Switch by scoped selector
   camp switch a1b2                   # Switch by ID prefix
-  camp switch --print                # Picker, output path only
+  camp switch --print                # Picker, output path only (local)
   camp switch obey-campaign@p        # Switch and navigate to projects/
   camp switch --all old-reference    # Include inactive/reference campaigns
   camp switch --org obey platform --json`,
@@ -287,7 +293,11 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return camperrors.Wrap(err, "load registry")
 	}
-	if reg.Len() == 0 {
+	hasMachines := false
+	if mf, merr := machines.Load(); merr == nil && len(mf.Machines) > 0 {
+		hasMachines = true
+	}
+	if reg.Len() == 0 && !hasMachines {
 		return camperrors.Newf("no campaigns registered (use 'camp init' to create one)")
 	}
 
@@ -302,6 +312,9 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 		}
 		if msel.Machine != "" && msel.Machine != machines.LocalMachineID {
 			return runRemoteSwitch(ctx, cmd, msel, printOnly, shellConnect, jsonOut)
+		}
+		if reg.Len() == 0 {
+			return camperrors.Newf("no campaigns registered (use 'camp init' to create one)")
 		}
 		// Local (no "machine:" prefix, or "local:"): Remainder equals args[0]
 		// verbatim for the no-colon case, so local resolution stays byte-identical.
@@ -328,11 +341,17 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 		if !tui.IsTerminal() {
 			return camperrors.New("campaign name required in non-interactive mode (use 'camp switch <name>' or run interactively)")
 		}
-		c, err := cmdutil.PickCampaignWithOptions(ctx, reg, cmdutil.PickCampaignOptions{Scope: scope})
+		pick, err := pickSwitchTarget(ctx, reg, pickSwitchTargetOptions{Scope: scope})
 		if err != nil {
 			return err
 		}
-		selected = c
+		if pick.Kind == switchPickRemote {
+			return runRemoteSwitch(ctx, cmd, cmdutil.ParsedMachineSelector{
+				Machine:   pick.Machine,
+				Remainder: pick.Name,
+			}, printOnly, shellConnect, jsonOut)
+		}
+		selected = pick.Local
 	}
 	if targetPath == "" {
 		targetPath = selected.Path

--- a/cmd/camp/switch_pick.go
+++ b/cmd/camp/switch_pick.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/ktr0731/go-fuzzyfinder"
+
+	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/machines"
+)
+
+// switchPickKind distinguishes local registry rows from remote machine rows.
+type switchPickKind int
+
+const (
+	switchPickLocal switchPickKind = iota
+	switchPickRemote
+)
+
+// switchPick is a heterogeneous picker candidate. Local rows carry a full
+// RegisteredCampaign; remote rows carry machine id + campaign name (and optional
+// preview path) and never invent a local Path that would poison registry mutate.
+type switchPick struct {
+	Kind    switchPickKind
+	Local   config.RegisteredCampaign
+	Machine string
+	Name    string
+	Org     string
+	Path    string // remote absolute path for preview only
+}
+
+// remoteCampaignLoader is the seam the switch picker uses for live fleet
+// enumerate. Production uses loadRemoteCampaigns; tests inject a fake fleet.
+type remoteCampaignLoader func(ctx context.Context, filter listFilter) ([]campaignEntry, []remoteResult, error)
+
+// pickSwitchTargetOptions controls the interactive switch picker.
+type pickSwitchTargetOptions struct {
+	Scope  cmdutil.CampaignScope
+	Load   remoteCampaignLoader // nil → loadRemoteCampaigns
+	Header string
+}
+
+// localSwitchPicks builds sorted local candidates (most recently accessed first).
+func localSwitchPicks(reg *config.Registry, scope cmdutil.CampaignScope) []switchPick {
+	locals := cmdutil.FilterCampaigns(reg, scope)
+	sort.Slice(locals, func(i, j int) bool {
+		return locals[i].LastAccess.After(locals[j].LastAccess)
+	})
+	out := make([]switchPick, 0, len(locals))
+	for _, c := range locals {
+		out = append(out, switchPick{Kind: switchPickLocal, Local: c})
+	}
+	return out
+}
+
+// remoteSwitchPicks converts successful remote campaign rows into picker
+// candidates, sorted by machine id then name. Unreachable machines are omitted
+// (caller surfaces them in the header).
+func remoteSwitchPicks(rows []campaignEntry) []switchPick {
+	out := make([]switchPick, 0, len(rows))
+	for _, r := range rows {
+		if r.Machine == "" || r.Machine == machines.LocalMachineID {
+			continue
+		}
+		out = append(out, switchPick{
+			Kind:    switchPickRemote,
+			Machine: r.Machine,
+			Name:    r.Name,
+			Org:     r.Org,
+			Path:    r.Path,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Machine != out[j].Machine {
+			return out[i].Machine < out[j].Machine
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// unreachableMachineIDs returns machine ids that failed during fan-out.
+func unreachableMachineIDs(results []remoteResult) []string {
+	var ids []string
+	for _, r := range results {
+		if r.err != nil {
+			ids = append(ids, r.machineID)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func switchPickLabel(p switchPick, currentPath string, showOrg bool) string {
+	prefix := "  "
+	switch p.Kind {
+	case switchPickRemote:
+		return prefix + p.Machine + " · " + p.Name
+	default:
+		if p.Local.Path == currentPath {
+			prefix = "* "
+		}
+		if showOrg {
+			return prefix + p.Local.Org + "/" + p.Local.Name
+		}
+		return prefix + p.Local.Name
+	}
+}
+
+func switchPickPreview(p switchPick, cfg *config.CampaignConfig, currentPath string, w int) string {
+	if p.Kind == switchPickRemote {
+		var b strings.Builder
+		pad := "  "
+		b.WriteString(fmt.Sprintf("%s%s · %s\n", pad, p.Machine, p.Name))
+		if p.Org != "" {
+			b.WriteString(fmt.Sprintf("%sOrg: %s\n", pad, p.Org))
+		}
+		if p.Path != "" {
+			b.WriteString(fmt.Sprintf("%sPath: %s\n", pad, p.Path))
+		}
+		b.WriteString(fmt.Sprintf("\n%s(remote — select to hop via shell-connect)\n", pad))
+		return b.String()
+	}
+	return formatSwitchLocalPreview(p.Local, cfg, currentPath, w)
+}
+
+// formatSwitchLocalPreview mirrors cmdutil's campaign preview for local rows
+// (kept here so switchPick stays self-contained without exporting cmdutil helpers).
+func formatSwitchLocalPreview(c config.RegisteredCampaign, cfg *config.CampaignConfig, currentPath string, w int) string {
+	var b strings.Builder
+	pad := "  "
+
+	b.WriteString(fmt.Sprintf("%s%s", pad, c.Name))
+	if c.Type != "" {
+		b.WriteString(fmt.Sprintf("  (%s)", c.Type))
+	}
+	b.WriteByte('\n')
+
+	if cfg != nil && cfg.Mission != "" {
+		b.WriteString(fmt.Sprintf("%s%s\n", pad, cfg.Mission))
+	}
+	if cfg != nil && cfg.Description != "" {
+		b.WriteString(fmt.Sprintf("%s%s\n", pad, cfg.Description))
+	}
+	if cfg != nil && len(cfg.Projects) > 0 {
+		b.WriteByte('\n')
+		b.WriteString(fmt.Sprintf("%sProjects: (%d)\n", pad, len(cfg.Projects)))
+		lineWidth := w - 6
+		if lineWidth < 20 {
+			lineWidth = 20
+		}
+		line := pad + "  "
+		for i, p := range cfg.Projects {
+			name := p.Name
+			if i < len(cfg.Projects)-1 {
+				name += ", "
+			}
+			if len(line)+len(name) > lineWidth && line != pad+"  " {
+				b.WriteString(line + "\n")
+				line = pad + "  "
+			}
+			line += name
+		}
+		if line != pad+"  " {
+			b.WriteString(line + "\n")
+		}
+	}
+
+	b.WriteByte('\n')
+	b.WriteString(fmt.Sprintf("%sPath: %s\n", pad, c.Path))
+	if !c.LastAccess.IsZero() {
+		b.WriteString(fmt.Sprintf("%sLast: %s\n", pad, c.LastAccess.Format("Jan 2 15:04")))
+	}
+	if c.Path == currentPath {
+		b.WriteString(fmt.Sprintf("\n%s(current)\n", pad))
+	}
+	return b.String()
+}
+
+// pickSwitchTarget opens the interactive switch picker. Locals render immediately;
+// when machines are configured, remotes append via go-fuzzyfinder hot reload so
+// open never blocks on SSH. Returns error when there are no local campaigns and
+// no machines (or remotes-only load yields nothing and was cancelled empty).
+func pickSwitchTarget(ctx context.Context, reg *config.Registry, opts pickSwitchTargetOptions) (switchPick, error) {
+	loader := opts.Load
+	if loader == nil {
+		loader = loadRemoteCampaigns
+	}
+
+	picks := localSwitchPicks(reg, opts.Scope)
+	mf, mfErr := machines.Load()
+	hasMachines := mfErr == nil && len(mf.Machines) > 0
+
+	if len(picks) == 0 && !hasMachines {
+		return switchPick{}, camperrors.New(fmt.Sprintf("no campaigns found%s", scopeDesc(opts.Scope)))
+	}
+
+	// Slice must be addressable for WithHotReloadLock.
+	items := picks
+	var mu sync.RWMutex
+	currentPath, _ := campaign.DetectCached(ctx)
+	showOrg := opts.Scope.Org == ""
+
+	header := opts.Header
+	if header == "" {
+		header = "  ↑/↓ navigate • type to filter • esc cancel"
+		if hasMachines {
+			header = "  ↑/↓ navigate • type to filter • remotes loading… • esc cancel"
+		}
+	}
+
+	cfgCache := map[string]*config.CampaignConfig{}
+	loadConfig := func(path string) *config.CampaignConfig {
+		if path == "" {
+			return nil
+		}
+		if cfg, ok := cfgCache[path]; ok {
+			return cfg
+		}
+		cfg, err := config.LoadCampaignConfig(ctx, path)
+		if err != nil {
+			cfgCache[path] = nil
+			return nil
+		}
+		cfgCache[path] = cfg
+		return cfg
+	}
+
+	if hasMachines {
+		go func() {
+			rows, results, err := loader(ctx, listFilterFromScope(opts.Scope))
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				// Keep locals; surface failure only in header isn't possible mid-flight
+				// without a second channel — remotes simply don't append.
+				return
+			}
+			remotes := remoteSwitchPicks(rows)
+			items = append(items, remotes...)
+			if unreach := unreachableMachineIDs(results); len(unreach) > 0 {
+				// Header is fixed at open; unreachable info lives in previews only.
+				// Locals remain selectable regardless.
+				_ = unreach
+			}
+		}()
+	}
+
+	findOpts := []fuzzyfinder.Option{
+		fuzzyfinder.WithPreviewWindow(func(i, w, h int) string {
+			mu.RLock()
+			defer mu.RUnlock()
+			if i < 0 || i >= len(items) {
+				return ""
+			}
+			p := items[i]
+			var cfg *config.CampaignConfig
+			if p.Kind == switchPickLocal {
+				cfg = loadConfig(p.Local.Path)
+			}
+			return switchPickPreview(p, cfg, currentPath, w)
+		}),
+		fuzzyfinder.WithPromptString("Switch to: "),
+		fuzzyfinder.WithHeader(header),
+		fuzzyfinder.WithContext(ctx),
+	}
+	if hasMachines {
+		findOpts = append(findOpts, fuzzyfinder.WithHotReloadLock(mu.RLocker()))
+	}
+
+	var slice any
+	if hasMachines {
+		slice = &items
+	} else {
+		slice = items
+	}
+
+	idx, err := fuzzyfinder.Find(
+		slice,
+		func(i int) string {
+			// itemFunc is locked by fuzzyfinder under hot reload — do not lock.
+			p := items[i]
+			return switchPickLabel(p, currentPath, showOrg)
+		},
+		findOpts...,
+	)
+	if err != nil {
+		if errors.Is(err, fuzzyfinder.ErrAbort) {
+			return switchPick{}, camperrors.Newf("cancelled")
+		}
+		return switchPick{}, camperrors.Wrap(err, "picker")
+	}
+
+	mu.RLock()
+	defer mu.RUnlock()
+	if idx < 0 || idx >= len(items) {
+		return switchPick{}, camperrors.New("picker selection out of range")
+	}
+	return items[idx], nil
+}
+
+func scopeDesc(scope cmdutil.CampaignScope) string {
+	var parts []string
+	if scope.Org != "" {
+		parts = append(parts, fmt.Sprintf("org %q", scope.Org))
+	}
+	if scope.Status != "" {
+		parts = append(parts, fmt.Sprintf("status %q", scope.Status))
+	} else if !scope.All {
+		parts = append(parts, fmt.Sprintf("status %q", config.StatusActive))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " in " + strings.Join(parts, ", ")
+}

--- a/cmd/camp/switch_pick_test.go
+++ b/cmd/camp/switch_pick_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
+	"github.com/Obedience-Corp/camp/internal/config"
+)
+
+func TestLocalSwitchPicksOrderAndScope(t *testing.T) {
+	reg := newSwitchScopedRegistry(
+		config.RegisteredCampaign{
+			ID: "1", Name: "older", Path: "/a", Org: "obey", Status: config.StatusActive,
+			LastAccess: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		config.RegisteredCampaign{
+			ID: "2", Name: "newer", Path: "/b", Org: "obey", Status: config.StatusActive,
+			LastAccess: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		},
+		config.RegisteredCampaign{
+			ID: "3", Name: "inactive", Path: "/c", Org: "obey", Status: config.StatusInactive,
+			LastAccess: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+		},
+	)
+	picks := localSwitchPicks(reg, cmdutil.CampaignScope{})
+	if len(picks) != 2 {
+		t.Fatalf("want 2 active locals, got %d", len(picks))
+	}
+	if picks[0].Local.Name != "newer" || picks[1].Local.Name != "older" {
+		t.Errorf("order wrong: %s then %s", picks[0].Local.Name, picks[1].Local.Name)
+	}
+}
+
+func TestRemoteSwitchPicksSortAndSkipLocal(t *testing.T) {
+	rows := []campaignEntry{
+		{Name: "z", Machine: "beta"},
+		{Name: "a", Machine: "alpha"},
+		{Name: "b", Machine: "alpha"},
+		{Name: "localish", Machine: "local"},
+		{Name: "nopath", Machine: ""},
+	}
+	picks := remoteSwitchPicks(rows)
+	if len(picks) != 3 {
+		t.Fatalf("want 3 remote picks, got %d: %+v", len(picks), picks)
+	}
+	want := []string{"alpha · a", "alpha · b", "beta · z"}
+	for i, p := range picks {
+		got := switchPickLabel(p, "", false)
+		if got != "  "+want[i] {
+			t.Errorf("pick %d = %q, want %q", i, got, "  "+want[i])
+		}
+		if p.Kind != switchPickRemote {
+			t.Errorf("pick %d kind = %v, want remote", i, p.Kind)
+		}
+	}
+}
+
+func TestSwitchPickLabelLocalCurrentAndOrg(t *testing.T) {
+	local := switchPick{
+		Kind:  switchPickLocal,
+		Local: config.RegisteredCampaign{Name: "camp", Org: "obey", Path: "/here"},
+	}
+	if got := switchPickLabel(local, "/here", true); got != "* obey/camp" {
+		t.Errorf("current org label = %q", got)
+	}
+	if got := switchPickLabel(local, "/other", false); got != "  camp" {
+		t.Errorf("plain label = %q", got)
+	}
+	remote := switchPick{Kind: switchPickRemote, Machine: "archdtop", Name: "lance-arch"}
+	if got := switchPickLabel(remote, "", true); got != "  archdtop · lance-arch" {
+		t.Errorf("remote label = %q", got)
+	}
+}
+
+func TestUnreachableMachineIDs(t *testing.T) {
+	ids := unreachableMachineIDs([]remoteResult{
+		{machineID: "b", err: errors.New("x")},
+		{machineID: "a", rows: nil},
+		{machineID: "c", err: errors.New("y")},
+	})
+	if len(ids) != 2 || ids[0] != "b" || ids[1] != "c" {
+		t.Fatalf("ids = %v, want [b c]", ids)
+	}
+}
+
+func TestListFilterFromScope(t *testing.T) {
+	f := listFilterFromScope(cmdutil.CampaignScope{Org: "obey", All: true})
+	if f.org != "obey" || !f.all || f.status != "" {
+		t.Errorf("filter = %+v", f)
+	}
+	f = listFilterFromScope(cmdutil.CampaignScope{Status: "inactive"})
+	if f.status != "inactive" || f.all {
+		t.Errorf("filter = %+v", f)
+	}
+}
+
+// TestRemoteLoaderSeam exercises the loader type used by the picker without
+// opening a fuzzyfinder UI (no live SSH).
+func TestRemoteLoaderSeam(t *testing.T) {
+	loader := remoteCampaignLoader(func(_ context.Context, filter listFilter) ([]campaignEntry, []remoteResult, error) {
+		if filter.org != "obey" {
+			t.Errorf("filter.org = %q", filter.org)
+		}
+		return []campaignEntry{
+				{Name: "lance-arch", Machine: "archdtop", Path: "/r"},
+			}, []remoteResult{
+				{machineID: "archdtop", rows: []campaignEntry{{Name: "lance-arch", Machine: "archdtop"}}},
+				{machineID: "dead", err: errors.New("timeout")},
+			}, nil
+	})
+	rows, results, err := loader(context.Background(), listFilter{org: "obey"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	picks := remoteSwitchPicks(rows)
+	if len(picks) != 1 || picks[0].Machine != "archdtop" {
+		t.Fatalf("picks = %+v", picks)
+	}
+	if un := unreachableMachineIDs(results); len(un) != 1 || un[0] != "dead" {
+		t.Fatalf("unreachable = %v", un)
+	}
+}

--- a/internal/shell/shell_connect_test.go
+++ b/internal/shell/shell_connect_test.go
@@ -34,3 +34,63 @@ func TestSwitchBranchEvalsShellConnect(t *testing.T) {
 		})
 	}
 }
+
+func TestListBranchHandlesSSHHopMarker(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		start  string
+		end    string
+		// Distinct markers that must appear in the list arm for remote go.
+		needles []string
+	}{
+		{
+			name:   "zsh",
+			output: generateZsh(),
+			start:  "list|ls)",
+			end:    "festivals)",
+			needles: []string{
+				"ssh-hop:",
+				`sel="${dest#ssh-hop:}"`,
+				`command camp switch "$sel" --shell-connect`,
+				`cd "$dest"`,
+			},
+		},
+		{
+			name:   "bash",
+			output: generateBash(),
+			start:  "list|ls)",
+			end:    "festivals)",
+			needles: []string{
+				"ssh-hop:",
+				`sel="${dest#ssh-hop:}"`,
+				`command camp switch "$sel" --shell-connect`,
+				`cd "$dest"`,
+			},
+		},
+		{
+			name:   "fish",
+			output: generateFish(),
+			start:  "case list ls",
+			end:    "case festivals",
+			needles: []string{
+				"ssh-hop:",
+				`string replace -r '^ssh-hop:'`,
+				"command camp switch $sel --shell-connect",
+				`cd "$dest"`,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Scope to the list arm so switch-branch shell-connect does not
+			// falsely satisfy the markers.
+			section := shellWrapperSection(t, tc.output, tc.start, tc.end)
+			for _, n := range tc.needles {
+				if !strings.Contains(section, n) {
+					t.Errorf("%s list arm missing %q", tc.name, n)
+				}
+			}
+		})
+	}
+}

--- a/internal/shell/templates/bash.sh.tmpl
+++ b/internal/shell/templates/bash.sh.tmpl
@@ -115,7 +115,7 @@ camp() {
       ;;
     list|ls)
       shift
-      local arg passthrough cmd_status tmp
+      local arg passthrough cmd_status tmp dest line sel
       passthrough=0
       for arg in "$@"; do
         case "$arg" in
@@ -146,7 +146,17 @@ camp() {
         dest=$(cat "$tmp")
         rm -f "$tmp"
         if [ -n "$dest" ]; then
-          cd "$dest" || return 1
+          # Remote go writes ssh-hop:<machine>:<campaign>; hop via switch.
+          case "$dest" in
+            ssh-hop:*)
+              sel="${dest#ssh-hop:}"
+              line=$(command camp switch "$sel" --shell-connect) || return $?
+              eval "$line"
+              ;;
+            *)
+              cd "$dest" || return 1
+              ;;
+          esac
         fi
       else
         rm -f "$tmp"

--- a/internal/shell/templates/fish.sh.tmpl
+++ b/internal/shell/templates/fish.sh.tmpl
@@ -173,7 +173,18 @@ function camp --description "Camp CLI wrapper with directory-changing support"
                 set -l dest (cat "$tmp")
                 rm -f "$tmp"
                 if test -n "$dest"
-                    cd "$dest"
+                    # Remote go writes ssh-hop:<machine>:<campaign>; hop via switch.
+                    if string match -q 'ssh-hop:*' -- $dest
+                        set -l sel (string replace -r '^ssh-hop:' '' -- $dest)
+                        set -l line (command camp switch $sel --shell-connect)
+                        set -l hop_status $status
+                        if test "$hop_status" -ne 0
+                            return $hop_status
+                        end
+                        eval "$line"
+                    else
+                        cd "$dest"
+                    end
                 end
             else
                 rm -f "$tmp"

--- a/internal/shell/templates/zsh.sh.tmpl
+++ b/internal/shell/templates/zsh.sh.tmpl
@@ -113,7 +113,7 @@ camp() {
       ;;
     list|ls)
       shift
-      local arg passthrough tmp dest cmd_status
+      local arg passthrough tmp dest cmd_status line sel
       passthrough=0
       for arg in "$@"; do
         case "$arg" in
@@ -144,7 +144,14 @@ camp() {
         dest=$(cat "$tmp")
         rm -f "$tmp"
         if [[ -n "$dest" ]]; then
-          cd "$dest"
+          # Remote go writes ssh-hop:<machine>:<campaign>; hop via switch.
+          if [[ "$dest" == ssh-hop:* ]]; then
+            sel="${dest#ssh-hop:}"
+            line=$(command camp switch "$sel" --shell-connect) || return $?
+            eval "$line"
+          else
+            cd "$dest"
+          fi
         fi
       else
         rm -f "$tmp"


### PR DESCRIPTION
## Summary

Implements design **WI-56d496** (remote list/switch discoverability) on top of dual-auth #481.

Operators can already **connect** (`csw machine:campaign`) but could not **see or pick** remotes from ordinary list/switch surfaces. This PR:

1. **Switch picker (R3/R5)** — Opens immediately with local campaigns; when `machines.yaml` has entries, remotes append via go-fuzzyfinder hot reload (never blocks open on SSH). Labels `machine · name`. Selecting a remote uses the existing `runRemoteSwitch` / `--shell-connect` hop path. Remotes-only fleets (empty local registry) are allowed.
2. **List TUI (R1)** — Key `r` toggles remote load asynchronously via `tea.Cmd` (status line can paint). Remote rows are read-only for status/org mutate. `g`/enter on a remote row writes `ssh-hop:<machine>:<campaign>` for shell-init hop.
3. **Shell list arms** — zsh/bash/fish list branches detect the `ssh-hop:` marker and `eval` `camp switch … --shell-connect` (local absolute paths still `cd`).
4. **Table hint (R2)** — Human table without `--remote` emits one dim stderr line when machines are configured **and stderr is a TTY** (pipes stay silent).
5. **Help (R6)** — list/switch long help mention shell-init, `csw`, and remotes.

Hop contract (R4) is unchanged: bare `command camp switch machine:…` still refuses silent hop.

## Test plan

- [x] `go test ./cmd/camp/ -count=1`
- [x] `go test ./internal/shell/ -count=1`
- [x] `go test ./... -count=1`
- [x] `just build-camp`
- [ ] Operator gate (live fleet):
  ```bash
  eval "$(camp shell-init zsh)"   # from built binary
  camp list                       # local TUI; r loads remotes
  camp list --remote              # still works
  # table hint: camp list --format table 2>&1 (TTY stderr)
  csw                             # picker: locals first, remotes append
  csw archdtop:lance-arch         # hop still works
  command camp switch archdtop:x  # still no silent hop
  ```

## Design refs

- Campaign design: `workflow/design/machine-remote-list-switch-surfaces/` (WI-56d496)
- Fathom amendments: non-blocking picker open; TTY-gated table hint; async list TUI load