### PR TITLE
feat(workitem): sweep eligibility planner + local-dungeon destination rule (WF0001 P1/S1)

### DIFF
--- a/internal/commands/workitem/sweep.go
+++ b/internal/commands/workitem/sweep.go
@@ -1,0 +1,20 @@
+package workitem
+
+import (
+	"path/filepath"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/locate"
+)
+
+// resolveSweepLocation resolves the locate.Location for a sweep candidate from
+// its RelativePath, reusing locate.DetectFromCwd (which is generic over any
+// path under the item, not literally the process cwd) so the sweep and
+// interactive promote share one notion of "where this item's dungeon lives."
+// Every candidate PlanSweep can produce today has a workflow/<type>/<slug>
+// RelativePath, so this is currently a pass-through onto DetectFromCwd's
+// existing resolution; phase 3 (rail residents in festivals/) extends
+// DetectFromCwd itself, and this function needs no change when that lands.
+func resolveSweepLocation(campaignRoot string, item wkitem.WorkItem) (*locate.Location, error) {
+	return locate.DetectFromCwd(campaignRoot, filepath.Join(campaignRoot, item.RelativePath))
+}

--- a/internal/commands/workitem/sweep_test.go
+++ b/internal/commands/workitem/sweep_test.go
@@ -1,0 +1,61 @@
+package workitem
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+// TestResolveSweepLocation_WorkflowHome locks today's pass-through behavior:
+// a design item resolves to its type-local dungeon at workflow/design/dungeon,
+// outside a dungeon. When phase 3 adds festivals/ support to DetectFromCwd this
+// baseline stays valid and the festivals/ negative case below flips; that is
+// the visible seam this task exists to create.
+func TestResolveSweepLocation_WorkflowHome(t *testing.T) {
+	root := t.TempDir()
+	itemRel := filepath.Join("workflow", "design", "some-item")
+	if err := os.MkdirAll(filepath.Join(root, itemRel), 0o755); err != nil {
+		t.Fatalf("mkdir fixture: %v", err)
+	}
+
+	loc, err := resolveSweepLocation(root, wkitem.WorkItem{RelativePath: itemRel})
+	if err != nil {
+		t.Fatalf("resolveSweepLocation: %v", err)
+	}
+	if loc.InDungeon {
+		t.Errorf("InDungeon = true, want false for a live workflow home")
+	}
+	wantDungeon := filepath.Join(root, "workflow", "design", "dungeon")
+	// EvalSymlinks resolves the temp root (macOS /var -> /private/var), so
+	// compare on the resolved root rather than the raw t.TempDir() value.
+	if resolved, rerr := filepath.EvalSymlinks(root); rerr == nil {
+		wantDungeon = filepath.Join(resolved, "workflow", "design", "dungeon")
+	}
+	if loc.DungeonPath != wantDungeon {
+		t.Errorf("DungeonPath = %q, want %q", loc.DungeonPath, wantDungeon)
+	}
+}
+
+// TestResolveSweepLocation_FestivalsHomeNotYetSupported locks the current
+// error for a festivals/ path. No sweep candidate has such a RelativePath
+// before phase 3 (PlanSweep excludes festivals), so this asserts the baseline
+// that phase 3 must deliberately change when it teaches DetectFromCwd about
+// festivals/ homes. Asserting the exact message catches a silent behavior drift.
+func TestResolveSweepLocation_FestivalsHomeNotYetSupported(t *testing.T) {
+	root := t.TempDir()
+	itemRel := filepath.Join("festivals", "ready", "foo-item")
+	if err := os.MkdirAll(filepath.Join(root, itemRel), 0o755); err != nil {
+		t.Fatalf("mkdir fixture: %v", err)
+	}
+
+	_, err := resolveSweepLocation(root, wkitem.WorkItem{RelativePath: itemRel})
+	if err == nil {
+		t.Fatal("expected error for festivals/ home, got nil")
+	}
+	const want = "not inside a workitem; cwd must be under workflow/<type>/<slug>/"
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}

