### PR TITLE
feat(transfer): machine-first grammar and cross-machine transport

### DIFF
--- a/cmd/camp/transfer.go
+++ b/cmd/camp/transfer.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +12,7 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/Obedience-Corp/camp/internal/machines"
 	"github.com/Obedience-Corp/camp/internal/transfer"
 	"github.com/spf13/cobra"
 )
@@ -73,8 +76,7 @@ func runTransfer(cmd *cobra.Command, args []string) error {
 		return transfer.BothRemoteError(src, dest)
 	}
 	if src.IsRemote() || dest.IsRemote() {
-		return camperrors.New("cross-machine transfer is not implemented yet; " +
-			"the grammar parses but the transport lands in a follow-up")
+		return runRemoteTransfer(ctx, cmd, root, src, dest, force)
 	}
 
 	srcPath, err := transfer.ResolveCrossCampaignPath(ctx, root, src.Spec)
@@ -204,4 +206,48 @@ func completeCampaignPath(campRoot, pathPrefix, colonPrefix string) ([]string, c
 		completions = append(completions, colonPrefix+prefix+name+suffix)
 	}
 	return completions, cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
+}
+
+// runRemoteTransfer moves one file between this machine and a fleet member. The
+// far campaign root is resolved by the remote's own camp, never computed here.
+func runRemoteTransfer(ctx context.Context, cmd *cobra.Command, root string, src, dest transfer.Endpoint, force bool) error {
+	remoteEnd, localSpec, pull := dest, src.Spec, false
+	if src.IsRemote() {
+		remoteEnd, localSpec, pull = src, dest.Spec, true
+	}
+
+	mf, err := machines.Load()
+	if err != nil {
+		return err
+	}
+	m, _, found := mf.Lookup(remoteEnd.Machine)
+	if !found {
+		return camperrors.New("unknown machine \"" + remoteEnd.Machine + "\"; add it to ~/.obey/machines.yaml")
+	}
+
+	localPath := transfer.ResolveCampaignRelative(root, localSpec)
+	if pull && transfer.IsDestDir(localPath) {
+		localPath = filepath.Join(localPath, filepath.Base(remoteEnd.Path))
+	}
+	if !pull {
+		if err := transfer.ValidatePathExists(localPath); err != nil {
+			return camperrors.Wrap(err, "source")
+		}
+	}
+
+	if err := transfer.CopyRemote(ctx, transfer.CopyOptions{
+		Machine:  m,
+		Endpoint: remoteEnd,
+		Local:    localPath,
+		Pull:     pull,
+		Force:    force,
+	}); err != nil {
+		if errors.Is(err, transfer.ErrDestinationExists) {
+			return camperrors.Newf("destination exists on %s, not overwritten (use --force)", m.ID)
+		}
+		return camperrors.Wrapf(err, "run 'camp machine diagnose %s' to check reachability", m.ID)
+	}
+
+	_, err = fmt.Printf("Transferred %s -> %s\n", src.Spec, dest.Spec)
+	return err
 }

--- a/cmd/camp/transfer.go
+++ b/cmd/camp/transfer.go
@@ -13,25 +13,38 @@ import (
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/machines"
+	"github.com/Obedience-Corp/camp/internal/remote"
 	"github.com/Obedience-Corp/camp/internal/transfer"
 	"github.com/spf13/cobra"
 )
 
 var transferCmd = &cobra.Command{
 	Use:   "transfer <src> <dest>",
-	Short: "Copy files between campaigns",
-	Long: `Copy files between different campaigns using campaign:path syntax.
+	Short: "Copy files between campaigns (and machines)",
+	Long: `Copy files between campaigns, and between this machine and a registered
+fleet machine.
 
 Transfer always copies — it never moves or deletes the source.
-Either the source or destination (or both) can use "campaign:path"
-notation to reference a different registered campaign. Paths without
-a campaign prefix resolve relative to the current campaign root.
 
-At least one side must reference a different campaign. For copies
-within the same campaign, use 'camp copy' instead.`,
-	Example: `  camp transfer docs/my-doc.md other-campaign:docs/my-doc.md     # push
-  camp transfer other-campaign:docs/my-doc.md docs/              # pull
-  camp transfer other:festivals/plan.md festivals/planned/       # pull into dir`,
+Local forms:
+  campaign:path     another registered campaign on this machine
+  path              relative to the current campaign root
+  local:campaign:path
+                    force the campaign reading when campaign name collides
+                    with a registered machine id
+
+Machine forms (one side only; both-remote is refused):
+  machine:campaign:path
+                    file on a machine registered in ~/.obey/machines.yaml
+
+At least one side must reference a different campaign or machine. For copies
+within the same campaign on this machine, use 'camp copy' instead.`,
+	Example: `  camp transfer docs/my-doc.md other-campaign:docs/my-doc.md     # local push
+  camp transfer other-campaign:docs/my-doc.md docs/              # local pull
+  camp transfer other:festivals/plan.md festivals/planned/       # pull into dir
+  camp transfer docs/x.md archdtop:obey-campaign:docs/x.md       # push to machine
+  camp transfer archdtop:obey-campaign:docs/x.md docs/x.md       # pull from machine
+  camp transfer local:other:docs/x.md archdtop:camp:docs/x.md    # local: escape hatch`,
 	Args: cobra.ExactArgs(2),
 	RunE: runTransfer,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -224,14 +237,30 @@ func runRemoteTransfer(ctx context.Context, cmd *cobra.Command, root string, src
 	if !found {
 		return camperrors.New("unknown machine \"" + remoteEnd.Machine + "\"; add it to ~/.obey/machines.yaml")
 	}
+	// Same auth precondition as hop/switch: password-auth machines fail here
+	// with an actionable message instead of a BatchMode transport failure.
+	if err := remote.EnsureKeyAuth(m); err != nil {
+		return err
+	}
 
-	localPath := transfer.ResolveCampaignRelative(root, localSpec)
+	// Cross-campaign local resolution (other-campaign:path, local:other:path →
+	// Spec "other:path") matches the local transfer path. ResolveCampaignRelative
+	// alone would treat the colon as a literal filename under the current root.
+	localPath, err := transfer.ResolveCrossCampaignPath(ctx, root, localSpec)
+	if err != nil {
+		return camperrors.Wrap(err, "resolve local path")
+	}
 	if pull && transfer.IsDestDir(localPath) {
 		localPath = filepath.Join(localPath, filepath.Base(remoteEnd.Path))
 	}
 	if !pull {
 		if err := transfer.ValidatePathExists(localPath); err != nil {
 			return camperrors.Wrap(err, "source")
+		}
+	} else {
+		// Parity with local transfer: create missing parent dirs before the copy.
+		if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+			return camperrors.Wrap(err, "create destination directory")
 		}
 	}
 
@@ -243,6 +272,11 @@ func runRemoteTransfer(ctx context.Context, cmd *cobra.Command, root string, src
 		Force:    force,
 	}); err != nil {
 		if errors.Is(err, transfer.ErrDestinationExists) {
+			// Phrase by where the destination lives — m.ID is always the far
+			// machine, so a pull must not blame the remote for a local path.
+			if pull {
+				return camperrors.Newf("destination %q already exists (use --force to overwrite)", localPath)
+			}
 			return camperrors.Newf("destination exists on %s, not overwritten (use --force)", m.ID)
 		}
 		return camperrors.Wrapf(err, "run 'camp machine diagnose %s' to check reachability", m.ID)

--- a/cmd/camp/transfer.go
+++ b/cmd/camp/transfer.go
@@ -57,11 +57,11 @@ func runTransfer(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	src, err := transfer.ParseEndpointDefault(args[0])
+	src, err := transfer.ParseEndpointDefault(ctx, args[0])
 	if err != nil {
 		return camperrors.Wrap(err, "resolve source")
 	}
-	dest, err := transfer.ParseEndpointDefault(args[1])
+	dest, err := transfer.ParseEndpointDefault(ctx, args[1])
 	if err != nil {
 		return camperrors.Wrap(err, "resolve destination")
 	}

--- a/cmd/camp/transfer.go
+++ b/cmd/camp/transfer.go
@@ -54,7 +54,30 @@ func runTransfer(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	srcPath, err := transfer.ResolveCrossCampaignPath(ctx, root, args[0])
+	src, err := transfer.ParseEndpointDefault(args[0])
+	if err != nil {
+		return camperrors.Wrap(err, "resolve source")
+	}
+	dest, err := transfer.ParseEndpointDefault(args[1])
+	if err != nil {
+		return camperrors.Wrap(err, "resolve destination")
+	}
+	for _, e := range []transfer.Endpoint{src, dest} {
+		if e.Shadowed {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), transfer.ShadowNote(e.Machine))
+		}
+	}
+	if src.IsRemote() && dest.IsRemote() {
+		// Brokering a copy between two far machines would need them to reach
+		// each other, which D003 says camp diagnoses rather than manages.
+		return transfer.BothRemoteError(src, dest)
+	}
+	if src.IsRemote() || dest.IsRemote() {
+		return camperrors.New("cross-machine transfer is not implemented yet; " +
+			"the grammar parses but the transport lands in a follow-up")
+	}
+
+	srcPath, err := transfer.ResolveCrossCampaignPath(ctx, root, src.Spec)
 	if err != nil {
 		return camperrors.Wrap(err, "resolve source")
 	}
@@ -62,13 +85,13 @@ func runTransfer(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "source")
 	}
 
