### PR TITLE
fix(cli): stop discarding remote error messages

### DIFF
--- a/cmd/camp/exit.go
+++ b/cmd/camp/exit.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// silentExit reports the exit code to propagate without printing, and whether
+// to do so.
+//
+// A command that returns a CommandError DIRECTLY is propagating a child
+// process's exit code (camp sync, doctor, clone, run) and has already said
+// whatever needed saying; printing again would be redundant.
+//
+// The type assertion is load-bearing, and errors.As would be wrong here.
+// Remote failures create a CommandError deep in the chain (remote.Run wraps a
+// non-zero ssh exit), and camp then wraps THAT with the sentence the operator
+// actually needs: which machine, which campaign, which diagnostic to run next.
+// Matching anywhere in the chain discarded all of it and exited silently with
+// ssh's code, so a failed hop printed nothing at all.
+//
+// This lives beside main rather than in the test that exercises it, so the rule
+// cannot pass in one place while production does something else.
+func silentExit(err error) (int, bool) {
+	cmdErr, ok := err.(*camperrors.CommandError)
+	if !ok || cmdErr.ExitCode == 0 {
+		return 0, false
+	}
+	return cmdErr.ExitCode, true
+}

--- a/cmd/camp/main.go
+++ b/cmd/camp/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -11,7 +10,6 @@ import (
 	// bginit must initialize before the bubbletea subtree under the command
 	// packages; its path keeps it first under gofmt.
 	_ "github.com/Obedience-Corp/camp/internal/bginit"
-	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 
 func main() {
@@ -19,21 +17,8 @@ func main() {
 	defer stop()
 
 	if err := Execute(ctx); err != nil {
-		// A command that returns a CommandError DIRECTLY is propagating a
-		// child process's exit code (camp sync, doctor, clone, run), and has
-		// already said whatever needed saying; printing again would be
-		// redundant.
-		//
-		// This is a type assertion, not errors.As, and the difference is
-		// load-bearing. Remote failures create a CommandError deep in the chain
-		// (remote.Run wraps a non-zero ssh exit), and camp then wraps THAT with
-		// the sentence the operator actually needs: which machine, which
-		// campaign, and which diagnostic to run next. Matching anywhere in the
-		// chain discarded all of it and exited silently with ssh's code, so a
-		// failed hop printed nothing at all.
-		var cmdErr *camperrors.CommandError
-		if ok := errors.As(err, &cmdErr); ok && cmdErr.ExitCode != 0 && error(cmdErr) == err {
-			os.Exit(cmdErr.ExitCode)
+		if code, silent := silentExit(err); silent {
+			os.Exit(code)
 		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/cmd/camp/main.go
+++ b/cmd/camp/main.go
@@ -19,10 +19,20 @@ func main() {
 	defer stop()
 
 	if err := Execute(ctx); err != nil {
-		// If a child process exited with a specific code (e.g. camp run),
-		// propagate that code without printing a redundant error message.
+		// A command that returns a CommandError DIRECTLY is propagating a
+		// child process's exit code (camp sync, doctor, clone, run), and has
+		// already said whatever needed saying; printing again would be
+		// redundant.
+		//
+		// This is a type assertion, not errors.As, and the difference is
+		// load-bearing. Remote failures create a CommandError deep in the chain
+		// (remote.Run wraps a non-zero ssh exit), and camp then wraps THAT with
+		// the sentence the operator actually needs: which machine, which
+		// campaign, and which diagnostic to run next. Matching anywhere in the
+		// chain discarded all of it and exited silently with ssh's code, so a
+		// failed hop printed nothing at all.
 		var cmdErr *camperrors.CommandError
-		if errors.As(err, &cmdErr) && cmdErr.ExitCode != 0 {
+		if ok := errors.As(err, &cmdErr); ok && cmdErr.ExitCode != 0 && error(cmdErr) == err {
 			os.Exit(cmdErr.ExitCode)
 		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/camp/main_exit_test.go
+++ b/cmd/camp/main_exit_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// silentExit mirrors main's decision so the rule is testable without spawning a
+// process. Keep the condition here identical to main().
+func silentExit(err error) (int, bool) {
+	var cmdErr *camperrors.CommandError
+	if ok := errors.As(err, &cmdErr); ok && cmdErr.ExitCode != 0 && error(cmdErr) == err {
+		return cmdErr.ExitCode, true
+	}
+	return 0, false
+}
+
+func TestSilentExitOnlyForDirectlyReturnedCommandErrors(t *testing.T) {
+	direct := camperrors.NewCommand("camp sync", 3, "", nil)
+
+	t.Run("direct return propagates the code silently", func(t *testing.T) {
+		code, silent := silentExit(direct)
+		if !silent || code != 3 {
+			t.Errorf("silentExit = (%d, %v), want (3, true)", code, silent)
+		}
+	})
+
+	t.Run("a wrapped remote failure must PRINT, not vanish", func(t *testing.T) {
+		// This is the shape a failed hop produces: ssh exits non-zero, remote.Run
+		// turns that into a CommandError, and camp wraps it with the sentence the
+		// operator needs. Matching anywhere in the chain threw all of it away and
+		// exited silently with ssh's code, so the hop printed nothing at all.
+		wrapped := camperrors.Wrapf(direct, "could not resolve %q on %s", "obey-campaign", "archdtop")
+		if _, silent := silentExit(wrapped); silent {
+			t.Error("a wrapped error was silenced; the operator would see an exit code and no message")
+		}
+	})
+
+	t.Run("doubly wrapped is still printed", func(t *testing.T) {
+		wrapped := camperrors.Wrapf(camperrors.Wrapf(direct, "resolve"), "run 'camp machine diagnose archdtop'")
+		if _, silent := silentExit(wrapped); silent {
+			t.Error("nested wrapping must not re-enable the silent path")
+		}
+	})
+
+	t.Run("zero exit code is never silent", func(t *testing.T) {
+		launchFailure := camperrors.NewCommand("camp run", 0, "", errors.New("exec failed"))
+		if _, silent := silentExit(launchFailure); silent {
+			t.Error("a launch failure has no exit code to propagate and must print")
+		}
+	})
+
+	t.Run("an ordinary error prints", func(t *testing.T) {
+		if _, silent := silentExit(errors.New("plain")); silent {
+			t.Error("plain errors must print")
+		}
+	})
+}

--- a/cmd/camp/main_exit_test.go
+++ b/cmd/camp/main_exit_test.go
@@ -7,16 +7,6 @@ import (
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 
-// silentExit mirrors main's decision so the rule is testable without spawning a
-// process. Keep the condition here identical to main().
-func silentExit(err error) (int, bool) {
-	var cmdErr *camperrors.CommandError
-	if ok := errors.As(err, &cmdErr); ok && cmdErr.ExitCode != 0 && error(cmdErr) == err {
-		return cmdErr.ExitCode, true
-	}
-	return 0, false
-}
-
 func TestSilentExitOnlyForDirectlyReturnedCommandErrors(t *testing.T) {
 	direct := camperrors.NewCommand("camp sync", 3, "", nil)
 


### PR DESCRIPTION
> **Independent of the MN0001 PR chain** (#504–#509). Based directly on `main`, small, and mergeable on its own. Worth taking first: it affects every remote command today.

A failed remote hop prints **nothing**. Not a vague message, nothing: exit 127 or 255 with empty stdout and empty stderr.

```
$ camp switch archdtop:lance-arch
$ echo $?
127
```

## Cause

`main()` propagates a child process's exit code without printing a redundant message. That is right for `camp sync`, `camp doctor`, `camp clone`, and `camp run`, which return a `CommandError` **directly** and have already said their piece.

But it matched with `errors.As`, which searches the whole chain. Remote failures create a `CommandError` deep inside (`remote.Run` wraps a non-zero ssh exit), and camp then wraps *that* with the sentence the operator actually needs: which campaign, which machine, and the escape hatch. `errors.As` found the inner error and threw the outer message away.

**The message was being built correctly all along and discarded before anyone could read it.**

## Fix

Scope the silent path to a `CommandError` that IS the returned error, rather than one anywhere in its chain. One condition, and the direct-return commands are unaffected.

```
before:  $ camp switch archdtop:lance-arch
         (nothing, exit 127)

after:   $ camp switch archdtop:lance-arch
         Error: could not resolve "lance-arch" on archdtop: remote camp not found on
         archdtop (tried "camp" via sh -lc, i.e. the machine's login-shell PATH); if
         camp lives outside that PATH, set CAMP_REMOTE_CAMP_PATH to its exact path on
         that machine: command "ssh lance@archdtop..." exited with code 127: sh: line 1:
         camp: command not found
```

That `CAMP_REMOTE_CAMP_PATH` hint has existed in the code the whole time. No user could ever have seen it.

## Tests

`TestSilentExitOnlyForDirectlyReturnedCommandErrors`, five rows: direct return still propagates silently; a wrapped remote failure prints; double-wrapping does not re-enable the silent path; a zero exit code (launch failure) prints; a plain error prints.

`just gate` green: 3740.

## How it was found

The MN0001 live fleet gate, which exists precisely to catch what unit suites cannot. Every test in the repo passed with these messages being discarded, because no test asserted that a human ever sees them. It surfaced the moment a real hop failed on a real second machine.