--- a/internal/workitem/sweep.go
+++ b/internal/workitem/sweep.go
@@ -1,0 +1,77 @@
+package workitem
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// EvidenceWorkflowRunCompleted names the tier-1 (loop-completion) evidence
+// kind. It is the only auto-promotion evidence tier; merged-branch evidence
+// (tier 2) prompts or reports and never reuses this constant.
+const EvidenceWorkflowRunCompleted = "workflow_run_completed"
+
+// runStatusCompleted is the RunStatus value the localrun replay assigns after a
+// workflow_run_completed event (internal/workitem/localrun.go).
+const runStatusCompleted = "completed"
+
+// SweepCandidate is a workitem eligible for tier-1 auto-promotion: its active
+// workflow run reached completed. Reason names the evidence kind so a future
+// evidence tier can share this shape; today it is always
+// EvidenceWorkflowRunCompleted. ActiveRunID is the run whose completion made
+// the item eligible, carried through for the promote event's evidence payload.
+type SweepCandidate struct {
+	Item        WorkItem
+	Reason      string
+	ActiveRunID string
+}
+
+// PlanSweep returns the subset of items eligible for tier-1 (loop-completion)
+// auto-promotion. Pure function: no I/O, no mutation, no context to cancel.
+// items is expected to come from Discover(), whose walk already excludes
+// dungeon subtrees and never populates WorkflowMeta for intents or festivals;
+// the checks below are still explicit so this rule survives a future change to
+// how items are gathered.
+func PlanSweep(items []WorkItem) []SweepCandidate {
+	var out []SweepCandidate
+	for _, item := range items {
+		if !sweepEligibleType(item.WorkflowType) {
+			continue
+		}
+		if item.WorkflowMeta == nil || item.WorkflowMeta.RunStatus != runStatusCompleted {
+			continue
+		}
+		if item.WorkflowMeta.ActiveRunID == "" {
+			continue
+		}
+		if inDungeonPath(item.RelativePath) {
+			continue
+		}
+		out = append(out, SweepCandidate{
+			Item:        item,
+			Reason:      EvidenceWorkflowRunCompleted,
+			ActiveRunID: item.WorkflowMeta.ActiveRunID,
+		})
+	}
+	return out
+}
+
+// sweepEligibleType excludes the workflow types that fest owns (festivals) or
+// that have their own promote paths (intents, v1). This is an explicit
+// scope-boundary rule per spec doc 03, not an accident of which discovery paths
+// populate WorkflowMeta today.
+func sweepEligibleType(wt WorkflowType) bool {
+	return wt != WorkflowTypeFestival && wt != WorkflowTypeIntent
+}
+
+// inDungeonPath reports whether relPath contains a dungeon path segment.
+// Discover() structurally cannot produce such an item, so this is a defensive
+// guard for differently-sourced callers; it compares whole segments so a
+// workitem literally named "my-dungeon-notes" is not falsely excluded.
+func inDungeonPath(relPath string) bool {
+	for _, seg := range strings.Split(filepath.ToSlash(relPath), "/") {
+		if seg == "dungeon" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/workitem/sweep_test.go
+++ b/internal/workitem/sweep_test.go
@@ -1,0 +1,245 @@
+package workitem
+
+import (
+	"context"
+	"testing"
+	"testing/fstest"
+)
+
+// completedMeta builds a WorkItemWorkflow in the completed state with a
+// non-empty active run id, the shape a real loop-completion produces.
+func completedMeta() *WorkItemWorkflow {
+	return &WorkItemWorkflow{ActiveRunID: "run-001", RunStatus: "completed"}
+}
+
+func TestPlanSweep_Eligibility(t *testing.T) {
+	tests := []struct {
+		name         string
+		item         WorkItem
+		wantIncluded bool
+	}{
+		// Exclusion cases first (campaign convention: error paths before happy paths).
+		{
+			name: "festival with forced completed meta is excluded by type",
+			item: WorkItem{
+				WorkflowType: WorkflowTypeFestival,
+				RelativePath: "festivals/active/foo-FA0001",
+				WorkflowMeta: completedMeta(),
+			},
+			wantIncluded: false,
+		},
+		{
+			name: "intent with forced completed meta is excluded by type",
+			item: WorkItem{
+				WorkflowType: WorkflowTypeIntent,
+				RelativePath: ".campaign/intents/active/foo.md",
+				WorkflowMeta: completedMeta(),
+			},
+			wantIncluded: false,
+		},
+		{
+			name: "nil workflow meta is excluded and never panics",
+			item: WorkItem{
+				WorkflowType: WorkflowTypeDesign,
+				RelativePath: "workflow/design/foo",
+				WorkflowMeta: nil,
+			},
+			wantIncluded: false,
+		},
+		{
+			name: "run status active is excluded",
+			item: WorkItem{
+				WorkflowType: WorkflowTypeDesign,
+				RelativePath: "workflow/design/foo",
+				WorkflowMeta: &WorkItemWorkflow{ActiveRunID: "run-001", RunStatus: "active"},
+			},
+			wantIncluded: false,
+		},
+		{
+			name: "run status blocked is excluded",
+			item: WorkItem{
+				WorkflowType: WorkflowTypeExplore,
+				RelativePath: "workflow/explore/foo",
+				WorkflowMeta: &WorkItemWorkflow{ActiveRunID: "run-001", RunStatus: "blocked"},
+			},
+			wantIncluded: false,
+		},
+		{
+			name: "run status abandoned is excluded",
+			item: WorkItem{
+				WorkflowType: WorkflowTypeDesign,
+				RelativePath: "workflow/design/foo",
+				WorkflowMeta: &WorkItemWorkflow{ActiveRunID: "run-001", RunStatus: "abandoned"},
+			},
+			wantIncluded: false,
+		},
+		{
+			name: "completed with empty active run id is excluded as malformed",
+			item: WorkItem{
+				WorkflowType: WorkflowTypeDesign,
+				RelativePath: "workflow/design/foo",
+				WorkflowMeta: &WorkItemWorkflow{ActiveRunID: "", RunStatus: "completed"},
+			},
+			wantIncluded: false,
+		},
+		{
+			name: "relative path with dungeon segment is excluded by defensive guard",
+			item: WorkItem{
+				WorkflowType: WorkflowTypeDesign,
+				RelativePath: "workflow/design/dungeon/foo",
+				WorkflowMeta: completedMeta(),
+			},
+			wantIncluded: false,
+		},
+		{
+			name: "workitem named my-dungeon-notes is NOT excluded (segment match, not substring)",
+			item: WorkItem{
+				WorkflowType: WorkflowTypeDesign,
+				RelativePath: "workflow/design/my-dungeon-notes",
+				WorkflowMeta: completedMeta(),
+			},
+			wantIncluded: true,
+		},
+		// Happy paths.
+		{
+			name: "design item with completed run is included",
+			item: WorkItem{
+				WorkflowType: WorkflowTypeDesign,
+				RelativePath: "workflow/design/foo",
+				WorkflowMeta: completedMeta(),
+			},
+			wantIncluded: true,
+		},
+		{
+			name: "explore item with completed run is included",
+			item: WorkItem{
+				WorkflowType: WorkflowTypeExplore,
+				RelativePath: "workflow/explore/bar",
+				WorkflowMeta: completedMeta(),
+			},
+			wantIncluded: true,
+		},
+		{
+			name: "custom-type item with completed run is included",
+			item: WorkItem{
+				WorkflowType: WorkflowType("research"),
+				RelativePath: "workflow/research/baz",
+				WorkflowMeta: completedMeta(),
+			},
+			wantIncluded: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PlanSweep([]WorkItem{tc.item})
+			if tc.wantIncluded && len(got) != 1 {
+				t.Fatalf("expected item included, got %d candidates", len(got))
+			}
+			if !tc.wantIncluded && len(got) != 0 {
+				t.Fatalf("expected item excluded, got %d candidates: %+v", len(got), got)
+			}
+		})
+	}
+}
+
+func TestPlanSweep_CandidatePayload(t *testing.T) {
+	item := WorkItem{
+		WorkflowType: WorkflowTypeDesign,
+		RelativePath: "workflow/design/foo",
+		WorkflowMeta: &WorkItemWorkflow{ActiveRunID: "run-042", RunStatus: "completed"},
+	}
+	got := PlanSweep([]WorkItem{item})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(got))
+	}
+	if got[0].Reason != EvidenceWorkflowRunCompleted {
+		t.Errorf("Reason = %q, want %q", got[0].Reason, EvidenceWorkflowRunCompleted)
+	}
+	if got[0].ActiveRunID != "run-042" {
+		t.Errorf("ActiveRunID = %q, want run-042", got[0].ActiveRunID)
+	}
+	if got[0].Item.RelativePath != item.RelativePath {
+		t.Errorf("Item.RelativePath = %q, want %q", got[0].Item.RelativePath, item.RelativePath)
+	}
+}
+
+func TestPlanSweep_MixedSliceReturnsOnlyEligible(t *testing.T) {
+	items := []WorkItem{
+		{WorkflowType: WorkflowTypeFestival, RelativePath: "festivals/active/x-FA0001", WorkflowMeta: completedMeta()},
+		{WorkflowType: WorkflowTypeDesign, RelativePath: "workflow/design/keep", WorkflowMeta: completedMeta()},
+		{WorkflowType: WorkflowTypeExplore, RelativePath: "workflow/explore/drop", WorkflowMeta: &WorkItemWorkflow{ActiveRunID: "run-001", RunStatus: "active"}},
+		{WorkflowType: WorkflowTypeExplore, RelativePath: "workflow/explore/keep2", WorkflowMeta: completedMeta()},
+	}
+	got := PlanSweep(items)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 candidates, got %d: %+v", len(got), got)
+	}
+	paths := map[string]bool{got[0].Item.RelativePath: true, got[1].Item.RelativePath: true}
+	if !paths["workflow/design/keep"] || !paths["workflow/explore/keep2"] {
+		t.Errorf("unexpected candidate set: %v", paths)
+	}
+}
+
+// TestPlanSweep_MultiRunCaveat verifies the read side the planner depends on:
+// when a new run starts after a completed one and workflow.yaml's
+// active_run_id points at the new run, LoadLocalRunFS replays only the active
+// run and never leaks the prior run's stale "completed" status. This is the
+// multi-run caveat from spec doc 03 (lines 63-67), verified in phase 1 rather
+// than deferred to the phase-3 verification spike.
+func TestPlanSweep_MultiRunCaveat(t *testing.T) {
+	const base = "campaign-root"
+	fsys := fstest.MapFS{
+		base + "/.workflow/workflow.yaml": {Data: []byte(`workflow_id: wf-multi
+active_run_id: run-002
+`)},
+		// Prior, completed run. Its completed event must never be replayed
+		// because it is not the active run.
+		base + "/.workflow/runs/run-001/run.yaml": {Data: []byte(`status: completed
+summary:
+  total_steps: 2
+`)},
+		base + "/.workflow/runs/run-001/progress_events.jsonl": {Data: []byte(`{"event_type":"wf_step_start"}
+{"event_type":"wf_step_done"}
+{"event_type":"wf_step_start"}
+{"event_type":"wf_step_done"}
+{"event_type":"workflow_run_completed"}
+`)},
+		// New active run, in progress.
+		base + "/.workflow/runs/run-002/run.yaml": {Data: []byte(`status: active
+summary:
+  total_steps: 3
+`)},
+		base + "/.workflow/runs/run-002/progress_events.jsonl": {Data: []byte(`{"event_type":"workflow_run_started"}
+{"event_type":"wf_step_start"}
+`)},
+	}
+
+	got, err := LoadLocalRunFS(context.Background(), fsys, base)
+	if err != nil {
+		t.Fatalf("LoadLocalRunFS: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected progress, got nil")
+	}
+	if got.ActiveRunID != "run-002" {
+		t.Errorf("ActiveRunID = %q, want run-002", got.ActiveRunID)
+	}
+	if got.RunStatus == "completed" {
+		t.Fatalf("RunStatus = %q; stale completed from run-001 leaked into active run-002", got.RunStatus)
+	}
+	if got.RunStatus != "active" {
+		t.Errorf("RunStatus = %q, want active (run-002 is in progress)", got.RunStatus)
+	}
+
+	// The planner consuming this meta must NOT treat the item as eligible:
+	// run-002 is active, not completed.
+	item := WorkItem{
+		WorkflowType: WorkflowTypeDesign,
+		RelativePath: "workflow/design/multi",
+		WorkflowMeta: &WorkItemWorkflow{ActiveRunID: got.ActiveRunID, RunStatus: got.RunStatus},
+	}
+	if cands := PlanSweep([]WorkItem{item}); len(cands) != 0 {
+		t.Errorf("expected multi-run item excluded (active run), got %d candidates", len(cands))
+	}
+}


