### PR TITLE
test(integration): isolate Colima Docker transport

### DIFF
--- a/tests/integration/colima_transport_other_test.go
+++ b/tests/integration/colima_transport_other_test.go
@@ -1,0 +1,7 @@
+//go:build integration && !darwin && !linux
+
+package integration
+
+func startDedicatedColimaDockerTransport() (func(), error) {
+	return func() {}, nil
+}

--- a/tests/integration/colima_transport_policy_test.go
+++ b/tests/integration/colima_transport_policy_test.go
@@ -1,0 +1,61 @@
+//go:build integration && (darwin || linux)
+
+package integration
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestColimaSSHConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		dockerHost string
+		config     string
+		host       string
+		ok         bool
+	}{
+		{
+			name:       "default profile",
+			dockerHost: "unix:///Users/test/.colima/default/docker.sock",
+			config:     "/Users/test/.colima/_lima/colima/ssh.config",
+			host:       "lima-colima",
+			ok:         true,
+		},
+		{
+			name:       "legacy default socket",
+			dockerHost: "unix:///Users/test/.colima/docker.sock",
+			config:     "/Users/test/.colima/_lima/colima/ssh.config",
+			host:       "lima-colima",
+			ok:         true,
+		},
+		{
+			name:       "named profile",
+			dockerHost: "unix:///Users/test/.colima/ci/docker.sock",
+			config:     "/Users/test/.colima/_lima/colima-ci/ssh.config",
+			host:       "lima-colima-ci",
+			ok:         true,
+		},
+		{name: "native Docker", dockerHost: "unix:///var/run/docker.sock"},
+		{name: "remote Docker", dockerHost: "tcp://docker.example:2376"},
+		{name: "not Docker socket", dockerHost: "unix:///Users/test/.colima/default/containerd.sock"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			config, host, ok := colimaSSHConfig(tt.dockerHost)
+			if ok != tt.ok {
+				t.Fatalf("colimaSSHConfig(%q) ok = %v, want %v", tt.dockerHost, ok, tt.ok)
+			}
+			if filepath.Clean(config) != filepath.Clean(tt.config) {
+				t.Errorf("colimaSSHConfig(%q) config = %q, want %q", tt.dockerHost, config, tt.config)
+			}
+			if host != tt.host {
+				t.Errorf("colimaSSHConfig(%q) host = %q, want %q", tt.dockerHost, host, tt.host)
+			}
+		})
+	}
+}

