### PR TITLE
feat(switch): carry hop origin, add 'camp switch -', resolve self-references locally

### DIFF
--- a/cmd/camp/hop_origin.go
+++ b/cmd/camp/hop_origin.go
@@ -10,7 +10,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/machines"
+	"github.com/Obedience-Corp/camp/internal/remote"
 )
 
 // HopOriginEnvVar carries the origin machine identity into a hopped session.
@@ -308,4 +312,98 @@ func suggestedMachineID(host string) string {
 		return ""
 	}
 	return id
+}
+
+// hopBackSelector is the reserved argument for the hop-back gesture. It is
+// checked before selector parsing because `-` is otherwise a legal campaign
+// query that reaches the fuzzy tier and matches an arbitrary hyphenated
+// campaign name, differently on every invocation.
+const hopBackSelector = "-"
+
+// transientOriginSuffix namespaces the in-memory machine built from a payload.
+// The id becomes a ControlMaster socket name, so colliding with a REGISTERED
+// machine id would make ssh reuse that machine's live master and land the hop
+// on the wrong host. A registered id ending in "-origin" would have to be
+// created deliberately.
+const transientOriginSuffix = "-origin"
+
+// runHopBack implements `camp switch -`: return to the machine and campaign this
+// session was hopped from. Registration-independent by design — the origin need
+// never have been adopted here — so it reads the payload and builds a transient
+// machine rather than consulting ~/.obey/machines.yaml. Nothing is written.
+func runHopBack(ctx context.Context, cmd *cobra.Command, printOnly, shellConnect, jsonOut bool) error {
+	raw := os.Getenv(HopOriginEnvVar)
+	if strings.TrimSpace(raw) == "" {
+		return camperrors.New("camp switch -: this session did not start from a camp hop (" +
+			HopOriginEnvVar + " is not set)")
+	}
+	origin, err := ParseHopOrigin(raw)
+	if err != nil {
+		return camperrors.New("camp switch -: " + HopOriginEnvVar + " is malformed (" + err.Error() +
+			"); hop back with 'camp switch <machine>:<campaign>'")
+	}
+	if origin.Campaign == "" {
+		return camperrors.New("camp switch -: origin campaign unknown (the outbound hop did not start " +
+			"inside a campaign); hop back with 'camp switch <machine>:<campaign>'")
+	}
+
+	m, registered := originTarget(origin)
+	if err := guardRemoteOutputFlags(m.ID, printOnly, jsonOut); err != nil {
+		return err
+	}
+	root, err := hopBackResolveRoot(ctx, m, origin.Campaign)
+	if err != nil {
+		return hopBackFailure(err, m, registered)
+	}
+	return emitHopOrRefuse(ctx, cmd, m, origin.Campaign, root, shellConnect)
+}
+
+// originTarget resolves the payload to a machine to hop to. A registered entry
+// matching the origin host wins: it carries the operator's own identity_file,
+// ssh_user, and auth_method, all better information than the payload has. This
+// is the expected steady state once a fleet is mutually adopted.
+//
+// Otherwise the machine is transient and in-memory. AuthMethod is left empty on
+// purpose: the hop argv is identical for tailscale-ssh and ssh-agent (authArgs
+// branches only on IdentityFile), EnsureKeyAuth rejects only ssh-password, and
+// failure classification reads ssh's own stderr. Guessing an auth mode would put
+// a wrong label on the one message an operator reads when a hop breaks.
+func originTarget(origin HopOrigin) (*machines.Machine, bool) {
+	want := strings.ToLower(normalizeDNSName(origin.Host))
+	if mf, err := machines.Load(); err == nil {
+		for i := range mf.Machines {
+			if strings.ToLower(normalizeDNSName(mf.Machines[i].Host)) == want {
+				return &mf.Machines[i], true
+			}
+		}
+	}
+	return &machines.Machine{
+		ID:      transientOriginID(origin.Host),
+		Label:   origin.Host,
+		Host:    origin.Host,
+		SSHUser: origin.User,
+	}, false
+}
+
+// transientOriginID derives the in-memory machine's id. It is only two things:
+// a ControlMaster path component and a name in error text. Both tolerate a
+// generic value; neither tolerates an empty one, which would collapse the socket
+// path to ~/.obey/ssh-ctl/.sock and share one socket across every degenerate
+// origin — the exact cross-host reuse the suffix exists to prevent.
+func transientOriginID(host string) string {
+	if id := suggestedMachineID(host); id != "" {
+		return id + transientOriginSuffix
+	}
+	return strings.TrimPrefix(transientOriginSuffix, "-")
+}
+
+// hopBackFailure explains an unreachable origin. The diagnostic pointer differs
+// by registration because `camp machine diagnose` only knows registered
+// machines: pointing an operator at it for a transient origin sends them to a
+// command that answers "unknown machine".
+func hopBackFailure(err error, m *machines.Machine, registered bool) error {
+	if registered {
+		return camperrors.Wrapf(err, "run 'camp machine diagnose %s' to check reachability", m.ID)
+	}
+	return camperrors.Wrapf(err, "the origin is not registered here, probe it with: %s", remote.ProbeCommand(m))
 }

--- a/cmd/camp/hop_origin.go
+++ b/cmd/camp/hop_origin.go
@@ -407,3 +407,31 @@ func hopBackFailure(err error, m *machines.Machine, registered bool) error {
 	}
 	return camperrors.Wrapf(err, "the origin is not registered here, probe it with: %s", remote.ProbeCommand(m))
 }
+
+// isSelfMachine reports whether a selector's machine segment names THIS
+// machine, by comparing against the id derived from this machine's reachable
+// name — character for character the derivation that fills the payload's id
+// field, so the two answers cannot disagree.
+//
+// Ordering matters and is deliberate. This is checked only AFTER
+// machines.LocalMachineID and only for a selector that would otherwise hop, so
+// the detection cost (a tailscale probe) never lands on a successful local
+// switch. A registered machine still wins: a machines.yaml entry pointing at
+// this machine is a misconfiguration that `camp machine adopt` refuses to
+// create, and honoring the operator's explicit file here is better than
+// second-guessing it on every hop.
+func isSelfMachine(ctx context.Context, id string) bool {
+	if id == "" {
+		return false
+	}
+	if mf, err := machines.Load(); err == nil {
+		if _, _, found := mf.Lookup(id); found {
+			return false
+		}
+	}
+	host, err := detectReachableName(ctx, runTailscaleStatusForSelf)
+	if err != nil || host == "" {
+		return false
+	}
+	return suggestedMachineID(host) == id
+}

