### PR TITLE
docs: explain how to find camp binary path after shell-init

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,30 @@ The eval hook provides:
 
 After adding the eval line, restart your shell or run `source ~/.zshrc` (or equivalent).
 
+### Finding the installed binary
+
+Shell integration defines `camp` as a **shell function** (so `camp go` / `cgo` can `cd` in your current shell). That means plain `which camp` usually prints the function body, not a filesystem path.
+
+Use these instead:
+
+```bash
+# zsh — path of the external binary (skips shell functions)
+whence -p camp
+# or: which -p camp
+
+# bash
+type -P camp
+
+# show the function plus every binary on PATH
+type -a camp
+
+# resolve symlinks to the real file
+realpath "$(whence -p camp)"   # zsh
+realpath "$(type -P camp)"     # bash
+```
+
+To run the binary without the wrapper (scripts, debugging): `command camp version`.
+
 ## Quick Start
 
 ```bash
@@ -408,8 +432,12 @@ camp project <TAB>       # Completes: add commit link list new prune remote remo
 #### Troubleshooting
 
 ```bash
-# Verify camp is in PATH
-which camp
+# Verify the camp binary is on PATH (do not use plain `which camp` —
+# after shell-init it prints the wrapper function, not the binary path)
+whence -p camp            # zsh: external binary only
+type -P camp              # bash: external binary only
+type -a camp              # function + every binary on PATH
+realpath "$(whence -p camp)"  # follow symlinks to the real install
 
 # Test shell-init output
 camp shell-init zsh

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -198,6 +198,31 @@ Using best match: api-service
 - Array syntax: `$argv[1]`, `$argv[2..-1]`
 - Excellent built-in completion support
 
+## Finding the installed binary
+
+`camp shell-init` defines a shell function named `camp` that wraps the real
+binary so navigation commands can change your working directory. Because of
+that, plain `which camp` usually prints the function body, not a path.
+
+```bash
+# zsh — external binary only (skips shell functions)
+whence -p camp
+# or: which -p camp
+
+# bash
+type -P camp
+
+# function + every binary on PATH
+type -a camp
+
+# resolve symlinks to the real install location
+realpath "$(whence -p camp)"   # zsh
+realpath "$(type -P camp)"     # bash
+```
+
+Run the binary without the wrapper with `command camp ...` (for example
+`command camp version`).
+
 ## Troubleshooting
 
 ### cgo not found
@@ -205,8 +230,9 @@ Using best match: api-service
 Make sure you added the shell-init line to your config and restarted your shell:
 
 ```bash
-# Check if camp is available
-which camp
+# Check if the camp binary is on PATH (not the shell function)
+whence -p camp   # zsh
+type -P camp     # bash
 
 # Re-source your config
 source ~/.zshrc  # or ~/.bashrc, config.fish


### PR DESCRIPTION
## Summary
- Document that shell-init defines `camp` as a shell function, so plain `which camp` prints the function body instead of a path.
- Show the correct discovery commands: `whence -p` / `which -p` (zsh), `type -P` (bash), `type -a`, and `realpath`.
- Fix the README troubleshooting tip that incorrectly recommended `which camp`.

## Test plan
- [ ] Read the new README and shell-integration sections for clarity
- [ ] After `eval "$(camp shell-init zsh)"`, confirm `whence -p camp` returns a binary path while `which camp` shows the function