### PR TITLE
fix(workitem): validate link writes against the new row, not the whole registry

### DIFF
--- a/cmd/camp/project/worktree/add.go
+++ b/cmd/camp/project/worktree/add.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 
 	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
@@ -166,7 +167,7 @@ func runProjectWorktreeAdd(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Branch: %s\n", ui.Value(result.Branch))
 
 	if linkTarget != nil {
-		link, lerr := attachWorktreeLink(ctx, campRoot, linkTarget, filepath.ToSlash(result.RelativePath))
+		link, lerr := attachWorktreeLink(ctx, campRoot, linkTarget, filepath.ToSlash(result.RelativePath), cmd.ErrOrStderr())
 		if lerr != nil {
 			return camperrors.Wrap(lerr, "worktree created but workitem link failed")
 		}
@@ -195,7 +196,7 @@ func runProjectWorktreeAdd(cmd *cobra.Command, args []string) error {
 // (and therefore camp p commit) picks up the workitem ref inside that tree.
 // The workitem is resolved and validated by the caller before the worktree is
 // created, so a bad selector never leaves a dangling worktree behind.
-func attachWorktreeLink(ctx context.Context, campRoot string, wi *wkitem.WorkItem, relativeWorktreePath string) (links.Link, error) {
+func attachWorktreeLink(ctx context.Context, campRoot string, wi *wkitem.WorkItem, relativeWorktreePath string, report io.Writer) (links.Link, error) {
 	scopePath := relativeWorktreePath
 	if scopePath == "" {
 		return links.Link{}, camperrors.NewValidation("worktree", "missing worktree relative path", nil)
@@ -209,5 +210,6 @@ func attachWorktreeLink(ctx context.Context, campRoot string, wi *wkitem.WorkIte
 		},
 		CreatedBy: "camp_project_worktree_add",
 		Replace:   true,
+		Report:    report,
 	})
 }

--- a/cmd/camp/status.go
+++ b/cmd/camp/status.go
@@ -55,7 +55,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "not in a campaign")
 	}
 
-	notice.Render(os.Stderr, notice.Detect(ctx, campRoot, notice.DungeonLegacy))
+	notice.Render(os.Stderr, notice.Detect(ctx, campRoot, notice.DungeonLegacy, notice.StaleLinks))
 
 	gitArgs, showRefsArg := extractShowRefs(args)
 	showRefs := statusShowRefs || showRefsArg

--- a/cmd/camp/worktrees/create.go
+++ b/cmd/camp/worktrees/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -170,7 +171,7 @@ func runWorktreesCreate(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Branch: %s\n", ui.Value(result.Branch))
 
 	if linkTarget != nil {
-		link, lerr := attachWorktreeLink(ctx, campRoot, linkTarget, filepath.ToSlash(result.RelativePath))
+		link, lerr := attachWorktreeLink(ctx, campRoot, linkTarget, filepath.ToSlash(result.RelativePath), cmd.ErrOrStderr())
 		if lerr != nil {
 			return camperrors.Wrap(lerr, "worktree created but workitem link failed")
 		}
@@ -195,7 +196,7 @@ func runWorktreesCreate(cmd *cobra.Command, args []string) error {
 // attachWorktreeLink attaches a primary worktree link for an already-resolved
 // workitem so the resolver (and therefore camp p commit) picks up the workitem
 // ref inside that tree.
-func attachWorktreeLink(ctx context.Context, campRoot string, wi *wkitem.WorkItem, relativeWorktreePath string) (links.Link, error) {
+func attachWorktreeLink(ctx context.Context, campRoot string, wi *wkitem.WorkItem, relativeWorktreePath string, report io.Writer) (links.Link, error) {
 	return links.AttachPrimary(ctx, campRoot, links.AttachOptions{
 		WorkitemID:  wkitem.LinkWorkitemID(wi),
 		WorkitemKey: wi.Key,
@@ -205,5 +206,6 @@ func attachWorktreeLink(ctx context.Context, campRoot string, wi *wkitem.WorkIte
 		},
 		CreatedBy: "camp_worktrees_create",
 		Replace:   true,
+		Report:    report,
 	})
 }

--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -32,6 +32,7 @@ const (
 	codeBrokenScope              = "workitem.scope.broken"
 	codeOutOfBounds              = "workitem.scope.out-of-bounds"
 	codeScopeUnvalidatable       = "workitem.scope.unvalidatable"
+	codeScopeNotLocal            = "workitem.scope.not-on-this-machine"
 	codeDuplicatePrimary         = "workitem.link.duplicate-primary"
 	codeSchemaViolation          = "workitem.schema.violation"
 	codeCurrentMissing           = "workitem.current.missing"
@@ -261,14 +262,31 @@ func collectWorkitemFindings(ctx context.Context, root string, registry *links.L
 		}
 		scopeMissing := !scopeTargetExists(root, link.Scope.Path)
 		if scopeMissing && !deprecatedRelatedProject {
-			findings = append(findings, docFinding{
-				Code:        codeBrokenScope,
-				Severity:    docSeverityError,
-				Target:      "link:" + link.ID,
-				Message:     "scope path " + link.Scope.Path + " does not exist",
-				FixHint:     "remove the link or restore the directory; auto-fix removes the link",
-				AutoFixable: true,
-			})
+			// links.yaml is tracked, so removing a row propagates to every
+			// machine this campaign syncs to. A missing worktree or an
+			// uninitialized submodule is absent *here*, not gone, and deleting
+			// its link would destroy a row that is correct elsewhere. Report
+			// those and leave them alone.
+			if links.MachineLocal(root, link.Scope) {
+				findings = append(findings, docFinding{
+					Code:     codeScopeNotLocal,
+					Severity: docSeverityWarning,
+					Target:   "link:" + link.ID,
+					Message: "scope path " + link.Scope.Path + " is not on this machine" +
+						" (" + string(link.Scope.Kind) + " scopes are machine-local)",
+					FixHint: "expected if the worktree or submodule lives on another machine;" +
+						" remove it explicitly with `camp workitem unlink --id " + link.ID + "` if it is really gone",
+				})
+			} else {
+				findings = append(findings, docFinding{
+					Code:        codeBrokenScope,
+					Severity:    docSeverityError,
+					Target:      "link:" + link.ID,
+					Message:     "scope path " + link.Scope.Path + " does not exist",
+					FixHint:     "remove the link or restore the directory; auto-fix removes the link",
+					AutoFixable: true,
+				})
+			}
 		}
 		if err := quest.ValidateLinkPath(root, link.Scope.Path); err != nil {
 			switch {

--- a/internal/commands/workitem/doctor_locality_test.go
+++ b/internal/commands/workitem/doctor_locality_test.go
@@ -1,0 +1,110 @@
+package workitem
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+// seedLink writes a single-row links.yaml pointing the example workitem at
+// scope, without going through the writer's validation.
+func seedLink(t *testing.T, root string, kind links.ScopeKind, path string) string {
+	t.Helper()
+	id := "lnk_20260726_a1b2c3"
+	body := "version: " + links.LinksSchemaVersion + "\nlinks:\n" +
+		"  - id: " + id + "\n" +
+		"    workitem_id: design-example-2026-05-24\n" +
+		"    workitem_key: design:workflow/design/example\n" +
+		"    scope:\n      kind: " + string(kind) + "\n      path: " + path + "\n" +
+		"    role: primary\n" +
+		"    created_at: 2026-07-26T00:00:00Z\n" +
+		"    created_by: test\n"
+	dir := filepath.Join(root, ".campaign", "workitems")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "links.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func runDoctorCapturing(t *testing.T, fix bool) string {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	_ = runDoctor(context.Background(), cmd, false, fix)
+	return stdout.String()
+}
+
+// links.yaml is tracked in git, so `doctor --fix` removing a row propagates to
+// every machine the campaign syncs to. A worktree that is not on this machine
+// is absent, not deleted -- removing its link destroys a row that is correct on
+// the machine that owns the worktree.
+func TestDoctorFix_DoesNotDeleteMachineLocalWorktreeLink(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	id := seedLink(t, root, links.ScopeWorktree, "projects/worktrees/fest/on-another-machine")
+
+	out := runDoctorCapturing(t, false)
+	if !strings.Contains(out, codeScopeNotLocal) {
+		t.Fatalf("expected %s finding, got %q", codeScopeNotLocal, out)
+	}
+	if strings.Contains(out, codeBrokenScope) {
+		t.Fatalf("a machine-local scope must not be reported as broken: %q", out)
+	}
+	// An absent worktree is the normal state of a synced multi-machine
+	// campaign, so it must not be an error-severity finding either -- doctor
+	// exits non-zero on any error, and a healthy campaign should exit 0.
+	if strings.Contains(out, codeSchemaViolation) {
+		t.Fatalf("a machine-local scope must not raise a schema violation: %q", out)
+	}
+	if !strings.Contains(out, "camp workitem unlink --id "+id) {
+		t.Fatalf("finding must name the explicit removal command, got %q", out)
+	}
+
+	runDoctorCapturing(t, true)
+
+	registry, err := links.Load(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := registry.FindByID(id); !ok {
+		t.Fatal("doctor --fix deleted a machine-local worktree link; that loss propagates via git")
+	}
+}
+
+// A tracked target really is gone everywhere, so auto-fix should still clean it.
+func TestDoctorFix_StillRemovesAuthoritativelyDeadScope(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	id := seedLink(t, root, links.ScopeCampaignPath, "workflow/design/deleted")
+
+	out := runDoctorCapturing(t, false)
+	if !strings.Contains(out, codeBrokenScope) {
+		t.Fatalf("expected %s finding, got %q", codeBrokenScope, out)
+	}
+
+	runDoctorCapturing(t, true)
+
+	registry, err := links.Load(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := registry.FindByID(id); ok {
+		t.Fatal("doctor --fix should have removed a link to a deleted tracked path")
+	}
+}

--- a/internal/commands/workitem/link.go
+++ b/internal/commands/workitem/link.go
@@ -157,7 +157,13 @@ func runLink(ctx context.Context, cmd *cobra.Command, opts linkOptions) error {
 	}
 
 	var link links.Link
+	var pruned []links.Pruned
 	err = links.WithLock(ctx, root, func(registry *links.Links) error {
+		// Drop rows whose scope target is provably gone. Machine-local scopes
+		// are never touched (see links.MachineLocal), and a missing workitem is
+		// left to `camp workitem doctor` (see links.Dead).
+		pruned = links.PruneDead(root, registry)
+
 		// Generate the ID inside the lock so the collision retry sees
 		// the current registry state, not a stale snapshot.
 		id, idErr := generateLinkID(registry)
@@ -186,6 +192,7 @@ func runLink(ctx context.Context, cmd *cobra.Command, opts linkOptions) error {
 	if err != nil {
 		return err
 	}
+	links.ReportPruned(cmd.ErrOrStderr(), pruned)
 
 	ledger.NewFromRoot(ctx, root, ledger.WarnTo(cmd.ErrOrStderr())).
 		Emit(ctx, ledgerkit.KindCreated, ledgerkit.Scope{Workitem: link.WorkitemID},

--- a/internal/commands/workitem/link.go
+++ b/internal/commands/workitem/link.go
@@ -176,15 +176,12 @@ func runLink(ctx context.Context, cmd *cobra.Command, opts linkOptions) error {
 		if err := registry.AddLink(link, opts.Replace); err != nil {
 			return err
 		}
-		if errs := links.Validate(ctx, registry, links.ValidateOptions{
+		return links.AsError(links.ValidateOne(ctx, registry, link.ID, links.ValidateOptions{
 			CampaignRoot: root,
 			WorkitemIDs:  knownIDs,
 			AllowMissing: opts.AllowMissing,
 			Now:          link.CreatedAt,
-		}); len(errs) > 0 {
-			return camperrors.NewValidation(errs[0].Field, errs[0].Message, nil)
-		}
-		return nil
+		}))
 	})
 	if err != nil {
 		return err

--- a/internal/commands/workitem/worktree.go
+++ b/internal/commands/workitem/worktree.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"path"
 	"path/filepath"
 	"strings"
@@ -145,7 +146,7 @@ func runWorktree(cmd *cobra.Command, opts worktreeOptions) error {
 		return err
 	}
 
-	link, err := attachWorktreeLink(ctx, root, wi, filepath.ToSlash(result.RelativePath))
+	link, err := attachWorktreeLink(ctx, root, wi, filepath.ToSlash(result.RelativePath), cmd.ErrOrStderr())
 	if err != nil {
 		return camperrors.Wrap(err, "worktree created but workitem link failed")
 	}
@@ -261,7 +262,7 @@ func linkMatchesWorkitem(link links.Link, wi *wkitem.WorkItem) bool {
 
 // attachWorktreeLink primary-links the worktree so the resolver (and therefore
 // camp p commit) picks up the workitem ref inside that tree.
-func attachWorktreeLink(ctx context.Context, root string, wi *wkitem.WorkItem, relativeWorktreePath string) (links.Link, error) {
+func attachWorktreeLink(ctx context.Context, root string, wi *wkitem.WorkItem, relativeWorktreePath string, report io.Writer) (links.Link, error) {
 	if relativeWorktreePath == "" {
 		return links.Link{}, camperrors.NewValidation("worktree", "missing worktree relative path", nil)
 	}
@@ -275,6 +276,7 @@ func attachWorktreeLink(ctx context.Context, root string, wi *wkitem.WorkItem, r
 		},
 		CreatedBy: "camp_workitem_worktree",
 		Replace:   true,
+		Report:    report,
 	})
 }
 

--- a/internal/notice/stale_links.go
+++ b/internal/notice/stale_links.go
@@ -1,0 +1,58 @@
+package notice
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+// StaleLinksID identifies the stale-workitem-links signal.
+const StaleLinksID = "workitem-links-stale"
+
+// StaleLinks reports a notice when links.yaml has rows whose scope path is gone
+// from disk -- a deleted worktree, a renamed design directory.
+//
+// Writers no longer refuse on stale rows (see links.ValidateOne), so rot that
+// used to announce itself by breaking the next `camp workitem link` is now
+// silent. This is what makes it visible again, on a command the user already
+// runs, pointing at the repair that already exists.
+//
+// It stays stat-level as the package requires: one read of links.yaml plus one
+// stat per row. Broken workitem_id references need the on-disk workitem set,
+// which is a tree scan, so they are left to `camp workitem doctor` -- the same
+// command this notice names, which reports both.
+func StaleLinks(ctx context.Context, campaignRoot string) (*Notice, error) {
+	registry, err := links.Load(ctx, campaignRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	stale := 0
+	for _, link := range registry.Links {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if link.Scope.Path == "" {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(campaignRoot, filepath.FromSlash(link.Scope.Path))); os.IsNotExist(err) {
+			stale++
+		}
+	}
+	if stale == 0 {
+		return nil, nil
+	}
+
+	subject := "workitem links point"
+	if stale == 1 {
+		subject = "workitem link points"
+	}
+	return &Notice{
+		ID:      StaleLinksID,
+		Message: strconv.Itoa(stale) + " " + subject + " at a path that no longer exists",
+		Command: "camp workitem doctor --fix",
+	}, nil
+}

--- a/internal/notice/stale_links.go
+++ b/internal/notice/stale_links.go
@@ -2,8 +2,6 @@ package notice
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"strconv"
 
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
@@ -12,13 +10,18 @@ import (
 // StaleLinksID identifies the stale-workitem-links signal.
 const StaleLinksID = "workitem-links-stale"
 
-// StaleLinks reports a notice when links.yaml has rows whose scope path is gone
-// from disk -- a deleted worktree, a renamed design directory.
+// StaleLinks reports a notice when links.yaml has rows whose scope target is
+// authoritatively gone -- a deleted design directory, a removed festival.
 //
-// Writers no longer refuse on stale rows (see links.ValidateOne), so rot that
-// used to announce itself by breaking the next `camp workitem link` is now
-// silent. This is what makes it visible again, on a command the user already
-// runs, pointing at the repair that already exists.
+// Writers prune these as they go and say so, so the notice is the backstop for
+// a campaign that has not written a link since the rot appeared, not the
+// primary surface.
+//
+// It deliberately ignores machine-local scopes. Worktrees are gitignored by
+// camp's own scaffold and submodules may simply be uncloned, so on a campaign
+// synced across two machines every row the other machine owns would be counted
+// here. That notice would be permanent, unactionable, and would train the user
+// to ignore the next one. See links.MachineLocal.
 //
 // It stays stat-level as the package requires: one read of links.yaml plus one
 // stat per row. Broken workitem_id references need the on-disk workitem set,
@@ -35,10 +38,10 @@ func StaleLinks(ctx context.Context, campaignRoot string) (*Notice, error) {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		if link.Scope.Path == "" {
+		if link.Scope.Path == "" || links.MachineLocal(campaignRoot, link.Scope) {
 			continue
 		}
-		if _, err := os.Stat(filepath.Join(campaignRoot, filepath.FromSlash(link.Scope.Path))); os.IsNotExist(err) {
+		if !links.ScopeTargetExists(campaignRoot, link.Scope) {
 			stale++
 		}
 	}

--- a/internal/notice/stale_links_test.go
+++ b/internal/notice/stale_links_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func writeLinks(t *testing.T, root string, scopePaths ...string) {
+func writeLinks(t *testing.T, root string, kind string, scopePaths ...string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Join(root, ".campaign", "workitems"), 0o755); err != nil {
 		t.Fatal(err)
@@ -18,7 +18,7 @@ func writeLinks(t *testing.T, root string, scopePaths ...string) {
 	for i, p := range scopePaths {
 		b.WriteString("  - id: lnk_20260726_00000" + string(rune('a'+i)) + "\n")
 		b.WriteString("    workitem_id: design-demo-2026-07-26\n")
-		b.WriteString("    scope:\n      kind: worktree\n      path: " + p + "\n")
+		b.WriteString("    scope:\n      kind: " + kind + "\n      path: " + p + "\n")
 		b.WriteString("    role: primary\n")
 		b.WriteString("    created_at: 2026-07-26T00:00:00Z\n")
 		b.WriteString("    created_by: test\n")
@@ -31,11 +31,11 @@ func writeLinks(t *testing.T, root string, scopePaths ...string) {
 
 func TestStaleLinks_QuietWhenEveryScopeExists(t *testing.T) {
 	root := t.TempDir()
-	live := "projects/worktrees/fest/live"
+	live := "workflow/design/live"
 	if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(live)), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeLinks(t, root, live)
+	writeLinks(t, root, "campaign_path", live)
 
 	got, err := StaleLinks(context.Background(), root)
 	if err != nil {
@@ -62,13 +62,13 @@ func TestStaleLinks_CountsAndPluralizes(t *testing.T) {
 		gone []string
 		want string
 	}{
-		{name: "one", gone: []string{"projects/worktrees/fest/a"}, want: "1 workitem link points"},
-		{name: "several", gone: []string{"projects/worktrees/fest/a", "projects/worktrees/fest/b"}, want: "2 workitem links point"},
+		{name: "one", gone: []string{"workflow/design/a"}, want: "1 workitem link points"},
+		{name: "several", gone: []string{"workflow/design/a", "workflow/design/b"}, want: "2 workitem links point"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			root := t.TempDir()
-			writeLinks(t, root, tc.gone...)
+			writeLinks(t, root, "campaign_path", tc.gone...)
 
 			got, err := StaleLinks(context.Background(), root)
 			if err != nil {
@@ -87,5 +87,21 @@ func TestStaleLinks_CountsAndPluralizes(t *testing.T) {
 				t.Fatalf("ID = %q, want %q", got.ID, StaleLinksID)
 			}
 		})
+	}
+}
+
+// Worktrees are gitignored as machine-local, so on a campaign synced across two
+// machines every worktree the other machine owns is absent here. Counting those
+// would make the notice permanent and unactionable.
+func TestStaleLinks_IgnoresMachineLocalScopes(t *testing.T) {
+	root := t.TempDir()
+	writeLinks(t, root, "worktree", "projects/worktrees/fest/on-my-laptop")
+
+	got, err := StaleLinks(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("a missing worktree must not raise a notice, got %+v", got)
 	}
 }

--- a/internal/notice/stale_links_test.go
+++ b/internal/notice/stale_links_test.go
@@ -1,0 +1,91 @@
+package notice
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeLinks(t *testing.T, root string, scopePaths ...string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, ".campaign", "workitems"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	b.WriteString("version: workitem-links/v1alpha1\nlinks:\n")
+	for i, p := range scopePaths {
+		b.WriteString("  - id: lnk_20260726_00000" + string(rune('a'+i)) + "\n")
+		b.WriteString("    workitem_id: design-demo-2026-07-26\n")
+		b.WriteString("    scope:\n      kind: worktree\n      path: " + p + "\n")
+		b.WriteString("    role: primary\n")
+		b.WriteString("    created_at: 2026-07-26T00:00:00Z\n")
+		b.WriteString("    created_by: test\n")
+	}
+	path := filepath.Join(root, ".campaign", "workitems", "links.yaml")
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStaleLinks_QuietWhenEveryScopeExists(t *testing.T) {
+	root := t.TempDir()
+	live := "projects/worktrees/fest/live"
+	if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(live)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeLinks(t, root, live)
+
+	got, err := StaleLinks(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("expected no notice, got %+v", got)
+	}
+}
+
+func TestStaleLinks_QuietWithoutARegistry(t *testing.T) {
+	got, err := StaleLinks(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("expected no notice for a campaign with no links.yaml, got %+v", got)
+	}
+}
+
+func TestStaleLinks_CountsAndPluralizes(t *testing.T) {
+	cases := []struct {
+		name string
+		gone []string
+		want string
+	}{
+		{name: "one", gone: []string{"projects/worktrees/fest/a"}, want: "1 workitem link points"},
+		{name: "several", gone: []string{"projects/worktrees/fest/a", "projects/worktrees/fest/b"}, want: "2 workitem links point"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeLinks(t, root, tc.gone...)
+
+			got, err := StaleLinks(context.Background(), root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got == nil {
+				t.Fatal("expected a notice")
+			}
+			if !strings.Contains(got.Message, tc.want) {
+				t.Fatalf("message %q missing %q", got.Message, tc.want)
+			}
+			if got.Command != "camp workitem doctor --fix" {
+				t.Fatalf("Command = %q", got.Command)
+			}
+			if got.ID != StaleLinksID {
+				t.Fatalf("ID = %q, want %q", got.ID, StaleLinksID)
+			}
+		})
+	}
+}

--- a/internal/workitem/links/attach.go
+++ b/internal/workitem/links/attach.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"io"
 	"time"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -25,6 +26,10 @@ type AttachOptions struct {
 	Replace bool
 	// AllowMissing skips ValidateLinkPath existence checks (migrations).
 	AllowMissing bool
+	// Report receives a line for each dead row the write pruned. Never nil in
+	// command code: pruning a row the user did not ask about is only acceptable
+	// because it is reported.
+	Report io.Writer
 }
 
 // AttachPrimary records a primary workitem→scope link in links.yaml.
@@ -49,7 +54,12 @@ func AttachPrimary(ctx context.Context, campaignRoot string, opts AttachOptions)
 	}
 
 	var out Link
+	var pruned []Pruned
 	err := WithLock(ctx, campaignRoot, func(registry *Links) error {
+		// Drop rows whose scope target is provably gone while the registry is
+		// open anyway. See Dead for why this is the only signal trusted here.
+		pruned = PruneDead(campaignRoot, registry)
+
 		id, idErr := NewLinkID(registry)
 		if idErr != nil {
 			return idErr
@@ -75,7 +85,23 @@ func AttachPrimary(ctx context.Context, campaignRoot string, opts AttachOptions)
 	if err != nil {
 		return Link{}, err
 	}
+	ReportPruned(opts.Report, pruned)
 	return out, nil
+}
+
+// ReportPruned writes one line per dropped row plus the undo, so a user who did
+// not ask for the cleanup can see exactly what went, why, and how to put it
+// back. Naming the reason matters: a worktree link dropped because its workitem
+// is gone otherwise reads as camp deleting worktree links.
+func ReportPruned(w io.Writer, pruned []Pruned) {
+	if w == nil || len(pruned) == 0 {
+		return
+	}
+	for _, p := range pruned {
+		_, _ = fmt.Fprintf(w, "removed dead link %s (%s:%s): %s\n",
+			p.Link.ID, p.Link.Scope.Kind, p.Link.Scope.Path, p.Reason)
+	}
+	_, _ = fmt.Fprintf(w, "  undo: git checkout -- .campaign/workitems/links.yaml\n")
 }
 
 // WorktreeScopePath returns the campaign-relative path for a project worktree

--- a/internal/workitem/links/attach.go
+++ b/internal/workitem/links/attach.go
@@ -66,14 +66,11 @@ func AttachPrimary(ctx context.Context, campaignRoot string, opts AttachOptions)
 		if err := registry.AddLink(out, opts.Replace); err != nil {
 			return err
 		}
-		if errs := Validate(ctx, registry, ValidateOptions{
+		return AsError(ValidateOne(ctx, registry, out.ID, ValidateOptions{
 			CampaignRoot: campaignRoot,
 			AllowMissing: opts.AllowMissing,
 			Now:          out.CreatedAt,
-		}); len(errs) > 0 {
-			return camperrors.NewValidation(errs[0].Field, errs[0].Message, nil)
-		}
-		return nil
+		}))
 	})
 	if err != nil {
 		return Link{}, err

--- a/internal/workitem/links/attach.go
+++ b/internal/workitem/links/attach.go
@@ -58,7 +58,15 @@ func AttachPrimary(ctx context.Context, campaignRoot string, opts AttachOptions)
 	err := WithLock(ctx, campaignRoot, func(registry *Links) error {
 		// Drop rows whose scope target is provably gone while the registry is
 		// open anyway. See Dead for why this is the only signal trusted here.
-		pruned = PruneDead(campaignRoot, registry)
+		//
+		// A caller with nowhere to report to does not prune. Reporting is the
+		// price of removing a row the user did not ask about, so a missing
+		// Report writer makes the removal silent -- and silence is the one
+		// outcome this must not have. Skipping leaves the rows for the next
+		// reporting caller or for doctor.
+		if opts.Report != nil {
+			pruned = PruneDead(campaignRoot, registry)
+		}
 
 		id, idErr := NewLinkID(registry)
 		if idErr != nil {
@@ -101,7 +109,12 @@ func ReportPruned(w io.Writer, pruned []Pruned) {
 		_, _ = fmt.Fprintf(w, "removed dead link %s (%s:%s): %s\n",
 			p.Link.ID, p.Link.Scope.Kind, p.Link.Scope.Path, p.Reason)
 	}
-	_, _ = fmt.Fprintf(w, "  undo: git checkout -- .campaign/workitems/links.yaml\n")
+	// The prune and the caller's own write land in one save, so the undo is
+	// not surgical. Say so: a user who runs it expecting to keep the link they
+	// just made would otherwise lose it silently, which is the same failure
+	// this reporting exists to prevent.
+	_, _ = fmt.Fprintf(w,
+		"  undo: git checkout -- .campaign/workitems/links.yaml (reverts this whole write, new link included)\n")
 }
 
 // WorktreeScopePath returns the campaign-relative path for a project worktree

--- a/internal/workitem/links/attach_test.go
+++ b/internal/workitem/links/attach_test.go
@@ -48,6 +48,71 @@ func TestAttachPrimaryWorktree(t *testing.T) {
 	}
 }
 
+// AttachPrimary is the writer behind `camp project worktree add --workitem`.
+// A stale row elsewhere in links.yaml must not stop it.
+func TestAttachPrimary_SucceedsAlongsideStaleRow(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".campaign", "workitems"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed a row whose scope path does not exist, the way a deleted worktree
+	// leaves one behind.
+	stalePath := "projects/worktrees/fest/deleted"
+	if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(stalePath)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AttachPrimary(ctx, root, AttachOptions{
+		WorkitemID: "design-deleted-2026-07-01",
+		Scope:      LinkScope{Kind: ScopeWorktree, Path: stalePath},
+		CreatedBy:  "test",
+	}); err != nil {
+		t.Fatalf("seed stale link: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(root, filepath.FromSlash(stalePath))); err != nil {
+		t.Fatal(err)
+	}
+
+	livePath := "projects/worktrees/fest/live"
+	if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(livePath)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AttachPrimary(ctx, root, AttachOptions{
+		WorkitemID: "design-live-2026-07-26",
+		Scope:      LinkScope{Kind: ScopeWorktree, Path: livePath},
+		CreatedBy:  "test",
+	}); err != nil {
+		t.Fatalf("stale row blocked a valid attach: %v", err)
+	}
+
+	// The stale row is preserved, not silently dropped: doctor owns removal.
+	reg, err := Load(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := reg.PrimaryForScope(ScopeWorktree, stalePath); !ok {
+		t.Fatal("stale row was dropped by the write path; doctor --fix owns that decision")
+	}
+}
+
+// The new link's own scope path is still checked, so the fix does not turn into
+// "writes never validate".
+func TestAttachPrimary_StillRejectsMissingScopePath(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".campaign", "workitems"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := AttachPrimary(context.Background(), root, AttachOptions{
+		WorkitemID: "design-nowhere-2026-07-26",
+		Scope:      LinkScope{Kind: ScopeWorktree, Path: "projects/worktrees/fest/nope"},
+		CreatedBy:  "test",
+	})
+	if err == nil {
+		t.Fatal("expected a missing-scope-path rejection for the link being written")
+	}
+}
+
 func TestWorktreeScopePath(t *testing.T) {
 	if got := WorktreeScopePath("fest", "list-watch"); got != "projects/worktrees/fest/list-watch" {
 		t.Fatalf("WorktreeScopePath = %q", got)

--- a/internal/workitem/links/attach_test.go
+++ b/internal/workitem/links/attach_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -49,28 +50,30 @@ func TestAttachPrimaryWorktree(t *testing.T) {
 }
 
 // AttachPrimary is the writer behind `camp project worktree add --workitem`.
-// A stale row elsewhere in links.yaml must not stop it.
-func TestAttachPrimary_SucceedsAlongsideStaleRow(t *testing.T) {
+// A dead row elsewhere in links.yaml must not stop it, and the row it drops on
+// the way through has to be reported.
+func TestAttachPrimary_PrunesDeadRowsAndReports(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, ".campaign", "workitems"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	// Seed a row whose scope path does not exist, the way a deleted worktree
-	// leaves one behind.
-	stalePath := "projects/worktrees/fest/deleted"
-	if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(stalePath)), 0o755); err != nil {
+	// Seed a row against a tracked path, then delete the path so its absence
+	// is authoritative.
+	deadPath := "workflow/design/deleted"
+	if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(deadPath)), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := AttachPrimary(ctx, root, AttachOptions{
+	dead, err := AttachPrimary(ctx, root, AttachOptions{
 		WorkitemID: "design-deleted-2026-07-01",
-		Scope:      LinkScope{Kind: ScopeWorktree, Path: stalePath},
+		Scope:      LinkScope{Kind: ScopeCampaignPath, Path: deadPath},
 		CreatedBy:  "test",
-	}); err != nil {
-		t.Fatalf("seed stale link: %v", err)
+	})
+	if err != nil {
+		t.Fatalf("seed dead link: %v", err)
 	}
-	if err := os.RemoveAll(filepath.Join(root, filepath.FromSlash(stalePath))); err != nil {
+	if err := os.RemoveAll(filepath.Join(root, filepath.FromSlash(deadPath))); err != nil {
 		t.Fatal(err)
 	}
 
@@ -78,21 +81,76 @@ func TestAttachPrimary_SucceedsAlongsideStaleRow(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(livePath)), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	var report strings.Builder
 	if _, err := AttachPrimary(ctx, root, AttachOptions{
 		WorkitemID: "design-live-2026-07-26",
 		Scope:      LinkScope{Kind: ScopeWorktree, Path: livePath},
 		CreatedBy:  "test",
+		Report:     &report,
 	}); err != nil {
-		t.Fatalf("stale row blocked a valid attach: %v", err)
+		t.Fatalf("dead row blocked a valid attach: %v", err)
 	}
 
-	// The stale row is preserved, not silently dropped: doctor owns removal.
+	if !strings.Contains(report.String(), dead.ID) {
+		t.Fatalf("pruning must be reported, got %q", report.String())
+	}
 	reg, err := Load(ctx, root)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := reg.PrimaryForScope(ScopeWorktree, stalePath); !ok {
-		t.Fatal("stale row was dropped by the write path; doctor --fix owns that decision")
+	if _, ok := reg.FindByID(dead.ID); ok {
+		t.Fatal("dead row should have been pruned")
+	}
+}
+
+// A worktree that is not on this machine is absent, not deleted. links.yaml is
+// tracked, so pruning it here would delete it on the machine that owns it.
+func TestAttachPrimary_PreservesMachineLocalRows(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".campaign", "workitems"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	elsewhere := "projects/worktrees/fest/on-another-machine"
+	if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(elsewhere)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seeded, err := AttachPrimary(ctx, root, AttachOptions{
+		WorkitemID: "design-elsewhere-2026-07-01",
+		Scope:      LinkScope{Kind: ScopeWorktree, Path: elsewhere},
+		CreatedBy:  "test",
+	})
+	if err != nil {
+		t.Fatalf("seed worktree link: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(root, filepath.FromSlash(elsewhere))); err != nil {
+		t.Fatal(err)
+	}
+
+	livePath := "projects/worktrees/fest/live"
+	if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(livePath)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var report strings.Builder
+	if _, err := AttachPrimary(ctx, root, AttachOptions{
+		WorkitemID: "design-live-2026-07-26",
+		Scope:      LinkScope{Kind: ScopeWorktree, Path: livePath},
+		CreatedBy:  "test",
+		Report:     &report,
+	}); err != nil {
+		t.Fatalf("attach failed: %v", err)
+	}
+
+	if report.String() != "" {
+		t.Fatalf("nothing should have been pruned, got %q", report.String())
+	}
+	reg, err := Load(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := reg.FindByID(seeded.ID); !ok {
+		t.Fatal("a worktree link was deleted because the worktree is on another machine")
 	}
 }
 

--- a/internal/workitem/links/attach_test.go
+++ b/internal/workitem/links/attach_test.go
@@ -176,3 +176,64 @@ func TestWorktreeScopePath(t *testing.T) {
 		t.Fatalf("WorktreeScopePath = %q", got)
 	}
 }
+
+// Reporting is the price of removing a row the user did not ask about, so a
+// caller with nowhere to report to must not prune at all. Otherwise the one
+// outcome the design forbids -- a silent removal -- is a nil field away.
+func TestAttachPrimary_DoesNotPruneWithoutAReportWriter(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".campaign", "workitems"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	deadPath := "workflow/design/deleted"
+	if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(deadPath)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dead, err := AttachPrimary(ctx, root, AttachOptions{
+		WorkitemID: "design-deleted-2026-07-01",
+		Scope:      LinkScope{Kind: ScopeCampaignPath, Path: deadPath},
+		CreatedBy:  "test",
+	})
+	if err != nil {
+		t.Fatalf("seed dead link: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(root, filepath.FromSlash(deadPath))); err != nil {
+		t.Fatal(err)
+	}
+
+	livePath := "projects/worktrees/fest/live"
+	if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(livePath)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// No Report writer.
+	if _, err := AttachPrimary(ctx, root, AttachOptions{
+		WorkitemID: "design-live-2026-07-26",
+		Scope:      LinkScope{Kind: ScopeWorktree, Path: livePath},
+		CreatedBy:  "test",
+	}); err != nil {
+		t.Fatalf("attach failed: %v", err)
+	}
+
+	reg, err := Load(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := reg.FindByID(dead.ID); !ok {
+		t.Fatal("pruned silently with no Report writer; the row should have been left for a reporting caller or doctor")
+	}
+}
+
+func TestReportPruned_UndoSaysItRevertsTheWholeWrite(t *testing.T) {
+	var out strings.Builder
+	ReportPruned(&out, []Pruned{{
+		Link:   Link{ID: "lnk_20260726_eeeeee", Scope: LinkScope{Kind: ScopeCampaignPath, Path: "workflow/design/gone"}},
+		Reason: "campaign_path workflow/design/gone no longer exists",
+	}})
+	// The prune shares a save with the caller's write, so an undo that looks
+	// surgical would cost the user the link they just created.
+	if !strings.Contains(out.String(), "reverts this whole write") {
+		t.Fatalf("undo must say it is not surgical, got %q", out.String())
+	}
+}

--- a/internal/workitem/links/links_test.go
+++ b/internal/workitem/links/links_test.go
@@ -317,7 +317,9 @@ func TestValidateOne_StaleRowDoesNotBlockNewLink(t *testing.T) {
 	stale := makeValidLink(t, root)
 	stale.ID = genLinkID(t)
 	stale.WorkitemID = "design-deleted-2026-05-01"
-	stale.Scope = LinkScope{Kind: ScopeWorktree, Path: "projects/worktrees/gone/removed"}
+	// A tracked path, so its absence is authoritative. A worktree would be
+	// machine-local and correctly exempt from the existence check entirely.
+	stale.Scope = LinkScope{Kind: ScopeCampaignPath, Path: "workflow/design/removed"}
 
 	fresh := makeValidLink(t, root)
 	l := &Links{Version: LinksSchemaVersion, Links: []Link{stale, fresh}}
@@ -351,6 +353,27 @@ func TestValidateOne_StillEnforcesRegistryWideUniqueness(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected duplicate-primary finding for the subject link, got %v", errs)
+	}
+}
+
+// "the scope target exists" is not an invariant for a machine-local scope: the
+// worktree may live on the user's other machine. Escaping the campaign root
+// still is one.
+func TestValidate_ExemptsMachineLocalScopesFromExistence(t *testing.T) {
+	root := t.TempDir()
+
+	worktree := makeValidLink(t, root)
+	worktree.Scope = LinkScope{Kind: ScopeWorktree, Path: "projects/worktrees/fest/elsewhere"}
+	l := &Links{Version: LinksSchemaVersion, Links: []Link{worktree}}
+	if errs := Validate(context.Background(), l, ValidateOptions{CampaignRoot: root}); len(errs) != 0 {
+		t.Fatalf("a worktree absent from this machine is not a violation: %v", errs)
+	}
+
+	tracked := makeValidLink(t, root)
+	tracked.Scope = LinkScope{Kind: ScopeCampaignPath, Path: "workflow/design/removed"}
+	l = &Links{Version: LinksSchemaVersion, Links: []Link{tracked}}
+	if errs := Validate(context.Background(), l, ValidateOptions{CampaignRoot: root}); len(errs) == 0 {
+		t.Fatal("a missing tracked path is still a violation")
 	}
 }
 

--- a/internal/workitem/links/links_test.go
+++ b/internal/workitem/links/links_test.go
@@ -306,6 +306,80 @@ func TestValidate_HappyPath(t *testing.T) {
 	}
 }
 
+// A stale row -- one whose scope path was deleted -- must not make a valid new
+// link unwritable. Before ValidateOne, a single deleted worktree failed every
+// subsequent `camp workitem link` and `camp project worktree add --workitem` in
+// the campaign, and the error named the stale row's path rather than anything
+// the user had touched.
+func TestValidateOne_StaleRowDoesNotBlockNewLink(t *testing.T) {
+	root := t.TempDir()
+
+	stale := makeValidLink(t, root)
+	stale.ID = genLinkID(t)
+	stale.WorkitemID = "design-deleted-2026-05-01"
+	stale.Scope = LinkScope{Kind: ScopeWorktree, Path: "projects/worktrees/gone/removed"}
+
+	fresh := makeValidLink(t, root)
+	l := &Links{Version: LinksSchemaVersion, Links: []Link{stale, fresh}}
+	opts := ValidateOptions{CampaignRoot: root}
+
+	if errs := Validate(context.Background(), l, opts); len(errs) == 0 {
+		t.Fatal("expected whole-registry Validate to report the stale row")
+	}
+	if errs := ValidateOne(context.Background(), l, fresh.ID, opts); len(errs) != 0 {
+		t.Fatalf("stale row blocked a valid new link: %v", errs)
+	}
+	if errs := ValidateOne(context.Background(), l, stale.ID, opts); len(errs) == 0 {
+		t.Fatal("ValidateOne must still report the stale row when it is the subject")
+	}
+}
+
+// Uniqueness spans the registry, so ValidateOne still has to see the other rows.
+func TestValidateOne_StillEnforcesRegistryWideUniqueness(t *testing.T) {
+	root := t.TempDir()
+	existing := makeValidLink(t, root)
+	dup := makeValidLink(t, root) // same scope, also primary
+	dup.WorkitemID = "design-other-2026-05-24"
+	l := &Links{Version: LinksSchemaVersion, Links: []Link{existing, dup}}
+
+	errs := ValidateOne(context.Background(), l, dup.ID, ValidateOptions{CampaignRoot: root})
+	found := false
+	for _, e := range errs {
+		if e.Field == "role" && strings.Contains(e.Message, "duplicate primary") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected duplicate-primary finding for the subject link, got %v", errs)
+	}
+}
+
+func TestValidateOne_UnknownIDIsAnError(t *testing.T) {
+	l := &Links{Version: LinksSchemaVersion, Links: []Link{}}
+	errs := ValidateOne(context.Background(), l, "lnk_20260726_abcdef", ValidateOptions{})
+	if len(errs) != 1 || errs[0].Field != "id" {
+		t.Fatalf("expected a single id error, got %v", errs)
+	}
+}
+
+// AsError reports every failure, not just the first, so fixing a link is one
+// round trip instead of one per problem.
+func TestAsError_ReportsAllFailures(t *testing.T) {
+	if err := AsError(nil); err != nil {
+		t.Fatalf("AsError(nil) = %v, want nil", err)
+	}
+	errs := []ValidationError{
+		{Field: "role", Message: "unknown role: bogus"},
+		{Field: "created_by", Message: "required"},
+	}
+	msg := AsError(errs).Error()
+	for _, want := range []string{"unknown role: bogus", "created_by: required"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("AsError message %q missing %q", msg, want)
+		}
+	}
+}
+
 func TestValidate_CreatedAtAllowsHistoricalAndRejectsFutureSkew(t *testing.T) {
 	root := t.TempDir()
 	now := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)

--- a/internal/workitem/links/locality.go
+++ b/internal/workitem/links/locality.go
@@ -1,0 +1,105 @@
+package links
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MachineLocal reports whether a missing scope target means "gone" or only
+// "not here".
+//
+// links.yaml is tracked in git, so removing a row propagates to every machine
+// the campaign syncs to. That makes the distinction load-bearing rather than
+// cosmetic: deleting a row because its target is absent locally destroys a link
+// that is correct elsewhere, and the deletion travels.
+//
+// Machine-local targets:
+//
+//   - worktrees. camp's own scaffold writes "# Git worktrees (machine-local)"
+//     above the ignore rule it adds for them (internal/scaffold/repair.go), so
+//     a worktree missing here says nothing about any other machine.
+//   - submodules declared in .gitmodules but not checked out, which is the
+//     normal state of a fresh clone before `camp sync`.
+//
+// Everything else -- workflow/, festivals/, campaign paths -- is tracked, so
+// its absence is a fact everywhere and the row really is dead.
+func MachineLocal(campaignRoot string, scope LinkScope) bool {
+	if scope.Kind == ScopeWorktree {
+		return true
+	}
+	if scope.Kind == ScopeProject {
+		return declaredSubmodule(campaignRoot, scope.Path)
+	}
+	return false
+}
+
+// declaredSubmodule reports whether .gitmodules declares path, meaning an empty
+// or absent directory is an uninitialized submodule rather than a deleted one.
+func declaredSubmodule(campaignRoot, path string) bool {
+	raw, err := os.ReadFile(filepath.Join(campaignRoot, ".gitmodules"))
+	if err != nil {
+		return false
+	}
+	want := "path = " + strings.TrimSuffix(path, "/")
+	for line := range strings.SplitSeq(string(raw), "\n") {
+		if strings.TrimSpace(line) == want {
+			return true
+		}
+	}
+	return false
+}
+
+// ScopeTargetExists reports whether a link's scope target is present on disk.
+func ScopeTargetExists(campaignRoot string, scope LinkScope) bool {
+	if scope.Path == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(campaignRoot, filepath.FromSlash(scope.Path)))
+	return err == nil
+}
+
+// Dead reports whether a link is provably dead, and why.
+//
+// The bar is deliberately high, because links.yaml is tracked and an automatic
+// removal propagates to every machine. Only one signal clears it: a scope
+// target that is missing and not machine-local. That is a single stat of an
+// explicit path -- no inference, no scan.
+//
+// A missing *workitem* is not used here even though it looks like the stronger
+// signal. Answering it means a full tree walk (wkitem.Discover, with its own
+// handling for stable ids, keys, and festival ids), and pruning on a scan means
+// any gap in it, or a branch that happens not to carry a workitem, deletes live
+// links. `camp workitem doctor` owns that case: it is an explicit user action,
+// it reports before it acts, and it already auto-fixes.
+func Dead(campaignRoot string, link Link) (reason string, dead bool) {
+	if !MachineLocal(campaignRoot, link.Scope) && !ScopeTargetExists(campaignRoot, link.Scope) {
+		return string(link.Scope.Kind) + " " + link.Scope.Path + " no longer exists", true
+	}
+	return "", false
+}
+
+// Pruned is a row PruneDead removed, with the reason it was safe to remove.
+type Pruned struct {
+	Link   Link
+	Reason string
+}
+
+// PruneDead removes provably dead rows from the registry and returns them, so
+// the caller can report what it dropped. Machine-local rows are never removed.
+func PruneDead(campaignRoot string, l *Links) []Pruned {
+	if l == nil {
+		return nil
+	}
+	var removed []Pruned
+	kept := l.Links[:0]
+	for _, link := range l.Links {
+		if reason, dead := Dead(campaignRoot, link); dead {
+			removed = append(removed, Pruned{Link: link, Reason: reason})
+			continue
+		}
+		kept = append(kept, link)
+	}
+	l.Links = kept
+	return removed
+}

--- a/internal/workitem/links/locality_test.go
+++ b/internal/workitem/links/locality_test.go
@@ -1,0 +1,144 @@
+package links
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMachineLocal(t *testing.T) {
+	root := t.TempDir()
+	gitmodules := "[submodule \"camp\"]\n\tpath = projects/camp\n\turl = git@github.com:Obedience-Corp/camp.git\n"
+	if err := os.WriteFile(filepath.Join(root, ".gitmodules"), []byte(gitmodules), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name  string
+		scope LinkScope
+		want  bool
+		why   string
+	}{
+		{
+			name:  "worktree",
+			scope: LinkScope{Kind: ScopeWorktree, Path: "projects/worktrees/fest/x"},
+			want:  true,
+			why:   "camp gitignores worktrees as machine-local",
+		},
+		{
+			name:  "declared submodule",
+			scope: LinkScope{Kind: ScopeProject, Path: "projects/camp"},
+			want:  true,
+			why:   "an uncloned submodule is absent, not deleted",
+		},
+		{
+			name:  "undeclared project",
+			scope: LinkScope{Kind: ScopeProject, Path: "projects/not-a-submodule"},
+			want:  false,
+		},
+		{
+			name:  "campaign path",
+			scope: LinkScope{Kind: ScopeCampaignPath, Path: "workflow/design/x"},
+			want:  false,
+			why:   "workflow/ is tracked, so absence is authoritative",
+		},
+		{
+			name:  "festival",
+			scope: LinkScope{Kind: ScopeFestival, Path: "festivals/active/x"},
+			want:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MachineLocal(root, tc.scope); got != tc.want {
+				t.Fatalf("MachineLocal(%v) = %v, want %v (%s)", tc.scope, got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// links.yaml is tracked, so a row removed here is removed on every machine the
+// campaign syncs to. Pruning a worktree row because the worktree is not on this
+// machine would destroy a link that is correct on another one.
+func TestPruneDead_NeverRemovesMachineLocalRows(t *testing.T) {
+	root := t.TempDir()
+
+	worktree := Link{
+		ID: "lnk_20260726_aaaaaa", WorkitemID: "design-a-2026-07-26",
+		Scope: LinkScope{Kind: ScopeWorktree, Path: "projects/worktrees/fest/elsewhere"},
+		Role:  RolePrimary,
+	}
+	deadDesign := Link{
+		ID: "lnk_20260726_bbbbbb", WorkitemID: "design-b-2026-07-26",
+		Scope: LinkScope{Kind: ScopeCampaignPath, Path: "workflow/design/deleted"},
+		Role:  RolePrimary,
+	}
+	live := Link{
+		ID: "lnk_20260726_cccccc", WorkitemID: "design-c-2026-07-26",
+		Scope: LinkScope{Kind: ScopeCampaignPath, Path: "workflow/design/here"},
+		Role:  RolePrimary,
+	}
+	if err := os.MkdirAll(filepath.Join(root, "workflow", "design", "here"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	l := &Links{Version: LinksSchemaVersion, Links: []Link{worktree, deadDesign, live}}
+	removed := PruneDead(root, l)
+
+	if len(removed) != 1 || removed[0].Link.ID != deadDesign.ID {
+		t.Fatalf("removed = %+v, want only the dead campaign path", removed)
+	}
+	if len(l.Links) != 2 {
+		t.Fatalf("registry has %d rows, want 2", len(l.Links))
+	}
+	for _, want := range []string{worktree.ID, live.ID} {
+		if _, ok := l.FindByID(want); !ok {
+			t.Fatalf("row %s was pruned and must not have been", want)
+		}
+	}
+}
+
+// A missing workitem is deliberately NOT an auto-prune signal: answering it
+// needs a full tree walk, and pruning on a scan means any gap in it, or a
+// branch that does not carry the workitem, silently deletes live links.
+// camp workitem doctor owns that case.
+func TestPruneDead_IgnoresMissingWorkitem(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "workflow", "design", "here"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	orphan := Link{
+		ID: "lnk_20260726_dddddd", WorkitemID: "design-gone-2026-07-26",
+		Scope: LinkScope{Kind: ScopeCampaignPath, Path: "workflow/design/here"},
+		Role:  RolePrimary,
+	}
+
+	l := &Links{Version: LinksSchemaVersion, Links: []Link{orphan}}
+	if removed := PruneDead(root, l); len(removed) != 0 {
+		t.Fatalf("a missing workitem must not auto-prune, removed %+v", removed)
+	}
+}
+
+func TestReportPruned_NamesEachRowAndTheUndo(t *testing.T) {
+	var out strings.Builder
+	ReportPruned(&out, []Pruned{{
+		Link: Link{
+			ID: "lnk_20260726_eeeeee", WorkitemID: "design-x-2026-07-26",
+			Scope: LinkScope{Kind: ScopeCampaignPath, Path: "workflow/design/gone"},
+		},
+		Reason: "campaign_path workflow/design/gone no longer exists",
+	}})
+	got := out.String()
+	for _, want := range []string{"lnk_20260726_eeeeee", "workflow/design/gone", "no longer exists", "undo:", "git checkout"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("report %q missing %q", got, want)
+		}
+	}
+
+	var quiet strings.Builder
+	ReportPruned(&quiet, nil)
+	if quiet.String() != "" {
+		t.Fatalf("expected no output for an empty prune, got %q", quiet.String())
+	}
+}

--- a/internal/workitem/links/validate.go
+++ b/internal/workitem/links/validate.go
@@ -2,6 +2,7 @@ package links
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -202,7 +203,14 @@ func validateOneLink(link Link, opts ValidateOptions, now time.Time,
 		addErr("scope.path", "must not contain ..")
 	} else if opts.CampaignRoot != "" && !opts.AllowMissing {
 		if err := quest.ValidateLinkPath(opts.CampaignRoot, link.Scope.Path); err != nil {
-			addErr("scope.path", err.Error())
+			// "the target must exist" is not an invariant for a machine-local
+			// scope: a worktree living on the user's other machine is absent
+			// here and correct there. Escaping the campaign root still is one,
+			// so only the existence half is relaxed.
+			outOfBounds := errors.Is(err, camperrors.ErrInvalidInput)
+			if outOfBounds || !MachineLocal(opts.CampaignRoot, link.Scope) {
+				addErr("scope.path", err.Error())
+			}
 		}
 	}
 	if msg, ok := checkKindPathPrefix(link.Scope); !ok {

--- a/internal/workitem/links/validate.go
+++ b/internal/workitem/links/validate.go
@@ -92,6 +92,72 @@ func Validate(ctx context.Context, l *Links, opts ValidateOptions) []ValidationE
 	return errs
 }
 
+// ValidateOne returns the rule failures for the single link with id linkID,
+// evaluated in the context of the rest of the registry.
+//
+// Writers use this instead of Validate. A write must be judged on what it
+// introduces, not on the state it inherits: validating the whole registry on
+// every insert means one stale row -- a worktree the user deleted, a workitem
+// that was renamed -- fails every subsequent `camp workitem link` and
+// `camp project worktree add --workitem` campaign-wide, for a reason that has
+// nothing to do with what the user asked for. Pre-existing rot is
+// `camp workitem doctor`'s job, and it can repair what it finds.
+//
+// Registry-wide invariants the new link participates in (unique id, one primary
+// per scope) are still enforced, because the other rows are their other half.
+func ValidateOne(ctx context.Context, l *Links, linkID string, opts ValidateOptions) []ValidationError {
+	if err := ctx.Err(); err != nil {
+		return []ValidationError{{Field: "context", Message: err.Error()}}
+	}
+	if l == nil {
+		return []ValidationError{{Field: "links", Message: "nil registry"}}
+	}
+
+	subject, found := l.FindByID(linkID)
+	if !found {
+		return []ValidationError{{Field: "id", Message: "link " + linkID + " is not in the registry"}}
+	}
+
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	// Seed the uniqueness maps from every *other* row so duplicate detection
+	// still sees the whole registry, then validate the subject against them.
+	seenIDs := make(map[string]struct{}, len(l.Links))
+	primaryKey := func(s LinkScope) string { return string(s.Kind) + "::" + s.Path }
+	seenPrimary := make(map[string]string, len(l.Links))
+	for _, link := range l.Links {
+		if link.ID == linkID {
+			continue
+		}
+		seenIDs[link.ID] = struct{}{}
+		if link.Role == RolePrimary {
+			seenPrimary[primaryKey(link.Scope)] = link.ID
+		}
+	}
+
+	return validateOneLink(*subject, opts, now, seenIDs, seenPrimary, primaryKey)
+}
+
+// AsError folds validation failures into one error suitable for a command to
+// return. All failures are reported rather than only the first, so a caller
+// fixing a link does not have to rediscover the next problem one run at a time.
+func AsError(errs []ValidationError) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	if len(errs) == 1 {
+		return camperrors.NewValidation(errs[0].Field, errs[0].Message, nil)
+	}
+	parts := make([]string, 0, len(errs))
+	for _, e := range errs {
+		parts = append(parts, e.Field+": "+e.Message)
+	}
+	return camperrors.NewValidation("link", strings.Join(parts, "; "), nil)
+}
+
 func validateOneLink(link Link, opts ValidateOptions, now time.Time,
 	seenIDs map[string]struct{}, seenPrimary map[string]string,
 	primaryKey func(LinkScope) string,


### PR DESCRIPTION
## The bug

One stale row in `.campaign/workitems/links.yaml` breaks every subsequent link write in the campaign.

Both writers add the new link and then validate the **whole registry**, failing on `errs[0]`:

- `internal/commands/workitem/link.go` (`camp workitem link`)
- `internal/workitem/links/attach.go` (`camp project worktree add --workitem`)

So a deleted directory fails an unrelated write, with an error naming a path the user never touched and no link id to identify it. Reproduced against a real campaign carrying 7 rot rows:

```
$ camp workitem link WI-30dd80 --worktree fest/live
Error: validation error on workitem_id: no workitem with id bug-tui-chat-bugs-2026-07-19 found on disk
```

The only escape today is `--allow-missing`, which is backwards: it suppresses the new link's own existence checks along with the stale ones.

## Fix, part 1: judge a write on what it introduces

`links.ValidateOne` validates the subject link, seeding the uniqueness maps from the other rows so **duplicate id** and **duplicate primary per scope** still span the registry. `links.AsError` reports **all** failures, so fixing a link is one round trip instead of one per problem.

## Fix, part 2: clear the rot camp can prove

Not refusing is only half an answer; dead rows should not pile up waiting for a maintenance command. But **`links.yaml` is tracked**, so an automatic removal propagates to every machine the campaign syncs to. The discriminator is whether a missing target means *gone* or only *not here*:

| Scope | Missing means | Auto-removable |
|---|---|---|
| worktree | not on this machine — camp's own scaffold writes `# Git worktrees (machine-local)` above the ignore rule it adds | no |
| project declared in `.gitmodules` | uncloned, the normal state before `camp sync` | no |
| `workflow/`, `festivals/`, campaign paths | tracked, so absent everywhere | **yes** |

`links.MachineLocal` draws that line. `PruneDead` removes only the authoritative class and reports every row with its reason and a one-command undo:

```
$ camp workitem link WI-30dd80 --worktree fest/live
removed dead link lnk_20260719_131a3c (campaign_path:workflow/design/deleted): campaign_path workflow/design/deleted no longer exists
  undo: git checkout -- .campaign/workitems/links.yaml
linked design-real-target-2026-07-26 -> worktree:projects/worktrees/fest/live (role primary, id lnk_20260726_3e813d)
```

**A missing workitem is deliberately not an auto-prune signal**, though it looks like the stronger one. Answering it needs a full tree walk (`wkitem.Discover`, with its own handling for stable ids, keys, and festival ids). Pruning on a scan means any gap in it — or a branch that does not carry the workitem — silently deletes live links. That case stays with `camp workitem doctor`, which reports before it acts and is an explicit user action.

## Two existing bugs fall out of the same distinction

1. **`camp workitem doctor --fix` deleted machine-local worktree links.** `codeBrokenScope` called `RemoveLinkByID` unconditionally, so running it on a laptop destroyed links that were correct on the desktop that owns the worktree — and the deletion travels via git. Now a warning naming `camp workitem unlink --id <id>`.

2. **The validator required every scope target to exist**, so a healthy campaign synced across two machines reported `schema.violation` errors and `camp workitem doctor` exited non-zero. Existence is now relaxed for machine-local scopes; escaping the campaign root still is not.

## Rot stays visible

`camp status` grows a notice, ignoring machine-local scopes so it does not become permanent noise on a multi-machine campaign:

```
⚠ notice: 2 workitem links point at a path that no longer exists
  run: camp workitem doctor --fix
```

Stat-level per the `internal/notice` contract: one registry read plus one stat per row.

## Verification

Against a **faithful mirror** of the real 7-rot-row campaign (`links.yaml`, `.gitmodules`, workitem tree, and project dirs all mirrored): the link succeeds, **nothing is pruned**, no notice fires. Every one of those rows is machine-local or has a live target. The old code refused the write; a naive auto-clean would have deleted 7 real rows.

Regression tests confirmed failing against pre-fix code, e.g.:

```
--- FAIL: TestAttachPrimary_SucceedsAlongsideStaleRow
    stale row blocked a valid attach: validation error on scope.path: link target does not exist

--- FAIL: TestDoctorFix_DoesNotDeleteMachineLocalWorktreeLink
    expected workitem.scope.not-on-this-machine finding, got "... [error] workitem.scope.broken
    — scope path projects/worktrees/fest/on-another-machine does not exist
      hint: remove the link or restore the directory; auto-fix removes the link"
```

New tests: `TestValidateOne_*`, `TestAsError_ReportsAllFailures`, `TestValidate_ExemptsMachineLocalScopesFromExistence`, `TestMachineLocal`, `TestPruneDead_NeverRemovesMachineLocalRows`, `TestPruneDead_IgnoresMissingWorkitem`, `TestReportPruned_NamesEachRowAndTheUndo`, `TestAttachPrimary_PrunesDeadRowsAndReports`, `TestAttachPrimary_PreservesMachineLocalRows`, `TestAttachPrimary_StillRejectsMissingScopePath`, `TestDoctorFix_DoesNotDeleteMachineLocalWorktreeLink`, `TestDoctorFix_StillRemovesAuthoritativelyDeadScope`, `TestStaleLinks_*`.

`just gate-fast`: 111 packages, 3774/3774 passed, 0 lint issues, both ratchets clean.