### PR DESCRIPTION
## Summary

Adds the pure sweep-eligibility planner and the local-dungeon destination
resolver that the tier-1 evidence-driven completion feature is built on. This is
the first sequence of the `workitem-festival-lifecycle` festival (WF0001), spec
of record `WI-75d77f` doc 03 (evidence-driven completion) and doc 05
(implementation plan, phase 1).

No user-facing behavior changes yet: this sequence lands the planner and the
resolver seam only. The `camp workitem sweep` verb (sequence 02) and `camp fresh`
wiring (sequence 03) execute against these in the following stacked PRs.

## What changed

- `internal/workitem/sweep.go` (new): `PlanSweep(items []WorkItem)
  []SweepCandidate`, a pure filter (no I/O, no context, no error return) over
  already-gathered `Discover()` output. Eligibility, cheapest checks first:
  workflow type is not `festival`/`intent` (explicit named exclusion, not an
  accident of which discovery paths populate `WorkflowMeta`), `WorkflowMeta`
  non-nil, `RunStatus == "completed"`, non-empty `ActiveRunID`, and a defensive
  whole-segment dungeon-path guard. `SweepCandidate` carries the item, a
  `Reason` (constant `EvidenceWorkflowRunCompleted`) future-proofed for a second
  evidence tier, and the `ActiveRunID` for the promote event payload.
