### PR TITLE
feat(fresh): tier-2 merged-branch backstop mapping + guard (WF0001 P2/S1)

### DIFF
--- a/internal/commands/fresh/batch.go
+++ b/internal/commands/fresh/batch.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 
+	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/project"
@@ -108,6 +109,10 @@ func runFreshBatch(ctx context.Context, cfg *config.FreshConfig, targets []fresh
 	fmt.Println(ui.Info(header))
 	fmt.Println()
 
+	// campRoot for the per-project merged-branch backstop; best-effort (the
+	// backstop no-ops on "off" and self-resolves the root if this is empty).
+	batchCampRoot, _ := campaign.DetectCached(ctx)
+
 	var succeeded, failed int
 	var failedNames []string
 
@@ -122,12 +127,14 @@ func runFreshBatch(ctx context.Context, cfg *config.FreshConfig, targets []fresh
 		followUps := resolveFreshFollowUps(cfg, t.name, flags.noFollowUp)
 
 		err := executeFresh(ctx, t.name, t.path, freshOptions{
-			branch:      branch,
-			prune:       doPrune,
-			pruneRemote: cfg.ResolveFreshPruneRemote(),
-			push:        doPush,
-			followUps:   followUps,
-			dryRun:      flags.dryRun,
+			branch:          branch,
+			prune:           doPrune,
+			pruneRemote:     cfg.ResolveFreshPruneRemote(),
+			push:            doPush,
+			followUps:       followUps,
+			dryRun:          flags.dryRun,
+			campRoot:        batchCampRoot,
+			mergedWorkitems: cfg.ResolveFreshMergedWorkitems(),
 		})
 		if err != nil {
 			fmt.Printf("  %s %s: %s\n", red.Render("FAILED"), t.name, err)

--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -273,8 +273,15 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 	// Capture the default branch SHA before the pull so the tier-2 backstop can
 	// scan commits newly reachable from the default branch after prune (the
 	// pruned branch refs themselves are gone by the time prune returns).
-	beforeSHAOut, _ := git.Output(ctx, path, "rev-parse", "HEAD")
+	beforeSHAOut, beforeSHAErr := git.Output(ctx, path, "rev-parse", "HEAD")
 	beforeSHA := strings.TrimSpace(beforeSHAOut)
+	if beforeSHAErr != nil || beforeSHA == "" {
+		// Best-effort: without a pre-pull HEAD the tier-2 commit-tag scan is
+		// skipped for this project (worktree-link matching still works). Log
+		// rather than fail the fresh cycle.
+		fmt.Fprintln(os.Stderr, ui.Dim(fmt.Sprintf(
+			"  merged-branch backstop: could not capture pre-pull HEAD for %s; commit-tag scan skipped (%v)", name, beforeSHAErr)))
+	}
 
 	// Step 2: Pull (ff-only)
 	if !syncState.detached {
@@ -363,7 +370,7 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 		// this project's just-deleted branches and the pre-pull beforeSHA. This
 		// is inference evidence, so it only reports (or, in a later sequence,
 		// prompts), never auto-promotes.
-		reportMergedBackstop(ctx, os.Stdout, backstopRoot(opts), path,
+		reportMergedBackstop(ctx, os.Stdout, backstopRoot(ctx, opts), path,
 			deletedNames, beforeSHA, opts.mergedWorkitems)
 	}
 

--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -132,12 +132,14 @@ Examples:
 			followUps := resolveFreshFollowUps(cfg, result.Name, freshNoFollowUp)
 
 			if err := executeFresh(ctx, result.Name, result.Path, freshOptions{
-				branch:      branch,
-				prune:       doPrune,
-				pruneRemote: cfg.ResolveFreshPruneRemote(),
-				push:        doPush,
-				followUps:   followUps,
-				dryRun:      freshDryRun,
+				branch:          branch,
+				prune:           doPrune,
+				pruneRemote:     cfg.ResolveFreshPruneRemote(),
+				push:            doPush,
+				followUps:       followUps,
+				dryRun:          freshDryRun,
+				campRoot:        campRoot,
+				mergedWorkitems: cfg.ResolveFreshMergedWorkitems(),
 			}); err != nil {
 				return err
 			}
@@ -171,12 +173,14 @@ Examples:
 }
 
 type freshOptions struct {
-	branch      string
-	prune       bool
-	pruneRemote bool
-	push        bool
-	followUps   []config.FollowUpConfig
-	dryRun      bool
+	branch          string
+	prune           bool
+	pruneRemote     bool
+	push            bool
+	followUps       []config.FollowUpConfig
+	dryRun          bool
+	campRoot        string
+	mergedWorkitems string
 }
 
 type freshSyncState struct {
@@ -266,6 +270,12 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 		fmt.Printf("%s── Checkout %-24s %s\n", prefix, defaultBranch, freshStepGreen.Render("done"))
 	}
 
+	// Capture the default branch SHA before the pull so the tier-2 backstop can
+	// scan commits newly reachable from the default branch after prune (the
+	// pruned branch refs themselves are gone by the time prune returns).
+	beforeSHAOut, _ := git.Output(ctx, path, "rev-parse", "HEAD")
+	beforeSHA := strings.TrimSpace(beforeSHAOut)
+
 	// Step 2: Pull (ff-only)
 	if !syncState.detached {
 		if opts.dryRun {
@@ -348,6 +358,13 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 			}
 			fmt.Printf("%s── Prune remote tracking refs      %s\n", prefix, style.Render(detail))
 		}
+
+		// Tier-2 merged-branch backstop: per project, right after prune, using
+		// this project's just-deleted branches and the pre-pull beforeSHA. This
+		// is inference evidence, so it only reports (or, in a later sequence,
+		// prompts) — never auto-promotes.
+		reportMergedBackstop(ctx, os.Stdout, backstopRoot(opts), path,
+			deletedNames, beforeSHA, opts.mergedWorkitems)
 	}
 
 	// Step 4: Create branch (optional)

--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -362,7 +362,7 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 		// Tier-2 merged-branch backstop: per project, right after prune, using
 		// this project's just-deleted branches and the pre-pull beforeSHA. This
 		// is inference evidence, so it only reports (or, in a later sequence,
-		// prompts) — never auto-promotes.
+		// prompts), never auto-promotes.
 		reportMergedBackstop(ctx, os.Stdout, backstopRoot(opts), path,
 			deletedNames, beforeSHA, opts.mergedWorkitems)
 	}

--- a/internal/commands/fresh/merged_backstop.go
+++ b/internal/commands/fresh/merged_backstop.go
@@ -23,11 +23,11 @@ import (
 // backstopRoot resolves the campaign root for the backstop: the threaded
 // campRoot when set, else a cwd detect (fresh runs at or under the campaign
 // root). Empty on failure disables the backstop for this project.
-func backstopRoot(opts freshOptions) string {
+func backstopRoot(ctx context.Context, opts freshOptions) string {
 	if opts.campRoot != "" {
 		return opts.campRoot
 	}
-	root, err := campaign.DetectCached(context.Background())
+	root, err := campaign.DetectCached(ctx)
 	if err != nil {
 		return ""
 	}
@@ -59,7 +59,7 @@ func reportMergedBackstop(ctx context.Context, out io.Writer, root, projectPath 
 		return
 	}
 	for _, m := range matches {
-		if HasOpenWork(root, registry, m.Workitem, m.ScopePath) {
+		if HasOpenWork(root, registry, m.Workitem, m.ScopePath, projectRelPath(root, projectPath)) {
 			continue
 		}
 		_, _ = fmt.Fprintf(out, "%s workitem %s had a merged branch and is still active; promote when done:\n    %s\n",
@@ -293,21 +293,31 @@ func refFromItem(wi wkitem.WorkItem) string {
 // HasOpenWork reports whether wi still has open work beyond the branch that just
 // merged, in which case a tier-2 match must be suppressed (doc 03 conservatism
 // guard: one merged PR out of several open ones is progress, not completion). A
-// workitem linked to a second project/repo, or with a still-existing worktree
+// workitem linked to a DIFFERENT project/repo, or with a still-existing worktree
 // other than the just-merged one, is "open." A stale worktree link whose
-// directory is already gone does not count as open.
-func HasOpenWork(root string, registry *links.Links, wi wkitem.WorkItem, justMergedScopePath string) bool {
+// directory is already gone does not count as open. mergedScopePath is the
+// scope that just merged (the matched worktree link's path, or the project path
+// for a commit-tag match); projectPath is the just-pruned project's
+// campaign-relative path, so the just-merged project's own project/repo link is
+// not mistaken for other open work.
+func HasOpenWork(root string, registry *links.Links, wi wkitem.WorkItem, mergedScopePath, projectPath string) bool {
 	for _, link := range registry.Links {
 		if !linkMatchesBackstopItem(link, wi) {
 			continue
 		}
 		switch link.Scope.Kind {
 		case links.ScopeProject, links.ScopeRepo:
-			if link.Scope.Path != justMergedScopePath {
+			// A project/repo link is open work only when it points at a
+			// DIFFERENT project than the one whose branch just merged. The
+			// just-merged project's own link is not "other" work (compare
+			// against projectPath, not the matched worktree's scope path).
+			if link.Scope.Path != projectPath {
 				return true
 			}
 		case links.ScopeWorktree:
-			if link.Scope.Path == justMergedScopePath {
+			// Skip the worktree that just merged; any OTHER worktree that still
+			// exists on disk is open work.
+			if link.Scope.Path == mergedScopePath {
 				continue
 			}
 			if worktreeDirExists(root, link.Scope.Path) {

--- a/internal/commands/fresh/merged_backstop.go
+++ b/internal/commands/fresh/merged_backstop.go
@@ -1,0 +1,329 @@
+package fresh
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	wkcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
+)
+
+// backstopRoot resolves the campaign root for the backstop: the threaded
+// campRoot when set, else a cwd detect (fresh runs at or under the campaign
+// root). Empty on failure disables the backstop for this project.
+func backstopRoot(opts freshOptions) string {
+	if opts.campRoot != "" {
+		return opts.campRoot
+	}
+	root, err := campaign.DetectCached(context.Background())
+	if err != nil {
+		return ""
+	}
+	return root
+}
+
+// reportMergedBackstop runs the tier-2 merged-branch backstop for one project
+// after prune: map the just-deleted branches to still-active workitems, drop
+// matches with open work elsewhere, and (mode "report", and "prompt" until the
+// interactive prompt lands in 02_fresh_prompt_flow) print the exact promote
+// command for each surviving match. Mode "off" or an empty root/branch list is
+// a no-op. Inference evidence never auto-promotes; a failure is reported to out
+// and never fails the fresh cycle.
+func reportMergedBackstop(ctx context.Context, out io.Writer, root, projectPath string, deletedBranches []string, beforeSHA, mode string) {
+	if mode == "off" || root == "" || len(deletedBranches) == 0 {
+		return
+	}
+	matches, err := MapMergedBranchesToWorkitems(ctx, root, projectPath, deletedBranches, beforeSHA)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "%s merged-branch backstop skipped: %v\n", ui.WarningIcon(), err)
+		return
+	}
+	if len(matches) == 0 {
+		return
+	}
+	registry, err := links.Load(ctx, root)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "%s merged-branch backstop skipped: %v\n", ui.WarningIcon(), err)
+		return
+	}
+	for _, m := range matches {
+		if HasOpenWork(root, registry, m.Workitem, mergedScopePath(projectPath, root)) {
+			continue
+		}
+		_, _ = fmt.Fprintf(out, "%s workitem %s had a merged branch and is still active; promote when done:\n    %s\n",
+			ui.InfoIcon(), backstopWorkitemLabel(m.Workitem), backstopPromoteCommand(m.Workitem))
+	}
+}
+
+// mergedScopePath is the campaign-relative project path used to match project/
+// repo scope links for the open-work guard.
+func mergedScopePath(projectPath, root string) string {
+	rel, err := filepath.Rel(root, projectPath)
+	if err != nil {
+		return projectPath
+	}
+	return filepath.ToSlash(rel)
+}
+
+// backstopPromoteCommand renders the exact, copy-pasteable promote command using
+// the workitem's resolvable id (StableID), not its internal Key.
+func backstopPromoteCommand(wi wkitem.WorkItem) string {
+	return "camp workitem promote " + backstopWorkitemID(wi) + " --target completed"
+}
+
+func backstopWorkitemID(wi wkitem.WorkItem) string {
+	if wi.StableID != "" {
+		return wi.StableID
+	}
+	return wi.Key
+}
+
+func backstopWorkitemLabel(wi wkitem.WorkItem) string {
+	if wi.Title != "" {
+		return wi.Title
+	}
+	return backstopWorkitemID(wi)
+}
+
+// Tier-2 evidence signals. A merged branch is inference-tier evidence: it
+// prompts or reports, never auto-promotes (FESTIVAL_RULES rule 2).
+const (
+	// SignalWorktreeLink means a pruned branch's name matched a worktree-scope
+	// link's directory basename (high confidence: the branch and its worktree
+	// dir share a name by construction at `camp workitem worktree` time).
+	SignalWorktreeLink = "worktree_link"
+	// SignalCommitTag means a WI- tag was found on a commit newly reachable
+	// from the default branch since this fresh cycle's pull (the fallback for
+	// quick fixes committed without a worktree).
+	SignalCommitTag = "commit_tag"
+)
+
+// MergedBackstopMatch is a still-active workitem whose merged branch (or merged
+// WI-tagged commit) was observed by camp fresh's prune step. It is inference
+// evidence: sequence 02_fresh_prompt_flow prompts on it, never auto-promotes.
+type MergedBackstopMatch struct {
+	Workitem wkitem.WorkItem
+	// Branch is the pruned branch that matched, for worktree-link matches.
+	// Empty for commit-tag matches, where the branch is already deleted and the
+	// evidence is the merged commit reachable from the default branch.
+	Branch string
+	Signal string
+}
+
+// MapMergedBranchesToWorkitems maps the branches camp fresh's prune step just
+// deleted for one project back to still-active workitems. Two signals, in
+// order of confidence: worktree-scope links (branch name == worktree dir
+// basename), then WI- commit tags on commits newly reachable from the default
+// branch since beforeSHA (captured before the pull, since the pruned branch ref
+// is gone by the time prune returns). Festivals and intents are excluded per
+// doc 03's scope boundary. Pure of prompt/UI concerns; git calls are I/O so it
+// takes ctx. Returns no error on "no matches": absence of evidence is not an
+// error.
+func MapMergedBranchesToWorkitems(ctx context.Context, root, projectPath string, prunedBranches []string, beforeSHA string) ([]MergedBackstopMatch, error) {
+	if len(prunedBranches) == 0 {
+		return nil, nil
+	}
+
+	registry, err := links.Load(ctx, root)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "load link registry")
+	}
+	cfg, _, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "load campaign config")
+	}
+	items, err := wkitem.Discover(ctx, root, paths.NewResolverFromConfig(root, cfg))
+	if err != nil {
+		return nil, camperrors.Wrap(err, "discover workitems")
+	}
+	active := activeBackstopItems(items)
+
+	var matches []MergedBackstopMatch
+	matchedKeys := map[string]bool{}
+	var unmatchedBranches []string
+
+	// Signal 1: worktree-scope links, per pruned branch.
+	for _, branch := range prunedBranches {
+		wi, ok := matchWorktreeLinkBranch(registry.Links, active, branch)
+		if !ok {
+			unmatchedBranches = append(unmatchedBranches, branch)
+			continue
+		}
+		matches = append(matches, MergedBackstopMatch{Workitem: wi, Branch: branch, Signal: SignalWorktreeLink})
+		matchedKeys[wi.Key] = true
+	}
+
+	// Signal 2: WI- commit tags on commits newly reachable from the default
+	// branch, only when some pruned branch had no worktree link. beforeSHA is
+	// required; without it the newly-reachable set is unknown, so skip.
+	if len(unmatchedBranches) > 0 && beforeSHA != "" {
+		refs, scanErr := newlyMergedWorkitemRefs(ctx, projectPath, beforeSHA)
+		if scanErr != nil {
+			return matches, scanErr
+		}
+		for _, wi := range active {
+			if matchedKeys[wi.Key] {
+				continue
+			}
+			if refMatchesActiveItem(refs, wi) {
+				matches = append(matches, MergedBackstopMatch{Workitem: wi, Signal: SignalCommitTag})
+				matchedKeys[wi.Key] = true
+			}
+		}
+	}
+
+	return matches, nil
+}
+
+// activeBackstopItems returns the discovered items eligible for tier-2 matching:
+// everything Discover produced except festivals and intents (doc 03 scope
+// boundary). Discover already excludes dungeon subtrees, so these are active.
+func activeBackstopItems(items []wkitem.WorkItem) []wkitem.WorkItem {
+	out := make([]wkitem.WorkItem, 0, len(items))
+	for _, item := range items {
+		if item.WorkflowType == wkitem.WorkflowTypeFestival || item.WorkflowType == wkitem.WorkflowTypeIntent {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+// matchWorktreeLinkBranch finds the active workitem whose worktree-scope link's
+// directory basename equals branch. Only ScopeWorktree links carry a
+// branch<->workitem correlation (via the shared name at creation); repo/project
+// scope links carry none, so they are ignored here.
+func matchWorktreeLinkBranch(all []links.Link, active []wkitem.WorkItem, branch string) (wkitem.WorkItem, bool) {
+	for _, link := range all {
+		if link.Scope.Kind != links.ScopeWorktree {
+			continue
+		}
+		if filepath.Base(filepath.FromSlash(link.Scope.Path)) != branch {
+			continue
+		}
+		if wi, ok := resolveLinkedActiveItem(link, active); ok {
+			return wi, true
+		}
+	}
+	return wkitem.WorkItem{}, false
+}
+
+// resolveLinkedActiveItem resolves a link to a still-active workitem by stable
+// id or key, matching worktree.go's linkMatchesWorkitem.
+func resolveLinkedActiveItem(link links.Link, active []wkitem.WorkItem) (wkitem.WorkItem, bool) {
+	for _, wi := range active {
+		if wi.StableID != "" && link.WorkitemID == wi.StableID {
+			return wi, true
+		}
+		if wi.Key != "" && link.WorkitemKey == wi.Key {
+			return wi, true
+		}
+	}
+	return wkitem.WorkItem{}, false
+}
+
+// newlyMergedWorkitemRefs scans commit subjects reachable from HEAD but not from
+// beforeSHA in projectPath and returns the set of WI- refs their campaign tags
+// carry. Scoped to one repo: fresh already operates one project at a time.
+func newlyMergedWorkitemRefs(ctx context.Context, projectPath, beforeSHA string) (map[string]bool, error) {
+	out, err := git.Output(ctx, projectPath, "log", beforeSHA+"..HEAD", "--pretty=format:%s")
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "scan newly merged commits in %s", projectPath)
+	}
+	return workitemRefsFromSubjects(strings.Split(out, "\n")), nil
+}
+
+// workitemRefsFromSubjects extracts the set of WI- refs carried by the campaign
+// tags on the given commit subjects. Pure: no I/O.
+func workitemRefsFromSubjects(subjects []string) map[string]bool {
+	refs := map[string]bool{}
+	for _, subject := range subjects {
+		subject = strings.TrimSpace(subject)
+		if subject == "" {
+			continue
+		}
+		if ref := commitkit.ParseTag(subject).WorkitemRef; ref != "" {
+			refs[ref] = true
+		}
+	}
+	return refs
+}
+
+// refMatchesActiveItem reports whether any newly-merged WI- ref names wi, using
+// the same alias resolution camp workitem commits uses (ref, stable id, key,
+// slug). wi's own ref lives in SourceMetadata["ref"].
+func refMatchesActiveItem(refs map[string]bool, wi wkitem.WorkItem) bool {
+	aliases := wkcmd.WorkitemAliases(refFromItem(wi), &wi)
+	for ref := range refs {
+		if aliases[ref] {
+			return true
+		}
+	}
+	return false
+}
+
+func refFromItem(wi wkitem.WorkItem) string {
+	if wi.SourceMetadata == nil {
+		return ""
+	}
+	if ref, ok := wi.SourceMetadata["ref"].(string); ok {
+		return ref
+	}
+	return ""
+}
+
+// HasOpenWork reports whether wi still has open work beyond the branch that just
+// merged, in which case a tier-2 match must be suppressed (doc 03 conservatism
+// guard: one merged PR out of several open ones is progress, not completion). A
+// workitem linked to a second project/repo, or with a still-existing worktree
+// other than the just-merged one, is "open." A stale worktree link whose
+// directory is already gone does not count as open.
+func HasOpenWork(root string, registry *links.Links, wi wkitem.WorkItem, justMergedScopePath string) bool {
+	for _, link := range registry.Links {
+		if !linkMatchesBackstopItem(link, wi) {
+			continue
+		}
+		switch link.Scope.Kind {
+		case links.ScopeProject, links.ScopeRepo:
+			if link.Scope.Path != justMergedScopePath {
+				return true
+			}
+		case links.ScopeWorktree:
+			if link.Scope.Path == justMergedScopePath {
+				continue
+			}
+			if worktreeDirExists(root, link.Scope.Path) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func linkMatchesBackstopItem(link links.Link, wi wkitem.WorkItem) bool {
+	if wi.StableID != "" && link.WorkitemID == wi.StableID {
+		return true
+	}
+	return wi.Key != "" && link.WorkitemKey == wi.Key
+}
+
+func worktreeDirExists(root, scopePath string) bool {
+	abs := scopePath
+	if !filepath.IsAbs(abs) {
+		abs = filepath.Join(root, filepath.FromSlash(scopePath))
+	}
+	info, err := os.Stat(abs)
+	return err == nil && info.IsDir()
+}

--- a/internal/commands/fresh/merged_backstop.go
+++ b/internal/commands/fresh/merged_backstop.go
@@ -59,22 +59,12 @@ func reportMergedBackstop(ctx context.Context, out io.Writer, root, projectPath 
 		return
 	}
 	for _, m := range matches {
-		if HasOpenWork(root, registry, m.Workitem, mergedScopePath(projectPath, root)) {
+		if HasOpenWork(root, registry, m.Workitem, m.ScopePath) {
 			continue
 		}
 		_, _ = fmt.Fprintf(out, "%s workitem %s had a merged branch and is still active; promote when done:\n    %s\n",
 			ui.InfoIcon(), backstopWorkitemLabel(m.Workitem), backstopPromoteCommand(m.Workitem))
 	}
-}
-
-// mergedScopePath is the campaign-relative project path used to match project/
-// repo scope links for the open-work guard.
-func mergedScopePath(projectPath, root string) string {
-	rel, err := filepath.Rel(root, projectPath)
-	if err != nil {
-		return projectPath
-	}
-	return filepath.ToSlash(rel)
 }
 
 // backstopPromoteCommand renders the exact, copy-pasteable promote command using
@@ -120,6 +110,11 @@ type MergedBackstopMatch struct {
 	// evidence is the merged commit reachable from the default branch.
 	Branch string
 	Signal string
+	// ScopePath is the campaign-relative scope whose work just merged: the
+	// worktree link's path for a worktree match, or the project path for a
+	// commit-tag match. The open-work guard uses it to avoid counting the
+	// just-merged scope itself as "other open work."
+	ScopePath string
 }
 
 // MapMergedBranchesToWorkitems maps the branches camp fresh's prune step just
@@ -154,14 +149,16 @@ func MapMergedBranchesToWorkitems(ctx context.Context, root, projectPath string,
 	matchedKeys := map[string]bool{}
 	var unmatchedBranches []string
 
+	projectScope := projectRelPath(root, projectPath)
+
 	// Signal 1: worktree-scope links, per pruned branch.
 	for _, branch := range prunedBranches {
-		wi, ok := matchWorktreeLinkBranch(registry.Links, active, branch)
+		wi, scopePath, ok := matchWorktreeLinkBranch(registry.Links, active, branch)
 		if !ok {
 			unmatchedBranches = append(unmatchedBranches, branch)
 			continue
 		}
-		matches = append(matches, MergedBackstopMatch{Workitem: wi, Branch: branch, Signal: SignalWorktreeLink})
+		matches = append(matches, MergedBackstopMatch{Workitem: wi, Branch: branch, Signal: SignalWorktreeLink, ScopePath: scopePath})
 		matchedKeys[wi.Key] = true
 	}
 
@@ -178,7 +175,7 @@ func MapMergedBranchesToWorkitems(ctx context.Context, root, projectPath string,
 				continue
 			}
 			if refMatchesActiveItem(refs, wi) {
-				matches = append(matches, MergedBackstopMatch{Workitem: wi, Signal: SignalCommitTag})
+				matches = append(matches, MergedBackstopMatch{Workitem: wi, Signal: SignalCommitTag, ScopePath: projectScope})
 				matchedKeys[wi.Key] = true
 			}
 		}
@@ -205,7 +202,7 @@ func activeBackstopItems(items []wkitem.WorkItem) []wkitem.WorkItem {
 // directory basename equals branch. Only ScopeWorktree links carry a
 // branch<->workitem correlation (via the shared name at creation); repo/project
 // scope links carry none, so they are ignored here.
-func matchWorktreeLinkBranch(all []links.Link, active []wkitem.WorkItem, branch string) (wkitem.WorkItem, bool) {
+func matchWorktreeLinkBranch(all []links.Link, active []wkitem.WorkItem, branch string) (wkitem.WorkItem, string, bool) {
 	for _, link := range all {
 		if link.Scope.Kind != links.ScopeWorktree {
 			continue
@@ -214,10 +211,19 @@ func matchWorktreeLinkBranch(all []links.Link, active []wkitem.WorkItem, branch 
 			continue
 		}
 		if wi, ok := resolveLinkedActiveItem(link, active); ok {
-			return wi, true
+			return wi, link.Scope.Path, true
 		}
 	}
-	return wkitem.WorkItem{}, false
+	return wkitem.WorkItem{}, "", false
+}
+
+// projectRelPath returns projectPath relative to the campaign root, slash-form.
+func projectRelPath(root, projectPath string) string {
+	rel, err := filepath.Rel(root, projectPath)
+	if err != nil {
+		return projectPath
+	}
+	return filepath.ToSlash(rel)
 }
 
 // resolveLinkedActiveItem resolves a link to a still-active workitem by stable

--- a/internal/commands/fresh/merged_backstop_test.go
+++ b/internal/commands/fresh/merged_backstop_test.go
@@ -42,18 +42,18 @@ func TestMatchWorktreeLinkBranch(t *testing.T) {
 		{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeRepo, Path: "projects/other/foo"}},
 	}
 
-	wi, ok := matchWorktreeLinkBranch(linkList, active, "foo")
+	wi, _, ok := matchWorktreeLinkBranch(linkList, active, "foo")
 	if !ok || wi.Key != "design:workflow/design/foo" {
 		t.Fatalf("expected worktree-link match for branch foo, got ok=%v wi=%+v", ok, wi)
 	}
 
-	if _, ok := matchWorktreeLinkBranch(linkList, active, "unrelated"); ok {
+	if _, _, ok := matchWorktreeLinkBranch(linkList, active, "unrelated"); ok {
 		t.Errorf("expected no match for a branch with no worktree link")
 	}
 
 	// Repo-scope only (no worktree link) must not match by basename.
 	repoOnly := []links.Link{{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeRepo, Path: "projects/other/foo"}}}
-	if _, ok := matchWorktreeLinkBranch(repoOnly, active, "foo"); ok {
+	if _, _, ok := matchWorktreeLinkBranch(repoOnly, active, "foo"); ok {
 		t.Errorf("repo-scope link must not match a branch by basename")
 	}
 }

--- a/internal/commands/fresh/merged_backstop_test.go
+++ b/internal/commands/fresh/merged_backstop_test.go
@@ -102,7 +102,7 @@ func TestHasOpenWork(t *testing.T) {
 		reg := &links.Links{Links: []links.Link{
 			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeProject, Path: mergedPath}},
 		}}
-		if HasOpenWork("/root", reg, wi, mergedPath) {
+		if HasOpenWork("/root", reg, wi, mergedPath, mergedPath) {
 			t.Errorf("single-scope workitem should not be suppressed")
 		}
 	})
@@ -112,7 +112,7 @@ func TestHasOpenWork(t *testing.T) {
 			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeProject, Path: mergedPath}},
 			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeProject, Path: "projects/festival-app"}},
 		}}
-		if !HasOpenWork("/root", reg, wi, mergedPath) {
+		if !HasOpenWork("/root", reg, wi, mergedPath, mergedPath) {
 			t.Errorf("workitem linked to a second project must be suppressed (open work elsewhere)")
 		}
 	})
@@ -123,7 +123,7 @@ func TestHasOpenWork(t *testing.T) {
 			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeProject, Path: mergedPath}},
 			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeWorktree, Path: "projects/worktrees/camp/gone"}},
 		}}
