### PR TITLE
feat(machine): push name-only snapshots so remotes can see the host

### DIFF
--- a/cmd/camp/completion_remote.go
+++ b/cmd/camp/completion_remote.go
@@ -17,16 +17,42 @@ import (
 // offered for completion before it is treated as stale (id-only) again.
 const machineCompletionTTL = 60 * time.Second
 
+// machineSnapshotTTL bounds a PUSHED snapshot instead. The two differ because
+// their refresh events differ: a pulled entry is replaced the next time the user
+// runs `camp list --remote`, which is often, while a pushed one is replaced by
+// the next hop from that host, which may be tomorrow. A 60s bound would make a
+// pushed snapshot unusable within a minute of arriving, i.e. never usable.
+//
+// The data is campaign NAMES, which change on the order of days, and the cost of
+// staleness is a completion suggestion for a renamed campaign. The cost of being
+// too short is the feature not working. Asymmetric costs, so this leans long.
+const machineSnapshotTTL = 24 * time.Hour
+
+// snapshotSource marks an entry that was pushed to us rather than pulled by us.
+const snapshotSource = "push"
+
 // machineCacheEntry is the on-disk per-machine completion cache: the remote
 // machine's campaign names and when they were fetched. It is a derived cache
 // (gitignored), warmed by `camp list --remote`, read on the keystroke path.
 type machineCacheEntry struct {
 	Campaigns []string `json:"campaigns"`
 	FetchedAt int64    `json:"fetched_at"` // unix nanoseconds
+	// Source is "" for entries this machine pulled and "push" for a snapshot a
+	// host sent us. It is omitempty and read with a plain json.Unmarshal, so a
+	// camp that predates this field ignores it and applies the shorter TTL,
+	// degrading to today's behavior rather than erroring.
+	Source string `json:"source,omitempty"`
 }
 
 func (e machineCacheEntry) fresh(now time.Time) bool {
-	return now.Sub(time.Unix(0, e.FetchedAt)) <= machineCompletionTTL
+	return now.Sub(time.Unix(0, e.FetchedAt)) <= e.ttl()
+}
+
+func (e machineCacheEntry) ttl() time.Duration {
+	if e.Source == snapshotSource {
+		return machineSnapshotTTL
+	}
+	return machineCompletionTTL
 }
 
 func machineCacheDir() string {
@@ -56,12 +82,28 @@ func readMachineCacheCampaigns(id string) ([]string, bool) {
 // means the next completion is a miss). Called from the `camp list --remote`
 // fan-out so real usage keeps completion data fresh without the keystroke path
 // ever doing a live ssh.
+// writeMachineSnapshotCampaigns records names a HOST pushed to us. It shares the
+// file with the pulled path deliberately: one read on the keystroke path stays
+// one os.ReadFile, and a pull always overwrites a push because data that came
+// from the machine itself is authoritative over another machine's guess.
+func writeMachineSnapshotCampaigns(id string, campaigns []string) {
+	writeMachineCacheEntry(id, machineCacheEntry{
+		Campaigns: campaigns,
+		FetchedAt: time.Now().UnixNano(),
+		Source:    snapshotSource,
+	})
+}
+
 func writeMachineCacheCampaigns(id string, campaigns []string) {
+	writeMachineCacheEntry(id, machineCacheEntry{Campaigns: campaigns, FetchedAt: time.Now().UnixNano()})
+}
+
+func writeMachineCacheEntry(id string, entry machineCacheEntry) {
 	dir := machineCacheDir()
 	if os.MkdirAll(dir, 0o700) != nil {
 		return
 	}
-	data, err := json.Marshal(machineCacheEntry{Campaigns: campaigns, FetchedAt: time.Now().UnixNano()})
+	data, err := json.Marshal(entry)
 	if err != nil {
 		return
 	}

--- a/cmd/camp/list_remote.go
+++ b/cmd/camp/list_remote.go
@@ -102,6 +102,11 @@ func enumerateRemoteFor(f listFilter) enumerateFunc {
 		// Warm the completion cache so `csw <id>:<tab>` has campaigns without the
 		// keystroke path ever doing a live ssh.
 		writeMachineCacheCampaigns(m.ID, names)
+		// A successful enumerate proves this machine can reach m, so it is also
+		// the moment to tell m about us. Silent on every failure.
+		if selfID, selfNames := selfSnapshot(ctx); selfID != "" {
+			pushSelfSnapshot(ctx, m, selfID, selfNames)
+		}
 		return rows, nil
 	}
 }

--- a/cmd/camp/list_remote.go
+++ b/cmd/camp/list_remote.go
@@ -80,6 +80,14 @@ func remoteListArgs(f listFilter) string {
 // the far machine).
 func enumerateRemoteFor(f listFilter) enumerateFunc {
 	args := remoteListArgs(f)
+	// selfSnapshot detects the tailnet name and loads the whole registry, and
+	// returns the same answer for every machine. Computing it inside the
+	// per-machine closure paid that cost N times over a concurrent fan-out;
+	// sync.Once shares one result across the goroutines.
+	var snapshotOnce sync.Once
+	var selfID string
+	var selfNames []string
+
 	return func(ctx context.Context, m *machines.Machine) ([]campaignEntry, error) {
 		out, err := remote.RunCampCommand(ctx, m, args)
 		if err != nil {
@@ -104,7 +112,8 @@ func enumerateRemoteFor(f listFilter) enumerateFunc {
 		writeMachineCacheCampaigns(m.ID, names)
 		// A successful enumerate proves this machine can reach m, so it is also
 		// the moment to tell m about us. Silent on every failure.
-		if selfID, selfNames := selfSnapshot(ctx); selfID != "" {
+		snapshotOnce.Do(func() { selfID, selfNames = selfSnapshot(ctx) })
+		if selfID != "" {
 			pushSelfSnapshot(ctx, m, selfID, selfNames)
 		}
 		return rows, nil

--- a/cmd/camp/machine.go
+++ b/cmd/camp/machine.go
@@ -177,6 +177,9 @@ func init() {
 	machineCmd.AddCommand(machineRemoveCmd)
 	machineCmd.AddCommand(machineDiagnoseCmd)
 	machineCmd.AddCommand(machineAdoptCmd)
+	machineCmd.AddCommand(machineCachePutCmd)
+	machineCachePutCmd.Flags().StringSliceVar(&cachePutCampaigns, "campaigns", nil,
+		"Comma-separated campaign names on the calling machine")
 	machineAdoptCmd.Flags().BoolVar(&machineAdoptForce, "force", false,
 		"Skip the reminder that you declined this origin before (never skips the confirmation)")
 

--- a/cmd/camp/machine.go
+++ b/cmd/camp/machine.go
@@ -178,8 +178,10 @@ func init() {
 	machineCmd.AddCommand(machineDiagnoseCmd)
 	machineCmd.AddCommand(machineAdoptCmd)
 	machineCmd.AddCommand(machineCachePutCmd)
-	machineCachePutCmd.Flags().StringSliceVar(&cachePutCampaigns, "campaigns", nil,
-		"Comma-separated campaign names on the calling machine")
+	// StringArray (not StringSlice): each --campaigns is one name intact, so
+	// names may contain commas. The push path emits repeated flags to match.
+	machineCachePutCmd.Flags().StringArrayVar(&cachePutCampaigns, "campaigns", nil,
+		"Campaign name on the calling machine (repeatable; names may contain commas)")
 	machineAdoptCmd.Flags().BoolVar(&machineAdoptForce, "force", false,
 		"Skip the reminder that you declined this origin before (never skips the confirmation)")
 

--- a/cmd/camp/machine_cache_put.go
+++ b/cmd/camp/machine_cache_put.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/machines"
+	"github.com/Obedience-Corp/camp/internal/remote"
+)
+
+// snapshotMaxNames caps how many campaign names one push may carry. The payload
+// crosses as an argv, so the bound protects the receiver's command line; the
+// rule is truncate-and-still-write rather than refuse, because a partial
+// completion list is useful and an error is not.
+const snapshotMaxNames = 500
+
+// snapshotMaxBytes bounds the joined names for the same reason, far below any
+// platform ARG_MAX.
+const snapshotMaxBytes = 64 * 1024
+
+var cachePutCampaigns []string
+
+// machineCachePutCmd is machine-to-machine plumbing, not an operator verb, so it
+// is hidden. A human who runs it by hand gets correct behavior; they are simply
+// not advertised it.
+var machineCachePutCmd = &cobra.Command{
+	Use:    "cache-put <machine-id>",
+	Short:  "Record another machine's campaign names in this machine's completion cache (internal)",
+	Hidden: true,
+	Long: `Record another machine's campaign names in this machine's completion cache.
+
+Hosts call this over ssh after hopping here, so this machine can complete
+'<id>:<campaign>' for them without ever connecting back. Names only: no paths, no
+ids, no auth material. The receiver validates everything it is handed.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runMachineCachePut,
+}
+
+func runMachineCachePut(cmd *cobra.Command, args []string) error {
+	id := args[0]
+	// Validated FIRST, and not merely as a naming nicety: the id becomes the
+	// cache file name, so this is what keeps a hostile value inside the cache
+	// directory.
+	if err := validateMachineID(id); err != nil {
+		return err
+	}
+	names, err := sanitizeSnapshotNames(cachePutCampaigns)
+	if err != nil {
+		return err
+	}
+	writeMachineSnapshotCampaigns(id, names)
+	// Stdout stays empty on every path so a caller can distinguish "wrote" from
+	// "said something" without parsing.
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "cached %d campaign names for %s\n", len(names), id)
+	return nil
+}
+
+// sanitizeSnapshotNames validates and bounds the pushed names. Names are display
+// and completion data on the receiver, never resolved as paths, and the
+// separator and control-character rules keep them that way.
+func sanitizeSnapshotNames(raw []string) ([]string, error) {
+	out := make([]string, 0, len(raw))
+	total := 0
+	for _, chunk := range raw {
+		for _, name := range strings.Split(chunk, ",") {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			if len(name) > 255 || strings.ContainsAny(name, "/:\x00\n\r") {
+				return nil, camperrors.New("invalid campaign name in snapshot: " + name)
+			}
+			if len(out) >= snapshotMaxNames || total+len(name) > snapshotMaxBytes {
+				return out, nil
+			}
+			out = append(out, name)
+			total += len(name)
+		}
+	}
+	if len(out) == 0 {
+		return nil, camperrors.New("no campaign names given (use --campaigns a,b,c)")
+	}
+	return out, nil
+}
+
+// snapshotPushTimeout bounds a push. It rides an already-established
+// ControlMaster connection and sends a few KiB, so this is generous; and it sits
+// in front of a hop the operator is waiting on, so the 10s control-plane default
+// would be a visible regression.
+const snapshotPushTimeout = 2 * time.Second
+
+// pushSnapshotRun is the seam that lets the push's silence be tested without ssh.
+var pushSnapshotRun = remote.RunCampCommand
+
+// pushSelfSnapshot tells m about this machine's campaigns, so completion works
+// in the other direction without m ever connecting back (D006).
+//
+// Every failure is silent by design. The operator asked to hop or to list, not
+// to sync caches, so an unreachable machine, an older camp without the verb, a
+// timeout, or a rejected payload must not surface. In particular an old remote
+// exits 127 (POSIX command-not-found, the same signal campNotFoundHint keys on)
+// or with cobra's unknown-command error, and both are swallowed here.
+//
+// It is called AFTER the hop line is written. The line is what the operator is
+// waiting for; the push is bookkeeping, and bookkeeping does not go first.
+func pushSelfSnapshot(ctx context.Context, m *machines.Machine, selfID string, names []string) {
+	if m == nil || selfID == "" || len(names) == 0 {
+		return
+	}
+	if validateMachineID(selfID) != nil {
+		return
+	}
+	safe, err := sanitizeSnapshotNames(names)
+	if err != nil || len(safe) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, snapshotPushTimeout)
+	defer cancel()
+	_, _ = pushSnapshotRun(ctx, m, "machine cache-put "+remote.ShellQuote(selfID)+
+		" --campaigns "+remote.ShellQuote(strings.Join(safe, ",")))
+}
+
+// selfSnapshot returns this machine's id and campaign names for a push, or
+// nothing when either is unavailable. Names only: no paths, no ids, no orgs, no
+// auth material, and no list of other machines. Each exclusion is a thing that
+// would otherwise leak to every machine this one hops to.
+func selfSnapshot(ctx context.Context) (string, []string) {
+	host, err := detectReachableName(ctx, runTailscaleStatusForSelf)
+	if err != nil {
+		return "", nil
+	}
+	id := suggestedMachineID(host)
+	if id == "" {
+		return "", nil
+	}
+	reg, err := config.LoadRegistry(ctx)
+	if err != nil {
+		return "", nil
+	}
+	all := reg.ListAll()
+	names := make([]string, 0, len(all))
+	for _, c := range all {
+		if c.Name != "" {
+			names = append(names, c.Name)
+		}
+	}
+	sort.Strings(names)
+	return id, names
+}

--- a/cmd/camp/machine_cache_put.go
+++ b/cmd/camp/machine_cache_put.go
@@ -66,7 +66,13 @@ func runMachineCachePut(cmd *cobra.Command, args []string) error {
 // completion cache wire format. Rejected characters would either escape path
 // boundaries if ever mis-resolved, or break shell/argv framing.
 func invalidSnapshotName(name string) bool {
-	return name == "" || len(name) > 255 || strings.ContainsAny(name, "/:\x00\n\r")
+	// Path separators keep a name from being resolved as a path, and every C0
+	// control (plus DEL) is rejected because these names are emitted as shell
+	// completion candidates and interpolated into error strings. A peer that can
+	// reach cache-put would otherwise park an ANSI escape in a cache with a 24h
+	// TTL and have it replayed into the operator's terminal on every TAB.
+	return name == "" || len(name) > 255 ||
+		strings.ContainsAny(name, "/:\x7f") || hopOriginHasC0(name)
 }
 
 // sanitizeSnapshotNames validates and bounds names on the RECEIVE path.

--- a/cmd/camp/machine_cache_put.go
+++ b/cmd/camp/machine_cache_put.go
@@ -62,32 +62,59 @@ func runMachineCachePut(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// sanitizeSnapshotNames validates and bounds the pushed names. Names are display
-// and completion data on the receiver, never resolved as paths, and the
-// separator and control-character rules keep them that way.
+// invalidSnapshotName reports whether a campaign name is unsafe for the
+// completion cache wire format. Rejected characters would either escape path
+// boundaries if ever mis-resolved, or break shell/argv framing.
+func invalidSnapshotName(name string) bool {
+	return name == "" || len(name) > 255 || strings.ContainsAny(name, "/:\x00\n\r")
+}
+
+// sanitizeSnapshotNames validates and bounds names on the RECEIVE path.
+// Each element of raw is one campaign name (repeated --campaigns flags via
+// StringArray); commas are allowed inside a name because the wire format no
+// longer joins on them. Invalid names fail the whole put — the receiver must
+// not write a half-trusted cache entry.
 func sanitizeSnapshotNames(raw []string) ([]string, error) {
 	out := make([]string, 0, len(raw))
 	total := 0
-	for _, chunk := range raw {
-		for _, name := range strings.Split(chunk, ",") {
-			name = strings.TrimSpace(name)
-			if name == "" {
-				continue
-			}
-			if len(name) > 255 || strings.ContainsAny(name, "/:\x00\n\r") {
-				return nil, camperrors.New("invalid campaign name in snapshot: " + name)
-			}
-			if len(out) >= snapshotMaxNames || total+len(name) > snapshotMaxBytes {
-				return out, nil
-			}
-			out = append(out, name)
-			total += len(name)
+	for _, name := range raw {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
 		}
+		if invalidSnapshotName(name) {
+			return nil, camperrors.New("invalid campaign name in snapshot: " + name)
+		}
+		if len(out) >= snapshotMaxNames || total+len(name) > snapshotMaxBytes {
+			return out, nil
+		}
+		out = append(out, name)
+		total += len(name)
 	}
 	if len(out) == 0 {
-		return nil, camperrors.New("no campaign names given (use --campaigns a,b,c)")
+		return nil, camperrors.New("no campaign names given (use --campaigns name, repeatable)")
 	}
 	return out, nil
+}
+
+// filterSnapshotNamesForPush soft-filters names on the OUTBOUND path. One bad
+// registry entry must not cancel the whole silent push: skip invalids, keep
+// the rest, and still bound by the same caps as the receiver.
+func filterSnapshotNamesForPush(raw []string) []string {
+	out := make([]string, 0, len(raw))
+	total := 0
+	for _, name := range raw {
+		name = strings.TrimSpace(name)
+		if invalidSnapshotName(name) {
+			continue
+		}
+		if len(out) >= snapshotMaxNames || total+len(name) > snapshotMaxBytes {
+			return out
+		}
+		out = append(out, name)
+		total += len(name)
+	}
+	return out
 }
 
 // snapshotPushTimeout bounds a push. It rides an already-established
@@ -117,14 +144,24 @@ func pushSelfSnapshot(ctx context.Context, m *machines.Machine, selfID string, n
 	if validateMachineID(selfID) != nil {
 		return
 	}
-	safe, err := sanitizeSnapshotNames(names)
-	if err != nil || len(safe) == 0 {
+	// Soft-filter on the way out: one bad local registry name must not abort
+	// the whole silent push. The receiver still hard-rejects invalid payloads.
+	safe := filterSnapshotNamesForPush(names)
+	if len(safe) == 0 {
 		return
 	}
 	ctx, cancel := context.WithTimeout(ctx, snapshotPushTimeout)
 	defer cancel()
-	_, _ = pushSnapshotRun(ctx, m, "machine cache-put "+remote.ShellQuote(selfID)+
-		" --campaigns "+remote.ShellQuote(strings.Join(safe, ",")))
+	// Repeated --campaigns flags, not comma-joined: campaign names may contain
+	// commas, and StringArray on the receiver treats each flag as one name.
+	var b strings.Builder
+	b.WriteString("machine cache-put ")
+	b.WriteString(remote.ShellQuote(selfID))
+	for _, name := range safe {
+		b.WriteString(" --campaigns ")
+		b.WriteString(remote.ShellQuote(name))
+	}
+	_, _ = pushSnapshotRun(ctx, m, b.String())
 }
 
 // selfSnapshot returns this machine's id and campaign names for a push, or

--- a/cmd/camp/machine_cache_put_test.go
+++ b/cmd/camp/machine_cache_put_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/machines"
+)
+
+func TestSanitizeSnapshotNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      []string
+		want    []string
+		wantErr bool
+	}{
+		{name: "comma separated", in: []string{"a,b,c"}, want: []string{"a", "b", "c"}},
+		{name: "trims and drops empties", in: []string{" a , ,b "}, want: []string{"a", "b"}},
+		{name: "empty input is an error", in: nil, wantErr: true},
+		{name: "only separators is an error", in: []string{",,"}, wantErr: true},
+		// A name is display and completion data on the receiver, never a path.
+		{name: "path separator rejected", in: []string{"a/b"}, wantErr: true},
+		{name: "colon rejected", in: []string{"a:b"}, wantErr: true},
+		{name: "newline rejected", in: []string{"a\nb"}, wantErr: true},
+		{name: "null byte rejected", in: []string{"a\x00b"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sanitizeSnapshotNames(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeSnapshotNamesTruncatesRatherThanRefuses(t *testing.T) {
+	// A partial completion list is useful; an error is not.
+	many := make([]string, 0, snapshotMaxNames+50)
+	for i := 0; i < snapshotMaxNames+50; i++ {
+		many = append(many, "campaign")
+	}
+	got, err := sanitizeSnapshotNames(many)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != snapshotMaxNames {
+		t.Errorf("len = %d, want the cap %d", len(got), snapshotMaxNames)
+	}
+}
+
+func TestCachePutRejectsHostileMachineID(t *testing.T) {
+	// The id becomes the cache FILE NAME, so this validation is what keeps the
+	// write inside the cache directory.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cachePutCampaigns = []string{"a"}
+	t.Cleanup(func() { cachePutCampaigns = nil })
+
+	for _, bad := range []string{"../escape", "/abs", "local", "Has-Caps", "1leading"} {
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.Background())
+		cmd.SetOut(new(strings.Builder))
+		cmd.SetErr(new(strings.Builder))
+		if err := runMachineCachePut(cmd, []string{bad}); err == nil {
+			t.Errorf("machine id %q was accepted", bad)
+		}
+	}
+}
+
+func TestCachePutWritesSnapshotEntry(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cachePutCampaigns = []string{"alpha,beta"}
+	t.Cleanup(func() { cachePutCampaigns = nil })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out, errb strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&errb)
+
+	if err := runMachineCachePut(cmd, []string{"mac-studio"}); err != nil {
+		t.Fatal(err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout must stay empty so callers need not parse it, got %q", out.String())
+	}
+
+	names, ok := readMachineCacheCampaigns("mac-studio")
+	if !ok {
+		t.Fatal("pushed snapshot did not read back")
+	}
+	if strings.Join(names, ",") != "alpha,beta" {
+		t.Errorf("names = %v", names)
+	}
+}
+
+func TestPushedSnapshotSurvivesTheShortCompletionTTL(t *testing.T) {
+	// The whole point of the source field: a pushed snapshot older than 60s must
+	// still be offered, or the feature is a no-op an hour after it works.
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	if err := os.MkdirAll(machineCacheDir(), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-30 * time.Minute).UnixNano()
+
+	write := func(id string, entry machineCacheEntry) {
+		data, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(machineCacheDir()+"/"+id+".json", data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("pushed", machineCacheEntry{Campaigns: []string{"a"}, FetchedAt: old, Source: snapshotSource})
+	write("pulled", machineCacheEntry{Campaigns: []string{"a"}, FetchedAt: old})
+
+	if _, ok := readMachineCacheCampaigns("pushed"); !ok {
+		t.Error("a 30-minute-old pushed snapshot must still be fresh")
+	}
+	if _, ok := readMachineCacheCampaigns("pulled"); ok {
+		t.Error("a 30-minute-old pulled entry must be stale")
+	}
+}
+
+func TestOldCampIgnoresTheSourceField(t *testing.T) {
+	// Decoder tolerance: a pre-change camp unmarshals into a struct without
+	// Source and applies the 60s rule, degrading to today's behavior.
+	type oldEntry struct {
+		Campaigns []string `json:"campaigns"`
+		FetchedAt int64    `json:"fetched_at"`
+	}
+	data, err := json.Marshal(machineCacheEntry{
+		Campaigns: []string{"a", "b"},
+		FetchedAt: time.Now().UnixNano(),
+		Source:    snapshotSource,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var old oldEntry
+	if err := json.Unmarshal(data, &old); err != nil {
+		t.Fatalf("an older camp must still parse the file: %v", err)
+	}
+	if len(old.Campaigns) != 2 {
+		t.Errorf("campaigns = %v", old.Campaigns)
+	}
+}
+
+func TestPushSilenceMatrix(t *testing.T) {
+	m := &machines.Machine{ID: "archdtop", Host: "archdtop.ts.net", SSHUser: "lance"}
+
+	tests := []struct {
+		name      string
+		selfID    string
+		names     []string
+		runErr    error
+		wantCalls int
+	}{
+		{name: "happy path pushes once", selfID: "mac-studio", names: []string{"a"}, wantCalls: 1},
+		{name: "no self id, no push", selfID: "", names: []string{"a"}},
+		{name: "invalid self id, no push", selfID: "Not-Valid", names: []string{"a"}},
+		{name: "no campaigns, no push", selfID: "mac-studio"},
+		// Old remote: unknown verb exits 127. Swallowed.
+		{name: "old remote is silent", selfID: "mac-studio", names: []string{"a"},
+			runErr: errors.New("exit status 127: unknown command"), wantCalls: 1},
+		{name: "unreachable is silent", selfID: "mac-studio", names: []string{"a"},
+			runErr: errors.New("connection refused"), wantCalls: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			restore := pushSnapshotRun
+			pushSnapshotRun = func(context.Context, *machines.Machine, string) ([]byte, error) {
+				calls++
+				return nil, tt.runErr
+			}
+			t.Cleanup(func() { pushSnapshotRun = restore })
+
+			// The contract is that this never panics and never returns an error;
+			// there is no error to assert because there is no error path.
+			pushSelfSnapshot(context.Background(), m, tt.selfID, tt.names)
+
+			if calls != tt.wantCalls {
+				t.Errorf("ssh calls = %d, want %d", calls, tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestPushCarriesNamesOnly(t *testing.T) {
+	// The invariant, asserted as an absence so a future field addition fails
+	// this test rather than quietly shipping.
+	var sent string
+	restore := pushSnapshotRun
+	pushSnapshotRun = func(_ context.Context, _ *machines.Machine, args string) ([]byte, error) {
+		sent = args
+		return nil, nil
+	}
+	t.Cleanup(func() { pushSnapshotRun = restore })
+
+	m := &machines.Machine{ID: "archdtop", Host: "archdtop.ts.net", SSHUser: "lance", IdentityFile: "/keys/secret"}
+	pushSelfSnapshot(context.Background(), m, "mac-studio", []string{"obey-campaign"})
+
+	for _, forbidden := range []string{"/keys/secret", "/Users/", "8deed8b4", "archdtop.ts.net", "org", "path"} {
+		if strings.Contains(sent, forbidden) {
+			t.Errorf("push argv leaked %q: %s", forbidden, sent)
+		}
+	}
+	if !strings.Contains(sent, "obey-campaign") || !strings.Contains(sent, "mac-studio") {
+		t.Errorf("push argv missing the names it should carry: %s", sent)
+	}
+}

--- a/cmd/camp/machine_cache_put_test.go
+++ b/cmd/camp/machine_cache_put_test.go
@@ -320,3 +320,26 @@ func TestSelfSnapshotNamesOnlyInvariant(t *testing.T) {
 		}
 	}
 }
+
+// Snapshot names are replayed as shell completion candidates and interpolated
+// into error strings, so a peer that can reach cache-put must not be able to
+// park an escape sequence in a cache with a 24h TTL.
+func TestInvalidSnapshotNameRejectsTerminalControlBytes(t *testing.T) {
+	for _, name := range []string{
+		"ok\x1b[31mred", // ESC
+		"ok\x07bell",    // BEL
+		"ok\ttab",       // TAB
+		"ok\x7fdel",     // DEL
+		"ok\x00nul",     // NUL
+		"ok\nnewline",
+	} {
+		if !invalidSnapshotName(name) {
+			t.Errorf("invalidSnapshotName(%q) = false; control bytes must be rejected", name)
+		}
+	}
+	// Commas are legal in campaign names and the wire format no longer splits
+	// on them, so they must survive.
+	if invalidSnapshotName("foo,bar") {
+		t.Error("a comma is a legal campaign-name character and must not be rejected")
+	}
+}

--- a/cmd/camp/machine_cache_put_test.go
+++ b/cmd/camp/machine_cache_put_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/machines"
 )
 
@@ -21,15 +22,20 @@ func TestSanitizeSnapshotNames(t *testing.T) {
 		want    []string
 		wantErr bool
 	}{
-		{name: "comma separated", in: []string{"a,b,c"}, want: []string{"a", "b", "c"}},
-		{name: "trims and drops empties", in: []string{" a , ,b "}, want: []string{"a", "b"}},
+		// Wire format is repeated --campaigns flags; each element is one name.
+		// Commas inside a name are allowed (they are no longer the delimiter).
+		{name: "repeated flags", in: []string{"a", "b", "c"}, want: []string{"a", "b", "c"}},
+		{name: "name with comma intact", in: []string{"foo,bar", "baz"}, want: []string{"foo,bar", "baz"}},
+		{name: "trims and drops empties", in: []string{" a ", "", "b "}, want: []string{"a", "b"}},
 		{name: "empty input is an error", in: nil, wantErr: true},
-		{name: "only separators is an error", in: []string{",,"}, wantErr: true},
+		{name: "only empties is an error", in: []string{"", "  "}, wantErr: true},
 		// A name is display and completion data on the receiver, never a path.
 		{name: "path separator rejected", in: []string{"a/b"}, wantErr: true},
 		{name: "colon rejected", in: []string{"a:b"}, wantErr: true},
 		{name: "newline rejected", in: []string{"a\nb"}, wantErr: true},
 		{name: "null byte rejected", in: []string{"a\x00b"}, wantErr: true},
+		// One invalid fails the whole receive (hard reject on put).
+		{name: "one bad fails all", in: []string{"good", "bad/path"}, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -43,10 +49,22 @@ func TestSanitizeSnapshotNames(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if strings.Join(got, ",") != strings.Join(tt.want, ",") {
+			if strings.Join(got, "\x00") != strings.Join(tt.want, "\x00") {
 				t.Errorf("got %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFilterSnapshotNamesForPushSkipsInvalid(t *testing.T) {
+	// Outbound soft-filter: drop bad names, keep the rest — never fail the push.
+	got := filterSnapshotNamesForPush([]string{"good", "bad/path", "also-good", "has:colon", ""})
+	want := []string{"good", "also-good"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got := filterSnapshotNamesForPush([]string{"bad/a", "x:y"}); len(got) != 0 {
+		t.Errorf("all-invalid must yield empty, got %v", got)
 	}
 }
 
@@ -85,7 +103,8 @@ func TestCachePutRejectsHostileMachineID(t *testing.T) {
 
 func TestCachePutWritesSnapshotEntry(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	cachePutCampaigns = []string{"alpha,beta"}
+	// Repeated flags: each element is one name (including names with commas).
+	cachePutCampaigns = []string{"alpha", "beta", "foo,bar"}
 	t.Cleanup(func() { cachePutCampaigns = nil })
 
 	cmd := &cobra.Command{}
@@ -105,7 +124,7 @@ func TestCachePutWritesSnapshotEntry(t *testing.T) {
 	if !ok {
 		t.Fatal("pushed snapshot did not read back")
 	}
-	if strings.Join(names, ",") != "alpha,beta" {
+	if strings.Join(names, "\x00") != "alpha\x00beta\x00foo,bar" {
 		t.Errorf("names = %v", names)
 	}
 }
@@ -218,14 +237,86 @@ func TestPushCarriesNamesOnly(t *testing.T) {
 	t.Cleanup(func() { pushSnapshotRun = restore })
 
 	m := &machines.Machine{ID: "archdtop", Host: "archdtop.ts.net", SSHUser: "lance", IdentityFile: "/keys/secret"}
-	pushSelfSnapshot(context.Background(), m, "mac-studio", []string{"obey-campaign"})
+	pushSelfSnapshot(context.Background(), m, "mac-studio", []string{"obey-campaign", "foo,bar", "bad/skip"})
 
-	for _, forbidden := range []string{"/keys/secret", "/Users/", "8deed8b4", "archdtop.ts.net", "org", "path"} {
+	for _, forbidden := range []string{"/keys/secret", "/Users/", "8deed8b4", "archdtop.ts.net", "org", "path", "bad/skip"} {
 		if strings.Contains(sent, forbidden) {
 			t.Errorf("push argv leaked %q: %s", forbidden, sent)
 		}
 	}
 	if !strings.Contains(sent, "obey-campaign") || !strings.Contains(sent, "mac-studio") {
 		t.Errorf("push argv missing the names it should carry: %s", sent)
+	}
+	// Repeated --campaigns, not a single comma-joined flag value.
+	if !strings.Contains(sent, "--campaigns") || strings.Count(sent, "--campaigns") < 2 {
+		t.Errorf("want repeated --campaigns flags, got %s", sent)
+	}
+	if !strings.Contains(sent, "foo,bar") {
+		t.Errorf("name with comma must survive as one flag value: %s", sent)
+	}
+}
+
+func TestPushSoftFiltersInvalidNames(t *testing.T) {
+	// One invalid registry name must not cancel the whole silent push.
+	var sent string
+	calls := 0
+	restore := pushSnapshotRun
+	pushSnapshotRun = func(_ context.Context, _ *machines.Machine, args string) ([]byte, error) {
+		calls++
+		sent = args
+		return nil, nil
+	}
+	t.Cleanup(func() { pushSnapshotRun = restore })
+
+	m := &machines.Machine{ID: "archdtop", Host: "archdtop.ts.net"}
+	pushSelfSnapshot(context.Background(), m, "mac-studio", []string{"good", "evil/path", "also-good"})
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1 (soft-filter continues)", calls)
+	}
+	if !strings.Contains(sent, "good") || !strings.Contains(sent, "also-good") {
+		t.Errorf("valid names missing from push: %s", sent)
+	}
+	if strings.Contains(sent, "evil") {
+		t.Errorf("invalid name leaked into push: %s", sent)
+	}
+}
+
+func TestSelfSnapshotNamesOnlyInvariant(t *testing.T) {
+	// selfSnapshot must emit campaign names only — never host, user, paths,
+	// orgs, or other registry fields that would leak to every hop target.
+	dir := t.TempDir()
+	t.Setenv("CAMP_REGISTRY_PATH", dir+"/registry.json")
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	// Force hostname fallback (no live tailscale) so the id is derived, but
+	// the names list is what we assert.
+	reg := config.NewRegistry()
+	if err := reg.RegisterWithOrg("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "obey-campaign",
+		"/secret/path/to/obey", config.CampaignTypeProduct, "secret-org"); err != nil {
+		t.Fatal(err)
+	}
+	if err := reg.RegisterWithOrg("ffffffff-0000-1111-2222-333333333333", "social-fitness",
+		"/Users/someone/.campaigns/social", config.CampaignTypeProduct, "other-org"); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveRegistry(context.Background(), reg); err != nil {
+		t.Fatal(err)
+	}
+
+	id, names := selfSnapshot(context.Background())
+	if id == "" {
+		t.Fatal("selfSnapshot id empty (hostname detection failed?)")
+	}
+	if strings.Join(names, ",") != "obey-campaign,social-fitness" {
+		t.Errorf("names = %v, want sorted campaign names only", names)
+	}
+	blob := id + " " + strings.Join(names, " ")
+	for _, forbidden := range []string{
+		"/secret/", "/Users/", "secret-org", "other-org",
+		"aaaaaaaa", "ffffffff", "ssh", "IdentityFile", "host",
+	} {
+		if strings.Contains(blob, forbidden) {
+			t.Errorf("selfSnapshot leaked %q: id=%q names=%v", forbidden, id, names)
+		}
 	}
 }

--- a/cmd/camp/switch_remote.go
+++ b/cmd/camp/switch_remote.go
@@ -71,7 +71,15 @@ func emitHopOrRefuse(ctx context.Context, cmd *cobra.Command, m *machines.Machin
 		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), ui.Dim("camp: "+warning))
 	}
 	if shellConnect {
-		return emitShellConnect(cmd.OutOrStdout(), true, root, m, hopOriginForEmit(ctx, cmd))
+		if err := emitShellConnect(cmd.OutOrStdout(), true, root, m, hopOriginForEmit(ctx, cmd)); err != nil {
+			return err
+		}
+		// After the line is written, never before: the operator is waiting on
+		// that line, and this is bookkeeping. It rides the ControlMaster socket
+		// the resolve already opened, so it costs no new connection.
+		selfID, names := selfSnapshot(ctx)
+		pushSelfSnapshot(ctx, m, selfID, names)
+		return nil
 	}
 	return camperrors.New("resolved " + m.ID + ":" + remainder + " -> " + root +
 		"; run via the csw shell wrapper to hop there")


### PR DESCRIPTION
> **Stacked on #506** (which is stacked on #505, on #504). Base is `mesh-skew-warning`.

Makes campaign-name completion work in both directions, without the remote ever connecting back.

Festival MN0001, phase 005 sequence 01. Design: `003_DESIGN/03_transfer_reach/outputs/snapshot-verb-spec.md`.

## Why

Completion is one-way today. `camp list --remote` on the host enumerates a remote and caches its campaign names, so `csw archdtop:<TAB>` works from the mac. Nothing warms the *remote's* cache about the host, because that would require archdtop to connect back to the mac, and D003 is explicit that camp diagnoses reverse reachability rather than managing it.

So the information exists, just on the wrong side of a one-way link. The fix is that the side which *can* reach pushes what it knows.

## What changed

**Hidden `camp machine cache-put <id> --campaigns a,b,c`** (`cmd/camp/machine_cache_put.go`). Machine-to-machine plumbing, so it is hidden from help. The **receiver** validates everything it is handed, which is the reason this is a verb rather than an scp of a JSON file into the remote's cache directory: a file drop writes to another machine's state without that machine's code checking it.

The machine id is validated **first**, and not as a naming nicety: it becomes the cache *file name*, so `validateMachineID` is what keeps a hostile value inside the cache directory. Campaign names reject `/`, `:`, newline, and NUL, because on the receiver they are display and completion data, never paths.

**Push triggers**: after a successful hop emit, and after a successful remote enumerate. Both ride the ControlMaster socket the triggering operation already opened, so neither adds a connection.

**Per-source TTL** (`cmd/camp/completion_remote.go`). Pushed entries live 24h; pulled ones keep their 60s. Their refresh events differ: a pulled entry is replaced the next time you run `list --remote`, a pushed one by the next hop from that host, which may be tomorrow. A 60s bound would make the feature stop working a minute after it started. One file, one `source` field, so the keystroke path stays a single `os.ReadFile`.

**Failures are silent**: unreachable, timed out, rejected payload, or an old remote whose camp has no such verb (exit 127, the same POSIX signal `campNotFoundHint` already keys on). The operator asked to hop or to list, not to sync caches.

## Tests

`just gate` green: 3792.

Notable: an 8-row name-validation table; hostile machine ids (`../escape`, `/abs`, `local`, caps, leading digit); a TTL test proving a 30-minute-old *pushed* entry is fresh while an identically-aged *pulled* one is stale; decoder tolerance verified by unmarshalling a `source`-bearing document into a pre-change struct; and a 6-row push-silence matrix including the exit-127 old-remote case.

`TestPushCarriesNamesOnly` asserts the invariant as an **absence** (no identity_file, no home paths, no campaign ids, no host, no org, no path), so a future field addition fails the test rather than quietly shipping.

## Spec correction included

The design spec argued the push had to happen *before* the hop line is emitted, reasoning that `exec` replaces camp's process so "after means never". That is wrong: camp only *prints* the line, and the wrapper evals it after camp exits. Emit-then-push is strictly better, because the line the operator is waiting on is written before any bookkeeping starts. The spec section is corrected in place with the original reasoning and why it fails, rather than the code silently diverging.
