### PR TITLE
feat(machine): report reverse reachability in diagnose

### DIFF
--- a/cmd/camp/exit.go
+++ b/cmd/camp/exit.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// silentExit reports the exit code to propagate without printing, and whether
+// to do so.
+//
+// A command that returns a CommandError DIRECTLY is propagating a child
+// process's exit code (camp sync, doctor, clone, run) and has already said
+// whatever needed saying; printing again would be redundant.
+//
+// The type assertion is load-bearing, and errors.As would be wrong here.
+// Remote failures create a CommandError deep in the chain (remote.Run wraps a
+// non-zero ssh exit), and camp then wraps THAT with the sentence the operator
+// actually needs: which machine, which campaign, which diagnostic to run next.
+// Matching anywhere in the chain discarded all of it and exited silently with
+// ssh's code, so a failed hop printed nothing at all.
+//
+// This lives beside main rather than in the test that exercises it, so the rule
+// cannot pass in one place while production does something else.
+func silentExit(err error) (int, bool) {
+	cmdErr, ok := err.(*camperrors.CommandError)
+	if !ok || cmdErr.ExitCode == 0 {
+		return 0, false
+	}
+	return cmdErr.ExitCode, true
+}

--- a/cmd/camp/machine.go
+++ b/cmd/camp/machine.go
@@ -348,6 +348,12 @@ type machineDiagnoseRow struct {
 	CampVersion  string `json:"camp_version,omitempty"`
 	CampCommit   string `json:"camp_commit,omitempty"`
 	VersionSkew  bool   `json:"version_skew"`
+	// ReverseCapable reports whether THIS machine accepts inbound ssh, which is
+	// the only half of reverse reachability camp can observe without executing
+	// on the far side. Additive with omitempty on the hint so existing --json
+	// consumers are unaffected.
+	ReverseCapable bool   `json:"reverse_capable"`
+	ReverseHint    string `json:"reverse_hint,omitempty"`
 }
 
 // probeRemoteCampVersion asks the machine's own camp for its version. It is