-	destPath, err := transfer.ResolveCrossCampaignPath(ctx, root, args[1])
+	destPath, err := transfer.ResolveCrossCampaignPath(ctx, root, dest.Spec)
 	if err != nil {
 		return camperrors.Wrap(err, "resolve destination")
 	}
 
 	// If dest is a directory or ends with /, place source inside it
-	destArg := args[1]
+	destArg := dest.Spec
 	// Strip campaign prefix for trailing slash check
 	if idx := strings.Index(destArg, ":"); idx >= 0 {
 		destArg = destArg[idx+1:]

--- a/internal/peer/peer.go
+++ b/internal/peer/peer.go
@@ -178,3 +178,14 @@ func (s *Source) Fetch(ctx context.Context, dir, relPath string) error {
 	}
 	return nil
 }
+
+// SSHCommandFor builds the `-e` value for a copy to m: the ssh binary plus the
+// same quoted option set a hop uses. Exposed so transfer rides one ssh option
+// construction rather than a second one that has to be kept in sync, which is
+// what makes "no new auth surface" structural rather than a promise.
+func SSHCommandFor(m *machines.Machine) string {
+	if m == nil {
+		return ""
+	}
+	return (&Source{target: remote.Target(m), sshOpts: remote.Opts(m)}).SSHCommand()
+}

--- a/internal/transfer/endpoint.go
+++ b/internal/transfer/endpoint.go
@@ -1,6 +1,11 @@
 package transfer
 
-import "github.com/Obedience-Corp/camp/internal/machines"
+import (
+	"context"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	"github.com/Obedience-Corp/camp/internal/machines"
+)
 
 // LocalPrefix forces the campaign reading of an endpoint whose leading segment
 // would otherwise be read as a machine id. It is spelled "local" to match