--- a/tests/integration/colima_transport_unix_test.go
+++ b/tests/integration/colima_transport_unix_test.go
@@ -1,0 +1,196 @@
+//go:build integration && (darwin || linux)
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const colimaTransportStartupTimeout = 10 * time.Second
+
+// startDedicatedColimaDockerTransport isolates the integration suite's Docker
+// traffic from Colima's lifecycle ControlMaster. Lima normally forwards
+// Colima's Docker socket over the same long-lived SSH process that owns VM port
+// forwarding. Hundreds of concurrent Docker exec streams can kill that SSH
+// process and leave Colima running with an unusable host socket. The suite uses
+// its own SSH process instead, so its load and lifecycle cannot take down the
+// user's global Docker transport.
+func startDedicatedColimaDockerTransport() (func(), error) {
+	sshConfig, sshHost, ok := colimaSSHConfig(os.Getenv("DOCKER_HOST"))
+	if !ok {
+		return func() {}, nil
+	}
+	if _, err := os.Stat(sshConfig); err != nil {
+		return nil, fmt.Errorf("Colima SSH config %s is unavailable: %w", sshConfig, err)
+	}
+
+	dir, err := os.MkdirTemp("", "camp-colima-docker-*")
+	if err != nil {
+		return nil, fmt.Errorf("create transport directory: %w", err)
+	}
+	socket := filepath.Join(dir, "docker.sock")
+
+	cmd := exec.Command("ssh",
+		"-F", sshConfig,
+		"-o", "ControlMaster=no",
+		"-o", "ControlPath=none",
+		"-o", "ExitOnForwardFailure=yes",
+		"-N",
+		"-L", socket+":/var/run/docker.sock",
+		sshHost,
+	)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	restoreLimit := raiseOpenFileLimitForChild()
+	if err := cmd.Start(); err != nil {
+		restoreLimit()
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("start Colima SSH transport: %w", err)
+	}
+	restoreLimit()
+
+	exited := make(chan error, 1)
+	go func() {
+		exited <- cmd.Wait()
+	}()
+
+	var stopOnce sync.Once
+	stop := func() {
+		stopOnce.Do(func() {
+			if cmd.Process != nil {
+				_ = cmd.Process.Signal(os.Interrupt)
+			}
+			select {
+			case <-exited:
+			case <-time.After(2 * time.Second):
+				if cmd.Process != nil {
+					_ = cmd.Process.Kill()
+				}
+				<-exited
+			}
+			_ = os.RemoveAll(dir)
+		})
+	}
+
+	deadline := time.Now().Add(colimaTransportStartupTimeout)
+	for {
+		if err := pingDockerSocket(socket); err == nil {
+			break
+		}
+		select {
+		case err := <-exited:
+			_ = os.RemoveAll(dir)
+			return nil, fmt.Errorf("Colima SSH transport exited during startup: %v: %s", err, strings.TrimSpace(stderr.String()))
+		default:
+		}
+		if time.Now().After(deadline) {
+			stop()
+			return nil, fmt.Errorf("Colima SSH transport was not ready after %s: %s", colimaTransportStartupTimeout, strings.TrimSpace(stderr.String()))
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	previousDockerHost := os.Getenv("DOCKER_HOST")
+	if err := os.Setenv("DOCKER_HOST", "unix://"+socket); err != nil {
+		stop()
+		return nil, fmt.Errorf("set isolated DOCKER_HOST: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "Integration Docker transport: isolated Colima tunnel at %s\n", socket)
+	return func() {
+		_ = os.Setenv("DOCKER_HOST", previousDockerHost)
+		stop()
+	}, nil
+}
+
+func colimaSSHConfig(dockerHost string) (config, host string, ok bool) {
+	u, err := url.Parse(dockerHost)
+	if err != nil || u.Scheme != "unix" {
+		return "", "", false
+	}
+	clean := filepath.Clean(u.Path)
+	marker := string(filepath.Separator) + ".colima" + string(filepath.Separator)
+	markerIndex := strings.Index(clean, marker)
+	if markerIndex < 0 || filepath.Base(clean) != "docker.sock" {
+		return "", "", false
+	}
+
+	colimaHome := filepath.Join(clean[:markerIndex], ".colima")
+	relative, err := filepath.Rel(colimaHome, clean)
+	if err != nil {
+		return "", "", false
+	}
+	parts := strings.Split(relative, string(filepath.Separator))
+	profile := "default"
+	if len(parts) == 2 {
+		profile = parts[0]
+	} else if len(parts) != 1 {
+		return "", "", false
+	}
+
+	instance := "colima"
+	if profile != "default" {
+		instance += "-" + profile
+	}
+	return filepath.Join(colimaHome, "_lima", instance, "ssh.config"), "lima-" + instance, true
+}
+
+func pingDockerSocket(socket string) error {
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{Timeout: 200 * time.Millisecond}).DialContext(ctx, "unix", socket)
+		},
+	}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{Transport: transport, Timeout: 500 * time.Millisecond}
+	response, err := client.Get("http://docker/_ping")
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return err
+	}
+	if response.StatusCode != http.StatusOK || strings.TrimSpace(string(body)) != "OK" {
+		return fmt.Errorf("Docker ping returned %s: %s", response.Status, strings.TrimSpace(string(body)))
+	}
+	return nil
+}
+
+// raiseOpenFileLimitForChild temporarily raises this process's soft descriptor
+// limit so the SSH child inherits enough capacity for parallel Docker streams.
+// The parent limit is restored immediately after the child starts.
+func raiseOpenFileLimitForChild() func() {
+	var original syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &original); err != nil {
+		return func() {}
+	}
+	raised := original
+	if raised.Cur < 4096 {
+		raised.Cur = 4096
+		if raised.Cur > raised.Max {
+			raised.Cur = raised.Max
+		}
+		if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &raised); err != nil {
+			return func() {}
+		}
+	}
+	return func() {
+		_ = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &original)
+	}
+}

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -42,8 +42,15 @@ var legacyCampSkip string
 func TestMain(m *testing.M) {
 	size := poolSize()
 
+	cleanupTransport, err := startDedicatedColimaDockerTransport()
+	if err != nil {
+		os.Stderr.WriteString("Failed to create isolated Docker transport: " + err.Error() + "\n")
+		os.Exit(1)
+	}
+
 	bins, cleanupBins, err := buildSharedBinaries()
 	if err != nil {
+		cleanupTransport()
 		os.Stderr.WriteString("Failed to build test binaries: " + err.Error() + "\n")
 		os.Exit(1)
 	}
@@ -78,6 +85,7 @@ func TestMain(m *testing.M) {
 		for _, c := range poolMembers {
 			c.Cleanup()
 		}
+		cleanupTransport()
 		os.Stderr.WriteString("Failed to create container pool: " + buildErr.Error() + "\n")
 		os.Exit(1)
 	}
@@ -87,6 +95,7 @@ func TestMain(m *testing.M) {
 	for _, c := range poolMembers {
 		c.Cleanup()
 	}
+	cleanupTransport()
 	os.Exit(code)
 }
 


### PR DESCRIPTION
## Summary

- route Colima-backed integration runs through a suite-owned SSH Unix-socket tunnel
- disable SSH ControlMaster reuse so Docker exec traffic cannot kill Colima's lifecycle transport
- raise the tunnel child's descriptor limit while preserving the parent process limit
- health-check the private Docker socket before container setup and clean it up after teardown
- support default, legacy, and named Colima profile socket layouts without changing native or remote Docker behavior

## Root cause

The integration pool sends hundreds of concurrent Docker exec streams through Colima's long-lived Lima SSH ControlMaster. Under the full suite, that SSH process exited while the VM, dockerd, containerd, and guest agent remained healthy. Because the same process owned Colima's global Docker socket forwarding, the test run left Colima reporting as running but made Docker unusable for the entire host.

The harness now gives its traffic an independent SSH transport. Integration load is isolated from Colima's lifecycle connection, and the existing pool size of six remains unchanged.

## Validation

- `go test -count=1 -v -tags=integration -run '^TestColimaSSHConfig$' -timeout=3m ./tests/integration`
- `just test integration` — 570/570 passed in 442.03s
- `just gate` — stable/dev builds, stable/dev/integration vet, lint, 3756 dev tests, and 3711 stable tests passed
- verified `docker info` through Colima's global socket during and after the full integration run
- verified the suite-owned SSH process and temporary socket were removed after teardown
