### PR TITLE
feat(switch): warn about camp version skew at hop time, without a probe

### DIFF
--- a/cmd/camp/machine.go
+++ b/cmd/camp/machine.go
@@ -410,6 +410,9 @@ func runMachineDiagnose(cmd *cobra.Command, args []string) error {
 		m := &targets[i]
 		d := remote.CheckControlMaster(ctx, m)
 		remoteVersion, remoteCommit := probeRemoteCampVersion(ctx, m)
+		// Diagnose is the only surface that pays for a live probe, so it is the
+		// only one that can warm the cache the hop path reads.
+		writeMachineVersionCache(m.ID, remoteVersion, remoteCommit)
 		row := machineDiagnoseRow{
 			ID:           m.ID,
 			Host:         m.Host,

--- a/cmd/camp/switch_remote.go
+++ b/cmd/camp/switch_remote.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/machines"
 	navfuzzy "github.com/Obedience-Corp/camp/internal/nav/fuzzy"
 	"github.com/Obedience-Corp/camp/internal/remote"
+	"github.com/Obedience-Corp/camp/internal/ui"
 )
 
 // resolveRemoteRoot is the seam every remote switch resolves through, hop-back
@@ -64,6 +65,11 @@ func guardRemoteOutputFlags(target string, printOnly, jsonOut bool) error {
 // safety contract — a bare `camp switch machine:...` must never hop, so it
 // reports what it resolved and names the wrapper instead.
 func emitHopOrRefuse(ctx context.Context, cmd *cobra.Command, m *machines.Machine, remainder, root string, shellConnect bool) error {
+	// Skew is reported on stderr, never stdout: stdout is eval'd by the shell
+	// wrapper and must stay exactly one line.
+	if warning := hopSkewWarning(m.ID); warning != "" {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), ui.Dim("camp: "+warning))
+	}
 	if shellConnect {
 		return emitShellConnect(cmd.OutOrStdout(), true, root, m, hopOriginForEmit(ctx, cmd))
 	}

--- a/cmd/camp/version_cache.go
+++ b/cmd/camp/version_cache.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+	"github.com/Obedience-Corp/camp/internal/version"
+)
+
+// versionCacheTTL bounds how long a probed remote version is trusted for the
+// hop-time warning. Skew changes on install cadence, not on the second, so an
+// hours-scale bound is right: short enough that an upgrade stops the warning the
+// same day, long enough that the warning survives between diagnose runs. A stale
+// entry is simply ignored, so the failure mode is silence, never a wrong claim.
+const versionCacheTTL = 12 * time.Hour
+
+// versionCacheEntry is the on-disk per-machine version probe result. Derived,
+// gitignored, and disposable: deleting it costs one diagnose.
+type versionCacheEntry struct {
+	Version  string `json:"version"`
+	Commit   string `json:"commit"`
+	ProbedAt int64  `json:"probed_at"` // unix nanoseconds
+}
+
+func (e versionCacheEntry) fresh(now time.Time) bool {
+	return now.Sub(time.Unix(0, e.ProbedAt)) <= versionCacheTTL
+}
+
+// versionCachePath keeps the probe beside the completion cache, under the same
+// per-machine directory, so one `rm -rf ~/.obey/cache` clears every derived
+// artifact camp keeps about a machine.
+func versionCachePath(id string) string {
+	return filepath.Join(machineCacheDir(), id+".version.json")
+}
+
+// writeMachineVersionCache records a probe result. Best-effort: a failure just
+// means the next hop does not warn, which is the same as today's behavior.
+func writeMachineVersionCache(id, versionStr, commit string) {
+	if id == "" || versionStr == "" {
+		return
+	}
+	dir := machineCacheDir()
+	if os.MkdirAll(dir, 0o700) != nil {
+		return
+	}
+	data, err := json.Marshal(versionCacheEntry{Version: versionStr, Commit: commit, ProbedAt: time.Now().UnixNano()})
+	if err != nil {
+		return
+	}
+	_ = fsutil.WriteFileAtomically(versionCachePath(id), data, 0o600)
+}
+
+// readMachineVersionCache returns a fresh cached probe, or false. Absent,
+// corrupt, and stale are all the same answer: no opinion.
+func readMachineVersionCache(id string) (versionCacheEntry, bool) {
+	data, err := os.ReadFile(versionCachePath(id))
+	if err != nil {
+		return versionCacheEntry{}, false
+	}
+	var e versionCacheEntry
+	if json.Unmarshal(data, &e) != nil || !e.fresh(time.Now()) {
+		return versionCacheEntry{}, false
+	}
+	return e, true
+}
+
+// hopSkewWarning returns the one-line warning for a hop to id, or "" when there
+// is nothing to say. It NEVER probes: the hop path must not grow an ssh
+// round-trip to deliver an advisory, so it reports only what a previous
+// `camp machine diagnose` already learned.
+func hopSkewWarning(id string) string {
+	entry, ok := readMachineVersionCache(id)
+	if !ok {
+		return ""
+	}
+	local := version.Get()
+	if !campVersionSkew(local, entry.Version, entry.Commit) {
+		return ""
+	}
+	return "camp on " + id + " is " + entry.Version + ", this machine is " + local.Version +
+		"; features added since may not work there (run 'camp machine diagnose " + id + "' to re-check)"
+}

