### PR TITLE
feat(fresh): interactive tier-2 merged-branch prompt flow (WF0001 P2/S2)

### DIFF
--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -370,7 +370,7 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 		// this project's just-deleted branches and the pre-pull beforeSHA. This
 		// is inference evidence, so it only reports (or, in a later sequence,
 		// prompts), never auto-promotes.
-		reportMergedBackstop(ctx, os.Stdout, backstopRoot(ctx, opts), path,
+		handleMergedBackstop(ctx, os.Stdout, backstopRoot(ctx, opts), path,
 			deletedNames, beforeSHA, opts.mergedWorkitems)
 	}
 

--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -368,10 +368,12 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 
 		// Tier-2 merged-branch backstop: per project, right after prune, using
 		// this project's just-deleted branches and the pre-pull beforeSHA. This
-		// is inference evidence, so it only reports (or, in a later sequence,
-		// prompts), never auto-promotes.
+		// is inference evidence, so it only reports or prompts, never
+		// auto-promotes. A dry-run downgrades to report-only (mirroring the
+		// tier-1 sweep) so it never reaches the prompt/promote path, matching
+		// the tier-1 dry-run contract.
 		handleMergedBackstop(ctx, os.Stdout, backstopRoot(ctx, opts), path,
-			deletedNames, beforeSHA, opts.mergedWorkitems)
+			deletedNames, beforeSHA, resolveBackstopMode(opts.mergedWorkitems, opts.dryRun))
 	}
 
 	// Step 4: Create branch (optional)

--- a/internal/commands/fresh/merged_backstop.go
+++ b/internal/commands/fresh/merged_backstop.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/charmbracelet/huh"
+
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	wkcmd "github.com/Obedience-Corp/camp/internal/commands/workitem"
 	"github.com/Obedience-Corp/camp/internal/config"
@@ -15,6 +17,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/git"
 	"github.com/Obedience-Corp/camp/internal/paths"
 	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/Obedience-Corp/camp/internal/ui/theme"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
 	"github.com/Obedience-Corp/camp/pkg/commitkit"
@@ -34,14 +37,15 @@ func backstopRoot(ctx context.Context, opts freshOptions) string {
 	return root
 }
 
