### PR TITLE
feat(list,switch,machine): remote surfaces v2 from operator gate feedback

### DIFF
--- a/cmd/camp/list_tui.go
+++ b/cmd/camp/list_tui.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -78,10 +79,12 @@ func listTUIRequested(cmd *cobra.Command, isTTY bool) bool {
 	if interactive, _ := cmd.Flags().GetBool("interactive"); interactive {
 		return true
 	}
-	for _, f := range []string{"sort", "org", "tag", "status", "all", "group", "no-group", "remote"} {
-		if cmd.Flags().Changed(f) {
-			return false
-		}
+	// --remote is deliberately NOT a shaping flag: in a TTY it opens the same
+	// browser (remotes auto-load when machines are configured); piped and
+	// --json runs still take the table path via the isTTY/format checks above.
+	shaping := []string{"sort", "org", "tag", "status", "all", "group", "no-group"}
+	if slices.ContainsFunc(shaping, cmd.Flags().Changed) {
+		return false
 	}
 	return isTTY
 }
@@ -144,9 +147,22 @@ func newListTUIModel(ctx context.Context, reg *config.Registry, orgFilter string
 	m := listTUIModel{ctx: ctx, input: ti, orgFilter: orgFilter}
 	if mf, err := machines.Load(); err == nil && len(mf.Machines) > 0 {
 		m.machinesConfigured = true
+		// Remotes load automatically on open (fail-open, async); `r` hides or
+		// reloads them. remoteLoading here lets the first frame show progress.
+		m.remoteLoading = true
 	}
 	m.loadFromRegistry(reg)
 	return m
+}
+
+// remoteListFilter mirrors the browser's current view (org + active-only) for
+// the remote fan-out so local and remote rows filter consistently.
+func (m listTUIModel) remoteListFilter() listFilter {
+	filter := listFilter{org: m.orgFilter}
+	if !m.activeOnly {
+		filter.all = true
+	}
+	return filter
 }
 
 func (m *listTUIModel) loadFromRegistry(reg *config.Registry) {
@@ -204,7 +220,12 @@ func (m *listTUIModel) reload() error {
 	return nil
 }
 
-func (m listTUIModel) Init() tea.Cmd { return textinput.Blink }
+func (m listTUIModel) Init() tea.Cmd {
+	if m.remoteLoading {
+		return tea.Batch(textinput.Blink, loadRemoteCampaignsCmd(m.ctx, m.remoteListFilter()))
+	}
+	return textinput.Blink
+}
 
 func (m *listTUIModel) cycleStatus() error {
 	e := m.visible[m.cursor]

--- a/cmd/camp/list_tui_test.go
+++ b/cmd/camp/list_tui_test.go
@@ -29,6 +29,10 @@ func setListRegistry(t *testing.T) {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "registry.json")
 	t.Setenv("CAMP_REGISTRY_PATH", path)
+	// Isolate from the runner's real fleet: without this, a developer machine
+	// with ~/.obey/machines.yaml constructs every test model in remote-loading
+	// state (remotes auto-load on open when machines are configured).
+	t.Setenv("CAMP_MACHINES_PATH", filepath.Join(t.TempDir(), "no-machines.yaml"))
 	if err := os.WriteFile(path, []byte(listFixture), 0o644); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
@@ -139,12 +143,20 @@ func TestListTUIRequested(t *testing.T) {
 			t.Error("a shaping flag should print the table, not open the browser")
 		}
 	})
-	t.Run("remote in a TTY forces the fan-out path", func(t *testing.T) {
+	t.Run("remote in a TTY opens the browser", func(t *testing.T) {
 		listJSON, listCount = false, false
 		c := listTestCmd()
 		_ = c.Flags().Set("remote", "true")
-		if listTUIRequested(c, true) {
-			t.Error("--remote must force the text fan-out path, not open the local browser")
+		if !listTUIRequested(c, true) {
+			t.Error("--remote in a TTY should open the browser (remotes auto-load); table is for pipes/--json")
+		}
+	})
+	t.Run("remote piped prints the table", func(t *testing.T) {
+		listJSON, listCount = false, false
+		c := listTestCmd()
+		_ = c.Flags().Set("remote", "true")
+		if listTUIRequested(c, false) {
+			t.Error("piped --remote must keep the scriptable table path")
 		}
 	})
 }
@@ -499,6 +511,57 @@ func TestListTUI_Go_RemoteWritesSSHHop(t *testing.T) {
 	}
 	if m.gotoPath != "ssh-hop:archdtop:lance-arch" {
 		t.Errorf("gotoPath = %q, want ssh-hop marker", m.gotoPath)
+	}
+}
+
+func TestListTUI_AutoLoadsRemotesOnOpen(t *testing.T) {
+	setListRegistry(t)
+	mpath := filepath.Join(t.TempDir(), "machines.yaml")
+	fleet := "version: 1\nmachines:\n  - id: archdtop\n    host: archdtop.example\n    auth_method: tailscale-ssh\n"
+	if err := os.WriteFile(mpath, []byte(fleet), 0o644); err != nil {
+		t.Fatalf("write machines fixture: %v", err)
+	}
+	t.Setenv("CAMP_MACHINES_PATH", mpath)
+
+	reg, err := config.LoadRegistry(context.Background())
+	if err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	m := newListTUIModel(context.Background(), reg, "")
+	if !m.machinesConfigured {
+		t.Fatal("machinesConfigured should be true with a seeded fleet")
+	}
+	if !m.remoteLoading {
+		t.Fatal("remotes should auto-load on open when machines are configured")
+	}
+	if m.Init() == nil {
+		t.Fatal("Init should return the auto-load command")
+	}
+	m.width, m.height = 120, 30
+	if !strings.Contains(m.View(), "loading remotes") {
+		t.Error("first frame should show the remote loading state")
+	}
+}
+
+func TestListTUI_NoAutoLoadWithoutMachines(t *testing.T) {
+	m := newTestListModel(t) // setListRegistry isolates the fleet path
+	if m.machinesConfigured || m.remoteLoading {
+		t.Fatalf("no fleet configured: machinesConfigured=%v remoteLoading=%v, want false/false",
+			m.machinesConfigured, m.remoteLoading)
+	}
+}
+
+func TestListTUI_RemoteListFilterMirrorsView(t *testing.T) {
+	m := newTestListModel(t)
+	m.orgFilter = "obey"
+	m.activeOnly = false
+	f := m.remoteListFilter()
+	if f.org != "obey" || !f.all {
+		t.Errorf("filter = %+v, want org=obey all=true", f)
+	}
+	m.activeOnly = true
+	if f := m.remoteListFilter(); f.all {
+		t.Error("active-only view must not request all statuses from remotes")
 	}
 }
 

--- a/cmd/camp/list_tui_update.go
+++ b/cmd/camp/list_tui_update.go
@@ -145,11 +145,7 @@ func (m listTUIModel) updateBrowse(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.remoteLoading = true
 		m.setStatus("loading remotes…", false)
-		filter := listFilter{org: m.orgFilter}
-		if !m.activeOnly {
-			filter.all = true
-		}
-		return m, loadRemoteCampaignsCmd(m.ctx, filter)
+		return m, loadRemoteCampaignsCmd(m.ctx, m.remoteListFilter())
 	}
 	return m, nil
 }

--- a/cmd/camp/machine.go
+++ b/cmd/camp/machine.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/pathutil"
 	"github.com/Obedience-Corp/camp/internal/remote"
 	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/internal/version"
 )
 
 // machineJSON mirrors machines.Machine's field names for JSON output
