### PR TITLE
fix(shell): stop appending --path-output to workitem subcommands in interactive wrapper

### DIFF
--- a/internal/shell/templates/bash.sh.tmpl
+++ b/internal/shell/templates/bash.sh.tmpl
@@ -74,11 +74,23 @@ camp() {
       ;;
     workitem|wi|workitems)
       shift
+      # A workitem subcommand (resolve, id, stage, rename, ...) is always the
+      # first token and is a bare word; the interactive dashboard takes no
+      # positional argument (only filter flags). Only the dashboard understands
+      # --path-output, so pass any subcommand invocation through verbatim. This
+      # is forward-compatible: new subcommands need no wrapper regeneration.
+      case "${1:-}" in
+        ""|-*) ;;
+        *)
+          command camp workitem "$@"
+          return
+          ;;
+      esac
       local arg passthrough
       passthrough=0
       for arg in "$@"; do
         case "$arg" in
-          --help|-h|--json|--json=*|--print|--print=*)
+          --help|-h|--json|--json=*|--print|--print=*|--list)
             passthrough=1
             break
             ;;

--- a/internal/shell/templates/fish.sh.tmpl
+++ b/internal/shell/templates/fish.sh.tmpl
@@ -91,10 +91,20 @@ function camp --description "Camp CLI wrapper with directory-changing support"
             end
         case workitem wi workitems
             set -l rest $argv[2..-1]
+            # A workitem subcommand (resolve, id, stage, rename, ...) is always
+            # the first token and is a bare word; the interactive dashboard
+            # takes no positional argument (only filter flags). Only the
+            # dashboard understands --path-output, so pass any subcommand
+            # invocation through verbatim. This is forward-compatible: new
+            # subcommands need no wrapper regeneration.
+            if test (count $rest) -gt 0; and not string match -qr -- '^-' $rest[1]
+                command camp workitem $rest
+                return $status
+            end
             set -l passthrough 0
             for arg in $rest
                 switch "$arg"
-                    case --help -h --json '--json=*' --print '--print=*'
+                    case --help -h --json '--json=*' --print '--print=*' --list
                         set passthrough 1
                         break
                 end

--- a/internal/shell/templates/zsh.sh.tmpl
+++ b/internal/shell/templates/zsh.sh.tmpl
@@ -73,10 +73,22 @@ camp() {
       ;;
     workitem|wi|workitems)
       shift
+      # A workitem subcommand (resolve, id, stage, rename, ...) is always the
+      # first token and is a bare word; the interactive dashboard takes no
+      # positional argument (only filter flags). Only the dashboard understands
+      # --path-output, so pass any subcommand invocation through verbatim. This
+      # is forward-compatible: new subcommands need no wrapper regeneration.
+      case "${1:-}" in
+        ""|-*) ;;
+        *)
+          command camp workitem "$@"
+          return
+          ;;
+      esac
       local arg passthrough=0
       for arg in "$@"; do
         case "$arg" in
-          --help|-h|--json|--json=*|--print|--print=*)
+          --help|-h|--json|--json=*|--print|--print=*|--list)
             passthrough=1
             break
             ;;

--- a/internal/shell/wrapper_transparency_test.go
+++ b/internal/shell/wrapper_transparency_test.go
@@ -75,6 +75,62 @@ func assertShellWrapperTransparency(t *testing.T, section string, expect shellWr
 	}
 }
 
