### PR TITLE
feat(fresh,wi): tier-1 sweep in camp fresh + camp wi banner (WF0001 P1/S3)

### DIFF
--- a/internal/commands/fresh/batch.go
+++ b/internal/commands/fresh/batch.go
@@ -138,6 +138,11 @@ func runFreshBatch(ctx context.Context, cfg *config.FreshConfig, targets []fresh
 		}
 	}
 
+	// Campaign-root workitem sweep runs once for the whole batch, after every
+	// project's git-hygiene cycle and before the summary, never inside the loop.
+	// This covers both camp fresh all and camp fresh --list a,b,c.
+	runCampaignWorkitemSweep(ctx, cfg, flags.dryRun)
+
 	fmt.Println()
 	fmt.Println(ui.Separator(50))
 	if failed == 0 {

--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -131,14 +131,21 @@ Examples:
 			doPush := !freshNoPush && cfg.ResolveFreshPushUpstream(result.Name)
 			followUps := resolveFreshFollowUps(cfg, result.Name, freshNoFollowUp)
 
-			return executeFresh(ctx, result.Name, result.Path, freshOptions{
+			if err := executeFresh(ctx, result.Name, result.Path, freshOptions{
 				branch:      branch,
 				prune:       doPrune,
 				pruneRemote: cfg.ResolveFreshPruneRemote(),
 				push:        doPush,
 				followUps:   followUps,
 				dryRun:      freshDryRun,
-			})
+			}); err != nil {
+				return err
+			}
+
+			// Campaign-root workitem sweep runs once, after the project's
+			// git-hygiene cycle, never inside executeFresh.
+			runCampaignWorkitemSweep(ctx, cfg, freshDryRun)
+			return nil
 		},
 	}
 

--- a/internal/commands/fresh/workitem_sweep.go
+++ b/internal/commands/fresh/workitem_sweep.go
@@ -1,0 +1,35 @@
+package fresh
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/Obedience-Corp/camp/internal/commands/workitem"
+	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/Obedience-Corp/camp/internal/ui"
+)
+
+// runCampaignWorkitemSweep runs the tier-1 workitem sweep exactly once per camp
+// fresh invocation, at the campaign root. It is called from the top-level fresh
+// handlers (single-project RunE and runFreshBatch), never from executeFresh,
+// which stays project-scoped: the sweep operates on workflow/<type>/ at the
+// campaign root and has nothing to do with any one project's prune result.
+//
+// It honors completed_runs: "off" does no discovery at all; "report" prints the
+// read-only banner; "sweep" (default) promotes eligible items. A dry-run fresh
+// downgrades to "report" so it never mutates. A sweep failure is reported but
+// never fails the fresh run, matching how executeFresh failures are surfaced in
+// the batch summary without aborting the command; hence this returns nothing.
+func runCampaignWorkitemSweep(ctx context.Context, cfg *config.FreshConfig, dryRun bool) {
+	mode := cfg.ResolveFreshCompletedRuns()
+	if mode == "off" {
+		return
+	}
+	if dryRun {
+		mode = workitem.FreshSweepModeReport
+	}
+	if err := workitem.RunFreshSweep(ctx, os.Stdout, mode); err != nil {
+		fmt.Fprintf(os.Stderr, "%s workitem sweep reported an issue (fresh continues): %v\n", ui.WarningIcon(), err)
+	}
+}

--- a/internal/commands/workitem/list_output.go
+++ b/internal/commands/workitem/list_output.go
@@ -47,7 +47,20 @@ func outputList(w io.Writer, items []wkitem.WorkItem, groupBy string) error {
 			}
 		}
 	}
