### PR TITLE
fix(quest): adopt dungeon spelling layer, stop recreating visible dungeon

### DIFF
--- a/internal/quest/autocommit_integration_test.go
+++ b/internal/quest/autocommit_integration_test.go
@@ -122,7 +122,7 @@ func TestAutoCommitLifecycle(t *testing.T) {
 	}
 
 	// Sanity: quest is in the completed dungeon bucket.
-	expectedDungeonParent := DungeonStatusDir(root, StatusCompleted)
+	expectedDungeonParent := mustDungeonStatusDir(t, ctx, root, StatusCompleted)
 	if !strings.HasPrefix(newQuestDir, expectedDungeonParent) {
 		t.Errorf("completed quest dir %q should be under dungeon/completed, got parent %q", newQuestDir, expectedDungeonParent)
 	}

--- a/internal/quest/dungeon_spelling_test.go
+++ b/internal/quest/dungeon_spelling_test.go
@@ -1,0 +1,143 @@
+package quest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/dungeon/spelling"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// isolateGlobalConfig points the global config at a throwaway XDG dir so the
+// dungeon_hidden default is deterministic and the developer's real config is
+// never read or written. When hidden is non-nil it writes that value.
+func isolateGlobalConfig(t *testing.T, hidden *bool) {
+	t.Helper()
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	if hidden == nil {
+		return
+	}
+	cfgDir := filepath.Join(xdg, "obey", "campaign")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := fmt.Sprintf(`{"dungeon_hidden": %v}`, *hidden)
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolveDungeonName(t *testing.T) {
+	hiddenTrue, hiddenFalse := true, false
+
+	tests := []struct {
+		name string
+		// hidden is the global dungeon_hidden setting; nil leaves it unset
+		// (which resolves to true), and only matters for the empty-campaign cases.
+		hidden *bool
+		// rootDungeon is the spelling created at the campaign root ("", "dungeon",
+		// or ".dungeon"); questDungeon is the spelling(s) under .campaign/quests
+		// ("", "dungeon", ".dungeon", or "both").
+		rootDungeon  string
+		questDungeon string
+		want         string
+		wantErr      bool
+	}{
+		{name: "both spellings under quests is a conflict", questDungeon: "both", wantErr: true},
+		{name: "existing hidden quest dungeon wins", questDungeon: spelling.Hidden, want: spelling.Hidden},
+		{name: "existing visible quest dungeon wins (legacy)", questDungeon: spelling.Visible, want: spelling.Visible},
+		{name: "campaign hidden spelling propagates to quests", rootDungeon: spelling.Hidden, want: spelling.Hidden},
+		{name: "campaign visible spelling propagates to quests", rootDungeon: spelling.Visible, want: spelling.Visible},
+		{name: "empty campaign defaults to hidden", hidden: &hiddenTrue, want: spelling.Hidden},
+		{name: "empty campaign honors visible default", hidden: &hiddenFalse, want: spelling.Visible},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateGlobalConfig(t, tt.hidden)
+			root := t.TempDir()
+			questsDir := filepath.Join(root, RootDirName)
+			mkdirAll(t, questsDir)
+
+			switch tt.rootDungeon {
+			case spelling.Hidden, spelling.Visible:
+				mkdirAll(t, filepath.Join(root, tt.rootDungeon))
+			}
+			switch tt.questDungeon {
+			case spelling.Hidden, spelling.Visible:
+				mkdirAll(t, filepath.Join(questsDir, tt.questDungeon))
+			case "both":
+				mkdirAll(t, filepath.Join(questsDir, spelling.Hidden))
+				mkdirAll(t, filepath.Join(questsDir, spelling.Visible))
+			}
+
+			got, err := resolveDungeonName(context.Background(), root)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("resolveDungeonName() = %q, want conflict error", got)
+				}
+				if !camperrors.Is(err, camperrors.ErrConflict) {
+					t.Fatalf("resolveDungeonName() error = %v, want ErrConflict", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveDungeonName() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveDungeonName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDungeonDir_UsesResolvedSpelling confirms DungeonDir joins the resolved
+// spelling under the quests directory, so an existing hidden dungeon is never
+// shadowed by a visible one.
+func TestDungeonDir_UsesResolvedSpelling(t *testing.T) {
+	isolateGlobalConfig(t, nil)
+	root := t.TempDir()
+	mkdirAll(t, filepath.Join(root, RootDirName, spelling.Hidden))
+
+	got, err := DungeonDir(context.Background(), root)
+	if err != nil {
+		t.Fatalf("DungeonDir() error = %v", err)
+	}
+	want := filepath.Join(root, RootDirName, spelling.Hidden)
+	if got != want {
+		t.Fatalf("DungeonDir() = %q, want %q", got, want)
+	}
+}
+
+// TestEnsureQuestDungeon_DoesNotCreateVisibleBesideHidden is the unit-level
+// regression for the reported bug: with a migrated hidden quest dungeon present,
+// EnsureQuestDungeon must reuse it and never scaffold a visible dungeon/ beside it.
+func TestEnsureQuestDungeon_DoesNotCreateVisibleBesideHidden(t *testing.T) {
+	isolateGlobalConfig(t, nil)
+	ctx := context.Background()
+	root := t.TempDir()
+	questsDir := filepath.Join(root, RootDirName)
+	mkdirAll(t, filepath.Join(questsDir, spelling.Hidden))
+
+	if _, err := EnsureQuestDungeon(ctx, root); err != nil {
+		t.Fatalf("EnsureQuestDungeon() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(questsDir, spelling.Visible)); !os.IsNotExist(err) {
+		t.Fatalf("visible dungeon must not be created beside hidden; stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(questsDir, spelling.Hidden, "completed")); err != nil {
+		t.Fatalf("hidden dungeon buckets should be ensured: %v", err)
+	}
+}

--- a/internal/quest/quest.go
+++ b/internal/quest/quest.go
@@ -9,6 +9,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/Obedience-Corp/camp/internal/dungeon/spelling"
 	"github.com/Obedience-Corp/camp/internal/editor"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/fsutil"
@@ -33,14 +35,43 @@ func QuestsDir(campaignRoot string) string {
 	return filepath.Join(campaignRoot, RootDirName)
 }
 
-// DungeonDir returns the root quest dungeon path.
-func DungeonDir(campaignRoot string) string {
-	return filepath.Join(QuestsDir(campaignRoot), "dungeon")
+// DungeonDir resolves the root quest dungeon path, honoring the campaign's
+// established dungeon spelling (visible "dungeon" vs hidden ".dungeon") instead
+// of hardcoding one. An existing quest dungeon wins; otherwise the campaign's
+// established spelling is used, falling back to the dungeon_hidden default. It
+// returns a spelling.ConflictError when both spellings exist under the quests
+// directory, the same loud failure the rest of camp uses.
+func DungeonDir(ctx context.Context, campaignRoot string) (string, error) {
+	name, err := resolveDungeonName(ctx, campaignRoot)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(QuestsDir(campaignRoot), name), nil
 }
 
-// DungeonStatusDir returns the quest dungeon bucket for the given status.
-func DungeonStatusDir(campaignRoot string, status Status) string {
-	return filepath.Join(DungeonDir(campaignRoot), status.String())
+// DungeonStatusDir resolves the quest dungeon bucket for the given status.
+func DungeonStatusDir(ctx context.Context, campaignRoot string, status Status) (string, error) {
+	dir, err := DungeonDir(ctx, campaignRoot)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, status.String()), nil
+}
+
+// resolveDungeonName selects the quest dungeon spelling. It mirrors how the
+// workflow and intent packages resolve their own dungeon spelling: an existing
+// dungeon under the quests directory wins, then the campaign's established
+// spelling, then the dungeon_hidden default.
+func resolveDungeonName(ctx context.Context, campaignRoot string) (string, error) {
+	globalCfg, err := config.LoadGlobalConfig(ctx)
+	if err != nil {
+		return "", camperrors.Wrap(err, "load global config for dungeon spelling")
+	}
+	campaignName, err := spelling.CampaignName(ctx, campaignRoot, globalCfg.ResolveDungeonHidden())
+	if err != nil {
+		return "", err
+	}
+	return spelling.NameForNew(ctx, QuestsDir(campaignRoot), campaignName)
 }
 
 // DefaultQuestPath returns the default quest metadata path.
@@ -130,7 +161,7 @@ func List(ctx context.Context, campaignRoot string, includeDungeon bool) ([]*Que
 		return nil, camperrors.Wrap(err, "read quests dir")
 	}
 	for _, entry := range rootEntries {
-		if !entry.IsDir() || entry.Name() == "dungeon" {
+		if !entry.IsDir() || spelling.IsDungeonName(entry.Name()) {
 			continue
 		}
 		q, err := Load(ctx, QuestPathForDir(filepath.Join(QuestsDir(campaignRoot), entry.Name())))
@@ -145,8 +176,12 @@ func List(ctx context.Context, campaignRoot string, includeDungeon bool) ([]*Que
 	}
 
 	if includeDungeon {
+		dungeonRoot, err := DungeonDir(ctx, campaignRoot)
+		if err != nil {
+			return nil, err
+		}
 		for _, status := range []Status{StatusCompleted, StatusArchived} {
-			statusDir := DungeonStatusDir(campaignRoot, status)
+			statusDir := filepath.Join(dungeonRoot, status.String())
 			entries, err := os.ReadDir(statusDir)
 			if err != nil {
 				if errors.Is(err, os.ErrNotExist) {

--- a/internal/quest/scaffold.go
+++ b/internal/quest/scaffold.go
@@ -28,7 +28,10 @@ func EnsureQuestDungeon(ctx context.Context, campaignRoot string) (*ScaffoldResu
 
 	result := &ScaffoldResult{}
 
-	dungeonRoot := DungeonPath(campaignRoot)
+	dungeonRoot, err := DungeonDir(ctx, campaignRoot)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "resolving quest dungeon spelling")
+	}
 	dungeonResult, err := dungeonscaffold.Init(ctx, dungeonRoot, dungeonscaffold.InitOptions{})
 	if err != nil {
 		return nil, camperrors.Wrap(err, "initializing quest dungeon")
@@ -168,11 +171,6 @@ func RootPath(campaignRoot string) string {
 // DefaultPath returns the default quest metadata file path.
 func DefaultPath(campaignRoot string) string {
 	return DefaultQuestPath(campaignRoot)
-}
-
-// DungeonPath returns the quest dungeon root.
-func DungeonPath(campaignRoot string) string {
-	return DungeonDir(campaignRoot)
 }
 
 func appendUnique(dst []string, items ...string) []string {

--- a/internal/quest/service.go
+++ b/internal/quest/service.go
@@ -572,7 +572,11 @@ func (s *Service) moveToStatus(ctx context.Context, identifier string, from []St
 	oldStatus := q.Status
 
 	oldDir := filepath.Dir(q.Path)
-	newDir := filepath.Join(DungeonStatusDir(s.campaignRoot, target), q.Slug)
+	statusDir, err := DungeonStatusDir(ctx, s.campaignRoot, target)
+	if err != nil {
+		return nil, err
+	}
+	newDir := filepath.Join(statusDir, q.Slug)
 	if _, err := os.Stat(newDir); err == nil {
 		return nil, camperrors.Wrapf(camperrors.ErrInvalidInput, "quest directory already exists: %s", newDir)
 	}

--- a/internal/quest/service_test.go
+++ b/internal/quest/service_test.go
@@ -25,6 +25,17 @@ func setupQuestCampaign(t *testing.T) (context.Context, string, *Service) {
 	return ctx, root, NewService(root)
 }
 
+// mustDungeonStatusDir resolves the quest dungeon bucket for a status, failing
+// the test on the (unexpected) spelling-resolution error.
+func mustDungeonStatusDir(t *testing.T, ctx context.Context, root string, status Status) string {
+	t.Helper()
+	dir, err := DungeonStatusDir(ctx, root, status)
+	if err != nil {
+		t.Fatalf("DungeonStatusDir(%s) error = %v", status, err)
+	}
+	return dir
+}
+
 func TestListSkipsCorruptQuest(t *testing.T) {
 	ctx, root, svc := setupQuestCampaign(t)
 
@@ -44,7 +55,7 @@ func TestListSkipsCorruptQuest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	corruptDungeon := filepath.Join(DungeonStatusDir(root, StatusCompleted), "corrupt-dungeon")
+	corruptDungeon := filepath.Join(mustDungeonStatusDir(t, ctx, root, StatusCompleted), "corrupt-dungeon")
 	if err := os.MkdirAll(corruptDungeon, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -300,7 +311,7 @@ func TestServiceCreatePauseResumeCompleteRestore(t *testing.T) {
 	if completed.Quest.Status != StatusCompleted {
 		t.Fatalf("completed quest status = %q, want %q", completed.Quest.Status, StatusCompleted)
 	}
-	if got := filepath.Dir(completed.Quest.Path); got != filepath.Join(DungeonStatusDir(root, StatusCompleted), completed.Quest.Slug) {
+	if got := filepath.Dir(completed.Quest.Path); got != filepath.Join(mustDungeonStatusDir(t, ctx, root, StatusCompleted), completed.Quest.Slug) {
 		t.Fatalf("completed quest directory = %q", got)
 	}
 

--- a/internal/scaffold/init_repair_test.go
+++ b/internal/scaffold/init_repair_test.go
@@ -417,7 +417,8 @@ func TestInit_RepairRestoresQuestScaffold(t *testing.T) {
 
 	removed := []string{
 		filepath.Join(campaignDir, quest.RootDirName, quest.DefaultDirName, quest.FileName),
-		filepath.Join(campaignDir, quest.RootDirName, "dungeon", "OBEY.md"),
+		// Hidden-default campaign: the quest dungeon uses ".dungeon" like the rest.
+		filepath.Join(campaignDir, quest.RootDirName, ".dungeon", "OBEY.md"),
 	}
 	for _, path := range removed {
 		if err := os.Remove(path); err != nil {

--- a/internal/scaffold/init_test.go
+++ b/internal/scaffold/init_test.go
@@ -200,13 +200,16 @@ func TestInit(t *testing.T) {
 			t.Errorf("stable init should not create quest scaffold, stat err = %v", err)
 		}
 	case "dev":
+		// The quest dungeon follows the campaign's spelling like every other
+		// dungeon, so a hidden-default campaign scaffolds ".dungeon", not the
+		// legacy visible "dungeon".
 		expectedQuestPaths := []string{
 			quest.RootDirName,
 			filepath.Join(quest.RootDirName, quest.DefaultDirName, quest.FileName),
-			filepath.Join(quest.RootDirName, "dungeon", "OBEY.md"),
-			filepath.Join(quest.RootDirName, "dungeon", "completed", ".gitkeep"),
-			filepath.Join(quest.RootDirName, "dungeon", "archived", ".gitkeep"),
-			filepath.Join(quest.RootDirName, "dungeon", "someday", ".gitkeep"),
+			filepath.Join(quest.RootDirName, ".dungeon", "OBEY.md"),
+			filepath.Join(quest.RootDirName, ".dungeon", "completed", ".gitkeep"),
+			filepath.Join(quest.RootDirName, ".dungeon", "archived", ".gitkeep"),
+			filepath.Join(quest.RootDirName, ".dungeon", "someday", ".gitkeep"),
 		}
 		for _, relPath := range expectedQuestPaths {
 			path := filepath.Join(campaignDir, relPath)

--- a/tests/integration/quest_dungeon_spelling_test.go
+++ b/tests/integration/quest_dungeon_spelling_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// initCampaignWithHidden runs `camp init` after pinning the dungeon_hidden
+// global setting, so the campaign scaffolds with a known dungeon spelling. It
+// deliberately avoids InitCampaign's git commit: these tests use quest
+// --no-commit and assert on-disk layout, not git state.
+func initCampaignWithHidden(t *testing.T, tc *TestContainer, path, name string, hidden bool) {
+	t.Helper()
+	cfg := `{"dungeon_hidden": false}`
+	if hidden {
+		cfg = `{"dungeon_hidden": true}`
+	}
+	require.NoError(t, tc.WriteGlobalConfig(cfg))
+	out, err := tc.RunCamp("init", path, "--name", name, "-d", "d", "-m", "m")
+	require.NoError(t, err, "camp init: %s", out)
+}
+
+// TestQuestDungeon_HiddenCampaignNeverCreatesVisible is the regression for
+// Lance's exact repro: on a hidden campaign, quest scaffolding must reuse the
+// hidden .dungeon and never recreate a visible .campaign/quests/dungeon.
+func TestQuestDungeon_HiddenCampaignNeverCreatesVisible(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := "/campaigns/quest-dungeon-hidden"
+	initCampaignWithHidden(t, tc, path, "quest-dungeon-hidden", true)
+
+	// Every one of these runs EnsureScaffold, the code path that recreated the
+	// visible dungeon before the fix.
+	out, err := tc.RunCampInDir(path, "quest", "create", "alpha", "--no-editor", "--no-commit")
+	require.NoError(t, err, out)
+	out, err = tc.RunCampInDir(path, "quest", "complete", "alpha", "--no-commit")
+	require.NoError(t, err, out)
+	out, err = tc.RunCampInDir(path, "quest", "create", "beta", "--no-editor", "--no-commit")
+	require.NoError(t, err, out)
+	out, err = tc.RunCampInDir(path, "quest", "use", "beta")
+	require.NoError(t, err, out)
+	out, err = tc.RunCampInDir(path, "quest", "list", "--all")
+	require.NoError(t, err, out)
+
+	visible, err := tc.CheckDirExists(path + "/.campaign/quests/dungeon")
+	require.NoError(t, err)
+	assert.False(t, visible, "visible quest dungeon must never be created on a hidden campaign")
+
+	hidden, err := tc.CheckDirExists(path + "/.campaign/quests/.dungeon")
+	require.NoError(t, err)
+	assert.True(t, hidden, "hidden quest dungeon should be present")
+
+	// The completed quest lives under the hidden dungeon and is listed.
+	completedDir, err := tc.CheckDirExists(path + "/.campaign/quests/.dungeon/completed")
+	require.NoError(t, err)
+	assert.True(t, completedDir, "completed bucket should exist under .dungeon")
+
+	listOut, err := tc.RunCampInDir(path, "quest", "list", "--all", "--json")
+	require.NoError(t, err, listOut)
+	assert.Contains(t, listOut, "alpha", "completed quest in .dungeon must appear in list --all")
+	assert.Contains(t, listOut, `"status": "completed"`)
+}
+
+// TestQuestDungeon_MigratedHiddenQuestIsVisible reproduces the second symptom:
+// a quest that already lives in .campaign/quests/.dungeon (as after a dungeon
+// migrate) is invisible to the quest service, which read the hardcoded visible
+// path. After the fix it appears in listings, and quest commands still never
+// create a visible dungeon beside it.
+func TestQuestDungeon_MigratedHiddenQuestIsVisible(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := "/campaigns/quest-dungeon-migrated"
+	initCampaignWithHidden(t, tc, path, "quest-dungeon-migrated", true)
+
+	questYAML := "id: qst_20260629_migold\n" +
+		"name: migrated-old\n" +
+		"status: completed\n" +
+		"created_at: 2026-06-29T00:00:00Z\n" +
+		"updated_at: 2026-06-29T00:00:00Z\n"
+	require.NoError(t, tc.WriteFile(
+		path+"/.campaign/quests/.dungeon/completed/20260629-migrated-old/quest.yaml", questYAML))
+
+	// The migrated quest, filed under .dungeon, must be visible again in listings.
+	listOut, err := tc.RunCampInDir(path, "quest", "list", "--all", "--json")
+	require.NoError(t, err, listOut)
+	assert.Contains(t, listOut, "migrated-old", "migrated hidden-dungeon quest must be visible in list --all")
+
+	// Lance's exact repro: creating and using a quest reran EnsureScaffold and
+	// recreated a visible dungeon beside the hidden one. It must not anymore.
+	out, err := tc.RunCampInDir(path, "quest", "create", "fresh", "--no-editor", "--no-commit")
+	require.NoError(t, err, out)
+	out, err = tc.RunCampInDir(path, "quest", "use", "fresh")
+	require.NoError(t, err, out)
+
+	visible, err := tc.CheckDirExists(path + "/.campaign/quests/dungeon")
+	require.NoError(t, err)
+	assert.False(t, visible, "quest commands must not recreate a visible dungeon beside .dungeon")
+}
+
+// TestQuestDungeon_LegacyCampaignKeepsVisible confirms the fix honors an
+// established visible spelling rather than forcing hidden: a legacy campaign
+// keeps completing quests into the visible dungeon and never grows a .dungeon.
+func TestQuestDungeon_LegacyCampaignKeepsVisible(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := "/campaigns/quest-dungeon-legacy"
+	initCampaignWithHidden(t, tc, path, "quest-dungeon-legacy", false)
+
+	out, err := tc.RunCampInDir(path, "quest", "create", "gamma", "--no-editor", "--no-commit")
+	require.NoError(t, err, out)
+	out, err = tc.RunCampInDir(path, "quest", "complete", "gamma", "--no-commit")
+	require.NoError(t, err, out)
+
+	visibleCompleted, err := tc.CheckDirExists(path + "/.campaign/quests/dungeon/completed")
+	require.NoError(t, err)
+	assert.True(t, visibleCompleted, "legacy campaign should keep using the visible dungeon")
+
+	hidden, err := tc.CheckDirExists(path + "/.campaign/quests/.dungeon")
+	require.NoError(t, err)
+	assert.False(t, hidden, "legacy campaign must not grow a hidden dungeon")
+
+	listOut, err := tc.RunCampInDir(path, "quest", "list", "--all", "--json")
+	require.NoError(t, err, listOut)
+	assert.Contains(t, listOut, "gamma")
+}


### PR DESCRIPTION
## Summary

Quest scaffolding never adopted camp's dungeon spelling layer, so it hardcoded
the visible `.campaign/quests/dungeon` path. Two bugs followed:

1. Every quest command that runs `EnsureScaffold` (`create`, `use`, `list`, ...)
   recreated a visible `.campaign/quests/dungeon/` even on a campaign that had
   migrated to the hidden `.dungeon` spelling. This is Lance's live repro:
   `camp quest use 20260629-new` produced an untracked `.campaign/quests/dungeon/`.
2. Quests already filed under `.campaign/quests/.dungeon/` (as after
   `camp dungeon migrate`) were invisible to the quest service, which only read
   the hardcoded visible path.

This routes every quest dungeon path through `internal/dungeon/spelling`, the
same layer the rest of camp uses, so quest behavior matches intents, workflows,
and the root dungeon.

## Root cause (with anchors)

- `internal/quest/quest.go` `DungeonDir` hardcoded `filepath.Join(QuestsDir(campaignRoot), "dungeon")`; `DungeonStatusDir` built on it.
- `internal/quest/scaffold.go` `EnsureQuestDungeon` scaffolded that hardcoded path via `dungeonscaffold.Init`, and `EnsureScaffold` calls it on the paths quest commands hit.
- `internal/quest/quest.go` `List` root scan skipped only `entry.Name() == "dungeon"`, and its include-dungeon branch read the hardcoded `DungeonStatusDir`, so `.dungeon` quests never loaded.
- `internal/quest/service.go` `moveToStatus` filed completed/archived quests into the hardcoded path.

The spelling machinery already existed and is what every other caller uses:
`internal/dungeon/spelling` (`Hidden = ".dungeon"`, `Resolve`, `CampaignName`,
`NameForNew`), the `dungeon_hidden` global default
(`internal/config/defaults.go` `ResolveDungeonHidden`, defaults true), and
`camp dungeon migrate`.

## The fix

- `DungeonDir(ctx, campaignRoot) (string, error)` and
  `DungeonStatusDir(ctx, campaignRoot, status) (string, error)` now resolve the
  spelling instead of hardcoding it, via a new `resolveDungeonName` helper that
  loads the global config internally (the same idiom as
  `internal/intent/migration.go` and `internal/commands/flow/helpers.go`).
- `EnsureQuestDungeon` scaffolds the resolved spelling, so it never creates a
  visible dungeon beside an existing hidden one. Removed the redundant
  `DungeonPath` wrapper.
- `List` skips both spellings at the root (`spelling.IsDungeonName`) and reads
  the resolved dungeon once, so migrated `.dungeon` quests reappear in listings.
- `moveToStatus` files completions into the resolved dungeon.

`EnsureQuestDungeon`'s signature is unchanged, so its one external caller
(`internal/scaffold/init.go`) needed no change.

## Resolution precedence chosen

Matches the workflow and intent packages exactly
(`spelling.CampaignName` then `spelling.NameForNew`):

1. An existing quest dungeon under `.campaign/quests/` wins (hidden or visible).
2. Otherwise the campaign's established spelling, taken from the authoritative
   root dungeon (`spelling.CampaignName`).
3. Otherwise (a campaign with no dungeon anywhere) the `dungeon_hidden` default,
   which is true, so fresh campaigns scaffold `.dungeon`.
4. Both spellings present under the quests directory returns a
   `spelling.ConflictError`, the same loud failure the rest of camp uses rather
   than silently hiding whichever side loses.

## Before / after for the repro

Before: on a campaign with `.campaign/quests/.dungeon`, `camp quest use <q>`
recreated `.campaign/quests/dungeon/` (visible, untracked), and a quest sitting
in `.dungeon/completed` did not show in `camp quest list --all`.

After: `camp quest use`/`create`/`list` reuse `.dungeon` and never create the
visible spelling; the dungeoned quest appears in `list --all`. Verified in the
containerized regression test below.

Note on already-corrupted campaigns: a campaign that the old bug already left
with both `.campaign/quests/dungeon` and `.campaign/quests/.dungeon` will now
surface the standard spelling `ConflictError` until the empty stray visible
dungeon is removed once (`rm -rf .campaign/quests/dungeon`). This fix prevents
the stray from ever being created again; it intentionally does not auto-delete
existing directories, consistent with how camp treats a both-spellings state
everywhere else.

## Real CLI output (dev binary, throwaway fixture)

Hidden campaign (default), after `quest create alpha` + `quest complete alpha` +
`quest create beta` + `quest use beta`:

```
$ ls -a .campaign/quests
.  ..  .dungeon  .gitkeep  20260724-beta  default
# no visible "dungeon" directory

$ camp quest list --all --json   (name/status per item)
 name=beta status=open
 name=default status=open
 name=alpha status=completed
# alpha, filed under .dungeon/completed, is visible again
```

Legacy visible campaign (`dungeon_hidden=false`), after `quest create gamma` +
`quest complete gamma`:

```
$ ls -a .campaign/quests
.  ..  .gitkeep  default  dungeon
# stays visible; no ".dungeon" grown

$ ls .campaign/quests/dungeon/completed
20260724-gamma
```

## Test coverage

- `internal/quest/dungeon_spelling_test.go` (new unit, table-driven, error case
  first): resolution precedence across only `.dungeon`, only visible `dungeon`,
  both (conflict), campaign-established spelling propagation, and empty campaign
  with `dungeon_hidden` true/false; plus `DungeonDir` composing the resolved
  spelling and `EnsureQuestDungeon` never creating a visible dungeon beside a
  hidden one. The global config is isolated via `XDG_CONFIG_HOME` so the default
  is deterministic.
- `tests/integration/quest_dungeon_spelling_test.go` (new, `//go:build
  integration`, containerized): the reported repro end to end - hidden campaign
  running quest create/complete/use/list never grows a visible dungeon and lists
  the dungeoned quest; a quest pre-filed under `.dungeon` is visible again in
  `list --all` and `quest create`/`use` do not recreate a visible dungeon; a
  legacy visible campaign keeps using the visible dungeon and never grows a
  hidden one.
- Updated `internal/scaffold/init_test.go` and `init_repair_test.go`, which had
  encoded the bug by expecting a visible quest dungeon while every other dungeon
  in the same hidden campaign was `.dungeon`. Updated
  `internal/quest/service_test.go` and `autocommit_integration_test.go` for the
  new `DungeonStatusDir` signature.

## Gates

- `go build ./...` (stable) and `go build -tags dev ./...`: clean.
- `just test unit` (stable, no dev tag): 3640/3640 passed.
- `go test -tags dev ./...`: all pass.
- `just lint`: `0 issues`; no host-fs-test or `fmt.Errorf` regressions.
- Integration: the 3 new `TestQuestDungeon_*` pass, and the existing
  `TestQuest*` / `TestDungeon*` / `TestInit*` integration suites still pass (no
  regression to migrate, hidden, conflict, or init behavior).

## Where reality differed from the task description

- `internal/quest/service.go` line 580 was cited as an area that "creates/uses"
  the dungeon path; the actual dungeon-path caller in that file is `moveToStatus`
  (the `DungeonStatusDir` join for completed/archived), which is fixed. `Restore`
  moves back to the quest root and reads the quest's own current path, so it did
  not hardcode a dungeon spelling and needed no change.
- The pure `DungeonDir`/`DungeonStatusDir` helpers had to change signature to
  take `ctx` and return an error (spelling resolution touches the filesystem and
  can conflict). All callers are internal to the quest package plus the three
  internal tests updated here; `EnsureQuestDungeon`'s signature is unchanged.

## Tradeoffs and deferred

- Resolution now loads the global config and stats the dungeon parents on each
  include-dungeon `List` (so on each `quest.Resolve`). This matches how the
  intent and workflow packages resolve spelling and is negligible for a CLI, not
  a hot loop; the common case is two stats because the root dungeon exists.
- No auto-healing of a pre-existing both-spellings state (see the repro note
  above); the conflict is surfaced loudly and reconciled once by the user, same
  as every other dungeon in camp.