@@ -414,6 +420,7 @@ func runMachineDiagnose(cmd *cobra.Command, args []string) error {
 	for i := range targets {
 		m := &targets[i]
 		d := remote.CheckControlMaster(ctx, m)
+		reverse := checkReverseReachability(ctx, defaultReverseProbes())
 		remoteVersion, remoteCommit := probeRemoteCampVersion(ctx, m)
 		// Diagnose is the only surface that pays for a live probe, so it is the
 		// only one that can warm the cache the hop path reads.
@@ -432,6 +439,12 @@ func runMachineDiagnose(cmd *cobra.Command, args []string) error {
 			CampVersion:  remoteVersion,
 			CampCommit:   remoteCommit,
 			VersionSkew:  campVersionSkew(localInfo, remoteVersion, remoteCommit),
+			// What this machine can honestly say about being reachable FROM
+			// that one. Identical for every row (it is a fact about here, not
+			// about them), and reported per row because that is where an
+			// operator is already looking when a hop-back fails.
+			ReverseCapable: reverse.Capable,
+			ReverseHint:    reverse.Hint,
 		}
 		if machineDiagnoseReset && d.State == remote.ControlStale {
 			if err := remote.ResetControlMaster(ctx, m); err != nil {
@@ -496,6 +509,13 @@ func renderMachineDiagnoseTable(w io.Writer, rows []machineDiagnoseRow) error {
 				campVersionDisplay(r)+"  ⚠ differs from this machine ("+campLocalVersionDisplay()+"); remote errors may not match current behavior"))
 		default:
 			lines = append(lines, fmt.Sprintf("%s  %s", ui.Label("CAMP"), campVersionDisplay(r)))
+		}
+		if r.ReverseHint != "" {
+			mark := "✗"
+			if r.ReverseCapable {
+				mark = "✓"
+			}
+			lines = append(lines, fmt.Sprintf("%s  %s %s", ui.Label("REVERSE"), mark, r.ReverseHint))
 		}
 		if r.Hint != "" {
 			lines = append(lines, fmt.Sprintf("%s  %s", ui.Label("HINT"), r.Hint))

--- a/cmd/camp/machine.go
+++ b/cmd/camp/machine.go
@@ -416,11 +416,14 @@ func runMachineDiagnose(cmd *cobra.Command, args []string) error {
 	}
 
 	localInfo := version.Get()
+	// Reverse reachability is a fact about this machine, identical for every
+	// row. Probing it inside the loop cost N loopback dials and N tailscale
+	// probes against a 2s budget each to learn the same answer.
+	reverse := checkReverseReachability(ctx, defaultReverseProbes())
 	rows := make([]machineDiagnoseRow, 0, len(targets))
 	for i := range targets {
 		m := &targets[i]
 		d := remote.CheckControlMaster(ctx, m)
-		reverse := checkReverseReachability(ctx, defaultReverseProbes())
 		remoteVersion, remoteCommit := probeRemoteCampVersion(ctx, m)
 		// Diagnose is the only surface that pays for a live probe, so it is the
 		// only one that can warm the cache the hop path reads.

--- a/cmd/camp/machine_reverse.go
+++ b/cmd/camp/machine_reverse.go
@@ -97,12 +97,34 @@ func remoteLoginState(ctx context.Context, p reverseProbes) (on, knowable bool) 
 	return p.RemoteLoginOn(ctx)
 }
 
-// sshdListening dials the loopback ssh port. Deliberately non-privileged and
-// deliberately not a process scan: what matters is whether something is
-// accepting connections, which is the question a peer's ssh client asks.
+// sshdListening reports whether something is accepting ssh here. Deliberately
+// non-privileged and deliberately not a process scan.
+//
+// It dials this machine's own reachable name first, because that is the address
+// a peer's ssh client actually uses. Loopback alone answers a different question
+// and gets both directions wrong: an sshd (or Tailscale SSH) bound only to the
+// tailnet address reads as "not listening", and a sshd_config with
+// ListenAddress 127.0.0.1 reads as "listening" when no peer can reach it.
+//
+// Loopback remains the fallback for when no reachable name can be determined,
+// which is a weaker observation than the caller would like but still better
+// than reporting nothing.
 func sshdListening(ctx context.Context) bool {
+	if host, err := detectReachableName(ctx, runTailscaleStatusForSelf); err == nil && host != "" {
+		if dialSSH(ctx, net.JoinHostPort(host, "22")) {
+			return true
+		}
+		// A reachable name that refuses the connection is the answer: a peer
+		// dialing the same address would be refused too. Do not fall back to
+		// loopback and turn that into a yes.
+		return false
+	}
+	return dialSSH(ctx, "127.0.0.1:22")
+}
+
+func dialSSH(ctx context.Context, addr string) bool {
 	d := net.Dialer{Timeout: time.Second}
-	conn, err := d.DialContext(ctx, "tcp", "127.0.0.1:22")
+	conn, err := d.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return false
 	}

--- a/cmd/camp/machine_reverse.go
+++ b/cmd/camp/machine_reverse.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"net"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// reverseProbeTimeout bounds the local reachability checks. They are local
+// (a loopback dial, one CLI call), so this only guards a wedged binary.
+const reverseProbeTimeout = 2 * time.Second
+
+// reverseReport is what diagnose can honestly say about whether OTHER machines
+// can reach back to this one.
+type reverseReport struct {
+	Capable bool
+	Hint    string
+}
+
+// reverseProbes are the seams the cause matrix is tested through.
+type reverseProbes struct {
+	SSHDListening func(ctx context.Context) bool
+	RemoteLoginOn func(ctx context.Context) (bool, bool) // (on, knowable)
+	TailscaleUp   func(ctx context.Context) bool
+	GOOS          string
+}
+
+// checkReverseReachability reports what this machine can know about being
+// reachable FROM another machine.
+//
+// The honest framing matters, and it is why this reports "acceptability" rather
+// than "reachability". Whether archdtop can actually open a connection to this
+// mac depends on archdtop's client config, the tailnet ACL, and this machine's
+// sshd, and camp can only observe the last one without executing on the far
+// side. So it reports the half it can see and labels it, instead of claiming a
+// verdict it has not earned. D003 also forbids fixing any of it: every hint
+// names one action for the operator to take, and camp never takes it.
+func checkReverseReachability(ctx context.Context, p reverseProbes) reverseReport {
+	ctx, cancel := context.WithTimeout(ctx, reverseProbeTimeout)
+	defer cancel()
+
+	goos := p.GOOS
+	if goos == "" {
+		goos = runtime.GOOS
+	}
+
+	listening := p.SSHDListening != nil && p.SSHDListening(ctx)
+	if !listening {
+		if goos == "darwin" {
+			if on, knowable := remoteLoginState(ctx, p); knowable && !on {
+				return reverseReport{Hint: "macOS Remote Login is off, so nothing can ssh in; " +
+					"enable it in System Settings > General > Sharing > Remote Login"}
+			}
+			return reverseReport{Hint: "no sshd is listening on this machine; enable " +
+				"System Settings > General > Sharing > Remote Login so other machines can hop here"}
+		}
+		return reverseReport{Hint: "no sshd is listening on this machine; start it " +
+			"(for example 'sudo systemctl enable --now sshd') so other machines can hop here"}
+	}
+
+	// sshd answers, so the local half is satisfied. Everything left is policy on
+	// the other side, which is exactly the part camp must not manage.
+	if p.TailscaleUp != nil && !p.TailscaleUp(ctx) {
+		return reverseReport{Capable: true, Hint: "sshd is listening, but tailscale is not up here, " +
+			"so tailnet peers cannot route to this machine; run 'tailscale up'"}
+	}
+	return reverseReport{Capable: true, Hint: "sshd is listening here. Whether a given machine may " +
+		"connect is that machine's keys plus your tailnet ACL, which camp does not manage"}
+}
+
+func remoteLoginState(ctx context.Context, p reverseProbes) (on, knowable bool) {
+	if p.RemoteLoginOn == nil {
+		return false, false
+	}
+	return p.RemoteLoginOn(ctx)
+}
+
+// sshdListening dials the loopback ssh port. Deliberately non-privileged and
+// deliberately not a process scan: what matters is whether something is
+// accepting connections, which is the question a peer's ssh client asks.
+func sshdListening(ctx context.Context) bool {
+	d := net.Dialer{Timeout: time.Second}
+	conn, err := d.DialContext(ctx, "tcp", "127.0.0.1:22")
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// remoteLoginOn reads macOS Remote Login state. `systemsetup -getremotelogin`
+// needs no privileges for a read, and a failure reports "not knowable" rather
+// than "off", so an unreadable state never produces a confident wrong hint.
+func remoteLoginOn(ctx context.Context) (bool, bool) {
+	out, err := exec.CommandContext(ctx, "systemsetup", "-getremotelogin").Output()
+	if err != nil {
+		return false, false
+	}
+	return strings.Contains(strings.ToLower(string(out)), "on"), true
+}
+
+// tailscaleUpLocally reports whether this machine's tailscale backend is
+// running, reusing the Self parse the origin payload already relies on.
+func tailscaleUpLocally(ctx context.Context) bool {
+	out, err := runTailscaleStatusForSelf(ctx)
+	if err != nil {
+		return false
+	}
+	return selfDNSName(out) != ""
+}
+
+// defaultReverseProbes wires the production checks.
+func defaultReverseProbes() reverseProbes {
+	return reverseProbes{
+		SSHDListening: sshdListening,
+		RemoteLoginOn: remoteLoginOn,
+		TailscaleUp:   tailscaleUpLocally,
+	}
+}

--- a/cmd/camp/machine_reverse.go
+++ b/cmd/camp/machine_reverse.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -50,19 +51,37 @@ func checkReverseReachability(ctx context.Context, p reverseProbes) reverseRepor
 	listening := p.SSHDListening != nil && p.SSHDListening(ctx)
 	if !listening {
 		if goos == "darwin" {
-			if on, knowable := remoteLoginState(ctx, p); knowable && !on {
-				return reverseReport{Hint: "macOS Remote Login is off, so nothing can ssh in; " +
-					"enable it in System Settings > General > Sharing > Remote Login"}
+			on, knowable := remoteLoginState(ctx, p)
+			switch {
+			case knowable && !on:
+				// Softened absolute claim: classic sshd is off, but Tailscale SSH
+				// can still accept on the tailnet IP without system Remote Login.
+				return reverseReport{Hint: "macOS Remote Login is off (system sshd will not " +
+					"accept on :22); enable it in System Settings > General > Sharing > Remote Login " +
+					"for classic ssh hops. Tailscale SSH, if enabled separately, may still work"}
+			case knowable && on:
+				// Remote Login already on but nothing answers: do not tell the
+				// operator to enable it again — point at sshd/port/firewall.
+				return reverseReport{Hint: "Remote Login reports on but nothing is accepting on " +
+					"port 22; check that sshd is running, listening on the expected port, and not " +
+					"blocked by a local firewall"}
+			default:
+				// State unreadable: never claim it is off. Point at the settings
+				// surface without asserting the current value.
+				return reverseReport{Hint: "no sshd is listening on this machine; check " +
+					"System Settings > General > Sharing > Remote Login and that sshd is " +
+					"accepting on port 22 so other machines can hop here via classic ssh"}
 			}
-			return reverseReport{Hint: "no sshd is listening on this machine; enable " +
-				"System Settings > General > Sharing > Remote Login so other machines can hop here"}
 		}
 		return reverseReport{Hint: "no sshd is listening on this machine; start it " +
-			"(for example 'sudo systemctl enable --now sshd') so other machines can hop here"}
+			"(for example 'sudo systemctl enable --now sshd') so other machines can hop here " +
+			"via classic ssh (Tailscale SSH, if enabled, may still work without system sshd)"}
 	}
 
 	// sshd answers, so the local half is satisfied. Everything left is policy on
 	// the other side, which is exactly the part camp must not manage.
+	// Capable stays true (local sshd half); the hint names the remaining local
+	// problem so operators do not treat the green mark as "reverse is fine".
 	if p.TailscaleUp != nil && !p.TailscaleUp(ctx) {
 		return reverseReport{Capable: true, Hint: "sshd is listening, but tailscale is not up here, " +
 			"so tailnet peers cannot route to this machine; run 'tailscale up'"}
@@ -91,15 +110,37 @@ func sshdListening(ctx context.Context) bool {
 	return true
 }
 
+// remoteLoginLine matches the English systemsetup line, requiring a word-boundary
+// state so "Off" is not a false positive for substring "on".
+var remoteLoginLine = regexp.MustCompile(`(?i)remote\s+login:\s*(on|off)\s*$`)
+
 // remoteLoginOn reads macOS Remote Login state. `systemsetup -getremotelogin`
 // needs no privileges for a read, and a failure reports "not knowable" rather
 // than "off", so an unreadable state never produces a confident wrong hint.
+// Parsing is line-based and exact on On/Off rather than a bare Contains("on").
 func remoteLoginOn(ctx context.Context) (bool, bool) {
 	out, err := exec.CommandContext(ctx, "systemsetup", "-getremotelogin").Output()
 	if err != nil {
 		return false, false
 	}
-	return strings.Contains(strings.ToLower(string(out)), "on"), true
+	return parseRemoteLoginOutput(string(out))
+}
+
+// parseRemoteLoginOutput is the pure half of remoteLoginOn, unit-tested with
+// fixture strings so localized or garbage success output stays unknowable.
+func parseRemoteLoginOutput(out string) (on, knowable bool) {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		m := remoteLoginLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		return strings.EqualFold(m[1], "on"), true
+	}
+	return false, false
 }
 
 // tailscaleUpLocally reports whether this machine's tailscale backend is

--- a/cmd/camp/machine_reverse_test.go
+++ b/cmd/camp/machine_reverse_test.go
@@ -24,7 +24,19 @@ func TestCheckReverseReachabilityCauseMatrix(t *testing.T) {
 				SSHDListening: no,
 				RemoteLoginOn: func(context.Context) (bool, bool) { return false, true },
 			},
-			wantHint: "macOS Remote Login is off",
+			wantHint:  "macOS Remote Login is off",
+			forbidden: "nothing can ssh in",
+		},
+		{
+			name: "darwin, Remote Login on but nothing listening",
+			probes: reverseProbes{
+				GOOS:          "darwin",
+				SSHDListening: no,
+				RemoteLoginOn: func(context.Context) (bool, bool) { return true, true },
+			},
+			// Already on: must not tell the operator to enable Remote Login again.
+			wantHint:  "Remote Login reports on but nothing is accepting on port 22",
+			forbidden: "enable",
 		},
 		{
 			name: "darwin, state unreadable, no sshd",
@@ -65,8 +77,36 @@ func TestCheckReverseReachabilityCauseMatrix(t *testing.T) {
 			if !strings.Contains(got.Hint, tt.wantHint) {
 				t.Errorf("hint %q must contain %q", got.Hint, tt.wantHint)
 			}
-			if tt.forbidden != "" && strings.Contains(got.Hint, tt.forbidden) {
-				t.Errorf("hint %q must not claim %q when the state is unknowable", got.Hint, tt.forbidden)
+			if tt.forbidden != "" && strings.Contains(strings.ToLower(got.Hint), strings.ToLower(tt.forbidden)) {
+				t.Errorf("hint %q must not contain %q", got.Hint, tt.forbidden)
+			}
+		})
+	}
+}
+
+func TestParseRemoteLoginOutput(t *testing.T) {
+	tests := []struct {
+		name         string
+		out          string
+		wantOn       bool
+		wantKnowable bool
+	}{
+		{name: "classic On", out: "Remote Login: On\n", wantOn: true, wantKnowable: true},
+		{name: "classic Off", out: "Remote Login: Off\n", wantOn: false, wantKnowable: true},
+		{name: "lowercase", out: "remote login: on", wantOn: true, wantKnowable: true},
+		{name: "extra padding", out: "  Remote Login:   Off  \n", wantOn: false, wantKnowable: true},
+		// "Off" contains "on" as a substring; a naive Contains("on") would misread it.
+		// The line parser must stay exact.
+		{name: "garbage success", out: "something on somewhere\n", wantKnowable: false},
+		{name: "empty", out: "", wantKnowable: false},
+		{name: "multiline with On", out: "header\nRemote Login: On\nfooter\n", wantOn: true, wantKnowable: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			on, knowable := parseRemoteLoginOutput(tt.out)
+			if knowable != tt.wantKnowable || on != tt.wantOn {
+				t.Errorf("parseRemoteLoginOutput(%q) = (%v, %v), want (%v, %v)",
+					tt.out, on, knowable, tt.wantOn, tt.wantKnowable)
 			}
 		})
 	}

--- a/cmd/camp/machine_reverse_test.go
+++ b/cmd/camp/machine_reverse_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestCheckReverseReachabilityCauseMatrix(t *testing.T) {
+	yes := func(context.Context) bool { return true }
+	no := func(context.Context) bool { return false }
+
+	tests := []struct {
+		name        string
+		probes      reverseProbes
+		wantCapable bool
+		wantHint    string
+		forbidden   string
+	}{
+		{
+			name: "darwin, Remote Login off",
+			probes: reverseProbes{
+				GOOS:          "darwin",
+				SSHDListening: no,
+				RemoteLoginOn: func(context.Context) (bool, bool) { return false, true },
+			},
+			wantHint: "macOS Remote Login is off",
+		},
+		{
+			name: "darwin, state unreadable, no sshd",
+			probes: reverseProbes{
+				GOOS:          "darwin",
+				SSHDListening: no,
+				RemoteLoginOn: func(context.Context) (bool, bool) { return false, false },
+			},
+			// Unknowable state must not produce a confident "it is off" claim.
+			wantHint:  "no sshd is listening",
+			forbidden: "Remote Login is off",
+		},
+		{
+			name:     "linux, no sshd",
+			probes:   reverseProbes{GOOS: "linux", SSHDListening: no},
+			wantHint: "systemctl enable --now sshd",
+		},
+		{
+			name:        "sshd up, tailscale down",
+			probes:      reverseProbes{GOOS: "linux", SSHDListening: yes, TailscaleUp: no},
+			wantCapable: true,
+			wantHint:    "tailscale is not up here",
+		},
+		{
+			name:        "sshd up, tailscale up",
+			probes:      reverseProbes{GOOS: "linux", SSHDListening: yes, TailscaleUp: yes},
+			wantCapable: true,
+			wantHint:    "camp does not manage",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkReverseReachability(context.Background(), tt.probes)
+			if got.Capable != tt.wantCapable {
+				t.Errorf("Capable = %v, want %v (hint %q)", got.Capable, tt.wantCapable, got.Hint)
+			}
+			if !strings.Contains(got.Hint, tt.wantHint) {
+				t.Errorf("hint %q must contain %q", got.Hint, tt.wantHint)
+			}
+			if tt.forbidden != "" && strings.Contains(got.Hint, tt.forbidden) {
+				t.Errorf("hint %q must not claim %q when the state is unknowable", got.Hint, tt.forbidden)
+			}
+		})
+	}
+}
+
+func TestReverseHintsNeverOfferToFixAnything(t *testing.T) {
+	// D003: diagnose, never manage. Each hint names one action for the OPERATOR;
+	// none may imply camp will do it.
+	probeSets := []reverseProbes{
+		{GOOS: "darwin", SSHDListening: func(context.Context) bool { return false },
+			RemoteLoginOn: func(context.Context) (bool, bool) { return false, true }},
+		{GOOS: "linux", SSHDListening: func(context.Context) bool { return false }},
+		{GOOS: "linux", SSHDListening: func(context.Context) bool { return true },
+			TailscaleUp: func(context.Context) bool { return false }},
+		{GOOS: "linux", SSHDListening: func(context.Context) bool { return true },
+			TailscaleUp: func(context.Context) bool { return true }},
+	}
+	for _, p := range probeSets {
+		hint := checkReverseReachability(context.Background(), p).Hint
+		for _, forbidden := range []string{"camp will", "camp can enable", "run 'camp machine fix", "automatically"} {
+			if strings.Contains(strings.ToLower(hint), strings.ToLower(forbidden)) {
+				t.Errorf("hint offers to manage: %q", hint)
+			}
+		}
+		if hint == "" {
+			t.Error("every cause must produce a hint")
+		}
+	}
+}
+
+func TestReverseReachabilityHonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// A cancelled context must not hang or panic; the probes see a dead context
+	// and report the not-listening path.
+	got := checkReverseReachability(ctx, defaultReverseProbes())
+	if got.Hint == "" {
+		t.Error("want a hint even under cancellation")
+	}
+}