-		if HasOpenWork(root, reg, wi, mergedPath) {
+		if HasOpenWork(root, reg, wi, mergedPath, mergedPath) {
 			t.Errorf("a worktree link whose directory no longer exists must not count as open")
 		}
 	})
@@ -138,8 +138,28 @@ func TestHasOpenWork(t *testing.T) {
 			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeProject, Path: mergedPath}},
 			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeWorktree, Path: filepath.ToSlash(wtRel)}},
 		}}
-		if !HasOpenWork(root, reg, wi, mergedPath) {
+		if !HasOpenWork(root, reg, wi, mergedPath, mergedPath) {
 			t.Errorf("an existing other worktree must count as open work")
+		}
+	})
+
+	// Regression (review #496): a workitem whose only links are the just-merged
+	// project AND its own (still-present) worktree must NOT read as open. Before
+	// the fix, the project link's path was compared against the worktree scope
+	// path and never matched, so the report never fired.
+	t.Run("project link + just-merged worktree link is not open", func(t *testing.T) {
+		root := t.TempDir()
+		wtRel := filepath.ToSlash(filepath.Join("projects", "worktrees", "camp", "myfeature"))
+		if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(wtRel)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		reg := &links.Links{Links: []links.Link{
+			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeProject, Path: mergedPath}},
+			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeWorktree, Path: wtRel}},
+		}}
+		// merged scope = the worktree that just merged; project = mergedPath.
+		if HasOpenWork(root, reg, wi, wtRel, mergedPath) {
+			t.Errorf("project link + its own just-merged worktree must NOT count as open work")
 		}
 	})
 }