@@ -101,6 +106,23 @@ func BothRemoteError(src, dest Endpoint) error {
 // campaign check that only runs when a machine already matched, so the common
 // case (no fleet configured) costs one cheap file read that Load already caches
 // behind an absent-file fast path.
-func ParseEndpointDefault(spec string) (Endpoint, error) {
-	return ParseEndpoint(spec, registeredMachine, nil)
+func ParseEndpointDefault(ctx context.Context, spec string) (Endpoint, error) {
+	return ParseEndpoint(spec, registeredMachine, registeredCampaign(ctx))
+}
+
+// registeredCampaign reports whether head also names a campaign, which is what
+// makes a spec ambiguous and worth a note. The registry is only read after a
+// machine id already matched, so an unconfigured fleet never pays for it.
+func registeredCampaign(ctx context.Context) campaignLookupFunc {
+	return func(head string) bool {
+		if head == "" {
+			return false
+		}
+		reg, err := config.LoadRegistry(ctx)
+		if err != nil {
+			return false
+		}
+		_, found := reg.GetByName(head)
+		return found
+	}
 }

--- a/internal/transfer/endpoint.go
+++ b/internal/transfer/endpoint.go
@@ -1,0 +1,106 @@
+package transfer
+
+import "github.com/Obedience-Corp/camp/internal/machines"
+
+// LocalPrefix forces the campaign reading of an endpoint whose leading segment
+// would otherwise be read as a machine id. It is spelled "local" to match
+// machines.LocalMachineID and `camp switch local:<campaign>`, so one reserved
+// word means the same thing in both commands.
+const LocalPrefix = machines.LocalMachineID
+
+// Endpoint is a parsed transfer endpoint. Machine is empty for every form that
+// exists today, which is what makes the new grammar additive: an unconfigured
+// fleet can never produce a non-empty Machine.
+type Endpoint struct {
+	Machine  string // registered machine id, or "" for local
+	Campaign string // campaign segment for a remote endpoint
+	Path     string // path within the campaign for a remote endpoint
+	Spec     string // the endpoint as the campaign resolver should see it
+	Shadowed bool   // head resolved as BOTH a machine id and a campaign
+}
+
+// IsRemote reports whether this endpoint lives on another machine.
+func (e Endpoint) IsRemote() bool { return e.Machine != "" }
+
+// machineLookupFunc reports whether id is a registered machine. Injected so the
+// grammar is testable without a machines.yaml on disk.
+type machineLookupFunc func(id string) bool
+
+// registeredMachine is the production lookup: machines.yaml, exactly the pair
+// runRemoteSwitch uses.
+func registeredMachine(id string) bool {
+	if id == "" || id == machines.LocalMachineID {
+		return false
+	}
+	mf, err := machines.Load()
+	if err != nil {
+		return false
+	}
+	_, _, found := mf.Lookup(id)
+	return found
+}
+
+// campaignLookupFunc reports whether head resolves as a campaign, used only to
+// detect shadowing so the note can name the escape hatch.
+type campaignLookupFunc func(head string) bool
+
+// ParseEndpoint applies the machine-first grammar. The behavior change is gated
+// on the leading segment matching a REGISTERED machine id, so a user with no
+// ~/.obey/machines.yaml gets byte-identical behavior: on an unconfigured fleet
+// the new grammar is unreachable.
+func ParseEndpoint(spec string, isMachine machineLookupFunc, isCampaign campaignLookupFunc) (Endpoint, error) {
+	head, rest, hasColon := parseSpec(spec)
+	if !hasColon {
+		return Endpoint{Spec: spec}, nil
+	}
+
+	// "local:" forces the campaign reading. It is the escape hatch for a
+	// campaign whose name or id prefix collides with a registered machine id;
+	// without it, registering a machine could make a campaign unreachable.
+	if head == LocalPrefix {
+		return Endpoint{Spec: rest}, nil
+	}
+
+	if isMachine == nil || !isMachine(head) {
+		return Endpoint{Spec: spec}, nil
+	}
+
+	campaign, path, hasSecond := parseSpec(rest)
+	if !hasSecond || campaign == "" || path == "" {
+		return Endpoint{}, errMachineNeedsCampaign(head, campaign)
+	}
+	shadowed := isCampaign != nil && isCampaign(head)
+	return Endpoint{Machine: head, Campaign: campaign, Path: path, Spec: spec, Shadowed: shadowed}, nil
+}
+
+// ShadowNote is the stderr line emitted when a head resolves as both a machine
+// and a campaign. It fires every time rather than once per process: it reports
+// an ambiguity in the command the operator just typed, and a silently different
+// reading of the second invocation is exactly what it exists to prevent.
+func ShadowNote(machine string) string {
+	return "camp: " + machine + " is a registered machine; reading it as machine:campaign:path " +
+		"(use " + LocalPrefix + ":" + machine + ":... for the campaign)"
+}
+
+func errMachineNeedsCampaign(machine, campaign string) error {
+	example := "notes.md"
+	if campaign != "" {
+		example = campaign
+	}
+	return newEndpointError(machine, example)
+}
+
+// BothRemoteError rejects a machine-to-machine copy. It is decidable from the
+// two parsed endpoints alone, so failing here costs the user nothing, and camp
+// cannot promise the two far machines can reach each other (D003).
+func BothRemoteError(src, dest Endpoint) error {
+	return newBothRemoteError(src.Machine, dest.Machine)
+}
+
+// ParseEndpointDefault is ParseEndpoint wired to the real machines.yaml and to a
+// campaign check that only runs when a machine already matched, so the common
+// case (no fleet configured) costs one cheap file read that Load already caches
+// behind an absent-file fast path.
+func ParseEndpointDefault(spec string) (Endpoint, error) {
+	return ParseEndpoint(spec, registeredMachine, nil)
+}

--- a/internal/transfer/endpoint_compat_test.go
+++ b/internal/transfer/endpoint_compat_test.go
@@ -1,0 +1,191 @@
+package transfer
+
+import "testing"
+
+// TestEndpointCompatMatrix pins every currently valid endpoint form BEFORE the
+// machine-first grammar exists, which is the order the festival constraints
+// require: write the matrix against today's parser, watch it pass, then change
+// the parser and watch only the intended rows move.
+//
+// Rows map one-to-one onto transfer-grammar-spec.md section 6.
+func TestEndpointCompatMatrix(t *testing.T) {
+	tests := []struct {
+		row      string
+		spec     string
+		head     string
+		rest     string
+		hasColon bool
+	}{
+		{row: "B1", spec: "docs/x.md", head: "docs/x.md"},
+		{row: "B2", spec: "./docs/x.md", head: "./docs/x.md"},
+		{row: "B3", spec: "/abs/path/x.md", head: "/abs/path/x.md"},
+		{row: "B4", spec: "other:docs/x.md", head: "other", rest: "docs/x.md", hasColon: true},
+		{row: "B5", spec: "8dee:docs/x.md", head: "8dee", rest: "docs/x.md", hasColon: true},
+		{row: "B6", spec: "8deed8b4-aaaa:docs/x.md", head: "8deed8b4-aaaa", rest: "docs/x.md", hasColon: true},
+		{row: "B7", spec: "other:", head: "other", rest: "", hasColon: true},
+		{row: "B8", spec: "other:festivals/plan.md", head: "other", rest: "festivals/plan.md", hasColon: true},
+		// The split is at the FIRST colon, so a path containing a colon stays
+		// part of the path.
+		{row: "B9", spec: "other:a:b", head: "other", rest: "a:b", hasColon: true},
+		{row: "B10", spec: "weird:name.md", head: "weird", rest: "name.md", hasColon: true},
+		{row: "B16", spec: "local:docs/x.md", head: "local", rest: "docs/x.md", hasColon: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.row+"_"+tt.spec, func(t *testing.T) {
+			head, rest, hasColon := parseSpec(tt.spec)
+			if head != tt.head || rest != tt.rest || hasColon != tt.hasColon {
+				t.Errorf("parseSpec(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tt.spec, head, rest, hasColon, tt.head, tt.rest, tt.hasColon)
+			}
+		})
+	}
+}
+
+// TestParseEndpointCompatAfterChange re-runs the same matrix through the NEW
+// grammar with a fleet configured, and asserts that only the two rows the spec
+// flagged as behavior changes actually moved.
+func TestParseEndpointCompatAfterChange(t *testing.T) {
+	fleet := func(id string) bool { return id == "archdtop" }
+	noCampaigns := func(string) bool { return false }
+
+	unchanged := []struct {
+		row      string
+		spec     string
+		wantSpec string
+	}{
+		{"B1", "docs/x.md", "docs/x.md"},
+		{"B2", "./docs/x.md", "./docs/x.md"},
+		{"B3", "/abs/path/x.md", "/abs/path/x.md"},
+		{"B4", "other:docs/x.md", "other:docs/x.md"},
+		{"B5", "8dee:docs/x.md", "8dee:docs/x.md"},
+		{"B7", "other:", "other:"},
+		{"B8", "other:festivals/plan.md", "other:festivals/plan.md"},
+		{"B9", "other:a:b", "other:a:b"},
+		{"B10", "weird:name.md", "weird:name.md"},
+		// B15: a machine NAME that is not registered still falls through.
+		{"B15", "archdtop-typo:docs/x.md", "archdtop-typo:docs/x.md"},
+	}
+	for _, tt := range unchanged {
+		t.Run(tt.row+"_unchanged", func(t *testing.T) {
+			got, err := ParseEndpoint(tt.spec, fleet, noCampaigns)
+			if err != nil {
+				t.Fatalf("ParseEndpoint(%q) errored: %v", tt.spec, err)
+			}
+			if got.IsRemote() {
+				t.Errorf("ParseEndpoint(%q) became remote: %+v", tt.spec, got)
+			}
+			if got.Spec != tt.wantSpec {
+				t.Errorf("ParseEndpoint(%q).Spec = %q, want %q", tt.spec, got.Spec, tt.wantSpec)
+			}
+		})
+	}
+
+	// B14: the ONE behavior change. A registered machine id as the head used to
+	// fail a campaign lookup; it now errors asking for the campaign segment.
+	t.Run("B14_changed", func(t *testing.T) {
+		_, err := ParseEndpoint("archdtop:docs/x.md", fleet, noCampaigns)
+		if err == nil {
+			t.Fatal("want the missing-campaign error")
+		}
+		for _, want := range []string{"is a machine", "machine:campaign:path", "archdtop"} {
+			if !contains(err.Error(), want) {
+				t.Errorf("error %q missing %q", err.Error(), want)
+			}
+		}
+	})
+
+	// B16: local: is new capability, previously an error.
+	t.Run("B16_new", func(t *testing.T) {
+		got, err := ParseEndpoint("local:docs/x.md", fleet, noCampaigns)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.IsRemote() || got.Spec != "docs/x.md" {
+			t.Errorf("local: should force the campaign reading, got %+v", got)
+		}
+	})
+}
+
+func TestParseEndpointNewForms(t *testing.T) {
+	fleet := func(id string) bool { return id == "archdtop" || id == "other" }
+
+	t.Run("N1_remote_endpoint", func(t *testing.T) {
+		got, err := ParseEndpoint("archdtop:obey-campaign:docs/x.md", fleet, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Machine != "archdtop" || got.Campaign != "obey-campaign" || got.Path != "docs/x.md" {
+			t.Errorf("got %+v", got)
+		}
+	})
+
+	t.Run("N5_first_colon_applies_to_the_remainder_too", func(t *testing.T) {
+		got, err := ParseEndpoint("archdtop:obey-campaign:a:b", fleet, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Campaign != "obey-campaign" || got.Path != "a:b" {
+			t.Errorf("got %+v", got)
+		}
+	})
+
+	t.Run("N6_local_disambiguates_a_shadowed_name", func(t *testing.T) {
+		got, err := ParseEndpoint("local:other:docs/x.md", fleet, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.IsRemote() {
+			t.Errorf("local: must win over the machine reading, got %+v", got)
+		}
+		if got.Spec != "other:docs/x.md" {
+			t.Errorf("Spec = %q", got.Spec)
+		}
+	})
+
+	t.Run("shadowing_is_reported", func(t *testing.T) {
+		isCampaign := func(head string) bool { return head == "archdtop" }
+		got, err := ParseEndpoint("archdtop:obey-campaign:x.md", fleet, isCampaign)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !got.Shadowed {
+			t.Error("a head that is both a machine and a campaign must be flagged")
+		}
+		note := ShadowNote(got.Machine)
+		for _, want := range []string{"registered machine", "local:archdtop:"} {
+			if !contains(note, want) {
+				t.Errorf("note %q missing %q", note, want)
+			}
+		}
+	})
+
+	errorRows := []struct {
+		name string
+		spec string
+	}{
+		{"E1_machine_without_campaign", "archdtop:notes.md"},
+		{"E2_empty_path", "archdtop:obey-campaign:"},
+		{"E3_empty_campaign", "archdtop::notes.md"},
+	}
+	for _, tt := range errorRows {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ParseEndpoint(tt.spec, fleet, nil); err == nil {
+				t.Errorf("ParseEndpoint(%q) should error", tt.spec)
+			}
+		})
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(needle) == 0 || (len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0)
+}
+
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/transfer/endpoint_errors.go
+++ b/internal/transfer/endpoint_errors.go
@@ -1,0 +1,17 @@
+package transfer
+
+import camperrors "github.com/Obedience-Corp/camp/internal/errors"
+
+// newEndpointError explains a machine endpoint that is missing its campaign
+// segment. Falling back to the campaign reading would look for a campaign named
+// after the machine, fail with "campaign not found", and send the operator
+// hunting for a campaign when the real problem is a missing segment.
+func newEndpointError(machine, example string) error {
+	return camperrors.New("\"" + machine + "\" is a machine; use machine:campaign:path " +
+		"(for example " + machine + ":<campaign>:" + example + ")")
+}
+
+func newBothRemoteError(srcMachine, destMachine string) error {
+	return camperrors.New("at most one endpoint may be on another machine (got " +
+		srcMachine + " and " + destMachine + ")")
+}

--- a/internal/transfer/endpoint_shadow_test.go
+++ b/internal/transfer/endpoint_shadow_test.go
@@ -1,0 +1,66 @@
+package transfer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The shadow note is the only thing that tells an operator their spec was read
+// as a machine when it could also name a campaign. ParseEndpointDefault passed
+// a nil campaign lookup, so Shadowed was always false and the note was
+// unreachable in production; the feature only ever ran in tests that injected
+// their own lookup.
+func TestParseEndpointDefaultDetectsARealShadow(t *testing.T) {
+	dir := t.TempDir()
+
+	machinesPath := filepath.Join(dir, "machines.yaml")
+	if err := os.WriteFile(machinesPath, []byte(
+		"version: 1\nmachines:\n  - id: archdtop\n    host: archdtop.example.ts.net\n    user: lance\n"),
+		0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CAMP_MACHINES_PATH", machinesPath)
+
+	registryPath := filepath.Join(dir, "registry.json")
+	if err := os.WriteFile(registryPath, []byte(
+		`{"version":1,"campaigns":{"archdtop":{"name":"archdtop","path":"`+dir+`","status":"active"}}}`),
+		0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CAMP_REGISTRY_PATH", registryPath)
+
+	ep, err := ParseEndpointDefault(context.Background(), "archdtop:demo:notes.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ep.Machine != "archdtop" {
+		t.Fatalf("machine = %q, want the machine reading to win", ep.Machine)
+	}
+	if !ep.Shadowed {
+		t.Error("a head that is both a machine and a campaign must be reported as shadowed")
+	}
+}
+
+// The check must not fire on an unambiguous spec, or every transfer would carry
+// a note about nothing.
+func TestParseEndpointDefaultQuietWhenOnlyAMachineMatches(t *testing.T) {
+	dir := t.TempDir()
+	machinesPath := filepath.Join(dir, "machines.yaml")
+	if err := os.WriteFile(machinesPath, []byte(
+		"version: 1\nmachines:\n  - id: archdtop\n    host: archdtop.example.ts.net\n    user: lance\n"),
+		0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CAMP_MACHINES_PATH", machinesPath)
+	t.Setenv("CAMP_REGISTRY_PATH", filepath.Join(dir, "absent.json"))
+
+	ep, err := ParseEndpointDefault(context.Background(), "archdtop:demo:notes.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ep.Shadowed {
+		t.Error("no campaign of that name exists; nothing is shadowed")
+	}
+}

--- a/internal/transfer/remote.go
+++ b/internal/transfer/remote.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"path"
 	"strings"
@@ -99,6 +100,24 @@ func copyWithFallback(ctx context.Context, opts CopyOptions, src, dest string) e
 		return camperrors.New("rsync not found on " + opts.Machine.ID + " and scp not found locally; " +
 			"install rsync on both machines, or scp on this one")
 	}
+
+	// scp has no portable no-clobber flag, so the guard rsync gets from
+	// --ignore-existing has to be a separate look. Without this the fallback
+	// silently overwrote the destination and still reported "Transferred",
+	// which is the opposite of what the command promises without --force.
+	//
+	// This is a check-then-copy, not an atomic claim: it establishes the
+	// operator's consent, not exclusion against a concurrent writer.
+	if !opts.Force {
+		exists, err := opts.destinationExists(ctx, dest)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return ErrDestinationExists
+		}
+	}
+
 	out, runErr := opts.Run(ctx, "scp", opts.scpArgs(src, dest)...)
 	if runErr != nil {
 		return camperrors.Wrapf(runErr, "%s %s: %s", opts.direction(), opts.Machine.ID, trimOutput(out))
@@ -157,6 +176,36 @@ func (o CopyOptions) scpArgs(src, dest string) []string {
 	args := append([]string{}, remote.Opts(o.Machine)...)
 	args = append(args, "-o", "ServerAliveInterval=15", "-o", "ServerAliveCountMax=4")
 	return append(args, quoteRemote(src), quoteRemote(dest))
+}
+
+// destinationExists reports whether dest is already occupied. A pull writes
+// locally, so it is a stat; a push writes on the far machine, so it is one ssh
+// using the same option set as the copy, which the ControlMaster socket already
+// opened for the resolve.
+func (o CopyOptions) destinationExists(ctx context.Context, dest string) (bool, error) {
+	host, remotePath, isRemote := strings.Cut(dest, ":")
+	if !isRemote {
+		if _, err := os.Stat(dest); err == nil {
+			return true, nil
+		} else if !os.IsNotExist(err) {
+			return false, camperrors.Wrapf(err, "check destination %s", dest)
+		}
+		return false, nil
+	}
+
+	args := append([]string{}, remote.Opts(o.Machine)...)
+	args = append(args, host, "test", "-e", remote.ShellQuote(remotePath))
+	out, err := o.Run(ctx, "ssh", args...)
+	if err == nil {
+		return true, nil
+	}
+	// `test -e` exits 1 for "not there"; anything else is a real failure and
+	// must not be read as permission to overwrite.
+	var exitErr *exec.ExitError
+	if asExitError(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, camperrors.Wrapf(err, "check destination on %s: %s", o.Machine.ID, trimOutput(out))
 }
 
 func quoteRemote(spec string) string {

--- a/internal/transfer/remote.go
+++ b/internal/transfer/remote.go
@@ -81,9 +81,17 @@ func copyWithFallback(ctx context.Context, opts CopyOptions, src, dest string) e
 	if opts.LookPath == nil {
 		opts.LookPath = exec.LookPath
 	}
-	if _, err := opts.LookPath("rsync"); err == nil {
+	localRsyncOK := true
+	if _, err := opts.LookPath("rsync"); err != nil {
+		localRsyncOK = false
+	}
+	if localRsyncOK {
 		out, runErr := opts.Run(ctx, "rsync", opts.rsyncArgs(src, dest)...)
 		if runErr == nil {
+			// Empty itemize with --ignore-existing is treated as no-clobber.
+			// That is an inference from the current argv set (only
+			// --ignore-existing produces a quiet successful no-op); if flags
+			// grow later, map empty itemize through a distinct outcome first.
 			if !opts.Force && !rsyncCopied(out) {
 				return ErrDestinationExists
 			}
@@ -97,6 +105,10 @@ func copyWithFallback(ctx context.Context, opts CopyOptions, src, dest string) e
 	}
 
 	if _, err := opts.LookPath("scp"); err != nil {
+		if !localRsyncOK {
+			return camperrors.New("rsync not found locally and scp not found locally; " +
+				"install rsync (preferred) or scp on this machine")
+		}
 		return camperrors.New("rsync not found on " + opts.Machine.ID + " and scp not found locally; " +
 			"install rsync on both machines, or scp on this one")
 	}
@@ -132,12 +144,37 @@ func (o CopyOptions) endpoints(ctx context.Context) (src, dest string, err error
 	if err != nil {
 		return "", "", err
 	}
-	remotePath := path.Join(root, o.Endpoint.Path)
+	remotePath, err := joinWithinRemoteRoot(root, o.Endpoint.Path)
+	if err != nil {
+		return "", "", err
+	}
 	target := remote.Target(o.Machine) + ":" + remotePath
 	if o.Pull {
 		return target, o.Local, nil
 	}
 	return o.Local, target, nil
+}
+
+// joinWithinRemoteRoot joins a campaign-relative path onto a remote campaign
+// root, rejecting absolute paths and ".." escapes. path.Join alone would drop
+// prior segments on an absolute element and walk out of the campaign on "..".
+func joinWithinRemoteRoot(root, rel string) (string, error) {
+	if rel == "" {
+		return "", camperrors.New("remote path is empty")
+	}
+	if path.IsAbs(rel) || strings.HasPrefix(rel, "/") {
+		return "", camperrors.New("remote path must stay within the campaign (absolute path rejected)")
+	}
+	cleaned := path.Clean(rel)
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", camperrors.New("remote path escapes the campaign root")
+	}
+	// Clean can also yield "." for empty-ish input; path.Join(root, ".") is fine
+	// but still not a file transfer target we want to allow as Endpoint.Path.
+	if cleaned == "." {
+		return "", camperrors.New("remote path is empty")
+	}
+	return path.Join(root, cleaned), nil
 }
 
 func (o CopyOptions) direction() string {

--- a/internal/transfer/remote.go
+++ b/internal/transfer/remote.go
@@ -1,0 +1,199 @@
+package transfer
+
+import (
+	"context"
+	"os/exec"
+	"path"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/machines"
+	"github.com/Obedience-Corp/camp/internal/peer"
+	"github.com/Obedience-Corp/camp/internal/remote"
+)
+
+// rsyncStallTimeout aborts a transfer that has stopped making progress. It is
+// deliberately not a wall-clock deadline: a size-scaled bound needs the source
+// size, which for a pull lives on the far machine, and any rate constant turns a
+// slow link into a spurious failure on a transfer that was working. Stall
+// detection answers the question a timeout is actually asking.
+const rsyncStallTimeout = "60"
+
+// remoteMissingExit is rsync's protocol-error code. Paired with a
+// connection-closed message and zero bytes transferred, it is the signature of
+// "the far side has no rsync", which is the only condition that triggers the scp
+// fallback.
+const remoteMissingExit = 12
+
+// Runner executes a copy. Injected so the fallback and the argv are testable
+// without moving bytes between machines.
+type Runner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+// execRunner is the production Runner.
+func execRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+// lookPathFunc is injected so the scp fallback can be exercised on a machine
+// that has rsync, which both fleet members do.
+type lookPathFunc func(string) (string, error)
+
+// CopyOptions describes one cross-machine copy.
+type CopyOptions struct {
+	Machine  *machines.Machine
+	Endpoint Endpoint // the remote side
+	Local    string   // absolute local path
+	Pull     bool     // true: remote to local; false: local to remote
+	Force    bool     // overwrite an existing destination
+	Run      Runner
+	LookPath lookPathFunc
+}
+
+// CopyRemote moves one file between this machine and Machine, reusing the same
+// ssh option set as a hop so there is no second auth surface to keep in sync.
+//
+// rsync first, scp as a fallback. Neither is probed for on the far side: an
+// earlier design folded a probe into the resolve round-trip, which would have
+// corrupted every resolved path because ResolveRoot treats all of stdout as the
+// path. Remote absence is detected from the failed attempt instead, which is
+// also free in the common case.
+func CopyRemote(ctx context.Context, opts CopyOptions) error {
+	if opts.Run == nil {
+		opts.Run = execRunner
+	}
+	if opts.LookPath == nil {
+		opts.LookPath = exec.LookPath
+	}
+	src, dest, err := opts.endpoints(ctx)
+	if err != nil {
+		return err
+	}
+	return copyWithFallback(ctx, opts, src, dest)
+}
+
+// copyWithFallback is the copy step with the remote resolution already done, so
+// the fallback rule is testable without ssh.
+func copyWithFallback(ctx context.Context, opts CopyOptions, src, dest string) error {
+	if opts.Run == nil {
+		opts.Run = execRunner
+	}
+	if opts.LookPath == nil {
+		opts.LookPath = exec.LookPath
+	}
+	if _, err := opts.LookPath("rsync"); err == nil {
+		out, runErr := opts.Run(ctx, "rsync", opts.rsyncArgs(src, dest)...)
+		if runErr == nil {
+			if !opts.Force && !rsyncCopied(out) {
+				return ErrDestinationExists
+			}
+			return nil
+		}
+		if !remoteLacksRsync(runErr, out) {
+			return camperrors.Wrapf(runErr, "%s %s: %s", opts.direction(), opts.Machine.ID, trimOutput(out))
+		}
+		// Safe to retry: rsync never started a data stream, so nothing was
+		// written on either side.
+	}
+
+	if _, err := opts.LookPath("scp"); err != nil {
+		return camperrors.New("rsync not found on " + opts.Machine.ID + " and scp not found locally; " +
+			"install rsync on both machines, or scp on this one")
+	}
+	out, runErr := opts.Run(ctx, "scp", opts.scpArgs(src, dest)...)
+	if runErr != nil {
+		return camperrors.Wrapf(runErr, "%s %s: %s", opts.direction(), opts.Machine.ID, trimOutput(out))
+	}
+	return nil
+}
+
+// endpoints resolves the remote campaign root through the remote's OWN camp, so
+// the far registry decides the path and this machine never computes it.
+func (o CopyOptions) endpoints(ctx context.Context) (src, dest string, err error) {
+	root, err := remote.ResolveRoot(ctx, o.Machine, o.Endpoint.Campaign)
+	if err != nil {
+		return "", "", err
+	}
+	remotePath := path.Join(root, o.Endpoint.Path)
+	target := remote.Target(o.Machine) + ":" + remotePath
+	if o.Pull {
+		return target, o.Local, nil
+	}
+	return o.Local, target, nil
+}
+
+func (o CopyOptions) direction() string {
+	if o.Pull {
+		return "pull from"
+	}
+	return "push to"
+}
+
+// rsyncArgs mirrors the artifact-pull argv minus the pieces that exist for a
+// no-clobber directory sync: no --compare-dest, no exclude file, no staging
+// tree. -s sends paths through the rsync protocol so spaces and metacharacters
+// do not depend on remote-shell parsing.
+func (o CopyOptions) rsyncArgs(src, dest string) []string {
+	// --itemize-changes makes the skip observable: with --ignore-existing rsync
+	// exits 0 whether it copied or declined, and reporting "Transferred" for a
+	// file that was left alone is a lie the operator acts on.
+	args := []string{"-a", "-s", "--no-links", "--itemize-changes", "--timeout=" + rsyncStallTimeout}
+	if !o.Force {
+		// The local guard is an os.Stat that cannot run for a remote
+		// destination, and a pre-check would be racy anyway. Enforcing it at
+		// the write itself keeps the user-visible contract identical: nothing
+		// is clobbered without --force.
+		args = append(args, "--ignore-existing")
+	}
+	if sshCmd := peer.SSHCommandFor(o.Machine); sshCmd != "" {
+		args = append(args, "-e", sshCmd)
+	}
+	return append(args, src, dest)
+}
+
+// scpArgs passes the same option set as flags rather than inside -e. Remote
+// paths go through the remote shell in this mode, so they are quoted; that is
+// the layer rsync's -s makes unnecessary.
+func (o CopyOptions) scpArgs(src, dest string) []string {
+	args := append([]string{}, remote.Opts(o.Machine)...)
+	args = append(args, "-o", "ServerAliveInterval=15", "-o", "ServerAliveCountMax=4")
+	return append(args, quoteRemote(src), quoteRemote(dest))
+}
+
+func quoteRemote(spec string) string {
+	host, p, ok := strings.Cut(spec, ":")
+	if !ok {
+		return spec
+	}
+	return host + ":" + remote.ShellQuote(p)
+}
+
+// remoteLacksRsync reports the one failure that justifies retrying with scp.
+func remoteLacksRsync(err error, out []byte) bool {
+	var exitErr *exec.ExitError
+	if !asExitError(err, &exitErr) || exitErr.ExitCode() != remoteMissingExit {
+		return false
+	}
+	text := strings.ToLower(string(out))
+	return strings.Contains(text, "connection unexpectedly closed") ||
+		strings.Contains(text, "command not found")
+}
+
+func trimOutput(out []byte) string {
+	return strings.TrimSpace(string(out))
+}
+
+// rsyncCopied reports whether an --itemize-changes run actually sent a file. An
+// itemized transfer line starts with '<' or '>' (direction); a run that only
+// declined existing files prints nothing itemized.
+func rsyncCopied(out []byte) bool {
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if line[0] == '<' || line[0] == '>' {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/transfer/remote_errors.go
+++ b/internal/transfer/remote_errors.go
@@ -1,0 +1,18 @@
+package transfer
+
+import (
+	"errors"
+	"os/exec"
+)
+
+// asExitError is errors.As specialized to *exec.ExitError, kept separate so the
+// fallback rule reads as one condition rather than three lines of plumbing.
+func asExitError(err error, target **exec.ExitError) bool {
+	return errors.As(err, target)
+}
+
+// ErrDestinationExists reports that a copy was declined because the destination
+// already existed and --force was not given. It is a distinct error so the
+// caller can phrase it as the deliberate no-clobber outcome rather than a
+// transport failure.
+var ErrDestinationExists = errors.New("destination already exists (use --force to overwrite)")

--- a/internal/transfer/remote_test.go
+++ b/internal/transfer/remote_test.go
@@ -171,6 +171,8 @@ func TestCopyRemoteDoesNotFallBackOnARealFailure(t *testing.T) {
 }
 
 func TestCopyRemoteMissingBothBinaries(t *testing.T) {
+	// Local rsync was never found, so the message must blame this machine —
+	// not the remote, which was never probed for rsync.
 	opts := CopyOptions{
 		Machine:  testMachine(),
 		LookPath: func(string) (string, error) { return "", errors.New("not found") },
@@ -180,10 +182,73 @@ func TestCopyRemoteMissingBothBinaries(t *testing.T) {
 	if err == nil {
 		t.Fatal("want an error")
 	}
-	for _, want := range []string{"rsync not found on archdtop", "scp not found locally"} {
+	for _, want := range []string{"rsync not found locally", "scp not found locally"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error must name which binary is missing where: %v", err)
 		}
+	}
+	if strings.Contains(err.Error(), "on archdtop") {
+		t.Errorf("must not blame the remote when local rsync was never attempted: %v", err)
+	}
+}
+
+func TestCopyRemoteMissingRemoteRsyncAndLocalScp(t *testing.T) {
+	// Local rsync ran and hit the remote-missing signature; scp is also gone.
+	opts := CopyOptions{
+		Machine: testMachine(),
+		LookPath: func(name string) (string, error) {
+			if name == "rsync" {
+				return "/usr/bin/rsync", nil
+			}
+			return "", errors.New("not found")
+		},
+		Run: func(_ context.Context, name string, _ ...string) ([]byte, error) {
+			if name == "rsync" {
+				return []byte("rsync: connection unexpectedly closed"), runExit(t, 12)
+			}
+			return nil, nil
+		},
+	}
+	err := copyWithFallback(context.Background(), opts, "s", "d")
+	if err == nil {
+		t.Fatal("want an error")
+	}
+	if !strings.Contains(err.Error(), "rsync not found on archdtop") {
+		t.Errorf("remote-missing signature should blame remote: %v", err)
+	}
+}
+
+func TestJoinWithinRemoteRoot(t *testing.T) {
+	tests := []struct {
+		name    string
+		root    string
+		rel     string
+		want    string
+		wantErr string
+	}{
+		{name: "simple", root: "/srv/camp", rel: "docs/x.md", want: "/srv/camp/docs/x.md"},
+		{name: "cleans dots", root: "/srv/camp", rel: "docs/./x.md", want: "/srv/camp/docs/x.md"},
+		{name: "absolute rejected", root: "/srv/camp", rel: "/etc/passwd", wantErr: "absolute"},
+		{name: "dotdot rejected", root: "/srv/camp", rel: "../../.ssh/id_rsa", wantErr: "escapes"},
+		{name: "empty rejected", root: "/srv/camp", rel: "", wantErr: "empty"},
+		{name: "dot alone rejected", root: "/srv/camp", rel: ".", wantErr: "empty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := joinWithinRemoteRoot(tt.root, tt.rel)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/transfer/remote_test.go
+++ b/internal/transfer/remote_test.go
@@ -1,0 +1,185 @@
+package transfer
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/machines"
+)
+
+func testMachine() *machines.Machine {
+	return &machines.Machine{
+		ID:         "archdtop",
+		Host:       "archdtop.tail37114b.ts.net",
+		SSHUser:    "lance",
+		AuthMethod: machines.AuthTailscaleSSH,
+	}
+}
+
+func TestRsyncArgsShape(t *testing.T) {
+	o := CopyOptions{Machine: testMachine(), Force: false}
+	args := strings.Join(o.rsyncArgs("src", "dest"), " ")
+
+	for _, want := range []string{"-a", "-s", "--no-links", "--timeout=60", "--ignore-existing", "-e "} {
+		if !strings.Contains(args, want) {
+			t.Errorf("rsync args missing %q: %s", want, args)
+		}
+	}
+	// Copy-only is structural: no argv in any path may carry a delete flag.
+	for _, forbidden := range []string{"--delete", "--remove-source-files"} {
+		if strings.Contains(args, forbidden) {
+			t.Errorf("rsync args carry %q, which would break the copy-only invariant: %s", forbidden, args)
+		}
+	}
+	// The ssh options must come from the shared builder, not a second copy.
+	if !strings.Contains(args, "ControlMaster=auto") || !strings.Contains(args, "BatchMode=yes") {
+		t.Errorf("rsync -e value is not the shared hop option set: %s", args)
+	}
+}
+
+func TestRsyncForceDropsIgnoreExisting(t *testing.T) {
+	o := CopyOptions{Machine: testMachine(), Force: true}
+	if strings.Contains(strings.Join(o.rsyncArgs("s", "d"), " "), "--ignore-existing") {
+		t.Error("--force must allow the overwrite")
+	}
+}
+
+func TestScpArgsQuoteTheRemotePath(t *testing.T) {
+	o := CopyOptions{Machine: testMachine()}
+	args := o.scpArgs("lance@host:/srv/a b/c.md", "/local/x.md")
+	joined := strings.Join(args, " ")
+
+	if !strings.Contains(joined, `'/srv/a b/c.md'`) {
+		t.Errorf("remote path must be quoted for the remote shell: %s", joined)
+	}
+	if !strings.Contains(joined, "ServerAliveInterval=15") {
+		t.Errorf("scp needs keepalives, since it has no --timeout: %s", joined)
+	}
+	if strings.Contains(joined, "'/local/x.md'") {
+		t.Errorf("the local path must not be shell-quoted; it never reaches a shell: %s", joined)
+	}
+}
+
+func TestRemoteLacksRsyncSignature(t *testing.T) {
+	exit12 := runExit(t, 12)
+	exit1 := runExit(t, 1)
+
+	tests := []struct {
+		name string
+		err  error
+		out  string
+		want bool
+	}{
+		{"exit 12 with connection closed", exit12, "rsync: connection unexpectedly closed", true},
+		{"exit 12 with command not found", exit12, "bash: rsync: command not found", true},
+		// Exit 12 is a general protocol error; without the signature it is a
+		// real failure, and retrying with scp would hide it.
+		{"exit 12 alone is not the signature", exit12, "some other protocol error", false},
+		{"a different exit code is not the signature", exit1, "connection unexpectedly closed", false},
+		{"a non-exec error is not the signature", errors.New("boom"), "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := remoteLacksRsync(tt.err, []byte(tt.out)); got != tt.want {
+				t.Errorf("remoteLacksRsync = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// runExit produces a real *exec.ExitError with the given code.
+func runExit(t *testing.T, code int) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", "exit "+itoa(code)).Run()
+	if err == nil {
+		t.Fatalf("expected a non-zero exit")
+	}
+	return err
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}
+
+func TestCopyRemoteFallsBackToScpOnlyOnTheSignature(t *testing.T) {
+	// Both fleet machines have rsync, so the fallback can never be exercised
+	// naturally. Forcing it here is the only way it ships executed.
+	var calls []string
+	opts := CopyOptions{
+		Machine:  testMachine(),
+		Endpoint: Endpoint{Machine: "archdtop", Campaign: "c", Path: "x.md"},
+		Local:    "/local/x.md",
+		Pull:     true,
+		LookPath: func(string) (string, error) { return "/usr/bin/found", nil },
+		Run: func(_ context.Context, name string, _ ...string) ([]byte, error) {
+			calls = append(calls, name)
+			if name == "rsync" {
+				return []byte("rsync: connection unexpectedly closed"), runExit(t, 12)
+			}
+			return nil, nil
+		},
+	}
+	// resolveRoot would need ssh, so drive the copy step directly.
+	if _, runErr := opts.Run(context.Background(), "rsync"); runErr == nil {
+		t.Fatal("fixture should fail")
+	}
+	calls = nil
+
+	if err := copyWithFallback(context.Background(), opts, "remote:src", "/local/x.md"); err != nil {
+		t.Fatalf("fallback should succeed: %v", err)
+	}
+	if strings.Join(calls, ",") != "rsync,scp" {
+		t.Errorf("call sequence = %v, want rsync then scp", calls)
+	}
+}
+
+func TestCopyRemoteDoesNotFallBackOnARealFailure(t *testing.T) {
+	var calls []string
+	opts := CopyOptions{
+		Machine:  testMachine(),
+		Pull:     true,
+		LookPath: func(string) (string, error) { return "/usr/bin/found", nil },
+		Run: func(_ context.Context, name string, _ ...string) ([]byte, error) {
+			calls = append(calls, name)
+			return []byte("permission denied"), runExit(t, 23)
+		},
+	}
+	err := copyWithFallback(context.Background(), opts, "remote:src", "/local/x.md")
+	if err == nil {
+		t.Fatal("a real failure must surface, not silently retry")
+	}
+	if strings.Join(calls, ",") != "rsync" {
+		t.Errorf("scp must not run for a non-signature failure, calls = %v", calls)
+	}
+	if !strings.Contains(err.Error(), "pull from archdtop") {
+		t.Errorf("error must name direction and machine: %v", err)
+	}
+}
+
+func TestCopyRemoteMissingBothBinaries(t *testing.T) {
+	opts := CopyOptions{
+		Machine:  testMachine(),
+		LookPath: func(string) (string, error) { return "", errors.New("not found") },
+		Run:      func(context.Context, string, ...string) ([]byte, error) { return nil, nil },
+	}
+	err := copyWithFallback(context.Background(), opts, "s", "d")
+	if err == nil {
+		t.Fatal("want an error")
+	}
+	for _, want := range []string{"rsync not found on archdtop", "scp not found locally"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error must name which binary is missing where: %v", err)
+		}
+	}
+}

--- a/internal/transfer/remote_test.go
+++ b/internal/transfer/remote_test.go
@@ -3,7 +3,10 @@ package transfer
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -181,5 +184,156 @@ func TestCopyRemoteMissingBothBinaries(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error must name which binary is missing where: %v", err)
 		}
+	}
+}
+
+// rsync honors --force through --ignore-existing. scp has no portable
+// equivalent, so without an explicit look the fallback silently overwrote the
+// destination and still reported success -- the opposite of what the command
+// promises without --force.
+func TestCopyRemoteScpFallbackRefusesToClobberLocalDestination(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "x.md")
+	if err := os.WriteFile(dest, []byte("do not lose me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls []string
+	opts := CopyOptions{
+		Machine:  testMachine(),
+		Pull:     true,
+		LookPath: func(string) (string, error) { return "/usr/bin/found", nil },
+		Run: func(_ context.Context, name string, _ ...string) ([]byte, error) {
+			calls = append(calls, name)
+			if name == "rsync" {
+				return []byte("rsync: connection unexpectedly closed"), runExit(t, 12)
+			}
+			return nil, nil
+		},
+	}
+
+	err := copyWithFallback(context.Background(), opts, "remote:src", dest)
+	if !errors.Is(err, ErrDestinationExists) {
+		t.Fatalf("err = %v, want ErrDestinationExists", err)
+	}
+	if slices.Contains(calls, "scp") {
+		t.Errorf("scp ran despite an occupied destination: %v", calls)
+	}
+	body, readErr := os.ReadFile(dest)
+	if readErr != nil || string(body) != "do not lose me" {
+		t.Errorf("destination was modified: %q (%v)", body, readErr)
+	}
+}
+
+// A push writes on the far machine, so the same guard has to be one ssh.
+func TestCopyRemoteScpFallbackRefusesToClobberRemoteDestination(t *testing.T) {
+	var calls []string
+	opts := CopyOptions{
+		Machine:  testMachine(),
+		LookPath: func(string) (string, error) { return "/usr/bin/found", nil },
+		Run: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			calls = append(calls, name)
+			switch name {
+			case "rsync":
+				return []byte("rsync: connection unexpectedly closed"), runExit(t, 12)
+			case "ssh":
+				if !slices.Contains(args, "test") {
+					t.Errorf("ssh probe should run test -e, got %v", args)
+				}
+				return nil, nil // exit 0: the file is there
+			}
+			return nil, nil
+		},
+	}
+
+	err := copyWithFallback(context.Background(), opts, "/local/x.md", "archdtop:/remote/x.md")
+	if !errors.Is(err, ErrDestinationExists) {
+		t.Fatalf("err = %v, want ErrDestinationExists", err)
+	}
+	if !slices.Contains(calls, "ssh") {
+		t.Errorf("no existence probe ran before scp: %v", calls)
+	}
+	if slices.Contains(calls, "scp") {
+		t.Errorf("scp ran despite an occupied destination: %v", calls)
+	}
+}
+
+func TestCopyRemoteScpFallbackCopiesWhenRemoteDestinationIsFree(t *testing.T) {
+	var calls []string
+	opts := CopyOptions{
+		Machine:  testMachine(),
+		LookPath: func(string) (string, error) { return "/usr/bin/found", nil },
+		Run: func(_ context.Context, name string, _ ...string) ([]byte, error) {
+			calls = append(calls, name)
+			switch name {
+			case "rsync":
+				return []byte("rsync: connection unexpectedly closed"), runExit(t, 12)
+			case "ssh":
+				return nil, runExit(t, 1) // test -e says "not there"
+			}
+			return nil, nil
+		},
+	}
+	if err := copyWithFallback(context.Background(), opts, "/local/x.md", "archdtop:/remote/x.md"); err != nil {
+		t.Fatalf("a free destination must copy: %v", err)
+	}
+	if !slices.Contains(calls, "scp") {
+		t.Errorf("scp never ran: %v", calls)
+	}
+}
+
+// --force is the consent the guard exists to require, so it must not pay for a
+// probe it would ignore.
+func TestCopyRemoteScpFallbackSkipsTheProbeUnderForce(t *testing.T) {
+	var calls []string
+	opts := CopyOptions{
+		Machine:  testMachine(),
+		Force:    true,
+		LookPath: func(string) (string, error) { return "/usr/bin/found", nil },
+		Run: func(_ context.Context, name string, _ ...string) ([]byte, error) {
+			calls = append(calls, name)
+			if name == "rsync" {
+				return []byte("rsync: connection unexpectedly closed"), runExit(t, 12)
+			}
+			return nil, nil
+		},
+	}
+	if err := copyWithFallback(context.Background(), opts, "/local/x.md", "archdtop:/remote/x.md"); err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(calls, "ssh") {
+		t.Errorf("--force should not probe: %v", calls)
+	}
+	if !slices.Contains(calls, "scp") {
+		t.Errorf("scp never ran: %v", calls)
+	}
+}
+
+// A probe that fails for any reason other than "not there" says nothing about
+// the destination, and must not be read as permission to overwrite it.
+func TestCopyRemoteScpFallbackTreatsAFailedProbeAsAnError(t *testing.T) {
+	var calls []string
+	opts := CopyOptions{
+		Machine:  testMachine(),
+		LookPath: func(string) (string, error) { return "/usr/bin/found", nil },
+		Run: func(_ context.Context, name string, _ ...string) ([]byte, error) {
+			calls = append(calls, name)
+			switch name {
+			case "rsync":
+				return []byte("rsync: connection unexpectedly closed"), runExit(t, 12)
+			case "ssh":
+				return []byte("permission denied"), runExit(t, 255)
+			}
+			return nil, nil
+		},
+	}
+	err := copyWithFallback(context.Background(), opts, "/local/x.md", "archdtop:/remote/x.md")
+	if err == nil {
+		t.Fatal("an unreadable destination must not be overwritten")
+	}
+	if errors.Is(err, ErrDestinationExists) {
+		t.Errorf("a probe failure is not the same as an occupied destination: %v", err)
+	}
+	if slices.Contains(calls, "scp") {
+		t.Errorf("scp ran after an inconclusive probe: %v", calls)
 	}
 }


### PR DESCRIPTION
> **Stacked on #507** (chain: #504 → #505 → #506 → #507). Base is `mesh-snapshot-push`.

Makes `camp transfer` work across machines: `camp transfer archdtop:obey-campaign:docs/x.md docs/`.

Festival MN0001, phase 005 sequence 02. Design: `003_DESIGN/03_transfer_reach/outputs/transfer-grammar-spec.md` and `transfer-transport-spec.md`.

## Backward compatibility was measured, not asserted

The compat matrix was written **first**, against the unchanged parser, and watched to pass. Only then did the parser change. Ten rows are pinned unchanged; exactly the two the design flagged moved.

The behavior change is gated on the leading segment matching a **registered machine id**, so a user with no `~/.obey/machines.yaml` gets byte-identical behavior. On an unconfigured fleet the new grammar is unreachable.

Live, against the real registry:

```
$ camp transfer weird:name.md /tmp/zzz          # unchanged
Error: resolve source: campaign "weird" not found in registry

$ camp transfer archdtop:notes.md /tmp/zzz      # the one change
Error: resolve source: "archdtop" is a machine; use machine:campaign:path (for example archdtop:<campaign>:notes.md)
```

That row used to fail a campaign lookup for a campaign named `archdtop`, sending the operator hunting for the wrong thing. `local:` is also new (it was an error before) and exists so registering a machine can never make a campaign unreachable by name.

## Transport

The far campaign root is resolved by the **remote's own camp**; nothing computes a far path locally. The copy rides the same ssh option set a hop uses, via `internal/peer`'s builder rather than a second construction, which is what makes "no new auth surface" structural.

**This applies the D005 amendment raised during design.** D005 said scp; reading CS0005 showed camp already has a reviewed, ssh-multiplexed **rsync** transport, and rsync brings path quoting through the protocol (`-s`), stall detection, and partial-transfer semantics scp has no vocabulary for. scp stays as the fallback since it ships with OpenSSH. If you'd rather keep D005 as written, the fallback ordering is the only thing that changes.

**Neither side is probed.** An earlier design folded a probe into the resolve round-trip, which would have corrupted every resolved remote path, because `ResolveRoot` treats *all* of stdout as the path. Remote absence is detected from the failed attempt instead (exit 12 + connection-closed + nothing transferred), which is free in the common case and safe to retry precisely because no data stream started.

**No wall-clock deadline on the copy.** A size-scaled bound needs the source size, which for a pull lives on the far machine, and any rate constant turns a slow link into a spurious failure. `rsync --timeout` detects a *stall*, which is the question a timeout is actually asking. scp gets keepalives.

## Live verification (mac-studio ↔ archdtop)

```
$ camp transfer mesh-test.txt archdtop:lance-arch:mesh-test.txt
Transferred mesh-test.txt -> archdtop:lance-arch:mesh-test.txt
$ ssh archdtop 'cat .../mesh-test.txt'
mesh transfer live test 115243

$ camp transfer mesh-test.txt archdtop:lance-arch:mesh-test.txt      # no --force
Error: destination exists on archdtop, not overwritten (use --force)

$ camp transfer ... --force        → overwrote, confirmed by reading the remote file
$ camp transfer archdtop:lance-arch:mesh-test.txt pulled.txt   → pulled, source untouched
```

Test files removed from both machines afterward.

## A defect only the live run could find

Without `--force` the copy correctly declined to overwrite and then printed **"Transferred"**. rsync exits 0 whether `--ignore-existing` copied or skipped, so the command reported success for a file it had left alone, which an operator would act on. Fixed with `--itemize-changes` and an explicit transfer-line check. Every unit test passed before and after the fix.

## Tests

`just gate` green: 3802.

Worth noting: **both fleet machines have rsync**, so the scp fallback can never be exercised naturally. It is forced in a test, which is the only way it ships executed rather than assumed. The fallback signature test also pins that exit 12 *alone* is not enough — it is a general protocol error, and retrying on it would hide real failures.

## Scope limit

Directories are not supported cross-machine here; local-to-local keeps its existing directory support, so nothing that worked stops working. Recursive copy interacts with the no-delete invariant, symlink policy, and partial-transfer reporting in ways that deserve their own pass.