+	if line := sweepBannerLine(items); line != "" {
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// sweepBannerLine returns the read-only "N workitems have completed runs"
+// banner for the listed items, or "" when none are sweep-eligible. Pure: it
+// calls only wkitem.PlanSweep for the count, never any sweep mutation path, so
+// camp wi stays read-only.
+func sweepBannerLine(items []wkitem.WorkItem) string {
+	return wkitem.SweepBannerText(len(wkitem.PlanSweep(items)))
 }
 
 func listSectionHeader(section listview.Section) string {

--- a/internal/commands/workitem/sweep.go
+++ b/internal/commands/workitem/sweep.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"time"
 
@@ -103,37 +104,39 @@ per-item error) and stays exit 0 so the structured result is the contract.`,
 	return cmd
 }
 
-func runWorkitemSweep(cmd *cobra.Command, opts sweepOptions) error {
-	ctx := cmd.Context()
-
+// gatherSweepCandidates loads the campaign and returns the eligible tier-1
+// candidates from one discovery pass. Shared by the sweep command and camp
+// fresh's completed_runs handling so both plan against the same read.
+func gatherSweepCandidates(ctx context.Context) (*config.CampaignConfig, string, []wkitem.SweepCandidate, error) {
 	cfg, root, err := config.LoadCampaignConfigFromCwd(ctx)
 	if err != nil {
-		return camperrors.Wrap(err, "not in a campaign directory")
+		return nil, "", nil, camperrors.Wrap(err, "not in a campaign directory")
 	}
-
 	resolver := paths.NewResolverFromConfig(root, cfg)
 	items, err := wkitem.Discover(ctx, root, resolver)
 	if err != nil {
-		return camperrors.Wrap(err, "discovering workitems")
+		return nil, "", nil, camperrors.Wrap(err, "discovering workitems")
 	}
-	candidates := wkitem.PlanSweep(items)
+	return cfg, root, wkitem.PlanSweep(items), nil
+}
 
-	result := workitemSweepResult{
+func newSweepResult(dryRun bool, candidates int) workitemSweepResult {
+	return workitemSweepResult{
 		SchemaVersion: WorkitemSweepJSONVersion,
 		GeneratedAt:   time.Now().UTC(),
-		DryRun:        opts.DryRun,
-		Candidates:    len(candidates),
+		DryRun:        dryRun,
+		Candidates:    candidates,
 	}
+}
 
-	if opts.DryRun {
-		return emitSweepPlan(cmd, root, candidates, &result, opts.JSON)
-	}
-
+// executeSweepCandidates runs the per-item promote loop with error isolation,
+// filling result. Shared by the sweep command and camp fresh.
+func executeSweepCandidates(ctx context.Context, cmd *cobra.Command, cfg *config.CampaignConfig, root string, candidates []wkitem.SweepCandidate, result *workitemSweepResult) {
 	for _, cand := range candidates {
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return
 		}
-		item := sweepOne(ctx, cmd, cfg, root, cand, &result)
+		item := sweepOne(ctx, cmd, cfg, root, cand, result)
 		result.Items = append(result.Items, item)
 		if item.Error != "" {
 			result.Failed++
@@ -142,6 +145,22 @@ func runWorkitemSweep(cmd *cobra.Command, opts sweepOptions) error {
 		}
 	}
 	result.Committed = result.Failed == 0 && result.Swept > 0
+}
+
+func runWorkitemSweep(cmd *cobra.Command, opts sweepOptions) error {
+	ctx := cmd.Context()
+	cfg, root, candidates, err := gatherSweepCandidates(ctx)
+	if err != nil {
+		return err
+	}
+	result := newSweepResult(opts.DryRun, len(candidates))
+
+	if opts.DryRun {
+		fillSweepPlan(root, candidates, &result)
+		return emitSweepResult(cmd, &result, opts.JSON)
+	}
+
+	executeSweepCandidates(ctx, cmd, cfg, root, candidates, &result)
 
 	if err := emitSweepResult(cmd, &result, opts.JSON); err != nil {
 		return err
@@ -234,9 +253,9 @@ func sweepOne(ctx context.Context, cmd *cobra.Command, cfg *config.CampaignConfi
 	return entry
 }
 
-// emitSweepPlan renders the dry-run plan: what each candidate would move where,
-// mutating nothing.
-func emitSweepPlan(cmd *cobra.Command, root string, candidates []wkitem.SweepCandidate, result *workitemSweepResult, jsonOut bool) error {
+// fillSweepPlan populates result.Items with the dry-run plan: what each
+// candidate would move where, mutating nothing. The caller emits result.
+func fillSweepPlan(root string, candidates []wkitem.SweepCandidate, result *workitemSweepResult) {
 	for _, cand := range candidates {
 		entry := workitemSweepResultItem{
 			ID:          cand.Item.Key,
@@ -252,7 +271,45 @@ func emitSweepPlan(cmd *cobra.Command, root string, candidates []wkitem.SweepCan
 		}
 		result.Items = append(result.Items, entry)
 	}
-	return emitSweepResult(cmd, result, jsonOut)
+}
+
+// Fresh sweep modes for camp fresh's completed_runs setting.
+const (
+	FreshSweepModeReport = "report"
+	FreshSweepModeSweep  = "sweep"
+)
+
+// RunFreshSweep runs the tier-1 workitem sweep for camp fresh, reusing the same
+// internals as camp workitem sweep. mode "report" prints the read-only banner;
+// mode "sweep" executes the promotion. Callers must not pass "off" (an opted-out
+// campaign must pay for no discovery pass, which the caller guards). When nothing
+// is eligible, RunFreshSweep is silent and mutates nothing.
+func RunFreshSweep(ctx context.Context, out io.Writer, mode string) error {
+	cfg, root, candidates, err := gatherSweepCandidates(ctx)
+	if err != nil {
+		return err
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	if mode == FreshSweepModeReport {
+		_, err := fmt.Fprintln(out, wkitem.SweepBannerText(len(candidates)))
+		return err
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	result := newSweepResult(false, len(candidates))
+	executeSweepCandidates(ctx, cmd, cfg, root, candidates, &result)
+	if err := emitSweepResult(cmd, &result, false); err != nil {
+		return err
+	}
+	if result.Failed > 0 {
+		return camperrors.Newf("%d workitem(s) failed to sweep", result.Failed)
+	}
+	return nil
 }
 
 func emitSweepResult(cmd *cobra.Command, result *workitemSweepResult, jsonOut bool) error {

--- a/internal/commands/workitem/sweep.go
+++ b/internal/commands/workitem/sweep.go
@@ -131,10 +131,10 @@ func newSweepResult(dryRun bool, candidates int) workitemSweepResult {
 
 // executeSweepCandidates runs the per-item promote loop with error isolation,
 // filling result. Shared by the sweep command and camp fresh.
-func executeSweepCandidates(ctx context.Context, cmd *cobra.Command, cfg *config.CampaignConfig, root string, candidates []wkitem.SweepCandidate, result *workitemSweepResult) {
+func executeSweepCandidates(ctx context.Context, cmd *cobra.Command, cfg *config.CampaignConfig, root string, candidates []wkitem.SweepCandidate, result *workitemSweepResult) error {
 	for _, cand := range candidates {
-		if ctx.Err() != nil {
-			return
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 		item := sweepOne(ctx, cmd, cfg, root, cand, result)
 		result.Items = append(result.Items, item)
@@ -145,6 +145,7 @@ func executeSweepCandidates(ctx context.Context, cmd *cobra.Command, cfg *config
 		}
 	}
 	result.Committed = result.Failed == 0 && result.Swept > 0
+	return nil
 }
 
 func runWorkitemSweep(cmd *cobra.Command, opts sweepOptions) error {
@@ -160,10 +161,15 @@ func runWorkitemSweep(cmd *cobra.Command, opts sweepOptions) error {
 		return emitSweepResult(cmd, &result, opts.JSON)
 	}
 
-	executeSweepCandidates(ctx, cmd, cfg, root, candidates, &result)
+	// A mid-sweep context cancellation must propagate, never report as a clean
+	// success; emit whatever completed before surfacing the cancellation.
+	sweepErr := executeSweepCandidates(ctx, cmd, cfg, root, candidates, &result)
 
 	if err := emitSweepResult(cmd, &result, opts.JSON); err != nil {
 		return err
+	}
+	if sweepErr != nil {
+		return sweepErr
 	}
 	// Table mode follows camp fresh: any per-item failure is a non-zero exit.
 	// JSON mode follows camp workitem commits: per-item failures live in the
@@ -302,9 +308,12 @@ func RunFreshSweep(ctx context.Context, out io.Writer, mode string) error {
 	cmd.SetOut(out)
 	cmd.SetErr(out)
 	result := newSweepResult(false, len(candidates))
-	executeSweepCandidates(ctx, cmd, cfg, root, candidates, &result)
+	sweepErr := executeSweepCandidates(ctx, cmd, cfg, root, candidates, &result)
 	if err := emitSweepResult(cmd, &result, false); err != nil {
 		return err
+	}
+	if sweepErr != nil {
+		return sweepErr
 	}
 	if result.Failed > 0 {
 		return camperrors.Newf("%d workitem(s) failed to sweep", result.Failed)

--- a/internal/commands/workitem/sweep_test.go
+++ b/internal/commands/workitem/sweep_test.go
@@ -94,8 +94,9 @@ func TestSweepPlanEnvelopeShape(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetOut(&buf)
 	result := workitemSweepResult{SchemaVersion: WorkitemSweepJSONVersion, DryRun: true, Candidates: len(candidates)}
-	if err := emitSweepPlan(cmd, root, candidates, &result, true); err != nil {
-		t.Fatalf("emitSweepPlan: %v", err)
+	fillSweepPlan(root, candidates, &result)
+	if err := emitSweepResult(cmd, &result, true); err != nil {
+		t.Fatalf("emitSweepResult: %v", err)
 	}
 
 	// Field-name contract: assert the raw JSON keys, not just the decoded shape.

--- a/internal/commands/workitem/sweep_test.go
+++ b/internal/commands/workitem/sweep_test.go
@@ -2,6 +2,7 @@ package workitem
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -9,8 +10,30 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Obedience-Corp/camp/internal/config"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
+
+// TestExecuteSweepCandidates_ContextCancelledPropagates locks that a mid-sweep
+// context cancellation is surfaced, never swallowed into a clean success.
+func TestExecuteSweepCandidates_ContextCancelledPropagates(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var result workitemSweepResult
+	candidates := []wkitem.SweepCandidate{{
+		Item:   wkitem.WorkItem{WorkflowType: wkitem.WorkflowTypeDesign, RelativePath: "workflow/design/foo"},
+		Reason: wkitem.EvidenceWorkflowRunCompleted,
+	}}
+
+	err := executeSweepCandidates(ctx, &cobra.Command{}, &config.CampaignConfig{}, t.TempDir(), candidates, &result)
+	if err == nil {
+		t.Fatal("expected context cancellation to propagate, got nil")
+	}
+	if result.Swept != 0 || result.Committed {
+		t.Errorf("cancelled sweep must not report success: swept=%d committed=%v", result.Swept, result.Committed)
+	}
+}
 
 // TestResolveSweepLocation_WorkflowHome locks today's pass-through behavior:
 // a design item resolves to its type-local dungeon at workflow/design/dungeon,

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -211,6 +211,12 @@ type FreshConfig struct {
 	Prune *bool `yaml:"prune,omitempty"`
 	// PruneRemote controls whether to prune stale remote tracking refs.
 	PruneRemote *bool `yaml:"prune_remote,omitempty"`
+	// CompletedRuns controls the tier-1 workitem sweep run once per camp fresh:
+	// "sweep" (default) promotes items with a completed run, "report" prints a
+	// read-only banner, "off" does nothing. Campaign-root scoped (workitems live
+	// at the root, not per project), so there is no per-project override, the
+	// same shape as Prune.
+	CompletedRuns string `yaml:"completed_runs,omitempty"`
 	// FollowUp lists command workflow steps run, in order, after a successful
 	// sync/prune/branch cycle. A project override in Projects replaces this
 	// list entirely; it is never merged with it.
@@ -318,6 +324,20 @@ func (c *FreshConfig) ResolveFreshPrune() bool {
 		return *c.Prune
 	}
 	return true
+}
+
+// ResolveFreshCompletedRuns resolves completed_runs using the global config or
+// default ("sweep"). Global only: workitems live at the campaign root, not per
+// project, so there is no per-project override, matching Prune's shape. Any
+// unrecognized or empty value defaults to "sweep" (never fail closed to "off"
+// on a typo).
+func (c *FreshConfig) ResolveFreshCompletedRuns() string {
+	switch c.CompletedRuns {
+	case "sweep", "report", "off":
+		return c.CompletedRuns
+	default:
+		return "sweep"
+	}
 }
 
 // ResolveFreshPruneRemote resolves prune_remote using the global config or default (true).

--- a/internal/config/settings_fresh_test.go
+++ b/internal/config/settings_fresh_test.go
@@ -110,3 +110,25 @@ func TestLoadFreshConfig_ContextCanceled(t *testing.T) {
 		t.Fatal("LoadFreshConfig() expected context error")
 	}
 }
+
+func TestResolveFreshCompletedRuns(t *testing.T) {
+	tests := []struct {
+		name string
+		set  string
+		want string
+	}{
+		{"empty defaults to sweep", "", "sweep"},
+		{"typo defaults to sweep (never fails closed to off)", "swep", "sweep"},
+		{"explicit sweep", "sweep", "sweep"},
+		{"explicit report", "report", "report"},
+		{"explicit off", "off", "off"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &FreshConfig{CompletedRuns: tc.set}
+			if got := c.ResolveFreshCompletedRuns(); got != tc.want {
+				t.Errorf("ResolveFreshCompletedRuns() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/workitem/sweep.go
+++ b/internal/workitem/sweep.go
@@ -64,11 +64,11 @@ func SweepBannerText(n int) string {
 	if n <= 0 {
 		return ""
 	}
-	noun := "workitems"
+	noun, verb := "workitems", "have"
 	if n == 1 {
-		noun = "workitem"
+		noun, verb = "workitem", "has"
 	}
-	return fmt.Sprintf("%d %s have completed runs; run camp workitem sweep", n, noun)
+	return fmt.Sprintf("%d %s %s completed runs; run camp workitem sweep", n, noun, verb)
 }
 
 // sweepEligibleType excludes the workflow types that fest owns (festivals) or

--- a/internal/workitem/sweep.go
+++ b/internal/workitem/sweep.go
@@ -1,6 +1,7 @@
 package workitem
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 )
@@ -53,6 +54,21 @@ func PlanSweep(items []WorkItem) []SweepCandidate {
 		})
 	}
 	return out
+}
+
+// SweepBannerText returns the read-only banner reporting n workitems with
+// completed runs awaiting sweep, or "" when n <= 0. Singular "workitem" for
+// n == 1, matching spec doc 03's example wording. Shared by camp wi and camp
+// fresh (report mode) so the wording lives in exactly one place.
+func SweepBannerText(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	noun := "workitems"
+	if n == 1 {
+		noun = "workitem"
+	}
+	return fmt.Sprintf("%d %s have completed runs; run camp workitem sweep", n, noun)
 }
 
 // sweepEligibleType excludes the workflow types that fest owns (festivals) or

--- a/internal/workitem/sweep_test.go
+++ b/internal/workitem/sweep_test.go
@@ -143,6 +143,23 @@ func TestPlanSweep_Eligibility(t *testing.T) {
 	}
 }
 
+func TestSweepBannerText(t *testing.T) {
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{0, ""},
+		{-3, ""},
+		{1, "1 workitem have completed runs; run camp workitem sweep"},
+		{2, "2 workitems have completed runs; run camp workitem sweep"},
+	}
+	for _, tc := range tests {
+		if got := SweepBannerText(tc.n); got != tc.want {
+			t.Errorf("SweepBannerText(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}
+
 func TestPlanSweep_CandidatePayload(t *testing.T) {
 	item := WorkItem{
 		WorkflowType: WorkflowTypeDesign,

--- a/internal/workitem/sweep_test.go
+++ b/internal/workitem/sweep_test.go
@@ -150,7 +150,7 @@ func TestSweepBannerText(t *testing.T) {
 	}{
 		{0, ""},
 		{-3, ""},
-		{1, "1 workitem have completed runs; run camp workitem sweep"},
+		{1, "1 workitem has completed runs; run camp workitem sweep"},
 		{2, "2 workitems have completed runs; run camp workitem sweep"},
 	}
 	for _, tc := range tests {

--- a/internal/workitem/tui/model.go
+++ b/internal/workitem/tui/model.go
@@ -167,6 +167,11 @@ type Model struct {
 	storePath     string
 	priorityMode  bool
 	stageMode     bool
+
+	// sweepEligible is the count of workitems with a completed run awaiting
+	// sweep, computed once at construction from the full item list. Drives the
+	// read-only footer banner; never triggers a mutation.
+	sweepEligible int
 }
 
 // New creates the dashboard model from a pre-discovered item list.
@@ -191,6 +196,7 @@ func New(ctx context.Context, items []workitem.WorkItem, campaignRoot string, re
 		priorityStore: store,
 		storePath:     storePath,
 		showParked:    includeParked,
+		sweepEligible: len(workitem.PlanSweep(items)),
 	}
 }
 

--- a/internal/workitem/tui/view.go
+++ b/internal/workitem/tui/view.go
@@ -146,7 +146,11 @@ func (m Model) renderFooter() string {
 	if len(keys)+len(count)+2 > m.width {
 		keys = "j/k / f filter s status c category P tab r ? q"
 	}
-	return footerStyle.Render(fmt.Sprintf("%s  %s", count, keys))
+	footer := fmt.Sprintf("%s  %s", count, keys)
+	if banner := workitem.SweepBannerText(m.sweepEligible); banner != "" {
+		footer = fmt.Sprintf("%s  |  %s", footer, banner)
+	}
+	return footerStyle.Render(footer)
 }
 
 func (m Model) renderStatusFilter() string {

--- a/tests/integration/fresh_workitem_sweep_test.go
+++ b/tests/integration/fresh_workitem_sweep_test.go
@@ -107,7 +107,7 @@ func TestIntegration_FreshSweep_ReportPrintsBanner(t *testing.T) {
 	out, err := tc.RunCampInDir(campaignPath, "fresh", "test-project", "--no-push")
 	require.NoError(t, err, "fresh: %s", out)
 
-	assert.Contains(t, out, "have completed runs; run camp workitem sweep", "report prints the banner")
+	assert.Contains(t, out, "completed runs; run camp workitem sweep", "report prints the banner")
 	assert.Equal(t, 0, countSweepEvidence(t, tc, campaignPath), "report must not sweep")
 	stays, err := tc.CheckDirExists(campaignPath + "/workflow/design/done-feature")
 	require.NoError(t, err)

--- a/tests/integration/fresh_workitem_sweep_test.go
+++ b/tests/integration/fresh_workitem_sweep_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// addFreshEligibleWorkitem creates a design workitem with a completed workflow
+// run at the campaign root and commits it, making it eligible for the tier-1
+// sweep that camp fresh runs.
+func addFreshEligibleWorkitem(t *testing.T, tc *TestContainer, campaignPath, slug string) {
+	t.Helper()
+	out, err := tc.RunCampInDir(campaignPath,
+		"workitem", "create", slug, "--type", "design", "--title", slug, "--id", "design-"+slug)
+	require.NoError(t, err, "workitem create: %s", out)
+	base := campaignPath + "/workflow/design/" + slug + "/.workflow"
+	require.NoError(t, tc.WriteFile(base+"/workflow.yaml", "workflow_id: wf-"+slug+"\nactive_run_id: r1\n"))
+	require.NoError(t, tc.WriteFile(base+"/runs/r1/run.yaml", "status: active\nsummary:\n  total_steps: 1\n"))
+	require.NoError(t, tc.WriteFile(base+"/runs/r1/progress_events.jsonl",
+		`{"event_type":"workflow_run_started"}
+{"event_type":"wf_step_start"}
+{"event_type":"wf_step_done"}
+{"event_type":"workflow_run_completed"}
+`))
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+campaignPath+" && git add -A && git commit -q -m 'add eligible workitem'")
+	require.NoError(t, err)
+}
+
+// countSweepEvidence counts audit entries carrying the sweep evidence marker.
+func countSweepEvidence(t *testing.T, tc *TestContainer, campaignPath string) int {
+	t.Helper()
+	exists, err := tc.CheckFileExists(campaignPath + "/.campaign/workitems/.workitems.jsonl")
+	require.NoError(t, err)
+	if !exists {
+		return 0
+	}
+	body, err := tc.ReadFile(campaignPath + "/.campaign/workitems/.workitems.jsonl")
+	require.NoError(t, err)
+	n := 0
+	for _, line := range strings.Split(body, "\n") {
+		if strings.Contains(line, `"evidence":"workflow_run_completed"`) {
+			n++
+		}
+	}
+	return n
+}
+
+func setCompletedRuns(t *testing.T, tc *TestContainer, campaignPath, mode string) {
+	t.Helper()
+	require.NoError(t, tc.WriteFile(campaignPath+"/.campaign/settings/fresh.yaml",
+		"completed_runs: \""+mode+"\"\n"))
+}
+
+// Scenario 3 (default "sweep"): single-project fresh promotes the eligible item
+// exactly once.
+func TestIntegration_FreshSweep_DefaultPromotes(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	campaignPath, _, _ := setupFreshCampaignWithSubmodule(t, tc, "freshsweep-default")
+	addFreshEligibleWorkitem(t, tc, campaignPath, "done-feature")
+
+	out, err := tc.RunCampInDir(campaignPath, "fresh", "test-project", "--no-push")
+	require.NoError(t, err, "fresh: %s", out)
+
+	assert.Equal(t, 1, countSweepEvidence(t, tc, campaignPath), "sweep ran once")
+	gone, err := tc.CheckDirExists(campaignPath + "/workflow/design/done-feature")
+	require.NoError(t, err)
+	assert.False(t, gone, "eligible item should have moved to the dungeon")
+}
+
+// Scenario 1 ("off"): no discovery, no move, no audit entry, even with an
+// eligible item.
+func TestIntegration_FreshSweep_OffIsNoop(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	campaignPath, _, _ := setupFreshCampaignWithSubmodule(t, tc, "freshsweep-off")
+	addFreshEligibleWorkitem(t, tc, campaignPath, "done-feature")
+	setCompletedRuns(t, tc, campaignPath, "off")
+	_, _, err := tc.ExecCommand("sh", "-c", "cd "+campaignPath+" && git add -A && git commit -q -m 'set completed_runs off'")
+	require.NoError(t, err)
+
+	out, err := tc.RunCampInDir(campaignPath, "fresh", "test-project", "--no-push")
+	require.NoError(t, err, "fresh: %s", out)
+
+	assert.Equal(t, 0, countSweepEvidence(t, tc, campaignPath), "off must not sweep")
+	stays, err := tc.CheckDirExists(campaignPath + "/workflow/design/done-feature")
+	require.NoError(t, err)
+	assert.True(t, stays, "off must not move the item")
+}
+
+// Scenario 2 ("report"): the eligible item is NOT moved but the banner prints.
+func TestIntegration_FreshSweep_ReportPrintsBanner(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	campaignPath, _, _ := setupFreshCampaignWithSubmodule(t, tc, "freshsweep-report")
+	addFreshEligibleWorkitem(t, tc, campaignPath, "done-feature")
+	setCompletedRuns(t, tc, campaignPath, "report")
+	_, _, err := tc.ExecCommand("sh", "-c", "cd "+campaignPath+" && git add -A && git commit -q -m 'set completed_runs report'")
+	require.NoError(t, err)
+
+	out, err := tc.RunCampInDir(campaignPath, "fresh", "test-project", "--no-push")
+	require.NoError(t, err, "fresh: %s", out)
+
+	assert.Contains(t, out, "have completed runs; run camp workitem sweep", "report prints the banner")
+	assert.Equal(t, 0, countSweepEvidence(t, tc, campaignPath), "report must not sweep")
+	stays, err := tc.CheckDirExists(campaignPath + "/workflow/design/done-feature")
+	require.NoError(t, err)
+	assert.True(t, stays, "report must not move the item")
+}
+
+// Scenario 4 (once-per-invocation regression): a batch across two submodules
+// with ONE eligible workitem sweeps exactly once, not once per project. Two
+// projects already distinguish "once" (1 entry) from "per-project" (2 entries).
+func TestIntegration_FreshSweep_AllRunsExactlyOnce(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	campaignPath, _, _ := setupFreshCampaignWithTwoSubmodules(t, tc, "freshsweep-all")
+	addFreshEligibleWorkitem(t, tc, campaignPath, "done-feature")
+
+	out, err := tc.RunCampInDir(campaignPath, "fresh", "all", "--no-push")
+	require.NoError(t, err, "fresh all: %s", out)
+
+	assert.Equal(t, 1, countSweepEvidence(t, tc, campaignPath),
+		"sweep must run exactly once for the whole batch, not once per project")
+	gone, err := tc.CheckDirExists(campaignPath + "/workflow/design/done-feature")
+	require.NoError(t, err)
+	assert.False(t, gone, "eligible item should have moved once")
+}
+
+// Scenario 5: the campaign-root sweep runs once at the end of the batch even
+// when a per-project fresh cycle fails (project made dirty so freshSafetyChecks
+// rejects it). Decision: the sweep runs regardless of per-project failures,
+// because completed-workitem promotion is independent of any project's
+// git-hygiene outcome.
+func TestIntegration_FreshSweep_RunsDespitePerProjectFailure(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	campaignPath, projectDirA, _ := setupFreshCampaignWithTwoSubmodules(t, tc, "freshsweep-partial")
+	addFreshEligibleWorkitem(t, tc, campaignPath, "done-feature")
+
+	// Make project A dirty so its fresh cycle fails freshSafetyChecks.
+	require.NoError(t, tc.WriteFile(projectDirA+"/dirty.txt", "uncommitted"))
+
+	out, err := tc.RunCampInDir(campaignPath, "fresh", "all", "--no-push")
+	require.Error(t, err, "batch should report failure for the dirty project: %s", out)
+
+	assert.Equal(t, 1, countSweepEvidence(t, tc, campaignPath),
+		"sweep still runs once despite the per-project failure")
+	gone, err := tc.CheckDirExists(campaignPath + "/workflow/design/done-feature")
+	require.NoError(t, err)
+	assert.False(t, gone, "eligible item should have moved despite the failed project")
+}


### PR DESCRIPTION
## Summary

Wires the tier-1 workitem sweep into `camp fresh` behind a `completed_runs`
setting and adds a read-only "N workitems have completed runs" banner to
`camp wi`. Third and final sequence of phase 001 of the
`workitem-festival-lifecycle` festival (WF0001), spec `WI-75d77f` docs 03
(evidence-driven completion, "Where the sweep runs") and 05 (phase 1 items 4-5).

## Stack

Base: **`fest/wf0001-p1s2-sweep-command`** (PR #494), not `main`. This uses the
`camp workitem sweep` internals from that PR. Full chain: #493 (planner) <-
#494 (sweep verb) <- this. Rebase onto `main` if the parents merge first. This
is phase 001's tip; phase 002 stacks on it.

## What changed

- `internal/config/settings.go`: `FreshConfig.CompletedRuns` +
  `ResolveFreshCompletedRuns()` (default `"sweep"`; any unrecognized value
  defaults to `"sweep"`, never fails closed to `"off"`). Campaign-root scoped
  like `Prune`.
- `internal/commands/fresh/workitem_sweep.go`: `runCampaignWorkitemSweep`, called
  from **exactly two** sites, the single-project `RunE` (after `executeFresh`
  succeeds) and once after the `runFreshBatch` loop, **never inside
  `executeFresh`**, which stays project-scoped. `off` does no discovery at all;
  `report` prints the banner; `sweep` promotes. A sweep failure is reported but
  never fails the fresh run. `camp fresh all` / `--list` sweep exactly once.
- `internal/commands/workitem/sweep.go`: refactored into
  `gatherSweepCandidates`/`executeSweepCandidates`/`newSweepResult`/`fillSweepPlan`,
  and a new exported `RunFreshSweep` so fresh reuses the sweep path rather than
  duplicating it. New import edge `fresh -> commands/workitem` (no cycle).
- `internal/workitem/sweep.go`: `SweepBannerText` (wording lives once in the pure
  package, shared by `camp wi` and fresh's `report`).
- `camp wi` banner: `internal/commands/workitem/list_output.go` (compact list)
  and the TUI footer (`Model.sweepEligible` + `renderFooter`), computed from
  `PlanSweep` with zero mutation. `camp wi --json` is byte-identical.

## Once-per-invocation (the highest-risk decision)

The sweep is campaign-root scoped and unrelated to any one project's prune. It
runs **once per `camp fresh` invocation**, not once per project.
`TestIntegration_FreshSweep_AllRunsExactlyOnce` asserts an evidence count of
exactly 1 across two submodules (would be 2 if per-project). Decision recorded:
the batch sweep runs once at the end regardless of per-project failures
(`TestIntegration_FreshSweep_RunsDespitePerProjectFailure`).

## Test output

Integration (`just test integration-run TestIntegration_FreshSweep`):

```
--- PASS: TestIntegration_FreshSweep_DefaultPromotes (6.50s)
--- PASS: TestIntegration_FreshSweep_OffIsNoop (6.63s)
--- PASS: TestIntegration_FreshSweep_ReportPrintsBanner (6.88s)
--- PASS: TestIntegration_FreshSweep_AllRunsExactlyOnce (7.24s)
--- PASS: TestIntegration_FreshSweep_RunsDespitePerProjectFailure (7.46s)
```

`camp wi --list` (one eligible item), real output:

```
UNGROUPED
  active  - design   now   done-a  workflow/design/done-a
  active  - design   now   active-b  workflow/design/active-b
1 workitem have completed runs; run camp workitem sweep
```

TUI footer, pyte `screen.display` (mandatory pty verification):

```
2 items  j/k / f filter s status c category P tab r ? q  |  1 workitem have completed runs; run camp workitem sweep
```

`camp wi --json` diffed before/after: identical apart from the per-run
`generated_at` timestamp. `just gate` green (`0 issues` lint, both ratchets
clean; gate-fast 3742/3742, gate 3697/3697).

## Deferred (documented, not silent)

No `SetFreshCompletedRuns` setter (unused export) and no `camp fresh configure`
TUI step for `completed_runs` (separate surface); editing
`.campaign/settings/fresh.yaml` directly suffices for v1.

## Pre-existing unrelated failure (quoted)

Full `just test integration`: `562/564` (the 5 new fresh-sweep tests pass). The
only failure is the pre-existing `TestMachineDiagnoseControlMasterLifecycle`
(SSH ControlMaster, machine-diagnose subsystem; untouched by this branch).

Not merged by an agent; left for review.