--- a/cmd/camp/main.go
+++ b/cmd/camp/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -11,7 +10,6 @@ import (
 	// bginit must initialize before the bubbletea subtree under the command
 	// packages; its path keeps it first under gofmt.
 	_ "github.com/Obedience-Corp/camp/internal/bginit"
-	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 
 func main() {
@@ -19,21 +17,8 @@ func main() {
 	defer stop()
 
 	if err := Execute(ctx); err != nil {
-		// A command that returns a CommandError DIRECTLY is propagating a
-		// child process's exit code (camp sync, doctor, clone, run), and has
-		// already said whatever needed saying; printing again would be
-		// redundant.
-		//
-		// This is a type assertion, not errors.As, and the difference is
-		// load-bearing. Remote failures create a CommandError deep in the chain
-		// (remote.Run wraps a non-zero ssh exit), and camp then wraps THAT with
-		// the sentence the operator actually needs: which machine, which
-		// campaign, and which diagnostic to run next. Matching anywhere in the
-		// chain discarded all of it and exited silently with ssh's code, so a
-		// failed hop printed nothing at all.
-		var cmdErr *camperrors.CommandError
-		if ok := errors.As(err, &cmdErr); ok && cmdErr.ExitCode != 0 && error(cmdErr) == err {
-			os.Exit(cmdErr.ExitCode)
+		if code, silent := silentExit(err); silent {
+			os.Exit(code)
 		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/cmd/camp/main.go
+++ b/cmd/camp/main.go
@@ -19,10 +19,20 @@ func main() {
 	defer stop()
 
 	if err := Execute(ctx); err != nil {
-		// If a child process exited with a specific code (e.g. camp run),
-		// propagate that code without printing a redundant error message.
+		// A command that returns a CommandError DIRECTLY is propagating a
+		// child process's exit code (camp sync, doctor, clone, run), and has
+		// already said whatever needed saying; printing again would be
+		// redundant.
+		//
+		// This is a type assertion, not errors.As, and the difference is
+		// load-bearing. Remote failures create a CommandError deep in the chain
+		// (remote.Run wraps a non-zero ssh exit), and camp then wraps THAT with
+		// the sentence the operator actually needs: which machine, which
+		// campaign, and which diagnostic to run next. Matching anywhere in the
+		// chain discarded all of it and exited silently with ssh's code, so a
+		// failed hop printed nothing at all.
 		var cmdErr *camperrors.CommandError
-		if errors.As(err, &cmdErr) && cmdErr.ExitCode != 0 {
+		if ok := errors.As(err, &cmdErr); ok && cmdErr.ExitCode != 0 && error(cmdErr) == err {
 			os.Exit(cmdErr.ExitCode)
 		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/camp/main_exit_test.go
+++ b/cmd/camp/main_exit_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// silentExit mirrors main's decision so the rule is testable without spawning a
+// process. Keep the condition here identical to main().
+func silentExit(err error) (int, bool) {
+	var cmdErr *camperrors.CommandError
+	if ok := errors.As(err, &cmdErr); ok && cmdErr.ExitCode != 0 && error(cmdErr) == err {
+		return cmdErr.ExitCode, true
+	}
+	return 0, false
+}
+
+func TestSilentExitOnlyForDirectlyReturnedCommandErrors(t *testing.T) {
+	direct := camperrors.NewCommand("camp sync", 3, "", nil)
+
+	t.Run("direct return propagates the code silently", func(t *testing.T) {
+		code, silent := silentExit(direct)
+		if !silent || code != 3 {
+			t.Errorf("silentExit = (%d, %v), want (3, true)", code, silent)
+		}
+	})
+
+	t.Run("a wrapped remote failure must PRINT, not vanish", func(t *testing.T) {
+		// This is the shape a failed hop produces: ssh exits non-zero, remote.Run
+		// turns that into a CommandError, and camp wraps it with the sentence the
+		// operator needs. Matching anywhere in the chain threw all of it away and
+		// exited silently with ssh's code, so the hop printed nothing at all.
+		wrapped := camperrors.Wrapf(direct, "could not resolve %q on %s", "obey-campaign", "archdtop")
+		if _, silent := silentExit(wrapped); silent {
+			t.Error("a wrapped error was silenced; the operator would see an exit code and no message")
+		}
+	})
+
+	t.Run("doubly wrapped is still printed", func(t *testing.T) {
+		wrapped := camperrors.Wrapf(camperrors.Wrapf(direct, "resolve"), "run 'camp machine diagnose archdtop'")
+		if _, silent := silentExit(wrapped); silent {
+			t.Error("nested wrapping must not re-enable the silent path")
+		}
+	})
+
+	t.Run("zero exit code is never silent", func(t *testing.T) {
+		launchFailure := camperrors.NewCommand("camp run", 0, "", errors.New("exec failed"))
+		if _, silent := silentExit(launchFailure); silent {
+			t.Error("a launch failure has no exit code to propagate and must print")
+		}
+	})
+
+	t.Run("an ordinary error prints", func(t *testing.T) {
+		if _, silent := silentExit(errors.New("plain")); silent {
+			t.Error("plain errors must print")
+		}
+	})
+}

--- a/cmd/camp/main_exit_test.go
+++ b/cmd/camp/main_exit_test.go
@@ -7,16 +7,6 @@ import (
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 
-// silentExit mirrors main's decision so the rule is testable without spawning a
-// process. Keep the condition here identical to main().
-func silentExit(err error) (int, bool) {
-	var cmdErr *camperrors.CommandError
-	if ok := errors.As(err, &cmdErr); ok && cmdErr.ExitCode != 0 && error(cmdErr) == err {
-		return cmdErr.ExitCode, true
-	}
-	return 0, false
-}
-
 func TestSilentExitOnlyForDirectlyReturnedCommandErrors(t *testing.T) {
 	direct := camperrors.NewCommand("camp sync", 3, "", nil)
 


### PR DESCRIPTION
> **Stacked on #508** (chain: #504 → #505 → #506 → #507 → #508). Base is `mesh-transfer-machine-first`.

Adds a REVERSE row to `camp machine diagnose`, so when a hop-back fails you can tell whether the problem is on this machine.

Festival MN0001, phase 005 sequence 03.

## The honest-reporting choice

Whether archdtop can open a connection to this mac depends on three things: archdtop's client config, the tailnet ACL, and this machine's sshd. Camp can only observe the **last one** without executing on the far side, which D003 rules out.

So this reports **acceptability** ("does this machine accept inbound ssh") and says so, rather than claiming a reachability verdict it has not earned. Getting that framing wrong would produce a green check that means nothing.

## Causes are separated because their fixes are

| Platform | State | Reported |
| --- | --- | --- |
| darwin | Remote Login readable and off | names Remote Login and where to enable it |
| darwin | state unreadable, no sshd | "no sshd is listening" — deliberately **not** "Remote Login is off" |
| linux | no sshd | names `systemctl enable --now sshd` |
| any | sshd up, tailscale down | capable, names `tailscale up` |
| any | sshd up, tailscale up | capable, and says the rest is keys plus ACL, which camp does not manage |

Row two is the one worth having: unreadable state must not become a confident wrong claim. It is asserted as a *forbidden* substring rather than a hoped-for one.

## D003 is enforced by a test, not by intention

`TestReverseHintsNeverOfferToFixAnything` sweeps every hint for offer-to-manage phrasing ("camp will", "automatically", …). Every hint names exactly one action for the operator to take, and camp never takes it.

## Live output

```
$ camp machine diagnose archdtop
ID  archdtop
HOST  archdtop.tail37114b.ts.net
AUTH  Tailscale SSH (identity) (tailscale-ssh)
SOCKET  none · ~/.obey/ssh-ctl/archdtop.sock
PROBE  ssh -o BatchMode=yes lance@archdtop.tail37114b.ts.net true
CAMP  unavailable (unreachable, or camp missing / too old for 'version --json')
REVERSE  ✓ sshd is listening here. Whether a given machine may connect is that machine's keys plus your tailnet ACL, which camp does not manage
HINT  Tailscale SSH: if hop fails, look for a login.tailscale.com check URL ...
```

## Notes

`just gate` green: 3805. Probes are local and non-privileged (a loopback dial rather than a process scan, because what matters is whether something *accepts* connections, which is the question a peer's ssh client asks), bounded at 2s, with cancellation tested. JSON fields are additive with `omitempty` on the hint.

One thing you might push on: the REVERSE row is identical for every machine, since it is a fact about *this* machine. It repeats per row anyway because that is where you are already looking when a hop-back to a specific machine fails. A single summary line would be less repetitive but would separate the answer from the question.