--- a/internal/commands/fresh/merged_backstop_test.go
+++ b/internal/commands/fresh/merged_backstop_test.go
@@ -1,0 +1,145 @@
+package fresh
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
+)
+
+func taggedSubject(ref, msg string) string {
+	return commitkit.PrependContextTagsFullNamed("obey-campaign", "8deed8b4", "", "", ref, msg)
+}
+
+func TestWorkitemRefsFromSubjects(t *testing.T) {
+	subjects := []string{
+		taggedSubject("WI-abc123", "fix a thing"),
+		"chore: no tag here",
+		"",
+		taggedSubject("WI-def456", "another fix"),
+		taggedSubject("WI-abc123", "same ref again"),
+	}
+	got := workitemRefsFromSubjects(subjects)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 distinct refs, got %d: %v", len(got), got)
+	}
+	if !got["WI-abc123"] || !got["WI-def456"] {
+		t.Errorf("unexpected ref set: %v", got)
+	}
+}
+
+func TestMatchWorktreeLinkBranch(t *testing.T) {
+	active := []wkitem.WorkItem{
+		{Key: "design:workflow/design/foo", StableID: "design-foo-01", RelativePath: "workflow/design/foo"},
+	}
+	linkList := []links.Link{
+		// Worktree link whose dir basename matches the branch name.
+		{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeWorktree, Path: "projects/worktrees/camp/foo"}},
+		// Repo-scope link with the same basename must be ignored (no branch identity).
+		{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeRepo, Path: "projects/other/foo"}},
+	}
+
+	wi, ok := matchWorktreeLinkBranch(linkList, active, "foo")
+	if !ok || wi.Key != "design:workflow/design/foo" {
+		t.Fatalf("expected worktree-link match for branch foo, got ok=%v wi=%+v", ok, wi)
+	}
+
+	if _, ok := matchWorktreeLinkBranch(linkList, active, "unrelated"); ok {
+		t.Errorf("expected no match for a branch with no worktree link")
+	}
+
+	// Repo-scope only (no worktree link) must not match by basename.
+	repoOnly := []links.Link{{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeRepo, Path: "projects/other/foo"}}}
+	if _, ok := matchWorktreeLinkBranch(repoOnly, active, "foo"); ok {
+		t.Errorf("repo-scope link must not match a branch by basename")
+	}
+}
+
+func TestRefMatchesActiveItem(t *testing.T) {
+	item := wkitem.WorkItem{
+		Key:            "design:workflow/design/foo",
+		StableID:       "design-foo-01",
+		RelativePath:   "workflow/design/foo",
+		SourceMetadata: map[string]any{"ref": "WI-abc123"},
+	}
+	if !refMatchesActiveItem(map[string]bool{"WI-abc123": true}, item) {
+		t.Errorf("expected match by WI- ref in SourceMetadata")
+	}
+	if !refMatchesActiveItem(map[string]bool{"design-foo-01": true}, item) {
+		t.Errorf("expected match by StableID alias")
+	}
+	if refMatchesActiveItem(map[string]bool{"WI-999999": true}, item) {
+		t.Errorf("expected no match for an unrelated ref")
+	}
+}
+
+func TestActiveBackstopItems_ExcludesFestivalsAndIntents(t *testing.T) {
+	items := []wkitem.WorkItem{
+		{Key: "design:a", WorkflowType: wkitem.WorkflowTypeDesign},
+		{Key: "festival:b", WorkflowType: wkitem.WorkflowTypeFestival},
+		{Key: "intent:c", WorkflowType: wkitem.WorkflowTypeIntent},
+		{Key: "explore:d", WorkflowType: wkitem.WorkflowTypeExplore},
+	}
+	got := activeBackstopItems(items)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 items (design, explore), got %d", len(got))
+	}
+	for _, wi := range got {
+		if wi.WorkflowType == wkitem.WorkflowTypeFestival || wi.WorkflowType == wkitem.WorkflowTypeIntent {
+			t.Errorf("festival/intent leaked into backstop set: %+v", wi)
+		}
+	}
+}
+
+func TestHasOpenWork(t *testing.T) {
+	wi := wkitem.WorkItem{Key: "design:foo", StableID: "design-foo-01"}
+	const mergedPath = "projects/camp"
+
+	t.Run("single scope, only the merged project link, is not open", func(t *testing.T) {
+		reg := &links.Links{Links: []links.Link{
+			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeProject, Path: mergedPath}},
+		}}
+		if HasOpenWork("/root", reg, wi, mergedPath) {
+			t.Errorf("single-scope workitem should not be suppressed")
+		}
+	})
+
+	t.Run("two distinct project links (WI-ca06e1 shape) is open", func(t *testing.T) {
+		reg := &links.Links{Links: []links.Link{
+			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeProject, Path: mergedPath}},
+			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeProject, Path: "projects/festival-app"}},
+		}}
+		if !HasOpenWork("/root", reg, wi, mergedPath) {
+			t.Errorf("workitem linked to a second project must be suppressed (open work elsewhere)")
+		}
+	})
+
+	t.Run("stale worktree link with a missing dir does not count as open", func(t *testing.T) {
+		root := t.TempDir()
+		reg := &links.Links{Links: []links.Link{
+			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeProject, Path: mergedPath}},
+			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeWorktree, Path: "projects/worktrees/camp/gone"}},
+		}}
+		if HasOpenWork(root, reg, wi, mergedPath) {
+			t.Errorf("a worktree link whose directory no longer exists must not count as open")
+		}
+	})
+
+	t.Run("existing other worktree is open", func(t *testing.T) {
+		root := t.TempDir()
+		wtRel := filepath.Join("projects", "worktrees", "camp", "live")
+		if err := os.MkdirAll(filepath.Join(root, wtRel), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		reg := &links.Links{Links: []links.Link{
+			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeProject, Path: mergedPath}},
+			{WorkitemID: "design-foo-01", Scope: links.LinkScope{Kind: links.ScopeWorktree, Path: filepath.ToSlash(wtRel)}},
+		}}
+		if !HasOpenWork(root, reg, wi, mergedPath) {
+			t.Errorf("an existing other worktree must count as open work")
+		}
+	})
+}