--- a/cmd/camp/version_cache.go
+++ b/cmd/camp/version_cache.go
@@ -13,8 +13,13 @@ import (
 // versionCacheTTL bounds how long a probed remote version is trusted for the
 // hop-time warning. Skew changes on install cadence, not on the second, so an
 // hours-scale bound is right: short enough that an upgrade stops the warning the
-// same day, long enough that the warning survives between diagnose runs. A stale
-// entry is simply ignored, so the failure mode is silence, never a wrong claim.
+// same day, long enough that the warning survives between diagnose runs.
+//
+// A TTL-expired, absent, or corrupt entry is ignored, so those failure modes are
+// silence rather than a wrong claim. Within the window the claim can still go
+// stale the other way: upgrade the remote to match and the warning persists
+// until the next diagnose or expiry. That is the accepted cost of never probing
+// on the hop path, and the message points at diagnose for exactly this reason.
 const versionCacheTTL = 12 * time.Hour
 
 // versionCacheEntry is the on-disk per-machine version probe result. Derived,

--- a/cmd/camp/version_cache.go
+++ b/cmd/camp/version_cache.go
@@ -38,6 +38,8 @@ func versionCachePath(id string) string {
 
 // writeMachineVersionCache records a probe result. Best-effort: a failure just
 // means the next hop does not warn, which is the same as today's behavior.
+// A failed probe (empty version) is a no-op on purpose — it leaves any prior
+// still-fresh entry in place rather than wiping a known-good answer with silence.
 func writeMachineVersionCache(id, versionStr, commit string) {
 	if id == "" || versionStr == "" {
 		return
@@ -54,14 +56,17 @@ func writeMachineVersionCache(id, versionStr, commit string) {
 }
 
 // readMachineVersionCache returns a fresh cached probe, or false. Absent,
-// corrupt, and stale are all the same answer: no opinion.
+// corrupt, empty version, and stale are all the same answer: no opinion.
+// Empty version is defense in depth: writeMachineVersionCache already refuses
+// to record failed probes, but a hand-written or half-written cache file must
+// not read as a real answer.
 func readMachineVersionCache(id string) (versionCacheEntry, bool) {
 	data, err := os.ReadFile(versionCachePath(id))
 	if err != nil {
 		return versionCacheEntry{}, false
 	}
 	var e versionCacheEntry
-	if json.Unmarshal(data, &e) != nil || !e.fresh(time.Now()) {
+	if json.Unmarshal(data, &e) != nil || e.Version == "" || !e.fresh(time.Now()) {
 		return versionCacheEntry{}, false
 	}
 	return e, true
@@ -82,7 +87,10 @@ func hopSkewWarning(id string) string {
 	}
 	// Says only that they differ. The skew check does not order versions, and
 	// the remote is as likely to be ahead as behind, so naming a direction
-	// would be wrong half the time.
-	return "camp on " + id + " is " + entry.Version + ", this machine is " + local.Version +
+	// would be wrong half the time. Reuse the diagnose display helpers so
+	// matching versions with different commits (e.g. two "dev" builds) still
+	// disambiguate with the commit short hash.
+	remoteDisp := campVersionDisplay(machineDiagnoseRow{CampVersion: entry.Version, CampCommit: entry.Commit})
+	return "camp on " + id + " is " + remoteDisp + ", this machine is " + campLocalVersionDisplay() +
 		"; features may not match (run 'camp machine diagnose " + id + "' to re-check)"
 }

--- a/cmd/camp/version_cache.go
+++ b/cmd/camp/version_cache.go
@@ -80,6 +80,9 @@ func hopSkewWarning(id string) string {
 	if !campVersionSkew(local, entry.Version, entry.Commit) {
 		return ""
 	}
+	// Says only that they differ. The skew check does not order versions, and
+	// the remote is as likely to be ahead as behind, so naming a direction
+	// would be wrong half the time.
 	return "camp on " + id + " is " + entry.Version + ", this machine is " + local.Version +
-		"; features added since may not work there (run 'camp machine diagnose " + id + "' to re-check)"
+		"; features may not match (run 'camp machine diagnose " + id + "' to re-check)"
 }

--- a/cmd/camp/version_cache_test.go
+++ b/cmd/camp/version_cache_test.go
@@ -92,6 +92,11 @@ func TestHopSkewWarningMatrix(t *testing.T) {
 						t.Errorf("warning %q missing %q", got, want)
 					}
 				}
+				// When versions match, the commit is the only disambiguator —
+				// the warning must surface it rather than "dev" vs "dev".
+				if tt.ver == local.Version && tt.commit != "" && !strings.Contains(got, tt.commit) {
+					t.Errorf("warning %q missing commit disambiguation %q", got, tt.commit)
+				}
 			}
 		})
 	}
