### PR TITLE
feat(commit): signal amend mode to message writers

### DIFF
--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -207,6 +207,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 		fmt.Println(ui.Info("Writing commit message..."))
 		var hookErr error
 		extraEnv := workitemEnvForCommit(ctx, campRoot, commitWorkitem)
+		extraEnv = commitkit.WithCommitAmendEnv(extraEnv, commitAmend)
 		message, hookErr = commitkit.AutoWriteCommitMessageWithEnv(ctx, campRoot, target.Path, extraEnv)
 		if hookErr != nil {
 			return hookErr

--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -174,6 +174,7 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 		fmt.Println(ui.Info("Writing commit message..."))
 		var hookErr error
 		extraEnv := workitemEnvForProjectCommit(ctx, campRoot, resolvedPath, projectCommitWorkitem)
+		extraEnv = commitkit.WithCommitAmendEnv(extraEnv, projectCommitAmend)
 		message, hookErr = commitkit.AutoWriteCommitMessageWithEnv(ctx, campRoot, resolvedPath, extraEnv)
 		if hookErr != nil {
 			return hookErr

--- a/cmd/camp/worktrees/commit.go
+++ b/cmd/camp/worktrees/commit.go
@@ -141,6 +141,7 @@ func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 	if wtCommitAutoWrite {
 		fmt.Println(ui.Info("Writing commit message..."))
 		extraEnv := workitemEnvForWorktreeCommit(ctx, campRoot, wtCtx.WorktreePath, wtCommitWorkitem)
+		extraEnv = commitkit.WithCommitAmendEnv(extraEnv, wtCommitAmend)
 		message, err = commitkit.AutoWriteCommitMessageWithEnv(ctx, campRoot, wtCtx.WorktreePath, extraEnv)
 		if err != nil {
 			return err

--- a/internal/config/campaign.go
+++ b/internal/config/campaign.go
@@ -163,7 +163,8 @@ func commentedHooksPlaceholder() []byte {
 #     # (-aw). Its stdout is used verbatim as the commit message. Any tool works;
 #     # 'ob commit --print-session-id' is one example; progress and any
 #     # session_id= line on stderr are forwarded to the terminal (session_id is
-#     # emitted when the hook finishes, not while it is generating).
+#     # emitted when the hook finishes, not while it is generating). Amend
+#     # auto-write invocations receive CAMP_COMMIT_AMEND=1.
 #     command: ob commit --print-session-id
 `)
 }

--- a/pkg/commitkit/autowrite_internal_test.go
+++ b/pkg/commitkit/autowrite_internal_test.go
@@ -11,12 +11,13 @@ func TestRunCommitMessageCommandForwardsDiagnostics(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name              string
-		command           string
-		wantMessage       string
-		wantErr           bool
-		wantDiagContains  []string
-		wantErrContains   []string
+		name             string
+		command          string
+		extraEnv         []string
+		wantMessage      string
+		wantErr          bool
+		wantDiagContains []string
+		wantErrContains  []string
 	}{
 		{
 			name:        "success forwards stderr and returns stdout",
@@ -25,6 +26,12 @@ func TestRunCommitMessageCommandForwardsDiagnostics(t *testing.T) {
 			wantDiagContains: []string{
 				"session_id=session-123\n",
 			},
+		},
+		{
+			name:        "passes explicit amend contract to writer",
+			command:     `test "$CAMP_COMMIT_AMEND" = "1" && printf 'fix: amended\n'`,
+			extraEnv:    WithCommitAmendEnv(nil, true),
+			wantMessage: "fix: amended",
 		},
 		{
 			// MultiWriter dual-path contract: live forward AND error wrapping.
@@ -51,9 +58,9 @@ func TestRunCommitMessageCommandForwardsDiagnostics(t *testing.T) {
 			var diagnostics bytes.Buffer
 			message, err := runCommitMessageCommandWithEnv(
 				context.Background(),
-				t.TempDir(),
+				".",
 				tt.command,
-				nil,
+				tt.extraEnv,
 				&diagnostics,
 			)
 

--- a/pkg/commitkit/workitem_env.go
+++ b/pkg/commitkit/workitem_env.go
@@ -6,6 +6,18 @@ import (
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
 
+const commitAmendEnv = "CAMP_COMMIT_AMEND=1"
+
+// WithCommitAmendEnv adds the Camp-to-writer amend signal when amend is true.
+// Writers use this explicit contract instead of inferring amend mode from an
+// empty staged index.
+func WithCommitAmendEnv(env []string, amend bool) []string {
+	if !amend {
+		return env
+	}
+	return append(env, commitAmendEnv)
+}
+
 // WorkitemEnv builds the CAMP_WORKITEM_* environment variables that the
 // auto-write commit-message hook receives. Returns nil when wi is nil so the
 // caller's "no workitem context" branch is just `append(env, nil...)`.

--- a/pkg/commitkit/workitem_env_test.go
+++ b/pkg/commitkit/workitem_env_test.go
@@ -14,6 +14,17 @@ func TestWorkitemEnv_NilReturnsNil(t *testing.T) {
 	}
 }
 
+func TestWithCommitAmendEnv(t *testing.T) {
+	base := []string{"CAMP_WORKITEM_REF=WI-abcdef"}
+	if got := commitkit.WithCommitAmendEnv(base, false); len(got) != 1 || got[0] != base[0] {
+		t.Fatalf("WithCommitAmendEnv(amend=false) = %v, want %v", got, base)
+	}
+	got := commitkit.WithCommitAmendEnv(base, true)
+	if value, ok := envValue(got, "CAMP_COMMIT_AMEND"); !ok || value != "1" {
+		t.Fatalf("WithCommitAmendEnv(amend=true) = %v, want CAMP_COMMIT_AMEND=1", got)
+	}
+}
+
 func TestWorkitemEnv_AllFiveBaseVarsPresent(t *testing.T) {
 	wi := &workitem.WorkItem{
 		StableID:     "design-timeline-2026-05-24",


### PR DESCRIPTION
## Summary

- add the explicit `CAMP_COMMIT_AMEND=1` contract for auto-write commit-message hooks
- send the amend signal from root, project, and worktree commit paths
- document the hook environment and cover helper plus subprocess propagation

## Why

Commit-message writers cannot safely infer amend mode from an empty staged index: a message-only amend has no newly staged delta, while an ordinary commit with an empty index should still fail. Camp now tells configured writers explicitly when it is preparing an amend.

## Impact

Writers such as `ob commit` can generate a message for the complete amended commit while ordinary auto-write behavior remains unchanged.

## Validation

- `just test unit` — 3,678/3,678 tests passed
- `just lint` — passed