--- a/cmd/camp/hop_origin.go
+++ b/cmd/camp/hop_origin.go
@@ -351,7 +351,7 @@ func runHopBack(ctx context.Context, cmd *cobra.Command, printOnly, shellConnect
 	if err := guardRemoteOutputFlags(m.ID, printOnly, jsonOut); err != nil {
 		return err
 	}
-	root, err := hopBackResolveRoot(ctx, m, origin.Campaign)
+	root, err := resolveRemoteRoot(ctx, m, origin.Campaign)
 	if err != nil {
 		return hopBackFailure(err, m, registered)
 	}

--- a/cmd/camp/hop_origin.go
+++ b/cmd/camp/hop_origin.go
@@ -149,14 +149,29 @@ func ParseHopOrigin(payload string) (HopOrigin, error) {
 		if hopOriginHasC0(val) {
 			return HopOrigin{}, camperrors.New("field \"" + key + "\" contains a control character")
 		}
+		// Re-apply encode-side field caps on the wire form (raw, pre-decode
+		// length matches encodeHopOrigin's len(encoded) checks). Required
+		// fields fail closed; optional fields drop, same as encode.
 		switch key {
 		case "host":
+			if len(raw) > hopOriginMaxHost {
+				return HopOrigin{}, camperrors.New("field \"host\" is too long")
+			}
 			o.Host = val
 		case "user":
+			if len(raw) > hopOriginMaxUser {
+				return HopOrigin{}, camperrors.New("field \"user\" is too long")
+			}
 			o.User = val
 		case "campaign":
+			if len(raw) > hopOriginMaxCampaign {
+				continue
+			}
 			o.Campaign = val
 		case "id":
+			if len(raw) > hopOriginMaxID {
+				continue
+			}
 			o.ID = val
 		}
 		// Unknown keys are ignored so additive v1 fields do not break older

--- a/cmd/camp/hop_origin.go
+++ b/cmd/camp/hop_origin.go
@@ -22,6 +22,21 @@ import (
 // the far machine can name where the session came from without any reverse
 // connection or sshd configuration. Mirrors the CAMP_QUEST pattern
 // (internal/quest/shellenv.go) with more fields.
+//
+// Trust model, because this value steers an ssh: it is session-local state, not
+// an authenticated claim. Anything that can set the environment of a camp
+// process can choose where `camp switch -` dials, and hops use
+// StrictHostKeyChecking=accept-new, so a first connection to a host named by a
+// forged payload accepts its key. Encoding bounds what a payload can SAY -- the
+// unreserved set keeps ';' and '=' out of values, parse rejects C0 controls and
+// re-applies the field caps, and remote.ShellQuote keeps the emitted line from
+// breaking out of its quoting -- but none of that binds the payload to a
+// cryptographic identity.
+//
+// What limits the blast radius is that the same trust already exists: a process
+// that can set this variable can equally invoke ssh directly. The value ranks
+// below the operator's own fleet file, which is why originTarget prefers a
+// registered row whose host matches, and hop-back never writes anything.
 const HopOriginEnvVar = "CAMP_HOP_ORIGIN"
 
 // hopOriginVersion prefixes every payload. A consumer that does not recognize
@@ -380,6 +395,14 @@ func runHopBack(ctx context.Context, cmd *cobra.Command, printOnly, shellConnect
 			"inside a campaign); hop back with 'camp switch <machine>:<campaign>'")
 	}
 
+	// A payload naming this machine is stale or forged; either way the hop it
+	// would emit is an ssh to ourselves, which yields a nested session rather
+	// than a switch. Say where the user already is instead.
+	if isSelfHost(ctx, origin.Host) {
+		return camperrors.New("camp switch -: the origin is this machine; " +
+			"you are already here — use 'camp switch " + origin.Campaign + "' to switch locally")
+	}
+
 	m, registered := originTarget(origin)
 	if err := guardRemoteOutputFlags(m.ID, printOnly, jsonOut); err != nil {
 		return err
@@ -452,16 +475,17 @@ func hopBackFailure(err error, m *machines.Machine, registered bool) error {
 // switch. A registered id wins over self-detection: Lookup(id) only — any
 // machines.yaml row whose id equals the selector suppresses local resolve,
 // regardless of that row's host. That honors the operator's explicit id
-// mapping; adopt refuses to create a true self-row, but a shared fleet file
-// that lists every node under its real id (including this one) will hop via
-// ssh rather than short-circuit locally.
+// mapping — except when that entry points back at this machine, which is the
+// one case where honoring it means sshing to ourselves. A fleet file shared
+// verbatim across every node lists this one under its real id, and that is an
+// ordinary way to run a mesh rather than a misconfiguration.
 func isSelfMachine(ctx context.Context, id string) bool {
 	if id == "" {
 		return false
 	}
 	if mf, err := machines.Load(); err == nil {
-		if _, _, found := mf.Lookup(id); found {
-			return false
+		if m, _, found := mf.Lookup(id); found {
+			return m != nil && isSelfHost(ctx, m.Host)
 		}
 	}
 	host, err := detectReachableName(ctx, runTailscaleStatusForSelf)
@@ -469,4 +493,44 @@ func isSelfMachine(ctx context.Context, id string) bool {
 		return false
 	}
 	return suggestedMachineID(host) == id
+}
+
+// selfHostNames returns the names this machine answers to: the tailnet name
+// when tailscale is up, and the bare hostname always.
+//
+// Both, because they disagree often enough to matter and a guard that knows
+// only one lets the mismatch through. A payload built while tailscale was down
+// carries the bare name; detection with tailscale up returns the tailnet one.
+func selfHostNames(ctx context.Context) []string {
+	var names []string
+	add := func(run reachableNameFunc) {
+		n, err := detectReachableName(ctx, run)
+		if err != nil || n == "" {
+			return
+		}
+		n = strings.ToLower(normalizeDNSName(n))
+		for _, have := range names {
+			if have == n {
+				return
+			}
+		}
+		names = append(names, n)
+	}
+	add(runTailscaleStatusForSelf)
+	add(nil)
+	return names
+}
+
+// isSelfHost reports whether host names this machine.
+func isSelfHost(ctx context.Context, host string) bool {
+	want := strings.ToLower(normalizeDNSName(host))
+	if want == "" {
+		return false
+	}
+	for _, n := range selfHostNames(ctx) {
+		if n == want {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/camp/hop_origin.go
+++ b/cmd/camp/hop_origin.go
@@ -143,6 +143,12 @@ func ParseHopOrigin(payload string) (HopOrigin, error) {
 		if err != nil {
 			return HopOrigin{}, err
 		}
+		// Reject C0 controls after decode so encode/parse stay symmetric:
+		// encode percent-encodes them, but a handcrafted env could still
+		// inject %0A/%0D and break the one-line shell-connect contract.
+		if hopOriginHasC0(val) {
+			return HopOrigin{}, camperrors.New("field \"" + key + "\" contains a control character")
+		}
 		switch key {
 		case "host":
 			o.Host = val
@@ -163,6 +169,18 @@ func ParseHopOrigin(payload string) (HopOrigin, error) {
 		return HopOrigin{}, camperrors.New("missing user")
 	}
 	return o, nil
+}
+
+// hopOriginHasC0 reports whether s contains a C0 control byte (including
+// newline/CR). Mirrors the encode-side newline guard so a hostile env cannot
+// smuggle controls past ParseHopOrigin via percent-encoding.
+func hopOriginHasC0(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 {
+			return true
+		}
+	}
+	return false
 }
 
 // hopOriginEncode percent-encodes everything outside the unreserved set, which
@@ -416,10 +434,12 @@ func hopBackFailure(err error, m *machines.Machine, registered bool) error {
 // Ordering matters and is deliberate. This is checked only AFTER
 // machines.LocalMachineID and only for a selector that would otherwise hop, so
 // the detection cost (a tailscale probe) never lands on a successful local
-// switch. A registered machine still wins: a machines.yaml entry pointing at
-// this machine is a misconfiguration that `camp machine adopt` refuses to
-// create, and honoring the operator's explicit file here is better than
-// second-guessing it on every hop.
+// switch. A registered id wins over self-detection: Lookup(id) only — any
+// machines.yaml row whose id equals the selector suppresses local resolve,
+// regardless of that row's host. That honors the operator's explicit id
+// mapping; adopt refuses to create a true self-row, but a shared fleet file
+// that lists every node under its real id (including this one) will hop via
+// ssh rather than short-circuit locally.
 func isSelfMachine(ctx context.Context, id string) bool {
 	if id == "" {
 		return false

--- a/cmd/camp/hop_origin.go
+++ b/cmd/camp/hop_origin.go
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"os/user"
+	"strings"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// HopOriginEnvVar carries the origin machine identity into a hopped session.
+// A child process inherits it, so `camp switch -` and `camp machine adopt` on
+// the far machine can name where the session came from without any reverse
+// connection or sshd configuration. Mirrors the CAMP_QUEST pattern
+// (internal/quest/shellenv.go) with more fields.
+const HopOriginEnvVar = "CAMP_HOP_ORIGIN"
+
+// hopOriginVersion prefixes every payload. A consumer that does not recognize
+// the version ignores the whole payload rather than salvaging fields from it,
+// so a future format cannot be half-read by an older camp.
+const hopOriginVersion = "v1"
+
+// Payload bounds. A field over its cap is dropped when optional and aborts the
+// payload when required: a truncated hostname is a wrong hostname, and wrong
+// routing is worse than absent routing.
+const (
+	hopOriginMaxTotal    = 1024
+	hopOriginMaxHost     = 253
+	hopOriginMaxUser     = 64
+	hopOriginMaxCampaign = 255
+	hopOriginMaxID       = 64
+)
+
+// hopOriginDetectTimeout bounds the tailscale probe. The hop already pays a
+// full ssh round-trip for ResolveRoot (bounded by remote.DefaultTimeout, 10s),
+// so this is a stall guard rather than a budget.
+const hopOriginDetectTimeout = 2 * time.Second
+
+// HopOrigin is a parsed CAMP_HOP_ORIGIN payload.
+type HopOrigin struct {
+	Host     string
+	User     string
+	Campaign string
+	ID       string
+}
+
+// buildHopOrigin assembles the v1 payload describing this machine, for
+// embedding in a hop to another machine. originCampaign may be empty (the hop
+// started outside a campaign); host and user may not, and an empty result means
+// "emit no origin", never a partial payload.
+func buildHopOrigin(ctx context.Context, originCampaign string, detect reachableNameFunc) (string, error) {
+	host, err := detectReachableName(ctx, detect)
+	if err != nil {
+		return "", err
+	}
+	if host == "" {
+		return "", camperrors.New("no reachable name for this machine")
+	}
+	u, err := user.Current()
+	if err != nil {
+		return "", camperrors.Wrap(err, "resolve current user")
+	}
+	return encodeHopOrigin(HopOrigin{
+		Host:     host,
+		User:     u.Username,
+		Campaign: originCampaign,
+		ID:       suggestedMachineID(host),
+	})
+}
+
+// encodeHopOrigin renders a payload, enforcing the caps. Pure, so the size and
+// encoding rules are testable without touching the network.
+func encodeHopOrigin(o HopOrigin) (string, error) {
+	host := hopOriginEncode(o.Host)
+	usr := hopOriginEncode(o.User)
+	if host == "" || len(host) > hopOriginMaxHost {
+		return "", camperrors.New("origin host is empty or too long")
+	}
+	if usr == "" || len(usr) > hopOriginMaxUser {
+		return "", camperrors.New("origin user is empty or too long")
+	}
+
+	parts := []string{hopOriginVersion, "host=" + host, "user=" + usr}
+	if c := hopOriginEncode(o.Campaign); c != "" && len(c) <= hopOriginMaxCampaign {
+		parts = append(parts, "campaign="+c)
+	}
+	if id := hopOriginEncode(o.ID); id != "" && len(id) <= hopOriginMaxID {
+		parts = append(parts, "id="+id)
+	}
+
+	payload := strings.Join(parts, ";")
+	if len(payload) > hopOriginMaxTotal {
+		// Drop optional fields rather than truncate: a truncated value is a
+		// wrong value, and every consumer treats absence as "unknown".
+		payload = strings.Join(parts[:3], ";")
+		if len(payload) > hopOriginMaxTotal {
+			return "", camperrors.New("origin payload exceeds size bound")
+		}
+	}
+	if strings.ContainsAny(payload, "\n\r") {
+		return "", camperrors.New("origin payload contains a newline")
+	}
+	return payload, nil
+}
+
+// ParseHopOrigin reads a payload. A malformed payload is an error rather than a
+// best-effort parse: the value routes a hop, and a half-understood route is the
+// failure mode the size rules already refuse.
+func ParseHopOrigin(payload string) (HopOrigin, error) {
+	payload = strings.TrimSpace(payload)
+	if payload == "" {
+		return HopOrigin{}, camperrors.New("empty payload")
+	}
+	if len(payload) > hopOriginMaxTotal {
+		return HopOrigin{}, camperrors.New("payload exceeds 1024 bytes")
+	}
+	tokens := strings.Split(payload, ";")
+	if tokens[0] != hopOriginVersion {
+		return HopOrigin{}, camperrors.New("unknown payload version")
+	}
+
+	var o HopOrigin
+	seen := make(map[string]bool, len(tokens))
+	for _, tok := range tokens[1:] {
+		key, raw, ok := strings.Cut(tok, "=")
+		if !ok || key == "" {
+			return HopOrigin{}, camperrors.New("token without '='")
+		}
+		if seen[key] {
+			return HopOrigin{}, camperrors.New("duplicate key \"" + key + "\"")
+		}
+		seen[key] = true
+		val, err := hopOriginDecode(raw)
+		if err != nil {
+			return HopOrigin{}, err
+		}
+		switch key {
+		case "host":
+			o.Host = val
+		case "user":
+			o.User = val
+		case "campaign":
+			o.Campaign = val
+		case "id":
+			o.ID = val
+		}
+		// Unknown keys are ignored so additive v1 fields do not break older
+		// consumers; a change in meaning bumps the version instead.
+	}
+	if o.Host == "" {
+		return HopOrigin{}, camperrors.New("missing host")
+	}
+	if o.User == "" {
+		return HopOrigin{}, camperrors.New("missing user")
+	}
+	return o, nil
+}
+
+// hopOriginEncode percent-encodes everything outside the unreserved set, which
+// means ';', '=', '%', whitespace, control bytes, and non-ASCII can never
+// appear raw in a value. The separators are therefore unambiguous by
+// construction rather than by convention, and a hostile campaign name cannot
+// inject a second field.
+func hopOriginEncode(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if hopOriginUnreserved(c) {
+			b.WriteByte(c)
+			continue
+		}
+		b.WriteByte('%')
+		b.WriteByte(hexUpper[c>>4])
+		b.WriteByte(hexUpper[c&0x0f])
+	}
+	return b.String()
+}
+
+func hopOriginDecode(s string) (string, error) {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] != '%' {
+			b.WriteByte(s[i])
+			continue
+		}
+		if i+2 >= len(s) {
+			return "", camperrors.New("invalid percent-encoding")
+		}
+		hi, ok1 := unhex(s[i+1])
+		lo, ok2 := unhex(s[i+2])
+		if !ok1 || !ok2 {
+			return "", camperrors.New("invalid percent-encoding")
+		}
+		b.WriteByte(hi<<4 | lo)
+		i += 2
+	}
+	return b.String(), nil
+}
+
+const hexUpper = "0123456789ABCDEF"
+
+func unhex(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	}
+	return 0, false
+}
+
+func hopOriginUnreserved(c byte) bool {
+	switch {
+	case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		return true
+	case c == '.', c == '_', c == '-', c == '~':
+		return true
+	}
+	return false
+}
+
+// reachableNameFunc runs `tailscale status --json` and returns raw stdout.
+// Injected so detection is testable without a live tailscale binary, mirroring
+// tailscaleStatusFunc (machine_discover.go).
+type reachableNameFunc func(ctx context.Context) ([]byte, error)
+
+// detectReachableName answers two questions with one derivation: what this
+// machine calls itself when embedding an origin, and whether a selector's
+// machine segment refers to this machine. One function so the two answers
+// cannot drift.
+//
+// Tailscale's own DNSName wins when the backend is running, because it is
+// reachable from anywhere on the tailnet; os.Hostname is the fallback and may
+// well be non-routable (a mac reports "Mac-Studio.local"), which is why every
+// consumer treats the value as advisory and shows it before acting on it.
+func detectReachableName(ctx context.Context, run reachableNameFunc) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if run != nil {
+		probeCtx, cancel := context.WithTimeout(ctx, hopOriginDetectTimeout)
+		defer cancel()
+		if out, err := run(probeCtx); err == nil {
+			if name := selfDNSName(out); name != "" {
+				return name, nil
+			}
+		}
+	}
+	host, err := os.Hostname()
+	if err != nil {
+		return "", camperrors.Wrap(err, "resolve hostname")
+	}
+	return normalizeDNSName(host), nil
+}
+
+// selfDNSName reads the Self node out of `tailscale status --json`.
+// parseTailscaleStatus deliberately DROPS Self (its caller is a picker of other
+// devices), so this is a sibling rather than a change to that function.
+func selfDNSName(data []byte) string {
+	start := bytes.IndexByte(data, '{')
+	if start < 0 {
+		return ""
+	}
+	var status tailscaleStatus
+	if json.Unmarshal(data[start:], &status) != nil {
+		return ""
+	}
+	if status.BackendState != "" && status.BackendState != "Running" {
+		return ""
+	}
+	if status.Self == nil {
+		return ""
+	}
+	return normalizeDNSName(status.Self.DNSName)
+}
+
+// runTailscaleStatusForSelf is the production reachableNameFunc. A missing
+// binary or a non-zero exit yields no name and the caller falls back to
+// hostname; unlike `machine add --discover`, self-detection is best-effort and
+// must never turn a working hop into an error.
+func runTailscaleStatusForSelf(ctx context.Context) ([]byte, error) {
+	if _, err := exec.LookPath("tailscale"); err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(ctx, "tailscale", "status", "--json")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = nil
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return stdout.Bytes(), nil
+}
+
+// suggestedMachineID derives an advisory machine id from a reachable name.
+// Empty when the name cannot produce a valid id (an IP literal, say): the field
+// is optional, and adopt prompts rather than registering a bad id.
+func suggestedMachineID(host string) string {
+	id := sanitizeID(host)
+	if validateMachineID(id) != nil {
+		return ""
+	}
+	return id
+}

--- a/cmd/camp/hop_origin_test.go
+++ b/cmd/camp/hop_origin_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/machines"
+)
+
+func TestEncodeHopOrigin(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      HopOrigin
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "all fields",
+			in:   HopOrigin{Host: "mac-studio.tail37114b.ts.net", User: "lancerogers", Campaign: "obey-campaign", ID: "mac-studio"},
+			want: "v1;host=mac-studio.tail37114b.ts.net;user=lancerogers;campaign=obey-campaign;id=mac-studio",
+		},
+		{
+			name: "campaign omitted when empty",
+			in:   HopOrigin{Host: "box.local", User: "lance", ID: "box"},
+			want: "v1;host=box.local;user=lance;id=box",
+		},
+		{
+			name: "id omitted when empty",
+			in:   HopOrigin{Host: "box.local", User: "lance", Campaign: "c"},
+			want: "v1;host=box.local;user=lance;campaign=c",
+		},
+		{
+			// The separator characters are the whole reason encoding exists: a
+			// campaign named "x;host=evil" must not inject a second host pair.
+			name: "separators in a value are encoded",
+			in:   HopOrigin{Host: "box.local", User: "lance", Campaign: "x;host=evil.example.com"},
+			want: "v1;host=box.local;user=lance;campaign=x%3Bhost%3Devil.example.com",
+		},
+		{
+			name: "quote and space encoded",
+			in:   HopOrigin{Host: "box.local", User: "lance", Campaign: "x'; rm -rf ~;'"},
+			want: "v1;host=box.local;user=lance;campaign=x%27%3B%20rm%20-rf%20~%3B%27",
+		},
+		{
+			name: "percent itself is encoded so decoding is unambiguous",
+			in:   HopOrigin{Host: "box.local", User: "lance", Campaign: "100%25"},
+			want: "v1;host=box.local;user=lance;campaign=100%2525",
+		},
+		{
+			name: "newline encoded, never raw",
+			in:   HopOrigin{Host: "box.local", User: "lance", Campaign: "a\nb"},
+			want: "v1;host=box.local;user=lance;campaign=a%0Ab",
+		},
+		{
+			name:    "empty host is refused",
+			in:      HopOrigin{User: "lance"},
+			wantErr: true,
+		},
+		{
+			name:    "empty user is refused",
+			in:      HopOrigin{Host: "box.local"},
+			wantErr: true,
+		},
+		{
+			name:    "over-long host is refused, never truncated",
+			in:      HopOrigin{Host: strings.Repeat("a", hopOriginMaxHost+1), User: "lance"},
+			wantErr: true,
+		},
+		{
+			// An over-cap optional field is dropped, not truncated: a truncated
+			// campaign name is a different campaign.
+			name: "over-long campaign is dropped, payload survives",
+			in:   HopOrigin{Host: "box.local", User: "lance", Campaign: strings.Repeat("c", hopOriginMaxCampaign+1), ID: "box"},
+			want: "v1;host=box.local;user=lance;id=box",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := encodeHopOrigin(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("encodeHopOrigin(%+v) = %q, want error", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("encodeHopOrigin(%+v) error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("encodeHopOrigin(%+v)\n got %q\nwant %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHopOriginRoundTrip(t *testing.T) {
+	// Values chosen to exercise every encoded class at once.
+	in := HopOrigin{
+		Host:     "mac-studio.tail37114b.ts.net",
+		User:     "lance rogers",
+		Campaign: "x'; rm -rf ~;' ;host=evil=1",
+		ID:       "mac-studio",
+	}
+	payload, err := encodeHopOrigin(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ParseHopOrigin(payload)
+	if err != nil {
+		t.Fatalf("ParseHopOrigin(%q): %v", payload, err)
+	}
+	if got != in {
+		t.Errorf("round trip\n got %+v\nwant %+v", got, in)
+	}
+}
+
+func TestParseHopOriginErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		wantErr string
+	}{
+		{"empty", "", "empty payload"},
+		{"unknown version", "v2;host=a;user=b", "unknown payload version"},
+		{"no version", "host=a;user=b", "unknown payload version"},
+		{"token without =", "v1;host=a;user=b;bare", "token without '='"},
+		{"duplicate key", "v1;host=a;host=b;user=c", `duplicate key "host"`},
+		{"bad percent escape", "v1;host=a%zz;user=b", "invalid percent-encoding"},
+		{"truncated percent escape", "v1;host=a%4;user=b", "invalid percent-encoding"},
+		{"missing host", "v1;user=b", "missing host"},
+		{"missing user", "v1;host=a", "missing user"},
+		{"over size bound", "v1;host=a;user=b;campaign=" + strings.Repeat("x", hopOriginMaxTotal), "exceeds 1024 bytes"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseHopOrigin(tt.payload)
+			if err == nil {
+				t.Fatalf("ParseHopOrigin(%q) = nil error, want %q", tt.payload, tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("ParseHopOrigin(%q) error = %v, want it to contain %q", tt.payload, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseHopOriginIgnoresUnknownKeys(t *testing.T) {
+	// Additive optional fields must not break an older consumer; only a change
+	// in an existing field's meaning bumps the version.
+	got, err := ParseHopOrigin("v1;host=a;user=b;future=whatever;id=c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Host != "a" || got.User != "b" || got.ID != "c" {
+		t.Errorf("unknown key changed the parse: %+v", got)
+	}
+}
+
+// tailscaleSelfFixture is a minimal `tailscale status --json` document. The
+// trailing dot on DNSName is real MagicDNS output and is why normalization is
+// mandatory rather than cosmetic.
+const tailscaleSelfFixture = `{
+  "BackendState": "Running",
+  "Self": {"HostName": "Mac Studio", "DNSName": "mac-studio.tail37114b.ts.net.", "OS": "macOS"}
+}`
+
+func TestDetectReachableNamePrefersTailscale(t *testing.T) {
+	got, err := detectReachableName(context.Background(), func(context.Context) ([]byte, error) {
+		return []byte(tailscaleSelfFixture), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "mac-studio.tail37114b.ts.net" {
+		t.Errorf("detectReachableName = %q, want the trailing dot trimmed", got)
+	}
+}
+
+func TestDetectReachableNameFallsBackToHostname(t *testing.T) {
+	cases := map[string]reachableNameFunc{
+		"no tailscale binary": nil,
+		"tailscale errors":    func(context.Context) ([]byte, error) { return nil, context.DeadlineExceeded },
+		"backend not running": func(context.Context) ([]byte, error) {
+			return []byte(`{"BackendState":"Stopped","Self":{"DNSName":"x.ts.net."}}`), nil
+		},
+		"self has no DNSName": func(context.Context) ([]byte, error) {
+			return []byte(`{"BackendState":"Running","Self":{"HostName":"box"}}`), nil
+		},
+		"unparseable output": func(context.Context) ([]byte, error) { return []byte("not json"), nil },
+	}
+	for name, run := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := detectReachableName(context.Background(), run)
+			if err != nil {
+				t.Fatalf("fallback must not error: %v", err)
+			}
+			if got == "" {
+				t.Error("fallback produced no name")
+			}
+			if got == "x.ts.net" {
+				t.Error("used a non-Running backend's DNSName")
+			}
+		})
+	}
+}
+
+func TestDetectReachableNameHonorsCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := detectReachableName(ctx, nil); err == nil {
+		t.Error("cancelled context must not be ignored")
+	}
+}
+
+func TestSuggestedMachineID(t *testing.T) {
+	tests := map[string]string{
+		"mac-studio.tail37114b.ts.net": "mac-studio",
+		"Mac-Studio.local":             "mac-studio",
+		"archdtop.tail37114b.ts.net":   "archdtop",
+		// A leading digit fails validateMachineID, so no id is suggested rather
+		// than an invalid one being written into machines.yaml by adopt.
+		"100.72.165.77": "",
+		"":              "",
+	}
+	for host, want := range tests {
+		if got := suggestedMachineID(host); got != want {
+			t.Errorf("suggestedMachineID(%q) = %q, want %q", host, got, want)
+		}
+	}
+}
+
+func TestBuildHopOriginUsesDetectedHost(t *testing.T) {
+	got, err := buildHopOrigin(context.Background(), "obey-campaign", func(context.Context) ([]byte, error) {
+		return []byte(tailscaleSelfFixture), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, err := ParseHopOrigin(got)
+	if err != nil {
+		t.Fatalf("built payload does not parse: %v (%q)", err, got)
+	}
+	if parsed.Host != "mac-studio.tail37114b.ts.net" {
+		t.Errorf("host = %q", parsed.Host)
+	}
+	if parsed.Campaign != "obey-campaign" {
+		t.Errorf("campaign = %q", parsed.Campaign)
+	}
+	if parsed.ID != "mac-studio" {
+		t.Errorf("id = %q", parsed.ID)
+	}
+	if parsed.User == "" {
+		t.Error("user must always be present")
+	}
+}
+
+func TestBuildHopOriginOutsideCampaign(t *testing.T) {
+	// Hopping from outside a campaign is legal; the payload simply carries no
+	// campaign, and `camp switch -` reports that rather than guessing.
+	got, err := buildHopOrigin(context.Background(), "", func(context.Context) ([]byte, error) {
+		return []byte(tailscaleSelfFixture), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got, "campaign=") {
+		t.Errorf("payload must omit an empty campaign: %q", got)
+	}
+	if _, err := ParseHopOrigin(got); err != nil {
+		t.Errorf("payload without campaign must still parse: %v", err)
+	}
+}
+
+func TestEmitShellConnectEmbedsOrigin(t *testing.T) {
+	var buf bytes.Buffer
+	m := &machines.Machine{ID: "archdtop", Host: "archdtop.tail37114b.ts.net", SSHUser: "lance", AuthMethod: machines.AuthTailscaleSSH}
+	origin := "v1;host=mac-studio.tail37114b.ts.net;user=lancerogers;campaign=obey-campaign;id=mac-studio"
+	if err := emitShellConnect(&buf, true, "/home/lance/campaigns/obey-campaign", m, origin); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+
+	want := `'export CAMP_HOP_ORIGIN='\''` + origin + `'\'' && cd '\''/home/lance/campaigns/obey-campaign'\'' && exec $SHELL -l'`
+	if !strings.Contains(out, want) {
+		t.Errorf("emitted remote command\n got %q\nwant it to contain %q", out, want)
+	}
+	// The export must precede the cd: it has to be set before exec replaces
+	// this process image with the login shell.
+	if strings.Index(out, "export CAMP_HOP_ORIGIN") > strings.Index(out, "cd ") {
+		t.Errorf("export must come before cd: %q", out)
+	}
+	if !strings.HasPrefix(out, "exec ssh -t ") || !strings.HasSuffix(out, "\n") {
+		t.Errorf("hop line shape changed: %q", out)
+	}
+	if strings.Count(out, "\n") != 1 {
+		t.Errorf("shell-connect must emit exactly one line: %q", out)
+	}
+}
+
+func TestEmitShellConnectHostileOriginIsQuoted(t *testing.T) {
+	var buf bytes.Buffer
+	m := &machines.Machine{ID: "box", Host: "box.local", AuthMethod: machines.AuthSSHAgent}
+	// A payload that somehow carried a raw quote (it cannot, encoding forbids
+	// it) must still be inert after ShellQuote. Belt and suspenders: this pins
+	// the shell layer independently of the encoding layer.
+	hostile := `v1;host=box.local;user=lance;campaign=x'; rm -rf ~;'`
+	if err := emitShellConnect(&buf, true, "/x", m, hostile); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if strings.Contains(out, `campaign=x'; rm -rf ~;'`) {
+		t.Errorf("hostile payload leaked unquoted: %q", out)
+	}
+	if !strings.Contains(out, `'\''`) {
+		t.Errorf("expected escaped quotes in the emitted line: %q", out)
+	}
+}
+
+func TestEmitShellConnectWithoutOriginIsUnchanged(t *testing.T) {
+	// Regression pin: an empty origin must produce byte-identical output to the
+	// pre-feature hop line, so a machine with no reachable name hops exactly as
+	// it does today.
+	var buf bytes.Buffer
+	m := &machines.Machine{ID: "devbox", Host: "devbox.ts.net", SSHUser: "lance", AuthMethod: machines.AuthSSHAgent}
+	if err := emitShellConnect(&buf, true, "/srv/campaigns/obey", m, ""); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "CAMP_HOP_ORIGIN") {
+		t.Errorf("empty origin must emit no export: %q", out)
+	}
+	if !strings.Contains(out, `'cd '\''/srv/campaigns/obey'\'' && exec $SHELL -l'`) {
+		t.Errorf("remote command shape changed without an origin: %q", out)
+	}
+}

--- a/cmd/camp/hop_origin_test.go
+++ b/cmd/camp/hop_origin_test.go
@@ -143,6 +143,10 @@ func TestParseHopOriginErrors(t *testing.T) {
 		{"newline in host via %0A", "v1;host=box%0Aevil;user=u", "control character"},
 		{"CR in user via %0D", "v1;host=a;user=u%0D", "control character"},
 		{"tab in campaign via %09", "v1;host=a;user=b;campaign=c%09d", "control character"},
+		// Field caps match encodeHopOrigin: required refuse, optional drop
+		// (optional over-cap is covered by TestParseHopOriginDropsOverlongOptional).
+		{"over-long host", "v1;host=" + strings.Repeat("a", hopOriginMaxHost+1) + ";user=u", "too long"},
+		{"over-long user", "v1;host=a;user=" + strings.Repeat("u", hopOriginMaxUser+1), "too long"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -166,6 +170,26 @@ func TestParseHopOriginIgnoresUnknownKeys(t *testing.T) {
 	}
 	if got.Host != "a" || got.User != "b" || got.ID != "c" {
 		t.Errorf("unknown key changed the parse: %+v", got)
+	}
+}
+
+func TestParseHopOriginDropsOverlongOptional(t *testing.T) {
+	// Encode drops optional fields over cap rather than truncating; parse must
+	// do the same so a handcrafted env cannot force an over-long campaign/id.
+	payload := "v1;host=a;user=b;campaign=" + strings.Repeat("c", hopOriginMaxCampaign+1) +
+		";id=" + strings.Repeat("i", hopOriginMaxID+1)
+	got, err := ParseHopOrigin(payload)
+	if err != nil {
+		t.Fatalf("ParseHopOrigin: %v", err)
+	}
+	if got.Host != "a" || got.User != "b" {
+		t.Errorf("required fields = %+v", got)
+	}
+	if got.Campaign != "" {
+		t.Errorf("over-long campaign must be dropped, got %q", got.Campaign)
+	}
+	if got.ID != "" {
+		t.Errorf("over-long id must be dropped, got %q", got.ID)
 	}
 }
 

--- a/cmd/camp/hop_origin_test.go
+++ b/cmd/camp/hop_origin_test.go
@@ -442,14 +442,14 @@ func TestRunHopBackDecisionTable(t *testing.T) {
 			// exercised deterministically, regardless of the developer's fleet.
 			t.Setenv("CAMP_MACHINES_PATH", filepath.Join(t.TempDir(), "machines.yaml"))
 
-			restore := hopBackResolveRoot
-			hopBackResolveRoot = func(_ context.Context, m *machines.Machine, campaign string) (string, error) {
+			restore := resolveRemoteRoot
+			resolveRemoteRoot = func(_ context.Context, m *machines.Machine, campaign string) (string, error) {
 				if tt.resolveErr != nil {
 					return "", tt.resolveErr
 				}
 				return "/home/lancerogers/Dev/AI/" + campaign, nil
 			}
-			t.Cleanup(func() { hopBackResolveRoot = restore })
+			t.Cleanup(func() { resolveRemoteRoot = restore })
 
 			cmd, stdout, _ := newHopBackCmd()
 			err := runHopBack(context.Background(), cmd, tt.printOnly, tt.shellConnect, tt.jsonOut)
@@ -485,11 +485,11 @@ func TestRunHopBackNeverWritesMachinesFile(t *testing.T) {
 	t.Setenv("CAMP_MACHINES_PATH", path)
 	t.Setenv(HopOriginEnvVar, testOriginPayload)
 
-	restore := hopBackResolveRoot
-	hopBackResolveRoot = func(context.Context, *machines.Machine, string) (string, error) {
+	restore := resolveRemoteRoot
+	resolveRemoteRoot = func(context.Context, *machines.Machine, string) (string, error) {
 		return "/srv/obey-campaign", nil
 	}
-	t.Cleanup(func() { hopBackResolveRoot = restore })
+	t.Cleanup(func() { resolveRemoteRoot = restore })
 
 	cmd, _, _ := newHopBackCmd()
 	if err := runHopBack(context.Background(), cmd, false, true, false); err != nil {
@@ -507,11 +507,11 @@ func TestRunHopBackReverseLineCarriesItsOwnOrigin(t *testing.T) {
 	t.Setenv("CAMP_MACHINES_PATH", filepath.Join(t.TempDir(), "machines.yaml"))
 	t.Setenv(HopOriginEnvVar, testOriginPayload)
 
-	restore := hopBackResolveRoot
-	hopBackResolveRoot = func(context.Context, *machines.Machine, string) (string, error) {
+	restore := resolveRemoteRoot
+	resolveRemoteRoot = func(context.Context, *machines.Machine, string) (string, error) {
 		return "/srv/obey-campaign", nil
 	}
-	t.Cleanup(func() { hopBackResolveRoot = restore })
+	t.Cleanup(func() { resolveRemoteRoot = restore })
 
 	cmd, stdout, _ := newHopBackCmd()
 	if err := runHopBack(context.Background(), cmd, false, true, false); err != nil {

--- a/cmd/camp/hop_origin_test.go
+++ b/cmd/camp/hop_origin_test.go
@@ -3,8 +3,13 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 
 	"github.com/Obedience-Corp/camp/internal/machines"
 )
@@ -334,5 +339,256 @@ func TestEmitShellConnectWithoutOriginIsUnchanged(t *testing.T) {
 	}
 	if !strings.Contains(out, `'cd '\''/srv/campaigns/obey'\'' && exec $SHELL -l'`) {
 		t.Errorf("remote command shape changed without an origin: %q", out)
+	}
+}
+
+// newHopBackCmd returns a cobra command whose streams are captured, so a row of
+// the decision table can assert exact stdout and stderr rather than "an error
+// happened".
+func newHopBackCmd() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	var out, errb bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	cmd.SetErr(&errb)
+	return cmd, &out, &errb
+}
+
+const testOriginPayload = "v1;host=mac-studio.tail37114b.ts.net;user=lancerogers;campaign=obey-campaign;id=mac-studio"
+
+func TestRunHopBackDecisionTable(t *testing.T) {
+	tests := []struct {
+		name         string
+		payload      string
+		setPayload   bool
+		printOnly    bool
+		jsonOut      bool
+		shellConnect bool
+		resolveErr   error
+		wantErr      string
+		wantStdout   string
+	}{
+		{
+			name:    "no origin in this session",
+			wantErr: "camp switch -: this session did not start from a camp hop (CAMP_HOP_ORIGIN is not set)",
+		},
+		{
+			name:       "empty payload reads as absent",
+			payload:    "   ",
+			setPayload: true,
+			wantErr:    "this session did not start from a camp hop",
+		},
+		{
+			name:       "malformed payload names the reason",
+			payload:    "v1;host=a;host=b;user=c",
+			setPayload: true,
+			wantErr:    `camp switch -: CAMP_HOP_ORIGIN is malformed (duplicate key "host"); hop back with 'camp switch <machine>:<campaign>'`,
+		},
+		{
+			name:       "unknown version is malformed, never half-parsed",
+			payload:    "v2;host=a;user=b;campaign=c",
+			setPayload: true,
+			wantErr:    "malformed (unknown payload version)",
+		},
+		{
+			name:       "origin campaign unknown",
+			payload:    "v1;host=mac.ts.net;user=lance",
+			setPayload: true,
+			wantErr:    "camp switch -: origin campaign unknown (the outbound hop did not start inside a campaign); hop back with 'camp switch <machine>:<campaign>'",
+		},
+		{
+			name:       "--print is refused like any remote target",
+			payload:    testOriginPayload,
+			setPayload: true,
+			printOnly:  true,
+			wantErr:    "--print is local-only; use the csw shell wrapper to hop there",
+		},
+		{
+			name:       "--json is refused like any remote target",
+			payload:    testOriginPayload,
+			setPayload: true,
+			jsonOut:    true,
+			wantErr:    "--json is not supported for a remote (machine:) switch; use the csw shell wrapper",
+		},
+		{
+			name:       "bare invocation resolves then refuses to hop",
+			payload:    testOriginPayload,
+			setPayload: true,
+			wantErr:    "; run via the csw shell wrapper to hop there",
+		},
+		{
+			name:         "shell-connect emits the reverse hop line",
+			payload:      testOriginPayload,
+			setPayload:   true,
+			shellConnect: true,
+			wantStdout:   "exec ssh -t ",
+		},
+		{
+			name:       "unreachable transient origin points at a probe, not diagnose",
+			payload:    testOriginPayload,
+			setPayload: true,
+			resolveErr: errors.New("connection refused"),
+			wantErr:    "the origin is not registered here, probe it with: ssh -o BatchMode=yes lancerogers@mac-studio.tail37114b.ts.net true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setPayload {
+				t.Setenv(HopOriginEnvVar, tt.payload)
+			} else {
+				t.Setenv(HopOriginEnvVar, "")
+			}
+			// Point machines.yaml at an absent file so the transient path is
+			// exercised deterministically, regardless of the developer's fleet.
+			t.Setenv("CAMP_MACHINES_PATH", filepath.Join(t.TempDir(), "machines.yaml"))
+
+			restore := hopBackResolveRoot
+			hopBackResolveRoot = func(_ context.Context, m *machines.Machine, campaign string) (string, error) {
+				if tt.resolveErr != nil {
+					return "", tt.resolveErr
+				}
+				return "/home/lancerogers/Dev/AI/" + campaign, nil
+			}
+			t.Cleanup(func() { hopBackResolveRoot = restore })
+
+			cmd, stdout, _ := newHopBackCmd()
+			err := runHopBack(context.Background(), cmd, tt.printOnly, tt.shellConnect, tt.jsonOut)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got nil (stdout %q)", tt.wantErr, stdout.String())
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error\n got %q\nwant it to contain %q", err.Error(), tt.wantErr)
+				}
+				if stdout.Len() != 0 {
+					t.Errorf("a failing hop-back must write nothing to stdout, got %q", stdout.String())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(stdout.String(), tt.wantStdout) {
+				t.Errorf("stdout\n got %q\nwant it to contain %q", stdout.String(), tt.wantStdout)
+			}
+		})
+	}
+}
+
+func TestRunHopBackNeverWritesMachinesFile(t *testing.T) {
+	// Registration-independence is the point of the gesture (D008): hopping back
+	// must work from a machine that has never heard of the origin, and must not
+	// quietly register it either.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "machines.yaml")
+	t.Setenv("CAMP_MACHINES_PATH", path)
+	t.Setenv(HopOriginEnvVar, testOriginPayload)
+
+	restore := hopBackResolveRoot
+	hopBackResolveRoot = func(context.Context, *machines.Machine, string) (string, error) {
+		return "/srv/obey-campaign", nil
+	}
+	t.Cleanup(func() { hopBackResolveRoot = restore })
+
+	cmd, _, _ := newHopBackCmd()
+	if err := runHopBack(context.Background(), cmd, false, true, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("hop-back created %s; it must never write the fleet file", path)
+	}
+}
+
+func TestRunHopBackReverseLineCarriesItsOwnOrigin(t *testing.T) {
+	// The toggle property: the session the reverse hop lands in must know the
+	// machine it just left, or a second `csw -` would claim the session did not
+	// start from a hop.
+	t.Setenv("CAMP_MACHINES_PATH", filepath.Join(t.TempDir(), "machines.yaml"))
+	t.Setenv(HopOriginEnvVar, testOriginPayload)
+
+	restore := hopBackResolveRoot
+	hopBackResolveRoot = func(context.Context, *machines.Machine, string) (string, error) {
+		return "/srv/obey-campaign", nil
+	}
+	t.Cleanup(func() { hopBackResolveRoot = restore })
+
+	cmd, stdout, _ := newHopBackCmd()
+	if err := runHopBack(context.Background(), cmd, false, true, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "export "+HopOriginEnvVar+"=") {
+		t.Errorf("reverse hop line carries no origin, so the gesture would be one-way: %q", stdout.String())
+	}
+}
+
+func TestTransientOriginID(t *testing.T) {
+	tests := map[string]string{
+		"mac-studio.tail37114b.ts.net": "mac-studio-origin",
+		"Mac-Studio.local":             "mac-studio-origin",
+		// An id that cannot be derived must still produce a non-empty socket
+		// component: "" would collapse the ControlPath to ~/.obey/ssh-ctl/.sock
+		// and share one socket across every degenerate origin.
+		"100.72.165.77": "origin",
+		"":              "origin",
+	}
+	for host, want := range tests {
+		if got := transientOriginID(host); got != want {
+			t.Errorf("transientOriginID(%q) = %q, want %q", host, got, want)
+		}
+	}
+}
+
+func TestOriginTargetPrefersRegisteredEntry(t *testing.T) {
+	// A registered entry carries the operator's own identity_file and
+	// auth_method, which is better information than the payload has.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "machines.yaml")
+	if err := os.WriteFile(path, []byte(`version: 1
+machines:
+    - id: studio
+      host: MAC-STUDIO.tail37114b.ts.net.
+      auth_method: tailscale-ssh
+      ssh_user: someoneelse
+      identity_file: /keys/id_ed25519
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CAMP_MACHINES_PATH", path)
+
+	origin, err := ParseHopOrigin(testOriginPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, registered := originTarget(origin)
+	if !registered {
+		t.Fatal("host match should have been found despite case and trailing-dot differences")
+	}
+	if m.ID != "studio" {
+		t.Errorf("id = %q, want the registered id", m.ID)
+	}
+	if m.IdentityFile != "/keys/id_ed25519" {
+		t.Errorf("registered identity_file was dropped: %+v", m)
+	}
+}
+
+func TestOriginTargetTransientLeavesAuthMethodEmpty(t *testing.T) {
+	// Guessing an auth mode would put a wrong label in front of a hop failure
+	// (FormatHopFailure prefixes by AuthMethod), and the argv is identical
+	// either way, so empty is the honest value.
+	t.Setenv("CAMP_MACHINES_PATH", filepath.Join(t.TempDir(), "machines.yaml"))
+	origin, err := ParseHopOrigin(testOriginPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, registered := originTarget(origin)
+	if registered {
+		t.Fatal("no machines file, so the origin cannot be registered")
+	}
+	if m.AuthMethod != "" {
+		t.Errorf("AuthMethod = %q, want empty", m.AuthMethod)
+	}
+	if m.Host != "mac-studio.tail37114b.ts.net" || m.SSHUser != "lancerogers" {
+		t.Errorf("transient machine = %+v", m)
 	}
 }

--- a/cmd/camp/hop_origin_test.go
+++ b/cmd/camp/hop_origin_test.go
@@ -642,3 +642,33 @@ func TestIsSelfMachine(t *testing.T) {
 		}
 	})
 }
+
+func TestRunSwitchHopBackWorksWithNoLocalRegistry(t *testing.T) {
+	// Hop-back resolves the campaign on the ORIGIN machine, so this machine
+	// having no registry is not a precondition. Before the check was hoisted,
+	// an empty registry produced "no campaigns registered (use 'camp init'…)",
+	// pointing the operator at an unrelated command.
+	t.Setenv("CAMP_REGISTRY_PATH", filepath.Join(t.TempDir(), "registry.json"))
+	t.Setenv("CAMP_MACHINES_PATH", filepath.Join(t.TempDir(), "machines.yaml"))
+	t.Setenv(HopOriginEnvVar, "")
+
+	cmd, _, _ := newHopBackCmd()
+	cmd.SetArgs([]string{"-"})
+	cmd.Flags().Bool("print", false, "")
+	cmd.Flags().Bool("json", false, "")
+	cmd.Flags().Bool("shell-connect", false, "")
+	cmd.Flags().String("org", "", "")
+	cmd.Flags().String("status", "", "")
+	cmd.Flags().Bool("all", false, "")
+
+	err := runSwitch(cmd, []string{"-"})
+	if err == nil {
+		t.Fatal("want the hop-back error, got nil")
+	}
+	if strings.Contains(err.Error(), "no campaigns registered") {
+		t.Errorf("hop-back was gated on the local registry: %v", err)
+	}
+	if !strings.Contains(err.Error(), "did not start from a camp hop") {
+		t.Errorf("error = %v, want the hop-back precondition message", err)
+	}
+}

--- a/cmd/camp/hop_origin_test.go
+++ b/cmd/camp/hop_origin_test.go
@@ -138,6 +138,11 @@ func TestParseHopOriginErrors(t *testing.T) {
 		{"missing host", "v1;user=b", "missing host"},
 		{"missing user", "v1;host=a", "missing user"},
 		{"over size bound", "v1;host=a;user=b;campaign=" + strings.Repeat("x", hopOriginMaxTotal), "exceeds 1024 bytes"},
+		// Percent-decoded C0 controls must fail closed so encode/parse stay
+		// symmetric and a handcrafted env cannot smuggle newlines into Host.
+		{"newline in host via %0A", "v1;host=box%0Aevil;user=u", "control character"},
+		{"CR in user via %0D", "v1;host=a;user=u%0D", "control character"},
+		{"tab in campaign via %09", "v1;host=a;user=b;campaign=c%09d", "control character"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/camp/hop_origin_test.go
+++ b/cmd/camp/hop_origin_test.go
@@ -382,7 +382,13 @@ func newHopBackCmd() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
 	return cmd, &out, &errb
 }
 
-const testOriginPayload = "v1;host=mac-studio.tail37114b.ts.net;user=lancerogers;campaign=obey-campaign;id=mac-studio"
+// testOriginPayload names a host that is deliberately NOT this machine.
+//
+// It used to carry the author's own tailnet name, which meant every hop-back
+// test silently exercised the self-origin path on that one machine and the
+// intended remote path everywhere else. A fixture for "somewhere else" has to
+// be somewhere else.
+const testOriginPayload = "v1;host=devbox.example.ts.net;user=alex;campaign=obey-campaign;id=devbox"
 
 func TestRunHopBackDecisionTable(t *testing.T) {
 	tests := []struct {
@@ -456,7 +462,7 @@ func TestRunHopBackDecisionTable(t *testing.T) {
 			payload:    testOriginPayload,
 			setPayload: true,
 			resolveErr: errors.New("connection refused"),
-			wantErr:    "the origin is not registered here, probe it with: ssh -o BatchMode=yes lancerogers@mac-studio.tail37114b.ts.net true",
+			wantErr:    "the origin is not registered here, probe it with: ssh -o BatchMode=yes alex@devbox.example.ts.net true",
 		},
 	}
 
@@ -576,7 +582,7 @@ func TestOriginTargetPrefersRegisteredEntry(t *testing.T) {
 	if err := os.WriteFile(path, []byte(`version: 1
 machines:
     - id: studio
-      host: MAC-STUDIO.tail37114b.ts.net.
+      host: DEVBOX.example.ts.net.
       auth_method: tailscale-ssh
       ssh_user: someoneelse
       identity_file: /keys/id_ed25519
@@ -617,7 +623,7 @@ func TestOriginTargetTransientLeavesAuthMethodEmpty(t *testing.T) {
 	if m.AuthMethod != "" {
 		t.Errorf("AuthMethod = %q, want empty", m.AuthMethod)
 	}
-	if m.Host != "mac-studio.tail37114b.ts.net" || m.SSHUser != "lancerogers" {
+	if m.Host != "devbox.example.ts.net" || m.SSHUser != "alex" {
 		t.Errorf("transient machine = %+v", m)
 	}
 }
@@ -655,10 +661,9 @@ func TestIsSelfMachine(t *testing.T) {
 		}
 	})
 
-	t.Run("a registered entry wins over self detection", func(t *testing.T) {
-		// A machines.yaml row pointing at this machine is a misconfiguration
-		// adopt refuses to create; honoring the operator's explicit file beats
-		// second-guessing it on every hop.
+	t.Run("a registered entry pointing elsewhere wins over self detection", func(t *testing.T) {
+		// Honoring the operator's explicit file beats second-guessing it, so a
+		// row that maps this id to another host still hops.
 		dir := t.TempDir()
 		path := filepath.Join(dir, "machines.yaml")
 		if err := os.WriteFile(path, []byte("version: 1\nmachines:\n    - id: "+self+
@@ -670,6 +675,49 @@ func TestIsSelfMachine(t *testing.T) {
 			t.Error("a registered entry must take precedence over self detection")
 		}
 	})
+
+	t.Run("a registered entry pointing at this machine still resolves locally", func(t *testing.T) {
+		// The case a shared fleet file produces: the same machines.yaml on every
+		// node, listing this one under its real id. Treating that as "registered,
+		// therefore remote" sends the hop to ourselves, which is the self-ssh
+		// this whole check exists to prevent.
+		host, err := detectReachableName(context.Background(), runTailscaleStatusForSelf)
+		if err != nil || host == "" {
+			t.Skip("no reachable name for this machine")
+		}
+		path := filepath.Join(t.TempDir(), "machines.yaml")
+		if err := os.WriteFile(path, []byte("version: 1\nmachines:\n    - id: "+self+
+			"\n      host: "+host+"\n      auth_method: ssh-agent\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("CAMP_MACHINES_PATH", path)
+		if !isSelfMachine(context.Background(), self) {
+			t.Error("a registered row whose host is this machine must resolve locally, not ssh to self")
+		}
+	})
+}
+
+// A payload naming this machine must not emit an ssh to ourselves.
+func TestRunSwitchHopBackRefusesASelfOrigin(t *testing.T) {
+	t.Setenv("CAMP_MACHINES_PATH", filepath.Join(t.TempDir(), "machines.yaml"))
+	host, err := detectReachableName(context.Background(), runTailscaleStatusForSelf)
+	if err != nil || host == "" {
+		t.Skip("no reachable name for this machine")
+	}
+	t.Setenv(HopOriginEnvVar, "v1;host="+host+";user=someone;campaign=demo;id=whatever")
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	err = runHopBack(context.Background(), cmd, false, true, false)
+	if err == nil {
+		t.Fatal("a self origin must not produce a hop")
+	}
+	if !strings.Contains(err.Error(), "already here") {
+		t.Errorf("error should say the user is already here, got: %v", err)
+	}
 }
 
 func TestRunSwitchHopBackWorksWithNoLocalRegistry(t *testing.T) {

--- a/cmd/camp/hop_origin_test.go
+++ b/cmd/camp/hop_origin_test.go
@@ -592,3 +592,53 @@ func TestOriginTargetTransientLeavesAuthMethodEmpty(t *testing.T) {
 		t.Errorf("transient machine = %+v", m)
 	}
 }
+
+func TestIsSelfMachine(t *testing.T) {
+	// This machine's own derived id, computed the same way the payload builder
+	// computes it, so the test asserts the shared derivation rather than a
+	// hardcoded hostname.
+	host, err := detectReachableName(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	self := suggestedMachineID(host)
+	if self == "" {
+		t.Skip("this machine's hostname does not derive a valid id")
+	}
+
+	t.Run("self id matches", func(t *testing.T) {
+		t.Setenv("CAMP_MACHINES_PATH", filepath.Join(t.TempDir(), "machines.yaml"))
+		if !isSelfMachine(context.Background(), self) {
+			t.Errorf("isSelfMachine(%q) = false, want true", self)
+		}
+	})
+
+	t.Run("another machine does not match", func(t *testing.T) {
+		t.Setenv("CAMP_MACHINES_PATH", filepath.Join(t.TempDir(), "machines.yaml"))
+		if isSelfMachine(context.Background(), "definitely-not-this-machine") {
+			t.Error("a foreign id must not read as self")
+		}
+	})
+
+	t.Run("empty id is not self", func(t *testing.T) {
+		if isSelfMachine(context.Background(), "") {
+			t.Error("empty id must not read as self")
+		}
+	})
+
+	t.Run("a registered entry wins over self detection", func(t *testing.T) {
+		// A machines.yaml row pointing at this machine is a misconfiguration
+		// adopt refuses to create; honoring the operator's explicit file beats
+		// second-guessing it on every hop.
+		dir := t.TempDir()
+		path := filepath.Join(dir, "machines.yaml")
+		if err := os.WriteFile(path, []byte("version: 1\nmachines:\n    - id: "+self+
+			"\n      host: somewhere.else\n      auth_method: ssh-agent\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("CAMP_MACHINES_PATH", path)
+		if isSelfMachine(context.Background(), self) {
+			t.Error("a registered entry must take precedence over self detection")
+		}
+	})
+}

--- a/cmd/camp/switch.go
+++ b/cmd/camp/switch.go
@@ -37,6 +37,13 @@ Use with the shell-init wrappers for instant navigation (recommended):
   csw a1b2                       # Switch by ID prefix
   csw obey/platform              # Switch by org-scoped selector
   csw archdtop:lance-arch        # Hop to a remote campaign over ssh
+  csw -                          # Hop back to the machine/campaign this session came from
+
+'camp switch -' (csw -) is the hop-back gesture: it returns to the origin
+encoded in CAMP_HOP_ORIGIN by the outbound hop. It is registration-independent
+— the origin need not be in this machine's machines.yaml. Like other remote
+targets it refuses --print/--json. '-' is reserved and is no longer a fuzzy
+campaign query.
 
 The --print flag outputs just the path for shell integration (local only):
   cd "$(camp switch --print)"
@@ -59,6 +66,7 @@ its exact path on that machine.`,
   csw                                # Interactive picker (local + remotes)
   csw obey-campaign                  # Switch by name
   csw archdtop:lance-arch            # Hop to remote campaign
+  csw -                              # Hop back via CAMP_HOP_ORIGIN
   camp switch --org obey platform    # Switch by name within an org
   camp switch obey/platform          # Switch by scoped selector
   camp switch a1b2                   # Switch by ID prefix

--- a/cmd/camp/switch.go
+++ b/cmd/camp/switch.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
-	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/machines"
 	"github.com/Obedience-Corp/camp/internal/nav"
@@ -307,6 +306,12 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 	targetTab := ""
 
 	if len(args) == 1 {
+		// The hop-back gesture is checked before selector parsing: "-" is
+		// otherwise a legal campaign query that reaches the fuzzy tier and
+		// matches an arbitrary hyphenated campaign, differently every run.
+		if args[0] == hopBackSelector {
+			return runHopBack(ctx, cmd, printOnly, shellConnect, jsonOut)
+		}
 		msel, err := cmdutil.ParseMachineSelector(args[0])
 		if err != nil {
 			return err
@@ -444,84 +449,6 @@ func parseSwitchArg(raw string, scope cmdutil.CampaignScope) (cmdutil.ParsedSwit
 		}
 	}
 	return parsed, nil
-}
-
-// runRemoteSwitch resolves a machine:campaign selector by asking the remote
-// machine's own `camp switch --print` for the absolute campaign root over ssh (so
-// the remote registry decides the path), then emits the interactive ssh hop line
-// under --shell-connect. --print is local-only: it MUST print nothing for a remote
-// target so `cd "$(camp switch x --print)"` fails loudly instead of cd-ing wrong.
-func runRemoteSwitch(ctx context.Context, cmd *cobra.Command, msel cmdutil.ParsedMachineSelector, printOnly, shellConnect, jsonOut bool) error {
-	if printOnly {
-		return camperrors.New("remote target " + msel.Machine +
-			": --print is local-only; use the csw shell wrapper to hop there")
-	}
-	if jsonOut {
-		return camperrors.New("--json is not supported for a remote (machine:) switch; use the csw shell wrapper")
-	}
-	mf, err := machines.Load()
-	if err != nil {
-		return err
-	}
-	m, _, found := mf.Lookup(msel.Machine)
-	if !found {
-		return camperrors.New("unknown machine \"" + msel.Machine + "\"; add it to ~/.obey/machines.yaml")
-	}
-	root, err := remote.ResolveRoot(ctx, m, msel.Remainder)
-	if err != nil {
-		return withRemoteSuggestions(err, msel)
-	}
-	if shellConnect {
-		return emitShellConnect(cmd.OutOrStdout(), true, root, m, hopOriginForEmit(ctx, cmd))
-	}
-	return camperrors.New("resolved " + msel.Machine + ":" + msel.Remainder + " -> " + root +
-		"; run via the csw shell wrapper to hop there")
-}
-
-// hopOriginForEmit builds the CAMP_HOP_ORIGIN payload describing THIS machine,
-// for the session on the far side. Every failure yields "" (no export), never
-// an error: the operator asked to hop, not to advertise an origin, so a machine
-// with no reachable name still hops exactly as it does today. A warning goes to
-// stderr because stdout is eval'd by the shell wrapper and must stay one line.
-func hopOriginForEmit(ctx context.Context, cmd *cobra.Command) string {
-	originCampaign := ""
-	if root, err := campaign.DetectCached(ctx); err == nil {
-		if cfg, err := config.LoadCampaignConfig(ctx, root); err == nil {
-			originCampaign = cfg.Name
-		}
-	}
-	origin, err := buildHopOrigin(ctx, originCampaign, runTailscaleStatusForSelf)
-	if err != nil {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
-			"camp: warning: hop origin unavailable (%v); 'camp switch -' will not work from that session\n", err)
-		return ""
-	}
-	return origin
-}
-
-// withRemoteSuggestions augments a remote resolve failure with near matches
-// from the per-machine completion cache. Cache-only on purpose: the failed
-// resolve already paid one SSH round-trip, and suggestions must not add
-// another. A cold cache simply yields no suggestions.
-func withRemoteSuggestions(err error, msel cmdutil.ParsedMachineSelector) error {
-	names, ok := readMachineCacheCampaigns(msel.Machine)
-	if !ok || len(names) == 0 {
-		return err
-	}
-	query := cmdutil.ParseSwitchSelector(msel.Remainder).Campaign
-	if query == "" {
-		return err
-	}
-	matches := navfuzzy.Filter(names, query)
-	if len(matches) == 0 {
-		return err
-	}
-	limit := min(len(matches), 3)
-	suggestions := make([]string, 0, limit)
-	for _, match := range matches[:limit] {
-		suggestions = append(suggestions, msel.Machine+":"+match.Target)
-	}
-	return camperrors.Wrapf(err, "did you mean %s?", strings.Join(suggestions, ", "))
 }
 
 type switchOutput struct {

--- a/cmd/camp/switch.go
+++ b/cmd/camp/switch.go
@@ -316,7 +316,11 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		if msel.Machine != "" && msel.Machine != machines.LocalMachineID {
+		// A selector naming THIS machine resolves locally. Without this, the
+		// same string that works on the host ("archdtop:notes" typed on the
+		// mac) would try to ssh archdtop to itself once you are on it, which is
+		// the shape agents and humans both produce after a hop.
+		if msel.Machine != "" && msel.Machine != machines.LocalMachineID && !isSelfMachine(ctx, msel.Machine) {
 			return runRemoteSwitch(ctx, cmd, msel, printOnly, shellConnect, jsonOut)
 		}
 		if reg.Len() == 0 {

--- a/cmd/camp/switch.go
+++ b/cmd/camp/switch.go
@@ -289,6 +289,17 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// The hop-back gesture is handled before the registry is even loaded, for
+	// two reasons. It is checked before selector parsing because "-" is
+	// otherwise a legal campaign query that reaches the fuzzy tier and matches
+	// an arbitrary hyphenated campaign, differently on every invocation. And it
+	// is checked before the "no campaigns registered" guard because hop-back
+	// resolves against the ORIGIN machine's registry, so a local registry is not
+	// a precondition and pointing the operator at `camp init` would be wrong.
+	if len(args) == 1 && args[0] == hopBackSelector {
+		return runHopBack(ctx, cmd, printOnly, shellConnect, jsonOut)
+	}
+
 	reg, err := config.LoadRegistry(ctx)
 	if err != nil {
 		return camperrors.Wrap(err, "load registry")
@@ -306,12 +317,6 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 	targetTab := ""
 
 	if len(args) == 1 {
-		// The hop-back gesture is checked before selector parsing: "-" is
-		// otherwise a legal campaign query that reaches the fuzzy tier and
-		// matches an arbitrary hyphenated campaign, differently every run.
-		if args[0] == hopBackSelector {
-			return runHopBack(ctx, cmd, printOnly, shellConnect, jsonOut)
-		}
 		msel, err := cmdutil.ParseMachineSelector(args[0])
 		if err != nil {
 			return err
@@ -414,45 +419,6 @@ func emitShellConnect(w io.Writer, isRemote bool, path string, m *machines.Machi
 	_, err := fmt.Fprintf(w, "exec ssh -t %s %s %s\n",
 		strings.Join(quoted, " "), remote.ShellQuote(remote.Target(m)), remote.ShellQuote(inner))
 	return err
-}
-
-func switchScopeFromFlags(cmd *cobra.Command) (cmdutil.CampaignScope, error) {
-	org, _ := cmd.Flags().GetString("org")
-	status, _ := cmd.Flags().GetString("status")
-	all, _ := cmd.Flags().GetBool("all")
-	if org != "" {
-		if err := config.ValidateName("org", org); err != nil {
-			return cmdutil.CampaignScope{}, err
-		}
-	}
-	if status != "" {
-		if err := config.ValidateStatus(status); err != nil {
-			return cmdutil.CampaignScope{}, err
-		}
-	}
-	if status != "" && all {
-		return cmdutil.CampaignScope{}, camperrors.New("cannot use --status with --all")
-	}
-	return cmdutil.CampaignScope{Org: org, Status: status, All: all}, nil
-}
-
-func parseSwitchArg(raw string, scope cmdutil.CampaignScope) (cmdutil.ParsedSwitchSelector, error) {
-	parsed := cmdutil.ParseSwitchSelector(raw)
-	if parsed.Org != "" {
-		if err := config.ValidateName("org", parsed.Org); err != nil {
-			return parsed, err
-		}
-		if strings.Contains(parsed.Campaign, "/") {
-			return parsed, camperrors.New("switch selector may contain at most one org separator")
-		}
-		if parsed.Campaign == "" {
-			return parsed, camperrors.New("campaign name required after org selector")
-		}
-		if scope.Org != "" && scope.Org != parsed.Org {
-			return parsed, camperrors.New(fmt.Sprintf("selector org %q conflicts with --org %q", parsed.Org, scope.Org))
-		}
-	}
-	return parsed, nil
 }
 
 type switchOutput struct {

--- a/cmd/camp/switch.go
+++ b/cmd/camp/switch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
+	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/machines"
 	"github.com/Obedience-Corp/camp/internal/nav"
@@ -365,23 +366,34 @@ func runSwitch(cmd *cobra.Command, args []string) error {
 	}
 
 	if shellConnect {
-		return emitShellConnect(cmd.OutOrStdout(), false, targetPath, nil)
+		return emitShellConnect(cmd.OutOrStdout(), false, targetPath, nil, "")
 	}
 	return emitSwitchSelection(cmd, selected, targetPath, targetTab, printOnly, jsonOut)
 }
 
 // emitShellConnect prints exactly one shell line for the camp() wrapper to eval.
 // Local: `cd -- '<abs-path>'` (identical effect to today's --print + wrapper cd).
-// Remote: `exec ssh -t <opts> '<target>' '<cd root && exec $SHELL -l>'`, where exec
-// replaces the shell (so quitting the remote shell returns the user locally), -t
-// forces a PTY, and $SHELL expands on the REMOTE side because the whole remote
-// command is single-quoted here so the local shell never touches the '$'.
-func emitShellConnect(w io.Writer, isRemote bool, path string, m *machines.Machine) error {
+// Remote: `exec ssh -t <opts> '<target>' '<export origin && cd root && exec $SHELL -l>'`,
+// where exec replaces the shell (so quitting the remote shell returns the user
+// locally), -t forces a PTY, and $SHELL expands on the REMOTE side because the
+// whole remote command is single-quoted here so the local shell never touches
+// the '$'.
+//
+// origin is a complete CAMP_HOP_ORIGIN payload or "". It is exported before the
+// cd so it survives into the login shell that replaces this process image: an
+// exported variable is part of the new image's envp, and login rc files may
+// extend the environment but do not reset an unrelated inherited variable.
+// Assembly and validation happen before the call, so this function's only job
+// stays rendering one line.
+func emitShellConnect(w io.Writer, isRemote bool, path string, m *machines.Machine, origin string) error {
 	if !isRemote {
 		_, err := fmt.Fprintf(w, "cd -- %s\n", remote.ShellQuote(path))
 		return err
 	}
 	inner := "cd " + remote.ShellQuote(path) + " && exec $SHELL -l"
+	if origin != "" {
+		inner = "export " + HopOriginEnvVar + "=" + remote.ShellQuote(origin) + " && " + inner
+	}
 	// Quote every opt token, not just target/inner: ControlPath (under $HOME) and
 	// an -i identity file may hold spaces/metacharacters, which would otherwise
 	// split the eval'd line into the wrong argv before ssh ever runs.
@@ -460,10 +472,31 @@ func runRemoteSwitch(ctx context.Context, cmd *cobra.Command, msel cmdutil.Parse
 		return withRemoteSuggestions(err, msel)
 	}
 	if shellConnect {
-		return emitShellConnect(cmd.OutOrStdout(), true, root, m)
+		return emitShellConnect(cmd.OutOrStdout(), true, root, m, hopOriginForEmit(ctx, cmd))
 	}
 	return camperrors.New("resolved " + msel.Machine + ":" + msel.Remainder + " -> " + root +
 		"; run via the csw shell wrapper to hop there")
+}
+
+// hopOriginForEmit builds the CAMP_HOP_ORIGIN payload describing THIS machine,
+// for the session on the far side. Every failure yields "" (no export), never
+// an error: the operator asked to hop, not to advertise an origin, so a machine
+// with no reachable name still hops exactly as it does today. A warning goes to
+// stderr because stdout is eval'd by the shell wrapper and must stay one line.
+func hopOriginForEmit(ctx context.Context, cmd *cobra.Command) string {
+	originCampaign := ""
+	if root, err := campaign.DetectCached(ctx); err == nil {
+		if cfg, err := config.LoadCampaignConfig(ctx, root); err == nil {
+			originCampaign = cfg.Name
+		}
+	}
+	origin, err := buildHopOrigin(ctx, originCampaign, runTailscaleStatusForSelf)
+	if err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+			"camp: warning: hop origin unavailable (%v); 'camp switch -' will not work from that session\n", err)
+		return ""
+	}
+	return origin
 }
 
 // withRemoteSuggestions augments a remote resolve failure with near matches

--- a/cmd/camp/switch_remote.go
+++ b/cmd/camp/switch_remote.go
@@ -16,9 +16,10 @@ import (
 	"github.com/Obedience-Corp/camp/internal/remote"
 )
 
-// hopBackResolveRoot is the seam that lets the hop-back decision table be tested
-// without a live ssh. Production is remote.ResolveRoot; tests substitute a stub.
-var hopBackResolveRoot = remote.ResolveRoot
+// resolveRemoteRoot is the seam every remote switch resolves through, hop-back
+// and machine:campaign alike, so both can be tested without a live ssh.
+// Production is remote.ResolveRoot; tests substitute a stub.
+var resolveRemoteRoot = remote.ResolveRoot
 
 // runRemoteSwitch resolves a machine:campaign selector by asking the remote
 // machine's own `camp switch --print` for the absolute campaign root over ssh (so
@@ -37,7 +38,7 @@ func runRemoteSwitch(ctx context.Context, cmd *cobra.Command, msel cmdutil.Parse
 	if !found {
 		return camperrors.New("unknown machine \"" + msel.Machine + "\"; add it to ~/.obey/machines.yaml")
 	}
-	root, err := hopBackResolveRoot(ctx, m, msel.Remainder)
+	root, err := resolveRemoteRoot(ctx, m, msel.Remainder)
 	if err != nil {
 		return withRemoteSuggestions(err, msel)
 	}

--- a/cmd/camp/switch_remote.go
+++ b/cmd/camp/switch_remote.go
@@ -19,6 +19,9 @@ import (
 // resolveRemoteRoot is the seam every remote switch resolves through, hop-back
 // and machine:campaign alike, so both can be tested without a live ssh.
 // Production is remote.ResolveRoot; tests substitute a stub.
+//
+// Not parallel-safe: tests swap this package-level var, so a test that does so
+// must not call t.Parallel().
 var resolveRemoteRoot = remote.ResolveRoot
 
 // runRemoteSwitch resolves a machine:campaign selector by asking the remote

--- a/cmd/camp/switch_remote.go
+++ b/cmd/camp/switch_remote.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/machines"
+	navfuzzy "github.com/Obedience-Corp/camp/internal/nav/fuzzy"
+	"github.com/Obedience-Corp/camp/internal/remote"
+)
+
+// hopBackResolveRoot is the seam that lets the hop-back decision table be tested
+// without a live ssh. Production is remote.ResolveRoot; tests substitute a stub.
+var hopBackResolveRoot = remote.ResolveRoot
+
+// runRemoteSwitch resolves a machine:campaign selector by asking the remote
+// machine's own `camp switch --print` for the absolute campaign root over ssh (so
+// the remote registry decides the path), then emits the interactive ssh hop line
+// under --shell-connect. --print is local-only: it MUST print nothing for a remote
+// target so `cd "$(camp switch x --print)"` fails loudly instead of cd-ing wrong.
+func runRemoteSwitch(ctx context.Context, cmd *cobra.Command, msel cmdutil.ParsedMachineSelector, printOnly, shellConnect, jsonOut bool) error {
+	if err := guardRemoteOutputFlags(msel.Machine, printOnly, jsonOut); err != nil {
+		return err
+	}
+	mf, err := machines.Load()
+	if err != nil {
+		return err
+	}
+	m, _, found := mf.Lookup(msel.Machine)
+	if !found {
+		return camperrors.New("unknown machine \"" + msel.Machine + "\"; add it to ~/.obey/machines.yaml")
+	}
+	root, err := hopBackResolveRoot(ctx, m, msel.Remainder)
+	if err != nil {
+		return withRemoteSuggestions(err, msel)
+	}
+	return emitHopOrRefuse(ctx, cmd, m, msel.Remainder, root, shellConnect)
+}
+
+// guardRemoteOutputFlags rejects the two flags that cannot mean anything for a
+// hop. Shared by every remote entry point so `camp switch -` and
+// `camp switch machine:campaign` refuse identically rather than drifting.
+func guardRemoteOutputFlags(target string, printOnly, jsonOut bool) error {
+	if printOnly {
+		return camperrors.New("remote target " + target +
+			": --print is local-only; use the csw shell wrapper to hop there")
+	}
+	if jsonOut {
+		return camperrors.New("--json is not supported for a remote (machine:) switch; use the csw shell wrapper")
+	}
+	return nil
+}
+
+// emitHopOrRefuse is the shared tail of every hop: emit the eval line under
+// --shell-connect, or resolve-and-refuse otherwise. The refusal is the agent
+// safety contract — a bare `camp switch machine:...` must never hop, so it
+// reports what it resolved and names the wrapper instead.
+func emitHopOrRefuse(ctx context.Context, cmd *cobra.Command, m *machines.Machine, remainder, root string, shellConnect bool) error {
+	if shellConnect {
+		return emitShellConnect(cmd.OutOrStdout(), true, root, m, hopOriginForEmit(ctx, cmd))
+	}
+	return camperrors.New("resolved " + m.ID + ":" + remainder + " -> " + root +
+		"; run via the csw shell wrapper to hop there")
+}
+
+// hopOriginForEmit builds the CAMP_HOP_ORIGIN payload describing THIS machine,
+// for the session on the far side. Every failure yields "" (no export), never
+// an error: the operator asked to hop, not to advertise an origin, so a machine
+// with no reachable name still hops exactly as it does today. A warning goes to
+// stderr because stdout is eval'd by the shell wrapper and must stay one line.
+//
+// This runs on the reverse hop too, which is what makes `camp switch -` a
+// toggle rather than a one-way trip: the session it lands in knows the machine
+// it just left.
+func hopOriginForEmit(ctx context.Context, cmd *cobra.Command) string {
+	originCampaign := ""
+	if root, err := campaign.DetectCached(ctx); err == nil {
+		if cfg, err := config.LoadCampaignConfig(ctx, root); err == nil {
+			originCampaign = cfg.Name
+		}
+	}
+	origin, err := buildHopOrigin(ctx, originCampaign, runTailscaleStatusForSelf)
+	if err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+			"camp: warning: hop origin unavailable (%v); 'camp switch -' will not work from that session\n", err)
+		return ""
+	}
+	return origin
+}
+
+// withRemoteSuggestions augments a remote resolve failure with near matches
+// from the per-machine completion cache. Cache-only on purpose: the failed
+// resolve already paid one SSH round-trip, and suggestions must not add
+// another. A cold cache simply yields no suggestions.
+func withRemoteSuggestions(err error, msel cmdutil.ParsedMachineSelector) error {
+	names, ok := readMachineCacheCampaigns(msel.Machine)
+	if !ok || len(names) == 0 {
+		return err
+	}
+	query := cmdutil.ParseSwitchSelector(msel.Remainder).Campaign
+	if query == "" {
+		return err
+	}
+	matches := navfuzzy.Filter(names, query)
+	if len(matches) == 0 {
+		return err
+	}
+	limit := min(len(matches), 3)
+	suggestions := make([]string, 0, limit)
+	for _, match := range matches[:limit] {
+		suggestions = append(suggestions, msel.Machine+":"+match.Target)
+	}
+	return camperrors.Wrapf(err, "did you mean %s?", strings.Join(suggestions, ", "))
+}

--- a/cmd/camp/switch_selector.go
+++ b/cmd/camp/switch_selector.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// Selector and scope parsing for `camp switch`. Split out of switch.go to keep
+// that file under the 500-line ceiling; behavior is unchanged.
+
+func switchScopeFromFlags(cmd *cobra.Command) (cmdutil.CampaignScope, error) {
+	org, _ := cmd.Flags().GetString("org")
+	status, _ := cmd.Flags().GetString("status")
+	all, _ := cmd.Flags().GetBool("all")
+	if org != "" {
+		if err := config.ValidateName("org", org); err != nil {
+			return cmdutil.CampaignScope{}, err
+		}
+	}
+	if status != "" {
+		if err := config.ValidateStatus(status); err != nil {
+			return cmdutil.CampaignScope{}, err
+		}
+	}
+	if status != "" && all {
+		return cmdutil.CampaignScope{}, camperrors.New("cannot use --status with --all")
+	}
+	return cmdutil.CampaignScope{Org: org, Status: status, All: all}, nil
+}
+
+func parseSwitchArg(raw string, scope cmdutil.CampaignScope) (cmdutil.ParsedSwitchSelector, error) {
+	parsed := cmdutil.ParseSwitchSelector(raw)
+	if parsed.Org != "" {
+		if err := config.ValidateName("org", parsed.Org); err != nil {
+			return parsed, err
+		}
+		if strings.Contains(parsed.Campaign, "/") {
+			return parsed, camperrors.New("switch selector may contain at most one org separator")
+		}
+		if parsed.Campaign == "" {
+			return parsed, camperrors.New("campaign name required after org selector")
+		}
+		if scope.Org != "" && scope.Org != parsed.Org {
+			return parsed, camperrors.New(fmt.Sprintf("selector org %q conflicts with --org %q", parsed.Org, scope.Org))
+		}
+	}
+	return parsed, nil
+}

--- a/cmd/camp/switch_shellconnect_test.go
+++ b/cmd/camp/switch_shellconnect_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestEmitShellConnectLocal(t *testing.T) {
 	var buf bytes.Buffer
-	if err := emitShellConnect(&buf, false, "/home/lance/campaigns/obey", nil); err != nil {
+	if err := emitShellConnect(&buf, false, "/home/lance/campaigns/obey", nil, ""); err != nil {
 		t.Fatal(err)
 	}
 	if got, want := buf.String(), "cd -- '/home/lance/campaigns/obey'\n"; got != want {
@@ -21,7 +21,7 @@ func TestEmitShellConnectLocal(t *testing.T) {
 func TestEmitShellConnectRemoteWithUser(t *testing.T) {
 	var buf bytes.Buffer
 	m := &machines.Machine{ID: "devbox", Host: "devbox.ts.net", SSHUser: "lance", AuthMethod: machines.AuthSSHAgent}
-	if err := emitShellConnect(&buf, true, "/srv/campaigns/obey", m); err != nil {
+	if err := emitShellConnect(&buf, true, "/srv/campaigns/obey", m, ""); err != nil {
 		t.Fatal(err)
 	}
 	out := buf.String()
@@ -42,7 +42,7 @@ func TestEmitShellConnectRemoteWithUser(t *testing.T) {
 func TestEmitShellConnectRemoteNoUser(t *testing.T) {
 	var buf bytes.Buffer
 	m := &machines.Machine{ID: "box", Host: "box.local", AuthMethod: machines.AuthSSHAgent}
-	if err := emitShellConnect(&buf, true, "/x", m); err != nil {
+	if err := emitShellConnect(&buf, true, "/x", m, ""); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(buf.String(), " 'box.local' ") {
@@ -61,7 +61,7 @@ func TestEmitShellConnectRemoteQuotesOptsWithSpaces(t *testing.T) {
 		AuthMethod:   machines.AuthSSHAgent,
 		IdentityFile: "/tmp/my key",
 	}
-	if err := emitShellConnect(&buf, true, "/x", m); err != nil {
+	if err := emitShellConnect(&buf, true, "/x", m, ""); err != nil {
 		t.Fatal(err)
 	}
 	out := buf.String()
@@ -79,7 +79,7 @@ func TestEmitShellConnectRemoteInjectionSafe(t *testing.T) {
 	m := &machines.Machine{ID: "box", Host: "box.local", AuthMethod: machines.AuthSSHAgent}
 	// A remote root containing shell metacharacters must be single-quoted so it
 	// cannot break out of the command.
-	if err := emitShellConnect(&buf, true, "/x; rm -rf $HOME", m); err != nil {
+	if err := emitShellConnect(&buf, true, "/x; rm -rf $HOME", m, ""); err != nil {
 		t.Fatal(err)
 	}
 	out := buf.String()

--- a/docs/cli-reference/camp_switch.md
+++ b/docs/cli-reference/camp_switch.md
@@ -10,13 +10,22 @@ Without arguments, opens an interactive picker to select a campaign.
 With an argument, looks up the campaign by name or ID prefix.
 Use --org or org/campaign to resolve inside one organization.
 
-Use with the cgo shell function for instant navigation:
-  cgo switch                 # Interactive campaign picker
-  cgo switch my-campaign     # Switch by name
-  cgo switch a1b2             # Switch by ID prefix
-  cgo switch obey/platform    # Switch by org-scoped selector
+Use with the shell-init wrappers for instant navigation (recommended):
+  eval "$(camp shell-init zsh)"   # or bash / fish — once per shell
+  csw                            # Interactive picker (local + remote machines)
+  csw my-campaign                # Switch by name
+  csw a1b2                       # Switch by ID prefix
+  csw obey/platform              # Switch by org-scoped selector
+  csw archdtop:lance-arch        # Hop to a remote campaign over ssh
+  csw -                          # Hop back to the machine/campaign this session came from
 
-The --print flag outputs just the path for shell integration:
+`camp switch -` (`csw -`) is the hop-back gesture: it returns to the origin
+encoded in `CAMP_HOP_ORIGIN` by the outbound hop. It is registration-independent
+— the origin need not be in this machine's `machines.yaml`. Like other remote
+targets it refuses `--print`/`--json`. `-` is reserved and is no longer a fuzzy
+campaign query.
+
+The --print flag outputs just the path for shell integration (local only):
   cd "$(camp switch --print)"
 
 Use campaign@tab to navigate to a specific location in the target campaign:
@@ -44,10 +53,12 @@ camp switch [campaign] [flags]
   camp switch --org obey platform    # Switch by name within an org
   camp switch obey/platform          # Switch by scoped selector
   camp switch a1b2                   # Switch by ID prefix
-  camp switch --print                # Picker, output path only
+  camp switch --print                # Picker, output path only (local)
   camp switch obey-campaign@p        # Switch and navigate to projects/
   camp switch --all old-reference    # Include inactive/reference campaigns
   camp switch --org obey platform --json
+  csw archdtop:lance-arch            # Hop to remote campaign
+  csw -                              # Hop back via CAMP_HOP_ORIGIN
 ```
 
 ### Options

--- a/internal/shell/shell_connect_test.go
+++ b/internal/shell/shell_connect_test.go
@@ -94,3 +94,64 @@ func TestListBranchHandlesSSHHopMarker(t *testing.T) {
 		})
 	}
 }
+
+// TestSwitchBranchEvalsQuoted pins the one property that decides whether an
+// embedded `export CAMP_HOP_ORIGIN='...'` survives the wrapper: the hop line
+// must be eval'd as a single quoted word. Unquoted (`eval $line`) the shell
+// word-splits the line before eval sees it, and a payload containing spaces or
+// quotes would be re-split into the wrong argv, silently mangling the origin or
+// the ssh options. Every dialect must quote.
+func TestSwitchBranchEvalsQuoted(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+	}{
+		{"zsh", generateZsh()},
+		{"bash", generateBash()},
+		{"fish", generateFish()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(tc.output, `eval "$line"`) {
+				t.Errorf("%s must eval the hop line as one quoted word", tc.name)
+			}
+			if strings.Contains(tc.output, "eval $line") {
+				t.Errorf("%s evals the hop line unquoted; an embedded export would be word-split", tc.name)
+			}
+		})
+	}
+}
+
+// TestSwitchBranchPassthroughGuardDoesNotSwallowDash pins that a bare "-"
+// reaches the binary. The guard list exists for scriptable flags
+// (--help/--json/--print); if "-" were ever added to it, the hop-back gesture
+// would silently become a non-hopping passthrough instead of a hop.
+//
+// The check tokenizes each guard line rather than substring-matching, because
+// every flag in the list starts with "-" and a naive substring test matches
+// them all.
+func TestSwitchBranchPassthroughGuardDoesNotSwallowDash(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		output string
+	}{
+		{"zsh", generateZsh()},
+		{"bash", generateBash()},
+		{"fish", generateFish()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, line := range strings.Split(tc.output, "\n") {
+				if !strings.Contains(line, "--help") {
+					continue
+				}
+				for _, tok := range strings.FieldsFunc(line, func(r rune) bool {
+					return r == ' ' || r == '|' || r == '\t' || r == ')' || r == '\''
+				}) {
+					if tok == "-" {
+						t.Errorf("%s passthrough guard matches a bare '-': %q", tc.name, strings.TrimSpace(line))
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Ships the P0 half of the mesh-navigation loop: a hop now carries where it came from, `camp switch -` returns, and a selector naming the current machine resolves locally instead of ssh-ing to itself.

Festival MN0001, phase 004 sequence 01. Design is in `festivals/active/mesh-navigation-mutual-machine-visibility-MN0001/003_DESIGN/01_origin_hopback/outputs/origin-hopback-spec.md` (every symbol in it is anchor-verified against camp main).

## Why

A hop knows where it landed but not where it came from, so the far session cannot offer to hop back or to register the origin. sshd's default `AcceptEnv` blocks `SendEnv` forwarding, so the identity rides the remote command instead of the ssh environment: no sshd config on any fleet member.

## What changed

**`CAMP_HOP_ORIGIN` payload** (`cmd/camp/hop_origin.go`). Single line, `v1;host=…;user=…;campaign=…;id=…`, every byte outside `[A-Za-z0-9._~-]` percent-encoded. That encoding is what makes a campaign named `x;host=evil.example.com` inert: it cannot inject a second `host` pair, and it cannot break out of either shell-quoting layer. Over-cap optional fields are dropped rather than truncated, because a truncated hostname is a wrong hostname and wrong routing is worse than absent routing.

**Embedding** (`cmd/camp/switch.go`). `emitShellConnect` gains an `origin` parameter and prepends `export CAMP_HOP_ORIGIN=<quoted> && ` to the remote command. `exec` preserves it into the login shell. The local `cd --` path is untouched and pinned by a regression test.

**`camp switch -`** (`cmd/camp/hop_origin.go`). Reads the payload, builds a transient in-memory machine, resolves the origin campaign on the origin's own camp, emits the reverse hop line. Never reads or writes `machines.yaml` for the gesture itself (D008: registration-independent), which a test asserts. The reverse line carries its own origin, so the gesture is a toggle rather than a one-way trip.

**Self-reference** (`cmd/camp/hop_origin.go`). `archdtop:notes` typed on archdtop resolves locally. One rule: the id derived from this machine's reachable name, using the same derivation that fills the payload's `id`, so the two answers cannot drift.

**File split.** `switch.go` was over the project's 500-line ceiling (545 before this work, 572 with it). This performs the shared-tail extraction the design spec already planned: `switch_remote.go` holds `guardRemoteOutputFlags` and `emitHopOrRefuse`, shared by both hop entry points so their refusal text cannot drift; `switch_selector.go` holds the selector/scope helpers. `switch.go` is now 469 lines. Pure moves.

## Live verification (mac-studio to archdtop)

Emitted line:

```
exec ssh -t '-o' 'StrictHostKeyChecking=accept-new' ... 'lance@archdtop.tail37114b.ts.net' 'export CAMP_HOP_ORIGIN='\''v1;host=mac-studio.tail37114b.ts.net;user=lancerogers;campaign=obey-campaign;id=mac-studio'\'' && cd '\''/home/lance/campaigns/lance-arch'\'' && exec $SHELL -l'
```

Executing its remote half:

```
host=archdtop
pwd=/home/lance/campaigns/lance-arch
CAMP_HOP_ORIGIN=v1;host=mac-studio.tail37114b.ts.net;user=lancerogers;campaign=obey-campaign;id=mac-studio
```

Gesture rows against the real fleet:

```
$ camp switch -
Error: camp switch -: this session did not start from a camp hop (CAMP_HOP_ORIGIN is not set)

$ CAMP_HOP_ORIGIN=<archdtop payload> camp switch -
Error: resolved archdtop:lance-arch -> /home/lance/campaigns/lance-arch; run via the csw shell wrapper to hop there

$ CAMP_HOP_ORIGIN=<archdtop payload> camp switch - --print
Error: remote target archdtop: --print is local-only; use the csw shell wrapper to hop there

$ CAMP_HOP_ORIGIN='v1;host=a;host=b;user=c' camp switch -
Error: camp switch -: CAMP_HOP_ORIGIN is malformed (duplicate key "host"); hop back with 'camp switch <machine>:<campaign>'
```

The bare row resolved through a live ssh to the real archdtop, which also exercises the registered-entry path (it used id `archdtop`, not the transient `archdtop-origin`).

Self-reference on the mac:

```
$ camp switch mac-studio:obey-campaign --print      -> /Users/lancerogers/Dev/AI/obey-campaign
$ camp switch mac-studio:obey-campaign@p --print    -> /Users/lancerogers/Dev/AI/obey-campaign/projects
$ camp switch mac-studio:obc/obey-campaign --print  -> /Users/lancerogers/Dev/AI/obey-campaign
$ camp switch archdtop:lance-arch --print           -> Error: remote target archdtop: --print is local-only …
```

## Tests

`just gate` green: 3762 tests. The hop-back decision table runs with no live ssh via an injected resolver seam, mirroring the existing `tailscaleStatusFunc` pattern. Notable coverage: 11 encode rows, 10 parse-rejection rows, 7 host-detection rows including five fallbacks, the full 10-row hop-back decision table each asserting stdout stays empty, plus pins for "empty origin emits byte-identical output to before", "hop-back never writes machines.yaml", and "the reverse line carries its own origin".

## Deliberate choices a reviewer may want to push on

1. **The transient machine leaves `auth_method` empty.** The hop argv is identical across auth methods (`authArgs` branches only on `IdentityFile`), `EnsureKeyAuth` rejects only `ssh-password`, and failure classification reads ssh's own stderr. Guessing would only put a wrong label in front of a broken hop.
2. **A registered entry wins over self-detection.** A `machines.yaml` row pointing at this machine is a misconfiguration that sequence 02's adopt verb is specified to refuse creating. Honoring an explicit operator file beats second-guessing it on every hop.
3. **Origin failures are warnings, never errors.** No reachable name, no tailscale, or no campaign context each yield no export and a stderr note; the hop itself is unaffected.

## Found while testing, not fixed here

`camp switch machine:campaign` exits **127 with entirely empty stdout and stderr** when the remote camp is not on the far machine's login PATH. Reproduces identically with the released binary from `main`, so it predates this branch. The actionable hint exists in `campNotFoundHint` (`internal/remote/ssh.go:602`) but never reaches the user. Worked around during testing with `CAMP_REMOTE_CAMP_PATH`. Deserves its own issue rather than scope creep here.