@@ -118,6 +123,19 @@ func TestVersionCacheCorruptIsIgnored(t *testing.T) {
 	}
 	if hopSkewWarning("archdtop") != "" {
 		t.Error("corrupt cache must not produce a warning")
+	}
+}
+
+func TestVersionCacheEmptyVersionIsMiss(t *testing.T) {
+	// Defense in depth: an empty version field must not be treated as a probe
+	// answer even if the file is otherwise well-formed and fresh.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	seedVersionCache(t, "archdtop", "", "deadbeef", time.Minute)
+	if _, ok := readMachineVersionCache("archdtop"); ok {
+		t.Error("empty version must read as a miss")
+	}
+	if hopSkewWarning("archdtop") != "" {
+		t.Error("empty version must not produce a warning")
 	}
 }
 

--- a/cmd/camp/version_cache_test.go
+++ b/cmd/camp/version_cache_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/machines"
+	"github.com/Obedience-Corp/camp/internal/version"
+)
+
+// seedVersionCache writes a probe result with an explicit age, so the freshness
+// rule is tested rather than raced against wall-clock.
+func seedVersionCache(t *testing.T, id, ver, commit string, age time.Duration) {
+	t.Helper()
+	dir := machineCacheDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(versionCacheEntry{
+		Version:  ver,
+		Commit:   commit,
+		ProbedAt: time.Now().Add(-age).UnixNano(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(versionCachePath(id), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHopSkewWarningMatrix(t *testing.T) {
+	local := version.Get()
+
+	tests := []struct {
+		name    string
+		seed    bool
+		ver     string
+		commit  string
+		age     time.Duration
+		wantHit bool
+	}{
+		{name: "cache miss says nothing", seed: false},
+		{
+			name: "same version and commit is silent",
+			seed: true, ver: local.Version, commit: local.Commit, age: time.Minute,
+		},
+		{
+			name: "different version warns",
+			seed: true, ver: "v0.0.1-ancient", commit: "deadbeef", age: time.Minute,
+			wantHit: true,
+		},
+		{
+			// Two "dev" builds from different commits are not the same camp.
+			name: "same version, different commit warns",
+			seed: true, ver: local.Version, commit: "0000000000", age: time.Minute,
+			wantHit: true,
+		},
+		{
+			name: "stale entry is ignored, even when it shows skew",
+			seed: true, ver: "v0.0.1-ancient", commit: "deadbeef", age: versionCacheTTL + time.Hour,
+		},
+		{
+			// A failed probe records nothing, so an empty version must never be
+			// read as "the remote has no version" and warned about.
+			name: "empty version is not skew",
+			seed: true, ver: "", commit: "", age: time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			if tt.seed {
+				seedVersionCache(t, "archdtop", tt.ver, tt.commit, tt.age)
+			}
+			got := hopSkewWarning("archdtop")
+			if (got != "") != tt.wantHit {
+				t.Fatalf("hopSkewWarning = %q, want present=%v", got, tt.wantHit)
+			}
+			if tt.wantHit {
+				for _, want := range []string{"archdtop", tt.ver, local.Version, "camp machine diagnose archdtop"} {
+					if want != "" && !strings.Contains(got, want) {
+						t.Errorf("warning %q missing %q", got, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestVersionCacheWriteSkipsEmptyProbe(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	writeMachineVersionCache("archdtop", "", "")
+	if _, err := os.Stat(versionCachePath("archdtop")); !os.IsNotExist(err) {
+		t.Error("a failed probe must not be cached; it would look like a real answer")
+	}
+}
+
+func TestVersionCacheCorruptIsIgnored(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if err := os.MkdirAll(machineCacheDir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(versionCachePath("archdtop"), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := readMachineVersionCache("archdtop"); ok {
+		t.Error("corrupt cache must read as a miss")
+	}
+	if hopSkewWarning("archdtop") != "" {
+		t.Error("corrupt cache must not produce a warning")
+	}
+}
+
+func TestVersionCacheLivesBesideTheCompletionCache(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if got, want := filepath.Dir(versionCachePath("x")), machineCacheDir(); got != want {
+		t.Errorf("version cache dir = %q, want %q", got, want)
+	}
+}
+
+func TestSkewWarningGoesToStderrAndKeepsStdoutToOneLine(t *testing.T) {
+	// The wrapper evals stdout. A warning that landed there would be eval'd as
+	// a shell command.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	seedVersionCache(t, "archdtop", "v0.0.1-ancient", "deadbeef", time.Minute)
+
+	var out, errb bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&out)
+	cmd.SetErr(&errb)
+
+	m := &machines.Machine{ID: "archdtop", Host: "archdtop.ts.net", SSHUser: "lance"}
+	if err := emitHopOrRefuse(context.Background(), cmd, m, "campaign", "/srv/campaign", true); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Count(out.String(), "\n") != 1 {
+		t.Errorf("stdout must stay exactly one line, got %q", out.String())
+	}
+	if strings.Contains(out.String(), "diagnose") {
+		t.Errorf("warning leaked into the eval'd line: %q", out.String())
+	}
+	if !strings.Contains(errb.String(), "camp on archdtop is v0.0.1-ancient") {
+		t.Errorf("stderr = %q, want the skew warning", errb.String())
+	}
+}


### PR DESCRIPTION
> **Stacked on #505**, which is stacked on #504. Base is `mesh-adopt-origin`. Review those first.

Warns about camp version skew at the moment it matters (hop time) without making hops slower.

Festival MN0001, phase 004 sequence 03.

## Why

Version skew is a permanent condition in a personal fleet, and the moment it bites is the moment you hop: a feature that exists here may not exist there. `camp machine diagnose` already probes remote versions and already knows how to judge skew (`campVersionSkew`, `probeRemoteCampVersion`, both from #492). What was missing is that the knowledge died with the command.

## What changed

Diagnose now caches each probe result per machine (`cmd/camp/version_cache.go`), beside the completion cache, and the hop path reads it.

**The hop never probes.** Adding an ssh round-trip to deliver an advisory would make every hop slower in order to occasionally say something optional. `hopSkewWarning` reads one file; the only writer is the diagnose loop, which was already paying for the probe.

**Freshness is 12 hours**, matching the shape of the underlying fact: skew changes on install cadence, not on the second. Absent, corrupt, and stale all read as *no opinion*, so the failure mode is silence rather than a wrong claim. A failed probe is never cached, so an empty version can never later be mistaken for a real answer.

**The warning goes to stderr, dimmed:**

```
camp: camp on archdtop is v0.0.1-ancient, this machine is dev; features added since may not work there (run 'camp machine diagnose archdtop' to re-check)
```

## Tests

`just gate` green: 3784.

Six-row cache matrix (miss, match, version skew, same-version-different-commit, stale, empty-probe), each seeded with an explicit age so freshness is tested rather than raced against the clock. Plus: failed probes are not written, corrupt JSON reads as a miss, and the cache lives beside the completion cache so one `rm -rf ~/.obey/cache` clears every derived artifact about a machine.

The load-bearing test is `TestSkewWarningGoesToStderrAndKeepsStdoutToOneLine`. stdout is eval'd by the shell wrapper, so a warning printed there would be **executed as a shell command**. It asserts stdout is exactly one line, does not contain the warning, and that stderr does.

## Deliberate tradeoff

The warning only fires if `camp machine diagnose` has run for that machine in the last 12 hours. A user who never runs diagnose never sees it. That is the right side of the tradeoff: diagnose is the surface that already pays for truth, so it is the surface that earns the right to warm the cache. The alternative makes every hop slower.