+// workitemArmExpectations describes the per-shell tokens that prove the
+// workitem wrapper arm passes subcommands through verbatim while still
+// intercepting the interactive dashboard.
+type workitemArmExpectations struct {
+	subcommandGuard string // construct that passes a bare-word subcommand through
+	passthroughCall string // the verbatim passthrough invocation
+	listPassthrough string // --list joined the dashboard output-mode flags
+	pathOutput      string // the dashboard --path-output interception, still present
+}
+
+func assertWorkitemArmPassesSubcommands(t *testing.T, section string, e workitemArmExpectations) {
+	t.Helper()
+
+	for _, required := range []string{e.subcommandGuard, e.passthroughCall, e.listPassthrough, e.pathOutput} {
+		if !strings.Contains(section, required) {
+			t.Fatalf("workitem arm missing %q in:\n%s", required, section)
+		}
+	}
+	// The subcommand guard must run BEFORE the --path-output interception; if it
+	// did not, a subcommand invocation (camp workitem resolve/id/stage/...) would
+	// still get --path-output appended and die with exit 2.
+	if strings.Index(section, e.subcommandGuard) >= strings.Index(section, e.pathOutput) {
+		t.Fatalf("workitem arm applies --path-output before guarding subcommands:\n%s", section)
+	}
+}
+
+func TestGenerateZsh_WorkitemArmPassesSubcommands(t *testing.T) {
+	section := shellWrapperSection(t, generateZsh(), "    workitem|wi|workitems)", "    list|ls)")
+	assertWorkitemArmPassesSubcommands(t, section, workitemArmExpectations{
+		subcommandGuard: `case "${1:-}" in`,
+		passthroughCall: `command camp workitem "$@"`,
+		listPassthrough: `--print|--print=*|--list)`,
+		pathOutput:      `--path-output "$tmp"`,
+	})
+}
+
+func TestGenerateBash_WorkitemArmPassesSubcommands(t *testing.T) {
+	section := shellWrapperSection(t, generateBash(), "    workitem|wi|workitems)", "    list|ls)")
+	assertWorkitemArmPassesSubcommands(t, section, workitemArmExpectations{
+		subcommandGuard: `case "${1:-}" in`,
+		passthroughCall: `command camp workitem "$@"`,
+		listPassthrough: `--print|--print=*|--list)`,
+		pathOutput:      `--path-output "$tmp"`,
+	})
+}
+
+func TestGenerateFish_WorkitemArmPassesSubcommands(t *testing.T) {
+	section := shellWrapperSection(t, generateFish(), "        case workitem wi workitems", "        case list ls")
+	assertWorkitemArmPassesSubcommands(t, section, workitemArmExpectations{
+		subcommandGuard: `not string match -qr -- '^-' $rest[1]`,
+		passthroughCall: `command camp workitem $rest`,
+		listPassthrough: `--print '--print=*' --list`,
+		pathOutput:      `--path-output "$tmp"`,
+	})
+}
+
 func shellWrapperSection(t *testing.T, output, startMarker, endMarker string) string {
 	t.Helper()
 


### PR DESCRIPTION
## The bug

The interactive `camp` shell wrapper (installed via `camp shell-init <shell>`) wraps `camp` in a shell function so directory-changing commands can `cd` the caller. Its workitem arm appended `--path-output <tmpfile>` to every `camp workitem ...` invocation on a TTY unless `--help`/`--json`/`--print` was present. That append is only valid for the bare interactive dashboard, which selects an item and writes its path for the wrapper to `cd` into. Workitem subcommands do not accept `--path-output`, so interactively they died:

```
$ camp workitem resolve --path-output /tmp/x     # exit 2, "unknown flag: --path-output"
$ camp workitem id --path-output /tmp/x           # exit 2
$ camp workitem stage x active --path-output /tmp/x  # exit 2
$ camp workitem --list --path-output /tmp/x       # exit 1, "--list and --path-output are mutually exclusive"
```

Every workitem subcommand (`resolve`, `id`, `stage`, `priority`, `promote`, `rename`, ...) was affected the moment it was run interactively through the wrapper. This was flagged as a pre-existing issue in PR #485 (the new `camp workitem id` verb was one of the casualties).

## The detection mechanic chosen (and why)

**Chosen: first-token detection.** A workitem subcommand is always the first token after `workitem` and is a bare word; the interactive dashboard is invoked with no positional argument (filter flags only). So: if the first token exists and is not a flag, pass the invocation through verbatim (`command camp workitem "$@"`); otherwise fall through to the dashboard `--path-output` interception.

This is forward-compatible: any new subcommand (`id`, `rename`, and whatever comes next) passes through with no wrapper regeneration, and users with stale installed wrappers are the only ones who keep misbehaving until they re-init. It matches the camp/cobra convention that the subcommand is always the first token, and mirrors how the existing `quest` arm dispatches on the subcommand position (`$2` is `use`/`clear`) rather than an enumerated flag list.

A flag *value* that is a bare word (e.g. `design` in `camp workitem --type design`) is never the first token, so filter-flag dashboard invocations are correctly still intercepted. This was verified behaviorally (below).

**Rejected: an explicit subcommand allowlist in the wrapper.** Brittle: every new subcommand would need wrapper regeneration, and users running a stale installed wrapper would silently break on new subcommands. That is exactly the failure this PR removes, so re-introducing an enumerated list would be self-defeating.

Also added `--list` to the dashboard output-mode passthrough set (alongside `--json`/`--print`/`--help`), because `--list` is a non-interactive dashboard mode that also rejects `--path-output`.

## Per-shell status

Fixed identically in all three generated wrappers (`internal/shell/templates/{zsh,bash,fish}.sh.tmpl`):

- **zsh** and **bash**: a `case "${1:-}" in ""|-*) ;; *) command camp workitem "$@"; return ;; esac` guard before the existing flag-passthrough loop; `--list` added to that loop.
- **fish**: `if test (count $rest) -gt 0; and not string match -qr -- '^-' $rest[1]; command camp workitem $rest; return $status; end` guard; `--list` added to the passthrough `switch`.

The `--path-output` interception for the bare dashboard is unchanged and still runs when no subcommand and no output-mode flag is present.

## Other wrapper arms audited

I enumerated subcommands for every arm that appends a flag to `command camp <cmd> "$@"`:

- `camp workitem` has 20 subcommands (`__complete workitem ""`) -> the only vulnerable arm; fixed.
- `camp list`, `camp festivals`, `camp go` have **no** subcommands; their positional (a campaign/target selector) and the appended flag (`--path-output` / `--print`) always land on the base command that defines the flag. Clean.
- `camp switch` has no subcommands either; its positional is a campaign name and `--shell-connect` is defined on the base command. Clean.

So `list`/`festivals`/`switch`/`go` are not affected by this class of bug, because the appended flag can never reach a subcommand that rejects it (there are no subcommands). No changes needed there.

## Verification (real shells, recorded argv)

The bug only manifests with a TTY (the interception is gated on `isatty`), so a plain `zsh -c` harness cannot exercise it. I sourced each generated wrapper in a real pty (isatty=true) with a stub `command camp` on PATH that records its argv, and asserted the recorded argv. zsh and bash both pass (fish is not installed on this machine; see below):

```
==== zsh (under pty, isatty=true) ====
  [PASS] typed: camp workitem id             -> logged: workitem id
  [PASS] typed: camp workitem resolve        -> logged: workitem resolve
  [PASS] typed: camp workitem stage x active -> logged: workitem stage x active
  [PASS] typed: camp workitem                -> logged: workitem --path-output /.../camp-workitem.XXXX
  [PASS] typed: camp workitem --type design  -> logged: workitem --type design --path-output /.../camp-workitem.XXXX
  [PASS] typed: camp workitem --list         -> logged: workitem --list
  [PASS] typed: camp workitem --json         -> logged: workitem --json
==== bash (same results) ====
```

Subcommands and `--list`/`--json` no longer receive `--path-output`; the bare dashboard and `--type design` still do. fish is not installed here, so it was verified by inspecting the generated wrapper and by the extended transparency test (identical guard structure and token ordering); the fish change is the direct translation of the same guard.

Committed regression coverage: `internal/shell/wrapper_transparency_test.go` gains `TestGenerate{Zsh,Bash,Fish}_WorkitemArmPassesSubcommands`, each asserting the generated workitem arm contains the subcommand guard, the verbatim passthrough call, `--list` in the passthrough set, the preserved `--path-output` interception, and that the guard appears before the interception.

## How the fix reaches users / stale wrappers

The wrapper is generated on demand by `camp shell-init <shell>` and installed via `eval "$(camp shell-init zsh)"` (or the fish/bash equivalents) in the user's shell rc. Users pick up the fix by re-running their shell init (new shell session after upgrading camp, or re-sourcing). Stale already-sourced wrappers keep the old behavior until re-init; the chosen first-token mechanic means that once re-init'd, no future subcommand additions will require another wrapper refresh. There is no runtime auto-reload of an already-sourced function.

Note: `docs/shell-integration.md` has uncommitted WIP in the main checkout (unrelated to this change), so I did not touch it. If it needs a line about re-init after upgrade, that should land separately to avoid colliding with the in-progress edit.

## Gates

Run from the worktree, all green:

- `just gate`: stable + dev build, `go vet` stable/dev/integration, `just lint` stable + dev (0 issues each), unit tests dev (3725 passed) and stable (3680 passed).
- No CLI help text changed, so no `just docs` regeneration was needed.

No pre-existing failures encountered.