--- a/internal/commands/workitem/commits.go
+++ b/internal/commands/workitem/commits.go
@@ -177,7 +177,7 @@ func runCommitsQuery(ctx context.Context, cmd *cobra.Command, flags commitsFlags
 	// git-log fan-out across every linked repo. In auto, an empty or unreadable
 	// ledger falls back to the cross-repo tag scan; --source scan forces the scan
 	// (the exhaustive git --all view) and --source ledger forces the ledger.
-	aliases := workitemAliases(ref, wi)
+	aliases := WorkitemAliases(ref, wi)
 	var records []CommitRecord
 	var queryErrs []commitsQueryError
 	answered := commitsSourceScan
@@ -223,10 +223,10 @@ func runCommitsQuery(ctx context.Context, cmd *cobra.Command, flags commitsFlags
 	return emitCommitsQueryWarnings(cmd.ErrOrStderr(), queryErrs)
 }
 
-// workitemAliases returns the identifier forms a ledger event's scope.workitem
+// WorkitemAliases returns the identifier forms a ledger event's scope.workitem
 // might carry for this workitem (D007 workitem-id normalization): the ref, the
 // stable id, the workitem key, and the on-disk directory slug all name it.
-func workitemAliases(ref string, wi *wkitem.WorkItem) map[string]bool {
+func WorkitemAliases(ref string, wi *wkitem.WorkItem) map[string]bool {
 	aliases := map[string]bool{}
 	if ref != "" {
 		aliases[ref] = true

--- a/internal/commands/workitem/commits_test.go
+++ b/internal/commands/workitem/commits_test.go
@@ -48,13 +48,13 @@ func TestWorkitemAliasesCollectsRefIdKeyAndSlug(t *testing.T) {
 		Key:          "design/camp-list-tui",
 		RelativePath: "workflow/design/camp-list-tui",
 	}
-	got := workitemAliases("WI-abc123", wi)
+	got := WorkitemAliases("WI-abc123", wi)
 	for _, want := range []string{"WI-abc123", "design-camp-list-tui-2026-06-24", "design/camp-list-tui", "camp-list-tui"} {
 		if !got[want] {
 			t.Fatalf("aliases missing %q; got %v", want, got)
 		}
 	}
-	if workitemAliases("", nil)["."] {
+	if WorkitemAliases("", nil)["."] {
 		t.Fatal("empty inputs should not alias the current dir")
 	}
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -217,6 +217,11 @@ type FreshConfig struct {
 	// at the root, not per project), so there is no per-project override, the
 	// same shape as Prune.
 	CompletedRuns string `yaml:"completed_runs,omitempty"`
+	// MergedWorkitems controls the tier-2 merged-branch backstop run per project
+	// in camp fresh: "prompt" asks on a TTY (reports otherwise), "report" prints
+	// the exact promote commands, "off" does nothing. Inference-tier evidence
+	// never auto-promotes. Global only, same shape as CompletedRuns.
+	MergedWorkitems string `yaml:"merged_workitems,omitempty"`
 	// FollowUp lists command workflow steps run, in order, after a successful
 	// sync/prune/branch cycle. A project override in Projects replaces this
 	// list entirely; it is never merged with it.
@@ -337,6 +342,20 @@ func (c *FreshConfig) ResolveFreshCompletedRuns() string {
 		return c.CompletedRuns
 	default:
 		return "sweep"
+	}
+}
+
+// ResolveFreshMergedWorkitems resolves merged_workitems using the global config.
+// Global only, same shape as CompletedRuns. This sequence (tier-2 mapping +
+// report) defaults to "off" until the interactive prompt lands in
+// 02_fresh_prompt_flow, which changes the default to the spec value "prompt".
+// Any unrecognized value falls back to the default rather than failing.
+func (c *FreshConfig) ResolveFreshMergedWorkitems() string {
+	switch c.MergedWorkitems {
+	case "prompt", "report", "off":
+		return c.MergedWorkitems
+	default:
+		return "off"
 	}
 }
 

--- a/tests/integration/fresh_merged_backstop_test.go
+++ b/tests/integration/fresh_merged_backstop_test.go
@@ -1,0 +1,118 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createBackstopWorkitem creates a design workitem at the campaign root and
+// commits it, returning the id used at creation.
+func createBackstopWorkitem(t *testing.T, tc *TestContainer, campaignPath, slug string) string {
+	t.Helper()
+	id := "design-" + slug
+	out, err := tc.RunCampInDir(campaignPath,
+		"workitem", "create", slug, "--type", "design", "--title", slug, "--id", id)
+	require.NoError(t, err, "workitem create: %s", out)
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+campaignPath+" && git add -A && git commit -q -m 'add workitem'")
+	require.NoError(t, err)
+	return id
+}
+
+// mergeAndPruneBranch creates branch in the submodule, merges it into main on
+// origin, and leaves it locally merged so camp fresh's prune deletes it.
+func mergeAndPruneBranch(t *testing.T, tc *TestContainer, projectDir, branch string) {
+	t.Helper()
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+git -C %[1]s checkout -b %[2]s
+printf 'work\n' > %[1]s/%[2]s.txt
+git -C %[1]s add .
+git -C %[1]s commit -m 'work on %[2]s'
+git -C %[1]s checkout main
+git -C %[1]s merge --no-ff -m 'merge %[2]s' %[2]s
+git -C %[1]s push origin main
+`, projectDir, branch))
+}
+
+// TestIntegration_FreshMergedBackstop_WorktreeLinkReported verifies the full
+// wiring: a pruned branch whose name matches a worktree-scope link's directory
+// basename is reported (merged_workitems: report) with the exact promote
+// command, and the workitem is not moved (inference evidence never auto-acts).
+func TestIntegration_FreshMergedBackstop_WorktreeLinkReported(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	campaignPath, projectDir, _ := setupFreshCampaignWithSubmodule(t, tc, "backstop-worktree")
+
+	createBackstopWorkitem(t, tc, campaignPath, "myfeature")
+	// Worktree-scope link whose path basename is the branch name. The link
+	// command validates the target exists, so create the directory first.
+	require.NoError(t, tc.WriteFile(campaignPath+"/projects/worktrees/test-project/myfeature/.keep", ""))
+	out, err := tc.RunCampInDir(campaignPath, "workitem", "link", "design-myfeature", "--worktree", "projects/worktrees/test-project/myfeature")
+	require.NoError(t, err, "link: %s", out)
+
+	require.NoError(t, tc.WriteFile(campaignPath+"/.campaign/settings/fresh.yaml", "merged_workitems: \"report\"\n"))
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+campaignPath+" && git add -A && git commit -q -m 'link + report mode'")
+	require.NoError(t, err)
+
+	mergeAndPruneBranch(t, tc, projectDir, "myfeature")
+
+	output, err := tc.RunCampInDir(campaignPath, "fresh", "test-project", "--no-push")
+	require.NoError(t, err, "fresh: %s", output)
+
+	assert.Contains(t, output, "had a merged branch and is still active",
+		"the merged worktree-linked branch should be reported:\n%s", output)
+	assert.Contains(t, output, "camp workitem promote design-myfeature --target completed",
+		"report should print the exact promote command:\n%s", output)
+
+	// Inference evidence: the workitem must NOT have been moved.
+	stays, err := tc.CheckDirExists(campaignPath + "/workflow/design/myfeature")
+	require.NoError(t, err)
+	assert.True(t, stays, "report mode must not move the workitem")
+}
+
+// TestIntegration_FreshMergedBackstop_OffIsSilent verifies merged_workitems: off
+// produces no backstop output even when a linked branch merged.
+func TestIntegration_FreshMergedBackstop_OffIsSilent(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	campaignPath, projectDir, _ := setupFreshCampaignWithSubmodule(t, tc, "backstop-off")
+
+	createBackstopWorkitem(t, tc, campaignPath, "myfeature")
+	require.NoError(t, tc.WriteFile(campaignPath+"/projects/worktrees/test-project/myfeature/.keep", ""))
+	out, err := tc.RunCampInDir(campaignPath, "workitem", "link", "design-myfeature", "--worktree", "projects/worktrees/test-project/myfeature")
+	require.NoError(t, err, "link: %s", out)
+	require.NoError(t, tc.WriteFile(campaignPath+"/.campaign/settings/fresh.yaml", "merged_workitems: \"off\"\n"))
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+campaignPath+" && git add -A && git commit -q -m 'off mode'")
+	require.NoError(t, err)
+
+	mergeAndPruneBranch(t, tc, projectDir, "myfeature")
+
+	output, err := tc.RunCampInDir(campaignPath, "fresh", "test-project", "--no-push")
+	require.NoError(t, err, "fresh: %s", output)
+	assert.NotContains(t, output, "had a merged branch", "off mode must produce no backstop output:\n%s", output)
+}
+
+// TestIntegration_FreshMergedBackstop_NoMatchIsSilent verifies a pruned branch
+// with neither a worktree link nor a WI-tagged commit produces no report.
+func TestIntegration_FreshMergedBackstop_NoMatchIsSilent(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	campaignPath, projectDir, _ := setupFreshCampaignWithSubmodule(t, tc, "backstop-nomatch")
+
+	createBackstopWorkitem(t, tc, campaignPath, "unrelated")
+	require.NoError(t, tc.WriteFile(campaignPath+"/.campaign/settings/fresh.yaml", "merged_workitems: \"report\"\n"))
+	_, _, err := tc.ExecCommand("sh", "-c", "cd "+campaignPath+" && git add -A && git commit -q -m 'report mode'")
+	require.NoError(t, err)
+
+	mergeAndPruneBranch(t, tc, projectDir, "some-branch")
+
+	output, err := tc.RunCampInDir(campaignPath, "fresh", "test-project", "--no-push")
+	require.NoError(t, err, "fresh: %s", output)
+	assert.NotContains(t, output, "had a merged branch", "a branch matching no workitem must not be reported:\n%s", output)
+}


### PR DESCRIPTION
## Summary

Adds the tier-2 merged-branch backstop mapping and open-work guard, wired into
`camp fresh` in report mode. When fresh prunes a merged branch, it maps that
branch back to a still-active workitem and (in `report` mode) prints the exact
`camp workitem promote` command, inference-tier evidence that **never
auto-promotes** (FESTIVAL_RULES rule 2). First sequence of phase 002 of the
`workitem-festival-lifecycle` festival (WF0001), spec `WI-75d77f` doc 03 tier 2.

## Stack

Base: **`fest/wf0001-p1s3-fresh-integration`** (PR #495), the phase-001 tip.
Full chain: #493 <- #494 <- #495 <- this. Rebase onto `main` if the parents merge
first. Sequence 02 (interactive prompt + `merged_branch` evidence promote + pty)
stacks on this.

## What changed

- `internal/commands/fresh/merged_backstop.go` (new): `MapMergedBranchesToWorkitems`
  maps a project's just-pruned branches to still-active workitems via two signals
 , worktree-scope links (branch name == worktree dir basename) and `WI-` commit
  tags on commits newly reachable from the default branch since a pre-pull
  `beforeSHA` (the pruned ref is gone by the time prune returns). `HasOpenWork`
  suppresses a match while the workitem has other open linked scopes (a second
  project/repo, or a still-existing other worktree), the WI-ca06e1 multi-PR
  shape. `reportMergedBackstop` prints the promote command for surviving matches.
- `internal/config/settings.go`: `merged_workitems` (`prompt|report|off`) +
  `ResolveFreshMergedWorkitems`. **Default is `off` in this sequence** (dormant
  until the interactive prompt exists); sequence 02 changes the default to the
  spec value `prompt` and adds the TTY prompt + `merged_branch` evidence.
- `internal/commands/fresh/fresh.go` + `batch.go`: capture `beforeSHA` before the
  pull, thread `campRoot`/`mergedWorkitems`, call the backstop once per project
  after prune (per-project, unlike phase 1's campaign-wide sweep, because pruned
  branches are only known inside a project's own prune pass).
- Exported `WorkitemAliases` (was `workitemAliases`) in `commits.go` for reuse.

## Design notes (called out)

- **Ledger fast-path** (doc-06 open question): uses a direct `beforeSHA..HEAD`
  git-log scan + `commitkit.ParseTag`, not the `camp workitem commits` ledger
  path, because the tag lives in the commit message regardless of ledger
  completeness (a raw `git commit` never reaches the ledger). The phase-3 spike
  may later prove the ledger path reusable as an optimization; follow-up, not a
  blocker.
- **Sequence boundary**: the `merged_workitems` setting + report wiring live here
  (not deferred to sequence 02 as the task doc split them) so the mapping is
  CLI-reachable and containerized-integration-testable in this PR; a standalone
  sequence-01 PR could otherwise neither compile the `beforeSHA` capture nor
  test the mapping. Detailed in the sequence results doc.
- **Guard scope-path**: `MergedBackstopMatch.ScopePath` carries the matched
  scope so the guard doesn't count the just-merged worktree itself as open work.

## Test output

Unit (pure mapping/guard):

```
--- PASS: TestWorkitemRefsFromSubjects
--- PASS: TestMatchWorktreeLinkBranch
--- PASS: TestRefMatchesActiveItem
--- PASS: TestActiveBackstopItems_ExcludesFestivalsAndIntents
--- PASS: TestHasOpenWork  (single-scope, WI-ca06e1 two-project suppressed, stale worktree, existing worktree)
```

Integration (end-to-end via `camp fresh`):

```
--- PASS: TestIntegration_FreshMergedBackstop_WorktreeLinkReported
--- PASS: TestIntegration_FreshMergedBackstop_OffIsSilent
--- PASS: TestIntegration_FreshMergedBackstop_NoMatchIsSilent
```

The worktree-link test asserts the report prints `camp workitem promote
design-myfeature --target completed` and the workitem is not moved. `just lint`
clean (0 issues, both ratchets); `just test unit` 3702/3702.

Not merged by an agent; left for review.