-// reportMergedBackstop runs the tier-2 merged-branch backstop for one project
-// after prune: map the just-deleted branches to still-active workitems, drop
-// matches with open work elsewhere, and (mode "report", and "prompt" until the
-// interactive prompt lands in 02_fresh_prompt_flow) print the exact promote
-// command for each surviving match. Mode "off" or an empty root/branch list is
-// a no-op. Inference evidence never auto-promotes; a failure is reported to out
-// and never fails the fresh cycle.
-func reportMergedBackstop(ctx context.Context, out io.Writer, root, projectPath string, deletedBranches []string, beforeSHA, mode string) {
+// handleMergedBackstop runs the tier-2 merged-branch backstop for one project
+// after prune: map the just-deleted branches to still-active workitems and drop
+// matches with open work elsewhere. On a TTY with mode "prompt" it asks per
+// surviving match and promotes (with EvidenceMergedBranch) on accept; in mode
+// "report", or "prompt" on a non-TTY (agents never get an auto path), it prints
+// the exact promote command. Mode "off" or an empty root/branch list is a no-op.
+// Inference evidence never auto-promotes; a failure is reported to out and never
+// fails the fresh cycle.
+func handleMergedBackstop(ctx context.Context, out io.Writer, root, projectPath string, deletedBranches []string, beforeSHA, mode string) {
 	if mode == "off" || root == "" || len(deletedBranches) == 0 {
 		return
 	}
@@ -58,13 +62,95 @@ func reportMergedBackstop(ctx context.Context, out io.Writer, root, projectPath 
 		_, _ = fmt.Fprintf(out, "%s merged-branch backstop skipped: %v\n", ui.WarningIcon(), err)
 		return
 	}
+
+	proj := projectRelPath(root, projectPath)
+	surviving := make([]MergedBackstopMatch, 0, len(matches))
 	for _, m := range matches {
-		if HasOpenWork(root, registry, m.Workitem, m.ScopePath, projectRelPath(root, projectPath)) {
+		if HasOpenWork(root, registry, m.Workitem, m.ScopePath, proj) {
 			continue
 		}
+		surviving = append(surviving, m)
+	}
+	if len(surviving) == 0 {
+		return
+	}
+
+	// FESTIVAL_RULES rule 2: inference evidence prompts on a TTY or reports; it
+	// never acts on its own. A non-TTY (agent) run always reports.
+	if mode == "prompt" && ui.IsTerminal() {
+		promoteMergedMatches(ctx, out, root, surviving)
+		return
+	}
+	for _, m := range surviving {
 		_, _ = fmt.Fprintf(out, "%s workitem %s had a merged branch and is still active; promote when done:\n    %s\n",
 			ui.InfoIcon(), backstopWorkitemLabel(m.Workitem), backstopPromoteCommand(m.Workitem))
 	}
+}
+
+// promoteMergedMatches asks per surviving match and promotes on accept. A
+// declined item offers a "skip all remaining" shortcut. A cancelled prompt
+// (Ctrl+C) is treated as skip. Every accept goes through the shared promote path
+// with EvidenceMergedBranch; nothing is promoted without an explicit accept.
+func promoteMergedMatches(ctx context.Context, out io.Writer, root string, matches []MergedBackstopMatch) {
+	skipAll := false
+	for i, m := range matches {
+		if skipAll {
+			break
+		}
+		promote, err := confirmMergedPromote(ctx, backstopPromptTitle(m))
+		if err != nil {
+			_, _ = fmt.Fprintf(out, "%s prompt failed for %s: %v\n", ui.WarningIcon(), backstopWorkitemLabel(m.Workitem), err)
+			continue
+		}
+		if promote {
+			if perr := wkcmd.PromoteMergedWorkitem(ctx, out, root, m.Workitem, wkitem.EvidenceMergedBranch); perr != nil {
+				_, _ = fmt.Fprintf(out, "%s promote failed for %s: %v\n", ui.WarningIcon(), backstopWorkitemLabel(m.Workitem), perr)
+			} else {
+				_, _ = fmt.Fprintf(out, "%s promoted %s to completed\n", ui.SuccessIcon(), backstopWorkitemLabel(m.Workitem))
+			}
+			continue
+		}
+		if i < len(matches)-1 {
+			if all, aerr := confirmMergedSkipAll(ctx, len(matches)-i-1); aerr == nil && all {
+				skipAll = true
+			}
+		}
+	}
+}
+
+// backstopPromptTitle is the per-item prompt question.
+func backstopPromptTitle(m MergedBackstopMatch) string {
+	return fmt.Sprintf("Workitem %s had a merged branch and is still active. Promote to completed?", backstopWorkitemLabel(m.Workitem))
+}
+
+func confirmMergedPromote(ctx context.Context, title string) (bool, error) {
+	var promote bool
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewConfirm().Title(title).Affirmative("Promote").Negative("Skip").Value(&promote),
+	))
+	if err := theme.RunForm(ctx, form); err != nil {
+		if theme.IsCancelled(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return promote, nil
+}
+
+func confirmMergedSkipAll(ctx context.Context, remaining int) (bool, error) {
+	var skipAll bool
+	form := huh.NewForm(huh.NewGroup(
+		huh.NewConfirm().
+			Title(fmt.Sprintf("Skip all %d remaining without asking?", remaining)).
+			Affirmative("Skip all").Negative("Keep asking").Value(&skipAll),
+	))
+	if err := theme.RunForm(ctx, form); err != nil {
+		if theme.IsCancelled(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return skipAll, nil
 }
 
 // backstopPromoteCommand renders the exact, copy-pasteable promote command using

--- a/internal/commands/fresh/merged_backstop.go
+++ b/internal/commands/fresh/merged_backstop.go
@@ -45,11 +45,30 @@ func backstopRoot(ctx context.Context, opts freshOptions) string {
 // the exact promote command. Mode "off" or an empty root/branch list is a no-op.
 // Inference evidence never auto-promotes; a failure is reported to out and never
 // fails the fresh cycle.
+// resolveBackstopMode downgrades a dry-run to report-only so a dry-run never
+// reaches the prompt/promote path (mirroring the tier-1 sweep's dry-run
+// contract): the user still sees WHAT would be prompted, but nothing mutates.
+// "off" stays off; "report" stays report.
+func resolveBackstopMode(configured string, dryRun bool) string {
+	if dryRun && configured != "off" {
+		return "report"
+	}
+	return configured
+}
+
 func handleMergedBackstop(ctx context.Context, out io.Writer, root, projectPath string, deletedBranches []string, beforeSHA, mode string) {
 	if mode == "off" || root == "" || len(deletedBranches) == 0 {
 		return
 	}
-	matches, err := MapMergedBranchesToWorkitems(ctx, root, projectPath, deletedBranches, beforeSHA)
+	// Load the campaign config once, keyed by the threaded root, so a non-root
+	// cwd with a threaded campRoot cannot resolve a different campaign than the
+	// mapping and promote paths operate on.
+	cfg, err := config.LoadCampaignConfig(ctx, root)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "%s merged-branch backstop skipped: %v\n", ui.WarningIcon(), err)
+		return
+	}
+	matches, err := MapMergedBranchesToWorkitems(ctx, cfg, root, projectPath, deletedBranches, beforeSHA)
 	if err != nil {
 		_, _ = fmt.Fprintf(out, "%s merged-branch backstop skipped: %v\n", ui.WarningIcon(), err)
 		return
@@ -78,7 +97,7 @@ func handleMergedBackstop(ctx context.Context, out io.Writer, root, projectPath 
 	// FESTIVAL_RULES rule 2: inference evidence prompts on a TTY or reports; it
 	// never acts on its own. A non-TTY (agent) run always reports.
 	if mode == "prompt" && ui.IsTerminal() {
-		promoteMergedMatches(ctx, out, root, surviving)
+		promoteMergedMatches(ctx, out, cfg, root, surviving)
 		return
 	}
 	for _, m := range surviving {
@@ -91,7 +110,7 @@ func handleMergedBackstop(ctx context.Context, out io.Writer, root, projectPath 
 // declined item offers a "skip all remaining" shortcut. A cancelled prompt
 // (Ctrl+C) is treated as skip. Every accept goes through the shared promote path
 // with EvidenceMergedBranch; nothing is promoted without an explicit accept.
-func promoteMergedMatches(ctx context.Context, out io.Writer, root string, matches []MergedBackstopMatch) {
+func promoteMergedMatches(ctx context.Context, out io.Writer, cfg *config.CampaignConfig, root string, matches []MergedBackstopMatch) {
 	skipAll := false
 	for i, m := range matches {
 		if skipAll {
@@ -103,7 +122,7 @@ func promoteMergedMatches(ctx context.Context, out io.Writer, root string, match
 			continue
 		}
 		if promote {
-			if perr := wkcmd.PromoteMergedWorkitem(ctx, out, root, m.Workitem, wkitem.EvidenceMergedBranch); perr != nil {
+			if perr := wkcmd.PromoteMergedWorkitem(ctx, out, cfg, root, m.Workitem, wkitem.EvidenceMergedBranch); perr != nil {
 				_, _ = fmt.Fprintf(out, "%s promote failed for %s: %v\n", ui.WarningIcon(), backstopWorkitemLabel(m.Workitem), perr)
 			} else {
 				_, _ = fmt.Fprintf(out, "%s promoted %s to completed\n", ui.SuccessIcon(), backstopWorkitemLabel(m.Workitem))
@@ -212,7 +231,7 @@ type MergedBackstopMatch struct {
 // doc 03's scope boundary. Pure of prompt/UI concerns; git calls are I/O so it
 // takes ctx. Returns no error on "no matches": absence of evidence is not an
 // error.
-func MapMergedBranchesToWorkitems(ctx context.Context, root, projectPath string, prunedBranches []string, beforeSHA string) ([]MergedBackstopMatch, error) {
+func MapMergedBranchesToWorkitems(ctx context.Context, cfg *config.CampaignConfig, root, projectPath string, prunedBranches []string, beforeSHA string) ([]MergedBackstopMatch, error) {
 	if len(prunedBranches) == 0 {
 		return nil, nil
 	}
@@ -220,10 +239,6 @@ func MapMergedBranchesToWorkitems(ctx context.Context, root, projectPath string,
 	registry, err := links.Load(ctx, root)
 	if err != nil {
 		return nil, camperrors.Wrap(err, "load link registry")
-	}
-	cfg, _, err := config.LoadCampaignConfigFromCwd(ctx)
-	if err != nil {
-		return nil, camperrors.Wrap(err, "load campaign config")
 	}
 	items, err := wkitem.Discover(ctx, root, paths.NewResolverFromConfig(root, cfg))
 	if err != nil {

--- a/internal/commands/fresh/merged_backstop_test.go
+++ b/internal/commands/fresh/merged_backstop_test.go
@@ -3,12 +3,32 @@ package fresh
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
 	"github.com/Obedience-Corp/camp/pkg/commitkit"
 )
+
+func TestBackstopPromoteCommand(t *testing.T) {
+	got := backstopPromoteCommand(wkitem.WorkItem{StableID: "design-foo-01", Key: "design:workflow/design/foo"})
+	if want := "camp workitem promote design-foo-01 --target completed"; got != want {
+		t.Errorf("promote command = %q, want %q", got, want)
+	}
+	// Falls back to Key when there is no StableID.
+	got = backstopPromoteCommand(wkitem.WorkItem{Key: "design:foo"})
+	if want := "camp workitem promote design:foo --target completed"; got != want {
+		t.Errorf("promote command (no StableID) = %q, want %q", got, want)
+	}
+}
+
+func TestBackstopPromptTitle(t *testing.T) {
+	title := backstopPromptTitle(MergedBackstopMatch{Workitem: wkitem.WorkItem{Title: "Fix login", StableID: "design-x"}})
+	if !strings.Contains(title, "Fix login") || !strings.Contains(title, "Promote to completed?") {
+		t.Errorf("prompt title missing label or question: %q", title)
+	}
+}
 
 func taggedSubject(ref, msg string) string {
 	return commitkit.PrependContextTagsFullNamed("obey-campaign", "8deed8b4", "", "", ref, msg)

--- a/internal/commands/fresh/merged_backstop_test.go
+++ b/internal/commands/fresh/merged_backstop_test.go
@@ -23,6 +23,35 @@ func TestBackstopPromoteCommand(t *testing.T) {
 	}
 }
 
+// TestResolveBackstopMode_DryRunNeverPrompts is the regression guard for the
+// dry-run mutation bug: a dry-run must downgrade to "report", so the prompt path
+// (the only path that can reach PromoteMergedWorkitem) is unreachable on a
+// dry-run regardless of TTY.
+func TestResolveBackstopMode_DryRunNeverPrompts(t *testing.T) {
+	tests := []struct {
+		configured string
+		dryRun     bool
+		want       string
+	}{
+		{"prompt", true, "report"},  // the bug: dry-run must NOT prompt/promote
+		{"prompt", false, "prompt"}, // normal run keeps prompt
+		{"report", true, "report"},
+		{"off", true, "off"}, // dry-run does not resurrect an opted-out backstop
+		{"off", false, "off"},
+	}
+	for _, tc := range tests {
+		if got := resolveBackstopMode(tc.configured, tc.dryRun); got != tc.want {
+			t.Errorf("resolveBackstopMode(%q, %v) = %q, want %q", tc.configured, tc.dryRun, got, tc.want)
+		}
+	}
+	// The prompt path is the sole caller of PromoteMergedWorkitem, and it only
+	// runs when the resolved mode is "prompt"; since dry-run never yields
+	// "prompt", a dry-run can never reach a promote.
+	if resolveBackstopMode("prompt", true) == "prompt" {
+		t.Fatal("dry-run resolved to prompt: a dry-run could reach PromoteMergedWorkitem")
+	}
+}
+
 func TestBackstopPromptTitle(t *testing.T) {
 	title := backstopPromptTitle(MergedBackstopMatch{Workitem: wkitem.WorkItem{Title: "Fix login", StableID: "design-x"}})
 	if !strings.Contains(title, "Fix login") || !strings.Contains(title, "Promote to completed?") {

--- a/internal/commands/workitem/sweep.go
+++ b/internal/commands/workitem/sweep.go
@@ -321,6 +321,28 @@ func RunFreshSweep(ctx context.Context, out io.Writer, mode string) error {
 	return nil
 }
 
+// PromoteMergedWorkitem promotes wi to its local dungeon/completed with the
+// given evidence, reusing the sweep's per-item move + audit + ledger + commit
+// path. Used by camp fresh's tier-2 merged-branch backstop when a human accepts
+// the prompt; evidence is EvidenceMergedBranch. Never called on inference
+// evidence without an explicit human accept upstream.
+func PromoteMergedWorkitem(ctx context.Context, out io.Writer, root string, wi wkitem.WorkItem, evidence string) error {
+	cfg, _, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	var result workitemSweepResult
+	item := sweepOne(ctx, cmd, cfg, root, wkitem.SweepCandidate{Item: wi, Reason: evidence}, &result)
+	if item.Error != "" {
+		return camperrors.New(item.Error)
+	}
+	return nil
+}
+
 func emitSweepResult(cmd *cobra.Command, result *workitemSweepResult, jsonOut bool) error {
 	if jsonOut {
 		enc := json.NewEncoder(cmd.OutOrStdout())

--- a/internal/commands/workitem/sweep.go
+++ b/internal/commands/workitem/sweep.go
@@ -325,12 +325,10 @@ func RunFreshSweep(ctx context.Context, out io.Writer, mode string) error {
 // given evidence, reusing the sweep's per-item move + audit + ledger + commit
 // path. Used by camp fresh's tier-2 merged-branch backstop when a human accepts
 // the prompt; evidence is EvidenceMergedBranch. Never called on inference
-// evidence without an explicit human accept upstream.
-func PromoteMergedWorkitem(ctx context.Context, out io.Writer, root string, wi wkitem.WorkItem, evidence string) error {
-	cfg, _, err := config.LoadCampaignConfigFromCwd(ctx)
-	if err != nil {
-		return camperrors.Wrap(err, "not in a campaign directory")
-	}
+// evidence without an explicit human accept upstream. Takes the already-resolved
+// cfg and root from the caller so a non-root cwd cannot resolve a different
+// campaign than the one fresh is operating on.
+func PromoteMergedWorkitem(ctx context.Context, out io.Writer, cfg *config.CampaignConfig, root string, wi wkitem.WorkItem, evidence string) error {
 	cmd := &cobra.Command{}
 	cmd.SetContext(ctx)
 	cmd.SetOut(out)

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -345,17 +345,17 @@ func (c *FreshConfig) ResolveFreshCompletedRuns() string {
 	}
 }
 
-// ResolveFreshMergedWorkitems resolves merged_workitems using the global config.
-// Global only, same shape as CompletedRuns. This sequence (tier-2 mapping +
-// report) defaults to "off" until the interactive prompt lands in
-// 02_fresh_prompt_flow, which changes the default to the spec value "prompt".
-// Any unrecognized value falls back to the default rather than failing.
+// ResolveFreshMergedWorkitems resolves merged_workitems using the global config
+// or the spec default ("prompt"). Global only, same shape as CompletedRuns. Any
+// unrecognized/empty value falls back to the default rather than failing.
+// "prompt" asks on a TTY and falls back to report on a non-TTY (agents never get
+// an auto path); "report" prints the exact promote command; "off" does nothing.
 func (c *FreshConfig) ResolveFreshMergedWorkitems() string {
 	switch c.MergedWorkitems {
 	case "prompt", "report", "off":
 		return c.MergedWorkitems
 	default:
-		return "off"
+		return "prompt"
 	}
 }
 

--- a/internal/config/settings_fresh_test.go
+++ b/internal/config/settings_fresh_test.go
@@ -132,3 +132,25 @@ func TestResolveFreshCompletedRuns(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveFreshMergedWorkitems(t *testing.T) {
+	tests := []struct {
+		name string
+		set  string
+		want string
+	}{
+		{"empty defaults to prompt", "", "prompt"},
+		{"typo defaults to prompt", "prmpt", "prompt"},
+		{"explicit prompt", "prompt", "prompt"},
+		{"explicit report", "report", "report"},
+		{"explicit off", "off", "off"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &FreshConfig{MergedWorkitems: tc.set}
+			if got := c.ResolveFreshMergedWorkitems(); got != tc.want {
+				t.Errorf("ResolveFreshMergedWorkitems() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/workitem/sweep.go
+++ b/internal/workitem/sweep.go
@@ -11,6 +11,11 @@ import (
 // (tier 2) prompts or reports and never reuses this constant.
 const EvidenceWorkflowRunCompleted = "workflow_run_completed"
 
+// EvidenceMergedBranch names the tier-2 (inference) evidence kind: a branch or
+// worktree linked to the workitem merged. It never auto-promotes; a human
+// accepting a camp fresh prompt is the only path that records it.
+const EvidenceMergedBranch = "merged_branch"
+
 // runStatusCompleted is the RunStatus value the localrun replay assigns after a
 // workflow_run_completed event (internal/workitem/localrun.go).
 const runStatusCompleted = "completed"

--- a/tests/integration/fresh_merged_backstop_test.go
+++ b/tests/integration/fresh_merged_backstop_test.go
@@ -76,6 +76,34 @@ func TestIntegration_FreshMergedBackstop_WorktreeLinkReported(t *testing.T) {
 	assert.True(t, stays, "report mode must not move the workitem")
 }
 
+// TestIntegration_FreshMergedBackstop_PromptFallsBackToReportOnNonTTY verifies
+// the default (prompt) reports rather than prompts/promotes on a non-TTY run,
+// so agents never get an auto-promote path (FESTIVAL_RULES rule 2).
+func TestIntegration_FreshMergedBackstop_PromptFallsBackToReportOnNonTTY(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	campaignPath, projectDir, _ := setupFreshCampaignWithSubmodule(t, tc, "backstop-prompt-nontty")
+
+	createBackstopWorkitem(t, tc, campaignPath, "myfeature")
+	require.NoError(t, tc.WriteFile(campaignPath+"/projects/worktrees/test-project/myfeature/.keep", ""))
+	out, err := tc.RunCampInDir(campaignPath, "workitem", "link", "design-myfeature", "--worktree", "projects/worktrees/test-project/myfeature")
+	require.NoError(t, err, "link: %s", out)
+	// No fresh.yaml written: merged_workitems defaults to "prompt".
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+campaignPath+" && git add -A && git commit -q -m 'link'")
+	require.NoError(t, err)
+
+	mergeAndPruneBranch(t, tc, projectDir, "myfeature")
+
+	output, err := tc.RunCampInDir(campaignPath, "fresh", "test-project", "--no-push")
+	require.NoError(t, err, "fresh: %s", output)
+
+	assert.Contains(t, output, "promote when done", "default prompt must fall back to report on a non-TTY:\n%s", output)
+	assert.Contains(t, output, "camp workitem promote design-myfeature --target completed")
+	stays, err := tc.CheckDirExists(campaignPath + "/workflow/design/myfeature")
+	require.NoError(t, err)
+	assert.True(t, stays, "non-TTY prompt must not auto-promote")
+}
+
 // TestIntegration_FreshMergedBackstop_OffIsSilent verifies merged_workitems: off
 // produces no backstop output even when a linked branch merged.
 func TestIntegration_FreshMergedBackstop_OffIsSilent(t *testing.T) {

--- a/tests/integration/fresh_merged_backstop_test.go
+++ b/tests/integration/fresh_merged_backstop_test.go
@@ -104,6 +104,33 @@ func TestIntegration_FreshMergedBackstop_PromptFallsBackToReportOnNonTTY(t *test
 	assert.True(t, stays, "non-TTY prompt must not auto-promote")
 }
 
+// TestIntegration_FreshMergedBackstop_DryRunNoMutation verifies a --dry-run run
+// reports the match but never promotes: the workitem is not moved. Combined with
+// the resolveBackstopMode unit test (which proves a dry-run downgrades prompt to
+// report even on a TTY), this covers the dry-run mutation guard.
+func TestIntegration_FreshMergedBackstop_DryRunNoMutation(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	campaignPath, projectDir, _ := setupFreshCampaignWithSubmodule(t, tc, "backstop-dryrun")
+
+	createBackstopWorkitem(t, tc, campaignPath, "myfeature")
+	require.NoError(t, tc.WriteFile(campaignPath+"/projects/worktrees/test-project/myfeature/.keep", ""))
+	out, err := tc.RunCampInDir(campaignPath, "workitem", "link", "design-myfeature", "--worktree", "projects/worktrees/test-project/myfeature")
+	require.NoError(t, err, "link: %s", out)
+	// Default merged_workitems is "prompt"; a dry-run must downgrade to report.
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+campaignPath+" && git add -A && git commit -q -m 'link'")
+	require.NoError(t, err)
+
+	mergeAndPruneBranch(t, tc, projectDir, "myfeature")
+
+	output, err := tc.RunCampInDir(campaignPath, "fresh", "test-project", "--no-push", "--dry-run")
+	require.NoError(t, err, "fresh --dry-run: %s", output)
+
+	stays, err := tc.CheckDirExists(campaignPath + "/workflow/design/myfeature")
+	require.NoError(t, err)
+	assert.True(t, stays, "dry-run must never promote (workitem must remain in place)")
+}
+
 // TestIntegration_FreshMergedBackstop_OffIsSilent verifies merged_workitems: off
 // produces no backstop output even when a linked branch merged.
 func TestIntegration_FreshMergedBackstop_OffIsSilent(t *testing.T) {


### PR DESCRIPTION
## Summary

Completes the tier-2 merged-branch backstop with the interactive prompt: on a
TTY, `camp fresh` now asks per surviving match whether to promote the workitem to
completed, and promotes on accept with `merged_branch` evidence. Final sequence
of phase 002 of the `workitem-festival-lifecycle` festival (WF0001), spec
`WI-75d77f` doc 03 tier 2 + doc 05 phase 2 item 3.

## Stack

Base: **`fest/wf0001-p2s1-branch-mapping`** (PR #496), which now carries the
merged #495 fixes and the #496 guard fix. Full chain: #493 <- #494 <- #495 <-
#496 <- this. Rebase onto `main` if the parents merge first.

## What changed

- `internal/config/settings.go`: `ResolveFreshMergedWorkitems` default flipped
  from `off` to the spec value **`prompt`**.
- `internal/workitem/sweep.go`: `EvidenceMergedBranch = "merged_branch"`.
- `internal/commands/workitem/sweep.go`: exported `PromoteMergedWorkitem`, which
  promotes a workitem to its local dungeon/completed with a given evidence by
  reusing the sweep's `sweepOne` move+audit+ledger+commit path (no parallel
  move implementation).
- `internal/commands/fresh/merged_backstop.go`: `handleMergedBackstop` (renamed
  from `reportMergedBackstop`) branches on mode + TTY. On `prompt` + TTY it runs
  the two-`huh.NewConfirm` flow (`Promote`/`Skip` per item, then a `Skip all N
  remaining?` follow-up when an item is skipped) and promotes on accept. `report`,
  and `prompt` on a non-TTY, still print the exact `camp workitem promote`
  command, **agents never get an auto path** (FESTIVAL_RULES rule 2).

## Evidence-tier invariant

The only caller of `PromoteMergedWorkitem` is `promoteMergedMatches`, and only
inside `if promote` after a human answers `confirmMergedPromote`. Non-TTY runs
never reach it. Cancelling a prompt (Ctrl+C) is treated as skip.

## Test output

Unit + non-TTY integration:

```
--- PASS: TestBackstopPromoteCommand
--- PASS: TestBackstopPromptTitle
--- PASS: TestResolveFreshMergedWorkitems
--- PASS: TestIntegration_FreshMergedBackstop_PromptFallsBackToReportOnNonTTY
--- PASS: TestIntegration_FreshMergedBackstop_WorktreeLinkReported / _OffIsSilent / _NoMatchIsSilent
```

**Mandatory pty verification** (real pyte `screen.display`, harness in scratch,
against a throwaway host fixture with a merged+pruned worktree-linked branch):

Per-item prompt renders and `y` (Promote) actually promotes:
```
┃ Workitem Fix login had a merged branch and is still active. Promote to completed?
┃                                 Promote     Skip
←/→ toggle • enter submit • y Promote • n Skip
```
```
✓ promoted Fix login to completed
```
Write verified: `workflow/design/myfeature` is gone (moved to the dungeon) after
the accept, not just rendered.

Skip-all follow-up confirm (two-item fixture, skipped the first):
```
┃ Skip all 1 remaining without asking?
┃      Skip all     Keep asking
←/→ toggle • enter submit • y Skip all • n Keep asking
```

`just gate` green (0 lint issues, both ratchets; gate-fast 3751/3751).

Not merged by an agent; left for review.