@@ -320,6 +322,38 @@ type machineDiagnoseRow struct {
 	Socket       string `json:"socket"`
 	State        string `json:"state"`
 	Reset        bool   `json:"reset"`
+	CampVersion  string `json:"camp_version,omitempty"`
+	CampCommit   string `json:"camp_commit,omitempty"`
+	VersionSkew  bool   `json:"version_skew"`
+}
+
+// probeRemoteCampVersion asks the machine's own camp for its version. It is
+// best-effort: any failure (unreachable, camp missing, ancient binary without
+// `version --json`) reports as an empty version, never a diagnose error —
+// diagnose must keep working against exactly the broken machines it exists for.
+func probeRemoteCampVersion(ctx context.Context, m *machines.Machine) (versionStr, commit string) {
+	out, err := remote.RunCampCommand(ctx, m, "version --json")
+	if err != nil {
+		return "", ""
+	}
+	var info version.Info
+	if err := json.Unmarshal(out, &info); err != nil {
+		return "", ""
+	}
+	return info.Version, info.Commit
+}
+
+// campVersionSkew reports whether a probed remote version differs from this
+// binary. Same version string but different commits (the dev-build case) also
+// counts — two "dev" builds from different commits are not the same camp.
+func campVersionSkew(local version.Info, remoteVersion, remoteCommit string) bool {
+	if remoteVersion == "" {
+		return false
+	}
+	if remoteVersion != local.Version {
+		return true
+	}
+	return remoteCommit != "" && local.Commit != "" && remoteCommit != local.Commit
 }
 
 func runMachineDiagnose(cmd *cobra.Command, args []string) error {
@@ -349,10 +383,12 @@ func runMachineDiagnose(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	localInfo := version.Get()
 	rows := make([]machineDiagnoseRow, 0, len(targets))
 	for i := range targets {
 		m := &targets[i]
 		d := remote.CheckControlMaster(ctx, m)
+		remoteVersion, remoteCommit := probeRemoteCampVersion(ctx, m)
 		row := machineDiagnoseRow{
 			ID:           m.ID,
 			Host:         m.Host,
@@ -364,6 +400,9 @@ func runMachineDiagnose(cmd *cobra.Command, args []string) error {
 			Hint:         remote.AuthModeHint(m),
 			Socket:       d.Socket,
 			State:        string(d.State),
+			CampVersion:  remoteVersion,
+			CampCommit:   remoteCommit,
+			VersionSkew:  campVersionSkew(localInfo, remoteVersion, remoteCommit),
 		}
 		if machineDiagnoseReset && d.State == remote.ControlStale {
 			if err := remote.ResetControlMaster(ctx, m); err != nil {
@@ -419,6 +458,16 @@ func renderMachineDiagnoseTable(w io.Writer, rows []machineDiagnoseRow) error {
 			fmt.Sprintf("%s  %s", ui.Label("SOCKET"), state+" · "+pathutil.AbbreviateHome(r.Socket)),
 			fmt.Sprintf("%s  %s", ui.Label("PROBE"), r.Probe),
 		)
+		switch {
+		case r.CampVersion == "":
+			lines = append(lines, fmt.Sprintf("%s  %s", ui.Label("CAMP"),
+				ui.Dim("unavailable (unreachable, or camp missing / too old for 'version --json')")))
+		case r.VersionSkew:
+			lines = append(lines, fmt.Sprintf("%s  %s", ui.Label("CAMP"),
+				campVersionDisplay(r)+"  ⚠ differs from this machine ("+campLocalVersionDisplay()+"); remote errors may not match current behavior"))
+		default:
+			lines = append(lines, fmt.Sprintf("%s  %s", ui.Label("CAMP"), campVersionDisplay(r)))
+		}
 		if r.Hint != "" {
 			lines = append(lines, fmt.Sprintf("%s  %s", ui.Label("HINT"), r.Hint))
 		}
@@ -439,6 +488,23 @@ func renderMachineDiagnoseTable(w io.Writer, rows []machineDiagnoseRow) error {
 		}
 	}
 	return nil
+}
+
+// campVersionDisplay formats a probed remote camp version, appending the
+// commit only when it disambiguates (dev builds all report version "dev").
+func campVersionDisplay(r machineDiagnoseRow) string {
+	if r.CampCommit != "" {
+		return r.CampVersion + " (" + r.CampCommit + ")"
+	}
+	return r.CampVersion
+}
+
+func campLocalVersionDisplay() string {
+	info := version.Get()
+	if info.Commit != "" {
+		return info.Version + " (" + info.Commit + ")"
+	}
+	return info.Version
 }
 
 func machineDiagnoseHasStale(rows []machineDiagnoseRow) bool {

--- a/cmd/camp/machine_test.go
+++ b/cmd/camp/machine_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Obedience-Corp/camp/internal/machines"
+	"github.com/Obedience-Corp/camp/internal/version"
 )
 
 func TestValidateMachineID(t *testing.T) {
@@ -129,5 +130,40 @@ func TestToMachineJSONRoundTripsAllFields(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("toMachineJSON() = %+v, want %+v", got, want)
+	}
+}
+
+func TestCampVersionSkew(t *testing.T) {
+	local := version.Info{Version: "v0.9.0", Commit: "abc1234"}
+	dev := version.Info{Version: "dev", Commit: "abc1234"}
+	tests := []struct {
+		name          string
+		local         version.Info
+		remoteVersion string
+		remoteCommit  string
+		want          bool
+	}{
+		{"probe failed reports no skew", local, "", "", false},
+		{"same version and commit", local, "v0.9.0", "abc1234", false},
+		{"older remote release", local, "v0.8.0", "def5678", true},
+		{"dev builds from different commits", dev, "dev", "def5678", true},
+		{"same version, remote commit unknown", local, "v0.9.0", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := campVersionSkew(tt.local, tt.remoteVersion, tt.remoteCommit); got != tt.want {
+				t.Errorf("campVersionSkew(%+v, %q, %q) = %v, want %v",
+					tt.local, tt.remoteVersion, tt.remoteCommit, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCampVersionDisplay(t *testing.T) {
+	if got := campVersionDisplay(machineDiagnoseRow{CampVersion: "dev", CampCommit: "abc1234"}); got != "dev (abc1234)" {
+		t.Errorf("with commit = %q", got)
+	}
+	if got := campVersionDisplay(machineDiagnoseRow{CampVersion: "v0.9.0"}); got != "v0.9.0" {
+		t.Errorf("without commit = %q", got)
 	}
 }

--- a/cmd/camp/switch.go
+++ b/cmd/camp/switch.go
@@ -457,13 +457,38 @@ func runRemoteSwitch(ctx context.Context, cmd *cobra.Command, msel cmdutil.Parse
 	}
 	root, err := remote.ResolveRoot(ctx, m, msel.Remainder)
 	if err != nil {
-		return err
+		return withRemoteSuggestions(err, msel)
 	}
 	if shellConnect {
 		return emitShellConnect(cmd.OutOrStdout(), true, root, m)
 	}
 	return camperrors.New("resolved " + msel.Machine + ":" + msel.Remainder + " -> " + root +
 		"; run via the csw shell wrapper to hop there")
+}
+
+// withRemoteSuggestions augments a remote resolve failure with near matches
+// from the per-machine completion cache. Cache-only on purpose: the failed
+// resolve already paid one SSH round-trip, and suggestions must not add
+// another. A cold cache simply yields no suggestions.
+func withRemoteSuggestions(err error, msel cmdutil.ParsedMachineSelector) error {
+	names, ok := readMachineCacheCampaigns(msel.Machine)
+	if !ok || len(names) == 0 {
+		return err
+	}
+	query := cmdutil.ParseSwitchSelector(msel.Remainder).Campaign
+	if query == "" {
+		return err
+	}
+	matches := navfuzzy.Filter(names, query)
+	if len(matches) == 0 {
+		return err
+	}
+	limit := min(len(matches), 3)
+	suggestions := make([]string, 0, limit)
+	for _, match := range matches[:limit] {
+		suggestions = append(suggestions, msel.Machine+":"+match.Target)
+	}
+	return camperrors.Wrapf(err, "did you mean %s?", strings.Join(suggestions, ", "))
 }
 
 type switchOutput struct {

--- a/cmd/camp/switch_pick.go
+++ b/cmd/camp/switch_pick.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -210,7 +211,7 @@ func pickSwitchTarget(ctx context.Context, reg *config.Registry, opts pickSwitch
 	if header == "" {
 		header = "  ↑/↓ navigate • type to filter • esc cancel"
 		if hasMachines {
-			header = "  ↑/↓ navigate • type to filter • remotes loading… • esc cancel"
+			header = "  ↑/↓ navigate • type to filter • esc cancel • remotes append when ready"
 		}
 	}
 
@@ -231,24 +232,34 @@ func pickSwitchTarget(ctx context.Context, reg *config.Registry, opts pickSwitch
 		return cfg
 	}
 
+	// Load outcome is reported on stderr after the picker closes: the
+	// fuzzyfinder header is fixed at open, so mid-flight failures cannot be
+	// rendered inside the TUI without fighting it for the terminal.
+	var loadErr error
+	var loadUnreachable []string
 	if hasMachines {
 		go func() {
 			rows, results, err := loader(ctx, listFilterFromScope(opts.Scope))
 			mu.Lock()
 			defer mu.Unlock()
 			if err != nil {
-				// Keep locals; surface failure only in header isn't possible mid-flight
-				// without a second channel — remotes simply don't append.
+				loadErr = err
 				return
 			}
-			remotes := remoteSwitchPicks(rows)
-			items = append(items, remotes...)
-			if unreach := unreachableMachineIDs(results); len(unreach) > 0 {
-				// Header is fixed at open; unreachable info lives in previews only.
-				// Locals remain selectable regardless.
-				_ = unreach
-			}
+			loadUnreachable = unreachableMachineIDs(results)
+			items = append(items, remoteSwitchPicks(rows)...)
 		}()
+	}
+	reportRemoteLoad := func() {
+		mu.RLock()
+		defer mu.RUnlock()
+		if loadErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: remote campaigns unavailable: %v\n", loadErr)
+			return
+		}
+		for _, id := range loadUnreachable {
+			fmt.Fprintf(os.Stderr, "warning: machine %s unreachable; its campaigns were not listed\n", id)
+		}
 	}
 
 	findOpts := []fuzzyfinder.Option{
@@ -289,6 +300,7 @@ func pickSwitchTarget(ctx context.Context, reg *config.Registry, opts pickSwitch
 		},
 		findOpts...,
 	)
+	reportRemoteLoad()
 	if err != nil {
 		if errors.Is(err, fuzzyfinder.ErrAbort) {
 			return switchPick{}, camperrors.Newf("cancelled")

--- a/cmd/camp/switch_test.go
+++ b/cmd/camp/switch_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"sort"
 	"strings"
 	"testing"
@@ -573,5 +574,29 @@ func TestCompleteSwitchTabs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestWithRemoteSuggestions(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	writeMachineCacheCampaigns("archdtop", []string{"lance-arch", "media-server"})
+	base := errors.New(`campaign "lance" not found`)
+
+	err := withRemoteSuggestions(base, cmdutil.ParsedMachineSelector{Machine: "archdtop", Remainder: "lance"})
+	if !strings.Contains(err.Error(), "archdtop:lance-arch") {
+		t.Errorf("suggestion missing from error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("original error dropped: %v", err)
+	}
+
+	if err := withRemoteSuggestions(base, cmdutil.ParsedMachineSelector{Machine: "coldcache", Remainder: "lance"}); err != base {
+		t.Errorf("cold cache should return the error unchanged, got: %v", err)
+	}
+	if err := withRemoteSuggestions(base, cmdutil.ParsedMachineSelector{Machine: "archdtop", Remainder: "zzzz"}); err != base {
+		t.Errorf("no fuzzy match should return the error unchanged, got: %v", err)
+	}
+	if err := withRemoteSuggestions(base, cmdutil.ParsedMachineSelector{Machine: "archdtop", Remainder: "@tab-only"}); err != base {
+		t.Errorf("empty campaign query should return the error unchanged, got: %v", err)
 	}
 }


### PR DESCRIPTION
Follow-up to #486 driven by the live operator gate on WI-56d496. Intent: remote-surfaces-v2-gate-feedback.

## Changes

1. **List TUI auto-loads remotes on open** when machines.yaml is non-empty (async via tea.Cmd, fail-open; locals render immediately, remote rows append). `r` now hides or reloads. This revises design decision R1 after operator experience: the toggle-only default hid the fleet.
2. **`camp list --remote` opens the same TUI in a TTY.** Pipes and `--json` keep the scriptable table path unchanged.
3. **Switch picker load-failure visibility**: loader errors and unreachable machines now print stderr warnings after the picker closes (fuzzyfinder headers are fixed at open, so in-TUI reporting is not possible). Header wording no longer claims perpetual loading.
4. **Remote switch suggestions**: a failed `machine:name` resolve appends near matches from the per-machine completion cache (cache-only, no extra SSH): `did you mean archdtop:lance-arch?`
5. **`camp machine diagnose` probes the remote camp version** (`version --json` over the existing RunCampCommand path) and warns on skew, including dev builds from different commits. The gate's misleading `csw archdtop:lance-arch` errors were an old fleet binary; skew is now visible instead of mysterious.
6. **Test hermeticity**: list TUI tests now isolate CAMP_MACHINES_PATH so a developer's real fleet cannot leak into model construction.

## Not changed on purpose

- The reported "picker fuzzy matching broken for remote rows" could NOT be reproduced: a standalone PTY repro with identical wiring (WithHotReloadLock, pointer slice, same label format, both type-first and append-first orderings) matches appended remote rows correctly. The observed failures trace to the old remote binary instead.
- Hop contract (R4), shell templates, BatchMode: untouched.

## Verification

- `just gate` green: 3683 tests.
- PTY-driven (pyte) against a fixture registry + dead machine: TUI opens with locals immediately, auto-load fails open with `loaded remotes (1 unreachable: deadbox)` status, `--remote` opens the TUI in a TTY, piped `--remote` still prints the MACHINE table.

Workitem: WI-56d496