### PR TITLE
feat(workitem): camp workitem sweep verb for tier-1 completion (WF0001 P1/S2)

### DIFF
--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -99,6 +99,7 @@ var manifestAgentAllowedReasons = map[string]string{
 	"workitem repair":            "Idempotent, non-destructive marker repair with --json and --dry-run",
 	"workitem resolve":           "Read-only workitem context resolution",
 	"workitem stage":             "Non-interactive attention-stage update with explicit selector",
+	"workitem sweep":             "Fully specified by flags; promotes every workitem with a completed run, no interactive selection",
 	"workitem unlink":            "Non-interactive workitem unlink operation",
 	"workitem validate":          "Read-only structural validator with --json output",
 	"workitem worktree":          "Creates an isolated worktree for a workitem with an explicit selector; --print yields a cd-able path",

--- a/internal/commands/workitem/json_contract.go
+++ b/internal/commands/workitem/json_contract.go
@@ -29,4 +29,6 @@ const (
 	WorkitemGatherJSONVersion = "workitem-gather/v1alpha1"
 	// WorkitemRenameJSONVersion is the schema version of camp workitem rename --json.
 	WorkitemRenameJSONVersion = "workitem-rename/v1alpha1"
+	// WorkitemSweepJSONVersion is the schema version of camp workitem sweep --json.
+	WorkitemSweepJSONVersion = "workitem-sweep/v1alpha1"
 )

--- a/internal/commands/workitem/sweep.go
+++ b/internal/commands/workitem/sweep.go
@@ -1,10 +1,26 @@
 package workitem
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"path/filepath"
+	"time"
 
+	"github.com/spf13/cobra"
+
+	dungeoncmd "github.com/Obedience-Corp/camp/cmd/camp/dungeon"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/jsoncontract"
+	"github.com/Obedience-Corp/camp/internal/ledger"
+	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	"github.com/Obedience-Corp/camp/internal/ui"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	wkaudit "github.com/Obedience-Corp/camp/internal/workitem/audit"
 	"github.com/Obedience-Corp/camp/internal/workitem/locate"
+	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
 )
 
 // resolveSweepLocation resolves the locate.Location for a sweep candidate from
