### PR TITLE
feat(machine): consented 'camp machine adopt' with decline memory and hints

### DIFF
--- a/cmd/camp/hop_origin.go
+++ b/cmd/camp/hop_origin.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"os/user"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -438,7 +439,8 @@ func hopBackFailure(err error, m *machines.Machine, registered bool) error {
 	if registered {
 		return camperrors.Wrapf(err, "run 'camp machine diagnose %s' to check reachability", m.ID)
 	}
-	return camperrors.Wrapf(err, "the origin is not registered here, probe it with: %s", remote.ProbeCommand(m))
+	return camperrors.Wrapf(err, "the origin is not registered here, probe it with: %s%s",
+		remote.ProbeCommand(m), hopBackHintSuffix())
 }
 
 // isSelfMachine reports whether a selector's machine segment names THIS
@@ -469,4 +471,60 @@ func isSelfMachine(ctx context.Context, id string) bool {
 		return false
 	}
 	return suggestedMachineID(host) == id
+}
+
+// originHintOnce bounds the unregistered-origin hint to one appearance per
+// process. Camp has no session daemon and constraints forbid adding one, so
+// "once per session" is not implementable without inventing a store for a
+// cosmetic problem; once per process is the honest bound, and the surfaces are
+// commands an operator runs deliberately rather than a prompt that redraws.
+var originHintOnce sync.Once
+
+// OriginHint returns the one-line suggestion to adopt the machine this session
+// was hopped from, or "" when it should stay silent. It is a suggestion, so it
+// behaves like one: quiet unless it can be acted on, and never more than once.
+//
+// Silent when: no payload, a malformed payload, the origin is already in the
+// fleet, the operator declined it, or the hint has already been shown. Callers
+// additionally suppress it for --json and non-TTY output; that is their
+// decision to make, not this function's.
+func OriginHint() string {
+	hint := ""
+	originHintOnce.Do(func() {
+		hint = originHintText()
+	})
+	return hint
+}
+
+func originHintText() string {
+	raw := strings.TrimSpace(os.Getenv(HopOriginEnvVar))
+	if raw == "" {
+		return ""
+	}
+	origin, err := ParseHopOrigin(raw)
+	if err != nil {
+		return ""
+	}
+	mf, err := machines.Load()
+	if err != nil {
+		return ""
+	}
+	want := machines.NormalizeHost(origin.Host)
+	for _, m := range mf.Machines {
+		if machines.NormalizeHost(m.Host) == want {
+			return ""
+		}
+	}
+	if declined, err := machines.LoadDeclined(); err == nil {
+		if _, was := declined.IsDeclined(origin.Host); was {
+			return ""
+		}
+	}
+	return "origin " + origin.Host + " is not in your fleet; run 'camp machine adopt' to add it"
+}
+
+// resetOriginHintForTest re-arms the once-per-process bound so a table test can
+// exercise more than one row.
+func resetOriginHintForTest() {
+	originHintOnce = sync.Once{}
 }

--- a/cmd/camp/machine.go
+++ b/cmd/camp/machine.go
@@ -209,9 +209,14 @@ func runMachineList(cmd *cobra.Command, _ []string) error {
 	if err := renderMachineListTable(cmd.OutOrStdout(), mf.Machines); err != nil {
 		return err
 	}
-	if hint := OriginHint(); hint != "" {
-		_, err := fmt.Fprintln(cmd.OutOrStdout(), ui.Dim(hint))
-		return err
+	// OriginHint's contract is non-TTY silence: piped/redirected list stays pure
+	// data, and the once-per-process token is not burned on non-interactive paths.
+	// --json already returns above; this covers bare table output without a TTY.
+	if ui.IsTerminal() {
+		if hint := OriginHint(); hint != "" {
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), ui.Dim(hint))
+			return err
+		}
 	}
 	return nil
 }

