### PR TITLE
test(fresh): align sweep fixtures with completed runs

### DIFF
--- a/tests/integration/fresh_workitem_sweep_test.go
+++ b/tests/integration/fresh_workitem_sweep_test.go
@@ -19,15 +19,7 @@ func addFreshEligibleWorkitem(t *testing.T, tc *TestContainer, campaignPath, slu
 	out, err := tc.RunCampInDir(campaignPath,
 		"workitem", "create", slug, "--type", "design", "--title", slug, "--id", "design-"+slug)
 	require.NoError(t, err, "workitem create: %s", out)
-	base := campaignPath + "/workflow/design/" + slug + "/.workflow"
-	require.NoError(t, tc.WriteFile(base+"/workflow.yaml", "workflow_id: wf-"+slug+"\nactive_run_id: r1\n"))
-	require.NoError(t, tc.WriteFile(base+"/runs/r1/run.yaml", "status: active\nsummary:\n  total_steps: 1\n"))
-	require.NoError(t, tc.WriteFile(base+"/runs/r1/progress_events.jsonl",
-		`{"event_type":"workflow_run_started"}
-{"event_type":"wf_step_start"}
-{"event_type":"wf_step_done"}
-{"event_type":"workflow_run_completed"}
-`))
+	stampCompletedRun(t, tc, campaignPath, "design", slug)
 	_, _, err = tc.ExecCommand("sh", "-c", "cd "+campaignPath+" && git add -A && git commit -q -m 'add eligible workitem'")
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

- align the fresh-sweep integration fixture with Fest's real post-completion workflow state
- reuse the shared `stampCompletedRun` helper so fresh and direct sweep tests exercise the same contract

## Root cause

The latest-run eligibility fix correctly requires a completed run in `workflow.yaml`'s `runs[]` index with no `active_run_id`. The fresh-sweep integration helper still synthesized the old impossible state: an active run whose event log ended in completion. As a result, all sweep-enabled fresh scenarios discovered zero eligible workitems.

## Impact

The four failing fresh-sweep integration scenarios now use the same completed-run shape Fest actually writes, while the `completed_runs: off` control remains unchanged.

## Validation

- `just test integration-run TestIntegration_FreshSweep` — 5/5 passed
- `just gate` — stable/dev builds, vet, lint, 3,756 dev-profile tests, and 3,711 stable-profile tests passed
- a subsequent full integration rerun was blocked before test execution when the Colima host socket became unavailable; the exact affected integration group had already passed in isolation