- `internal/commands/workitem/sweep.go` (new): `resolveSweepLocation`, a thin
  named wrapper over `locate.DetectFromCwd`. Every candidate `PlanSweep` can
  produce today has a `workflow/<type>/<slug>` path, so this is currently a
  pass-through; phase 3 extends `DetectFromCwd` itself for `festivals/` homes and
  this wrapper needs no change. It is the single seam a future contributor greps
  for.
- Table-driven tests for both, exclusion cases before happy paths per campaign
  convention. Includes a multi-run fixture (`TestPlanSweep_MultiRunCaveat`)
  driving `LoadLocalRunFS` against an `fstest.MapFS` where `active_run_id` points
  at an in-progress `run-002` while `run-001` holds a `workflow_run_completed`
  event, proving the stale `completed` never leaks. The `resolveSweepLocation`
  negative test asserts the exact current error for a `festivals/` path, a locked
  baseline phase 3 must change deliberately.

## Evidence-tier invariant

Only loop-completion evidence (`workflow_run_completed`) is represented here, and
`PlanSweep` is the sole eligibility gate for tier-1 auto-promotion. Nothing in
this sequence acts on merged-branch (inference-tier) evidence; that is phase 2,
prompt/report only.

## Test output

```
$ go test ./internal/workitem/ ./internal/commands/workitem/ -run 'Sweep|PlanSweep|MultiRun|ResolveSweep' -v
--- PASS: TestPlanSweep_Eligibility (0.00s)
    --- PASS: TestPlanSweep_Eligibility/festival_with_forced_completed_meta_is_excluded_by_type (0.00s)
    --- PASS: TestPlanSweep_Eligibility/intent_with_forced_completed_meta_is_excluded_by_type (0.00s)
    --- PASS: TestPlanSweep_Eligibility/nil_workflow_meta_is_excluded_and_never_panics (0.00s)
    --- PASS: TestPlanSweep_Eligibility/run_status_active_is_excluded (0.00s)
    --- PASS: TestPlanSweep_Eligibility/run_status_blocked_is_excluded (0.00s)
    --- PASS: TestPlanSweep_Eligibility/run_status_abandoned_is_excluded (0.00s)
    --- PASS: TestPlanSweep_Eligibility/completed_with_empty_active_run_id_is_excluded_as_malformed (0.00s)
    --- PASS: TestPlanSweep_Eligibility/relative_path_with_dungeon_segment_is_excluded_by_defensive_guard (0.00s)
    --- PASS: TestPlanSweep_Eligibility/workitem_named_my-dungeon-notes_is_NOT_excluded_(segment_match,_not_substring) (0.00s)
    --- PASS: TestPlanSweep_Eligibility/design_item_with_completed_run_is_included (0.00s)
    --- PASS: TestPlanSweep_Eligibility/explore_item_with_completed_run_is_included (0.00s)
    --- PASS: TestPlanSweep_Eligibility/custom-type_item_with_completed_run_is_included (0.00s)
--- PASS: TestPlanSweep_CandidatePayload (0.00s)
--- PASS: TestPlanSweep_MixedSliceReturnsOnlyEligible (0.00s)
--- PASS: TestPlanSweep_MultiRunCaveat (0.00s)
--- PASS: TestResolveSweepLocation_WorkflowHome (0.00s)
--- PASS: TestResolveSweepLocation_FestivalsHomeNotYetSupported (0.00s)
```

Full repo gate `just gate` is green (gate-fast 3738/3738, stable 3693/3693; both
`lint-no-fmt-errorf` and `lint-no-host-fs-tests` ratchets clean).

## Stack

Base: `main`. This is the first sequence of phase 001; nothing to stack on.
Follow-on PRs stack in order: sequence 02 (`camp workitem sweep`) on this branch,
sequence 03 (`camp fresh` wiring + `camp wi` banner) on sequence 02.

## Notes

- Spec-of-record discrepancy surfaced (not silently resolved): FESTIVAL_OVERVIEW
  groups "localrun eligibility fields" with the phase-3 spikes, but doc 05
  requires the multi-run read-side to be correct in phase 1. This sequence
  verifies it now via `TestPlanSweep_MultiRunCaveat` rather than deferring.
  Written up in the sequence's `results/testing-and-verify.md`.
- Not merged by an agent; left for review.