@@ -17,4 +33,272 @@ import (
 // DetectFromCwd itself, and this function needs no change when that lands.
 func resolveSweepLocation(campaignRoot string, item wkitem.WorkItem) (*locate.Location, error) {
 	return locate.DetectFromCwd(campaignRoot, filepath.Join(campaignRoot, item.RelativePath))
+}
+
+type sweepOptions struct {
+	DryRun bool
+	JSON   bool
+}
+
+// workitemSweepResult is the --json envelope for camp workitem sweep. It follows
+// the batch-result skeleton established by workitemGatherResult (schema version,
+// generated-at, dry-run flag, per-item slice, top-level committed/warnings).
+type workitemSweepResult struct {
+	SchemaVersion string                    `json:"schema_version"`
+	GeneratedAt   time.Time                 `json:"generated_at"`
+	DryRun        bool                      `json:"dry_run,omitempty"`
+	Candidates    int                       `json:"candidates"`
+	Swept         int                       `json:"swept"`
+	Failed        int                       `json:"failed"`
+	Items         []workitemSweepResultItem `json:"items"`
+	Committed     bool                      `json:"committed"`
+	Warnings      []string                  `json:"warnings,omitempty"`
+}
+
+type workitemSweepResultItem struct {
+	ID          string `json:"id,omitempty"`
+	Ref         string `json:"ref,omitempty"`
+	Type        string `json:"type"`
+	From        string `json:"from"`
+	To          string `json:"to,omitempty"`
+	Evidence    string `json:"evidence,omitempty"`
+	ActiveRunID string `json:"active_run_id,omitempty"`
+	Committed   bool   `json:"committed"`
+	Error       string `json:"error,omitempty"`
+}
+
+func newSweepCommand() *cobra.Command {
+	var (
+		dryRun  bool
+		jsonOut bool
+	)
+	cmd := &cobra.Command{
+		Use:   "sweep",
+		Short: "Promote workitems with completed runs",
+		Long: `Promote every workitem whose active workflow run has completed to its
+local dungeon (tier-1 evidence-driven completion).
+
+Only loop-completion evidence (workflow_run_completed) drives this sweep, and it
+only ever auto-promotes; merged-branch evidence is handled separately by camp
+fresh, which prompts. Festivals and intents are excluded.
+
+Each eligible item moves independently: a failure on one (dirty git state, a
+path collision at its destination) is reported and the sweep continues to the
+next. Use --dry-run to see the plan without moving anything, and --json for a
+structured result. In table mode any per-item failure yields a non-zero exit,
+matching camp fresh; --json reports failures in the payload (failed count and
+per-item error) and stays exit 0 so the structured result is the contract.`,
+		Args: jsoncontract.Args(WorkitemSweepJSONVersion, func() bool { return jsonOut }, cobra.NoArgs),
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Fully specified by flags; no interactive selection",
+		},
+		RunE: jsoncontract.RunE(WorkitemSweepJSONVersion, func() bool { return jsonOut }, func(cmd *cobra.Command, _ []string) error {
+			return runWorkitemSweep(cmd, sweepOptions{DryRun: dryRun, JSON: jsonOut})
+		}),
+	}
+	f := cmd.Flags()
+	f.BoolVar(&dryRun, "dry-run", false, "Print the sweep plan, change nothing")
+	f.BoolVar(&jsonOut, "json", false, "Output result as a single JSON object")
+	return cmd
+}
+
+func runWorkitemSweep(cmd *cobra.Command, opts sweepOptions) error {
+	ctx := cmd.Context()
+
+	cfg, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	resolver := paths.NewResolverFromConfig(root, cfg)
+	items, err := wkitem.Discover(ctx, root, resolver)
+	if err != nil {
+		return camperrors.Wrap(err, "discovering workitems")
+	}
+	candidates := wkitem.PlanSweep(items)
+
+	result := workitemSweepResult{
+		SchemaVersion: WorkitemSweepJSONVersion,
+		GeneratedAt:   time.Now().UTC(),
+		DryRun:        opts.DryRun,
+		Candidates:    len(candidates),
+	}
+
+	if opts.DryRun {
+		return emitSweepPlan(cmd, root, candidates, &result, opts.JSON)
+	}
+
+	for _, cand := range candidates {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		item := sweepOne(ctx, cmd, cfg, root, cand, &result)
+		result.Items = append(result.Items, item)
+		if item.Error != "" {
+			result.Failed++
+		} else {
+			result.Swept++
+		}
+	}
+	result.Committed = result.Failed == 0 && result.Swept > 0
+
+	if err := emitSweepResult(cmd, &result, opts.JSON); err != nil {
+		return err
+	}
+	// Table mode follows camp fresh: any per-item failure is a non-zero exit.
+	// JSON mode follows camp workitem commits: per-item failures live in the
+	// payload (failed count and per-item error), and the command exits 0 so the
+	// structured result stays the single, clean contract on stdout.
+	if result.Failed > 0 && !opts.JSON {
+		return camperrors.Newf("%d workitem(s) failed to sweep", result.Failed)
+	}
+	return nil
+}
+
+// sweepOne executes a single candidate's promotion with the same move, audit,
+// ledger, commit, and nav-invalidation sequence runWorkitemPromote uses for one
+// item, isolated so a failure returns a populated result entry instead of
+// aborting the batch. The move either fully applies (move + audit + ledger +
+// commit) or the entry carries an error; nothing is reported swept without the
+// move landing.
+func sweepOne(ctx context.Context, cmd *cobra.Command, cfg *config.CampaignConfig, root string, cand wkitem.SweepCandidate, result *workitemSweepResult) workitemSweepResultItem {
+	entry := workitemSweepResultItem{
+		Type:        string(cand.Item.WorkflowType),
+		Evidence:    cand.Reason,
+		ActiveRunID: cand.ActiveRunID,
+	}
+
+	loc, err := resolveSweepLocation(root, cand.Item)
+	if err != nil {
+		entry.Error = err.Error()
+		return entry
+	}
+	entry.From = filepath.ToSlash(dungeoncmd.RelFromRoot(root, loc.SourcePath))
+
+	// Read the marker before the move: MoveToDungeon relocates loc.SourcePath,
+	// so the id/ref/title used for ledger correlation must be captured now. A
+	// missing marker falls back to the slug, matching runWorkitemPromote.
+	ledgerID, ledgerRef, ledgerTitle := loc.Slug, "", ""
+	if meta, metaErr := wkitem.LoadMetadata(ctx, loc.SourcePath); metaErr == nil && meta != nil {
+		ledgerID, ledgerRef, ledgerTitle = meta.ID, meta.Ref, meta.Title
+	}
+	entry.ID, entry.Ref = ledgerID, ledgerRef
+
+	moveRes, err := MoveToDungeon(ctx, root, loc, "completed")
+	if err != nil {
+		entry.Error = err.Error()
+		return entry
+	}
+	entry.To = moveRes.ToRel
+
+	appendWorkitemAuditEvent(ctx, cmd, root, wkaudit.Event{
+		Event:    wkaudit.EventPromote,
+		ID:       ledgerID,
+		Ref:      ledgerRef,
+		Title:    ledgerTitle,
+		Type:     entry.Type,
+		From:     entry.From,
+		To:       entry.To,
+		Target:   "completed",
+		Evidence: cand.Reason,
+	})
+
+	ledger.NewFromRoot(ctx, root, ledger.WarnTo(cmd.ErrOrStderr())).
+		Emit(ctx, ledgerkit.KindTransitioned, ledgerkit.Scope{Workitem: ledgerID},
+			ledger.WithWhy("sweep promote to completed"),
+			ledger.WithPayload(map[string]any{
+				"target": "completed", "from": entry.From, "to": entry.To,
+				"evidence": cand.Reason, "active_run_id": cand.ActiveRunID,
+			}))
+
+	destPaths := append([]string{moveRes.TargetPath}, moveRes.CreatedFiles...)
+	destPaths = append(destPaths, filepath.Join(root, ".campaign", "workitems", wkaudit.AuditFile))
+	outcome := dungeoncmd.StageAndCommitDungeonMove(ctx, &dungeoncmd.DungeonMoveCommit{
+		Config:           cfg,
+		CampaignRoot:     root,
+		Description:      fmt.Sprintf("Promote workitem %s to completed (sweep: %s)", loc.Slug, cand.Reason),
+		SourcePaths:      []string{loc.SourcePath},
+		DestinationPaths: destPaths,
+		RewrittenFiles:   moveRes.Svc.RewrittenLinkFiles(),
+	})
+	entry.Committed = outcome.Committed
+	if cerr := outcome.Err(); cerr != nil {
+		entry.Error = cerr.Error()
+		return entry
+	}
+
+	if navErr := navindex.Delete(root); navErr != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("failed to invalidate navigation cache after %s: %v", ledgerID, navErr))
+	}
+	return entry
+}
+
+// emitSweepPlan renders the dry-run plan: what each candidate would move where,
+// mutating nothing.
+func emitSweepPlan(cmd *cobra.Command, root string, candidates []wkitem.SweepCandidate, result *workitemSweepResult, jsonOut bool) error {
+	for _, cand := range candidates {
+		entry := workitemSweepResultItem{
+			ID:          cand.Item.Key,
+			Type:        string(cand.Item.WorkflowType),
+			From:        filepath.ToSlash(cand.Item.RelativePath),
+			Evidence:    cand.Reason,
+			ActiveRunID: cand.ActiveRunID,
+		}
+		if loc, err := resolveSweepLocation(root, cand.Item); err == nil {
+			entry.To = filepath.ToSlash(dungeoncmd.RelFromRoot(root, filepath.Join(loc.DungeonPath, "completed")))
+		} else {
+			entry.Error = err.Error()
+		}
+		result.Items = append(result.Items, entry)
+	}
+	return emitSweepResult(cmd, result, jsonOut)
+}
+
+func emitSweepResult(cmd *cobra.Command, result *workitemSweepResult, jsonOut bool) error {
+	if jsonOut {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(result); err != nil {
+			return camperrors.Wrap(err, "encoding JSON output")
+		}
+		return nil
+	}
+
+	out := cmd.OutOrStdout()
+	if result.DryRun {
+		if len(result.Items) == 0 {
+			_, err := fmt.Fprintln(out, "No workitems with completed runs to sweep.")
+			return err
+		}
+		if _, err := fmt.Fprintf(out, "Sweep plan (%d workitem(s) with completed runs):\n", len(result.Items)); err != nil {
+			return err
+		}
+		for _, it := range result.Items {
+			if _, err := fmt.Fprintf(out, "  %s (%s) -> %s\n", it.From, it.Type, it.To); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if result.Candidates == 0 {
+		_, err := fmt.Fprintln(out, "No workitems with completed runs to sweep.")
+		return err
+	}
+	for _, it := range result.Items {
+		line := fmt.Sprintf("  %s %s -> %s\n", ui.SuccessIcon(), it.From, it.To)
+		if it.Error != "" {
+			line = fmt.Sprintf("  %s %s (%s): %s\n", ui.WarningIcon(), it.From, it.Type, it.Error)
+		}
+		if _, err := fmt.Fprint(out, line); err != nil {
+			return err
+		}
+	}
+	summary := fmt.Sprintf("%s Swept %d workitem(s) to completed\n", ui.SuccessIcon(), result.Swept)
+	if result.Failed > 0 {
+		summary = fmt.Sprintf("%s %d swept, %d failed\n", ui.WarningIcon(), result.Swept, result.Failed)
+	}
+	_, err := fmt.Fprint(out, summary)
+	return err
 }

--- a/internal/commands/workitem/sweep_test.go
+++ b/internal/commands/workitem/sweep_test.go
@@ -1,9 +1,13 @@
 package workitem
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/spf13/cobra"
 
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
@@ -57,5 +61,73 @@ func TestResolveSweepLocation_FestivalsHomeNotYetSupported(t *testing.T) {
 	const want = "not inside a workitem; cwd must be under workflow/<type>/<slug>/"
 	if err.Error() != want {
 		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestWorkitemSweepJSONVersion(t *testing.T) {
+	if WorkitemSweepJSONVersion != "workitem-sweep/v1alpha1" {
+		t.Errorf("WorkitemSweepJSONVersion = %q, want workitem-sweep/v1alpha1", WorkitemSweepJSONVersion)
+	}
+}
+
+// TestSweepPlanEnvelopeShape builds the dry-run plan from a constructed
+// []SweepCandidate (no discovery pass) and asserts the --json envelope's field
+// names and per-item mapping, so a contract change is a deliberate edit. Uses a
+// temp root only for DetectFromCwd's symlink/path resolution; it mutates
+// nothing (creates empty dirs so EvalSymlinks resolves).
+func TestSweepPlanEnvelopeShape(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "workflow", "design", "alpha"), 0o755); err != nil {
+		t.Fatalf("mkdir fixture: %v", err)
+	}
+	candidates := []wkitem.SweepCandidate{{
+		Item: wkitem.WorkItem{
+			Key:          "design:workflow/design/alpha",
+			WorkflowType: wkitem.WorkflowTypeDesign,
+			RelativePath: "workflow/design/alpha",
+		},
+		Reason:      wkitem.EvidenceWorkflowRunCompleted,
+		ActiveRunID: "run-007",
+	}}
+
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	result := workitemSweepResult{SchemaVersion: WorkitemSweepJSONVersion, DryRun: true, Candidates: len(candidates)}
+	if err := emitSweepPlan(cmd, root, candidates, &result, true); err != nil {
+		t.Fatalf("emitSweepPlan: %v", err)
+	}
+
+	// Field-name contract: assert the raw JSON keys, not just the decoded shape.
+	raw := buf.String()
+	for _, key := range []string{
+		`"schema_version"`, `"dry_run"`, `"candidates"`, `"items"`,
+		`"id"`, `"type"`, `"from"`, `"to"`, `"evidence"`, `"active_run_id"`,
+	} {
+		if !bytes.Contains(buf.Bytes(), []byte(key)) {
+			t.Errorf("envelope missing key %s in output:\n%s", key, raw)
+		}
+	}
+
+	var decoded workitemSweepResult
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("unmarshal envelope: %v\n%s", err, raw)
+	}
+	if decoded.SchemaVersion != WorkitemSweepJSONVersion {
+		t.Errorf("schema_version = %q, want %q", decoded.SchemaVersion, WorkitemSweepJSONVersion)
+	}
+	if !decoded.DryRun || decoded.Candidates != 1 {
+		t.Errorf("envelope top-level fields wrong: %+v", decoded)
+	}
+	if len(decoded.Items) != 1 {
+		t.Fatalf("want 1 item, got %d", len(decoded.Items))
+	}
+	it := decoded.Items[0]
+	if it.Type != "design" || it.From != "workflow/design/alpha" ||
+		it.Evidence != wkitem.EvidenceWorkflowRunCompleted || it.ActiveRunID != "run-007" {
+		t.Errorf("item did not map from candidate: %+v", it)
+	}
+	if it.To == "" {
+		t.Errorf("dry-run item should carry a destination, got empty")
 	}
 }

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -151,6 +151,7 @@ Examples:
 	cmd.AddCommand(newStageCommand())
 	cmd.AddCommand(newGroupCommand())
 	cmd.AddCommand(newPromoteCommand())
+	cmd.AddCommand(newSweepCommand())
 	cmd.AddCommand(newRenameCommand())
 	cmd.AddCommand(newDoctorCommand())
 	cmd.AddCommand(newValidateCommand())

--- a/internal/commands/workitem/workitem_test.go
+++ b/internal/commands/workitem/workitem_test.go
@@ -462,7 +462,7 @@ func TestWorkitemSubcommandsStayRegisteredAndVisible(t *testing.T) {
 	want := []string{
 		"adopt", "commit", "commits", "create", "current", "doctor", "group",
 		"id", "link", "links", "list", "priority", "promote", "rename", "repair",
-		"resolve", "stage", "unlink", "validate", "worktree",
+		"resolve", "stage", "sweep", "unlink", "validate", "worktree",
 	}
 
 	for _, name := range want {

--- a/internal/workitem/audit/audit.go
+++ b/internal/workitem/audit/audit.go
@@ -41,6 +41,10 @@ type Event struct {
 	Target       string    `json:"target,omitempty"`
 	PromotedTo   string    `json:"promoted_to,omitempty"`
 	GatheredInto string    `json:"gathered_into,omitempty"`
+	// Evidence names why an automated transition fired, e.g.
+	// "workflow_run_completed" for a tier-1 sweep promote. Empty for manual
+	// promotes. Additive and omitempty: existing readers ignore it.
+	Evidence string `json:"evidence,omitempty"`
 }
 
 func AppendEvent(ctx context.Context, campaignRoot string, e Event) error {

--- a/tests/integration/workitem_sweep_test.go
+++ b/tests/integration/workitem_sweep_test.go
@@ -1,0 +1,246 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sweepResultItem mirrors one entry of the workitemSweepResult --json envelope
+// (internal/commands/workitem/sweep.go). Kept local so a schema change here is a
+// deliberate, reviewable edit.
+type sweepResultItem struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	From        string `json:"from"`
+	To          string `json:"to"`
+	Evidence    string `json:"evidence"`
+	ActiveRunID string `json:"active_run_id"`
+	Committed   bool   `json:"committed"`
+	Error       string `json:"error"`
+}
+
+type sweepResult struct {
+	SchemaVersion string            `json:"schema_version"`
+	DryRun        bool              `json:"dry_run"`
+	Candidates    int               `json:"candidates"`
+	Swept         int               `json:"swept"`
+	Failed        int               `json:"failed"`
+	Committed     bool              `json:"committed"`
+	Items         []sweepResultItem `json:"items"`
+}
+
+// stampCompletedRun writes a fest-style .workflow/ runtime whose active run has
+// completed, making the workitem at <campaign>/workflow/<wkType>/<slug>
+// eligible for tier-1 sweep. Only the active run's events are replayed by camp's
+// localrun loader, so a single completed run is enough.
+func stampCompletedRun(t *testing.T, tc *TestContainer, campaignPath, wkType, slug string) {
+	t.Helper()
+	base := campaignPath + "/workflow/" + wkType + "/" + slug + "/.workflow"
+	require.NoError(t, tc.WriteFile(base+"/workflow.yaml", "workflow_id: wf-"+slug+"\nactive_run_id: r1\n"))
+	require.NoError(t, tc.WriteFile(base+"/runs/r1/run.yaml", "status: active\nsummary:\n  total_steps: 1\n"))
+	require.NoError(t, tc.WriteFile(base+"/runs/r1/progress_events.jsonl",
+		`{"event_type":"workflow_run_started"}
+{"event_type":"wf_step_start"}
+{"event_type":"wf_step_done"}
+{"event_type":"workflow_run_completed"}
+`))
+}
+
+// stampActiveRun writes an in-progress run (no completed event), so the item is
+// discovered but not sweep-eligible.
+func stampActiveRun(t *testing.T, tc *TestContainer, campaignPath, wkType, slug string) {
+	t.Helper()
+	base := campaignPath + "/workflow/" + wkType + "/" + slug + "/.workflow"
+	require.NoError(t, tc.WriteFile(base+"/workflow.yaml", "workflow_id: wf-"+slug+"\nactive_run_id: r1\n"))
+	require.NoError(t, tc.WriteFile(base+"/runs/r1/run.yaml", "status: active\nsummary:\n  total_steps: 2\n"))
+	require.NoError(t, tc.WriteFile(base+"/runs/r1/progress_events.jsonl",
+		`{"event_type":"workflow_run_started"}
+{"event_type":"wf_step_start"}
+`))
+}
+
+func createSweepWorkitem(t *testing.T, tc *TestContainer, campaignPath, wkType, slug string) {
+	t.Helper()
+	out, err := tc.RunCampInDir(campaignPath,
+		"workitem", "create", slug, "--type", wkType, "--title", slug, "--id", wkType+"-"+slug+"-fixed")
+	require.NoError(t, err, "workitem create should succeed: %s", out)
+}
+
+func commitFixture(t *testing.T, tc *TestContainer, path string) {
+	t.Helper()
+	_, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git add -A && git commit -q -m 'fixture'")
+	require.NoError(t, err)
+}
+
+func runSweepJSON(t *testing.T, tc *TestContainer, path string, extraArgs ...string) sweepResult {
+	t.Helper()
+	args := append([]string{"workitem", "sweep", "--json"}, extraArgs...)
+	out, err := tc.RunCampInDir(path, args...)
+	require.NoError(t, err, "json sweep returns nil even with per-item failures: %s", out)
+	var res sweepResult
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &res), "must parse: %s", out)
+	assert.Equal(t, "workitem-sweep/v1alpha1", res.SchemaVersion)
+	return res
+}
+
+// Scenario 1: zero eligible items -> empty result, exit 0, no commit.
+func TestIntegration_WorkitemSweep_ZeroEligible(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupDungeonCampaign(t, tc, "sweep-zero")
+	createSweepWorkitem(t, tc, path, "design", "active-only")
+	stampActiveRun(t, tc, path, "design", "active-only")
+	commitFixture(t, tc, path)
+	headBefore := strings.TrimSpace(tc.GitOutput(t, path, "rev-parse", "HEAD"))
+
+	res := runSweepJSON(t, tc, path)
+	assert.Equal(t, 0, res.Candidates)
+	assert.Empty(t, res.Items)
+	assert.Equal(t, 0, res.Swept)
+
+	headAfter := strings.TrimSpace(tc.GitOutput(t, path, "rev-parse", "HEAD"))
+	assert.Equal(t, headBefore, headAfter, "no commit when nothing to sweep")
+}
+
+// Scenario 2: one eligible design item -> moves to dungeon/completed, evidence
+// on jsonl, commit created.
+func TestIntegration_WorkitemSweep_SingleEligibleMovesAndCommits(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupDungeonCampaign(t, tc, "sweep-single")
+	createSweepWorkitem(t, tc, path, "design", "done-feature")
+	stampCompletedRun(t, tc, path, "design", "done-feature")
+	commitFixture(t, tc, path)
+	headBefore := strings.TrimSpace(tc.GitOutput(t, path, "rev-parse", "HEAD"))
+
+	res := runSweepJSON(t, tc, path)
+	require.Len(t, res.Items, 1)
+	assert.Equal(t, 1, res.Swept)
+	assert.Equal(t, 0, res.Failed)
+	assert.Equal(t, "workflow_run_completed", res.Items[0].Evidence)
+	assert.Equal(t, "r1", res.Items[0].ActiveRunID)
+	assert.True(t, res.Items[0].Committed)
+	assert.Contains(t, res.Items[0].To, "dungeon/completed")
+
+	// Source gone, item now in a dated dungeon/completed bucket.
+	exists, err := tc.CheckDirExists(path + "/workflow/design/done-feature")
+	require.NoError(t, err)
+	assert.False(t, exists, "source dir should be gone after sweep")
+	found, err := checkDatedDungeonStatusItemExists(tc, path+"/workflow/design/dungeon/completed", "done-feature")
+	require.NoError(t, err)
+	assert.True(t, found, "item should be in a dated dungeon/completed bucket")
+
+	// Evidence recorded and a commit created.
+	audit, err := tc.ReadFile(path + "/.campaign/workitems/.workitems.jsonl")
+	require.NoError(t, err)
+	assert.Contains(t, audit, `"evidence":"workflow_run_completed"`)
+	headAfter := strings.TrimSpace(tc.GitOutput(t, path, "rev-parse", "HEAD"))
+	assert.NotEqual(t, headBefore, headAfter, "sweep should create a commit")
+}
+
+// Scenario 3: one eligible + one ineligible (active) -> only eligible moves.
+func TestIntegration_WorkitemSweep_EligibleAndIneligible(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupDungeonCampaign(t, tc, "sweep-mixed")
+	createSweepWorkitem(t, tc, path, "design", "ready-item")
+	stampCompletedRun(t, tc, path, "design", "ready-item")
+	createSweepWorkitem(t, tc, path, "design", "busy-item")
+	stampActiveRun(t, tc, path, "design", "busy-item")
+	commitFixture(t, tc, path)
+
+	res := runSweepJSON(t, tc, path)
+	assert.Equal(t, 1, res.Candidates, "only the completed-run item is a candidate")
+	assert.Equal(t, 1, res.Swept)
+
+	gone, err := tc.CheckDirExists(path + "/workflow/design/ready-item")
+	require.NoError(t, err)
+	assert.False(t, gone, "eligible item moved")
+	stays, err := tc.CheckDirExists(path + "/workflow/design/busy-item")
+	require.NoError(t, err)
+	assert.True(t, stays, "active item stays put")
+}
+
+// Scenario 4: --dry-run mutates nothing and names the eligible item.
+func TestIntegration_WorkitemSweep_DryRunNoMutation(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupDungeonCampaign(t, tc, "sweep-dryrun")
+	createSweepWorkitem(t, tc, path, "design", "done-feature")
+	stampCompletedRun(t, tc, path, "design", "done-feature")
+	commitFixture(t, tc, path)
+	headBefore := strings.TrimSpace(tc.GitOutput(t, path, "rev-parse", "HEAD"))
+
+	res := runSweepJSON(t, tc, path, "--dry-run")
+	assert.True(t, res.DryRun)
+	require.Len(t, res.Items, 1)
+	assert.Contains(t, res.Items[0].From, "workflow/design/done-feature")
+	assert.Contains(t, res.Items[0].To, "dungeon/completed")
+
+	exists, err := tc.CheckDirExists(path + "/workflow/design/done-feature")
+	require.NoError(t, err)
+	assert.True(t, exists, "dry-run must not move the item")
+	headAfter := strings.TrimSpace(tc.GitOutput(t, path, "rev-parse", "HEAD"))
+	assert.Equal(t, headBefore, headAfter, "dry-run must not commit")
+}
+
+// Scenario 5: per-item failure isolation. The second item's dungeon resolution
+// is made ambiguous (both spellings present), so its move fails while the first
+// still moves and commits.
+func TestIntegration_WorkitemSweep_PerItemErrorIsolation(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupDungeonCampaign(t, tc, "sweep-isolation")
+	createSweepWorkitem(t, tc, path, "design", "good-feature")
+	stampCompletedRun(t, tc, path, "design", "good-feature")
+	createSweepWorkitem(t, tc, path, "explore", "bad-feature")
+	stampCompletedRun(t, tc, path, "explore", "bad-feature")
+	require.NoError(t, tc.WriteFile(path+"/workflow/explore/dungeon/.keep", ""))
+	require.NoError(t, tc.WriteFile(path+"/workflow/explore/.dungeon/.keep", ""))
+	commitFixture(t, tc, path)
+
+	res := runSweepJSON(t, tc, path)
+	assert.Equal(t, 2, res.Candidates)
+	assert.Equal(t, 1, res.Swept)
+	assert.Equal(t, 1, res.Failed)
+
+	var good, bad *sweepResultItem
+	for i := range res.Items {
+		if res.Items[i].Type == "design" {
+			good = &res.Items[i]
+		} else {
+			bad = &res.Items[i]
+		}
+	}
+	require.NotNil(t, good)
+	require.NotNil(t, bad)
+	assert.Empty(t, good.Error)
+	assert.True(t, good.Committed)
+	assert.NotEmpty(t, bad.Error, "conflicting item reports an error")
+
+	gone, err := tc.CheckDirExists(path + "/workflow/design/good-feature")
+	require.NoError(t, err)
+	assert.False(t, gone, "healthy item moved")
+	stays, err := tc.CheckDirExists(path + "/workflow/explore/bad-feature")
+	require.NoError(t, err)
+	assert.True(t, stays, "failed item stays put")
+}
+
+// Scenario 6: idempotency. Re-running immediately after a successful sweep finds
+// nothing, because the swept item is now inside a dungeon that Discover skips.
+func TestIntegration_WorkitemSweep_Idempotent(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupDungeonCampaign(t, tc, "sweep-idempotent")
+	createSweepWorkitem(t, tc, path, "design", "once-item")
+	stampCompletedRun(t, tc, path, "design", "once-item")
+	commitFixture(t, tc, path)
+
+	first := runSweepJSON(t, tc, path)
+	assert.Equal(t, 1, first.Swept)
+
+	second := runSweepJSON(t, tc, path)
+	assert.Equal(t, 0, second.Candidates, "swept item is no longer eligible")
+	assert.Empty(t, second.Items)
+}


### PR DESCRIPTION
## Summary

Adds `camp workitem sweep`, the tier-1 mutation path of evidence-driven
completion: it promotes every workitem whose active workflow run has completed
to that item's local `dungeon/completed`. Second sequence of the
`workitem-festival-lifecycle` festival (WF0001), spec of record `WI-75d77f`
docs 03 (evidence-driven completion) and 05 (implementation plan, phase 1
item 3).

## Stack

Base: **`fest/wf0001-p1s1-sweep-planner`** (PR #493), not `main`. This sequence
uses `PlanSweep`/`SweepCandidate`/`resolveSweepLocation` from that PR and will
not compile without them. If #493 merges to `main` first, rebase this onto
`main`. Sequence 03 (`camp fresh` wiring + `camp wi` banner) stacks on this
branch next.

## What changed

- `internal/commands/workitem/sweep.go`: `newSweepCommand` + `runWorkitemSweep`.
  Gathers workitems, plans via `PlanSweep`, and for each candidate runs the same
  per-item sequence `runWorkitemPromote` uses for a single item -
  `MoveToDungeon(…, "completed")`, audit event, ledger `KindTransitioned` emit,
  `StageAndCommitDungeonMove`, nav-cache invalidation, inside a loop with
  per-item error isolation. `--dry-run` returns the plan before any mutation;
  `--json` emits a `workitem-sweep/v1alpha1` envelope shaped like
  `workitemGatherResult`. Agent-allowed; `cobra.NoArgs`, no interactive selector.
- `internal/workitem/audit/audit.go`: additive `Evidence string
  json:"evidence,omitempty"` on `Event`. Set to `workflow_run_completed` for
  sweep promotes; left empty for the untouched manual-promote path.
- `internal/commands/workitem/json_contract.go`: `WorkitemSweepJSONVersion`.
- `internal/commands/workitem/workitem.go` + `cmd/camp/zz_manifest_annotations.go`:
  register the command and its agent-allowed allowlist entry.
- `tests/integration/workitem_sweep_test.go`: six containerized scenarios.
  Host unit tests for the JSON envelope shape and version constant.

## Evidence-tier invariant

Only loop-completion evidence promotes, and only ever to `completed` (never
`archived`/`someday`). No merged-branch (inference-tier) evidence is acted on
here; that is phase 2, prompt/report only.

## Exit-code / --json decision (called out)

Requirement 6 asks the exit code to reflect failures. Two in-repo precedents
conflict for a `--json` batch: `runFreshBatch` (table, non-zero on failure) vs
`camp workitem commits --json` (per-item errors in payload, exit 0). Resolution:
**table mode returns non-zero on any per-item failure; `--json` reports failures
in the payload (`failed` count, per-item `error`) and exits 0** so the structured
result stays one clean object on stdout. Documented in the command `Long` help
and a code comment.

## Test output

Host unit suite: `108 packages  3695/3695 tests passed`. Integration:

```
--- PASS: TestIntegration_WorkitemSweep_ZeroEligible (5.20s)
--- PASS: TestIntegration_WorkitemSweep_Idempotent (5.52s)
--- PASS: TestIntegration_WorkitemSweep_DryRunNoMutation (5.83s)
--- PASS: TestIntegration_WorkitemSweep_SingleEligibleMovesAndCommits (6.10s)
--- PASS: TestIntegration_WorkitemSweep_EligibleAndIneligible (6.17s)
--- PASS: TestIntegration_WorkitemSweep_PerItemErrorIsolation (6.59s)
```

Real dry-run `--json`:

```
$ camp workitem sweep --dry-run --json
{
  "schema_version": "workitem-sweep/v1alpha1",
  "generated_at": "2026-07-24T11:21:51.210819Z",
  "dry_run": true,
  "candidates": 1,
  "swept": 0,
  "failed": 0,
  "items": [
    {
      "id": "design:workflow/design/done-feature",
      "type": "design",
      "from": "workflow/design/done-feature",
      "to": "workflow/design/.dungeon/completed",
      "evidence": "workflow_run_completed",
      "active_run_id": "r1",
      "committed": false
    }
  ],
  "committed": false
}
```

`just lint` clean (`0 issues`; both ratchets clean); `just build` green.

## Pre-existing unrelated failure (quoted, not introduced here)

Full `just test integration`: `557/559 tests passed`. The one failure,
`TestMachineDiagnoseControlMasterLifecycle`, is a pre-existing,
environment-dependent SSH ControlMaster test in the machine-diagnose subsystem.
It fails identically in isolation and this branch touches nothing there (full
diff is the sweep command, the additive audit field, the JSON version, the
registration/allowlist, and the sweep tests). Quoted per the sequence's testing
gate rather than silently skipped.

## Notes

- The move/commit sequence is reused from `camp workitem promote` unchanged; a
  commit failure after a successful move leaves an uncommitted move (reported as
  failed, self-healing since the item is now in the dungeon and excluded from
  re-sweep). Same non-atomicity promote has; documented in the sequence review.
- Not merged by an agent; left for review.