--- a/cmd/camp/machine.go
+++ b/cmd/camp/machine.go
@@ -201,9 +201,19 @@ func runMachineList(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	if machineListJSON {
+		// JSON consumers get data, never advice: the hint is suppressed here
+		// rather than inside OriginHint, because whether advice belongs in the
+		// output is the caller's decision.
 		return writeMachineListJSON(cmd.OutOrStdout(), mf)
 	}
-	return renderMachineListTable(cmd.OutOrStdout(), mf.Machines)
+	if err := renderMachineListTable(cmd.OutOrStdout(), mf.Machines); err != nil {
+		return err
+	}
+	if hint := OriginHint(); hint != "" {
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), ui.Dim(hint))
+		return err
+	}
+	return nil
 }
 
 func writeMachineListJSON(w io.Writer, mf *machines.File) error {

--- a/cmd/camp/machine.go
+++ b/cmd/camp/machine.go
@@ -176,6 +176,9 @@ func init() {
 	machineCmd.AddCommand(machineAddCmd)
 	machineCmd.AddCommand(machineRemoveCmd)
 	machineCmd.AddCommand(machineDiagnoseCmd)
+	machineCmd.AddCommand(machineAdoptCmd)
+	machineAdoptCmd.Flags().BoolVar(&machineAdoptForce, "force", false,
+		"Skip the reminder that you declined this origin before (never skips the confirmation)")
 
 	machineListCmd.Flags().BoolVar(&machineListJSON, "json", false, "Output as JSON")
 

--- a/cmd/camp/machine_adopt.go
+++ b/cmd/camp/machine_adopt.go
@@ -39,7 +39,7 @@ var machineAdoptCmd = &cobra.Command{
 what will be written.
 
 A hop carries its origin in CAMP_HOP_ORIGIN. This reads that value and offers to
-add the origin to ~/.obey/machines.yaml so hops and completion work in the other
+add the origin to your machines file so hops and completion work in the other
 direction too. The hop itself never registers anything: adopting is an explicit,
 interactive act, and there is no flag that skips the confirmation.
 
@@ -91,6 +91,15 @@ func runMachineAdopt(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// The TTY refusal comes before any human-oriented output. A non-interactive
+	// run that has already printed a decline reminder and then errors leaves
+	// half a consent surface on stdout, which is exactly what the rest of this
+	// command avoids.
+	if !adoptIsTerminal() {
+		return camperrors.New("camp machine adopt requires an interactive terminal: registering a " +
+			"machine is an explicit consent step and cannot be automated")
+	}
+
 	declined, declineErr := machines.LoadDeclined()
 	if declineErr != nil {
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "camp: warning: %v (treating as no declines)\n", declineErr)
@@ -98,11 +107,6 @@ func runMachineAdopt(cmd *cobra.Command, _ []string) error {
 	if d, was := declined.IsDeclined(origin.Host); was && !machineAdoptForce {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "You declined this origin on %s; adopting now will register it.\n\n",
 			d.DeclinedAt.Format("2006-01-02"))
-	}
-
-	if !adoptIsTerminal() {
-		return camperrors.New("camp machine adopt requires an interactive terminal: registering a " +
-			"machine is an explicit consent step and cannot be automated")
 	}
 
 	if _, err := fmt.Fprint(cmd.OutOrStdout(), adoptPreview(origin, entry)); err != nil {
@@ -200,7 +204,7 @@ func adoptPreview(origin HopOrigin, entry machines.Machine) string {
 	if origin.Campaign != "" {
 		fmt.Fprintf(&b, "  campaign  %s\n", origin.Campaign)
 	}
-	b.WriteString("\nThis entry will be appended to ~/.obey/machines.yaml:\n\n")
+	b.WriteString("\nThis entry will be appended to " + machines.MachinesPath() + ":\n\n")
 	// Marshal the row the same way Save does so quoting/escaping match disk.
 	yml, err := yaml.Marshal([]machines.Machine{entry})
 	if err != nil {

--- a/cmd/camp/machine_adopt.go
+++ b/cmd/camp/machine_adopt.go
@@ -22,6 +22,16 @@ var machineAdoptForce bool
 var adoptIsTerminal = ui.IsTerminal
 var adoptConfirm = confirmForm
 
+// adoptDetectTailnet / adoptDetectBare are the dual reachable-name probes used
+// by isSelfOrigin. Production uses tailscale Self + os.Hostname; tests inject
+// pure functions so the dual-name matrix is covered without a live tailnet.
+var adoptDetectTailnet = func(ctx context.Context) (string, error) {
+	return detectReachableName(ctx, runTailscaleStatusForSelf)
+}
+var adoptDetectBare = func(ctx context.Context) (string, error) {
+	return detectReachableName(ctx, nil)
+}
+
 var machineAdoptCmd = &cobra.Command{
 	Use:   "adopt",
 	Short: "Register the machine this session was hopped from",
@@ -236,14 +246,14 @@ func isSelfOrigin(ctx context.Context, origin HopOrigin) (bool, error) {
 	if want == "" {
 		return false, nil
 	}
-	tailnet, err := detectReachableName(ctx, runTailscaleStatusForSelf)
+	tailnet, err := adoptDetectTailnet(ctx)
 	if err != nil {
 		return false, err
 	}
 	if machines.NormalizeHost(tailnet) == want {
 		return true, nil
 	}
-	bare, err := detectReachableName(ctx, nil)
+	bare, err := adoptDetectBare(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/camp/machine_adopt.go
+++ b/cmd/camp/machine_adopt.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/machines"
@@ -15,6 +16,11 @@ import (
 )
 
 var machineAdoptForce bool
+
+// adoptIsTerminal and adoptConfirm are production seams for the consent path.
+// Tests swap them so cancel vs explicit-No can be asserted without a real TTY.
+var adoptIsTerminal = ui.IsTerminal
+var adoptConfirm = confirmForm
 
 var machineAdoptCmd = &cobra.Command{
 	Use:   "adopt",
@@ -30,8 +36,9 @@ interactive act, and there is no flag that skips the confirmation.
 Adopting records how to REACH a machine. It does not make that machine reachable:
 that depends on its own sshd or tailnet policy. Verify with 'camp machine diagnose'.
 
-Declining is remembered, so hints stay quiet until you ask again. Re-running this
-command always works; --force only skips the reminder that you declined before.`,
+Answering No is remembered, so hints stay quiet until you ask again. Esc/cancel
+aborts without writing decline memory. Re-running this command always works;
+--force only skips the reminder that you declined before.`,
 	Args: cobra.NoArgs,
 	RunE: runMachineAdopt,
 }
@@ -48,7 +55,13 @@ func runMachineAdopt(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	if self, err := isSelfOrigin(ctx, origin); err == nil && self {
+	// Fail closed on detection errors: a skipped self-guard could write a
+	// machines.yaml row pointing at this host and break self-reference resolve.
+	self, err := isSelfOrigin(ctx, origin)
+	if err != nil {
+		return camperrors.Wrap(err, "camp machine adopt: cannot determine whether this origin is this machine")
+	}
+	if self {
 		return camperrors.New("camp machine adopt: this origin is this machine (" + origin.Host +
 			"); nothing to adopt")
 	}
@@ -77,7 +90,7 @@ func runMachineAdopt(cmd *cobra.Command, _ []string) error {
 			d.DeclinedAt.Format("2006-01-02"))
 	}
 
-	if !ui.IsTerminal() {
+	if !adoptIsTerminal() {
 		return camperrors.New("camp machine adopt requires an interactive terminal: registering a " +
 			"machine is an explicit consent step and cannot be automated")
 	}
@@ -85,8 +98,13 @@ func runMachineAdopt(cmd *cobra.Command, _ []string) error {
 	if _, err := fmt.Fprint(cmd.OutOrStdout(), adoptPreview(origin, entry)); err != nil {
 		return err
 	}
-	ok, err := confirmForm(ctx, fmt.Sprintf("Add machine %q?", entry.ID))
+	ok, canceled, err := adoptConfirm(ctx, fmt.Sprintf("Add machine %q?", entry.ID))
 	if err != nil {
+		return err
+	}
+	if canceled {
+		// Esc/abort is not a deliberate decline — leave decline memory alone.
+		_, err := fmt.Fprintln(cmd.OutOrStdout(), "Not adopted.")
 		return err
 	}
 	if !ok {
@@ -161,8 +179,9 @@ func adoptEntry(mf *machines.File, origin HopOrigin) (machines.Machine, error) {
 	}, nil
 }
 
-// adoptPreview renders exactly the YAML that will be appended, plus the
-// reachability caveat. The operator approves the bytes, not a summary of them.
+// adoptPreview renders the YAML that will be appended (via the same
+// yaml.Marshal path File.Save uses), plus the reachability caveat. The
+// operator approves the bytes, not a hand-formatted summary of them.
 func adoptPreview(origin HopOrigin, entry machines.Machine) string {
 	var b strings.Builder
 	b.WriteString("\nOrigin from this session:\n\n")
@@ -172,12 +191,17 @@ func adoptPreview(origin HopOrigin, entry machines.Machine) string {
 		fmt.Fprintf(&b, "  campaign  %s\n", origin.Campaign)
 	}
 	b.WriteString("\nThis entry will be appended to ~/.obey/machines.yaml:\n\n")
-	fmt.Fprintf(&b, "    - id: %s\n", entry.ID)
-	fmt.Fprintf(&b, "      label: %s\n", entry.Label)
-	fmt.Fprintf(&b, "      host: %s\n", entry.Host)
-	fmt.Fprintf(&b, "      auth_method: %s\n", entry.AuthMethod)
-	if entry.SSHUser != "" {
-		fmt.Fprintf(&b, "      ssh_user: %s\n", entry.SSHUser)
+	// Marshal the row the same way Save does so quoting/escaping match disk.
+	yml, err := yaml.Marshal([]machines.Machine{entry})
+	if err != nil {
+		// Unreachable for a well-formed Machine; keep the preview usable.
+		fmt.Fprintf(&b, "    - id: %s\n      host: %s\n", entry.ID, entry.Host)
+	} else {
+		for _, line := range strings.Split(strings.TrimRight(string(yml), "\n"), "\n") {
+			b.WriteString("    ")
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
 	}
 	fmt.Fprintf(&b, "\n  auth_method is a default; change it with 'camp machine add %s --auth tailscale-ssh'\n", entry.ID)
 	fmt.Fprintf(&b, "\nAdopting records how to reach %s. It does not make %s reachable:\n", entry.ID, entry.ID)

--- a/cmd/camp/machine_adopt.go
+++ b/cmd/camp/machine_adopt.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/machines"
+	"github.com/Obedience-Corp/camp/internal/ui"
+)
+
+var machineAdoptForce bool
+
+var machineAdoptCmd = &cobra.Command{
+	Use:   "adopt",
+	Short: "Register the machine this session was hopped from",
+	Long: `Register the machine this session was hopped from, after showing you exactly
+what will be written.
+
+A hop carries its origin in CAMP_HOP_ORIGIN. This reads that value and offers to
+add the origin to ~/.obey/machines.yaml so hops and completion work in the other
+direction too. The hop itself never registers anything: adopting is an explicit,
+interactive act, and there is no flag that skips the confirmation.
+
+Adopting records how to REACH a machine. It does not make that machine reachable:
+that depends on its own sshd or tailnet policy. Verify with 'camp machine diagnose'.
+
+Declining is remembered, so hints stay quiet until you ask again. Re-running this
+command always works; --force only skips the reminder that you declined before.`,
+	Args: cobra.NoArgs,
+	RunE: runMachineAdopt,
+}
+
+func runMachineAdopt(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	jsonOut, _ := cmd.Flags().GetBool("json")
+	if jsonOut {
+		return camperrors.New("camp machine adopt does not support --json: registering a machine is " +
+			"an explicit consent step, not a query")
+	}
+
+	origin, err := adoptOrigin()
+	if err != nil {
+		return err
+	}
+	if self, err := isSelfOrigin(ctx, origin); err == nil && self {
+		return camperrors.New("camp machine adopt: this origin is this machine (" + origin.Host +
+			"); nothing to adopt")
+	}
+
+	mf, err := machines.Load()
+	if err != nil {
+		return err
+	}
+	if existing, found := machineByHost(mf, origin.Host); found {
+		_, err := fmt.Fprintf(cmd.OutOrStdout(), "%s is already in your fleet as %q; nothing to adopt\n",
+			origin.Host, existing.ID)
+		return err
+	}
+
+	entry, err := adoptEntry(mf, origin)
+	if err != nil {
+		return err
+	}
+
+	declined, declineErr := machines.LoadDeclined()
+	if declineErr != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "camp: warning: %v (treating as no declines)\n", declineErr)
+	}
+	if d, was := declined.IsDeclined(origin.Host); was && !machineAdoptForce {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "You declined this origin on %s; adopting now will register it.\n\n",
+			d.DeclinedAt.Format("2006-01-02"))
+	}
+
+	if !ui.IsTerminal() {
+		return camperrors.New("camp machine adopt requires an interactive terminal: registering a " +
+			"machine is an explicit consent step and cannot be automated")
+	}
+
+	if _, err := fmt.Fprint(cmd.OutOrStdout(), adoptPreview(origin, entry)); err != nil {
+		return err
+	}
+	ok, err := confirmForm(ctx, fmt.Sprintf("Add machine %q?", entry.ID))
+	if err != nil {
+		return err
+	}
+	if !ok {
+		declined.Decline(entry.ID, origin.Host, time.Now())
+		if err := declined.Save(); err != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "camp: warning: could not record the decline: %v\n", err)
+		}
+		_, err := fmt.Fprintln(cmd.OutOrStdout(),
+			"Not adopted. Run 'camp machine adopt' again if you change your mind.")
+		return err
+	}
+
+	mf.Upsert(entry)
+	if err := mf.Save(); err != nil {
+		return err
+	}
+	declined.Remove(origin.Host)
+	if err := declined.Save(); err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "camp: warning: could not clear the decline record: %v\n", err)
+	}
+
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s machine %q adopted (%s, %s)\n  next: camp machine diagnose %s\n",
+		ui.SuccessIcon(), entry.ID, entry.Host, entry.AuthMethod, entry.ID)
+	return err
+}
+
+// adoptOrigin reads and parses the session payload, translating both failure
+// shapes into messages that explain what the command is for. The likeliest
+// reader of either error ran adopt on the wrong machine or outside a hop.
+func adoptOrigin() (HopOrigin, error) {
+	raw := strings.TrimSpace(os.Getenv(HopOriginEnvVar))
+	if raw == "" {
+		return HopOrigin{}, camperrors.New("camp machine adopt: no origin in this session (" +
+			HopOriginEnvVar + " is not set); this command adopts the machine you hopped here from")
+	}
+	origin, err := ParseHopOrigin(raw)
+	if err != nil {
+		return HopOrigin{}, camperrors.New("camp machine adopt: " + HopOriginEnvVar +
+			" is malformed (" + err.Error() + "); nothing to adopt")
+	}
+	return origin, nil
+}
+
+// adoptEntry maps the payload to a machines.yaml row. auth_method is never
+// inferred from the payload (it carries none, deliberately): defaulting to
+// ssh-agent is honest, and the preview says so. The label records provenance,
+// which is the only way to tell a hop-suggested entry from a typed one later.
+func adoptEntry(mf *machines.File, origin HopOrigin) (machines.Machine, error) {
+	id := origin.ID
+	if validateMachineID(id) != nil {
+		id = suggestedMachineID(origin.Host)
+	}
+	if id == "" {
+		return machines.Machine{}, camperrors.New("camp machine adopt: cannot derive a valid machine id from " +
+			origin.Host + "; add it explicitly with 'camp machine add <id> --host " + origin.Host + "'")
+	}
+	if _, _, found := mf.Lookup(id); found {
+		return machines.Machine{}, camperrors.New("camp machine adopt: machine id " + id +
+			" is already used by a different host; add this one explicitly with " +
+			"'camp machine add <id> --host " + origin.Host + "'")
+	}
+	auth, err := normalizeAuthMethod("")
+	if err != nil {
+		return machines.Machine{}, err
+	}
+	return machines.Machine{
+		ID:         id,
+		Label:      "adopted from hop " + time.Now().Format("2006-01-02"),
+		Host:       origin.Host,
+		AuthMethod: auth,
+		SSHUser:    origin.User,
+	}, nil
+}
+
+// adoptPreview renders exactly the YAML that will be appended, plus the
+// reachability caveat. The operator approves the bytes, not a summary of them.
+func adoptPreview(origin HopOrigin, entry machines.Machine) string {
+	var b strings.Builder
+	b.WriteString("\nOrigin from this session:\n\n")
+	fmt.Fprintf(&b, "  host      %s\n", origin.Host)
+	fmt.Fprintf(&b, "  user      %s\n", origin.User)
+	if origin.Campaign != "" {
+		fmt.Fprintf(&b, "  campaign  %s\n", origin.Campaign)
+	}
+	b.WriteString("\nThis entry will be appended to ~/.obey/machines.yaml:\n\n")
+	fmt.Fprintf(&b, "    - id: %s\n", entry.ID)
+	fmt.Fprintf(&b, "      label: %s\n", entry.Label)
+	fmt.Fprintf(&b, "      host: %s\n", entry.Host)
+	fmt.Fprintf(&b, "      auth_method: %s\n", entry.AuthMethod)
+	if entry.SSHUser != "" {
+		fmt.Fprintf(&b, "      ssh_user: %s\n", entry.SSHUser)
+	}
+	fmt.Fprintf(&b, "\n  auth_method is a default; change it with 'camp machine add %s --auth tailscale-ssh'\n", entry.ID)
+	fmt.Fprintf(&b, "\nAdopting records how to reach %s. It does not make %s reachable:\n", entry.ID, entry.ID)
+	fmt.Fprintf(&b, "that depends on its own sshd or tailnet policy. Verify with 'camp machine\ndiagnose %s' after adopting.\n\n", entry.ID)
+	return b.String()
+}
+
+// machineByHost finds an entry for host regardless of id, so one machine cannot
+// end up registered twice under two names. Two rows for one host would mean two
+// ControlMaster sockets to the same place and an ambiguous machine list.
+func machineByHost(mf *machines.File, host string) (machines.Machine, bool) {
+	want := machines.NormalizeHost(host)
+	for _, m := range mf.Machines {
+		if machines.NormalizeHost(m.Host) == want {
+			return m, true
+		}
+	}
+	return machines.Machine{}, false
+}
+
+// isSelfOrigin guards the one entry that would break self-reference resolution:
+// a machines.yaml row pointing at the adopting machine. The guard belongs here,
+// at write time, because this is the only place such a row can be created.
+//
+// It compares against BOTH names this machine can legitimately be called: the
+// tailnet name and the plain hostname. detectReachableName returns whichever is
+// available, so a payload built when tailscale was down would carry the hostname
+// while this machine now reports its tailnet name, and a single comparison would
+// miss it. Both are this machine, so both must count.
+func isSelfOrigin(ctx context.Context, origin HopOrigin) (bool, error) {
+	want := machines.NormalizeHost(origin.Host)
+	if want == "" {
+		return false, nil
+	}
+	tailnet, err := detectReachableName(ctx, runTailscaleStatusForSelf)
+	if err != nil {
+		return false, err
+	}
+	if machines.NormalizeHost(tailnet) == want {
+		return true, nil
+	}
+	bare, err := detectReachableName(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	return machines.NormalizeHost(bare) == want, nil
+}

--- a/cmd/camp/machine_adopt_test.go
+++ b/cmd/camp/machine_adopt_test.go
@@ -283,3 +283,124 @@ func TestDeclineFileLivesBesideMachinesFile(t *testing.T) {
 func timeFixture() time.Time {
 	return time.Date(2026, 7, 26, 9, 14, 22, 0, time.UTC)
 }
+
+func TestOriginHintSuppression(t *testing.T) {
+	tests := []struct {
+		name     string
+		payload  string
+		fleet    string
+		declined bool
+		want     bool
+	}{
+		{name: "no payload", want: false},
+		{name: "malformed payload", payload: "v1;host=a;host=b;user=c", want: false},
+		{name: "unregistered origin", payload: adoptPayload, want: true},
+		{
+			name:    "already registered under any id",
+			payload: adoptPayload,
+			fleet: `version: 1
+machines:
+    - id: whatever
+      host: ORIGIN-BOX.tail37114b.ts.net.
+      auth_method: ssh-agent
+`,
+			want: false,
+		},
+		{name: "declined origin stays quiet", payload: adoptPayload, declined: true, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := isolateFleet(t)
+			resetOriginHintForTest()
+			t.Setenv(HopOriginEnvVar, tt.payload)
+			if tt.fleet != "" {
+				if err := os.WriteFile(filepath.Join(dir, "machines.yaml"), []byte(tt.fleet), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.declined {
+				f, err := machines.LoadDeclined()
+				if err != nil {
+					t.Fatal(err)
+				}
+				f.Decline("origin-box", "origin-box.tail37114b.ts.net", timeFixture())
+				if err := f.Save(); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			hint := OriginHint()
+			if got := hint != ""; got != tt.want {
+				t.Errorf("OriginHint() = %q, want present=%v", hint, tt.want)
+			}
+			if tt.want && !strings.Contains(hint, "camp machine adopt") {
+				t.Errorf("hint must name the command: %q", hint)
+			}
+		})
+	}
+}
+
+func TestOriginHintFiresAtMostOncePerProcess(t *testing.T) {
+	isolateFleet(t)
+	resetOriginHintForTest()
+	t.Setenv(HopOriginEnvVar, adoptPayload)
+
+	if first := OriginHint(); first == "" {
+		t.Fatal("first call should produce the hint")
+	}
+	if second := OriginHint(); second != "" {
+		t.Errorf("second call must stay quiet, got %q", second)
+	}
+}
+
+func TestMachineListJSONNeverCarriesTheHint(t *testing.T) {
+	// JSON consumers get data, not advice.
+	isolateFleet(t)
+	resetOriginHintForTest()
+	t.Setenv(HopOriginEnvVar, adoptPayload)
+
+	var buf bytes.Buffer
+	mf, err := machines.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeMachineListJSON(&buf, mf); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "camp machine adopt") {
+		t.Errorf("json output carried the hint: %s", buf.String())
+	}
+}
+
+func TestMachineTUIShowsOriginHintAtOpen(t *testing.T) {
+	isolateFleet(t)
+	resetOriginHintForTest()
+	t.Setenv(HopOriginEnvVar, adoptPayload)
+
+	mf, err := machines.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	model := newMachineTUIModel(context.Background(), mf)
+	if !strings.Contains(model.status, "camp machine adopt") {
+		t.Errorf("status line = %q, want the adopt hint", model.status)
+	}
+	if model.statusErr {
+		t.Error("a suggestion must not render as an error")
+	}
+}
+
+func TestMachineTUIStaysQuietWithoutAnOrigin(t *testing.T) {
+	isolateFleet(t)
+	resetOriginHintForTest()
+	t.Setenv(HopOriginEnvVar, "")
+
+	mf, err := machines.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status := newMachineTUIModel(context.Background(), mf).status; status != "" {
+		t.Errorf("status = %q, want empty", status)
+	}
+}

--- a/cmd/camp/machine_adopt_test.go
+++ b/cmd/camp/machine_adopt_test.go
@@ -386,8 +386,16 @@ func TestMachineTUIShowsOriginHintAtOpen(t *testing.T) {
 	if !strings.Contains(model.status, "camp machine adopt") {
 		t.Errorf("status line = %q, want the adopt hint", model.status)
 	}
-	if model.statusErr {
+	if model.statusKind == statusError {
 		t.Error("a suggestion must not render as an error")
+	}
+	// Nor as a success. This is the first screen after a hop, and a check mark
+	// beside "not in your fleet" reads as something that worked.
+	if model.statusKind != statusAdvice {
+		t.Errorf("status kind = %v, want %v", model.statusKind, statusAdvice)
+	}
+	if line := model.statusLine(); strings.Contains(line, "\u2713") {
+		t.Errorf("advisory rendered with a success glyph: %q", line)
 	}
 }
 

--- a/cmd/camp/machine_adopt_test.go
+++ b/cmd/camp/machine_adopt_test.go
@@ -160,6 +160,89 @@ func TestAdoptRefusesSelfHost(t *testing.T) {
 	}
 }
 
+func TestAdoptSelfOriginDetectionErrorFailsClosed(t *testing.T) {
+	// Detection errors must refuse adopt rather than skip the self-guard and
+	// risk writing a row that points at this machine.
+	isolateFleet(t)
+	t.Setenv(HopOriginEnvVar, adoptPayload)
+	cmd, out, _ := newAdoptCmd(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd.SetContext(ctx)
+
+	err := runMachineAdopt(cmd, nil)
+	if err == nil {
+		t.Fatal("want fail-closed error when self-origin detection fails")
+	}
+	if !strings.Contains(err.Error(), "cannot determine whether this origin is this machine") {
+		t.Errorf("error = %v, want the fail-closed wrap", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout must stay empty, got %q", out.String())
+	}
+	if _, statErr := os.Stat(machines.MachinesPath()); !os.IsNotExist(statErr) {
+		t.Error("fail-closed adopt must not write the fleet file")
+	}
+}
+
+func TestAdoptCancelDoesNotWriteDecline(t *testing.T) {
+	// Esc/abort is not a deliberate No — decline memory must stay empty.
+	isolateFleet(t)
+	t.Setenv(HopOriginEnvVar, adoptPayload)
+	cmd, out, _ := newAdoptCmd(t)
+
+	prevTerm, prevConfirm := adoptIsTerminal, adoptConfirm
+	t.Cleanup(func() {
+		adoptIsTerminal, adoptConfirm = prevTerm, prevConfirm
+	})
+	adoptIsTerminal = func() bool { return true }
+	adoptConfirm = func(context.Context, string) (bool, bool, error) {
+		return false, true, nil // canceled
+	}
+
+	if err := runMachineAdopt(cmd, nil); err != nil {
+		t.Fatalf("cancel is not an error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Not adopted.") {
+		t.Errorf("stdout = %q, want Not adopted", out.String())
+	}
+	if _, err := os.Stat(machines.DeclinedPath()); !os.IsNotExist(err) {
+		t.Error("cancel must not create declined_origins.yaml")
+	}
+	if _, err := os.Stat(machines.MachinesPath()); !os.IsNotExist(err) {
+		t.Error("cancel must not write machines.yaml")
+	}
+}
+
+func TestAdoptExplicitNoWritesDecline(t *testing.T) {
+	isolateFleet(t)
+	t.Setenv(HopOriginEnvVar, adoptPayload)
+	cmd, out, _ := newAdoptCmd(t)
+
+	prevTerm, prevConfirm := adoptIsTerminal, adoptConfirm
+	t.Cleanup(func() {
+		adoptIsTerminal, adoptConfirm = prevTerm, prevConfirm
+	})
+	adoptIsTerminal = func() bool { return true }
+	adoptConfirm = func(context.Context, string) (bool, bool, error) {
+		return false, false, nil // explicit No
+	}
+
+	if err := runMachineAdopt(cmd, nil); err != nil {
+		t.Fatalf("explicit No is not an error: %v", err)
+	}
+	if !strings.Contains(out.String(), "if you change your mind") {
+		t.Errorf("stdout = %q, want the durable-decline message", out.String())
+	}
+	f, err := machines.LoadDeclined()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := f.IsDeclined("origin-box.tail37114b.ts.net"); !ok {
+		t.Error("explicit No must record decline memory")
+	}
+}
+
 func TestAdoptEntryMapping(t *testing.T) {
 	origin, err := ParseHopOrigin(adoptPayload)
 	if err != nil {

--- a/cmd/camp/machine_adopt_test.go
+++ b/cmd/camp/machine_adopt_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -182,6 +183,80 @@ func TestAdoptSelfOriginDetectionErrorFailsClosed(t *testing.T) {
 	}
 	if _, statErr := os.Stat(machines.MachinesPath()); !os.IsNotExist(statErr) {
 		t.Error("fail-closed adopt must not write the fleet file")
+	}
+}
+
+func TestIsSelfOriginDualNameMatrix(t *testing.T) {
+	// The dual-name guard exists because detectReachableName prefers tailnet
+	// when available: a payload built while tailscale was down carries the bare
+	// hostname, and a single comparison against today's tailnet name would miss
+	// it. Both names are this machine, so both must count — and this is
+	// injectable so the matrix does not depend on a live tailnet or hostname.
+	const (
+		tailnet = "mac-studio.tail37114b.ts.net"
+		bare    = "Mac-Studio.local"
+		other   = "archdtop.tail37114b.ts.net"
+	)
+	prevTail, prevBare := adoptDetectTailnet, adoptDetectBare
+	t.Cleanup(func() {
+		adoptDetectTailnet, adoptDetectBare = prevTail, prevBare
+	})
+	adoptDetectTailnet = func(context.Context) (string, error) { return tailnet, nil }
+	adoptDetectBare = func(context.Context) (string, error) { return bare, nil }
+
+	tests := []struct {
+		name   string
+		host   string
+		want   bool
+		wantErr string
+		// override detectors for error rows
+		tailnetErr, bareErr error
+	}{
+		{name: "matches tailnet only", host: tailnet, want: true},
+		{name: "matches bare only", host: bare, want: true},
+		{name: "matches neither", host: other, want: false},
+		{name: "empty host", host: "", want: false},
+		{
+			name:       "tailnet probe error fails closed",
+			host:       other,
+			wantErr:    "tailnet down",
+			tailnetErr: errors.New("tailnet down"),
+		},
+		{
+			name:    "bare probe error after tailnet miss fails closed",
+			host:    other,
+			wantErr: "hostname failed",
+			bareErr: errors.New("hostname failed"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adoptDetectTailnet = func(context.Context) (string, error) {
+				if tt.tailnetErr != nil {
+					return "", tt.tailnetErr
+				}
+				return tailnet, nil
+			}
+			adoptDetectBare = func(context.Context) (string, error) {
+				if tt.bareErr != nil {
+					return "", tt.bareErr
+				}
+				return bare, nil
+			}
+			got, err := isSelfOrigin(context.Background(), HopOrigin{Host: tt.host, User: "u"})
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("isSelfOrigin: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("isSelfOrigin(%q) = %v, want %v", tt.host, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cmd/camp/machine_adopt_test.go
+++ b/cmd/camp/machine_adopt_test.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/machines"
+)
+
+// adoptPayload names a machine that is deliberately NOT the machine running the
+// tests: a payload whose host is the local machine trips the self-guard first,
+// which would make every other assertion here measure the wrong branch.
+const adoptPayload = "v1;host=origin-box.tail37114b.ts.net;user=lancerogers;campaign=obey-campaign;id=origin-box"
+
+func newAdoptCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	var out, errb bytes.Buffer
+	cmd := &cobra.Command{}
+	// Production always runs under ExecuteContext; a bare command has a nil
+	// context, and every I/O path here takes ctx as its first parameter.
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&out)
+	cmd.SetErr(&errb)
+	cmd.Flags().Bool("json", false, "")
+	return cmd, &out, &errb
+}
+
+// isolateFleet points both fleet files at a scratch directory so a test can
+// never read or write the developer's real ~/.obey.
+func isolateFleet(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("CAMP_MACHINES_PATH", filepath.Join(dir, "machines.yaml"))
+	return dir
+}
+
+// T4 from registration-spec.md section 8.
+func TestAdoptPayloadAbsent(t *testing.T) {
+	isolateFleet(t)
+	t.Setenv(HopOriginEnvVar, "")
+	cmd, out, _ := newAdoptCmd(t)
+
+	err := runMachineAdopt(cmd, nil)
+	if err == nil {
+		t.Fatal("want an error when no origin is present")
+	}
+	want := "camp machine adopt: no origin in this session (CAMP_HOP_ORIGIN is not set); " +
+		"this command adopts the machine you hopped here from"
+	if err.Error() != want {
+		t.Errorf("error\n got %q\nwant %q", err.Error(), want)
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout must stay empty, got %q", out.String())
+	}
+	if _, statErr := os.Stat(machines.MachinesPath()); !os.IsNotExist(statErr) {
+		t.Error("a failed adopt must not create the fleet file")
+	}
+}
+
+func TestAdoptPayloadMalformed(t *testing.T) {
+	isolateFleet(t)
+	t.Setenv(HopOriginEnvVar, "v1;host=a;host=b;user=c")
+	cmd, out, _ := newAdoptCmd(t)
+
+	err := runMachineAdopt(cmd, nil)
+	if err == nil {
+		t.Fatal("want an error for a malformed payload")
+	}
+	if !strings.Contains(err.Error(), `is malformed (duplicate key "host"); nothing to adopt`) {
+		t.Errorf("error = %q, want it to name the parse reason", err.Error())
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout must stay empty, got %q", out.String())
+	}
+}
+
+// T5: non-TTY is a hard error that writes nothing. The test binary has no
+// terminal, so this is the default path here and is what makes the other
+// write-nothing assertions meaningful.
+func TestAdoptNonTTYWritesNothing(t *testing.T) {
+	isolateFleet(t)
+	t.Setenv(HopOriginEnvVar, adoptPayload)
+	cmd, _, _ := newAdoptCmd(t)
+
+	err := runMachineAdopt(cmd, nil)
+	if err == nil {
+		t.Fatal("want an error without a terminal")
+	}
+	want := "camp machine adopt requires an interactive terminal: registering a machine is " +
+		"an explicit consent step and cannot be automated"
+	if err.Error() != want {
+		t.Errorf("error\n got %q\nwant %q", err.Error(), want)
+	}
+	if _, statErr := os.Stat(machines.MachinesPath()); !os.IsNotExist(statErr) {
+		t.Error("non-TTY adopt must not write the fleet file")
+	}
+}
+
+func TestAdoptJSONIsRefused(t *testing.T) {
+	isolateFleet(t)
+	t.Setenv(HopOriginEnvVar, adoptPayload)
+	cmd, _, _ := newAdoptCmd(t)
+	if err := cmd.Flags().Set("json", "true"); err != nil {
+		t.Fatal(err)
+	}
+	err := runMachineAdopt(cmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "does not support --json") {
+		t.Errorf("error = %v, want the --json refusal", err)
+	}
+}
+
+func TestAdoptAlreadyRegisteredUnderAnotherID(t *testing.T) {
+	// Two rows for one host would mean two ControlMaster sockets to the same
+	// machine and an ambiguous `camp machine list`.
+	dir := isolateFleet(t)
+	if err := os.WriteFile(filepath.Join(dir, "machines.yaml"), []byte(`version: 1
+machines:
+    - id: studio
+      host: ORIGIN-BOX.tail37114b.ts.net.
+      auth_method: ssh-agent
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(HopOriginEnvVar, adoptPayload)
+	cmd, out, _ := newAdoptCmd(t)
+
+	if err := runMachineAdopt(cmd, nil); err != nil {
+		t.Fatalf("an already-registered host is not an error: %v", err)
+	}
+	if !strings.Contains(out.String(), `is already in your fleet as "studio"; nothing to adopt`) {
+		t.Errorf("stdout = %q", out.String())
+	}
+}
+
+func TestAdoptRefusesSelfHost(t *testing.T) {
+	// A row pointing at this machine would shadow self-reference resolution,
+	// which is why the guard lives at write time.
+	isolateFleet(t)
+	host, err := detectReachableName(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := encodeHopOrigin(HopOrigin{Host: host, User: "someone", Campaign: "c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(HopOriginEnvVar, payload)
+	cmd, _, _ := newAdoptCmd(t)
+
+	err = runMachineAdopt(cmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "this origin is this machine") {
+		t.Errorf("error = %v, want the self-host refusal", err)
+	}
+}
+
+func TestAdoptEntryMapping(t *testing.T) {
+	origin, err := ParseHopOrigin(adoptPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, err := adoptEntry(&machines.File{Version: 1}, origin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entry.ID != "origin-box" || entry.Host != "origin-box.tail37114b.ts.net" || entry.SSHUser != "lancerogers" {
+		t.Errorf("entry = %+v", entry)
+	}
+	if entry.AuthMethod != machines.AuthSSHAgent {
+		t.Errorf("auth_method = %q, want the ssh-agent default (the payload carries none)", entry.AuthMethod)
+	}
+	if !strings.HasPrefix(entry.Label, "adopted from hop ") {
+		t.Errorf("label = %q, want provenance", entry.Label)
+	}
+	if entry.IdentityFile != "" {
+		t.Errorf("identity_file must never be guessed, got %q", entry.IdentityFile)
+	}
+}
+
+func TestAdoptEntryIDCollisionIsRefused(t *testing.T) {
+	// U8: never auto-suffix. Two ids differing by a digit are invisible in
+	// `camp machine list` and the next hop becomes a coin flip.
+	mf := &machines.File{Version: 1, Machines: []machines.Machine{
+		{ID: "origin-box", Host: "something.else", AuthMethod: machines.AuthSSHAgent},
+	}}
+	origin, err := ParseHopOrigin(adoptPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = adoptEntry(mf, origin)
+	if err == nil || !strings.Contains(err.Error(), "is already used by a different host") {
+		t.Errorf("error = %v, want the collision refusal", err)
+	}
+	if err != nil && !strings.Contains(err.Error(), "camp machine add") {
+		t.Errorf("collision error must name the explicit escape hatch: %v", err)
+	}
+}
+
+func TestAdoptEntryUndeliverableID(t *testing.T) {
+	origin := HopOrigin{Host: "100.72.165.77", User: "lance"}
+	_, err := adoptEntry(&machines.File{Version: 1}, origin)
+	if err == nil || !strings.Contains(err.Error(), "cannot derive a valid machine id") {
+		t.Errorf("error = %v, want the derivation failure to name 'camp machine add'", err)
+	}
+}
+
+func TestAdoptPreviewShowsExactYAML(t *testing.T) {
+	origin, err := ParseHopOrigin(adoptPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, err := adoptEntry(&machines.File{Version: 1}, origin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preview := adoptPreview(origin, entry)
+	for _, want := range []string{
+		"    - id: origin-box",
+		"      host: origin-box.tail37114b.ts.net",
+		"      auth_method: ssh-agent",
+		"      ssh_user: lancerogers",
+		"auth_method is a default",
+		"It does not make origin-box reachable",
+		"camp machine\ndiagnose origin-box",
+	} {
+		if !strings.Contains(preview, want) {
+			t.Errorf("preview missing %q:\n%s", want, preview)
+		}
+	}
+}
+
+func TestDeclineMemoryRoundTrip(t *testing.T) {
+	isolateFleet(t)
+
+	f, err := machines.LoadDeclined()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Declined) != 0 {
+		t.Errorf("absent file must load empty, got %+v", f.Declined)
+	}
+
+	f.Decline("origin-box", "ORIGIN-Box.tail37114b.ts.net.", timeFixture())
+	if err := f.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded, err := machines.LoadDeclined()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Matching normalizes case and the trailing dot: the same machine arriving
+	// under a different spelling is still declined.
+	if _, ok := reloaded.IsDeclined("origin-box.tail37114b.ts.net"); !ok {
+		t.Errorf("decline not found after reload: %+v", reloaded.Declined)
+	}
+	if _, ok := reloaded.IsDeclined("other.host"); ok {
+		t.Error("an unrelated host must not read as declined")
+	}
+
+	reloaded.Remove("origin-box.tail37114b.ts.net")
+	if _, ok := reloaded.IsDeclined("origin-box.tail37114b.ts.net"); ok {
+		t.Error("adopting must clear the decline")
+	}
+}
+
+func TestDeclineFileLivesBesideMachinesFile(t *testing.T) {
+	dir := isolateFleet(t)
+	if got, want := filepath.Dir(machines.DeclinedPath()), dir; got != want {
+		t.Errorf("declined path dir = %q, want %q", got, want)
+	}
+	if filepath.Base(machines.DeclinedPath()) == filepath.Base(machines.MachinesPath()) {
+		t.Error("the decline file must not collide with machines.yaml")
+	}
+}
+
+func timeFixture() time.Time {
+	return time.Date(2026, 7, 26, 9, 14, 22, 0, time.UTC)
+}

--- a/cmd/camp/machine_tui.go
+++ b/cmd/camp/machine_tui.go
@@ -203,6 +203,14 @@ func newMachineTUIModel(ctx context.Context, mf *machines.File) *machineTUIModel
 		spin:           newMachineSpinner(),
 	}
 	m.rebuildRows("")
+	// The fleet screen is where an operator looks at machines, so it is where
+	// an unregistered origin is worth mentioning. It names the command rather
+	// than offering a key: the adopt confirmation is a huh form that takes over
+	// the terminal, and this model already owns it. One preview, one consent
+	// surface, nothing to keep in sync.
+	if hint := OriginHint(); hint != "" {
+		m.setStatus(hint)
+	}
 	return m
 }
 

--- a/cmd/camp/machine_tui.go
+++ b/cmd/camp/machine_tui.go
@@ -144,7 +144,7 @@ type machineTUIModel struct {
 	spin spinner.Model
 
 	status    string
-	statusErr bool
+	statusKind statusKind
 	width     int
 	height    int
 	quitting  bool
@@ -209,7 +209,7 @@ func newMachineTUIModel(ctx context.Context, mf *machines.File) *machineTUIModel
 	// the terminal, and this model already owns it. One preview, one consent
 	// surface, nothing to keep in sync.
 	if hint := OriginHint(); hint != "" {
-		m.setStatus(hint)
+		m.setAdvice(hint)
 	}
 	return m
 }
@@ -303,12 +303,30 @@ func clampIndex(i, n int) int {
 	return i
 }
 
+// A status line has three meanings, not two. Reporting an advisory through the
+// success path put a check mark next to "this origin is not in your fleet",
+// which reads as something that worked on the first screen an operator sees
+// after a hop.
+type statusKind int
+
+const (
+	statusOK statusKind = iota
+	statusAdvice
+	statusError
+)
+
 func (m *machineTUIModel) setStatus(message string) {
-	m.status, m.statusErr = message, false
+	m.status, m.statusKind = message, statusOK
+}
+
+// setAdvice reports something worth knowing that is neither success nor
+// failure: nothing was done, and nothing went wrong.
+func (m *machineTUIModel) setAdvice(message string) {
+	m.status, m.statusKind = message, statusAdvice
 }
 
 func (m *machineTUIModel) setError(err error) {
-	m.status, m.statusErr = err.Error(), true
+	m.status, m.statusKind = err.Error(), statusError
 }
 
 // configuredHosts indexes the fleet by host so a tailnet device already in the

--- a/cmd/camp/machine_tui_test.go
+++ b/cmd/camp/machine_tui_test.go
@@ -67,10 +67,10 @@ func TestLocalRowRefusesEditRemoveAndSocketReset(t *testing.T) {
 		{"reset socket", func() { m.resetSelectedSocket() }, "no ControlMaster socket"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			m.status, m.statusErr, m.overlay = "", false, machineNoOverlay
+			m.status, m.statusKind, m.overlay = "", statusOK, machineNoOverlay
 			tc.run()
-			if !m.statusErr || !strings.Contains(m.status, tc.want) {
-				t.Errorf("status = %q (err=%v), want an error containing %q", m.status, m.statusErr, tc.want)
+			if m.statusKind != statusError || !strings.Contains(m.status, tc.want) {
+				t.Errorf("status = %q (kind=%v), want an error containing %q", m.status, m.statusKind, tc.want)
 			}
 			if m.overlay != machineNoOverlay {
 				t.Error("a refused action must not open an overlay")
@@ -436,7 +436,7 @@ func TestTestSelectedRefusesLocal(t *testing.T) {
 	if cmd := m.testSelected(); cmd != nil {
 		t.Fatal("testing local should not run a command")
 	}
-	if !m.statusErr || !strings.Contains(m.status, "nothing to connect to") {
+	if m.statusKind != statusError || !strings.Contains(m.status, "nothing to connect to") {
 		t.Errorf("status = %q, want a refusal naming local", m.status)
 	}
 }

--- a/cmd/camp/machine_tui_update.go
+++ b/cmd/camp/machine_tui_update.go
@@ -33,7 +33,10 @@ func (m *machineTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case healthMsg:
 		m.health[msg.id] = msg.health
 		m.setStatus(healthStatusLine(msg.id, msg.health))
-		m.statusErr = msg.health.State != healthReachable
+		m.statusKind = statusOK
+		if msg.health.State != healthReachable {
+			m.statusKind = statusError
+		}
 		return m, nil
 	case tea.KeyMsg:
 		if m.overlay != machineNoOverlay {

--- a/cmd/camp/machine_tui_view.go
+++ b/cmd/camp/machine_tui_view.go
@@ -417,10 +417,14 @@ func (m *machineTUIModel) statusLine() string {
 	// reads as a message that continues, which it does: the pane beside the
 	// list shows the same reason with room to breathe.
 	message := ui.Truncate(m.status, max(m.layout().width-4, 20))
-	if m.statusErr {
+	switch m.statusKind {
+	case statusError:
 		return machineErrorStyle.Render("✗ " + message)
+	case statusAdvice:
+		return machineMuted.Render("· " + message)
+	default:
+		return machineOKStyle.Render("✓ " + message)
 	}
-	return machineOKStyle.Render("✓ " + message)
 }
 
 // footer groups keys by what they are for rather than listing eight of them at

--- a/cmd/camp/settings_registry.go
+++ b/cmd/camp/settings_registry.go
@@ -122,7 +122,7 @@ func editRegistryEntry(ctx context.Context, c config.RegisteredCampaign, uuid st
 		fmt.Println(ui.Warning("Path does not exist or is not a directory; leaving the registry path unchanged."))
 		path = c.Path
 	case pathNeedsConfirm:
-		ok, err := confirmForm(ctx, fmt.Sprintf("Repoint %q to %s?", c.Name, path))
+		ok, _, err := confirmForm(ctx, fmt.Sprintf("Repoint %q to %s?", c.Name, path))
 		if err != nil {
 			return err
 		}
@@ -188,20 +188,22 @@ func isExistingDir(path string) bool {
 	return err == nil && fi.IsDir()
 }
 
-// confirmForm asks a yes/no question, defaulting to No. A cancelled prompt is
-// treated as No so the caller does not apply the guarded change.
-func confirmForm(ctx context.Context, prompt string) (bool, error) {
-	var ok bool
+// confirmForm asks a yes/no question, defaulting to No. canceled is true when
+// the operator dismissed the prompt (Esc / user abort) without answering;
+// callers that persist a deliberate "No" must not treat cancel the same way.
+// Callers that only guard a mutation can treat !ok (including cancel) as refuse.
+func confirmForm(ctx context.Context, prompt string) (ok, canceled bool, err error) {
+	var value bool
 	form := huh.NewForm(huh.NewGroup(
-		huh.NewConfirm().Title(prompt).Value(&ok),
+		huh.NewConfirm().Title(prompt).Value(&value),
 	))
 	if err := theme.RunForm(ctx, form); err != nil {
 		if theme.IsCancelled(err) {
-			return false, nil
+			return false, true, nil
 		}
-		return false, err
+		return false, false, err
 	}
-	return ok, nil
+	return value, false, nil
 }
 
 // saveRegistryEntry persists a single entry through UpdateRegistry, which holds

--- a/cmd/camp/switch_remote.go
+++ b/cmd/camp/switch_remote.go
@@ -71,6 +71,17 @@ func emitHopOrRefuse(ctx context.Context, cmd *cobra.Command, m *machines.Machin
 		"; run via the csw shell wrapper to hop there")
 }
 
+// hopBackHintSuffix appends the adopt suggestion to a hop-back failure when the
+// origin is unregistered here. Registering is exactly what would have made the
+// failure diagnosable with `camp machine diagnose`, so the suggestion is on
+// topic rather than generic advice bolted onto an error.
+func hopBackHintSuffix() string {
+	if hint := OriginHint(); hint != "" {
+		return "; 'camp machine adopt' registers it so future hops know the way back"
+	}
+	return ""
+}
+
 // hopOriginForEmit builds the CAMP_HOP_ORIGIN payload describing THIS machine,
 // for the session on the far side. Every failure yields "" (no export), never
 // an error: the operator asked to hop, not to advertise an origin, so a machine

--- a/internal/machines/declined.go
+++ b/internal/machines/declined.go
@@ -1,0 +1,121 @@
+package machines
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+	"gopkg.in/yaml.v3"
+)
+
+// declinedFileName sits beside machines.yaml rather than inside it. A decline is
+// a camp-terminal concept with no meaning to the festival app, which mirrors
+// machines.yaml field-for-field, and a declined origin is by definition not a
+// machine, so it has no row to attach to. A separate file is also strictly safer
+// for version skew: an older camp does not read it at all, so it cannot misparse
+// it, and the worst it does is prompt again.
+const declinedFileName = "declined_origins.yaml"
+
+// DeclinedFile is the on-disk shape of declined_origins.yaml.
+type DeclinedFile struct {
+	Version  int            `yaml:"version"`
+	Declined []DeclinedHost `yaml:"declined"`
+}
+
+// DeclinedHost records one origin the operator said no to. Host is the identity
+// that matters: the same machine arriving under a different suggested id is the
+// same machine, and a decline a re-derived id could bypass would re-prompt
+// exactly the operator who declined. Id is kept for display.
+type DeclinedHost struct {
+	ID         string    `yaml:"id,omitempty"`
+	Host       string    `yaml:"host"`
+	DeclinedAt time.Time `yaml:"declined_at"`
+}
+
+// DeclinedPath returns the decline file path, resolved from MachinesPath so the
+// CAMP_MACHINES_PATH and XDG_CONFIG_HOME overrides isolate both files together.
+func DeclinedPath() string {
+	return filepath.Join(filepath.Dir(MachinesPath()), declinedFileName)
+}
+
+// LoadDeclined reads the decline list. An absent file is not an error: it is the
+// normal state. A corrupt one is reported so the caller can warn, but callers
+// treat it as empty, because a broken suppression list must never prevent an
+// operator from adopting.
+func LoadDeclined() (*DeclinedFile, error) {
+	data, err := os.ReadFile(DeclinedPath())
+	if errors.Is(err, fs.ErrNotExist) {
+		return &DeclinedFile{Version: currentVersion}, nil
+	}
+	if err != nil {
+		return &DeclinedFile{Version: currentVersion}, camperrors.Wrap(err, "read declined origins file")
+	}
+	var f DeclinedFile
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return &DeclinedFile{Version: currentVersion}, camperrors.Wrap(err, "parse declined origins file")
+	}
+	return &f, nil
+}
+
+// Save writes f atomically with 0600 perms, matching machines.yaml: the file
+// names hosts an operator chose not to register.
+func (f *DeclinedFile) Save() error {
+	path := DeclinedPath()
+	f.Version = currentVersion
+	data, err := yaml.Marshal(f)
+	if err != nil {
+		return camperrors.Wrap(err, "encode declined origins")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return camperrors.Wrap(err, "create declined origins directory")
+	}
+	if err := fsutil.WriteFileAtomically(path, data, 0o600); err != nil {
+		return camperrors.Wrap(err, "write declined origins file")
+	}
+	return nil
+}
+
+// IsDeclined reports whether host was declined, matching on the normalized host
+// so case and a trailing FQDN dot do not create a second identity for one
+// machine.
+func (f *DeclinedFile) IsDeclined(host string) (DeclinedHost, bool) {
+	want := NormalizeHost(host)
+	for _, d := range f.Declined {
+		if NormalizeHost(d.Host) == want {
+			return d, true
+		}
+	}
+	return DeclinedHost{}, false
+}
+
+// Decline records a decline, replacing any earlier one for the same host so the
+// timestamp reflects the most recent answer.
+func (f *DeclinedFile) Decline(id, host string, at time.Time) {
+	f.Remove(host)
+	f.Declined = append(f.Declined, DeclinedHost{ID: id, Host: host, DeclinedAt: at.UTC()})
+}
+
+// Remove drops any decline for host. Adopting clears the memory: the origin is
+// no longer declined.
+func (f *DeclinedFile) Remove(host string) {
+	want := NormalizeHost(host)
+	kept := f.Declined[:0]
+	for _, d := range f.Declined {
+		if NormalizeHost(d.Host) != want {
+			kept = append(kept, d)
+		}
+	}
+	f.Declined = kept
+}
+
+// NormalizeHost trims whitespace and the trailing dot MagicDNS names carry, then
+// lowercases. Hostnames are case-insensitive, so "MAC-STUDIO.ts.net." and
+// "mac-studio.ts.net" are one machine.
+func NormalizeHost(h string) string {
+	return strings.ToLower(strings.TrimSuffix(strings.TrimSpace(h), "."))
+}


### PR DESCRIPTION
> **Stacked on #504.** Base is `mesh-origin-threading`, not `main`. Review #504 first; this PR's diff assumes the payload and parser it adds.

Adds the consent half of the mesh loop: the verb that turns a hop origin into a fleet entry, and the surfaces that tell you it exists.

Festival MN0001, phase 004 sequence 02. Design: `festivals/active/mesh-navigation-mutual-machine-visibility-MN0001/003_DESIGN/02_registration/outputs/registration-spec.md`.

## Why

PR-A makes a hop carry its origin. Nothing may act on that automatically: writing to another machine's fleet file because you connected to it is exactly the behavior D001 exists to prevent. So the payload sits inert until the operator runs one command and says yes.

## What changed

**`camp machine adopt`** (`cmd/camp/machine_adopt.go`). Reads `CAMP_HOP_ORIGIN`, shows the exact YAML that will be appended plus the reachability caveat, and writes only on an explicit yes.

Consent is structural rather than advisory:
- TTY-only. Non-TTY is a hard error that writes nothing.
- Default no, via the existing `confirmForm`.
- `--json` refused: there is no machine-readable representation of a consent decision.
- **No `--yes` flag.** The design originally specified one; review removed it. The `machineAddYes` precedent is a *selection* shortcut (pick the first discovered device), and adopt has exactly one candidate, so `--yes` could only mean "skip the consent". `--force` exists but only skips the reminder that you declined before.

**Decline memory** (`internal/machines/declined.go`). `declined_origins.yaml` beside `machines.yaml`. A separate file rather than a field, because `machines.yaml` is a cross-tool contract the festival app mirrors field-for-field, a declined origin is by definition not a machine, and an older camp that cannot read the new file simply prompts again. Matching normalizes case and the trailing MagicDNS dot so one machine cannot present as two identities. Adopting clears the record. A corrupt file warns and is treated as empty: a broken suppression list must never block an adopt.

**Two guards.**
- A host already registered under a *different* id reports and exits without writing. Two rows for one host would mean two ControlMaster sockets to the same machine and an ambiguous `camp machine list`.
- Adopting **this** machine is refused. Such a row would shadow the self-reference resolution from #504. The guard lives at write time because that is the only place the row can be created.

**Id collisions prompt for `camp machine add`** rather than auto-suffixing. Two ids differing by a digit are invisible in `camp machine list` and make the next hop a coin flip.

**Hint surfaces**, all sharing one predicate so suppression cannot drift: the `camp machine list` footer, the machine TUI status line at open, and the hop-back failure when the origin is unregistered here. Silent when there is no payload, the payload is malformed, the origin is already in the fleet under any id, it was declined, or the hint already fired this process. Never in `--json`.

## Tests

`just gate` green: 3779 tests.

Four of the design's five transcripts are asserted. The fifth (confirm-and-write) cannot run headless *by construction*, and `TestAdoptNonTTYWritesNothing` asserts exactly that, which is the stronger statement. Plus: entry mapping (including that `identity_file` is never guessed), collision refusal naming the escape hatch, duplicate-host detection, self-host refusal, `--json` refusal, the exact preview bytes, decline round-trip across three spellings of one host, a 5-row hint suppression matrix, and the once-per-process bound.

## Two real defects the tests caught

**The self-host guard compared against only one of this machine's two names.** `detectReachableName` returns the tailnet name when tailscale is up and the hostname otherwise. A payload built while tailscale was down carries the hostname, so a single comparison would not recognize it as this machine and the guard would let a self-entry through, re-opening the bug #504 closes. Now both are compared.

**A test fixture used the developer's own tailnet name**, so three green tests were silently exercising the self-guard branch instead of what they claimed. The fixture now names a deliberately foreign machine. Green is not correct when a fixture accidentally matches the host environment.

## PTY verification

The TUI change was driven in a real pty with pyte, not trusted to model assertions:

```
╰─────────────────────────────╯ ╰─────────────────────────────────────────────────────────────╯
✓ origin origin-box.tail37114b.ts.net is not in your fleet; run 'camp machine adopt' to add it
t test connection  ·  e edit · d remove  ·  a add · s scan tailnet  ·  ? help · q quit
```

## One thing for you to decide

The pty capture shows the hint rendering as **`✓ origin … is not in your fleet`**. `statusLine()` prefixes any non-error status with `✓`, so an advisory line reads as a success report. It is not wrong (the glyph is the status marker, not a claim), and fixing it means adding a third status kind to a mechanism shared by every message on that screen. That is a TUI convention call for you rather than something I should change unilaterally, so I left it and am flagging it. Happy to add a neutral status kind if you want one.
