### PR TITLE
fix(machine): stop diagnose probes from healing the ControlMaster socket they report

### DIFF
--- a/cmd/camp/machine.go
+++ b/cmd/camp/machine.go
@@ -331,8 +331,11 @@ type machineDiagnoseRow struct {
 // best-effort: any failure (unreachable, camp missing, ancient binary without
 // `version --json`) reports as an empty version, never a diagnose error —
 // diagnose must keep working against exactly the broken machines it exists for.
+// The hop is reuse-only: under ControlMaster=auto this probe would unlink a
+// stale socket and open a fresh master, so diagnose would heal the exact stale
+// state it is reporting and the follow-up --reset would find nothing to clear.
 func probeRemoteCampVersion(ctx context.Context, m *machines.Machine) (versionStr, commit string) {
-	out, err := remote.RunCampCommand(ctx, m, "version --json")
+	out, err := remote.RunCampCommandReuseOnly(ctx, m, "version --json")
 	if err != nil {
 		return "", ""
 	}

--- a/cmd/camp/machine_tui.go
+++ b/cmd/camp/machine_tui.go
@@ -369,6 +369,11 @@ func (m *machineTUIModel) scanTailnet(intoOverlay bool, gen uint64) tea.Cmd {
 // round trip answers everything the screen needs: whether ssh authenticates,
 // whether the host resolves, and whether camp is installed over there, which
 // is the failure a socket state can never show.
+//
+// The hop is reuse-only so testing a machine cannot rewrite the socket column
+// next to it: probeSockets runs once at Init and no healthMsg refreshes it, so
+// a ControlMaster=auto probe would silently replace a stale socket while the
+// screen kept displaying "stale" for the rest of the session.
 func (m *machineTUIModel) testMachine(target machines.Machine) tea.Cmd {
 	ctx := m.ctx
 	return func() tea.Msg {
@@ -378,7 +383,7 @@ func (m *machineTUIModel) testMachine(target machines.Machine) tea.Cmd {
 				Detail: "camp cannot hop to a password-auth machine yet",
 			}}
 		}
-		out, err := remote.RunCampCommand(ctx, &target, "--version")
+		out, err := remote.RunCampCommandReuseOnly(ctx, &target, "--version")
 		if err != nil {
 			return healthMsg{id: target.ID, health: machineHealth{
 				State:  healthUnreachable,

--- a/internal/remote/ssh.go
+++ b/internal/remote/ssh.go
@@ -159,14 +159,39 @@ func expandTilde(path string) string {
 // Conceptually mirrors the app's ssh_base_args (connection.rs:241-255); host
 // details beyond the machine's identity_file are left to the user's ~/.ssh/config.
 func Opts(m *machines.Machine) []string {
-	opts := []string{
+	opts := append(baseOpts(),
+		"-o", "ControlMaster=auto",
+		"-o", "ControlPath="+controlPath(m),
+		"-o", "ControlPersist=30s",
+	)
+	return append(opts, authArgs(m)...)
+}
+
+// OptsReuseOnly returns ssh options for a hop that must not change m's
+// ControlMaster socket. ControlMaster=no still reuses a live master when one
+// exists (one auth, no extra handshake), but it never opens a master, and —
+// unlike ControlMaster=auto — never unlinks a stale socket to replace it with a
+// fresh one. That last part is why this exists: any surface that reports socket
+// state must hop this way, or its own probe heals the stale socket it is
+// reporting, and the operator is told to reset a socket that no longer exists.
+// ControlPersist is omitted because nothing here creates a master to persist,
+// and the path comes from ControlSocketPath (not controlPath) so a read-only
+// diagnostic does not create ~/.obey/ssh-ctl as a side effect.
+func OptsReuseOnly(m *machines.Machine) []string {
+	opts := append(baseOpts(),
+		"-o", "ControlMaster=no",
+		"-o", "ControlPath="+ControlSocketPath(m),
+	)
+	return append(opts, authArgs(m)...)
+}
+
+// baseOpts returns the ssh options shared by every camp hop, excluding the
+// ControlMaster settings (which differ by hop kind) and auth args.
+func baseOpts() []string {
+	return []string{
 		"-o", "StrictHostKeyChecking=accept-new",
 		"-o", "ConnectTimeout=8",
-		"-o", "ControlMaster=auto",
-		"-o", "ControlPath=" + controlPath(m),
-		"-o", "ControlPersist=30s",
 	}
-	return append(opts, authArgs(m)...)
 }
 
 // controlDir is ~/.obey/ssh-ctl, the directory holding one ControlMaster socket
@@ -532,11 +557,23 @@ func remoteCampBinary() string {
 // bash/zsh because POSIX guarantees /bin/sh exists; the user's actual login
 // shell is whatever their own account is configured to run.
 func RunCampCommand(ctx context.Context, m *machines.Machine, args string) ([]byte, error) {
+	return runCampCommand(ctx, m, args, Opts(m))
+}
+
+// RunCampCommandReuseOnly is RunCampCommand for callers that also report m's
+// ControlMaster state (`camp machine diagnose`, the machine screen). It hops
+// with OptsReuseOnly so the probe cannot create or replace the very socket
+// being reported alongside it.
+func RunCampCommandReuseOnly(ctx context.Context, m *machines.Machine, args string) ([]byte, error) {
+	return runCampCommand(ctx, m, args, OptsReuseOnly(m))
+}
+
+func runCampCommand(ctx context.Context, m *machines.Machine, args string, opts []string) ([]byte, error) {
 	if err := EnsureKeyAuth(m); err != nil {
 		return nil, err
 	}
 	binary := remoteCampBinary()
-	out, err := Run(ctx, Target(m), Opts(m), campRemoteCommandLine(binary, args))
+	out, err := Run(ctx, Target(m), opts, campRemoteCommandLine(binary, args))
 	if err != nil {
 		return nil, campNotFoundHint(err, m, binary)
 	}

--- a/internal/remote/ssh_test.go
+++ b/internal/remote/ssh_test.go
@@ -183,6 +183,42 @@ func TestOptsControlMaster(t *testing.T) {
 	}
 }
 
+// TestOptsReuseOnlyDoesNotDisturbSocket pins the property that makes diagnose
+// truthful: the probe hop reuses a master but never creates or replaces one.
+// ControlMaster=auto would unlink a stale socket and open a fresh master, which
+// is exactly the state diagnose exists to report.
+func TestOptsReuseOnlyDoesNotDisturbSocket(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	m := &machines.Machine{ID: "devbox", Host: "devbox.ts.net", AuthMethod: machines.AuthSSHAgent}
+	opts := OptsReuseOnly(m)
+
+	if !slices.Contains(opts, "ControlMaster=no") {
+		t.Errorf("OptsReuseOnly must set ControlMaster=no, got: %v", opts)
+	}
+	for _, banned := range []string{"ControlMaster=auto", "ControlPersist=30s"} {
+		if slices.Contains(opts, banned) {
+			t.Errorf("OptsReuseOnly must not set %q (it would open a master): %v", banned, opts)
+		}
+	}
+	// The ControlPath still points at the per-machine socket, so a live master
+	// is reused rather than paying a second handshake.
+	var ctlPath string
+	for _, o := range opts {
+		if after, ok := strings.CutPrefix(o, "ControlPath="); ok {
+			ctlPath = after
+		}
+	}
+	if !strings.HasSuffix(ctlPath, "/ssh-ctl/devbox.sock") {
+		t.Errorf("ControlPath not the per-machine socket: %q", ctlPath)
+	}
+	// A read-only diagnostic must not create the socket dir just by building opts.
+	if _, err := os.Stat(filepath.Join(home, ".obey", "ssh-ctl")); !os.IsNotExist(err) {
+		t.Errorf("OptsReuseOnly created the socket dir (stat err = %v); it must be side-effect free", err)
+	}
+}
+
 func TestEnsureKeyAuth(t *testing.T) {
 	if err := EnsureKeyAuth(&machines.Machine{ID: "dev", AuthMethod: machines.AuthSSHAgent}); err != nil {
 		t.Errorf("agent auth rejected: %v", err)


### PR DESCRIPTION
## Summary

`TestMachineDiagnoseControlMasterLifecycle` has been failing since #492. It is not a flaky test: #492 added a per-machine camp version probe to `camp machine diagnose`, and that probe hops with `ControlMaster=auto`. Against a **stale** ControlPath, OpenSSH unlinks the socket and opens a fresh master, so diagnose healed the exact stale state it was reporting.

The operator recovery path the feature exists for was broken:

| Operator step | Reported | Socket after the call |
| --- | --- | --- |
| `camp machine diagnose self` | `stale` | probe replaced it, now **live** |
| `camp machine diagnose self --reset` | `live`, `reset:false` | nothing to clear |

See a stale socket, run `--reset`, clear nothing. And in a single `--reset` run the order is check(stale) -> probe(opens fresh master) -> reset, so `--reset` tore down a healthy connection it had just created.

History confirms the direction: the test landed green in 2f7f8a85; `probeRemoteCampVersion` arrived later in aae497f6 (#492).

## Root cause, verified

Reproduced in an Alpine 3.21 container against a real loopback sshd. After SIGKILLing the master (socket left behind, `-O check` refused), one normal `ControlMaster=auto` hop:

```
before: stale
hop:    PROBE_OK
after:  socket present / check: Master running (pid=46)   <-- healed
```

## Fix

`OptsReuseOnly` / `RunCampCommandReuseOnly` in `internal/remote/ssh.go`, built on `ControlMaster=no`: reuse a live master when one exists, but never open one and never unlink a stale socket. Verified against all three socket states in the same container:

- **none** -> probe works, no socket created
- **live** -> reuses the existing master (same pid, no extra handshake, one-auth property kept)
- **stale** -> probe works, socket stays stale

`switch`/`ResolveRoot` keep `ControlMaster=auto`, so the one-auth resolve-plus-hop property is untouched and `remote_switch_ssh_test.go`'s single-socket assertion still holds.

`ControlPath` comes from `ControlSocketPath` rather than `controlPath`, so a read-only diagnostic no longer creates `~/.obey/ssh-ctl` as a side effect.

## Second bug found while tracing

The machine TUI's `testMachine` had the same defect, and it is worse there: `probeSockets` runs only at `Init` and no `healthMsg` refreshes it, so testing a machine silently replaced a stale socket while the screen kept displaying `stale` for the rest of the session. Same one-line call change.

## Verification

- `TestMachineDiagnoseControlMasterLifecycle` — **PASS** (was FAIL)
- Full integration suite — **552 passed, 0 failed, 8 skipped**, exit 0 (was 551 passed / 1 failed)
- `just gate-fast` — vet + lint clean across stable/dev/integration profiles, 3733 unit tests pass
- New `TestOptsReuseOnlyDoesNotDisturbSocket` pins the no-create / no-unlink / no-side-effect-dir properties

## Tradeoffs

A probe against a machine with **no** live master now pays its own handshake instead of leaving a warm master behind for a subsequent hop. That is the intended cost: a surface that reports socket state must not mutate it. Operators who want a warm master get one from `camp switch`, which is unchanged.
