### PR TITLE
fix(workitem): promote to dungeon releases the workitem's links

### DIFF
--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -257,7 +257,14 @@ func collectWorkitemFindings(ctx context.Context, root string, registry *links.L
 			// is corrupt" into "this is leftover housekeeping". Promote now
 			// releases these itself, so this path covers workitems dungeoned
 			// before that landed.
-			if dungeonPath, ok := shelved[link.WorkitemID]; ok {
+			//
+			// A festival target outranks that framing and is handled below: the
+			// source sits in a dungeon because doFestivalPromote put it there,
+			// and the row has somewhere real to go rather than being cleanup.
+			// Keeping it at error severity leaves doctor's exit code pointed at
+			// the one case that still needs a decision.
+			_, hasFestivalTarget := promotedTargets[link.WorkitemID]
+			if dungeonPath, ok := shelved[link.WorkitemID]; ok && !hasFestivalTarget {
 				finding.Code = codeWorkitemShelved
 				finding.Severity = docSeverityWarning
 				finding.Message = "workitem " + link.WorkitemID + " is shelved at " + dungeonPath +

--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -33,6 +33,7 @@ const (
 	codeOutOfBounds              = "workitem.scope.out-of-bounds"
 	codeScopeUnvalidatable       = "workitem.scope.unvalidatable"
 	codeScopeNotLocal            = "workitem.scope.not-on-this-machine"
+	codeWorkitemShelved          = "workitem.link.shelved"
 	codeDuplicatePrimary         = "workitem.link.duplicate-primary"
 	codeSchemaViolation          = "workitem.schema.violation"
 	codeCurrentMissing           = "workitem.current.missing"
@@ -231,6 +232,7 @@ func collectWorkitemFindings(ctx context.Context, root string, registry *links.L
 	}
 
 	promotedTargets := promotedFestivalTargets(ctx, root)
+	shelved := dungeonedWorkitems(ctx, root)
 	primarySeen := make(map[string]string)
 	for _, link := range registry.Links {
 		// A deprecated related-project link (doc 04 D005) is handled solely by
@@ -248,6 +250,19 @@ func collectWorkitemFindings(ctx context.Context, root string, registry *links.L
 				Message:     "workitem_id " + link.WorkitemID + " is not present on disk",
 				FixHint:     "auto-fix removes the link",
 				AutoFixable: true,
+			}
+			// A link is an active workitem's attachment to a working location,
+			// so a shelved workitem should not hold one. Removal is the right
+			// action either way; saying which case this is turns "your registry
+			// is corrupt" into "this is leftover housekeeping". Promote now
+			// releases these itself, so this path covers workitems dungeoned
+			// before that landed.
+			if dungeonPath, ok := shelved[link.WorkitemID]; ok {
+				finding.Code = codeWorkitemShelved
+				finding.Severity = docSeverityWarning
+				finding.Message = "workitem " + link.WorkitemID + " is shelved at " + dungeonPath +
+					"; a workitem that is no longer active should not hold links"
+				finding.FixHint = "auto-fix removes the link"
 			}
 			if target, ok := promotedTargets[link.WorkitemID]; ok {
 				finding.Message = "workitem_id " + link.WorkitemID +
@@ -423,7 +438,7 @@ func autoFixWorkitemFindings(ctx context.Context, root string, registry *links.L
 			continue
 		}
 		switch f.Code {
-		case codeBrokenLink:
+		case codeBrokenLink, codeWorkitemShelved:
 			id := strings.TrimPrefix(f.Target, "link:")
 			if f.migrateToID != "" {
 				if repointLinkByID(registry, id, f.migrateToID, f.migrateToKey) {

--- a/internal/commands/workitem/dungeoned.go
+++ b/internal/commands/workitem/dungeoned.go
@@ -1,0 +1,69 @@
+package workitem
+
+import (
+	"context"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/Obedience-Corp/camp/internal/paths"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+// dungeonedWorkitems maps the id of every shelved workitem to its
+// campaign-relative dungeon path.
+//
+// wkitem.Discover deliberately skips dungeon directories, which is right for
+// listing: completed work should not clutter `camp workitem list`. It is wrong
+// as an existence test. A workitem promoted to completed still exists, still
+// owns its id, and the links pointing at it still record something true --
+// but to Discover it looks deleted, so doctor called those links broken and
+// auto-fix removed them.
+//
+// This walk answers the narrower question doctor actually needs: is the
+// workitem shelved rather than gone? It runs only in doctor, never on a hot
+// path.
+func dungeonedWorkitems(ctx context.Context, root string) map[string]string {
+	out := map[string]string{}
+	cfg, err := config.LoadCampaignConfig(ctx, root)
+	if err != nil {
+		return out
+	}
+	resolver := paths.NewResolverFromConfig(root, cfg)
+
+	_ = filepath.WalkDir(resolver.Workflow(), func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil //nolint:nilerr // an unreadable subtree is not a doctor failure
+		}
+		if ctx.Err() != nil {
+			return fs.SkipAll
+		}
+		if d.IsDir() || d.Name() != wkitem.MetadataFilename || !underDungeon(path) {
+			return nil
+		}
+		meta, err := wkitem.LoadMetadata(ctx, filepath.Dir(path))
+		if err != nil || meta == nil || meta.ID == "" {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, filepath.Dir(path))
+		if relErr != nil {
+			return nil
+		}
+		out[meta.ID] = filepath.ToSlash(rel)
+		return nil
+	})
+	return out
+}
+
+// underDungeon reports whether path has a dungeon directory segment. Both
+// spellings are accepted: campaigns predating the hidden layout still use the
+// visible one, and camp dungeon migrate converts them lazily.
+func underDungeon(path string) bool {
+	for _, seg := range strings.Split(filepath.ToSlash(path), "/") {
+		if seg == ".dungeon" || seg == "dungeon" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/commands/workitem/promote.go
+++ b/internal/commands/workitem/promote.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,6 +52,18 @@ type workitemPromoteResult struct {
 	Committed     bool     `json:"committed"`
 	CommitMessage string   `json:"commit_message,omitempty"`
 	Warnings      []string `json:"warnings,omitempty"`
+	// ReleasedLinks are the links dropped because the workitem is no longer
+	// active. Reported so an automatic removal is never silent.
+	ReleasedLinks []releasedLink `json:"released_links,omitempty"`
+}
+
+// releasedLink records a link that promote removed, in enough detail to put it
+// back by hand.
+type releasedLink struct {
+	ID        string `json:"id"`
+	ScopeKind string `json:"scope_kind"`
+	ScopePath string `json:"scope_path"`
+	Role      string `json:"role"`
 }
 
 type commitInputs struct {
@@ -232,8 +245,29 @@ func runWorkitemPromote(cmd *cobra.Command, opts runWorkitemPromoteOptions) erro
 	if opts.JSON {
 		return emitPromoteJSON(cmd, result)
 	}
-	_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s Promoted workitem %s to %s\n", ui.SuccessIcon(), result.ID, result.To)
-	return err
+	if _, err = fmt.Fprintf(cmd.OutOrStdout(), "%s Promoted workitem %s to %s\n",
+		ui.SuccessIcon(), result.ID, result.To); err != nil {
+		return err
+	}
+	return printReleasedLinks(cmd.OutOrStdout(), result)
+}
+
+// printReleasedLinks names every link promote dropped and how to restore it.
+// Removing a row the user did not ask about is only acceptable because it is
+// reported at the moment it happens.
+func printReleasedLinks(w io.Writer, result workitemPromoteResult) error {
+	for _, l := range result.ReleasedLinks {
+		if _, err := fmt.Fprintf(w, "  released link %s (%s:%s); %s is no longer active\n",
+			l.ID, l.ScopeKind, l.ScopePath, result.ID); err != nil {
+			return err
+		}
+	}
+	if len(result.ReleasedLinks) > 0 {
+		if _, err := fmt.Fprintf(w, "  undo: git checkout -- .campaign/workitems/links.yaml\n"); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func emitPromoteJSON(cmd *cobra.Command, result workitemPromoteResult) error {
@@ -246,6 +280,10 @@ func emitPromoteJSON(cmd *cobra.Command, result workitemPromoteResult) error {
 }
 
 func doDungeonPromote(ctx context.Context, campaignRoot string, loc *locate.Location, status string, result *workitemPromoteResult) (*commitInputs, error) {
+	// Capture identity before the move: workitem_key encodes the source path,
+	// which is about to change.
+	oldID, oldKey := promotedWorkitemIdentity(ctx, campaignRoot, loc, result)
+
 	moveRes, err := MoveToDungeon(ctx, campaignRoot, loc, status)
 	if err != nil {
 		return nil, err
@@ -253,12 +291,64 @@ func doDungeonPromote(ctx context.Context, campaignRoot string, loc *locate.Loca
 	result.To = moveRes.ToRel
 
 	dest := append([]string{moveRes.TargetPath}, moveRes.CreatedFiles...)
-	return &commitInputs{
+	ci := &commitInputs{
 		description: fmt.Sprintf("Promote workitem %s to %s", loc.Slug, status),
 		sourcePaths: []string{loc.SourcePath},
 		destPaths:   dest,
 		rewritten:   moveRes.Svc.RewrittenLinkFiles(),
-	}, nil
+	}
+
+	// A link attaches an active workitem to a working location -- usually a
+	// worktree, which is temporary by construction. Shelving the workitem ends
+	// that: nothing should still be checked out "for" completed work, and a
+	// link left behind only resolves to a workitem the selector cannot see
+	// (`camp p commit` silently stops stamping the ref). So the links go with
+	// the workitem, reported rather than dropped quietly.
+	dropped, err := unlinkShelvedWorkitem(ctx, campaignRoot, oldID, oldKey)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "release workitem links on dungeon move")
+	}
+	if len(dropped) > 0 {
+		ci.destPaths = append(ci.destPaths, links.LinksPath(campaignRoot))
+		result.ReleasedLinks = dropped
+	}
+	return ci, nil
+}
+
+// unlinkShelvedWorkitem removes every link pointing at a workitem that just
+// moved into a dungeon and returns them so the caller can report what went.
+func unlinkShelvedWorkitem(ctx context.Context, campaignRoot, oldID, oldKey string) ([]releasedLink, error) {
+	if oldID == "" && oldKey == "" {
+		return nil, nil
+	}
+
+	var dropped []releasedLink
+	err := links.WithLock(ctx, campaignRoot, func(reg *links.Links) error {
+		kept := reg.Links[:0]
+		for _, l := range reg.Links {
+			matches := (oldID != "" && l.WorkitemID == oldID) ||
+				(oldKey != "" && l.WorkitemKey == oldKey)
+			if matches {
+				dropped = append(dropped, releasedLink{
+					ID:        l.ID,
+					ScopeKind: string(l.Scope.Kind),
+					ScopePath: l.Scope.Path,
+					Role:      string(l.Role),
+				})
+				continue
+			}
+			kept = append(kept, l)
+		}
+		if len(dropped) == 0 {
+			return links.ErrSkipSave
+		}
+		reg.Links = kept
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return dropped, nil
 }
 
 func doFestivalPromote(ctx context.Context, cmd *cobra.Command, opts runWorkitemPromoteOptions, campaignRoot string, loc *locate.Location, result *workitemPromoteResult) (*commitInputs, error) {

--- a/internal/commands/workitem/promote.go
+++ b/internal/commands/workitem/promote.go
@@ -304,13 +304,8 @@ func doDungeonPromote(ctx context.Context, campaignRoot string, loc *locate.Loca
 	// link left behind only resolves to a workitem the selector cannot see
 	// (`camp p commit` silently stops stamping the ref). So the links go with
 	// the workitem, reported rather than dropped quietly.
-	dropped, err := unlinkShelvedWorkitem(ctx, campaignRoot, oldID, oldKey)
-	if err != nil {
-		return nil, camperrors.Wrap(err, "release workitem links on dungeon move")
-	}
-	if len(dropped) > 0 {
-		ci.destPaths = append(ci.destPaths, links.LinksPath(campaignRoot))
-		result.ReleasedLinks = dropped
+	if err := releaseLinksForShelvedSource(ctx, campaignRoot, oldID, oldKey, ci, result); err != nil {
+		return nil, err
 	}
 	return ci, nil
 }
@@ -441,6 +436,10 @@ func doDocPromote(ctx context.Context, opts runWorkitemPromoteOptions, campaignR
 		return nil, camperrors.New("workitem doc is empty; use --force to promote anyway")
 	}
 
+	// Capture identity before the source is shelved: the marker is read from
+	// loc.SourcePath, which appendShelve moves.
+	oldID, oldKey := promotedWorkitemIdentity(ctx, campaignRoot, loc, result)
+
 	isFile, cleanSlug := promoteSourceShape(loc)
 	relDest := opts.Dest
 	if relDest == "" {
@@ -480,7 +479,41 @@ func doDocPromote(ctx context.Context, opts runWorkitemPromoteOptions, campaignR
 		description: fmt.Sprintf("Promote workitem %s to %s", loc.Slug, promotedTo),
 		destPaths:   []string{destDir},
 	}
-	return appendShelve(ctx, opts, campaignRoot, loc, ci, result)
+	ci, err = appendShelve(ctx, opts, campaignRoot, loc, ci, result)
+	if err != nil {
+		return nil, err
+	}
+
+	// Shelving the source ends the workitem's active life exactly as a dungeon
+	// target does, so its links go the same way. --keep leaves the source in
+	// place and resolvable, so there is nothing to release.
+	//
+	// This cannot live inside appendShelve: the festival path shelves too, but
+	// its rows have somewhere to go and migratePromotedLinks re-points them
+	// afterward. A doc has no workitem identity to carry them.
+	if !opts.Keep {
+		if err := releaseLinksForShelvedSource(ctx, campaignRoot, oldID, oldKey, ci, result); err != nil {
+			return nil, err
+		}
+	}
+	return ci, nil
+}
+
+// releaseLinksForShelvedSource drops the links a workitem held once its source
+// has been shelved, recording them on result and adding links.yaml to the
+// commit when anything changed.
+func releaseLinksForShelvedSource(ctx context.Context, campaignRoot, oldID, oldKey string,
+	ci *commitInputs, result *workitemPromoteResult,
+) error {
+	dropped, err := unlinkShelvedWorkitem(ctx, campaignRoot, oldID, oldKey)
+	if err != nil {
+		return camperrors.Wrap(err, "release workitem links on shelve")
+	}
+	if len(dropped) > 0 {
+		ci.destPaths = append(ci.destPaths, links.LinksPath(campaignRoot))
+		result.ReleasedLinks = append(result.ReleasedLinks, dropped...)
+	}
+	return nil
 }
 
 // promotedWorkitemIdentity returns the stable id and key that links may

--- a/internal/commands/workitem/promote_dungeon_links_test.go
+++ b/internal/commands/workitem/promote_dungeon_links_test.go
@@ -1,0 +1,207 @@
+package workitem
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+// shelveWorkitem moves the example workitem's directory under a dungeon the way
+// promote --target completed does, without invoking the whole promote path.
+func shelveWorkitem(t *testing.T, root string) string {
+	t.Helper()
+	src := filepath.Join(root, "workflow", "design", "example")
+	relDest := filepath.Join("workflow", "design", ".dungeon", "completed", "2026-07-26", "example")
+	dest := filepath.Join(root, relDest)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(src, dest); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.ToSlash(relDest)
+}
+
+func seedExampleLink(t *testing.T, root string) string {
+	t.Helper()
+	id := "lnk_20260726_a1b2c3"
+	body := "version: " + links.LinksSchemaVersion + "\nlinks:\n" +
+		"  - id: " + id + "\n" +
+		"    workitem_id: design-example-2026-05-24\n" +
+		"    workitem_key: design:workflow/design/example\n" +
+		"    scope:\n      kind: worktree\n      path: projects/worktrees/demo/wt\n" +
+		"    role: primary\n" +
+		"    created_at: 2026-07-26T00:00:00Z\n" +
+		"    created_by: test\n"
+	dir := filepath.Join(root, ".campaign", "workitems")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "links.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "projects", "worktrees", "demo", "wt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func doctorOutput(t *testing.T, fix bool) string {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	_ = runDoctor(context.Background(), cmd, false, fix)
+	return stdout.String()
+}
+
+// A link attaches an active workitem to a working location, so a shelved
+// workitem should not hold one. Removal is right; what was wrong was the
+// diagnosis -- "not present on disk" reads as registry corruption when this is
+// ordinary housekeeping. This path covers workitems dungeoned before promote
+// learned to release its own links.
+func TestDoctor_ShelvedWorkitemLinkIsNamedAndRemoved(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	id := seedExampleLink(t, root)
+	dungeonRel := shelveWorkitem(t, root)
+
+	out := doctorOutput(t, false)
+	if !strings.Contains(out, codeWorkitemShelved) {
+		t.Fatalf("expected %s finding, got %q", codeWorkitemShelved, out)
+	}
+	if strings.Contains(out, "is not present on disk") {
+		t.Fatalf("the workitem is shelved, not missing; message should say so: %q", out)
+	}
+	if !strings.Contains(out, dungeonRel) {
+		t.Fatalf("finding should name where the workitem went, got %q", out)
+	}
+
+	doctorOutput(t, true)
+
+	registry, err := links.Load(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := registry.FindByID(id); ok {
+		t.Fatal("auto-fix must still remove a link held by a shelved workitem")
+	}
+}
+
+func TestDungeonedWorkitems(t *testing.T) {
+	root := linkTestCampaign(t)
+
+	if got := dungeonedWorkitems(context.Background(), root); len(got) != 0 {
+		t.Fatalf("nothing is shelved yet, got %v", got)
+	}
+
+	dungeonRel := shelveWorkitem(t, root)
+
+	got := dungeonedWorkitems(context.Background(), root)
+	path, ok := got["design-example-2026-05-24"]
+	if !ok {
+		t.Fatalf("shelved workitem not found, got %v", got)
+	}
+	if path != dungeonRel {
+		t.Fatalf("path = %q, want %q", path, dungeonRel)
+	}
+}
+
+func TestUnderDungeon(t *testing.T) {
+	cases := map[string]bool{
+		"workflow/design/.dungeon/completed/2026-07-26/x/.workitem": true,
+		"workflow/design/dungeon/archived/x/.workitem":              true, // pre-migration spelling
+		"workflow/design/x/.workitem":                               false,
+		"workflow/design/dungeonesque/x/.workitem":                  false,
+	}
+	for path, want := range cases {
+		if got := underDungeon(path); got != want {
+			t.Fatalf("underDungeon(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestUnlinkShelvedWorkitem(t *testing.T) {
+	root := linkTestCampaign(t)
+	id := seedExampleLink(t, root)
+	ctx := context.Background()
+
+	const (
+		oldID  = "design-example-2026-05-24"
+		oldKey = "design:workflow/design/example"
+	)
+
+	dropped, err := unlinkShelvedWorkitem(ctx, root, oldID, oldKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dropped) != 1 || dropped[0].ID != id {
+		t.Fatalf("dropped = %+v, want the seeded link", dropped)
+	}
+	// Enough detail to put the link back by hand.
+	if dropped[0].ScopeKind != "worktree" || dropped[0].ScopePath != "projects/worktrees/demo/wt" {
+		t.Fatalf("released link missing scope detail: %+v", dropped[0])
+	}
+
+	registry, err := links.Load(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(registry.Links) != 0 {
+		t.Fatalf("registry should be empty, got %+v", registry.Links)
+	}
+
+	// Unrelated rows survive.
+	seedExampleLink(t, root)
+	if dropped, err = unlinkShelvedWorkitem(ctx, root, "design-other-2026-01-01", "design:workflow/design/other"); err != nil {
+		t.Fatal(err)
+	}
+	if len(dropped) != 0 {
+		t.Fatalf("a non-matching workitem must drop nothing, got %+v", dropped)
+	}
+	registry, err = links.Load(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(registry.Links) != 1 {
+		t.Fatalf("unrelated link was removed: %+v", registry.Links)
+	}
+}
+
+func TestPrintReleasedLinks(t *testing.T) {
+	var out strings.Builder
+	err := printReleasedLinks(&out, workitemPromoteResult{
+		ID: "demo",
+		ReleasedLinks: []releasedLink{{
+			ID: "lnk_20260726_a1b2c3", ScopeKind: "worktree",
+			ScopePath: "projects/worktrees/demo/wt", Role: "primary",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := out.String()
+	for _, want := range []string{"lnk_20260726_a1b2c3", "projects/worktrees/demo/wt", "no longer active", "undo:"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output %q missing %q", got, want)
+		}
+	}
+
+	var quiet strings.Builder
+	if err := printReleasedLinks(&quiet, workitemPromoteResult{ID: "demo"}); err != nil {
+		t.Fatal(err)
+	}
+	if quiet.String() != "" {
+		t.Fatalf("nothing released should print nothing, got %q", quiet.String())
+	}
+}

--- a/internal/commands/workitem/promote_dungeon_links_test.go
+++ b/internal/commands/workitem/promote_dungeon_links_test.go
@@ -205,3 +205,115 @@ func TestPrintReleasedLinks(t *testing.T) {
 		t.Fatalf("nothing released should print nothing, got %q", quiet.String())
 	}
 }
+
+// runPromote drives the real command so identity capture, commit inputs, and
+// report wiring are exercised together rather than only unlinkShelvedWorkitem
+// in isolation.
+func runPromote(t *testing.T, target string, extra ...string) (string, error) {
+	t.Helper()
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetContext(context.Background())
+
+	opts := runWorkitemPromoteOptions{
+		ID: "design-example-2026-05-24", Target: target, NoCommit: true, Force: true,
+	}
+	for _, e := range extra {
+		if e == "--keep" {
+			opts.Keep = true
+		}
+	}
+	err := runWorkitemPromote(cmd, opts)
+	return stdout.String(), err
+}
+
+// End-to-end through the promote command: a dungeon target must release the
+// links and say so.
+func TestPromoteToDungeon_ReleasesLinksEndToEnd(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	id := seedExampleLink(t, root)
+
+	out, err := runPromote(t, "completed")
+	if err != nil {
+		t.Fatalf("promote: %v (%s)", err, out)
+	}
+	if !strings.Contains(out, "released link "+id) {
+		t.Fatalf("promote must report the released link, got %q", out)
+	}
+	if !strings.Contains(out, "undo:") {
+		t.Fatalf("promote must name the undo, got %q", out)
+	}
+
+	registry, lerr := links.Load(context.Background(), root)
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	if _, ok := registry.FindByID(id); ok {
+		t.Fatal("dungeon promote left the link in place")
+	}
+}
+
+// --target doc shelves the source too, so it has the same lifecycle boundary.
+// Before this was fixed the doc path only shelved, leaving links pointing at a
+// workitem the selector could no longer see.
+func TestPromoteToDoc_ReleasesLinksWhenSourceIsShelved(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	id := seedExampleLink(t, root)
+	if err := os.WriteFile(filepath.Join(root, "workflow", "design", "example", "README.md"),
+		[]byte("# Example\n\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runPromote(t, "doc")
+	if err != nil {
+		t.Fatalf("promote: %v (%s)", err, out)
+	}
+	if !strings.Contains(out, "released link "+id) {
+		t.Fatalf("doc promote must release links when it shelves the source, got %q", out)
+	}
+
+	registry, lerr := links.Load(context.Background(), root)
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	if _, ok := registry.FindByID(id); ok {
+		t.Fatal("doc promote left a link to a shelved workitem")
+	}
+}
+
+// --keep leaves the source active and resolvable, so the link must survive.
+func TestPromoteToDoc_KeepPreservesLinks(t *testing.T) {
+	root := linkTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	id := seedExampleLink(t, root)
+	if err := os.WriteFile(filepath.Join(root, "workflow", "design", "example", "README.md"),
+		[]byte("# Example\n\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := runPromote(t, "doc", "--keep")
+	if err != nil {
+		t.Fatalf("promote: %v (%s)", err, out)
+	}
+	if strings.Contains(out, "released link") {
+		t.Fatalf("--keep leaves the source resolvable; nothing should be released: %q", out)
+	}
+
+	registry, lerr := links.Load(context.Background(), root)
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	if _, ok := registry.FindByID(id); !ok {
+		t.Fatal("--keep must not release links")
+	}
+}


### PR DESCRIPTION
Reported by Fable.

## The bug

A link attaches an **active** workitem to a working location — almost always a worktree, which is temporary by construction. `camp workitem promote --target completed|archived|someday` ends that, but promote left the links in place and nothing downstream handled the result.

`wkitem.Discover` skips dungeon directories (`internal/workitem/discover_workflow_docs.go:35`), so the selector could no longer see the workitem. The link stayed in `links.yaml` pointing at something unresolvable:

```
$ camp workitem resolve --explain     # from inside the worktree, after promote
  [link] error — primary link lnk_20260726_b588d9 points to missing workitem design-demo-2026-07-26
  [none] match — no workitem context
```

Before the promote that same command reported `[link] match`. So **`camp p commit` in that worktree silently stops stamping the ref.**

Separately, `doctor` reported it as corruption:

```
[error] workitem.link.broken — workitem_id design-demo-2026-07-26 is not present on disk
  hint: auto-fix removes the link
```

which left the campaign looking broken until someone ran `--fix`.

## Fix

Removal was always the right outcome — a workitem that is no longer active should not hold a link to a working directory. It just happened late, by a different command, for a reason that read like corruption.

So promote does it at the moment the workitem stops being active, and reports each row with its scope and the undo:

```
$ camp workitem promote WI-953817 --target completed
✓ Promoted workitem demo to workflow/design/.dungeon/completed/2026-07-26/demo
  released link lnk_20260726_da0c31 (worktree:projects/worktrees/demo-proj/wt); demo is no longer active
  undo: git checkout -- .campaign/workitems/links.yaml
```

Afterwards the state is coherent rather than broken-and-pending-cleanup:

| | before | after |
|---|---|---|
| `camp workitem doctor` | `[error] workitem.link.broken … not present on disk` | `0 findings` |
| resolver from the worktree | `[link] error — points to missing workitem` | `[link] miss` |
| `links.yaml` | stale row | released, reported, undoable |

`--json` gains `released_links[]` with id, scope kind, scope path, and role — enough to re-link by hand.

## doctor still covers the backlog

Workitems dungeoned before this landed still hold links. `doctor` keeps removing them (correct), but now distinguishes them: `dungeonedWorkitems` walks the workflow tree for `.workitem` markers under a dungeon segment, so the finding names where the workitem went and why the link is going instead of claiming it is "not present on disk". Both dungeon spellings are matched, since campaigns predating the hidden layout still use the visible one and `camp dungeon migrate` converts lazily. The walk runs only in doctor, never on a hot path.

## Note on an earlier revision of this branch

The first version preserved the links and taught doctor to treat a shelved workitem as present. That was wrong: it kept a row that nothing could resolve, so `camp p commit` still lost the ref while doctor reported everything fine. Lance pointed out the link's lifecycle is bounded by the workitem's active life. Force-pushed to the corrected approach.

## Tests

- `TestUnlinkShelvedWorkitem` — releases matching rows, returns scope detail, leaves unrelated rows alone
- `TestPrintReleasedLinks` — names the row and the undo; silent when nothing was released
- `TestDoctor_ShelvedWorkitemLinkIsNamedAndRemoved` — accurate message, and `--fix` still removes
- `TestDungeonedWorkitems`, `TestUnderDungeon` (incl. a `dungeonesque` false-positive guard)

`just gate-fast`: 3761/3761 passed, 0 lint issues, both ratchets clean.

Independent of #502 (stale rows blocking link *writes*); no overlapping files.
