### PR TITLE
fix(sweep): key tier-1 eligibility on the latest completed run (sweep never fired)

### DIFF
--- a/internal/commands/workitem/sweep.go
+++ b/internal/commands/workitem/sweep.go
@@ -56,15 +56,15 @@ type workitemSweepResult struct {
 }
 
 type workitemSweepResultItem struct {
-	ID          string `json:"id,omitempty"`
-	Ref         string `json:"ref,omitempty"`
-	Type        string `json:"type"`
-	From        string `json:"from"`
-	To          string `json:"to,omitempty"`
-	Evidence    string `json:"evidence,omitempty"`
-	ActiveRunID string `json:"active_run_id,omitempty"`
-	Committed   bool   `json:"committed"`
-	Error       string `json:"error,omitempty"`
+	ID        string `json:"id,omitempty"`
+	Ref       string `json:"ref,omitempty"`
+	Type      string `json:"type"`
+	From      string `json:"from"`
+	To        string `json:"to,omitempty"`
+	Evidence  string `json:"evidence,omitempty"`
+	RunID     string `json:"run_id,omitempty"`
+	Committed bool   `json:"committed"`
+	Error     string `json:"error,omitempty"`
 }
 
 func newSweepCommand() *cobra.Command {
@@ -164,9 +164,9 @@ func runWorkitemSweep(cmd *cobra.Command, opts sweepOptions) error {
 // move landing.
 func sweepOne(ctx context.Context, cmd *cobra.Command, cfg *config.CampaignConfig, root string, cand wkitem.SweepCandidate, result *workitemSweepResult) workitemSweepResultItem {
 	entry := workitemSweepResultItem{
-		Type:        string(cand.Item.WorkflowType),
-		Evidence:    cand.Reason,
-		ActiveRunID: cand.ActiveRunID,
+		Type:     string(cand.Item.WorkflowType),
+		Evidence: cand.Reason,
+		RunID:    cand.RunID,
 	}
 
 	loc, err := resolveSweepLocation(root, cand.Item)
@@ -209,7 +209,7 @@ func sweepOne(ctx context.Context, cmd *cobra.Command, cfg *config.CampaignConfi
 			ledger.WithWhy("sweep promote to completed"),
 			ledger.WithPayload(map[string]any{
 				"target": "completed", "from": entry.From, "to": entry.To,
-				"evidence": cand.Reason, "active_run_id": cand.ActiveRunID,
+				"evidence": cand.Reason, "run_id": cand.RunID,
 			}))
 
 	destPaths := append([]string{moveRes.TargetPath}, moveRes.CreatedFiles...)
@@ -239,11 +239,11 @@ func sweepOne(ctx context.Context, cmd *cobra.Command, cfg *config.CampaignConfi
 func emitSweepPlan(cmd *cobra.Command, root string, candidates []wkitem.SweepCandidate, result *workitemSweepResult, jsonOut bool) error {
 	for _, cand := range candidates {
 		entry := workitemSweepResultItem{
-			ID:          cand.Item.Key,
-			Type:        string(cand.Item.WorkflowType),
-			From:        filepath.ToSlash(cand.Item.RelativePath),
-			Evidence:    cand.Reason,
-			ActiveRunID: cand.ActiveRunID,
+			ID:       cand.Item.Key,
+			Type:     string(cand.Item.WorkflowType),
+			From:     filepath.ToSlash(cand.Item.RelativePath),
+			Evidence: cand.Reason,
+			RunID:    cand.RunID,
 		}
 		if loc, err := resolveSweepLocation(root, cand.Item); err == nil {
 			entry.To = filepath.ToSlash(dungeoncmd.RelFromRoot(root, filepath.Join(loc.DungeonPath, "completed")))

--- a/internal/commands/workitem/sweep_test.go
+++ b/internal/commands/workitem/sweep_test.go
@@ -86,8 +86,8 @@ func TestSweepPlanEnvelopeShape(t *testing.T) {
 			WorkflowType: wkitem.WorkflowTypeDesign,
 			RelativePath: "workflow/design/alpha",
 		},
-		Reason:      wkitem.EvidenceWorkflowRunCompleted,
-		ActiveRunID: "run-007",
+		Reason: wkitem.EvidenceWorkflowRunCompleted,
+		RunID:  "run-007",
 	}}
 
 	var buf bytes.Buffer
@@ -102,7 +102,7 @@ func TestSweepPlanEnvelopeShape(t *testing.T) {
 	raw := buf.String()
 	for _, key := range []string{
 		`"schema_version"`, `"dry_run"`, `"candidates"`, `"items"`,
-		`"id"`, `"type"`, `"from"`, `"to"`, `"evidence"`, `"active_run_id"`,
+		`"id"`, `"type"`, `"from"`, `"to"`, `"evidence"`, `"run_id"`,
 	} {
 		if !bytes.Contains(buf.Bytes(), []byte(key)) {
 			t.Errorf("envelope missing key %s in output:\n%s", key, raw)
@@ -124,7 +124,7 @@ func TestSweepPlanEnvelopeShape(t *testing.T) {
 	}
 	it := decoded.Items[0]
 	if it.Type != "design" || it.From != "workflow/design/alpha" ||
-		it.Evidence != wkitem.EvidenceWorkflowRunCompleted || it.ActiveRunID != "run-007" {
+		it.Evidence != wkitem.EvidenceWorkflowRunCompleted || it.RunID != "run-007" {
 		t.Errorf("item did not map from candidate: %+v", it)
 	}
 	if it.To == "" {

--- a/internal/workitem/discover_workflow_docs.go
+++ b/internal/workitem/discover_workflow_docs.go
@@ -126,6 +126,8 @@ func buildWorkflowDirItem(ctx context.Context, campaignRoot, dirPath string, wfT
 		item.WorkflowMeta.TotalSteps = run.TotalSteps
 		item.WorkflowMeta.CompletedSteps = run.CompletedSteps
 		item.WorkflowMeta.RunStatus = run.RunStatus
+		item.WorkflowMeta.LatestRunID = run.LatestRunID
+		item.WorkflowMeta.LatestRunStatus = run.LatestRunStatus
 		item.WorkflowMeta.Blocked = run.Blocked
 		item.WorkflowMeta.DocHashChanged = run.DocHashChanged
 	}

--- a/internal/workitem/localrun.go
+++ b/internal/workitem/localrun.go
@@ -38,21 +38,40 @@ const (
 // Camp and fest are separate Go modules; this is a thin duplicate of the
 // fields camp needs from fest's localstore. Fest is the source of truth.
 type LocalRunProgress struct {
-	WorkflowID     string
-	ActiveRunID    string
-	RunStatus      string
-	CurrentStep    int
-	TotalSteps     int
-	CompletedSteps int
-	Blocked        bool
-	DocHashChanged bool
+	WorkflowID  string
+	ActiveRunID string
+	RunStatus   string
+	// LatestRunID / LatestRunStatus surface the most recent run's terminal
+	// state when there is no active run. fest clears active_run_id from
+	// workflow.yaml the instant a run completes (see fest localstore), so a
+	// genuinely completed standalone workflow has an empty ActiveRunID and its
+	// completed run survives only in the manifest's runs[] index. The status is
+	// verified by replaying that run's events (events are authoritative), with
+	// the manifest used only as the index of which run is latest.
+	LatestRunID     string
+	LatestRunStatus string
+	CurrentStep     int
+	TotalSteps      int
+	CompletedSteps  int
+	Blocked         bool
+	DocHashChanged  bool
 }
 
 type localWorkflowManifest struct {
-	WorkflowID  string `yaml:"workflow_id"`
-	ActiveRunID string `yaml:"active_run_id"`
-	DocHash     string `yaml:"doc_hash"`
-	DocPath     string `yaml:"doc_path"`
+	WorkflowID  string          `yaml:"workflow_id"`
+	ActiveRunID string          `yaml:"active_run_id"`
+	DocHash     string          `yaml:"doc_hash"`
+	DocPath     string          `yaml:"doc_path"`
+	Runs        []localRunIndex `yaml:"runs"`
+}
+
+// localRunIndex is one entry in workflow.yaml's runs[] list: the index fest
+// keeps of every run, newest appended last. Used only to find WHICH run is
+// latest; its cached status is not trusted (the run's events are replayed).
+type localRunIndex struct {
+	RunID   string `yaml:"run_id"`
+	Status  string `yaml:"status"`
+	EndedAt string `yaml:"ended_at"`
 }
 
 type localRunManifest struct {
@@ -103,24 +122,32 @@ func LoadLocalRunFS(ctx context.Context, fsys fs.FS, base string) (*LocalRunProg
 	}
 
 	if mf.ActiveRunID != "" {
-		runDir := filepath.Join(base, ".workflow", "runs", mf.ActiveRunID)
-		runYAML, runErr := fs.ReadFile(fsys, filepath.Join(runDir, "run.yaml"))
-		if runErr == nil {
-			var rm localRunManifest
-			if uErr := yaml.Unmarshal(runYAML, &rm); uErr != nil {
-				return nil, camperrors.Wrapf(uErr, "parsing %s/run.yaml", runDir)
-			}
-			replayed, repErr := replayLocalRunFSE(ctx, fsys, filepath.Join(runDir, "progress_events.jsonl"), rm)
-			if repErr != nil {
-				return nil, repErr
-			}
-			out.RunStatus = replayed.Status
-			out.CurrentStep = replayed.Summary.CurrentStep
-			out.CompletedSteps = replayed.Summary.CompletedSteps
-			out.Blocked = replayed.Summary.Blocked
+		rm, ok, rErr := readReplayedRun(ctx, fsys, base, mf.ActiveRunID)
+		if rErr != nil {
+			return nil, rErr
+		}
+		if ok {
+			out.RunStatus = rm.Status
+			out.CurrentStep = rm.Summary.CurrentStep
+			out.CompletedSteps = rm.Summary.CompletedSteps
+			out.Blocked = rm.Summary.Blocked
 			out.TotalSteps = rm.Summary.TotalSteps
-		} else if !errors.Is(runErr, fs.ErrNotExist) {
-			return nil, camperrors.Wrapf(runErr, "reading run manifest")
+		}
+	} else if latest := latestRunID(mf.Runs); latest != "" {
+		// No active run: fest cleared active_run_id on completion, so surface the
+		// latest run's terminal state from the replayed events (not the manifest
+		// cache). This is the signal the tier-1 sweep keys eligibility on.
+		rm, ok, rErr := readReplayedRun(ctx, fsys, base, latest)
+		if rErr != nil {
+			return nil, rErr
+		}
+		if ok {
+			out.LatestRunID = latest
+			out.LatestRunStatus = rm.Status
+			out.CurrentStep = rm.Summary.CurrentStep
+			out.CompletedSteps = rm.Summary.CompletedSteps
+			out.Blocked = rm.Summary.Blocked
+			out.TotalSteps = rm.Summary.TotalSteps
 		}
 	}
 
@@ -132,6 +159,48 @@ func LoadLocalRunFS(ctx context.Context, fsys fs.FS, base string) (*LocalRunProg
 	}
 
 	return out, nil
+}
+
+// readReplayedRun reads runs/<runID>/run.yaml and replays its events, returning
+// the authoritative state. ok is false when the run directory has no run.yaml
+// (nothing to report), which is not an error.
+func readReplayedRun(ctx context.Context, fsys fs.FS, base, runID string) (localRunManifest, bool, error) {
+	runDir := filepath.Join(base, ".workflow", "runs", runID)
+	runYAML, runErr := fs.ReadFile(fsys, filepath.Join(runDir, "run.yaml"))
+	if errors.Is(runErr, fs.ErrNotExist) {
+		return localRunManifest{}, false, nil
+	}
+	if runErr != nil {
+		return localRunManifest{}, false, camperrors.Wrapf(runErr, "reading run manifest")
+	}
+	var rm localRunManifest
+	if uErr := yaml.Unmarshal(runYAML, &rm); uErr != nil {
+		return localRunManifest{}, false, camperrors.Wrapf(uErr, "parsing %s/run.yaml", runDir)
+	}
+	replayed, repErr := replayLocalRunFSE(ctx, fsys, filepath.Join(runDir, "progress_events.jsonl"), rm)
+	if repErr != nil {
+		return localRunManifest{}, false, repErr
+	}
+	// Replay does not carry TotalSteps; keep it from the run.yaml cache.
+	replayed.Summary.TotalSteps = rm.Summary.TotalSteps
+	return replayed, true, nil
+}
+
+// latestRunID picks the most recent run from the manifest's runs[] index: the
+// run with the newest ended_at, tie-broken by list order (fest appends newest
+// last). Returns "" when there are no runs. The chosen run's status is verified
+// by replay elsewhere; this only decides WHICH run is latest.
+func latestRunID(runs []localRunIndex) string {
+	latest, latestEnded := "", ""
+	for _, r := range runs {
+		if r.RunID == "" {
+			continue
+		}
+		if latest == "" || r.EndedAt >= latestEnded {
+			latest, latestEnded = r.RunID, r.EndedAt
+		}
+	}
+	return latest
 }
 
 func replayLocalRunFSE(ctx context.Context, fsys fs.FS, eventsPath string, cache localRunManifest) (localRunManifest, error) {

--- a/internal/workitem/localrun_fs_test.go
+++ b/internal/workitem/localrun_fs_test.go
@@ -323,3 +323,83 @@ func TestLoadLocalRun_HostWrapperSmoke(t *testing.T) {
 		t.Errorf("expected WorkflowID=wf-host via host wrapper, got %+v", got)
 	}
 }
+
+// TestLatestRunID covers the runs[] index selection that decides WHICH run the
+// post-completion path replays, and therefore which items the tier-1 sweep
+// considers eligible. LoadLocalRunFS's fixtures only ever carry one completed
+// run, so the multi-entry ordering rules are pinned directly here.
+//
+// The string compare on ended_at is safe because fest writes RFC 3339 UTC
+// (Zulu) timestamps, which sort lexicographically in time order.
+func TestLatestRunID(t *testing.T) {
+	tests := []struct {
+		name string
+		runs []localRunIndex
+		want string
+	}{
+		{
+			name: "no runs",
+			runs: nil,
+			want: "",
+		},
+		{
+			name: "single run",
+			runs: []localRunIndex{{RunID: "run-001", EndedAt: "2026-07-24T19:00:00Z"}},
+			want: "run-001",
+		},
+		{
+			name: "newest ended_at wins regardless of list order",
+			runs: []localRunIndex{
+				{RunID: "run-003", EndedAt: "2026-07-24T21:00:00Z"},
+				{RunID: "run-001", EndedAt: "2026-07-24T19:00:00Z"},
+				{RunID: "run-002", EndedAt: "2026-07-24T20:00:00Z"},
+			},
+			want: "run-003",
+		},
+		{
+			name: "tie on ended_at breaks to the last list entry",
+			runs: []localRunIndex{
+				{RunID: "run-001", EndedAt: "2026-07-24T19:00:00Z"},
+				{RunID: "run-002", EndedAt: "2026-07-24T19:00:00Z"},
+			},
+			want: "run-002",
+		},
+		{
+			name: "all ended_at empty falls back to the last entry (fest appends newest last)",
+			runs: []localRunIndex{
+				{RunID: "run-001"},
+				{RunID: "run-002"},
+			},
+			want: "run-002",
+		},
+		{
+			name: "entries with no run_id are skipped",
+			runs: []localRunIndex{
+				{RunID: "", EndedAt: "2026-07-24T23:00:00Z"},
+				{RunID: "run-001", EndedAt: "2026-07-24T19:00:00Z"},
+			},
+			want: "run-001",
+		},
+		{
+			name: "every entry missing run_id yields no latest",
+			runs: []localRunIndex{{EndedAt: "2026-07-24T19:00:00Z"}, {}},
+			want: "",
+		},
+		{
+			name: "a dated run beats an undated one written after it",
+			runs: []localRunIndex{
+				{RunID: "run-001", EndedAt: "2026-07-24T19:00:00Z"},
+				{RunID: "run-002"},
+			},
+			want: "run-001",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := latestRunID(tt.runs); got != tt.want {
+				t.Errorf("latestRunID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/workitem/model.go
+++ b/internal/workitem/model.go
@@ -72,14 +72,19 @@ type ProjectRef struct {
 // WorkItemWorkflow carries local runtime progress when .workflow/ is present
 // (sourced from the fest local runtime, populated by camp's localrun loader).
 type WorkItemWorkflow struct {
-	WorkflowID     string `json:"workflow_id,omitempty"`
-	ActiveRunID    string `json:"active_run_id,omitempty"`
-	CurrentStep    int    `json:"current_step"`
-	TotalSteps     int    `json:"total_steps"`
-	CompletedSteps int    `json:"completed_steps"`
-	RunStatus      string `json:"run_status,omitempty"`
-	Blocked        bool   `json:"blocked"`
-	DocHashChanged bool   `json:"doc_hash_changed"`
+	WorkflowID  string `json:"workflow_id,omitempty"`
+	ActiveRunID string `json:"active_run_id,omitempty"`
+	// LatestRunID / LatestRunStatus report the most recent run's terminal state
+	// when there is no active run (fest clears active_run_id on completion).
+	// Additive JSON fields (omitempty); existing readers ignore them.
+	LatestRunID     string `json:"latest_run_id,omitempty"`
+	LatestRunStatus string `json:"latest_run_status,omitempty"`
+	CurrentStep     int    `json:"current_step"`
+	TotalSteps      int    `json:"total_steps"`
+	CompletedSteps  int    `json:"completed_steps"`
+	RunStatus       string `json:"run_status,omitempty"`
+	Blocked         bool   `json:"blocked"`
+	DocHashChanged  bool   `json:"doc_hash_changed"`
 }
 
 // AbsPath resolves the item's absolute path from the campaign root.

--- a/internal/workitem/sweep.go
+++ b/internal/workitem/sweep.go
@@ -20,9 +20,12 @@ const runStatusCompleted = "completed"
 // EvidenceWorkflowRunCompleted. ActiveRunID is the run whose completion made
 // the item eligible, carried through for the promote event's evidence payload.
 type SweepCandidate struct {
-	Item        WorkItem
-	Reason      string
-	ActiveRunID string
+	Item   WorkItem
+	Reason string
+	// RunID is the completed run whose terminal state made the item eligible.
+	// Because fest clears active_run_id on completion, this is the workitem's
+	// latest run (not an active run), carried through for the promote evidence.
+	RunID string
 }
 
 // PlanSweep returns the subset of items eligible for tier-1 (loop-completion)
@@ -37,19 +40,28 @@ func PlanSweep(items []WorkItem) []SweepCandidate {
 		if !sweepEligibleType(item.WorkflowType) {
 			continue
 		}
-		if item.WorkflowMeta == nil || item.WorkflowMeta.RunStatus != runStatusCompleted {
+		wf := item.WorkflowMeta
+		if wf == nil {
 			continue
 		}
-		if item.WorkflowMeta.ActiveRunID == "" {
+		// Eligible iff the LATEST run reached completed AND no newer run is
+		// active. fest clears active_run_id on completion, so a genuinely
+		// completed workitem has ActiveRunID == "" and LatestRunStatus ==
+		// "completed"; a run started afterward repoints ActiveRunID and makes it
+		// ineligible again (the multi-run caveat).
+		if wf.ActiveRunID != "" {
+			continue
+		}
+		if wf.LatestRunStatus != runStatusCompleted || wf.LatestRunID == "" {
 			continue
 		}
 		if inDungeonPath(item.RelativePath) {
 			continue
 		}
 		out = append(out, SweepCandidate{
-			Item:        item,
-			Reason:      EvidenceWorkflowRunCompleted,
-			ActiveRunID: item.WorkflowMeta.ActiveRunID,
+			Item:   item,
+			Reason: EvidenceWorkflowRunCompleted,
+			RunID:  wf.LatestRunID,
 		})
 	}
 	return out

--- a/internal/workitem/sweep_test.go
+++ b/internal/workitem/sweep_test.go
@@ -6,10 +6,12 @@ import (
 	"testing/fstest"
 )
 
-// completedMeta builds a WorkItemWorkflow in the completed state with a
-// non-empty active run id, the shape a real loop-completion produces.
+// completedMeta builds a WorkItemWorkflow in the REAL post-completion shape fest
+// produces: active_run_id is CLEARED on completion, and the completed run
+// survives as the latest run. (The previous fixtures set active_run_id at the
+// completed run, a state fest never emits; that bug is what this PR fixes.)
 func completedMeta() *WorkItemWorkflow {
-	return &WorkItemWorkflow{ActiveRunID: "run-001", RunStatus: "completed"}
+	return &WorkItemWorkflow{LatestRunStatus: "completed", LatestRunID: "run-001"}
 }
 
 func TestPlanSweep_Eligibility(t *testing.T) {
@@ -47,16 +49,16 @@ func TestPlanSweep_Eligibility(t *testing.T) {
 			wantIncluded: false,
 		},
 		{
-			name: "run status active is excluded",
+			name: "a newer run is active is excluded (multi-run: latest completed but a new run started)",
 			item: WorkItem{
 				WorkflowType: WorkflowTypeDesign,
 				RelativePath: "workflow/design/foo",
-				WorkflowMeta: &WorkItemWorkflow{ActiveRunID: "run-001", RunStatus: "active"},
+				WorkflowMeta: &WorkItemWorkflow{ActiveRunID: "run-002", RunStatus: "active", LatestRunStatus: "completed", LatestRunID: "run-001"},
 			},
 			wantIncluded: false,
 		},
 		{
-			name: "run status blocked is excluded",
+			name: "an active (blocked) run is excluded",
 			item: WorkItem{
 				WorkflowType: WorkflowTypeExplore,
 				RelativePath: "workflow/explore/foo",
@@ -65,20 +67,20 @@ func TestPlanSweep_Eligibility(t *testing.T) {
 			wantIncluded: false,
 		},
 		{
-			name: "run status abandoned is excluded",
+			name: "latest run abandoned is excluded (not completed)",
 			item: WorkItem{
 				WorkflowType: WorkflowTypeDesign,
 				RelativePath: "workflow/design/foo",
-				WorkflowMeta: &WorkItemWorkflow{ActiveRunID: "run-001", RunStatus: "abandoned"},
+				WorkflowMeta: &WorkItemWorkflow{LatestRunStatus: "abandoned", LatestRunID: "run-001"},
 			},
 			wantIncluded: false,
 		},
 		{
-			name: "completed with empty active run id is excluded as malformed",
+			name: "latest completed but empty latest run id is excluded as malformed",
 			item: WorkItem{
 				WorkflowType: WorkflowTypeDesign,
 				RelativePath: "workflow/design/foo",
-				WorkflowMeta: &WorkItemWorkflow{ActiveRunID: "", RunStatus: "completed"},
+				WorkflowMeta: &WorkItemWorkflow{LatestRunStatus: "completed", LatestRunID: ""},
 			},
 			wantIncluded: false,
 		},
@@ -147,7 +149,7 @@ func TestPlanSweep_CandidatePayload(t *testing.T) {
 	item := WorkItem{
 		WorkflowType: WorkflowTypeDesign,
 		RelativePath: "workflow/design/foo",
-		WorkflowMeta: &WorkItemWorkflow{ActiveRunID: "run-042", RunStatus: "completed"},
+		WorkflowMeta: &WorkItemWorkflow{LatestRunStatus: "completed", LatestRunID: "run-042"},
 	}
 	got := PlanSweep([]WorkItem{item})
 	if len(got) != 1 {
@@ -156,8 +158,8 @@ func TestPlanSweep_CandidatePayload(t *testing.T) {
 	if got[0].Reason != EvidenceWorkflowRunCompleted {
 		t.Errorf("Reason = %q, want %q", got[0].Reason, EvidenceWorkflowRunCompleted)
 	}
-	if got[0].ActiveRunID != "run-042" {
-		t.Errorf("ActiveRunID = %q, want run-042", got[0].ActiveRunID)
+	if got[0].RunID != "run-042" {
+		t.Errorf("RunID = %q, want run-042", got[0].RunID)
 	}
 	if got[0].Item.RelativePath != item.RelativePath {
 		t.Errorf("Item.RelativePath = %q, want %q", got[0].Item.RelativePath, item.RelativePath)
@@ -168,7 +170,7 @@ func TestPlanSweep_MixedSliceReturnsOnlyEligible(t *testing.T) {
 	items := []WorkItem{
 		{WorkflowType: WorkflowTypeFestival, RelativePath: "festivals/active/x-FA0001", WorkflowMeta: completedMeta()},
 		{WorkflowType: WorkflowTypeDesign, RelativePath: "workflow/design/keep", WorkflowMeta: completedMeta()},
-		{WorkflowType: WorkflowTypeExplore, RelativePath: "workflow/explore/drop", WorkflowMeta: &WorkItemWorkflow{ActiveRunID: "run-001", RunStatus: "active"}},
+		{WorkflowType: WorkflowTypeExplore, RelativePath: "workflow/explore/drop", WorkflowMeta: &WorkItemWorkflow{ActiveRunID: "run-001", RunStatus: "active"}}, // a run is active -> excluded
 		{WorkflowType: WorkflowTypeExplore, RelativePath: "workflow/explore/keep2", WorkflowMeta: completedMeta()},
 	}
 	got := PlanSweep(items)
@@ -241,5 +243,64 @@ summary:
 	}
 	if cands := PlanSweep([]WorkItem{item}); len(cands) != 0 {
 		t.Errorf("expected multi-run item excluded (active run), got %d candidates", len(cands))
+	}
+}
+
+// TestLoadLocalRunFS_LatestRunWhenActiveCleared verifies the REAL post-completion
+// shape: fest clears active_run_id and the completed run survives in runs[].
+// LoadLocalRunFS must surface the latest run's terminal status (replayed from
+// its events), and PlanSweep must treat the item as eligible. This is the
+// scenario the previous fixtures never modeled (the bug this PR fixes).
+func TestLoadLocalRunFS_LatestRunWhenActiveCleared(t *testing.T) {
+	const base = "campaign-root"
+	fsys := fstest.MapFS{
+		// No active_run_id: fest cleared it on completion. The completed run is
+		// indexed in runs[].
+		base + "/.workflow/workflow.yaml": {Data: []byte(`workflow_id: wf-done
+runs:
+    - run_id: run-001
+      status: completed
+      ended_at: "2026-07-24T19:00:00Z"
+`)},
+		base + "/.workflow/runs/run-001/run.yaml": {Data: []byte(`status: completed
+summary:
+  total_steps: 2
+`)},
+		base + "/.workflow/runs/run-001/progress_events.jsonl": {Data: []byte(`{"event_type":"wf_step_start"}
+{"event_type":"wf_step_done"}
+{"event_type":"wf_step_start"}
+{"event_type":"wf_step_done"}
+{"event_type":"workflow_run_completed"}
+`)},
+	}
+
+	got, err := LoadLocalRunFS(context.Background(), fsys, base)
+	if err != nil {
+		t.Fatalf("LoadLocalRunFS: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected progress, got nil")
+	}
+	if got.ActiveRunID != "" {
+		t.Errorf("ActiveRunID = %q, want empty (fest cleared it on completion)", got.ActiveRunID)
+	}
+	if got.LatestRunID != "run-001" {
+		t.Errorf("LatestRunID = %q, want run-001", got.LatestRunID)
+	}
+	if got.LatestRunStatus != "completed" {
+		t.Errorf("LatestRunStatus = %q, want completed (replayed from events)", got.LatestRunStatus)
+	}
+
+	item := WorkItem{
+		WorkflowType: WorkflowTypeDesign,
+		RelativePath: "workflow/design/done",
+		WorkflowMeta: &WorkItemWorkflow{ActiveRunID: got.ActiveRunID, LatestRunID: got.LatestRunID, LatestRunStatus: got.LatestRunStatus},
+	}
+	cands := PlanSweep([]WorkItem{item})
+	if len(cands) != 1 {
+		t.Fatalf("expected the completed item eligible, got %d candidates", len(cands))
+	}
+	if cands[0].RunID != "run-001" {
+		t.Errorf("candidate RunID = %q, want run-001", cands[0].RunID)
 	}
 }

--- a/internal/workitem/tui/view.go
+++ b/internal/workitem/tui/view.go
@@ -542,7 +542,8 @@ func renderPreview(item workitem.WorkItem, width, height int) string {
 			previewLabelStyle.Render("stable id:"),
 			previewValueStyle.Render(truncate(item.StableID, maxValueWidth))))
 	}
-	if item.WorkflowMeta != nil && (item.WorkflowMeta.WorkflowID != "" || item.WorkflowMeta.TotalSteps > 0 || item.WorkflowMeta.RunStatus != "") {
+	if item.WorkflowMeta != nil && (item.WorkflowMeta.WorkflowID != "" || item.WorkflowMeta.TotalSteps > 0 ||
+		item.WorkflowMeta.RunStatus != "" || item.WorkflowMeta.LatestRunStatus != "") {
 		b.WriteString("\n")
 		b.WriteString(previewLabelStyle.Render("WORKFLOW"))
 		b.WriteString("\n")
@@ -559,8 +560,16 @@ func renderPreview(item workitem.WorkItem, width, height int) string {
 			}
 			b.WriteString(fmt.Sprintf("  progress  %s\n", previewValueStyle.Render(progress)))
 		}
-		if item.WorkflowMeta.RunStatus != "" {
-			b.WriteString(fmt.Sprintf("  status    %s\n", previewValueStyle.Render(item.WorkflowMeta.RunStatus)))
+		// RunStatus carries a live run's state; once fest clears active_run_id the
+		// terminal state lives in LatestRunStatus instead. The loader populates
+		// exactly one of the two, so falling back reports whichever applies —
+		// without it a completed workitem renders progress steps and no status.
+		status := item.WorkflowMeta.RunStatus
+		if status == "" {
+			status = item.WorkflowMeta.LatestRunStatus
+		}
+		if status != "" {
+			fmt.Fprintf(&b, "  status    %s\n", previewValueStyle.Render(status))
 		}
 		if item.WorkflowMeta.DocHashChanged {
 			b.WriteString(fmt.Sprintf("  %s\n", previewLabelStyle.Render("⚠ workflow doc changed since run started")))

--- a/internal/workitem/tui/view_preview_test.go
+++ b/internal/workitem/tui/view_preview_test.go
@@ -1,0 +1,61 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+// TestRenderPreviewWorkflowStatus drives the real preview renderer, not a
+// helper: after fest clears active_run_id the terminal state moves from
+// run_status to latest_run_status, and the preview must still show a status
+// line. Without the fallback a completed workitem rendered its progress steps
+// and no status at all.
+func TestRenderPreviewWorkflowStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		meta *workitem.WorkItemWorkflow
+		want string
+	}{
+		{
+			name: "active run reports run_status",
+			meta: &workitem.WorkItemWorkflow{
+				WorkflowID: "wf-1", ActiveRunID: "run-001", RunStatus: "active",
+				CurrentStep: 1, TotalSteps: 3,
+			},
+			want: "active",
+		},
+		{
+			name: "completed run reports latest_run_status once active is cleared",
+			meta: &workitem.WorkItemWorkflow{
+				WorkflowID: "wf-1", LatestRunID: "run-001", LatestRunStatus: "completed",
+				CurrentStep: 3, TotalSteps: 3,
+			},
+			want: "completed",
+		},
+		{
+			name: "latest_run_status alone still renders the workflow block",
+			meta: &workitem.WorkItemWorkflow{LatestRunStatus: "abandoned"},
+			want: "abandoned",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := renderPreview(workitem.WorkItem{
+				Key:          "workflow/design/sweep-me",
+				Title:        "sweep me",
+				RelativePath: "workflow/design/sweep-me",
+				WorkflowMeta: tt.meta,
+			}, 80, 24)
+
+			if !strings.Contains(out, "WORKFLOW") {
+				t.Fatalf("preview missing WORKFLOW block:\n%s", out)
+			}
+			if !strings.Contains(out, tt.want) {
+				t.Errorf("preview missing status %q:\n%s", tt.want, out)
+			}
+		})
+	}
+}

--- a/tests/integration/workitem_sweep_test.go
+++ b/tests/integration/workitem_sweep_test.go
@@ -16,14 +16,14 @@ import (
 // (internal/commands/workitem/sweep.go). Kept local so a schema change here is a
 // deliberate, reviewable edit.
 type sweepResultItem struct {
-	ID          string `json:"id"`
-	Type        string `json:"type"`
-	From        string `json:"from"`
-	To          string `json:"to"`
-	Evidence    string `json:"evidence"`
-	ActiveRunID string `json:"active_run_id"`
-	Committed   bool   `json:"committed"`
-	Error       string `json:"error"`
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	From      string `json:"from"`
+	To        string `json:"to"`
+	Evidence  string `json:"evidence"`
+	RunID     string `json:"run_id"`
+	Committed bool   `json:"committed"`
+	Error     string `json:"error"`
 }
 
 type sweepResult struct {
@@ -36,15 +36,19 @@ type sweepResult struct {
 	Items         []sweepResultItem `json:"items"`
 }
 
-// stampCompletedRun writes a fest-style .workflow/ runtime whose active run has
-// completed, making the workitem at <campaign>/workflow/<wkType>/<slug>
-// eligible for tier-1 sweep. Only the active run's events are replayed by camp's
-// localrun loader, so a single completed run is enough.
+// stampCompletedRun writes the REAL post-completion .workflow/ shape fest
+// produces: active_run_id is CLEARED and the completed run survives in the
+// manifest's runs[] index, its terminal status verifiable by replaying its
+// events. This makes the workitem at <campaign>/workflow/<wkType>/<slug>
+// eligible for tier-1 sweep. (Hand-written fixtures previously left active_run_id
+// pointed at the completed run, a state fest never emits; that is the bug this
+// PR fixes.)
 func stampCompletedRun(t *testing.T, tc *TestContainer, campaignPath, wkType, slug string) {
 	t.Helper()
 	base := campaignPath + "/workflow/" + wkType + "/" + slug + "/.workflow"
-	require.NoError(t, tc.WriteFile(base+"/workflow.yaml", "workflow_id: wf-"+slug+"\nactive_run_id: r1\n"))
-	require.NoError(t, tc.WriteFile(base+"/runs/r1/run.yaml", "status: active\nsummary:\n  total_steps: 1\n"))
+	require.NoError(t, tc.WriteFile(base+"/workflow.yaml",
+		"workflow_id: wf-"+slug+"\nruns:\n    - run_id: r1\n      status: completed\n      ended_at: \"2026-07-24T19:00:00Z\"\n"))
+	require.NoError(t, tc.WriteFile(base+"/runs/r1/run.yaml", "status: completed\nsummary:\n  total_steps: 1\n"))
 	require.NoError(t, tc.WriteFile(base+"/runs/r1/progress_events.jsonl",
 		`{"event_type":"workflow_run_started"}
 {"event_type":"wf_step_start"}
@@ -90,6 +94,47 @@ func runSweepJSON(t *testing.T, tc *TestContainer, path string, extraArgs ...str
 	return res
 }
 
+// TestIntegration_WorkitemSweep_EndToEndFestDrivenCompletion is the acceptance
+// bar for the latest-run eligibility fix: it drives the REAL fest binary to
+// complete a standalone loop (so active_run_id is genuinely cleared, the shape
+// hand-written fixtures never modeled), then asserts camp workitem sweep
+// actually promotes the completed workitem.
+func TestIntegration_WorkitemSweep_EndToEndFestDrivenCompletion(t *testing.T) {
+	if !festAvailable {
+		t.Skip("fest binary not available in container; skipping fest-driven e2e sweep test")
+	}
+	tc := GetSharedContainer(t)
+	path := setupDungeonCampaign(t, tc, "sweep-e2e-fest")
+	createSweepWorkitem(t, tc, path, "design", "e2e-feature")
+	wi := path + "/workflow/design/e2e-feature"
+
+	// Drive a real fest standalone loop (1 step) to completion.
+	_, _, err := tc.ExecCommand("sh", "-c",
+		"cd "+wi+" && fest create workflow e2e --steps '{\"title\":\"E2E\",\"steps\":[{\"name\":\"s1\",\"goal\":\"g1\"}]}'")
+	require.NoError(t, err)
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+wi+" && fest workflow advance")
+	require.NoError(t, err)
+
+	// Real post-completion shape: fest clears active_run_id on completion.
+	wf, err := tc.ReadFile(wi + "/.workflow/workflow.yaml")
+	require.NoError(t, err)
+	assert.NotContains(t, wf, "active_run_id:",
+		"fest must clear active_run_id on completion (the shape the sweep now keys on):\n%s", wf)
+
+	commitFixture(t, tc, path)
+
+	// The sweep must fire on the genuinely fest-completed workitem.
+	res := runSweepJSON(t, tc, path)
+	assert.Equal(t, 1, res.Swept, "a fest-completed workitem must be swept: %+v", res)
+	require.Len(t, res.Items, 1)
+	assert.Equal(t, "workflow_run_completed", res.Items[0].Evidence)
+	assert.NotEmpty(t, res.Items[0].RunID, "the completed run's id must be recorded as evidence")
+
+	exists, err := tc.CheckDirExists(wi)
+	require.NoError(t, err)
+	assert.False(t, exists, "swept item's source dir should be gone (moved to the dungeon)")
+}
+
 // Scenario 1: zero eligible items -> empty result, exit 0, no commit.
 func TestIntegration_WorkitemSweep_ZeroEligible(t *testing.T) {
 	tc := GetSharedContainer(t)
@@ -123,7 +168,7 @@ func TestIntegration_WorkitemSweep_SingleEligibleMovesAndCommits(t *testing.T) {
 	assert.Equal(t, 1, res.Swept)
 	assert.Equal(t, 0, res.Failed)
 	assert.Equal(t, "workflow_run_completed", res.Items[0].Evidence)
-	assert.Equal(t, "r1", res.Items[0].ActiveRunID)
+	assert.Equal(t, "r1", res.Items[0].RunID)
 	assert.True(t, res.Items[0].Committed)
 	assert.Contains(t, res.Items[0].To, "dungeon/completed")
 


### PR DESCRIPTION
## Summary

Fixes a correctness bug in the tier-1 workitem sweep (shipped in #493/#494): as
merged, `camp workitem sweep` never fires on a genuinely completed workitem. This
was found by spike B of the WF0001 verification-spikes sequence
(`003_FESTIVAL_RAIL/01_verification_spikes/results/spike-b-localrun-eligibility.md`).

## Root cause (verified anchors)

- fest clears `active_run_id` from `.workflow/workflow.yaml` the instant a run
  reaches a terminal event: `projects/fest/internal/workflow/localstore/store.go:321-322`
  (`if m.ActiveRunID == evt.RunID { m.ActiveRunID = "" }`, inside the
  `EventWorkflowRunCompleted`/`Abandoned` branch at `store.go:290`). The completed
  run survives only in the manifest's `runs[]` index with `status: completed`.
- camp's `LoadLocalRunFS` only reads the run referenced by `active_run_id`
  (`internal/workitem/localrun.go:105`, `if mf.ActiveRunID != ""`). Once it is
  cleared, the loader returns `RunStatus:""`, `ActiveRunID:""`, an empty
  workflow.
- The shipped `PlanSweep` keyed eligibility on `RunStatus == "completed" &&
  ActiveRunID != ""`. Real completed workitems have `RunStatus == "" &&
  ActiveRunID == ""`, so they were never eligible. The phase-1 fixtures hand-set
  `active_run_id` at the completed run, a state fest never emits, so the tests
  were green but the sweep never fired in production.

## Fix

- `internal/workitem/localrun.go`: when `active_run_id` is empty, surface the
  LATEST run from the manifest's `runs[]` index (newest by `ended_at`, tie-broken
  by list order) and verify its terminal status by REPLAYING that run's
  `progress_events.jsonl` (events stay authoritative; the manifest is only the
  index of which run is latest). New `LatestRunID` / `LatestRunStatus` on
  `LocalRunProgress`, and additive `latest_run_id` / `latest_run_status` (omitempty)
  on `WorkItemWorkflow`.
- `internal/workitem/sweep.go`: re-key `PlanSweep` to "the latest run reached
  completed AND no newer run is active (`active_run_id` empty)". Dropped the
  `ActiveRunID != ""` requirement. `SweepCandidate.RunID` (json `run_id`, renamed
  from `active_run_id` since it is no longer an active run) carries the completed
  run's id for the promote evidence. The multi-run caveat still holds: a new run
  repoints `active_run_id`, making the item ineligible again.
- Fixtures rewritten to the REAL post-completion shape (`active_run_id` cleared,
  `runs[]` terminal). Banner/report/promote layers needed no change (verified).

## Acceptance-bar test (drives real fest)

`TestIntegration_WorkitemSweep_EndToEndFestDrivenCompletion` drives the real
`fest` binary in the container: `fest create workflow` + `fest workflow advance`
to completion, asserts `active_run_id` is actually cleared in the on-disk
manifest, then runs `camp workitem sweep` and asserts the workitem is promoted
(source dir gone, `run_id` recorded). This is the exact end-to-end path that
would have failed before the fix.

```
--- PASS: TestIntegration_WorkitemSweep_EndToEndFestDrivenCompletion (4.29s)
```

All six `TestIntegration_WorkitemSweep_*` scenarios pass against the corrected
fixtures; unit tests include `TestLoadLocalRunFS_LatestRunWhenActiveCleared`.
`just gate` green: 0 lint issues, both ratchets clean.

## Notes

- Base `main`. Independent of the WF0001 stack (#495/#496/#497); this fixes the
  already-merged #493/#494 detection logic.
- `camp wi --json` gains additive `latest_run_id`/`latest_run_status`
  (omitempty). The `workitem-sweep/v1alpha1` per-item `active_run_id` field is
  renamed to `run_id` (the feature is fresh and the value is the completed, not
  active, run); called out here as a deliberate contract correction.

Not merged by an agent; left for review.

