### PR TITLE
feat(stageguard): size and bulk staging guards, artifact root gitignore handling (CA0004 phase 001)

### DIFF
--- a/cmd/camp/artifacts.go
+++ b/cmd/camp/artifacts.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -133,7 +132,7 @@ func runArtifactsList(cmd *cobra.Command, _ []string) error {
 			Path:       artifacts.NormalizeRootPath(r.Path),
 			Policy:     r.EffectivePolicy(),
 			Exists:     exists,
-			Gitignored: verr == nil && isGitignored(cmd, campRoot, r.Path),
+			Gitignored: verr == nil && artifacts.IsGitignored(cmd.Context(), campRoot, r.Path),
 		})
 	}
 
@@ -187,12 +186,12 @@ func runArtifactsAdd(cmd *cobra.Command, args []string) error {
 	normalized := artifacts.NormalizeRootPath(args[0])
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Declared artifact root %s\n", ui.SuccessIcon(), normalized)
 
-	if hasTrackedFiles(cmd, campRoot, normalized) {
+	if artifacts.HasTrackedFiles(cmd.Context(), campRoot, normalized) {
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
 			"%s %s contains git-tracked files; artifact roots must not overlap git content (untrack them or pick another directory)\n",
 			ui.WarningIcon(), normalized)
 	}
-	if !isGitignored(cmd, campRoot, normalized) {
+	if !artifacts.IsGitignored(cmd.Context(), campRoot, normalized) {
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
 			"%s %s is not gitignored; add it to .gitignore so artifact bytes never land in git\n",
 			ui.WarningIcon(), normalized)
@@ -250,21 +249,4 @@ func runArtifactsManifest(cmd *cobra.Command, args []string) error {
 	}
 	_, err = cmd.OutOrStdout().Write(data)
 	return err
-}
-
-// isGitignored reports whether git ignores the path (the recommended state
-// for artifact roots).
-func isGitignored(cmd *cobra.Command, campRoot, rel string) bool {
-	check := exec.CommandContext(cmd.Context(), "git", "-C", campRoot, "check-ignore", "-q", "--",
-		filepath.FromSlash(artifacts.NormalizeRootPath(rel)))
-	return check.Run() == nil
-}
-
-// hasTrackedFiles reports whether git tracks anything under the path (a
-// class conflict: the same bytes would be both git content and artifacts).
-func hasTrackedFiles(cmd *cobra.Command, campRoot, rel string) bool {
-	ls := exec.CommandContext(cmd.Context(), "git", "-C", campRoot, "ls-files", "--",
-		filepath.FromSlash(artifacts.NormalizeRootPath(rel)))
-	out, err := ls.Output()
-	return err == nil && len(strings.TrimSpace(string(out))) > 0
 }

--- a/cmd/camp/artifacts.go
+++ b/cmd/camp/artifacts.go
@@ -252,8 +252,10 @@ func printArtifactsMixed(cmd *cobra.Command, normalized string, survey artifacts
 	_, _ = fmt.Fprintf(out, "%s Declared artifact root %s (mixed)\n", ui.SuccessIcon(), normalized)
 	_, _ = fmt.Fprintf(out, "  %s git-tracked files stay with git and are excluded from artifact sync\n",
 		ui.FormatCount(survey.Tracked))
+	// The byte figure describes the artifact set, not the directory: tracked
+	// scripts sitting beside the footage are git's and rsync never carries them.
 	_, _ = fmt.Fprintf(out, "  %s untracked files (%s) are the artifact set\n",
-		ui.FormatCount(survey.Untracked), ui.FormatBytes(survey.TotalBytes))
+		ui.FormatCount(survey.Untracked), ui.FormatBytes(survey.UntrackedBytes))
 	_, _ = fmt.Fprintf(out, "  .gitignore not modified: ignoring this root would hide tracked content\n")
 }
 
@@ -273,6 +275,10 @@ func reportCleanRoot(cmd *cobra.Command, campRoot, normalized string) error {
 	}
 
 	if artifacts.IsGitignored(cmd.Context(), campRoot, normalized) {
+		// Already ignored, by an existing rule or a parent's. Say so rather
+		// than printing nothing, so the absence of an "Added ..." line does
+		// not read as camp having silently skipped the step.
+		_, _ = fmt.Fprintf(out, "  Already gitignored; .gitignore not modified\n")
 		return nil
 	}
 

--- a/cmd/camp/artifacts.go
+++ b/cmd/camp/artifacts.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/artifacts"
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
 	"github.com/Obedience-Corp/camp/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -72,8 +73,10 @@ useful for scripting and for comparing roots across machines.`,
 }
 
 var artifactsOpts struct {
-	json   bool
-	policy string
+	json        bool
+	policy      string
+	dryRun      bool
+	noGitignore bool
 }
 
 func init() {
@@ -81,6 +84,10 @@ func init() {
 		"Output as JSON for scripting")
 	artifactsAddCmd.Flags().StringVar(&artifactsOpts.policy, "policy", artifacts.PolicyAlways,
 		"Sync policy: always (every peer sync) or on-demand (--artifacts-only)")
+	artifactsAddCmd.Flags().BoolVar(&artifactsOpts.dryRun, "dry-run", false,
+		"Report what declaring this root would cover; write nothing")
+	artifactsAddCmd.Flags().BoolVar(&artifactsOpts.noGitignore, "no-gitignore", false,
+		"Declare the root without adding its .gitignore rule")
 
 	artifactsCmd.AddCommand(artifactsListCmd)
 	artifactsCmd.AddCommand(artifactsAddCmd)
@@ -162,12 +169,30 @@ func runArtifactsList(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
+// gitignoreRuleComment explains, in the file itself, why the rule is there.
+const gitignoreRuleComment = "# Camp artifact root (synced with 'camp sync', not git)"
+
 func runArtifactsAdd(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	campRoot, err := campaign.DetectCached(ctx)
 	if err != nil {
 		return camperrors.Wrap(err, "not in a campaign")
 	}
+	normalized := artifacts.NormalizeRootPath(args[0])
+
+	// Survey before declaring so --dry-run and the mixed-root report share one
+	// source of truth, and so a user asking "what would this cover" gets the
+	// same numbers the real run would act on.
+	survey, err := artifacts.SurveyRoot(ctx, campRoot, normalized)
+	if err != nil {
+		return err
+	}
+
+	if artifactsOpts.dryRun {
+		printArtifactsDryRun(cmd, normalized, survey)
+		return nil
+	}
+
 	cfg, err := artifacts.Load(campRoot)
 	if err != nil {
 		return err
@@ -183,19 +208,78 @@ func runArtifactsAdd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	normalized := artifacts.NormalizeRootPath(args[0])
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Declared artifact root %s\n", ui.SuccessIcon(), normalized)
+	if survey.Mixed() {
+		printArtifactsMixed(cmd, normalized, survey)
+		return nil
+	}
+	return reportCleanRoot(cmd, campRoot, normalized)
+}
 
-	if artifacts.HasTrackedFiles(cmd.Context(), campRoot, normalized) {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
-			"%s %s contains git-tracked files; artifact roots must not overlap git content (untrack them or pick another directory)\n",
-			ui.WarningIcon(), normalized)
+// printArtifactsDryRun renders the pre-declaration report: what the root holds
+// and how declaring it would split those files.
+func printArtifactsDryRun(cmd *cobra.Command, normalized string, survey artifacts.RootSurvey) {
+	out := cmd.OutOrStdout()
+	policy := artifactsOpts.policy
+	if policy == "" {
+		policy = artifacts.PolicyAlways
 	}
-	if !artifacts.IsGitignored(cmd.Context(), campRoot, normalized) {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
-			"%s %s is not gitignored; add it to .gitignore so artifact bytes never land in git\n",
-			ui.WarningIcon(), normalized)
+	_, _ = fmt.Fprintf(out, "%s would be declared as an artifact root (policy: %s)\n", normalized, policy)
+	// Counts are right-aligned to a common width so the breakdown lines up
+	// under the total, per design doc 03's sample. Wider counts widen the
+	// column rather than breaking the alignment.
+	_, _ = fmt.Fprintf(out, "%7s files, %s total\n",
+		ui.FormatCount(survey.TotalFiles()), ui.FormatBytes(survey.TotalBytes))
+	_, _ = fmt.Fprintf(out, "%7s tracked      excluded from artifact sync\n", ui.FormatCount(survey.Tracked))
+	_, _ = fmt.Fprintf(out, "%7s untracked    the artifact set\n", ui.FormatCount(survey.Untracked))
+	_, _ = fmt.Fprintf(out, "%7s ignored\n", ui.FormatCount(survey.Ignored))
+	_, _ = fmt.Fprintf(out, "\nNothing was written. Re-run without --dry-run to declare it.\n")
+}
+
+// printArtifactsMixed reports a root that holds tracked content. Camp never
+// gitignores such a root: the rule would hide tracked files from git without
+// untracking them, so the split is reported and the file is left alone.
+func printArtifactsMixed(cmd *cobra.Command, normalized string, survey artifacts.RootSurvey) {
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "%s Declared artifact root %s (mixed)\n", ui.SuccessIcon(), normalized)
+	_, _ = fmt.Fprintf(out, "  %s git-tracked files stay with git and are excluded from artifact sync\n",
+		ui.FormatCount(survey.Tracked))
+	_, _ = fmt.Fprintf(out, "  %s untracked files (%s) are the artifact set\n",
+		ui.FormatCount(survey.Untracked), ui.FormatBytes(survey.TotalBytes))
+	_, _ = fmt.Fprintf(out, "  .gitignore not modified: ignoring this root would hide tracked content\n")
+}
+
+// reportCleanRoot handles a root with no tracked content: the case where a
+// blanket ignore rule is exactly right and camp can act without judgment.
+func reportCleanRoot(cmd *cobra.Command, campRoot, normalized string) error {
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "%s Declared artifact root %s\n", ui.SuccessIcon(), normalized)
+
+	if artifactsOpts.noGitignore {
+		if !artifacts.IsGitignored(cmd.Context(), campRoot, normalized) {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+				"%s %s is not gitignored; add it to .gitignore so artifact bytes never land in git\n",
+				ui.WarningIcon(), normalized)
+		}
+		return nil
 	}
+
+	if artifacts.IsGitignored(cmd.Context(), campRoot, normalized) {
+		return nil
+	}
+
+	rule := normalized + "/"
+	wrote, err := fsutil.AppendGitignoreEntryIfMissing(
+		filepath.Join(campRoot, ".gitignore"), rule, gitignoreRuleComment)
+	if err != nil {
+		return camperrors.Wrapf(err, "add %q to .gitignore", rule)
+	}
+	if !wrote {
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(out, "%s Added '%s' to .gitignore\n", ui.SuccessIcon(), rule)
+	_, _ = fmt.Fprintf(out, "  Everything in this root now lives outside git and syncs between your\n")
+	_, _ = fmt.Fprintf(out, "  machines with 'camp sync'. Undo: camp artifacts remove %s\n", normalized)
 	return nil
 }
 

--- a/cmd/camp/artifacts.go
+++ b/cmd/camp/artifacts.go
@@ -178,6 +178,15 @@ func runArtifactsAdd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return camperrors.Wrap(err, "not in a campaign")
 	}
+	// Validate before doing any work. Add validates too, but --dry-run never
+	// reaches Add, and reporting on a declaration that could never succeed
+	// would be worse than a plain error.
+	if err := artifacts.ValidateRootPath(args[0]); err != nil {
+		return err
+	}
+	if err := artifacts.ValidatePolicy(artifactsOpts.policy); err != nil {
+		return err
+	}
 	normalized := artifacts.NormalizeRootPath(args[0])
 
 	// Survey before declaring so --dry-run and the mixed-root report share one

--- a/cmd/camp/artifacts.go
+++ b/cmd/camp/artifacts.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
 	"github.com/Obedience-Corp/camp/internal/artifacts"
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -169,9 +170,6 @@ func runArtifactsList(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// gitignoreRuleComment explains, in the file itself, why the rule is there.
-const gitignoreRuleComment = "# Camp artifact root (synced with 'camp sync', not git)"
-
 func runArtifactsAdd(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	campRoot, err := campaign.DetectCached(ctx)
@@ -284,7 +282,7 @@ func reportCleanRoot(cmd *cobra.Command, campRoot, normalized string) error {
 
 	rule := normalized + "/"
 	wrote, err := fsutil.AppendGitignoreEntryIfMissing(
-		filepath.Join(campRoot, ".gitignore"), rule, gitignoreRuleComment)
+		filepath.Join(campRoot, ".gitignore"), rule, cmdutil.GitignoreRuleComment)
 	if err != nil {
 		return camperrors.Wrapf(err, "add %q to .gitignore", rule)
 	}

--- a/cmd/camp/cache/commands.go
+++ b/cmd/camp/cache/commands.go
@@ -112,16 +112,11 @@ func runCacheInfo(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// formatBytes formats a byte count as a human-readable string.
+// formatBytes formats a byte count as a human-readable string. Delegates to
+// ui.FormatBytes so camp has one byte formatter; the shared one also carries
+// GB and TB tiers, which a cache large enough to need pruning will reach.
 func formatBytes(b int64) string {
-	switch {
-	case b >= 1024*1024:
-		return fmt.Sprintf("%.1f MB", float64(b)/(1024*1024))
-	case b >= 1024:
-		return fmt.Sprintf("%.1f KB", float64(b)/1024)
-	default:
-		return fmt.Sprintf("%d B", b)
-	}
+	return ui.FormatBytes(b)
 }
 
 // formatDuration formats a duration as a human-readable string.

--- a/cmd/camp/cmdutil/git.go
+++ b/cmd/camp/cmdutil/git.go
@@ -3,6 +3,7 @@ package cmdutil
 import (
 	"context"
 	"fmt"
+	"io"
 	"os/exec"
 )
 
@@ -18,5 +19,19 @@ func ShowStagedSummary(ctx context.Context, repoPath string) {
 		fmt.Println("\nChanges to be committed:")
 		fmt.Print(string(output))
 		fmt.Println()
+	}
+}
+
+// ShowStagedSummaryTo writes the staged summary to an explicit writer, so a
+// caller emitting machine output can keep it off stdout.
+func ShowStagedSummaryTo(w io.Writer, ctx context.Context, repoPath string) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "diff", "--cached", "--stat")
+	output, err := cmd.Output()
+	if err != nil {
+		return
+	}
+	if len(output) > 0 {
+		_, _ = fmt.Fprintln(w, "\nChanges to be committed:")
+		_, _ = fmt.Fprint(w, string(output))
 	}
 }

--- a/cmd/camp/cmdutil/guardreport.go
+++ b/cmd/camp/cmdutil/guardreport.go
@@ -1,0 +1,436 @@
+package cmdutil
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/Obedience-Corp/camp/internal/artifacts"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+	"github.com/Obedience-Corp/camp/internal/git"
+	"github.com/Obedience-Corp/camp/internal/stageguard"
+	"github.com/Obedience-Corp/camp/internal/ui"
+)
+
+// What the user sees when the staging guard acts. The guard itself returns
+// typed data and no prose; all copy lives here, so camp's wording and fest's
+// can differ without either reimplementing the decision.
+//
+// Two rules shape every message below. Camp acting automatically is only safe
+// if it says what it did, so nothing here is silent. And every line announcing
+// new behavior carries its own undo or off switch, so a user who disagrees
+// with camp is one command from reversing it rather than searching docs.
+
+// GitignoreRuleComment explains, in the file itself, why an artifact root's
+// ignore rule is there.
+const GitignoreRuleComment = "# Camp artifact root (synced with 'camp sync', not git)"
+
+// GuardHandling is the result of acting on a staging outcome, kept as data so
+// `camp commit --json` renders the same facts the human output describes.
+type GuardHandling struct {
+	// Declared holds roots camp declared during this commit.
+	Declared []DeclaredRoot
+	// Refused holds files camp excluded but would not choose a root for.
+	Refused []RefusedFile
+	// ProjectExcluded holds files excluded inside a project, where camp never
+	// declares anything.
+	ProjectExcluded []RefusedFile
+	// TrackedGrowth holds tracked files reported but always committed.
+	TrackedGrowth []stageguard.GuardViolation
+}
+
+// DeclaredRoot records one artifact root camp declared, or reused.
+type DeclaredRoot struct {
+	Root string
+	// Files are the over-threshold paths that landed under this root.
+	Files []stageguard.GuardViolation
+	// Bytes is the total size kept out of git for this root.
+	Bytes int64
+	// GitignoreWritten is true when camp also added the ignore rule, which
+	// only happens for a clean root.
+	GitignoreWritten bool
+	// KeptWithGit names the files under this root that were still staged, so
+	// the report can say what git still owns.
+	KeptWithGit string
+	// Existing is true when the root was already declared and camp reused it.
+	Existing bool
+}
+
+// RefusedFile is a file camp excluded without declaring anything.
+type RefusedFile struct {
+	Violation stageguard.GuardViolation
+	// Reason is the machine-readable cause, surfaced verbatim in --json.
+	Reason string
+	// Refusal is the specific boundary that was hit, so the report can explain
+	// which rule applied rather than stating a generic refusal.
+	Refusal artifacts.RefusalReason
+}
+
+// Reasons reported in --json, matching the design's vocabulary.
+const (
+	reasonNeedsRootDecision = "needs_root_decision"
+	reasonProjectLargeFile  = "project_large_file"
+)
+
+// handleStageOutcome acts on the guard's decision and reports it.
+//
+// At the campaign root it declares artifact roots for excluded files and
+// stages the resulting bookkeeping into the same commit, so the commit that
+// excluded the footage also carries the declaration explaining why. Inside a
+// project it declares nothing: an artifact root there would keep the bytes off
+// the project's remote, and camp cannot know whether collaborators need them.
+func HandleStageOutcome(
+	ctx context.Context,
+	out io.Writer,
+	campRoot, repoPath string,
+	outcome *git.StageOutcome,
+) (*GuardHandling, error) {
+	if outcome.Empty() {
+		return nil, nil
+	}
+
+	handling := &GuardHandling{TrackedGrowth: outcome.Reported}
+
+	if outcome.Limits.ScopeProject {
+		for _, v := range outcome.Excluded {
+			handling.ProjectExcluded = append(handling.ProjectExcluded,
+				RefusedFile{Violation: v, Reason: reasonProjectLargeFile})
+		}
+	} else if err := declareRootsForExclusions(ctx, campRoot, outcome, handling); err != nil {
+		return nil, err
+	}
+
+	renderGuardHandling(out, campRoot, repoPath, handling, outcome.Limits)
+	return handling, nil
+}
+
+// declareRootsForExclusions resolves and writes an artifact root per excluded
+// file, grouping files that share one root.
+func declareRootsForExclusions(
+	ctx context.Context,
+	campRoot string,
+	outcome *git.StageOutcome,
+	handling *GuardHandling,
+) error {
+	cfg, err := artifacts.Load(campRoot)
+	if err != nil {
+		return err
+	}
+
+	byRoot := make(map[string]*DeclaredRoot)
+	var order []string
+
+	for _, v := range outcome.Excluded {
+		resolved := artifacts.ResolveAutoRoot(cfg, campRoot, v.Path)
+		if resolved.Refusal != artifacts.RefusalNone {
+			handling.Refused = append(handling.Refused,
+				RefusedFile{Violation: v, Reason: reasonNeedsRootDecision, Refusal: resolved.Refusal})
+			continue
+		}
+
+		entry, seen := byRoot[resolved.Path]
+		if !seen {
+			entry = &DeclaredRoot{Root: resolved.Path, Existing: resolved.Existing}
+			byRoot[resolved.Path] = entry
+			order = append(order, resolved.Path)
+
+			if resolved.Declared() {
+				if addErr := cfg.Add(artifacts.Root{Path: resolved.Path}); addErr != nil {
+					return camperrors.Wrapf(addErr, "declare artifact root %s", resolved.Path)
+				}
+			}
+		}
+		entry.Files = append(entry.Files, v)
+		entry.Bytes += v.Size
+	}
+
+	if len(order) == 0 {
+		return nil
+	}
+	if err := cfg.Save(campRoot); err != nil {
+		return err
+	}
+
+	// A clean root gets its ignore rule, which makes everything landing there
+	// later artifact content by construction. A mixed root never does: the
+	// rule would hide its tracked files from git without untracking them.
+	for _, root := range order {
+		entry := byRoot[root]
+		if entry.Existing {
+			continue
+		}
+		wrote, err := writeCleanRootIgnoreRule(ctx, campRoot, root)
+		if err != nil {
+			return err
+		}
+		entry.GitignoreWritten = wrote
+	}
+
+	// Ask git what is still staged under each root, so the report names the
+	// files that remain git's rather than guessing from the exclusion list.
+	for _, root := range order {
+		byRoot[root].KeptWithGit = stagedNamesUnder(ctx, campRoot, root)
+	}
+
+	handling.Declared = append(handling.Declared, collectRoots(order, byRoot)...)
+	return stageGuardBookkeeping(ctx, campRoot, handling)
+}
+
+func collectRoots(order []string, byRoot map[string]*DeclaredRoot) []DeclaredRoot {
+	roots := make([]DeclaredRoot, 0, len(order))
+	for _, root := range order {
+		roots = append(roots, *byRoot[root])
+	}
+	return roots
+}
+
+// stagedNamesUnder renders the staged file names beneath a root as a human
+// list ("script.md and notes.md"), or "" when nothing under it is staged.
+func stagedNamesUnder(ctx context.Context, campRoot, root string) string {
+	paths, err := git.StagedPathsUnder(ctx, campRoot, root)
+	if err != nil || len(paths) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(paths))
+	for _, p := range paths {
+		names = append(names, filepath.Base(p))
+	}
+	switch len(names) {
+	case 1:
+		return names[0]
+	case 2:
+		return names[0] + " and " + names[1]
+	default:
+		return fmt.Sprintf("%s and %s more", names[0], ui.FormatCount(len(names)-1))
+	}
+}
+
+// writeCleanRootIgnoreRule adds the ignore rule when the root holds no tracked
+// content, reporting whether it wrote.
+func writeCleanRootIgnoreRule(ctx context.Context, campRoot, root string) (bool, error) {
+	if artifacts.HasTrackedFiles(ctx, campRoot, root) {
+		return false, nil
+	}
+	if artifacts.IsGitignored(ctx, campRoot, root) {
+		return false, nil
+	}
+	wrote, err := fsutil.AppendGitignoreEntryIfMissing(
+		filepath.Join(campRoot, ".gitignore"), root+"/", GitignoreRuleComment)
+	if err != nil {
+		return false, camperrors.Wrapf(err, "add %q to .gitignore", root+"/")
+	}
+	return wrote, nil
+}
+
+// stageGuardBookkeeping stages the declaration file and .gitignore into the
+// commit that excluded the bytes, so the commit carries its own explanation
+// rather than leaving the declaration for a later, unrelated commit.
+//
+// manifests: phase 002 adds committed artifact manifests here.
+func stageGuardBookkeeping(ctx context.Context, campRoot string, handling *GuardHandling) error {
+	paths := []string{artifacts.ConfigRelPath}
+	for _, d := range handling.Declared {
+		if d.GitignoreWritten {
+			paths = append(paths, ".gitignore")
+			break
+		}
+	}
+	// Explicit paths, so this staging call is not itself guarded.
+	return git.StageFiles(ctx, campRoot, paths...)
+}
+
+// renderGuardHandling writes the human report.
+func renderGuardHandling(
+	out io.Writer,
+	campRoot, repoPath string,
+	handling *GuardHandling,
+	limits stageguard.GuardLimits,
+) {
+	for _, d := range handling.Declared {
+		renderDeclaredRoot(out, campRoot, d)
+	}
+	for _, r := range handling.Refused {
+		renderRootRefusal(out, r)
+	}
+	for _, p := range handling.ProjectExcluded {
+		renderProjectExclusion(out, p)
+	}
+	for _, t := range handling.TrackedGrowth {
+		renderTrackedGrowth(out, t, limits)
+	}
+}
+
+// renderDeclaredRoot reports a root camp declared or reused.
+//
+// Reporting is proportionate: a newly declared root gets the full block that
+// teaches what an artifact root is, because it is new behavior the user has
+// not seen. Adding files to a root they already declared gets one tally line,
+// because they already know.
+func renderDeclaredRoot(out io.Writer, campRoot string, d DeclaredRoot) {
+	if d.Existing {
+		_, _ = fmt.Fprintf(out, "%s %s/ +%s files (%s) kept out of git\n",
+			ui.SuccessIcon(), d.Root, ui.FormatCount(len(d.Files)), ui.FormatBytes(d.Bytes))
+		return
+	}
+
+	names := violationNames(d.Files)
+	_, _ = fmt.Fprintf(out, "%s %s/ is now an artifact root (%s, %s)\n",
+		ui.SuccessIcon(), d.Root, names, ui.FormatBytes(d.Bytes))
+	_, _ = fmt.Fprintf(out, "  Kept out of git, syncs with 'camp sync --from <machine>'\n")
+
+	// Name what still belongs to git. Without this the user has just been told
+	// their directory is now "artifact content" and has no way to know the
+	// notes they wrote beside the footage are still versioned.
+	if kept := d.KeptWithGit; kept != "" {
+		_, _ = fmt.Fprintf(out, "  %s stay with git\n", kept)
+	}
+	_, _ = fmt.Fprintf(out, "  Undo: camp artifacts remove %s\n", d.Root)
+
+	if siblings := siblingSuggestion(campRoot, d.Root); siblings != "" {
+		_, _ = fmt.Fprint(out, siblings)
+	}
+}
+
+// siblingSuggestion offers to collapse accumulated sibling roots. Camp
+// suggests and never collapses: merging roots changes what syncs, and only the
+// user knows whether that is wanted.
+func siblingSuggestion(campRoot, root string) string {
+	cfg, err := artifacts.Load(campRoot)
+	if err != nil {
+		return ""
+	}
+	parent := filepath.ToSlash(filepath.Dir(root))
+	if parent == "." || parent == "" {
+		return ""
+	}
+	if n := artifacts.SiblingRootCount(cfg, parent); n >= 3 {
+		return fmt.Sprintf("  %d artifact roots now under %s/. Collapse with: camp artifacts add %s\n",
+			n, parent, parent)
+	}
+	return ""
+}
+
+// renderRootRefusal reports a file camp excluded but would not choose a root
+// for. The commit still succeeded; only this file was left out.
+func renderRootRefusal(out io.Writer, r RefusedFile) {
+	v := r.Violation
+	_, _ = fmt.Fprintf(out, "%s %s %s %s\n",
+		ui.WarningIcon(), ui.FormatBytes(v.Size), v.Path, refusalExplanation(r.Refusal))
+	_, _ = fmt.Fprintf(out, "  It was left out of this commit.\n")
+	_, _ = fmt.Fprintf(out, "    camp artifacts add <a directory you choose>   or gitignore it\n")
+}
+
+// refusalExplanation says why camp declined, in the terms of the specific
+// boundary that was hit. A generic "camp will not create a root here" leaves
+// the user guessing which rule applied and therefore what to do instead.
+func refusalExplanation(reason artifacts.RefusalReason) string {
+	switch reason {
+	case artifacts.RefusalCampaignRoot:
+		return "sits at the campaign root; camp will not make the campaign an artifact root."
+	case artifacts.RefusalCampaignState:
+		return "lives under .campaign/; camp will not make its own state tree an artifact root."
+	case artifacts.RefusalRepoRoot:
+		return "sits at a git repository root; an artifact root there would cross a repo boundary."
+	default:
+		return "sits where camp will not create an artifact root."
+	}
+}
+
+// renderProjectExclusion reports a large file inside a project, where camp
+// declares nothing and says what it cannot decide.
+func renderProjectExclusion(out io.Writer, r RefusedFile) {
+	v := r.Violation
+	_, _ = fmt.Fprintf(out, "%s %s (%s) was left out of this commit\n",
+		ui.WarningIcon(), v.Path, ui.FormatBytes(v.Size))
+	_, _ = fmt.Fprintf(out, "  Camp does not auto-manage large files inside a project: an artifact root\n")
+	_, _ = fmt.Fprintf(out, "  would keep it off the project's remote, so collaborators would not get it.\n")
+	_, _ = fmt.Fprintf(out, "    if it is build output   echo '%s' >> .gitignore\n", v.Path)
+	_, _ = fmt.Fprintf(out, "    if others need it       git lfs track '%s'\n", lfsPattern(v.Path))
+	_, _ = fmt.Fprintf(out, "    if it belongs in git    add to commit.guards.allow, or --commit-large\n")
+}
+
+// renderTrackedGrowth reports a tracked file that crossed the threshold. It is
+// always committed: excluding it would leave the stale blob in git while the
+// new bytes on disk belonged to nothing.
+func renderTrackedGrowth(out io.Writer, v stageguard.GuardViolation, limits stageguard.GuardLimits) {
+	_, _ = fmt.Fprintf(out, "%s %s is tracked and now %s (limit %s)\n",
+		ui.WarningIcon(), v.Path, ui.FormatBytes(v.Size), ui.FormatBytes(limits.MaxFileSize))
+	_, _ = fmt.Fprintf(out, "  Tracked files are always committed. To stop tracking it:\n")
+	_, _ = fmt.Fprintf(out, "    git rm --cached %s\n", v.Path)
+	_, _ = fmt.Fprintf(out, "    camp artifacts add %s\n", filepath.ToSlash(filepath.Dir(v.Path)))
+	_, _ = fmt.Fprintf(out, "  Or allow it: commit.guards.allow in .campaign/campaign.yaml\n")
+}
+
+// violationNames renders the file names behind a root, abbreviating past two
+// so a root absorbing hundreds of files does not print hundreds of names.
+func violationNames(violations []stageguard.GuardViolation) string {
+	switch len(violations) {
+	case 0:
+		return ""
+	case 1:
+		return filepath.Base(violations[0].Path)
+	case 2:
+		return filepath.Base(violations[0].Path) + ", " + filepath.Base(violations[1].Path)
+	default:
+		return fmt.Sprintf("%s and %s more",
+			filepath.Base(violations[0].Path), ui.FormatCount(len(violations)-1))
+	}
+}
+
+// lfsPattern turns a path into the glob a user would most likely want to track,
+// keeping the directory and widening only the file name to its extension.
+func lfsPattern(path string) string {
+	dir := filepath.ToSlash(filepath.Dir(path))
+	ext := filepath.Ext(path)
+	if ext == "" {
+		return path
+	}
+	if dir == "." || dir == "" {
+		return "*" + ext
+	}
+	return dir + "/*" + ext
+}
+
+// GuardExcludedEverything reports whether the guard kept files out and nothing
+// remains staged.
+//
+// The unstaged-changes check that normally decides "is there anything to
+// commit" answers yes here, because the excluded file is still sitting in the
+// worktree as an unstaged change. Without this, camp reports what it kept out
+// and then fails with git's "nothing to commit", which reads as camp having
+// broken rather than having done exactly what it said.
+func GuardExcludedEverything(ctx context.Context, repoPath string, handling *GuardHandling) (bool, error) {
+	if handling == nil || !handling.ExcludedAnything() {
+		return false, nil
+	}
+	staged, err := git.HasStagedChanges(ctx, repoPath)
+	if err != nil {
+		return false, err
+	}
+	return !staged, nil
+}
+
+// ExcludedAnything reports whether the guard kept any file out of the index.
+// Tracked growth does not count: those files are always committed.
+func (h *GuardHandling) ExcludedAnything() bool {
+	if h == nil {
+		return false
+	}
+	if len(h.Refused) > 0 || len(h.ProjectExcluded) > 0 {
+		return true
+	}
+	for _, d := range h.Declared {
+		if len(d.Files) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// ReportNothingLeftToCommit tells the user the commit was a no-op because
+// everything they changed was kept out of git, and exits the caller cleanly.
+func ReportNothingLeftToCommit(out io.Writer) {
+	_, _ = fmt.Fprintf(out, "%s Nothing left to commit: everything changed was kept out of git\n", ui.SuccessIcon())
+}

--- a/cmd/camp/cmdutil/guardreport.go
+++ b/cmd/camp/cmdutil/guardreport.go
@@ -24,6 +24,18 @@ import (
 // new behavior carries its own undo or off switch, so a user who disagrees
 // with camp is one command from reversing it rather than searching docs.
 
+// GuardUnavailableLine says the staging guard did not run.
+//
+// It names the cause rather than saying "guard unavailable", because the two
+// realistic causes need different responses from the user: a repository camp
+// cannot read yet is nothing to act on, while git being broken is.
+func GuardUnavailableLine(cause error) string {
+	return fmt.Sprintf(
+		"Staged without the size and bulk guard: %v\n"+
+			"  Large files were not checked. Run 'camp doctor -c bigfiles' if you want to look.",
+		cause)
+}
+
 // GitignoreRuleComment explains, in the file itself, why an artifact root's
 // ignore rule is there.
 const GitignoreRuleComment = "# Camp artifact root (synced with 'camp sync', not git)"
@@ -93,6 +105,13 @@ func HandleStageOutcome(
 ) (*GuardHandling, error) {
 	if outcome.Empty() {
 		return nil, nil
+	}
+
+	// The guard could not evaluate this repository and staging went ahead
+	// without it. Said out loud, because the dangerous version of degrading is
+	// the quiet one: a user who is not told assumes the protection ran.
+	if outcome.Unavailable != nil {
+		_, _ = fmt.Fprintln(out, ui.Warning(GuardUnavailableLine(outcome.Unavailable)))
 	}
 
 	handling := &GuardHandling{TrackedGrowth: outcome.Reported}

--- a/cmd/camp/cmdutil/guardreport.go
+++ b/cmd/camp/cmdutil/guardreport.go
@@ -2,6 +2,7 @@ package cmdutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -433,4 +434,76 @@ func (h *GuardHandling) ExcludedAnything() bool {
 // everything they changed was kept out of git, and exits the caller cleanly.
 func ReportNothingLeftToCommit(out io.Writer) {
 	_, _ = fmt.Fprintf(out, "%s Nothing left to commit: everything changed was kept out of git\n", ui.SuccessIcon())
+}
+
+// RenderGuardRefusal writes the full report for a guard refusal, in place of
+// the one-line error a caller would otherwise print.
+//
+// A refusal is the one moment the package spends the user's attention, so it
+// has to pay for it: what was found, where, that nothing was staged, and the
+// three ways out. A bare "staging refused" would leave the user to discover
+// all of that themselves.
+//
+// It reports whether it rendered, so the caller can suppress the ordinary
+// error print rather than showing both.
+func RenderGuardRefusal(out io.Writer, err error, commandName string) bool {
+	var blocked *git.GuardBlockedError
+	if !errors.As(err, &blocked) {
+		return false
+	}
+	switch blocked.Kind {
+	case stageguard.Bulk:
+		renderBulkRefusal(out, blocked, commandName)
+	default:
+		renderLargeFileRefusal(out, blocked, commandName)
+	}
+	return true
+}
+
+func renderBulkRefusal(out io.Writer, blocked *git.GuardBlockedError, commandName string) {
+	var total int
+	var bytes int64
+	var worst stageguard.GuardViolation
+	for _, v := range blocked.Violations {
+		total += v.Count
+		bytes += v.TotalBytes
+		if v.Count > worst.Count {
+			worst = v
+		}
+	}
+
+	_, _ = fmt.Fprintf(out, "Error: %s untracked files (%s) would be committed\n\n",
+		ui.FormatCount(total), ui.FormatBytes(bytes))
+	_, _ = fmt.Fprintf(out, "  %s/   %s files, %s\n\n",
+		worst.CommonPrefix, ui.FormatCount(worst.Count), ui.FormatBytes(worst.TotalBytes))
+	_, _ = fmt.Fprintf(out, "Nothing was staged. Camp does not guess on bulk directories:\n\n")
+	// The gitignore line interpolates the detected prefix. No directory name
+	// is hardcoded anywhere in the logic or the copy: size and shape decide,
+	// never a name camp was taught to recognize.
+	_, _ = fmt.Fprintf(out, "  gitignore it        echo '%s/' >> .gitignore\n", worst.CommonPrefix)
+	_, _ = fmt.Fprintf(out, "  keep and sync it    camp artifacts add %s\n", worst.CommonPrefix)
+	_, _ = fmt.Fprintf(out, "  commit it anyway    %s --commit-large -m \"...\"\n", commandName)
+	_, _ = fmt.Fprintf(out, "  turn the guard off  camp settings set local.commit.guards.bulk off\n")
+}
+
+func renderLargeFileRefusal(out io.Writer, blocked *git.GuardBlockedError, commandName string) {
+	_, _ = fmt.Fprintf(out, "Error: %s over the %s limit would be committed\n\n",
+		pluralFiles(len(blocked.Violations)), ui.FormatBytes(blocked.Limits.MaxFileSize))
+	for _, v := range blocked.Violations {
+		_, _ = fmt.Fprintf(out, "  %s   %s\n", v.Path, ui.FormatBytes(v.Size))
+	}
+	_, _ = fmt.Fprintf(out, "\nNothing was staged. commit.guards.large_files is set to block:\n\n")
+	for _, v := range blocked.Violations {
+		_, _ = fmt.Fprintf(out, "  keep and sync it    camp artifacts add %s\n",
+			filepath.ToSlash(filepath.Dir(v.Path)))
+	}
+	_, _ = fmt.Fprintf(out, "  commit it anyway    %s --commit-large -m \"...\"\n", commandName)
+	_, _ = fmt.Fprintf(out, "  handle it for me    camp settings set local.commit.guards.large_files auto\n")
+}
+
+func pluralFiles(n int) string {
+	if n == 1 {
+		return "1 file"
+	}
+	return ui.FormatCount(n) + " files"
 }

--- a/cmd/camp/cmdutil/guardreport.go
+++ b/cmd/camp/cmdutil/guardreport.go
@@ -55,6 +55,9 @@ type DeclaredRoot struct {
 	// KeptWithGit names the files under this root that were still staged, so
 	// the report can say what git still owns.
 	KeptWithGit string
+	// KeptWithGitCount is how many those names cover, so the sentence agrees
+	// in number.
+	KeptWithGitCount int
 	// Existing is true when the root was already declared and camp reused it.
 	Existing bool
 }
@@ -172,7 +175,9 @@ func declareRootsForExclusions(
 	// Ask git what is still staged under each root, so the report names the
 	// files that remain git's rather than guessing from the exclusion list.
 	for _, root := range order {
-		byRoot[root].KeptWithGit = stagedNamesUnder(ctx, campRoot, root)
+		names, n := stagedNamesUnder(ctx, campRoot, root)
+		byRoot[root].KeptWithGit = names
+		byRoot[root].KeptWithGitCount = n
 	}
 
 	handling.Declared = append(handling.Declared, collectRoots(order, byRoot)...)
@@ -189,10 +194,10 @@ func collectRoots(order []string, byRoot map[string]*DeclaredRoot) []DeclaredRoo
 
 // stagedNamesUnder renders the staged file names beneath a root as a human
 // list ("script.md and notes.md"), or "" when nothing under it is staged.
-func stagedNamesUnder(ctx context.Context, campRoot, root string) string {
+func stagedNamesUnder(ctx context.Context, campRoot, root string) (string, int) {
 	paths, err := git.StagedPathsUnder(ctx, campRoot, root)
 	if err != nil || len(paths) == 0 {
-		return ""
+		return "", 0
 	}
 	names := make([]string, 0, len(paths))
 	for _, p := range paths {
@@ -200,11 +205,11 @@ func stagedNamesUnder(ctx context.Context, campRoot, root string) string {
 	}
 	switch len(names) {
 	case 1:
-		return names[0]
+		return names[0], 1
 	case 2:
-		return names[0] + " and " + names[1]
+		return names[0] + " and " + names[1], 2
 	default:
-		return fmt.Sprintf("%s and %s more", names[0], ui.FormatCount(len(names)-1))
+		return fmt.Sprintf("%s and %s more", names[0], ui.FormatCount(len(names)-1)), len(names)
 	}
 }
 
@@ -285,7 +290,11 @@ func renderDeclaredRoot(out io.Writer, campRoot string, d DeclaredRoot) {
 	// their directory is now "artifact content" and has no way to know the
 	// notes they wrote beside the footage are still versioned.
 	if kept := d.KeptWithGit; kept != "" {
-		_, _ = fmt.Fprintf(out, "  %s stay with git\n", kept)
+		verb := "stay"
+		if d.KeptWithGitCount == 1 {
+			verb = "stays"
+		}
+		_, _ = fmt.Fprintf(out, "  %s %s with git\n", kept, verb)
 	}
 	_, _ = fmt.Fprintf(out, "  Undo: camp artifacts remove %s\n", d.Root)
 

--- a/cmd/camp/cmdutil/guardreport_test.go
+++ b/cmd/camp/cmdutil/guardreport_test.go
@@ -1,0 +1,192 @@
+package cmdutil
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/artifacts"
+	"github.com/Obedience-Corp/camp/internal/git"
+	"github.com/Obedience-Corp/camp/internal/stageguard"
+)
+
+func TestViolationNames(t *testing.T) {
+	cases := []struct {
+		name       string
+		violations []stageguard.GuardViolation
+		want       string
+	}{
+		{name: "none", violations: nil, want: ""},
+		{
+			name:       "one names the file",
+			violations: []stageguard.GuardViolation{{Path: "videos/my-video/footage.mp4"}},
+			want:       "footage.mp4",
+		},
+		{
+			name: "two are both named",
+			violations: []stageguard.GuardViolation{
+				{Path: "a/footage.mp4"}, {Path: "a/broll.mp4"},
+			},
+			want: "footage.mp4, broll.mp4",
+		},
+		{
+			// A root absorbing hundreds of files must not print hundreds of
+			// names; the first plus a count carries the same information.
+			name: "three or more abbreviate",
+			violations: []stageguard.GuardViolation{
+				{Path: "a/one.mp4"}, {Path: "a/two.mp4"}, {Path: "a/three.mp4"},
+			},
+			want: "one.mp4 and 2 more",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := violationNames(tc.violations); got != tc.want {
+				t.Errorf("violationNames() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLFSPattern(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "keeps the directory, widens the name", path: "testdata/corpus.tar", want: "testdata/*.tar"},
+		{name: "nested directory", path: "a/b/c/blob.bin", want: "a/b/c/*.bin"},
+		{name: "root-level file", path: "corpus.tar", want: "*.tar"},
+		{name: "no extension falls back to the path", path: "testdata/corpus", want: "testdata/corpus"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lfsPattern(tc.path); got != tc.want {
+				t.Errorf("lfsPattern(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// Each refusal explains the specific boundary that was hit. A generic message
+// would leave the user guessing which rule applied, and therefore what to do.
+func TestRefusalExplanation(t *testing.T) {
+	cases := []struct {
+		reason artifacts.RefusalReason
+		want   string
+	}{
+		{reason: artifacts.RefusalCampaignRoot, want: "campaign an artifact root"},
+		{reason: artifacts.RefusalCampaignState, want: ".campaign/"},
+		{reason: artifacts.RefusalRepoRoot, want: "repo boundary"},
+		{reason: artifacts.RefusalEscapesCampaign, want: "camp will not create an artifact root"},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.reason), func(t *testing.T) {
+			got := refusalExplanation(tc.reason)
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("refusalExplanation(%q) = %q, want it to mention %q", tc.reason, got, tc.want)
+			}
+		})
+	}
+}
+
+// Tracked growth is reported but always committed, so it must not count as an
+// exclusion; treating it as one would make camp claim a no-op commit while
+// there was real content to commit.
+func TestGuardHandlingExcludedAnything(t *testing.T) {
+	cases := []struct {
+		name     string
+		handling *GuardHandling
+		want     bool
+	}{
+		{name: "nil", handling: nil, want: false},
+		{name: "empty", handling: &GuardHandling{}, want: false},
+		{
+			name: "tracked growth alone is not an exclusion",
+			handling: &GuardHandling{
+				TrackedGrowth: []stageguard.GuardViolation{{Path: "graph.png"}},
+			},
+			want: false,
+		},
+		{
+			name: "a declared root with no files is not an exclusion",
+			handling: &GuardHandling{
+				Declared: []DeclaredRoot{{Root: "videos"}},
+			},
+			want: false,
+		},
+		{
+			name: "a declared root holding files is",
+			handling: &GuardHandling{
+				Declared: []DeclaredRoot{{Root: "videos", Files: []stageguard.GuardViolation{{Path: "v.mp4"}}}},
+			},
+			want: true,
+		},
+		{
+			name:     "a refusal is",
+			handling: &GuardHandling{Refused: []RefusedFile{{Reason: reasonNeedsRootDecision}}},
+			want:     true,
+		},
+		{
+			name:     "a project exclusion is",
+			handling: &GuardHandling{ProjectExcluded: []RefusedFile{{Reason: reasonProjectLargeFile}}},
+			want:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.handling.ExcludedAnything(); got != tc.want {
+				t.Errorf("ExcludedAnything() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPluralFiles(t *testing.T) {
+	cases := []struct {
+		n    int
+		want string
+	}{
+		{n: 1, want: "1 file"},
+		{n: 2, want: "2 files"},
+		{n: 8432, want: "8,432 files"},
+	}
+	for _, tc := range cases {
+		if got := pluralFiles(tc.n); got != tc.want {
+			t.Errorf("pluralFiles(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}
+
+// The bulk refusal must never name a directory camp was taught to recognize:
+// the prefix comes from detection, so the same copy works for any vendor tree.
+func TestRenderBulkRefusalInterpolatesDetectedPrefix(t *testing.T) {
+	var out strings.Builder
+	blocked := &git.GuardBlockedError{
+		Kind: stageguard.Bulk,
+		Violations: []stageguard.GuardViolation{{
+			Kind:         stageguard.Bulk,
+			CommonPrefix: "some/deep/vendor_dir",
+			Count:        8432,
+			TotalBytes:   61 << 20,
+		}},
+	}
+	renderBulkRefusal(&out, blocked, "camp commit")
+
+	got := out.String()
+	for _, want := range []string{
+		"8,432 untracked files",
+		"some/deep/vendor_dir",
+		"echo 'some/deep/vendor_dir/' >> .gitignore",
+		"camp artifacts add some/deep/vendor_dir",
+		"camp commit --commit-large",
+		"Nothing was staged",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("bulk refusal missing %q; got:\n%s", want, got)
+		}
+	}
+}

--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -59,6 +59,7 @@ var (
 	commitWorkitem    string
 	commitNoEdit      bool
 	commitLarge       bool
+	commitJSONOut     bool
 )
 
 func init() {
@@ -72,6 +73,7 @@ func init() {
 	commitCmd.Flags().BoolVar(&commitAutoWrite, "auto-write", false, "Run configured commit message writer")
 	commitCmd.Flags().StringVar(&commitWorkitem, "workitem", "", "explicit workitem selector for the commit tag (overrides cwd-based resolution)")
 	commitCmd.Flags().BoolVar(&commitLarge, "commit-large", false, "Commit over-threshold files instead of keeping them out of git")
+	commitCmd.Flags().BoolVar(&commitJSONOut, "json", false, "Emit a JSON result on stdout; human output goes to stderr")
 
 	rootCmd.AddCommand(commitCmd)
 	commitCmd.GroupID = "git"
@@ -100,6 +102,16 @@ func completeProjectFlag(cmd *cobra.Command, args []string, toComplete string) (
 func runCommit(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 
+	// Under --json, stdout carries exactly one document and nothing else.
+	// Human lines go to stderr rather than being dropped, so a person watching
+	// a scripted run still sees what happened. fest has the interleave bug
+	// this avoids; the point of doing it here is not to recreate it.
+	humanOut := cmd.OutOrStdout()
+	if commitJSONOut {
+		humanOut = cmd.ErrOrStderr()
+	}
+	jsonResult := newCommitJSONResult("")
+
 	// Join repeated -m values git-style before any tag prepending so the tag
 	// lands on the subject line.
 	commitMessage := commitkit.JoinMessages(commitMessages)
@@ -117,7 +129,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	}
 
 	if target.IsSubmodule {
-		fmt.Println(ui.Info(fmt.Sprintf("Operating on submodule: %s", target.Name)))
+		_, _ = fmt.Fprintln(humanOut, ui.Info(fmt.Sprintf("Operating on submodule: %s", target.Name)))
 	}
 
 	if commitAutoWrite && commitMessage != "" {
@@ -153,7 +165,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 
 	// Stage if requested
 	if stageAll {
-		fmt.Println(ui.Info("Staging changes..."))
+		_, _ = fmt.Fprintln(humanOut, ui.Info("Staging changes..."))
 		var guardOutcome *git.StageOutcome
 		if target.IsSubmodule || commitIncludeRefs {
 			outcome, err := git.StageWithGuardOptions(ctx, target.Path, nil, git.StageOptions{CommitLarge: commitLarge})
@@ -185,10 +197,11 @@ func runCommit(cmd *cobra.Command, args []string) error {
 
 		// Act on what the guard decided and tell the user. Runs after staging
 		// so the declaration it may write lands in this same commit.
-		handling, err := cmdutil.HandleStageOutcome(ctx, cmd.OutOrStdout(), campRoot, target.Path, guardOutcome)
+		handling, err := cmdutil.HandleStageOutcome(ctx, humanOut, campRoot, target.Path, guardOutcome)
 		if err != nil {
 			return err
 		}
+		jsonResult.applyGuardHandling(handling)
 		// The excluded file is still an unstaged worktree change, so the
 		// ordinary has-changes check would say yes and git would then reject
 		// the empty commit. Report the no-op instead of failing.
@@ -197,13 +210,13 @@ func runCommit(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if empty && !commitAmend {
-			cmdutil.ReportNothingLeftToCommit(cmd.OutOrStdout())
-			return nil
+			cmdutil.ReportNothingLeftToCommit(humanOut)
+			return commitJSONNoop(cmd, jsonResult)
 		}
 	}
 
 	// Show what will be committed
-	cmdutil.ShowStagedSummary(ctx, target.Path)
+	cmdutil.ShowStagedSummaryTo(humanOut, ctx, target.Path)
 
 	// Refuse root content commits that would accidentally sweep pre-staged
 	// submodule gitlinks into this commit's message/tag context. The user can
@@ -224,12 +237,12 @@ func runCommit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if !hasChanges && !commitAmend {
-		fmt.Println(ui.Success("Nothing to commit, working tree clean"))
-		return nil
+		_, _ = fmt.Fprintln(humanOut, ui.Success("Nothing to commit, working tree clean"))
+		return commitJSONNoop(cmd, jsonResult)
 	}
 
 	if commitAutoWrite {
-		fmt.Println(ui.Info("Writing commit message..."))
+		_, _ = fmt.Fprintln(humanOut, ui.Info("Writing commit message..."))
 		var hookErr error
 		extraEnv := workitemEnvForCommit(ctx, campRoot, commitWorkitem)
 		extraEnv = commitkit.WithCommitAmendEnv(extraEnv, commitAmend)
@@ -255,7 +268,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	}
 
 	// Perform commit
-	fmt.Println(ui.Info("Committing changes..."))
+	_, _ = fmt.Fprintln(humanOut, ui.Info("Committing changes..."))
 	opts := &git.CommitOptions{
 		Message: message,
 		Amend:   commitAmend,
@@ -270,13 +283,13 @@ func runCommit(cmd *cobra.Command, args []string) error {
 					return camperrors.Wrap(driftErr, "check unstaged submodule refs")
 				}
 				if len(driftRefs) > 0 {
-					fmt.Println(ui.Warning("Nothing to commit (submodule ref changes are excluded by default)"))
-					fmt.Println(ui.Dim("  Use 'camp refs-sync' to commit only the submodule pointers."))
-					fmt.Println(ui.Dim("  Use 'camp commit --include-refs -m \"...\"' to include them in this commit."))
+					_, _ = fmt.Fprintln(humanOut, ui.Warning("Nothing to commit (submodule ref changes are excluded by default)"))
+					_, _ = fmt.Fprintln(humanOut, ui.Dim("  Use 'camp refs-sync' to commit only the submodule pointers."))
+					_, _ = fmt.Fprintln(humanOut, ui.Dim("  Use 'camp commit --include-refs -m \"...\"' to include them in this commit."))
 					return nil
 				}
 			}
-			fmt.Println(ui.Success("Nothing to commit"))
+			_, _ = fmt.Fprintln(humanOut, ui.Success("Nothing to commit"))
 			return nil
 		}
 		return err
@@ -290,8 +303,26 @@ func runCommit(cmd *cobra.Command, args []string) error {
 			CommitEvidence(ctx, ledgerkit.Scope{Workitem: workitemRef, Festival: festivalRef}, campRoot, target.Path, sha, message)
 	}
 
-	fmt.Println(ui.Success("Changes committed successfully"))
+	_, _ = fmt.Fprintln(humanOut, ui.Success("Changes committed successfully"))
+
+	if commitJSONOut {
+		jsonResult.Repo = target.Path
+		if err := jsonResult.finalize(ctx, target.Path); err != nil {
+			return err
+		}
+		return jsonResult.emit(cmd.OutOrStdout())
+	}
 	return nil
+}
+
+// commitJSONNoop emits the document for a run that legitimately produced no
+// commit, so a machine caller always receives one document per invocation
+// rather than having to treat "no output" as a distinct outcome.
+func commitJSONNoop(cmd *cobra.Command, result *commitJSONResult) error {
+	if !commitJSONOut {
+		return nil
+	}
+	return result.emit(cmd.OutOrStdout())
 }
 
 func worktreesRelPath(ctx context.Context, campRoot string) string {

--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -58,6 +58,7 @@ var (
 	commitAutoWrite   bool
 	commitWorkitem    string
 	commitNoEdit      bool
+	commitLarge       bool
 )
 
 func init() {
@@ -70,6 +71,7 @@ func init() {
 	commitCmd.Flags().BoolVar(&commitIncludeRefs, "include-refs", false, "Include submodule ref changes when staging at campaign root")
 	commitCmd.Flags().BoolVar(&commitAutoWrite, "auto-write", false, "Run configured commit message writer")
 	commitCmd.Flags().StringVar(&commitWorkitem, "workitem", "", "explicit workitem selector for the commit tag (overrides cwd-based resolution)")
+	commitCmd.Flags().BoolVar(&commitLarge, "commit-large", false, "Commit over-threshold files instead of keeping them out of git")
 
 	rootCmd.AddCommand(commitCmd)
 	commitCmd.GroupID = "git"
@@ -154,7 +156,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 		fmt.Println(ui.Info("Staging changes..."))
 		var guardOutcome *git.StageOutcome
 		if target.IsSubmodule || commitIncludeRefs {
-			outcome, err := git.StageWithGuard(ctx, target.Path, nil)
+			outcome, err := git.StageWithGuardOptions(ctx, target.Path, nil, git.StageOptions{CommitLarge: commitLarge})
 			if err != nil {
 				return err
 			}
@@ -166,7 +168,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 			if pathErr != nil {
 				return pathErr
 			}
-			outcome, err := git.StageAllExcludingWithGuard(ctx, target.Path, paths)
+			outcome, err := git.StageAllExcludingWithGuardOptions(ctx, target.Path, paths, git.StageOptions{CommitLarge: commitLarge})
 			if err != nil {
 				return err
 			}

--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -152,10 +152,13 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	// Stage if requested
 	if stageAll {
 		fmt.Println(ui.Info("Staging changes..."))
+		var guardOutcome *git.StageOutcome
 		if target.IsSubmodule || commitIncludeRefs {
-			if err := executor.StageAll(ctx); err != nil {
+			outcome, err := git.StageWithGuard(ctx, target.Path, nil)
+			if err != nil {
 				return err
 			}
+			guardOutcome = outcome
 		} else {
 			// Campaign root: exclude submodule refs to prevent accidental
 			// ref changes from polluting content commits.
@@ -163,9 +166,11 @@ func runCommit(cmd *cobra.Command, args []string) error {
 			if pathErr != nil {
 				return pathErr
 			}
-			if err := git.StageAllExcluding(ctx, target.Path, paths); err != nil {
+			outcome, err := git.StageAllExcludingWithGuard(ctx, target.Path, paths)
+			if err != nil {
 				return err
 			}
+			guardOutcome = outcome
 			// git add rejects exclude pathspecs whose target contains
 			// gitignored entries, so worktrees are unstaged after staging
 			// instead of excluded up front.
@@ -174,6 +179,24 @@ func runCommit(cmd *cobra.Command, args []string) error {
 					return err
 				}
 			}
+		}
+
+		// Act on what the guard decided and tell the user. Runs after staging
+		// so the declaration it may write lands in this same commit.
+		handling, err := cmdutil.HandleStageOutcome(ctx, cmd.OutOrStdout(), campRoot, target.Path, guardOutcome)
+		if err != nil {
+			return err
+		}
+		// The excluded file is still an unstaged worktree change, so the
+		// ordinary has-changes check would say yes and git would then reject
+		// the empty commit. Report the no-op instead of failing.
+		empty, err := cmdutil.GuardExcludedEverything(ctx, target.Path, handling)
+		if err != nil {
+			return err
+		}
+		if empty && !commitAmend {
+			cmdutil.ReportNothingLeftToCommit(cmd.OutOrStdout())
+			return nil
 		}
 	}
 

--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -166,13 +166,18 @@ func runCommit(cmd *cobra.Command, args []string) error {
 	// Stage if requested
 	if stageAll {
 		_, _ = fmt.Fprintln(humanOut, ui.Info("Staging changes..."))
-		var guardOutcome *git.StageOutcome
+		// The guard error is routed through the JSON reporter for both
+		// branches, hoisted below. A submodule commit that returned it raw
+		// emitted no document under --json, so a machine caller saw a bare
+		// non-zero exit where the campaign-root branch gave it a refusal it
+		// could act on.
+		var (
+			guardOutcome *git.StageOutcome
+			stageErr     error
+		)
 		if target.IsSubmodule || commitIncludeRefs {
-			outcome, err := git.StageWithGuardOptions(ctx, target.Path, nil, git.StageOptions{CommitLarge: commitLarge})
-			if err != nil {
-				return err
-			}
-			guardOutcome = outcome
+			guardOutcome, stageErr = git.StageWithGuardOptions(
+				ctx, target.Path, nil, git.StageOptions{CommitLarge: commitLarge})
 		} else {
 			// Campaign root: exclude submodule refs to prevent accidental
 			// ref changes from polluting content commits.
@@ -180,19 +185,21 @@ func runCommit(cmd *cobra.Command, args []string) error {
 			if pathErr != nil {
 				return pathErr
 			}
-			outcome, err := git.StageAllExcludingWithGuardOptions(ctx, target.Path, paths, git.StageOptions{CommitLarge: commitLarge})
-			if err != nil {
-				return reportGuardRefusalJSON(cmd, jsonResult, err)
-			}
-			guardOutcome = outcome
-			// git add rejects exclude pathspecs whose target contains
-			// gitignored entries, so worktrees are unstaged after staging
-			// instead of excluded up front.
-			if wt := worktreesRelPath(ctx, campRoot); wt != "" {
-				if err := git.UnstagePath(ctx, target.Path, wt); err != nil {
-					return err
+			guardOutcome, stageErr = git.StageAllExcludingWithGuardOptions(
+				ctx, target.Path, paths, git.StageOptions{CommitLarge: commitLarge})
+			if stageErr == nil {
+				// git add rejects exclude pathspecs whose target contains
+				// gitignored entries, so worktrees are unstaged after staging
+				// instead of excluded up front.
+				if wt := worktreesRelPath(ctx, campRoot); wt != "" {
+					if err := git.UnstagePath(ctx, target.Path, wt); err != nil {
+						return err
+					}
 				}
 			}
+		}
+		if stageErr != nil {
+			return reportGuardRefusalJSON(cmd, jsonResult, stageErr)
 		}
 
 		// Act on what the guard decided and tell the user. Runs after staging

--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -182,7 +182,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 			}
 			outcome, err := git.StageAllExcludingWithGuardOptions(ctx, target.Path, paths, git.StageOptions{CommitLarge: commitLarge})
 			if err != nil {
-				return err
+				return reportGuardRefusalJSON(cmd, jsonResult, err)
 			}
 			guardOutcome = outcome
 			// git add rejects exclude pathspecs whose target contains

--- a/cmd/camp/commit_json.go
+++ b/cmd/camp/commit_json.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+
+	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git"
+)
+
+// CommitJSONVersion is the schema version of `camp commit --json`.
+const CommitJSONVersion = "commit/v1alpha1"
+
+// commitJSONResult is the document `camp commit --json` writes to stdout.
+//
+// The load-bearing field is Excluded. A machine caller that only sees a commit
+// hash cannot tell that a file it wrote never entered the commit; without this
+// array, camp's automatic handling would be invisible to exactly the callers
+// least able to notice it from prose.
+//
+// The contract is synchronous: this document always carries a real commit
+// hash, never a job id or a promise. Deferral, added later, must not change
+// that, and the test asserting it exists now so the guarantee cannot regress
+// silently.
+type commitJSONResult struct {
+	SchemaVersion string `json:"schema_version"`
+	// OK is true when the commit landed.
+	OK bool `json:"ok"`
+	// Repo is the repository the commit was made in.
+	Repo string `json:"repo"`
+	// Commit is the full commit hash. Never empty when OK is true.
+	Commit string `json:"commit"`
+	// Staged counts the paths that entered the commit.
+	Staged int `json:"staged"`
+	// Excluded lists files the guard kept out. Always an array, never null.
+	Excluded []excludedFileJSON `json:"excluded"`
+	// ArtifactRootsDeclared lists roots camp declared during this commit.
+	// Always an array, never null.
+	ArtifactRootsDeclared []string `json:"artifact_roots_declared"`
+}
+
+// excludedFileJSON is one file the guard kept out of the commit.
+type excludedFileJSON struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+	// Reason is why the file was excluded. The complete set:
+	//
+	//   size_guard           over the threshold; camp declared an artifact
+	//                        root for it, named in ArtifactRoot
+	//   needs_root_decision  over the threshold, but camp would not choose a
+	//                        root (campaign root, .campaign/, a repo root)
+	//   project_large_file   over the threshold inside a project, where an
+	//                        artifact root would keep it off the remote
+	Reason string `json:"reason"`
+	// ArtifactRoot is the root camp declared, set only for size_guard.
+	ArtifactRoot string `json:"artifact_root,omitempty"`
+}
+
+// Exclusion reasons. size_guard is the auto-handled case; the other two come
+// from the refusal paths and are already named in GuardHandling.
+const reasonSizeGuard = "size_guard"
+
+// newCommitJSONResult builds the document with every slice initialized.
+//
+// Nil slices marshal to null, which has broken camp --json consumers before:
+// a caller iterating `.excluded[]` gets a type error rather than zero
+// iterations. The empty-slice initialization is the contract, not a detail.
+func newCommitJSONResult(repo string) *commitJSONResult {
+	return &commitJSONResult{
+		SchemaVersion:         CommitJSONVersion,
+		Repo:                  repo,
+		Excluded:              []excludedFileJSON{},
+		ArtifactRootsDeclared: []string{},
+	}
+}
+
+// applyGuardHandling folds what the guard did into the result.
+func (r *commitJSONResult) applyGuardHandling(h *cmdutil.GuardHandling) {
+	if h == nil {
+		return
+	}
+	for _, d := range h.Declared {
+		r.ArtifactRootsDeclared = append(r.ArtifactRootsDeclared, d.Root)
+		for _, v := range d.Files {
+			r.Excluded = append(r.Excluded, excludedFileJSON{
+				Path: v.Path, Size: v.Size, Reason: reasonSizeGuard, ArtifactRoot: d.Root,
+			})
+		}
+	}
+	for _, f := range h.Refused {
+		r.Excluded = append(r.Excluded, excludedFileJSON{
+			Path: f.Violation.Path, Size: f.Violation.Size, Reason: f.Reason,
+		})
+	}
+	for _, f := range h.ProjectExcluded {
+		r.Excluded = append(r.Excluded, excludedFileJSON{
+			Path: f.Violation.Path, Size: f.Violation.Size, Reason: f.Reason,
+		})
+	}
+}
+
+// finalize records the landed commit, resolving the full hash.
+func (r *commitJSONResult) finalize(ctx context.Context, repoPath string) error {
+	hash, err := git.FullHash(ctx, repoPath)
+	if err != nil {
+		return camperrors.Wrapf(err, "resolve commit hash in %s", repoPath)
+	}
+	staged, err := git.CommitPathCount(ctx, repoPath)
+	if err != nil {
+		return camperrors.Wrapf(err, "count committed paths in %s", repoPath)
+	}
+	r.OK = true
+	r.Commit = hash
+	r.Staged = staged
+	return nil
+}
+
+// emit writes the document as the only thing on stdout.
+func (r *commitJSONResult) emit(out io.Writer) error {
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(r)
+}

--- a/cmd/camp/commit_json.go
+++ b/cmd/camp/commit_json.go
@@ -3,11 +3,15 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
+
+	"github.com/spf13/cobra"
 
 	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/git"
+	"github.com/Obedience-Corp/camp/internal/stageguard"
 )
 
 // CommitJSONVersion is the schema version of `camp commit --json`.
@@ -53,14 +57,28 @@ type excludedFileJSON struct {
 	//                        root (campaign root, .campaign/, a repo root)
 	//   project_large_file   over the threshold inside a project, where an
 	//                        artifact root would keep it off the remote
+	//
+	// A refusal, where nothing was staged at all, uses its own two:
+	//
+	//   size_guard_blocked   over the threshold under large_files: block
+	//   bulk_guard           a bulk directory refused the whole commit; Path
+	//                        is the directory and Size its total
 	Reason string `json:"reason"`
 	// ArtifactRoot is the root camp declared, set only for size_guard.
 	ArtifactRoot string `json:"artifact_root,omitempty"`
 }
 
-// Exclusion reasons. size_guard is the auto-handled case; the other two come
-// from the refusal paths and are already named in GuardHandling.
-const reasonSizeGuard = "size_guard"
+// Exclusion reasons. size_guard is the auto-handled case; the next two come
+// from the refusal paths and are already named in GuardHandling. The last two
+// describe a refusal, where nothing was staged at all.
+const (
+	reasonSizeGuard = "size_guard"
+	// reasonSizeGuardBlocked is an over-threshold file under large_files:
+	// block, where camp refused rather than excluding-and-continuing.
+	reasonSizeGuardBlocked = "size_guard_blocked"
+	// reasonBulkGuard is a bulk directory that refused the whole commit.
+	reasonBulkGuard = "bulk_guard"
+)
 
 // newCommitJSONResult builds the document with every slice initialized.
 //
@@ -122,4 +140,50 @@ func (r *commitJSONResult) emit(out io.Writer) error {
 	encoder := json.NewEncoder(out)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(r)
+}
+
+// applyGuardRefusal records a refusal: nothing was staged, no commit exists,
+// and the document says which files caused it.
+//
+// Without this, `camp commit --json` on a refusal emits an exit code and an
+// empty stdout, leaving a machine caller unable to tell a refusal from a
+// crash. The schema carries an `ok` field precisely so a well-formed document
+// can describe a run that produced no commit.
+func (r *commitJSONResult) applyGuardRefusal(blocked *git.GuardBlockedError) {
+	r.OK = false
+	r.Commit = ""
+	r.Staged = 0
+	r.Repo = blocked.RepoPath
+
+	reason := reasonSizeGuardBlocked
+	if blocked.Kind == stageguard.Bulk {
+		reason = reasonBulkGuard
+	}
+	for _, v := range blocked.Violations {
+		path := v.Path
+		size := v.Size
+		if v.Kind == stageguard.Bulk {
+			// A bulk violation describes a directory, not one file; report the
+			// prefix and its total so the caller sees what was refused.
+			path = v.CommonPrefix
+			size = v.TotalBytes
+		}
+		r.Excluded = append(r.Excluded, excludedFileJSON{
+			Path: path, Size: size, Reason: reason,
+		})
+	}
+}
+
+// reportGuardRefusalJSON emits the refusal document under --json and returns
+// the error either way, so the human path and the exit code are unchanged.
+func reportGuardRefusalJSON(cmd *cobra.Command, result *commitJSONResult, err error) error {
+	var blocked *git.GuardBlockedError
+	if !commitJSONOut || !errors.As(err, &blocked) {
+		return err
+	}
+	result.applyGuardRefusal(blocked)
+	if emitErr := result.emit(cmd.OutOrStdout()); emitErr != nil {
+		return emitErr
+	}
+	return err
 }

--- a/cmd/camp/doctor.go
+++ b/cmd/camp/doctor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"os"
+	"strings"
 
 	"github.com/Obedience-Corp/camp/internal/campaign"
 	"github.com/Obedience-Corp/camp/internal/doctor"
@@ -102,7 +103,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	)
 
 	// Register all checks
-	registerChecks(d)
+	registerChecks(d, doctorOpts.checks...)
 
 	// Run doctor
 	result, err := d.Run(ctx)
@@ -126,7 +127,10 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 
 // registerChecks registers all health checks with the doctor.
 // OrphanCheck runs first because orphaned gitlinks can break other checks.
-func registerChecks(d *doctor.Doctor) {
+//
+// requested names the checks the user asked for with -c, so opt-in checks can
+// stay out of the default run.
+func registerChecks(d *doctor.Doctor, requested ...string) {
 	d.RegisterCheck(checks.NewOrphanCheck())
 	d.RegisterCheck(checks.NewURLCheck())
 	d.RegisterCheck(checks.NewIntegrityCheck())
@@ -136,6 +140,25 @@ func registerChecks(d *doctor.Doctor) {
 	d.RegisterCheck(checks.NewLockCheck())
 	d.RegisterCheck(checks.NewLedgerCheck())
 	d.RegisterCheck(checks.NewArtifactsCheck())
+
+	// bigfiles is opt-in. Every other check here is a git invocation costing
+	// milliseconds; this one walks the whole campaign, measured at 17.9s over
+	// 843,522 files on a real campaign. Putting that in the default run would
+	// make `camp doctor` something users stop running, which costs more than
+	// the check finds.
+	if requestedCheck(requested, checks.NewBigFilesCheck().ID()) {
+		d.RegisterCheck(checks.NewBigFilesCheck())
+	}
+}
+
+// requestedCheck reports whether the user named a check with -c.
+func requestedCheck(requested []string, id string) bool {
+	for _, r := range requested {
+		if strings.EqualFold(strings.TrimSpace(r), id) {
+			return true
+		}
+	}
+	return false
 }
 
 type doctorJSONPayload struct {

--- a/cmd/camp/doctor.go
+++ b/cmd/camp/doctor.go
@@ -135,6 +135,7 @@ func registerChecks(d *doctor.Doctor) {
 	d.RegisterCheck(checks.NewCommitsCheck())
 	d.RegisterCheck(checks.NewLockCheck())
 	d.RegisterCheck(checks.NewLedgerCheck())
+	d.RegisterCheck(checks.NewArtifactsCheck())
 }
 
 type doctorJSONPayload struct {

--- a/cmd/camp/main.go
+++ b/cmd/camp/main.go
@@ -25,7 +25,7 @@ func main() {
 		// user's attention, so it prints the full report (what was found,
 		// that nothing was staged, and the ways forward) in place of the
 		// one-line error, rather than in addition to it.
-		if cmdutil.RenderGuardRefusal(os.Stderr, err, "camp commit") {
+		if cmdutil.RenderGuardRefusal(os.Stderr, err, ExecutedCommandPath()) {
 			os.Exit(1)
 		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/camp/main.go
+++ b/cmd/camp/main.go
@@ -10,6 +10,7 @@ import (
 
 	// bginit must initialize before the bubbletea subtree under the command
 	// packages; its path keeps it first under gofmt.
+	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
 	_ "github.com/Obedience-Corp/camp/internal/bginit"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
@@ -24,6 +25,13 @@ func main() {
 		var cmdErr *camperrors.CommandError
 		if errors.As(err, &cmdErr) && cmdErr.ExitCode != 0 {
 			os.Exit(cmdErr.ExitCode)
+		}
+		// A staging-guard refusal is the one moment this package spends the
+		// user's attention, so it prints the full report (what was found,
+		// that nothing was staged, and the ways forward) in place of the
+		// one-line error, rather than in addition to it.
+		if cmdutil.RenderGuardRefusal(os.Stderr, err, "camp commit") {
+			os.Exit(1)
 		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/cmd/camp/notify.go
+++ b/cmd/camp/notify.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Obedience-Corp/camp/internal/campaign"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/notice"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+// Every dismissible notice prints its own dismiss command, so this surface is
+// never the only way to act on one. A user who wants the notice gone can copy
+// the line they are already reading rather than going looking for a command
+// they have not met yet.
+var notifyCmd = &cobra.Command{
+	Use:   "notify",
+	Short: "Manage campaign state notices",
+	Long: `Manage the advisory notices camp surfaces on commands you already run.
+
+Notices describe campaign state you may not know is true, such as a declared
+artifact root that has never synced. Each one carries its own dismiss command.
+
+Dismissals are stored in .campaign/notices.yaml, which is committed: a
+dismissal you make on one machine travels to your others, the same way the
+artifact declarations it concerns do.`,
+}
+
+var notifyDismissCmd = &cobra.Command{
+	Use:   "dismiss <notice-id>",
+	Short: "Stop showing a notice",
+	Long: `Dismiss a notice by id.
+
+Dismissal is per signature, not per kind. Dismissing the notice for one
+artifact root does not silence a root you declare later: that one has its own
+id and notifies on its own terms.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runNotifyDismiss,
+}
+
+var notifyListCmd = &cobra.Command{
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List dismissed notices",
+	Args:    cobra.NoArgs,
+	RunE:    runNotifyList,
+}
+
+func init() {
+	notifyCmd.AddCommand(notifyDismissCmd)
+	notifyCmd.AddCommand(notifyListCmd)
+	rootCmd.AddCommand(notifyCmd)
+}
+
+func runNotifyDismiss(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	campRoot, err := campaign.DetectCached(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign")
+	}
+
+	id := args[0]
+	dismissals, err := notice.LoadDismissals(campRoot)
+	if err != nil {
+		return err
+	}
+	if !dismissals.Dismiss(id, time.Now()) {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s %s was already dismissed\n", ui.SuccessIcon(), id)
+		return nil
+	}
+	if err := dismissals.Save(campRoot); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Dismissed %s\n", ui.SuccessIcon(), id)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Recorded in %s. Undo: camp notify restore %s\n",
+		notice.DismissalRelPath, id)
+	return nil
+}
+
+var notifyRestoreCmd = &cobra.Command{
+	Use:   "restore <notice-id>",
+	Short: "Show a dismissed notice again",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runNotifyRestore,
+}
+
+func init() {
+	notifyCmd.AddCommand(notifyRestoreCmd)
+}
+
+func runNotifyRestore(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	campRoot, err := campaign.DetectCached(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign")
+	}
+
+	id := args[0]
+	dismissals, err := notice.LoadDismissals(campRoot)
+	if err != nil {
+		return err
+	}
+	if !dismissals.IsDismissed(id) {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s %s is not dismissed\n", ui.SuccessIcon(), id)
+		return nil
+	}
+	delete(dismissals.Dismissed, id)
+	if err := dismissals.Save(campRoot); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s Restored %s\n", ui.SuccessIcon(), id)
+	return nil
+}
+
+func runNotifyList(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	campRoot, err := campaign.DetectCached(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign")
+	}
+
+	dismissals, err := notice.LoadDismissals(campRoot)
+	if err != nil {
+		return err
+	}
+	if len(dismissals.Dismissed) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No dismissed notices")
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "DISMISSED NOTICES\n")
+	for id, at := range dismissals.Dismissed {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s  %s\n", at.Format("2006-01-02"), id)
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nRestore one: camp notify restore <id>\n")
+	return nil
+}

--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -152,8 +152,24 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 	// Stage if requested
 	if projectCommitAll {
 		fmt.Println(ui.Info("Staging changes..."))
-		if err := executor.StageAll(ctx); err != nil {
-			return camperrors.Wrap(err, "failed to stage")
+		guardOutcome, stageErr := git.StageWithGuard(ctx, resolvedPath, nil)
+		if stageErr != nil {
+			return camperrors.Wrap(stageErr, "failed to stage")
+		}
+		// A project exclusion is never silent: camp cannot fix a large file
+		// here (an artifact root would keep it off the project's remote), so
+		// the least it owes the user is saying what it left out and why.
+		handling, hErr := cmdutil.HandleStageOutcome(ctx, cmd.OutOrStdout(), campRoot, resolvedPath, guardOutcome)
+		if hErr != nil {
+			return hErr
+		}
+		empty, eErr := cmdutil.GuardExcludedEverything(ctx, resolvedPath, handling)
+		if eErr != nil {
+			return eErr
+		}
+		if empty && !projectCommitAmend {
+			cmdutil.ReportNothingLeftToCommit(cmd.OutOrStdout())
+			return nil
 		}
 	}
 

--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -53,6 +53,7 @@ var (
 	projectCommitNoSync    bool
 	projectCommitAutoWrite bool
 	projectCommitWorkitem  string
+	projectCommitLarge     bool
 )
 
 func init() {
@@ -64,6 +65,7 @@ func init() {
 	projectCommitCmd.Flags().BoolVar(&projectCommitNoSync, "no-sync", false, "Do not sync submodule ref even if settings enable it")
 	projectCommitCmd.Flags().BoolVar(&projectCommitAutoWrite, "auto-write", false, "Run configured commit message writer")
 	projectCommitCmd.Flags().StringVar(&projectCommitWorkitem, "workitem", "", "explicit workitem selector for the commit tag (overrides cwd-based resolution)")
+	projectCommitCmd.Flags().BoolVar(&projectCommitLarge, "commit-large", false, "Commit over-threshold files instead of keeping them out of git")
 
 	if err := projectCommitCmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjectName); err != nil {
 		panic(err)
@@ -152,7 +154,7 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 	// Stage if requested
 	if projectCommitAll {
 		fmt.Println(ui.Info("Staging changes..."))
-		guardOutcome, stageErr := git.StageWithGuard(ctx, resolvedPath, nil)
+		guardOutcome, stageErr := git.StageWithGuardOptions(ctx, resolvedPath, nil, git.StageOptions{CommitLarge: projectCommitLarge})
 		if stageErr != nil {
 			return camperrors.Wrap(stageErr, "failed to stage")
 		}

--- a/cmd/camp/root.go
+++ b/cmd/camp/root.go
@@ -85,8 +85,25 @@ func Execute(ctx context.Context) error {
 		return err
 	}
 
-	return rootCmd.ExecuteContext(ctx)
+	// ExecuteContextC rather than ExecuteContext: it returns the command that
+	// actually ran, which is how a guard refusal can name the invocation the
+	// user typed instead of always saying "camp commit". Telling someone who
+	// ran `camp p commit` to rerun `camp commit --commit-large` sends them to
+	// a different repository.
+	executed, err := rootCmd.ExecuteContextC(ctx)
+	if executed != nil {
+		executedCommandPath = executed.CommandPath()
+	}
+	return err
 }
+
+// executedCommandPath is the command cobra dispatched to, for error rendering
+// after Execute returns. Set once per process; main is the only reader.
+var executedCommandPath = "camp commit"
+
+// ExecutedCommandPath returns the invocation that ran, defaulting to the
+// commit path when cobra never dispatched (a parse failure before dispatch).
+func ExecutedCommandPath() string { return executedCommandPath }
 
 // expandShortcuts expands shortcut aliases in os.Args before cobra parses them.
 // For example, "camp p list" becomes "camp project list" if "p" maps to "project".

--- a/cmd/camp/settings_cli.go
+++ b/cmd/camp/settings_cli.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/jsoncontract"
+	"github.com/Obedience-Corp/camp/internal/stageguard"
 )
 
 // SettingsJSONVersion is the schema version of camp settings get --json.
@@ -45,6 +46,15 @@ const (
 	settingsKeyLocalCampaignType        = "local.campaign.type"
 	settingsKeyLocalCampaignCommitHook  = "local.campaign.commit_hook"
 
+	// Staging guard keys. Campaign-scoped because the thresholds describe the
+	// campaign's own content, and every default the guard applies has to be
+	// reversible in one command.
+	settingsKeyLocalGuardMaxFileSize        = "local.commit.guards.max_file_size"
+	settingsKeyLocalGuardMaxProjectFileSize = "local.commit.guards.max_project_file_size"
+	settingsKeyLocalGuardMaxAddedFiles      = "local.commit.guards.max_added_files"
+	settingsKeyLocalGuardLargeFiles         = "local.commit.guards.large_files"
+	settingsKeyLocalGuardBulk               = "local.commit.guards.bulk"
+
 	// Commit behavior (global defaults + local overrides + effective view).
 	settingsKeyGlobalCommitSyncRefs       = "global.commit.sync_project_refs"
 	settingsKeyGlobalCommitDisableTags    = "global.commit.disable_commit_tags"
@@ -73,6 +83,11 @@ func settingsKeys() []string {
 		settingsKeyLocalCampaignMission,
 		settingsKeyLocalCampaignType,
 		settingsKeyLocalCampaignCommitHook,
+		settingsKeyLocalGuardMaxFileSize,
+		settingsKeyLocalGuardMaxProjectFileSize,
+		settingsKeyLocalGuardMaxAddedFiles,
+		settingsKeyLocalGuardLargeFiles,
+		settingsKeyLocalGuardBulk,
 	}
 }
 
@@ -80,7 +95,10 @@ func isCampaignScalarKey(key string) bool {
 	switch key {
 	case settingsKeyLocalCampaignName, settingsKeyLocalCampaignDescription,
 		settingsKeyLocalCampaignMission, settingsKeyLocalCampaignType,
-		settingsKeyLocalCampaignCommitHook:
+		settingsKeyLocalCampaignCommitHook,
+		settingsKeyLocalGuardMaxFileSize, settingsKeyLocalGuardMaxProjectFileSize,
+		settingsKeyLocalGuardMaxAddedFiles, settingsKeyLocalGuardLargeFiles,
+		settingsKeyLocalGuardBulk:
 		return true
 	default:
 		return false
@@ -288,6 +306,16 @@ func campaignScalarGet(ctx context.Context, key string) (any, error) {
 		return string(cfg.Type), nil
 	case settingsKeyLocalCampaignCommitHook:
 		return cfg.Hooks.CommitMessage.Command, nil
+	case settingsKeyLocalGuardMaxFileSize:
+		return cfg.Commit.Guards.MaxFileSize, nil
+	case settingsKeyLocalGuardMaxProjectFileSize:
+		return cfg.Commit.Guards.MaxProjectFileSize, nil
+	case settingsKeyLocalGuardMaxAddedFiles:
+		return cfg.Commit.Guards.MaxAddedFiles, nil
+	case settingsKeyLocalGuardLargeFiles:
+		return cfg.Commit.Guards.LargeFiles, nil
+	case settingsKeyLocalGuardBulk:
+		return cfg.Commit.Guards.Bulk, nil
 	default:
 		return nil, errSettingsUnknownKey(key)
 	}
@@ -495,9 +523,64 @@ func applyCampaignScalarKey(cfg *config.CampaignConfig, key, value string) (stri
 	case settingsKeyLocalCampaignCommitHook:
 		cfg.Hooks.CommitMessage.Command = strings.TrimSpace(value)
 		return cfg.Hooks.CommitMessage.Command, nil
+	case settingsKeyLocalGuardMaxFileSize, settingsKeyLocalGuardMaxProjectFileSize:
+		return applyGuardSizeKey(cfg, key, value)
+	case settingsKeyLocalGuardMaxAddedFiles:
+		return applyGuardCountKey(cfg, key, value)
+	case settingsKeyLocalGuardLargeFiles, settingsKeyLocalGuardBulk:
+		return applyGuardModeKey(cfg, key, value)
 	default:
 		return "", errSettingsUnknownKey(key)
 	}
+}
+
+// applyGuardSizeKey validates a byte-size setting with the same parser the
+// guard uses, so a value accepted here can never be rejected at commit time.
+func applyGuardSizeKey(cfg *config.CampaignConfig, key, value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if _, err := stageguard.ParseByteSize(trimmed); err != nil {
+		return "", camperrors.NewValidation(key,
+			fmt.Sprintf("%v (examples: 10MiB, 50MB, 1048576)", err), err)
+	}
+	if key == settingsKeyLocalGuardMaxFileSize {
+		cfg.Commit.Guards.MaxFileSize = trimmed
+	} else {
+		cfg.Commit.Guards.MaxProjectFileSize = trimmed
+	}
+	return trimmed, nil
+}
+
+// applyGuardCountKey validates the bulk trigger count.
+func applyGuardCountKey(cfg *config.CampaignConfig, key, value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	n, err := strconv.Atoi(trimmed)
+	if err != nil || n < 0 {
+		return "", camperrors.NewValidation(key,
+			fmt.Sprintf("must be a non-negative whole number, got %q", value), nil)
+	}
+	cfg.Commit.Guards.MaxAddedFiles = n
+	return trimmed, nil
+}
+
+// applyGuardModeKey validates a guard mode. The bulk guard deliberately has no
+// "auto": camp cannot infer whether a large untracked tree wants gitignore or
+// an artifact root, so offering the mode would promise a decision it cannot make.
+func applyGuardModeKey(cfg *config.CampaignConfig, key, value string) (string, error) {
+	trimmed := strings.ToLower(strings.TrimSpace(value))
+	if key == settingsKeyLocalGuardBulk {
+		if trimmed != string(stageguard.ModeBlock) && trimmed != string(stageguard.ModeOff) {
+			return "", camperrors.NewValidation(key,
+				fmt.Sprintf("must be block or off, got %q", value), nil)
+		}
+		cfg.Commit.Guards.Bulk = trimmed
+		return trimmed, nil
+	}
+	if !stageguard.Mode(trimmed).Valid() {
+		return "", camperrors.NewValidation(key,
+			fmt.Sprintf("must be auto, block, or off, got %q", value), nil)
+	}
+	cfg.Commit.Guards.LargeFiles = trimmed
+	return trimmed, nil
 }
 
 func setGlobalSetting(ctx context.Context, cmd *cobra.Command, key, value string) error {

--- a/cmd/camp/settings_cli.go
+++ b/cmd/camp/settings_cli.go
@@ -551,12 +551,23 @@ func applyGuardSizeKey(cfg *config.CampaignConfig, key, value string) (string, e
 }
 
 // applyGuardCountKey validates the bulk trigger count.
+//
+// Zero is rejected rather than accepted. The overlay only applies a configured
+// count when it is greater than zero, so storing 0 left the default 1000 in
+// force while the settings file said 0. A user who set it to turn the guard off
+// would have been told it worked and still been blocked at 1000, which is worse
+// than an error: the setting reads as applied.
 func applyGuardCountKey(cfg *config.CampaignConfig, key, value string) (string, error) {
 	trimmed := strings.TrimSpace(value)
 	n, err := strconv.Atoi(trimmed)
 	if err != nil || n < 0 {
 		return "", camperrors.NewValidation(key,
 			fmt.Sprintf("must be a non-negative whole number, got %q", value), nil)
+	}
+	if n == 0 {
+		return "", camperrors.NewValidation(key,
+			"0 would not disable the bulk guard, it would keep the default; "+
+				"set commit.guards.bulk to off to turn it off", nil)
 	}
 	cfg.Commit.Guards.MaxAddedFiles = n
 	return trimmed, nil

--- a/cmd/camp/status.go
+++ b/cmd/camp/status.go
@@ -55,7 +55,13 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		return camperrors.Wrap(err, "not in a campaign")
 	}
 
-	notice.Render(os.Stderr, notice.Detect(ctx, campRoot, notice.DungeonLegacy, notice.StaleLinks))
+	notice.Render(os.Stderr, notice.FilterDismissed(campRoot, notice.Detect(ctx, campRoot,
+		notice.DungeonLegacy,
+		notice.StaleLinks,
+		notice.ArtifactRootNeverSynced,
+		notice.ArtifactRootsMissingLocally,
+		notice.ArtifactRootDrift,
+	)))
 
 	gitArgs, showRefsArg := extractShowRefs(args)
 	showRefs := statusShowRefs || showRefsArg

--- a/cmd/camp/worktrees/commit.go
+++ b/cmd/camp/worktrees/commit.go
@@ -124,8 +124,13 @@ func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 	// Stage if requested
 	if wtCommitAll {
 		fmt.Println(ui.Info("Staging changes..."))
-		if err := stageWorktreeWithGuard(ctx, cmd, campRoot, wtCtx.WorktreePath); err != nil {
-			return camperrors.Wrap(err, "failed to stage")
+		empty, stageErr := stageWorktreeWithGuard(ctx, cmd, campRoot, wtCtx.WorktreePath)
+		if stageErr != nil {
+			return camperrors.Wrap(stageErr, "failed to stage")
+		}
+		if empty && !wtCommitAmend {
+			cmdutil.ReportNothingLeftToCommit(cmd.OutOrStdout())
+			return nil
 		}
 	}
 
@@ -190,12 +195,23 @@ func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 // it excludes, says what it left out, and offers the three ways forward. The
 // reporting is shared with `camp commit` and `camp p commit` so the same
 // situation never reads differently depending on which command found it.
-func stageWorktreeWithGuard(ctx context.Context, cmd *cobra.Command, campRoot, worktreePath string) error {
+// It reports whether the guard excluded everything there was to commit, which
+// the caller needs to say "nothing left to commit" rather than falling through
+// to git's generic "nothing to commit". A worktree holding only over-threshold
+// files hits exactly that: the guard excludes them all, the index is empty, and
+// without this the user is told their working tree is clean while looking at
+// files they just created.
+func stageWorktreeWithGuard(
+	ctx context.Context, cmd *cobra.Command, campRoot, worktreePath string,
+) (excludedEverything bool, err error) {
 	outcome, err := git.StageWithGuardOptions(ctx, worktreePath, nil,
 		git.StageOptions{CommitLarge: wtCommitLarge})
 	if err != nil {
-		return err
+		return false, err
 	}
-	_, err = cmdutil.HandleStageOutcome(ctx, cmd.OutOrStdout(), campRoot, worktreePath, outcome)
-	return err
+	handling, err := cmdutil.HandleStageOutcome(ctx, cmd.OutOrStdout(), campRoot, worktreePath, outcome)
+	if err != nil {
+		return false, err
+	}
+	return cmdutil.GuardExcludedEverything(ctx, worktreePath, handling)
 }

--- a/cmd/camp/worktrees/commit.go
+++ b/cmd/camp/worktrees/commit.go
@@ -1,6 +1,7 @@
 package worktrees
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -23,6 +24,7 @@ var (
 	wtCommitAmend     bool
 	wtCommitAutoWrite bool
 	wtCommitWorkitem  string
+	wtCommitLarge     bool
 )
 
 var worktreesCommitCmd = &cobra.Command{
@@ -60,6 +62,8 @@ func init() {
 		"Amend the previous commit")
 	worktreesCommitCmd.Flags().BoolVar(&wtCommitAutoWrite, "auto-write", false,
 		"Run configured commit message writer")
+	worktreesCommitCmd.Flags().BoolVar(&wtCommitLarge, "commit-large", false,
+		"Commit over-threshold files instead of keeping them out of git")
 	worktreesCommitCmd.Flags().StringVar(&wtCommitWorkitem, "workitem", "",
 		"explicit workitem selector for the commit tag (overrides cwd-based resolution)")
 }
@@ -120,7 +124,7 @@ func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 	// Stage if requested
 	if wtCommitAll {
 		fmt.Println(ui.Info("Staging changes..."))
-		if err := executor.StageAll(ctx); err != nil {
+		if err := stageWorktreeWithGuard(ctx, cmd, campRoot, wtCtx.WorktreePath); err != nil {
 			return camperrors.Wrap(err, "failed to stage")
 		}
 	}
@@ -177,4 +181,21 @@ func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 	fmt.Println(ui.Success("Changes committed in worktree"))
 
 	return nil
+}
+
+// stageWorktreeWithGuard stages a worktree through the guarded chokepoint and
+// reports what the guard decided.
+//
+// A worktree is project scope, so camp never declares an artifact root here:
+// it excludes, says what it left out, and offers the three ways forward. The
+// reporting is shared with `camp commit` and `camp p commit` so the same
+// situation never reads differently depending on which command found it.
+func stageWorktreeWithGuard(ctx context.Context, cmd *cobra.Command, campRoot, worktreePath string) error {
+	outcome, err := git.StageWithGuardOptions(ctx, worktreePath, nil,
+		git.StageOptions{CommitLarge: wtCommitLarge})
+	if err != nil {
+		return err
+	}
+	_, err = cmdutil.HandleStageOutcome(ctx, cmd.OutOrStdout(), campRoot, worktreePath, outcome)
+	return err
 }

--- a/internal/artifacts/autoroot.go
+++ b/internal/artifacts/autoroot.go
@@ -1,0 +1,156 @@
+package artifacts
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RefusalReason says why camp declined to choose an artifact root for a file.
+// It is data, not a message: the CLI renders each reason with the ask that
+// fits it, and --json reports the reason verbatim.
+type RefusalReason string
+
+const (
+	// RefusalNone means a root was resolved.
+	RefusalNone RefusalReason = ""
+	// RefusalCampaignRoot: the file sits directly at the campaign root, so the
+	// only candidate parent is the campaign itself. Declaring that would turn
+	// the whole campaign into an artifact root.
+	RefusalCampaignRoot RefusalReason = "campaign_root"
+	// RefusalCampaignState: the path is inside .campaign/, camp's own state
+	// tree. A regenerated graph export escaping its gitignore must not turn a
+	// subdirectory of camp's state into a user artifact root.
+	RefusalCampaignState RefusalReason = "campaign_state"
+	// RefusalRepoRoot: the candidate is a git repository root, including a
+	// submodule's. Artifact roots are campaign-relative, so one here would
+	// cross a repo boundary.
+	RefusalRepoRoot RefusalReason = "repo_root"
+	// RefusalEscapesCampaign: the path is not inside the campaign at all.
+	RefusalEscapesCampaign RefusalReason = "escapes_campaign"
+)
+
+// AutoRoot is the outcome of choosing a root for one over-threshold file.
+type AutoRoot struct {
+	// Path is the campaign-relative root to declare, empty when refused.
+	Path string
+	// Refusal says why no root was chosen. RefusalNone means Path is usable.
+	Refusal RefusalReason
+	// Existing is true when Path is already declared, or lies inside an
+	// already-declared root. Camp reuses it rather than declaring a sibling.
+	Existing bool
+}
+
+// Declared reports whether a new declaration is needed.
+func (r AutoRoot) Declared() bool {
+	return r.Refusal == RefusalNone && !r.Existing
+}
+
+// ResolveAutoRoot chooses the artifact root to declare for an over-threshold
+// file, or refuses.
+//
+// The default is the file's parent directory. That is safe specifically
+// because tracked files inside a declared root stay git's: declaring
+// videos/my-video/ does not disturb the script.md sitting beside the footage,
+// so camp can make the declaration without inferring intent.
+//
+// Refusal is per file. The caller excludes that one file, reports the ask, and
+// commits everything else; aborting the whole commit here would reintroduce
+// the decision point this package exists to remove, for a case that is not rare.
+func ResolveAutoRoot(cfg *File, campRoot, fileRel string) AutoRoot {
+	normalized := NormalizeRootPath(fileRel)
+	if normalized == "" || normalized == "." {
+		return AutoRoot{Refusal: RefusalEscapesCampaign}
+	}
+	if !filepath.IsLocal(filepath.FromSlash(normalized)) {
+		return AutoRoot{Refusal: RefusalEscapesCampaign}
+	}
+	if isCampaignState(normalized) {
+		return AutoRoot{Refusal: RefusalCampaignState}
+	}
+
+	parent := parentDir(normalized)
+	if parent == "" {
+		// The file sits at the campaign root; its only candidate parent is the
+		// campaign itself.
+		return AutoRoot{Refusal: RefusalCampaignRoot}
+	}
+	if isCampaignState(parent) {
+		return AutoRoot{Refusal: RefusalCampaignState}
+	}
+
+	// Reuse a root that already covers this file rather than declaring a
+	// nested sibling inside it.
+	if existing, ok := enclosingRoot(cfg, normalized); ok {
+		return AutoRoot{Path: existing, Existing: true}
+	}
+
+	if isRepoRoot(campRoot, parent) {
+		return AutoRoot{Refusal: RefusalRepoRoot}
+	}
+	return AutoRoot{Path: parent}
+}
+
+// parentDir returns the slash-separated parent of a campaign-relative path, or
+// "" when the path sits directly at the campaign root.
+func parentDir(rel string) string {
+	idx := strings.LastIndex(rel, "/")
+	if idx <= 0 {
+		return ""
+	}
+	return rel[:idx]
+}
+
+// isCampaignState reports whether a campaign-relative path is .campaign or
+// lives beneath it. Case-insensitive to match ValidateRootPath, since a
+// case-insensitive filesystem would otherwise let ".Campaign/" through.
+func isCampaignState(rel string) bool {
+	return strings.EqualFold(rel, CampaignStateDir) ||
+		hasCaseInsensitivePrefix(rel, CampaignStateDir+"/")
+}
+
+// CampaignStateDir is camp's own state tree, never a user artifact root.
+const CampaignStateDir = ".campaign"
+
+// enclosingRoot returns the declared root that already covers rel, if any.
+func enclosingRoot(cfg *File, rel string) (string, bool) {
+	if cfg == nil {
+		return "", false
+	}
+	for _, r := range cfg.Roots {
+		root := NormalizeRootPath(r.Path)
+		if root == "" {
+			continue
+		}
+		if rel == root || strings.HasPrefix(rel, root+"/") {
+			return root, true
+		}
+	}
+	return "", false
+}
+
+// isRepoRoot reports whether a campaign-relative directory is a git repository
+// root. A submodule carries a .git file rather than a directory, so both
+// spellings count.
+func isRepoRoot(campRoot, rel string) bool {
+	gitPath := filepath.Join(campRoot, filepath.FromSlash(rel), ".git")
+	_, err := os.Lstat(gitPath)
+	return err == nil
+}
+
+// SiblingRootCount counts declared roots that share a parent directory, so the
+// CLI can suggest collapsing them. Camp suggests; it never collapses, because
+// merging roots changes what syncs and only the user knows if that is wanted.
+func SiblingRootCount(cfg *File, parent string) int {
+	if cfg == nil || parent == "" {
+		return 0
+	}
+	parent = NormalizeRootPath(parent)
+	n := 0
+	for _, r := range cfg.Roots {
+		if parentDir(NormalizeRootPath(r.Path)) == parent {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/artifacts/autoroot_test.go
+++ b/internal/artifacts/autoroot_test.go
@@ -1,0 +1,186 @@
+package artifacts
+
+import "testing"
+
+// The refusal list is the safety boundary: every entry exists because
+// auto-declaring there would produce a state the rest of the package calls
+// invalid. Error cases first.
+func TestResolveAutoRootRefusals(t *testing.T) {
+	cases := []struct {
+		name string
+		file string
+		want RefusalReason
+	}{
+		{
+			name: "file at the campaign root would make the campaign an artifact root",
+			file: "render.mov",
+			want: RefusalCampaignRoot,
+		},
+		{
+			name: "path inside camp's own state tree",
+			file: ".campaign/graphs/campaign-graph.png",
+			want: RefusalCampaignState,
+		},
+		{
+			name: "the state directory itself",
+			file: ".campaign",
+			want: RefusalCampaignState,
+		},
+		{
+			name: "state tree is matched case-insensitively",
+			file: ".Campaign/cache/big.bin",
+			want: RefusalCampaignState,
+		},
+		{
+			name: "path escaping the campaign",
+			file: "../outside/huge.bin",
+			want: RefusalEscapesCampaign,
+		},
+		{
+			name: "empty path",
+			file: "",
+			want: RefusalEscapesCampaign,
+		},
+		{
+			name: "dot path",
+			file: ".",
+			want: RefusalEscapesCampaign,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveAutoRoot(&File{Version: 1}, t.TempDir(), tc.file)
+			if got.Refusal != tc.want {
+				t.Errorf("ResolveAutoRoot(%q).Refusal = %q, want %q", tc.file, got.Refusal, tc.want)
+			}
+			if got.Path != "" {
+				t.Errorf("ResolveAutoRoot(%q).Path = %q, want empty on refusal", tc.file, got.Path)
+			}
+		})
+	}
+}
+
+func TestResolveAutoRootChoosesParent(t *testing.T) {
+	cases := []struct {
+		name string
+		file string
+		want string
+	}{
+		{
+			name: "parent directory of the offending file",
+			file: "videos/my-video/footage.mp4",
+			want: "videos/my-video",
+		},
+		{
+			name: "single-level directory",
+			file: "media/huge.bin",
+			want: "media",
+		},
+		{
+			name: "deeply nested",
+			file: "a/b/c/d/huge.bin",
+			want: "a/b/c/d",
+		},
+		{
+			name: "dot-prefixed spelling normalizes",
+			file: "./media/huge.bin",
+			want: "media",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveAutoRoot(&File{Version: 1}, t.TempDir(), tc.file)
+			if got.Refusal != RefusalNone {
+				t.Fatalf("ResolveAutoRoot(%q) refused with %q", tc.file, got.Refusal)
+			}
+			if got.Path != tc.want {
+				t.Errorf("ResolveAutoRoot(%q).Path = %q, want %q", tc.file, got.Path, tc.want)
+			}
+			if !got.Declared() {
+				t.Error("Declared() = false, want true for a fresh root")
+			}
+		})
+	}
+}
+
+// Criterion 10: a file already inside a declared root reuses that root rather
+// than declaring a nested sibling inside it.
+func TestResolveAutoRootReusesEnclosingRoot(t *testing.T) {
+	cfg := &File{Version: 1, Roots: []Root{{Path: "videos"}}}
+
+	cases := []struct {
+		name string
+		file string
+		want string
+	}{
+		{name: "directly inside the declared root", file: "videos/footage.mp4", want: "videos"},
+		{name: "nested below the declared root", file: "videos/2026/q3/footage.mp4", want: "videos"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveAutoRoot(cfg, t.TempDir(), tc.file)
+			if got.Refusal != RefusalNone {
+				t.Fatalf("refused with %q", got.Refusal)
+			}
+			if got.Path != tc.want {
+				t.Errorf("Path = %q, want the enclosing root %q", got.Path, tc.want)
+			}
+			if !got.Existing {
+				t.Error("Existing = false, want true for an already-declared root")
+			}
+			if got.Declared() {
+				t.Error("Declared() = true; an existing root needs no new declaration")
+			}
+		})
+	}
+}
+
+// A root that merely shares a name prefix is not enclosing.
+func TestResolveAutoRootPrefixIsNotEnclosing(t *testing.T) {
+	cfg := &File{Version: 1, Roots: []Root{{Path: "videos"}}}
+
+	got := ResolveAutoRoot(cfg, t.TempDir(), "videos-archive/footage.mp4")
+	if got.Existing {
+		t.Error("Existing = true; 'videos' must not enclose 'videos-archive'")
+	}
+	if got.Path != "videos-archive" {
+		t.Errorf("Path = %q, want %q", got.Path, "videos-archive")
+	}
+}
+
+func TestSiblingRootCount(t *testing.T) {
+	cfg := &File{Version: 1, Roots: []Root{
+		{Path: "videos/one"},
+		{Path: "videos/two"},
+		{Path: "videos/three"},
+		{Path: "media/other"},
+		{Path: "toplevel"},
+	}}
+
+	cases := []struct {
+		parent string
+		want   int
+	}{
+		{parent: "videos", want: 3},
+		{parent: "media", want: 1},
+		{parent: "", want: 0},
+		{parent: "absent", want: 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.parent, func(t *testing.T) {
+			if got := SiblingRootCount(cfg, tc.parent); got != tc.want {
+				t.Errorf("SiblingRootCount(%q) = %d, want %d", tc.parent, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSiblingRootCountNilConfig(t *testing.T) {
+	if got := SiblingRootCount(nil, "videos"); got != 0 {
+		t.Errorf("SiblingRootCount(nil, _) = %d, want 0", got)
+	}
+}

--- a/internal/artifacts/config.go
+++ b/internal/artifacts/config.go
@@ -113,14 +113,25 @@ func (f *File) Add(root Root) error {
 		return err
 	}
 	root.Path = NormalizeRootPath(root.Path)
-	if !knownPolicy(root.Policy) {
-		return camperrors.Newf("unknown policy %q (want %s or %s)", root.Policy, PolicyAlways, PolicyOnDemand)
+	if err := ValidatePolicy(root.Policy); err != nil {
+		return err
 	}
 	if _, exists := f.Find(root.Path); exists {
 		return camperrors.Newf("artifact root %q is already declared", root.Path)
 	}
 	f.Roots = append(f.Roots, root)
 	return nil
+}
+
+// ValidatePolicy rejects an unknown sync policy. Exported so callers can
+// reject bad input before doing any work, rather than only discovering it
+// inside Add: a preview path that never reaches Add would otherwise report on
+// a declaration that could never succeed.
+func ValidatePolicy(p string) error {
+	if knownPolicy(p) {
+		return nil
+	}
+	return camperrors.Newf("unknown policy %q (want %s or %s)", p, PolicyAlways, PolicyOnDemand)
 }
 
 // knownPolicy reports whether p is a recognized root policy (empty means the

--- a/internal/artifacts/gitstate.go
+++ b/internal/artifacts/gitstate.go
@@ -1,0 +1,38 @@
+package artifacts
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// The two questions every caller asks about an artifact root's relationship to
+// git. They live here rather than in the CLI because three consumers need the
+// same answers: `camp artifacts add` deciding whether it may write a gitignore
+// rule, the doctor checks reporting root health, and the staging path deciding
+// what to exclude. Three copies of a git invocation would drift.
+
+// IsGitignored reports whether git ignores rel, which is the desired state for
+// a clean artifact root.
+//
+// It asks git rather than reimplementing the rules, so negation patterns,
+// nested .gitignore files, and excludesfile all resolve the way they do
+// everywhere else. A failed invocation reports false: the caller's safe
+// direction is to assume content is still visible to git.
+func IsGitignored(ctx context.Context, campRoot, rel string) bool {
+	check := exec.CommandContext(ctx, "git", "-C", campRoot, "check-ignore", "-q", "--",
+		filepath.FromSlash(NormalizeRootPath(rel)))
+	return check.Run() == nil
+}
+
+// HasTrackedFiles reports whether git tracks anything under rel, which makes
+// the root "mixed": the same bytes would be both git content and artifact
+// content. A mixed root must never be blanket-gitignored, because that would
+// hide tracked files from git without removing them.
+func HasTrackedFiles(ctx context.Context, campRoot, rel string) bool {
+	ls := exec.CommandContext(ctx, "git", "-C", campRoot, "ls-files", "--",
+		filepath.FromSlash(NormalizeRootPath(rel)))
+	out, err := ls.Output()
+	return err == nil && len(strings.TrimSpace(string(out))) > 0
+}

--- a/internal/artifacts/survey.go
+++ b/internal/artifacts/survey.go
@@ -1,0 +1,124 @@
+package artifacts
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// RootSurvey counts what a directory holds, split the way declaring it as an
+// artifact root would split it.
+//
+// The split is git's own, per WI-77a632 Proposal A: inside a declared root,
+// tracked files belong to git and everything else is the artifact set. Asking
+// git rather than inferring from names or extensions means the answer stays
+// correct as files change class.
+type RootSurvey struct {
+	// Tracked files stay with git and are excluded from artifact sync.
+	Tracked int
+	// Untracked files are the artifact set rsync carries between machines.
+	Untracked int
+	// Ignored files are already invisible to git.
+	Ignored int
+	// TotalBytes is the size of every counted file, from lstat. Symlinks
+	// report their own size and are never followed.
+	TotalBytes int64
+}
+
+// TotalFiles is every file the survey counted, in all three classes.
+func (s RootSurvey) TotalFiles() int {
+	return s.Tracked + s.Untracked + s.Ignored
+}
+
+// Mixed reports whether the root holds git-tracked content. A mixed root must
+// never be blanket-gitignored: the rule would hide tracked files from git
+// without untracking them.
+func (s RootSurvey) Mixed() bool {
+	return s.Tracked > 0
+}
+
+// SurveyRoot inspects rel under campRoot and reports its tracked, untracked,
+// and ignored split with a total byte count.
+//
+// It runs three git queries rather than walking and classifying by hand, so
+// nested .gitignore files, negation rules, and the index are git's answer.
+// Sizing is lstat only: nothing is opened, read, or hashed, which is what
+// makes this cheap enough to run before declaring a multi-gigabyte directory.
+func SurveyRoot(ctx context.Context, campRoot, rel string) (RootSurvey, error) {
+	if ctx.Err() != nil {
+		return RootSurvey{}, ctx.Err()
+	}
+	normalized := NormalizeRootPath(rel)
+
+	classes := []struct {
+		args  []string
+		count *int
+	}{
+		{args: []string{"-c"}},
+		{args: []string{"-o", "--exclude-standard"}},
+		{args: []string{"-o", "-i", "--exclude-standard"}},
+	}
+
+	var survey RootSurvey
+	counts := []*int{&survey.Tracked, &survey.Untracked, &survey.Ignored}
+	seen := make(map[string]bool)
+
+	for i, class := range classes {
+		paths, err := lsFiles(ctx, campRoot, normalized, class.args)
+		if err != nil {
+			return RootSurvey{}, err
+		}
+		*counts[i] = len(paths)
+		for _, p := range paths {
+			// A path can in principle surface in more than one query; size it
+			// once so TotalBytes cannot double-count.
+			if seen[p] {
+				continue
+			}
+			seen[p] = true
+			survey.TotalBytes += fileSize(campRoot, p)
+		}
+	}
+	return survey, nil
+}
+
+// lsFiles runs one git ls-files query scoped to rel and returns its paths.
+func lsFiles(ctx context.Context, campRoot, rel string, args []string) ([]string, error) {
+	full := append([]string{"-C", campRoot, "ls-files", "-z"}, args...)
+	full = append(full, "--", filepath.FromSlash(rel))
+
+	cmd := exec.CommandContext(ctx, "git", full...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "git ls-files %s in %s: %s",
+			strings.Join(args, " "), campRoot, strings.TrimSpace(stderr.String()))
+	}
+
+	fields := bytes.Split(bytes.TrimRight(out, "\x00"), []byte{0})
+	paths := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if len(field) == 0 {
+			continue
+		}
+		paths = append(paths, string(field))
+	}
+	return paths, nil
+}
+
+// fileSize lstats a repo-relative path. A path that cannot be stated
+// contributes zero rather than failing the survey: a broken symlink or a file
+// removed mid-walk should not stop the user from seeing the totals.
+func fileSize(campRoot, rel string) int64 {
+	info, err := os.Lstat(filepath.Join(campRoot, filepath.FromSlash(rel)))
+	if err != nil {
+		return 0
+	}
+	return info.Size()
+}

--- a/internal/artifacts/survey.go
+++ b/internal/artifacts/survey.go
@@ -25,6 +25,11 @@ type RootSurvey struct {
 	Untracked int
 	// Ignored files are already invisible to git.
 	Ignored int
+	// UntrackedBytes is the size of the artifact set alone. Reported when
+	// describing what rsync would carry, which is not the same number as the
+	// directory's total: tracked scripts and ignored scratch files live in the
+	// same directory but are not artifacts.
+	UntrackedBytes int64
 	// TotalBytes is the size of every counted file, from lstat. Symlinks
 	// report their own size and are never followed.
 	TotalBytes int64
@@ -55,33 +60,36 @@ func SurveyRoot(ctx context.Context, campRoot, rel string) (RootSurvey, error) {
 	}
 	normalized := NormalizeRootPath(rel)
 
-	classes := []struct {
-		args  []string
-		count *int
-	}{
-		{args: []string{"-c"}},
-		{args: []string{"-o", "--exclude-standard"}},
-		{args: []string{"-o", "-i", "--exclude-standard"}},
+	// One query per class, in the order the counts are assigned below.
+	classes := [][]string{
+		{"-c"},                             // tracked
+		{"-o", "--exclude-standard"},       // untracked: the artifact set
+		{"-o", "-i", "--exclude-standard"}, // ignored
 	}
 
 	var survey RootSurvey
 	counts := []*int{&survey.Tracked, &survey.Untracked, &survey.Ignored}
+	const untrackedClass = 1
 	seen := make(map[string]bool)
 
 	for i, class := range classes {
-		paths, err := lsFiles(ctx, campRoot, normalized, class.args)
+		paths, err := lsFiles(ctx, campRoot, normalized, class)
 		if err != nil {
 			return RootSurvey{}, err
 		}
 		*counts[i] = len(paths)
 		for _, p := range paths {
+			size := fileSize(campRoot, p)
+			if i == untrackedClass {
+				survey.UntrackedBytes += size
+			}
 			// A path can in principle surface in more than one query; size it
 			// once so TotalBytes cannot double-count.
 			if seen[p] {
 				continue
 			}
 			seen[p] = true
-			survey.TotalBytes += fileSize(campRoot, p)
+			survey.TotalBytes += size
 		}
 	}
 	return survey, nil

--- a/internal/config/guards.go
+++ b/internal/config/guards.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"context"
+
+	"github.com/Obedience-Corp/camp/internal/campaign"
+)
+
+// ErrNotInCampaign reports that no campaign root exists at or above a path.
+// Re-exported so callers resolving campaign-scoped config can distinguish
+// "there is no campaign here" (a supported state with shipped defaults) from a
+// filesystem or cancellation failure, without importing internal/campaign.
+var ErrNotInCampaign = campaign.ErrNotInCampaign
+
+// DetectCampaignRoot walks up from startDir and returns the directory holding
+// .campaign/. It returns ErrNotInCampaign when there is none.
+func DetectCampaignRoot(ctx context.Context, startDir string) (string, error) {
+	return campaign.Detect(ctx, startDir)
+}
+
+// CommitConfig holds campaign-scoped commit behavior from campaign.yaml. It is
+// distinct from CommitPrefs, which lives in machine-global config.json and
+// campaign-local settings/local.json and governs ref syncing and subject tags.
+type CommitConfig struct {
+	// Guards configures the staging guards applied at camp's stage chokepoint.
+	Guards GuardsConfig `yaml:"guards,omitempty"`
+}
+
+// GuardsConfig configures the size and bulk staging guards. Empty fields take
+// the shipped defaults; see the stageguard package for their values.
+type GuardsConfig struct {
+	// LargeFiles selects the per-file guard mode: "auto" (declare an artifact
+	// root, exclude, report), "block" (refuse the commit), or "off".
+	LargeFiles string `yaml:"large_files,omitempty"`
+	// Bulk selects the bulk guard mode: "block" or "off". There is deliberately
+	// no "auto" -- camp cannot infer whether a large untracked tree wants
+	// gitignore or an artifact root.
+	Bulk string `yaml:"bulk,omitempty"`
+	// Allow lists globs exempt from every guard, for the legitimate large file
+	// committed once.
+	Allow []string `yaml:"allow,omitempty"`
+	// MaxFileSize is the campaign-root per-file threshold ("10MiB").
+	MaxFileSize string `yaml:"max_file_size,omitempty"`
+	// MaxProjectFileSize is the per-file threshold applied inside a project
+	// submodule ("25MiB"). It is higher than MaxFileSize because the project
+	// outcome is a stop rather than a silent fix, and stops must stay rare.
+	MaxProjectFileSize string `yaml:"max_project_file_size,omitempty"`
+	// MaxAddedFiles is the bulk trigger: untracked files under one dominant
+	// prefix. There is no total-bytes leg.
+	MaxAddedFiles int `yaml:"max_added_files,omitempty"`
+	// Projects holds per-project overrides keyed by project name.
+	Projects map[string]GuardsProjectConfig `yaml:"projects,omitempty"`
+}
+
+// GuardsProjectConfig holds per-project guard overrides. Pointer types
+// distinguish "not set" from "set to the zero value", matching the
+// FreshProjectConfig precedent.
+type GuardsProjectConfig struct {
+	LargeFiles    *string `yaml:"large_files,omitempty"`
+	Bulk          *string `yaml:"bulk,omitempty"`
+	MaxFileSize   *string `yaml:"max_file_size,omitempty"`
+	MaxAddedFiles *int    `yaml:"max_added_files,omitempty"`
+	// Allow, when non-nil (including an explicit empty list), entirely replaces
+	// the campaign-wide Allow list for this project rather than extending it,
+	// following the FollowUp override precedent.
+	Allow []string `yaml:"allow,omitempty"`
+}
+
+// ResolveGuardMode returns the large_files mode for projectName, preferring a
+// project override over the campaign-wide value. An empty projectName resolves
+// campaign-root scope. The zero value "" means "unset"; the caller applies the
+// shipped default.
+func (g GuardsConfig) ResolveGuardMode(projectName string) string {
+	if pc, ok := g.Projects[projectName]; ok && pc.LargeFiles != nil {
+		return *pc.LargeFiles
+	}
+	return g.LargeFiles
+}
+
+// ResolveBulkMode returns the bulk mode for projectName, preferring a project
+// override over the campaign-wide value.
+func (g GuardsConfig) ResolveBulkMode(projectName string) string {
+	if pc, ok := g.Projects[projectName]; ok && pc.Bulk != nil {
+		return *pc.Bulk
+	}
+	return g.Bulk
+}
+
+// ResolveMaxFileSize returns the per-file threshold string for projectName.
+// Inside a project the priority is project override, then the campaign-wide
+// project default, then "". At the campaign root the project legs do not apply.
+func (g GuardsConfig) ResolveMaxFileSize(projectName string) string {
+	if projectName == "" {
+		return g.MaxFileSize
+	}
+	if pc, ok := g.Projects[projectName]; ok && pc.MaxFileSize != nil {
+		return *pc.MaxFileSize
+	}
+	return g.MaxProjectFileSize
+}
+
+// ResolveMaxAddedFiles returns the bulk trigger count for projectName,
+// preferring a project override. Zero means "unset".
+func (g GuardsConfig) ResolveMaxAddedFiles(projectName string) int {
+	if pc, ok := g.Projects[projectName]; ok && pc.MaxAddedFiles != nil {
+		return *pc.MaxAddedFiles
+	}
+	return g.MaxAddedFiles
+}
+
+// ResolveAllow returns the allowlist globs for projectName. A non-nil project
+// list replaces the campaign-wide list entirely.
+func (g GuardsConfig) ResolveAllow(projectName string) []string {
+	if pc, ok := g.Projects[projectName]; ok && pc.Allow != nil {
+		return pc.Allow
+	}
+	return g.Allow
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -45,6 +45,8 @@ type CampaignConfig struct {
 	Intents IntentsConfig `yaml:"intents,omitempty"`
 	// Workflows holds the campaign workflow-category taxonomy.
 	Workflows WorkflowsConfig `yaml:"workflows,omitempty"`
+	// Commit holds campaign-scoped commit behavior, including the staging guards.
+	Commit CommitConfig `yaml:"commit,omitempty"`
 
 	// Jumps holds the loaded jumps configuration (from .campaign/settings/jumps.yaml).
 	// This field is not serialized to campaign.yaml - it's loaded separately.

--- a/internal/doctor/checks/artifacts.go
+++ b/internal/doctor/checks/artifacts.go
@@ -1,0 +1,301 @@
+package checks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/artifacts"
+	"github.com/Obedience-Corp/camp/internal/doctor"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+	"github.com/Obedience-Corp/camp/internal/git"
+)
+
+// ArtifactsCheck validates every declared artifact root.
+//
+// A campaign can reach a bad artifact state without camp ever choosing it:
+// artifacts.yaml is committed and hand-editable, roots are declared on one
+// machine and evaluated on another, and the auto-declare path deliberately
+// refuses cases a human can still write by hand. None of that is visible at
+// commit time, because the commit path only sees what git status reports.
+// This check is where an already-broken campaign becomes findable.
+type ArtifactsCheck struct{}
+
+// NewArtifactsCheck creates a new artifact root health check.
+func NewArtifactsCheck() *ArtifactsCheck {
+	return &ArtifactsCheck{}
+}
+
+// ID returns the check identifier.
+func (c *ArtifactsCheck) ID() string {
+	return "artifacts"
+}
+
+// Name returns the human-readable check name.
+func (c *ArtifactsCheck) Name() string {
+	return "Artifact Roots"
+}
+
+// Description returns a brief explanation of what this check does.
+func (c *ArtifactsCheck) Description() string {
+	return "Validates declared artifact roots against gitignore, location, and overlap rules"
+}
+
+// Detail keys carried on each issue so --json consumers can act on the row
+// without parsing the description.
+const (
+	artifactsDetailRoot   = "root"
+	artifactsDetailReason = "reason"
+)
+
+// Row reasons, one per condition in the design's table.
+const (
+	reasonCleanNotIgnored  = "clean_root_not_gitignored"
+	reasonRootMissing      = "root_missing_locally"
+	reasonEscapesCampaign  = "root_escapes_campaign"
+	reasonNestedRoot       = "root_nested_in_declared_root"
+	reasonCrossesSubmodule = "root_crosses_submodule_boundary"
+	reasonDVCOverlap       = "root_also_dvc_tracked"
+	reasonManifestDrift    = "manifest_drift"
+)
+
+// Run validates every declared root.
+func (c *ArtifactsCheck) Run(ctx context.Context, repoRoot string) (*doctor.CheckResult, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	result := &doctor.CheckResult{
+		Passed:  true,
+		Total:   0,
+		Issues:  make([]doctor.Issue, 0),
+		Details: make(map[string]any),
+	}
+
+	cfg, err := artifacts.Load(repoRoot)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "load artifact declarations")
+	}
+	result.Total = len(cfg.Roots)
+	if len(cfg.Roots) == 0 {
+		return result, nil
+	}
+
+	submodules, err := git.ListSubmodulePaths(ctx, repoRoot)
+	if err != nil {
+		// A campaign without submodules, or a repo git cannot read, should not
+		// fail the whole check; the other rows are still worth reporting.
+		submodules = nil
+	}
+
+	for _, root := range cfg.Roots {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		issues := c.inspectRoot(ctx, repoRoot, cfg, root, submodules)
+		result.Issues = append(result.Issues, issues...)
+	}
+
+	// Criterion 27 lives in this check but needs committed manifests, which
+	// phase 002 introduces. Recorded as a skip rather than omitted so the
+	// check's coverage gap is visible rather than silently absent.
+	result.Details["skipped_rows"] = []string{reasonManifestDrift}
+	result.Details["skipped_reason"] = "manifest drift requires committed manifests (phase 002)"
+
+	for _, issue := range result.Issues {
+		if issue.Severity == doctor.SeverityError {
+			result.Passed = false
+			break
+		}
+	}
+	return result, nil
+}
+
+// inspectRoot runs the condition table against one declared root.
+func (c *ArtifactsCheck) inspectRoot(
+	ctx context.Context,
+	repoRoot string,
+	cfg *artifacts.File,
+	root artifacts.Root,
+	submodules []string,
+) []doctor.Issue {
+	var issues []doctor.Issue
+	normalized := artifacts.NormalizeRootPath(root.Path)
+
+	// Location first. A root that escapes the campaign or sits inside another
+	// repo cannot be meaningfully evaluated for the remaining rows, and its
+	// remedy is different in kind: the declaration itself is wrong.
+	if _, err := artifacts.EnsureRootWithin(repoRoot, root.Path); err != nil {
+		return append(issues, artifactIssue(c.ID(), normalized, reasonEscapesCampaign,
+			doctor.SeverityError,
+			fmt.Sprintf("%s escapes the campaign root: %v", normalized, err),
+			"camp artifacts remove "+normalized))
+	}
+
+	if parent, ok := enclosingDeclaredRoot(cfg, normalized); ok {
+		issues = append(issues, artifactIssue(c.ID(), normalized, reasonNestedRoot,
+			doctor.SeverityError,
+			fmt.Sprintf("%s is nested inside declared root %s; one root should own it", normalized, parent),
+			"camp artifacts remove "+normalized))
+	}
+
+	if sub, ok := crossesSubmodule(normalized, submodules); ok {
+		issues = append(issues, artifactIssue(c.ID(), normalized, reasonCrossesSubmodule,
+			doctor.SeverityError,
+			fmt.Sprintf("%s crosses into submodule %s; artifact roots are campaign-relative, so its bytes "+
+				"would never reach the submodule's remote. Camp never creates this state, so it was "+
+				"hand-written into artifacts.yaml", normalized, sub),
+			"camp artifacts remove "+normalized))
+	}
+
+	if dvcPath, ok := dvcGoverned(repoRoot, normalized); ok {
+		issues = append(issues, artifactIssue(c.ID(), normalized, reasonDVCOverlap,
+			doctor.SeverityError,
+			fmt.Sprintf("%s is also tracked by DVC (%s); two systems owning the same bytes will fight",
+				normalized, dvcPath),
+			"camp artifacts remove "+normalized))
+	}
+
+	abs := filepath.Join(repoRoot, filepath.FromSlash(normalized))
+	if _, err := os.Stat(abs); os.IsNotExist(err) {
+		// Not an error: a declared root legitimately lives on another machine
+		// until synced, which is the whole point of declaring it centrally.
+		return append(issues, artifactIssue(c.ID(), normalized, reasonRootMissing,
+			doctor.SeverityWarning,
+			fmt.Sprintf("%s is declared but not present locally; it may live on another machine", normalized),
+			""))
+	}
+
+	// A mixed root is a supported state under Proposal A (tracked files are
+	// git's, everything else is the artifact set). Reporting it as a finding
+	// would train users to ignore this check, so it is never one.
+	if artifacts.HasTrackedFiles(ctx, repoRoot, normalized) {
+		return issues
+	}
+	if !artifacts.IsGitignored(ctx, repoRoot, normalized) {
+		issues = append(issues, artifactIssue(c.ID(), normalized, reasonCleanNotIgnored,
+			doctor.SeverityError,
+			fmt.Sprintf("%s holds no tracked files but is not gitignored; its content will be committed", normalized),
+			"camp doctor -c artifacts --fix"))
+		issues[len(issues)-1].AutoFixable = true
+	}
+	return issues
+}
+
+// artifactIssue builds one finding with its machine-readable details.
+func artifactIssue(checkID, root, reason string, severity doctor.Severity, desc, fixCmd string) doctor.Issue {
+	return doctor.Issue{
+		Severity:    severity,
+		CheckID:     checkID,
+		Description: desc,
+		FixCommand:  fixCmd,
+		Details: map[string]any{
+			artifactsDetailRoot:   root,
+			artifactsDetailReason: reason,
+		},
+	}
+}
+
+// Fix appends the ignore rule for clean roots that lack one.
+//
+// That is the only automatic repair here, and deliberately so. Every other row
+// needs a decision camp cannot make: which root to keep when two nest, whether
+// DVC or camp should own the bytes, whether a missing root should be synced or
+// undeclared. Fix never untracks a file, because untracking is destructive to
+// git history in a way appending a line is not.
+func (c *ArtifactsCheck) Fix(ctx context.Context, repoPath string, issues []doctor.Issue) ([]doctor.Issue, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	fixed := make([]doctor.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if issue.CheckID != c.ID() || !issue.AutoFixable {
+			continue
+		}
+		if reason, _ := issue.Details[artifactsDetailReason].(string); reason != reasonCleanNotIgnored {
+			continue
+		}
+		root, _ := issue.Details[artifactsDetailRoot].(string)
+		if root == "" {
+			continue
+		}
+
+		// Re-check rather than trusting the finding: state can change between
+		// Run and Fix, and appending an ignore rule to a root that has since
+		// gained tracked files would hide them from git.
+		if artifacts.HasTrackedFiles(ctx, repoPath, root) {
+			continue
+		}
+		wrote, err := fsutil.AppendGitignoreEntryIfMissing(
+			filepath.Join(repoPath, ".gitignore"), root+"/", artifactsGitignoreComment)
+		if err != nil {
+			return fixed, camperrors.Wrapf(err, "add %q to .gitignore", root+"/")
+		}
+		if wrote {
+			fixed = append(fixed, issue)
+		}
+	}
+	return fixed, nil
+}
+
+// artifactsGitignoreComment explains the rule in the file itself.
+const artifactsGitignoreComment = "# Camp artifact root (synced with 'camp sync', not git)"
+
+// enclosingDeclaredRoot returns another declared root that already contains
+// this one, if any.
+func enclosingDeclaredRoot(cfg *artifacts.File, normalized string) (string, bool) {
+	for _, other := range cfg.Roots {
+		candidate := artifacts.NormalizeRootPath(other.Path)
+		if candidate == "" || candidate == normalized {
+			continue
+		}
+		if strings.HasPrefix(normalized, candidate+"/") {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+// crossesSubmodule reports whether a root is at or inside a submodule.
+func crossesSubmodule(normalized string, submodules []string) (string, bool) {
+	for _, sub := range submodules {
+		s := artifacts.NormalizeRootPath(sub)
+		if s == "" {
+			continue
+		}
+		if normalized == s || strings.HasPrefix(normalized, s+"/") {
+			return s, true
+		}
+	}
+	return "", false
+}
+
+// dvcGoverned reports whether DVC also tracks this root, via a sibling .dvc
+// pointer file or a .dvc/ directory at or above it.
+//
+// Overlap matters because both systems move the same bytes out of git and
+// then disagree about who restores them; the user has to pick one.
+func dvcGoverned(repoRoot, normalized string) (string, bool) {
+	pointer := filepath.Join(repoRoot, filepath.FromSlash(normalized)+".dvc")
+	if _, err := os.Lstat(pointer); err == nil {
+		return normalized + ".dvc", true
+	}
+
+	dir := normalized
+	for {
+		candidate := filepath.Join(repoRoot, filepath.FromSlash(dir), ".dvc")
+		if info, err := os.Lstat(candidate); err == nil && info.IsDir() {
+			return strings.TrimPrefix(dir+"/.dvc", "/"), true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir || parent == "." {
+			break
+		}
+		dir = parent
+	}
+	return "", false
+}

--- a/internal/doctor/checks/bigfiles.go
+++ b/internal/doctor/checks/bigfiles.go
@@ -1,0 +1,338 @@
+package checks
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/artifacts"
+	"github.com/Obedience-Corp/camp/internal/doctor"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/stageguard"
+)
+
+// BigFilesCheck finds large files the commit path structurally cannot see.
+//
+// Two blind spots motivate it. Files already gitignored never appear in
+// git status, so the staging guard cannot detect them at all — and that is the
+// most common real state: the user gitignored their media long ago, and it now
+// moves by no mechanism whatsoever, since git skips it and no artifact root
+// claims it. Second, blobs already committed are past the guard by definition;
+// the guard stops the next one, not the last one.
+//
+// Solving either at commit time would mean walking the disk on every commit.
+// This check is where that cost belongs, which is why it is opt-in.
+type BigFilesCheck struct{}
+
+// NewBigFilesCheck creates a new large-file sweep.
+func NewBigFilesCheck() *BigFilesCheck {
+	return &BigFilesCheck{}
+}
+
+// ID returns the check identifier.
+func (c *BigFilesCheck) ID() string {
+	return "bigfiles"
+}
+
+// Name returns the human-readable check name.
+func (c *BigFilesCheck) Name() string {
+	return "Large Files"
+}
+
+// Description returns a brief explanation of what this check does.
+func (c *BigFilesCheck) Description() string {
+	return "Finds large files owned by no system, and large blobs already in git history"
+}
+
+// Detail keys and ownership states.
+const (
+	bigFilesDetailPath  = "path"
+	bigFilesDetailSize  = "size"
+	bigFilesDetailState = "state"
+
+	// stateTrackedInHistory is a blob already committed. Removing it requires
+	// a history rewrite, which is a human decision camp will not make.
+	stateTrackedInHistory = "tracked_in_history"
+	// stateUnowned is a large file on disk that git ignores and no artifact
+	// root, LFS filter, or DVC pointer claims. It moves by no mechanism.
+	stateUnowned = "owned_by_no_system"
+)
+
+// Run performs both passes.
+func (c *BigFilesCheck) Run(ctx context.Context, repoRoot string) (*doctor.CheckResult, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	result := &doctor.CheckResult{
+		Passed:  true,
+		Issues:  make([]doctor.Issue, 0),
+		Details: make(map[string]any),
+	}
+
+	// The guard's own thresholds, so doctor and commit never disagree about
+	// what "large" means. A user who raises the limit raises it everywhere.
+	limits, err := stageguard.ResolveLimits(ctx, repoRoot)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "resolve large-file thresholds")
+	}
+	result.Details["threshold_bytes"] = limits.MaxFileSize
+
+	tracked, err := trackedBlobsAtHEAD(ctx, repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	for _, blob := range tracked {
+		if blob.size <= limits.MaxFileSize {
+			continue
+		}
+		result.Issues = append(result.Issues, bigFileIssue(c.ID(), blob.path, blob.size,
+			stateTrackedInHistory,
+			fmt.Sprintf("%s is %s in git history", blob.path, humanBytes(blob.size)),
+			""))
+	}
+
+	unowned, err := c.unownedLargeFiles(ctx, repoRoot, limits, tracked)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range unowned {
+		result.Issues = append(result.Issues, bigFileIssue(c.ID(), f.path, f.size,
+			stateUnowned,
+			fmt.Sprintf("%s (%s) is owned by no system: git ignores it and no artifact root claims it",
+				f.path, humanBytes(f.size)),
+			"camp artifacts add "+filepath.ToSlash(filepath.Dir(f.path))))
+	}
+
+	result.Total = len(tracked) + len(unowned)
+	// Detection only. Both states are reported as warnings because neither is
+	// something camp will repair: a history rewrite is a human decision, and
+	// adopting an unowned directory is a choice about what should sync.
+	return result, nil
+}
+
+// Fix is a no-op. This check never remediates.
+//
+// Removing a blob from history rewrites it, and deciding that an unowned
+// directory should become an artifact root changes what syncs between
+// machines. Both are the user's call; camp's job here is to make the state
+// visible, which it could not do at commit time.
+func (c *BigFilesCheck) Fix(ctx context.Context, repoPath string, issues []doctor.Issue) ([]doctor.Issue, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return nil, nil
+}
+
+// sizedPath is one file with its size.
+type sizedPath struct {
+	path string
+	size int64
+}
+
+// trackedBlobsAtHEAD lists every blob at HEAD with its size, in one git call.
+func trackedBlobsAtHEAD(ctx context.Context, repoRoot string) ([]sizedPath, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "ls-tree", "-r", "-l", "-z", "HEAD")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		// A repository with no commits yet has no HEAD; that is not a fault,
+		// it just means the tracked pass has nothing to report.
+		return nil, nil
+	}
+
+	var blobs []sizedPath
+	for _, record := range bytes.Split(bytes.TrimRight(out, "\x00"), []byte{0}) {
+		if len(record) == 0 {
+			continue
+		}
+		blob, ok := parseLsTreeLongRecord(string(record))
+		if ok {
+			blobs = append(blobs, blob)
+		}
+	}
+	return blobs, nil
+}
+
+// parseLsTreeLongRecord parses one `ls-tree -l` record:
+//
+//	<mode> SP <type> SP <object> SP <size> TAB <path>
+//
+// Size is "-" for entries that are not blobs (submodule gitlinks, trees).
+func parseLsTreeLongRecord(record string) (sizedPath, bool) {
+	tab := strings.IndexByte(record, '\t')
+	if tab < 0 {
+		return sizedPath{}, false
+	}
+	meta, path := record[:tab], record[tab+1:]
+
+	fields := strings.Fields(meta)
+	if len(fields) < 4 || fields[1] != "blob" {
+		return sizedPath{}, false
+	}
+	size, err := strconv.ParseInt(fields[3], 10, 64)
+	if err != nil {
+		return sizedPath{}, false
+	}
+	return sizedPath{path: filepath.ToSlash(path), size: size}, true
+}
+
+// unownedLargeFiles walks the campaign for large files no system claims.
+func (c *BigFilesCheck) unownedLargeFiles(
+	ctx context.Context,
+	repoRoot string,
+	limits stageguard.GuardLimits,
+	tracked []sizedPath,
+) ([]sizedPath, error) {
+	trackedSet := make(map[string]bool, len(tracked))
+	for _, t := range tracked {
+		trackedSet[t.path] = true
+	}
+
+	cfg, err := artifacts.Load(repoRoot)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "load artifact declarations")
+	}
+	roots := make([]string, 0, len(cfg.Roots))
+	for _, r := range cfg.Roots {
+		if n := artifacts.NormalizeRootPath(r.Path); n != "" {
+			roots = append(roots, n)
+		}
+	}
+
+	var found []sizedPath
+	walkErr := filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // an unreadable subtree is not worth failing the sweep
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		rel, relErr := filepath.Rel(repoRoot, path)
+		if relErr != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+
+		if d.IsDir() {
+			if shouldSkipDir(rel, roots) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if trackedSet[rel] || rel == "." {
+			return nil
+		}
+
+		info, statErr := d.Info()
+		if statErr != nil || info.Size() <= limits.MaxFileSize {
+			return nil
+		}
+		if stageguard.MatchesAllow(rel, limits.Allow) {
+			return nil
+		}
+		if _, governed := dvcGoverned(repoRoot, rel); governed {
+			return nil
+		}
+		found = append(found, sizedPath{path: rel, size: info.Size()})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, camperrors.Wrap(walkErr, "walk campaign for large files")
+	}
+
+	return filterLFSManaged(ctx, repoRoot, found), nil
+}
+
+// shouldSkipDir reports directories the sweep must not descend into.
+//
+// A declared artifact root is skipped because sync already owns its contents:
+// reporting them would tell the user to fix something they have already fixed,
+// which is how a check trains people to ignore it.
+func shouldSkipDir(rel string, roots []string) bool {
+	if rel == "." {
+		return false
+	}
+	base := filepath.Base(rel)
+	if base == ".git" {
+		return true
+	}
+	for _, root := range roots {
+		if rel == root || strings.HasPrefix(rel, root+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// filterLFSManaged drops paths git-LFS already governs.
+func filterLFSManaged(ctx context.Context, repoRoot string, files []sizedPath) []sizedPath {
+	if len(files) == 0 {
+		return files
+	}
+	var stdin bytes.Buffer
+	for _, f := range files {
+		stdin.WriteString(f.path)
+		stdin.WriteByte(0)
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "check-attr", "-z", "--stdin", "filter")
+	cmd.Stdin = &stdin
+	out, err := cmd.Output()
+	if err != nil {
+		return files // cannot ask; report what we have rather than dropping it
+	}
+
+	managed := make(map[string]bool)
+	fields := bytes.Split(bytes.TrimRight(out, "\x00"), []byte{0})
+	for i := 0; i+2 < len(fields); i += 3 {
+		if string(fields[i+2]) == "lfs" {
+			managed[string(fields[i])] = true
+		}
+	}
+
+	kept := make([]sizedPath, 0, len(files))
+	for _, f := range files {
+		if !managed[f.path] {
+			kept = append(kept, f)
+		}
+	}
+	return kept
+}
+
+// bigFileIssue builds one finding with its machine-readable details.
+func bigFileIssue(checkID, path string, size int64, state, desc, fixCmd string) doctor.Issue {
+	return doctor.Issue{
+		Severity:    doctor.SeverityWarning,
+		CheckID:     checkID,
+		Description: desc,
+		FixCommand:  fixCmd,
+		AutoFixable: false,
+		Details: map[string]any{
+			bigFilesDetailPath:  path,
+			bigFilesDetailSize:  size,
+			bigFilesDetailState: state,
+		},
+	}
+}
+
+// humanBytes renders a size for a finding description.
+func humanBytes(b int64) string {
+	switch {
+	case b >= 1<<30:
+		return fmt.Sprintf("%.2f GB", float64(b)/float64(1<<30))
+	case b >= 1<<20:
+		return fmt.Sprintf("%.2f MB", float64(b)/float64(1<<20))
+	case b >= 1<<10:
+		return fmt.Sprintf("%.2f KB", float64(b)/float64(1<<10))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/internal/doctor/checks/bigfiles.go
+++ b/internal/doctor/checks/bigfiles.go
@@ -264,6 +264,16 @@ func shouldSkipDir(rel string, roots []string) bool {
 	if base == ".git" {
 		return true
 	}
+	// Camp's own state tree is never user content. Skipping it is not a
+	// convenience: .campaign holds machine-local derived state (the graph
+	// database, peer snapshots, caches) that is gitignored and claimed by no
+	// artifact root, so the sweep would classify it as "owned by no system"
+	// and suggest `camp artifacts add .campaign` — a remedy ValidateRootPath
+	// refuses outright. A finding whose only fix is rejected is worse than no
+	// finding: it teaches the user this check is wrong.
+	if rel == artifacts.CampaignStateDir || strings.HasPrefix(rel, artifacts.CampaignStateDir+"/") {
+		return true
+	}
 	for _, root := range roots {
 		if rel == root || strings.HasPrefix(rel, root+"/") {
 			return true

--- a/internal/fsutil/gitignore.go
+++ b/internal/fsutil/gitignore.go
@@ -1,0 +1,76 @@
+package fsutil
+
+import (
+	"os"
+	"strings"
+)
+
+// Gitignore rule editing, shared so camp has exactly one writer of ignore
+// rules. Scaffold owns the campaign's own state rules during init and repair;
+// `camp artifacts add` owns the rule for a clean artifact root. Two
+// independent append implementations would drift on the details that matter
+// here: what counts as "already present", and whether a trailing newline is
+// preserved.
+
+// HasGitignoreRule reports whether content contains an active rule equal to
+// entry.
+//
+// Lines are compared after trimming; blank lines and comments are skipped. A
+// substring match such as `not-<entry>`, or a commented-out `# <entry>`, is
+// deliberately not a match, because git would still track the file and
+// reporting the rule as present would be wrong in the direction that loses
+// data.
+func HasGitignoreRule(content, entry string) bool {
+	target := strings.TrimSpace(entry)
+	if target == "" {
+		return false
+	}
+	for line := range strings.SplitSeq(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if trimmed == target {
+			return true
+		}
+	}
+	return false
+}
+
+// AppendGitignoreEntryIfMissing adds entry to the gitignore file at path,
+// preceded by comment, unless an active rule for it is already there. It
+// reports whether it wrote anything, so callers can tell the user what
+// actually happened rather than claiming an edit that did not occur.
+//
+// A missing file is created: "ensure this rule exists" is the caller's intent
+// whether or not the file is there yet. The write is atomic, and a file that
+// did not end in a newline gains a blank separator line so the appended rule
+// never joins the last line.
+func AppendGitignoreEntryIfMissing(path, entry, comment string) (bool, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+	if HasGitignoreRule(string(raw), entry) {
+		return false, nil
+	}
+
+	var addition strings.Builder
+	if len(raw) > 0 {
+		addition.WriteString("\n")
+		if raw[len(raw)-1] != '\n' {
+			addition.WriteString("\n")
+		}
+	}
+	if comment != "" {
+		addition.WriteString(comment)
+		addition.WriteString("\n")
+	}
+	addition.WriteString(entry)
+	addition.WriteString("\n")
+
+	if err := WriteFileAtomically(path, append(raw, addition.String()...), 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/fsutil/gitignore_test.go
+++ b/internal/fsutil/gitignore_test.go
@@ -1,0 +1,55 @@
+package fsutil_test
+
+import (
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+)
+
+func TestHasGitignoreRule(t *testing.T) {
+	const content = `# Machine-local campaign state
+.campaign/cache/
+
+media/renders/
+# videos/
+not-videos/
+  spaced/
+`
+
+	cases := []struct {
+		name  string
+		entry string
+		want  bool
+	}{
+		{name: "empty entry is never present", entry: "", want: false},
+		{name: "whitespace entry is never present", entry: "   ", want: false},
+		{name: "commented-out rule does not count", entry: "videos/", want: false},
+		{name: "substring of another rule does not count", entry: "os/", want: false},
+		{name: "exact active rule", entry: "media/renders/", want: true},
+		{name: "rule matched after trimming the line", entry: "spaced/", want: true},
+		{name: "entry matched after trimming the entry", entry: "  media/renders/  ", want: true},
+		{name: "rule that only appears as a prefix", entry: "media/", want: false},
+		{name: "absent rule", entry: "datasets/", want: false},
+		{name: "the literal prefixed rule is present", entry: "not-videos/", want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fsutil.HasGitignoreRule(content, tc.entry); got != tc.want {
+				t.Errorf("HasGitignoreRule(_, %q) = %v, want %v", tc.entry, got, tc.want)
+			}
+		})
+	}
+}
+
+// A commented-out rule must not read as present: git would still track the
+// file, so reporting it as ignored would be wrong in the direction that loses
+// data.
+func TestHasGitignoreRuleIgnoresCommentsAndBlanks(t *testing.T) {
+	if fsutil.HasGitignoreRule("# media/renders/\n\n", "media/renders/") {
+		t.Error("HasGitignoreRule() = true for a commented-out rule, want false")
+	}
+	if fsutil.HasGitignoreRule("", "media/renders/") {
+		t.Error("HasGitignoreRule() = true for empty content, want false")
+	}
+}

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -419,13 +419,40 @@ func CommitAll(ctx context.Context, repoPath, message string) error {
 
 // Stage adds files to the git index (staging area) with automatic lock handling.
 // If files is empty, stages all changes (git add .).
+//
+// Stage-everything forms run the staging guard first; see StageWithGuard. This
+// signature is kept so existing callers compile unchanged, and it discards the
+// guard's outcome. Callers that render what the guard did use StageWithGuard.
 func Stage(ctx context.Context, repoPath string, files []string) error {
+	_, err := StageWithGuard(ctx, repoPath, files)
+	return err
+}
+
+// StageWithGuard stages like Stage and returns what the staging guard decided.
+//
+// The guard runs before anything is staged, so a refusal leaves the index
+// exactly as it was. Over-threshold untracked files are folded into the
+// pathspec as exclusions rather than staged and removed, which keeps staging a
+// single git invocation and composes with exclusions the caller already built.
+//
+// A nil outcome means the guard had nothing to say: the call named explicit
+// paths, the guard is off, or nothing crossed a limit.
+func StageWithGuard(ctx context.Context, repoPath string, files []string) (*StageOutcome, error) {
+	outcome, excluded, err := runStageGuard(ctx, repoPath, files)
+	if err != nil {
+		return nil, err
+	}
+	staged := applyGuardExclusions(files, excluded)
+
 	cfg := DefaultRetryConfig()
 	cfg.OperationName = "stage"
 
-	return WithLockRetry(ctx, repoPath, cfg, func() error {
-		return executeStage(ctx, repoPath, files)
-	})
+	if err := WithLockRetry(ctx, repoPath, cfg, func() error {
+		return executeStage(ctx, repoPath, staged)
+	}); err != nil {
+		return nil, err
+	}
+	return outcome, nil
 }
 
 // executeStage runs the actual git add command.

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -665,19 +665,30 @@ func StageFiles(ctx context.Context, repoPath string, files ...string) error {
 // StageAllExcluding stages all changes except paths matching the given exclusions.
 // Uses git literal pathspec exclusions for atomic single-operation staging.
 func StageAllExcluding(ctx context.Context, repoPath string, excludePaths []string) error {
+	_, err := StageAllExcludingWithGuard(ctx, repoPath, excludePaths)
+	return err
+}
+
+// StageAllExcludingWithGuard stages like StageAllExcluding and returns what the
+// staging guard decided.
+//
+// The caller's exclusions and the guard's are applied in one git invocation:
+// the campaign root always excludes submodule refs, and staging twice would
+// leave a window where the index holds bytes the guard has already ruled out.
+func StageAllExcludingWithGuard(ctx context.Context, repoPath string, excludePaths []string) (*StageOutcome, error) {
 	if ctx.Err() != nil {
-		return ctx.Err()
+		return nil, ctx.Err()
 	}
 
 	if len(excludePaths) == 0 {
-		return StageAll(ctx, repoPath)
+		return StageWithGuard(ctx, repoPath, nil)
 	}
 
 	files := []string{"--", "."}
 	for _, p := range excludePaths {
 		files = append(files, ":(exclude,literal)"+p)
 	}
-	return Stage(ctx, repoPath, files)
+	return StageWithGuard(ctx, repoPath, files)
 }
 
 // HasStagedChanges checks if there are any staged changes ready to commit.

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -438,7 +438,13 @@ func Stage(ctx context.Context, repoPath string, files []string) error {
 // A nil outcome means the guard had nothing to say: the call named explicit
 // paths, the guard is off, or nothing crossed a limit.
 func StageWithGuard(ctx context.Context, repoPath string, files []string) (*StageOutcome, error) {
-	outcome, excluded, err := runStageGuard(ctx, repoPath, files)
+	return StageWithGuardOptions(ctx, repoPath, files, StageOptions{})
+}
+
+// StageWithGuardOptions stages like StageWithGuard under explicit guard
+// overrides, such as --commit-large.
+func StageWithGuardOptions(ctx context.Context, repoPath string, files []string, opts StageOptions) (*StageOutcome, error) {
+	outcome, excluded, err := runStageGuard(ctx, repoPath, files, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -676,19 +682,27 @@ func StageAllExcluding(ctx context.Context, repoPath string, excludePaths []stri
 // the campaign root always excludes submodule refs, and staging twice would
 // leave a window where the index holds bytes the guard has already ruled out.
 func StageAllExcludingWithGuard(ctx context.Context, repoPath string, excludePaths []string) (*StageOutcome, error) {
+	return StageAllExcludingWithGuardOptions(ctx, repoPath, excludePaths, StageOptions{})
+}
+
+// StageAllExcludingWithGuardOptions stages all changes except excludePaths,
+// under explicit guard overrides.
+func StageAllExcludingWithGuardOptions(
+	ctx context.Context, repoPath string, excludePaths []string, opts StageOptions,
+) (*StageOutcome, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
 
 	if len(excludePaths) == 0 {
-		return StageWithGuard(ctx, repoPath, nil)
+		return StageWithGuardOptions(ctx, repoPath, nil, opts)
 	}
 
 	files := []string{"--", "."}
 	for _, p := range excludePaths {
 		files = append(files, ":(exclude,literal)"+p)
 	}
-	return StageWithGuard(ctx, repoPath, files)
+	return StageWithGuardOptions(ctx, repoPath, files, opts)
 }
 
 // HasStagedChanges checks if there are any staged changes ready to commit.

--- a/internal/git/funnel_test.go
+++ b/internal/git/funnel_test.go
@@ -1,0 +1,121 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The staging guard covers camp with a single edit only because every
+// stage-everything operation reaches executeStage. That is a structural
+// property, not a documented intention: a new `git add` anywhere else is
+// silently unguarded, and nothing else in the build would notice.
+//
+// Design doc 01 asserted this property, and the assertion was already wrong
+// when written — internal/project/new.go ran a bare `git add .` for five
+// months before the guard existed. This test is what makes the claim true
+// going forward.
+//
+// The rule: every `git add` invocation in production code lives in this
+// package. internal/git/commit.go holds three, each deliberate:
+//
+//   - executeStage, the guarded chokepoint
+//   - AddPathsToTempIndex, explicit named paths into a temp index
+//   - StageTrackedChanges (`git add -u`), which cannot introduce a new path
+//
+// A staging invocation names "add" alongside the git binary or its -C flag in
+// the same argument list. Requiring that companion token keeps cobra command
+// declarations (`Use: "add"`) and unrelated "add" constants out of the match.
+var gitAddInvocation = regexp.MustCompile(`"add"[,)\s]`)
+
+// hasGitArgContext reports whether a line carries the rest of a git argument
+// list, distinguishing a real invocation from an incidental "add" literal.
+func hasGitArgContext(line string) bool {
+	return strings.Contains(line, `"git"`) || strings.Contains(line, `"-C"`)
+}
+
+func TestNoStagingPathBypassesTheFunnel(t *testing.T) {
+	root := repoRootForTest(t)
+
+	// Invocations of other git subcommands that merely take an "add" literal
+	// argument are not staging: `remote add`, `submodule add`, `worktree add`.
+	notStaging := []string{
+		`"remote", "add"`,
+		`"submodule", "add"`,
+		`"worktree", "add"`,
+		`NewGit("add"`,
+	}
+
+	var offenders []string
+	for _, dir := range []string{"cmd", "internal", "pkg"} {
+		walkErr := filepath.Walk(filepath.Join(root, dir), func(path string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() {
+				return err
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			rel, _ := filepath.Rel(root, path)
+			rel = filepath.ToSlash(rel)
+			// This package is where staging is allowed to live.
+			if strings.HasPrefix(rel, "internal/git/") {
+				return nil
+			}
+
+			data, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+			for _, line := range strings.Split(string(data), "\n") {
+				if !gitAddInvocation.MatchString(line) || !hasGitArgContext(line) {
+					continue
+				}
+				if isAllowed(line, notStaging) {
+					continue
+				}
+				offenders = append(offenders, rel+": "+strings.TrimSpace(line))
+			}
+			return nil
+		})
+		if walkErr != nil {
+			t.Fatalf("walk %s: %v", dir, walkErr)
+		}
+	}
+
+	if len(offenders) > 0 {
+		t.Errorf("git add outside internal/git bypasses the staging guard:\n  %s\n\n"+
+			"Route staging through git.Stage (or StageWithGuard to report what the guard did). "+
+			"If the call genuinely is not staging, extend the allowlist in this test.",
+			strings.Join(offenders, "\n  "))
+	}
+}
+
+func isAllowed(line string, allowed []string) bool {
+	for _, a := range allowed {
+		if strings.Contains(line, a) {
+			return true
+		}
+	}
+	return false
+}
+
+// repoRootForTest walks up from the working directory to the module root.
+func repoRootForTest(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found above the working directory")
+		}
+		dir = parent
+	}
+}

--- a/internal/git/stageguard.go
+++ b/internal/git/stageguard.go
@@ -243,3 +243,31 @@ func StagedPathsUnder(ctx context.Context, repoPath, dir string) ([]string, erro
 	}
 	return paths, nil
 }
+
+// FullHash returns the full 40-character commit hash of HEAD.
+//
+// Machine callers get the full hash rather than the abbreviated one the human
+// output shows: an abbreviation is display formatting, and a consumer that
+// stores it has to guess how many characters stay unambiguous as the repo grows.
+func FullHash(ctx context.Context, repoPath string) (string, error) {
+	out, err := Output(ctx, repoPath, "rev-parse", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// CommitPathCount returns how many paths the HEAD commit touched.
+func CommitPathCount(ctx context.Context, repoPath string) (int, error) {
+	out, err := Output(ctx, repoPath, "show", "--name-only", "--format=", "HEAD")
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) != "" {
+			n++
+		}
+	}
+	return n, nil
+}

--- a/internal/git/stageguard.go
+++ b/internal/git/stageguard.go
@@ -1,7 +1,10 @@
 package git
 
 import (
+	"bytes"
 	"context"
+	"os"
+	"os/exec"
 	"strings"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -192,4 +195,31 @@ func applyGuardExclusions(files []string, excluded []string) []string {
 		files = append(files, ":(exclude,literal)"+p)
 	}
 	return files
+}
+
+// StagedPathsUnder returns the staged paths beneath a repo-relative directory.
+// Used to report which files inside a newly declared artifact root still
+// belong to git, which is the difference between telling a user their notes
+// are versioned and leaving them to assume otherwise.
+func StagedPathsUnder(ctx context.Context, repoPath, dir string) ([]string, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath,
+		"diff", "--cached", "--name-only", "-z", "--", dir)
+	cmd.Env = gitEnv(os.Environ())
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "list staged paths under %s", dir)
+	}
+
+	fields := bytes.Split(bytes.TrimRight(out, "\x00"), []byte{0})
+	paths := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if len(f) > 0 {
+			paths = append(paths, string(f))
+		}
+	}
+	return paths, nil
 }

--- a/internal/git/stageguard.go
+++ b/internal/git/stageguard.go
@@ -45,11 +45,24 @@ type StageOutcome struct {
 	// Limits is the policy that produced this outcome, so callers can render
 	// the threshold they were measured against without resolving it again.
 	Limits stageguard.GuardLimits
+	// Unavailable is set when the guard could not evaluate this repository and
+	// staging proceeded without it.
+	//
+	// Degrading is deliberate: the guard is a safety net, not a precondition
+	// for camp working. A repository it cannot read (mid-scaffold, git
+	// unavailable, a transient failure) must still be stageable, or an
+	// unrelated fault takes the user's ability to commit away entirely.
+	//
+	// It is recorded rather than swallowed because degrading silently is the
+	// version of this that is actually dangerous: the user would believe they
+	// were protected. The caller reports it.
+	Unavailable error
 }
 
 // Empty reports whether the guard found nothing worth telling the user about.
 func (o *StageOutcome) Empty() bool {
-	return o == nil || (len(o.Excluded) == 0 && len(o.Reported) == 0)
+	return o == nil ||
+		(len(o.Excluded) == 0 && len(o.Reported) == 0 && o.Unavailable == nil)
 }
 
 // ExcludedPaths returns the repo-relative paths kept out of the index.
@@ -137,10 +150,15 @@ func isStageEverything(files []string) bool {
 // runStageGuard evaluates the guard for a staging operation and returns both
 // the outcome and the pathspec exclusions to apply.
 //
-// It is deliberately fail-closed on refusals and fail-open on its own errors:
-// a repository the guard cannot read (not a repo yet, git unavailable) must
-// still be stageable, because the guard is a safety net rather than a
-// precondition for camp working at all.
+// It is fail-closed on refusals and fail-open on its own errors: a repository
+// the guard cannot read (not a repo yet, git unavailable) must still be
+// stageable, because the guard is a safety net rather than a precondition for
+// camp working at all.
+//
+// Fail-open here means "stage, and say the guard did not run", never "stage
+// quietly". The outcome carries Unavailable so the caller can report it; a
+// silent degradation would leave the user believing they were protected, which
+// is worse than either refusing or reporting.
 func runStageGuard(ctx context.Context, repoPath string, files []string, opts StageOptions) (*StageOutcome, []string, error) {
 	if !isStageEverything(files) {
 		return nil, nil, nil
@@ -155,7 +173,8 @@ func runStageGuard(ctx context.Context, repoPath string, files []string, opts St
 
 	limits, err := stageguard.ResolveLimits(ctx, repoPath)
 	if err != nil {
-		return nil, nil, camperrors.Wrapf(err, "resolve staging guard limits for %s", repoPath)
+		return &StageOutcome{Unavailable: camperrors.Wrapf(
+			err, "resolve staging guard limits for %s", repoPath)}, nil, nil
 	}
 	if limits.LargeFiles == stageguard.ModeOff && limits.Bulk == stageguard.ModeOff {
 		return nil, nil, nil
@@ -163,7 +182,8 @@ func runStageGuard(ctx context.Context, repoPath string, files []string, opts St
 
 	violations, err := stageguard.CheckStaging(ctx, repoPath, limits)
 	if err != nil {
-		return nil, nil, camperrors.Wrapf(err, "evaluate staging guard for %s", repoPath)
+		return &StageOutcome{Limits: limits, Unavailable: camperrors.Wrapf(
+			err, "evaluate staging guard for %s", repoPath)}, nil, nil
 	}
 	if len(violations) == 0 {
 		return nil, nil, nil

--- a/internal/git/stageguard.go
+++ b/internal/git/stageguard.go
@@ -1,0 +1,195 @@
+package git
+
+import (
+	"context"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/stageguard"
+)
+
+// The staging guard's attachment point. internal/git may import stageguard;
+// the leaf constraint only forbids the reverse edge, since stageguard running
+// its own git status is what keeps it importable from both sides.
+//
+// The guard runs before executeStage, never after. Staging first and cleaning
+// up afterward would leave a window where the index holds bytes camp has
+// already decided do not belong in the commit, and a failure in that window
+// would leave it there.
+
+// StageOutcome is what the guard decided about a staging operation, returned
+// so the CLI can report it. Rendering belongs to the caller: camp's commit
+// command writes remedy menus, fest renders the same values its own way.
+type StageOutcome struct {
+	// Excluded holds over-threshold untracked files kept out of the index.
+	Excluded []stageguard.GuardViolation
+	// Reported holds tracked files whose new content crossed the threshold.
+	// They are always staged; the user is told about them instead.
+	Reported []stageguard.GuardViolation
+	// Limits is the policy that produced this outcome, so callers can render
+	// the threshold they were measured against without resolving it again.
+	Limits stageguard.GuardLimits
+}
+
+// Empty reports whether the guard found nothing worth telling the user about.
+func (o *StageOutcome) Empty() bool {
+	return o == nil || (len(o.Excluded) == 0 && len(o.Reported) == 0)
+}
+
+// ExcludedPaths returns the repo-relative paths kept out of the index.
+func (o *StageOutcome) ExcludedPaths() []string {
+	if o == nil {
+		return nil
+	}
+	paths := make([]string, 0, len(o.Excluded))
+	for _, v := range o.Excluded {
+		paths = append(paths, v.Path)
+	}
+	return paths
+}
+
+// GuardBlockedError reports that the guard refused a staging operation. It
+// carries the violations as typed data so no caller ever parses a message to
+// find out what happened.
+type GuardBlockedError struct {
+	// Kind is the guard that refused: stageguard.Bulk or
+	// stageguard.OverThreshold (the latter only in block mode).
+	Kind       stageguard.ViolationKind
+	Violations []stageguard.GuardViolation
+	Limits     stageguard.GuardLimits
+	// RepoPath is the repository the refusal applies to.
+	RepoPath string
+}
+
+func (e *GuardBlockedError) Error() string {
+	switch e.Kind {
+	case stageguard.Bulk:
+		for _, v := range e.Violations {
+			if v.Kind == stageguard.Bulk {
+				return "staging refused: " + v.CommonPrefix + " would add " +
+					itoa(v.Count) + " untracked files"
+			}
+		}
+		return "staging refused: bulk directory"
+	default:
+		paths := make([]string, 0, len(e.Violations))
+		for _, v := range e.Violations {
+			paths = append(paths, v.Path)
+		}
+		return "staging refused: files over the size limit: " + strings.Join(paths, ", ")
+	}
+}
+
+// itoa avoids pulling strconv in for one call site in an error path.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}
+
+// isStageEverything reports whether a files argument means "stage the whole
+// worktree" rather than an explicit list the user named.
+//
+// The distinction is the design's: an explicit `git add path/to/media.mp4` is
+// an intent, and camp honors it. Only the sweep forms are guarded, because
+// only they can pick up something the user never mentioned.
+//
+// StageAllExcluding passes "--", "." plus exclusion pathspecs, which is a
+// sweep and must be guarded; missing that would leave the campaign root's
+// commit path (which always excludes submodule refs) unguarded.
+func isStageEverything(files []string) bool {
+	if len(files) == 0 {
+		return true
+	}
+	for _, f := range files {
+		switch {
+		case f == "--" || f == "." || strings.HasPrefix(f, ":(exclude"):
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// runStageGuard evaluates the guard for a staging operation and returns both
+// the outcome and the pathspec exclusions to apply.
+//
+// It is deliberately fail-closed on refusals and fail-open on its own errors:
+// a repository the guard cannot read (not a repo yet, git unavailable) must
+// still be stageable, because the guard is a safety net rather than a
+// precondition for camp working at all.
+func runStageGuard(ctx context.Context, repoPath string, files []string) (*StageOutcome, []string, error) {
+	if !isStageEverything(files) {
+		return nil, nil, nil
+	}
+
+	limits, err := stageguard.ResolveLimits(ctx, repoPath)
+	if err != nil {
+		return nil, nil, camperrors.Wrapf(err, "resolve staging guard limits for %s", repoPath)
+	}
+	if limits.LargeFiles == stageguard.ModeOff && limits.Bulk == stageguard.ModeOff {
+		return nil, nil, nil
+	}
+
+	violations, err := stageguard.CheckStaging(ctx, repoPath, limits)
+	if err != nil {
+		return nil, nil, camperrors.Wrapf(err, "evaluate staging guard for %s", repoPath)
+	}
+	if len(violations) == 0 {
+		return nil, nil, nil
+	}
+
+	outcome := &StageOutcome{Limits: limits}
+	var bulk []stageguard.GuardViolation
+	var overThreshold []stageguard.GuardViolation
+
+	for _, v := range violations {
+		switch v.Kind {
+		case stageguard.Bulk:
+			bulk = append(bulk, v)
+		case stageguard.TrackedGrowth:
+			outcome.Reported = append(outcome.Reported, v)
+		case stageguard.OverThreshold:
+			overThreshold = append(overThreshold, v)
+		}
+	}
+
+	// Bulk is checked first: it refuses the whole operation, so there is no
+	// point deciding exclusions the caller will never apply.
+	if len(bulk) > 0 && limits.Bulk == stageguard.ModeBlock {
+		return nil, nil, &GuardBlockedError{
+			Kind: stageguard.Bulk, Violations: bulk, Limits: limits, RepoPath: repoPath,
+		}
+	}
+	if len(overThreshold) > 0 && limits.LargeFiles == stageguard.ModeBlock {
+		return nil, nil, &GuardBlockedError{
+			Kind: stageguard.OverThreshold, Violations: overThreshold, Limits: limits, RepoPath: repoPath,
+		}
+	}
+
+	outcome.Excluded = overThreshold
+	return outcome, outcome.ExcludedPaths(), nil
+}
+
+// applyGuardExclusions folds guard exclusions into the pathspec, composing
+// with any exclusions the caller already built (the campaign root always
+// excludes submodule refs) so staging stays one git invocation.
+func applyGuardExclusions(files []string, excluded []string) []string {
+	if len(excluded) == 0 {
+		return files
+	}
+	if len(files) == 0 {
+		files = []string{"--", "."}
+	}
+	for _, p := range excluded {
+		files = append(files, ":(exclude,literal)"+p)
+	}
+	return files
+}

--- a/internal/git/stageguard.go
+++ b/internal/git/stageguard.go
@@ -20,6 +20,19 @@ import (
 // already decided do not belong in the commit, and a failure in that window
 // would leave it there.
 
+// StageOptions carries per-invocation overrides of the guard's decision.
+type StageOptions struct {
+	// CommitLarge forces over-threshold files and bulk directories into the
+	// index for this invocation, and declares nothing.
+	//
+	// The name is the inverse of what it would have been under a blocking
+	// guard. With auto-handling, the thing a user needs to override is camp's
+	// decision to EXCLUDE ("no, this release binary belongs in git"), so
+	// naming it --allow-large would read as "skip the safety check", which is
+	// backwards.
+	CommitLarge bool
+}
+
 // StageOutcome is what the guard decided about a staging operation, returned
 // so the CLI can report it. Rendering belongs to the caller: camp's commit
 // command writes remedy menus, fest renders the same values its own way.
@@ -128,8 +141,15 @@ func isStageEverything(files []string) bool {
 // a repository the guard cannot read (not a repo yet, git unavailable) must
 // still be stageable, because the guard is a safety net rather than a
 // precondition for camp working at all.
-func runStageGuard(ctx context.Context, repoPath string, files []string) (*StageOutcome, []string, error) {
+func runStageGuard(ctx context.Context, repoPath string, files []string, opts StageOptions) (*StageOutcome, []string, error) {
 	if !isStageEverything(files) {
+		return nil, nil, nil
+	}
+	// --commit-large is the user overruling camp's decision to exclude, which
+	// is the thing that actually needs an override once handling is automatic.
+	// It suppresses detection entirely rather than excluding-then-restoring,
+	// so the index ends up exactly as an unguarded stage would leave it.
+	if opts.CommitLarge {
 		return nil, nil, nil
 	}
 

--- a/internal/git/stageguard_test.go
+++ b/internal/git/stageguard_test.go
@@ -1,0 +1,222 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/stageguard"
+)
+
+// The guard only applies to sweep forms. An explicit `git add path/to/big.mp4`
+// is an intent camp honors, so naming a file must switch the guard off.
+func TestIsStageEverything(t *testing.T) {
+	cases := []struct {
+		name  string
+		files []string
+		want  bool
+	}{
+		{name: "nil is stage-everything", files: nil, want: true},
+		{name: "empty slice is stage-everything", files: []string{}, want: true},
+		{name: "bare dot", files: []string{"."}, want: true},
+		{name: "separator and dot", files: []string{"--", "."}, want: true},
+		{
+			name:  "StageAllExcluding form is still a sweep",
+			files: []string{"--", ".", ":(exclude,literal)projects/alpha"},
+			want:  true,
+		},
+		{
+			name:  "several exclusions are still a sweep",
+			files: []string{"--", ".", ":(exclude,literal)a", ":(exclude,literal)b"},
+			want:  true,
+		},
+		{name: "one explicit file is not a sweep", files: []string{"notes.md"}, want: false},
+		{
+			name:  "explicit file after separator is not a sweep",
+			files: []string{"--", "videos/footage.mp4"},
+			want:  false,
+		},
+		{
+			name:  "explicit file mixed with exclusions is not a sweep",
+			files: []string{"--", ".", "notes.md", ":(exclude,literal)a"},
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isStageEverything(tc.files); got != tc.want {
+				t.Errorf("isStageEverything(%q) = %v, want %v", tc.files, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyGuardExclusions(t *testing.T) {
+	cases := []struct {
+		name     string
+		files    []string
+		excluded []string
+		want     []string
+	}{
+		{
+			name:     "no exclusions leaves the pathspec alone",
+			files:    nil,
+			excluded: nil,
+			want:     nil,
+		},
+		{
+			name:     "exclusions on a bare sweep materialize the pathspec",
+			files:    nil,
+			excluded: []string{"videos/footage.mp4"},
+			want:     []string{"--", ".", ":(exclude,literal)videos/footage.mp4"},
+		},
+		{
+			name:     "guard exclusions compose with caller exclusions",
+			files:    []string{"--", ".", ":(exclude,literal)projects/alpha"},
+			excluded: []string{"videos/footage.mp4"},
+			want: []string{
+				"--", ".",
+				":(exclude,literal)projects/alpha",
+				":(exclude,literal)videos/footage.mp4",
+			},
+		},
+		{
+			name:     "several guard exclusions all land",
+			files:    nil,
+			excluded: []string{"a.bin", "b.bin"},
+			want:     []string{"--", ".", ":(exclude,literal)a.bin", ":(exclude,literal)b.bin"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applyGuardExclusions(tc.files, tc.excluded)
+			if len(got) != len(tc.want) {
+				t.Fatalf("applyGuardExclusions() = %q, want %q", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("applyGuardExclusions()[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// Composition is the property that matters at the campaign root, where the
+// commit path always excludes submodule refs: the caller's exclusions must
+// survive the guard adding its own.
+func TestApplyGuardExclusionsPreservesCallerExclusions(t *testing.T) {
+	files := []string{"--", ".", ":(exclude,literal)projects/alpha", ":(exclude,literal)projects/beta"}
+	got := applyGuardExclusions(files, []string{"media/huge.bin"})
+
+	var sawAlpha, sawBeta, sawGuard bool
+	for _, f := range got {
+		switch f {
+		case ":(exclude,literal)projects/alpha":
+			sawAlpha = true
+		case ":(exclude,literal)projects/beta":
+			sawBeta = true
+		case ":(exclude,literal)media/huge.bin":
+			sawGuard = true
+		}
+	}
+	if !sawAlpha || !sawBeta || !sawGuard {
+		t.Errorf("applyGuardExclusions() = %q; want all caller and guard exclusions present", got)
+	}
+}
+
+func TestStageOutcomeEmptyAndPaths(t *testing.T) {
+	var nilOutcome *StageOutcome
+	if !nilOutcome.Empty() {
+		t.Error("nil outcome Empty() = false, want true")
+	}
+	if paths := nilOutcome.ExcludedPaths(); paths != nil {
+		t.Errorf("nil outcome ExcludedPaths() = %v, want nil", paths)
+	}
+
+	empty := &StageOutcome{}
+	if !empty.Empty() {
+		t.Error("zero outcome Empty() = false, want true")
+	}
+
+	reportedOnly := &StageOutcome{
+		Reported: []stageguard.GuardViolation{{Kind: stageguard.TrackedGrowth, Path: "graph.png"}},
+	}
+	if reportedOnly.Empty() {
+		t.Error("outcome with a tracked-growth report Empty() = true, want false")
+	}
+	if paths := reportedOnly.ExcludedPaths(); len(paths) != 0 {
+		t.Errorf("ExcludedPaths() = %v; tracked growth is never excluded", paths)
+	}
+
+	excluded := &StageOutcome{
+		Excluded: []stageguard.GuardViolation{
+			{Kind: stageguard.OverThreshold, Path: "a.bin"},
+			{Kind: stageguard.OverThreshold, Path: "b.bin"},
+		},
+	}
+	paths := excluded.ExcludedPaths()
+	if len(paths) != 2 || paths[0] != "a.bin" || paths[1] != "b.bin" {
+		t.Errorf("ExcludedPaths() = %v, want [a.bin b.bin]", paths)
+	}
+}
+
+func TestGuardBlockedErrorMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		err  *GuardBlockedError
+		want string
+	}{
+		{
+			name: "bulk names the directory and count",
+			err: &GuardBlockedError{
+				Kind: stageguard.Bulk,
+				Violations: []stageguard.GuardViolation{
+					{Kind: stageguard.Bulk, CommonPrefix: "node_modules", Count: 8432},
+				},
+			},
+			want: "staging refused: node_modules would add 8432 untracked files",
+		},
+		{
+			name: "over threshold lists the paths",
+			err: &GuardBlockedError{
+				Kind: stageguard.OverThreshold,
+				Violations: []stageguard.GuardViolation{
+					{Kind: stageguard.OverThreshold, Path: "a.bin"},
+					{Kind: stageguard.OverThreshold, Path: "b.bin"},
+				},
+			},
+			want: "staging refused: files over the size limit: a.bin, b.bin",
+		},
+		{
+			name: "bulk kind with no bulk violation still renders",
+			err:  &GuardBlockedError{Kind: stageguard.Bulk},
+			want: "staging refused: bulk directory",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestItoa(t *testing.T) {
+	cases := []struct {
+		in   int
+		want string
+	}{
+		{in: 0, want: "0"},
+		{in: 7, want: "7"},
+		{in: 1000, want: "1000"},
+		{in: 8432, want: "8432"},
+	}
+	for _, tc := range cases {
+		if got := itoa(tc.in); got != tc.want {
+			t.Errorf("itoa(%d) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/notice/artifacts.go
+++ b/internal/notice/artifacts.go
@@ -27,7 +27,6 @@ import (
 const (
 	neverSyncedIDPrefix = "artifact-root-never-synced:"
 	missingRootID       = "artifact-roots-missing-locally"
-	driftIDPrefix       = "artifact-root-drift:"
 )
 
 // ArtifactRootNeverSynced reports a declared root that has never left this

--- a/internal/notice/artifacts.go
+++ b/internal/notice/artifacts.go
@@ -1,0 +1,154 @@
+package notice
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Obedience-Corp/camp/internal/artifacts"
+)
+
+// The forward-looking artifact notices: states camp itself created, surfaced
+// on a command the user already runs.
+//
+// The line these detectors hold is that a notice describes something the user
+// may not know is true, and is dismissible. A report of an action camp just
+// took is neither, and lives in the commit path instead. The backward-looking
+// case — a large file gitignored years ago and owned by nothing — is
+// deliberately absent here: a deliberate gitignore is not a defect to nag
+// about on every status, and `camp doctor -c bigfiles` is its surface.
+//
+// Every detector below is stat-level over the declared-root list. None scans
+// the campaign tree, so a campaign with no declared roots does no work at all.
+
+// Notice ID prefixes. The root path is part of the ID so a newly declared root
+// produces a new signature and notifies even if an older one was dismissed.
+const (
+	neverSyncedIDPrefix = "artifact-root-never-synced:"
+	missingRootID       = "artifact-roots-missing-locally"
+	driftIDPrefix       = "artifact-root-drift:"
+)
+
+// ArtifactRootNeverSynced reports a declared root that has never left this
+// machine.
+//
+// This is the notice that justifies the surface. Declaring a root moves its
+// bytes out of git's care and into sync's, and until a sync actually runs
+// there is exactly one copy of them anywhere. The user believes the
+// declaration protected the data; it did not, yet.
+func ArtifactRootNeverSynced(ctx context.Context, campaignRoot string) (*Notice, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	cfg, err := artifacts.Load(campaignRoot)
+	if err != nil || len(cfg.Roots) == 0 {
+		return nil, err
+	}
+
+	peers, err := artifacts.ListSnapshotPeers(campaignRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	// Dismissals are consulted here rather than left to the caller's filter.
+	// A detector reports at most one notice, so filtering afterward would let
+	// a dismissal on the first root suppress every root behind it: the user
+	// silences one and never hears about the next one they declare. Per
+	// signature has to mean the detector skips signatures already answered.
+	dismissals, err := LoadDismissals(campaignRoot)
+	if err != nil {
+		dismissals = &DismissalFile{}
+	}
+
+	for _, root := range cfg.Roots {
+		rel := artifacts.NormalizeRootPath(root.Path)
+		if rel == "" || !rootExists(campaignRoot, rel) {
+			continue
+		}
+		if hasAnySnapshot(campaignRoot, peers, rel) {
+			continue
+		}
+		if dismissals.IsDismissed(neverSyncedIDPrefix + rel) {
+			continue
+		}
+		id := neverSyncedIDPrefix + rel
+		return &Notice{
+			ID: id,
+			Message: fmt.Sprintf(
+				"%s is a declared artifact root that has never synced; its contents exist on this machine only",
+				rel),
+			Command: "camp sync --from <machine>   (dismiss: camp notify dismiss " + id + ")",
+		}, nil
+	}
+	return nil, nil
+}
+
+// ArtifactRootsMissingLocally reports declared roots absent from this machine.
+//
+// Same fact `camp artifacts list` shows, surfaced without being asked. It is
+// one line naming a count rather than a list, because the actionable answer is
+// the same for all of them and a per-root enumeration would crowd the command
+// the user actually ran.
+func ArtifactRootsMissingLocally(ctx context.Context, campaignRoot string) (*Notice, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	cfg, err := artifacts.Load(campaignRoot)
+	if err != nil || len(cfg.Roots) == 0 {
+		return nil, err
+	}
+
+	missing := 0
+	for _, root := range cfg.Roots {
+		rel := artifacts.NormalizeRootPath(root.Path)
+		if rel != "" && !rootExists(campaignRoot, rel) {
+			missing++
+		}
+	}
+	if missing == 0 {
+		return nil, nil
+	}
+
+	plural := "roots are"
+	if missing == 1 {
+		plural = "root is"
+	}
+	return &Notice{
+		ID:      missingRootID,
+		Message: fmt.Sprintf("%d declared artifact %s not on this machine", missing, plural),
+		Command: "camp sync --from <machine>   (dismiss: camp notify dismiss " + missingRootID + ")",
+	}, nil
+}
+
+// ArtifactRootDrift reports a declared root whose contents no longer match its
+// committed manifest.
+//
+// Registered now and deliberately silent: the comparison needs committed
+// manifests, which phase 002 introduces. Wiring the detector in ahead of its
+// data keeps the notice surface's shape visible and means the later change is
+// one function body rather than another round of plumbing.
+func ArtifactRootDrift(ctx context.Context, campaignRoot string) (*Notice, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	// manifests: phase 002 sequence 04 fills this in.
+	return nil, nil
+}
+
+// rootExists reports whether a declared root is present on this machine.
+func rootExists(campaignRoot, rel string) bool {
+	_, err := os.Stat(filepath.Join(campaignRoot, filepath.FromSlash(rel)))
+	return err == nil
+}
+
+// hasAnySnapshot reports whether any peer has ever recorded a transfer for a
+// root. One stat per peer per root: no hashing, no walking the root itself.
+func hasAnySnapshot(campaignRoot string, peers []string, rel string) bool {
+	for _, peer := range peers {
+		if snap, err := artifacts.LoadSnapshot(campaignRoot, peer, rel); err == nil && snap != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/notice/dismissal.go
+++ b/internal/notice/dismissal.go
@@ -104,6 +104,12 @@ func FilterDismissed(campaignRoot string, notices []Notice) []Notice {
 		// is not.
 		return notices
 	}
+	return f.Filter(notices)
+}
+
+// Filter drops notices this dismissal set covers. Separated from the disk load
+// so the decision is testable without a filesystem.
+func (f *DismissalFile) Filter(notices []Notice) []Notice {
 	kept := make([]Notice, 0, len(notices))
 	for _, n := range notices {
 		if !f.IsDismissed(n.ID) {

--- a/internal/notice/dismissal.go
+++ b/internal/notice/dismissal.go
@@ -1,0 +1,114 @@
+package notice
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/fsutil"
+	"gopkg.in/yaml.v3"
+)
+
+// DismissalRelPath is where dismissals live, campaign-relative.
+//
+// Committed, not cached. A dismissal is a judgement the user made about their
+// own campaign ("yes, I know, stop telling me"), and that judgement should
+// travel to their other machines the same way the artifact declarations it
+// concerns do. Putting it under .campaign/cache would make the same notice
+// reappear on every machine, which is how an advisory becomes noise.
+const DismissalRelPath = ".campaign/notices.yaml"
+
+// DismissalFile is the on-disk shape of .campaign/notices.yaml.
+type DismissalFile struct {
+	Version int `yaml:"version"`
+	// Dismissed maps a notice ID to when it was dismissed. Keyed by ID rather
+	// than by notice kind, so a signal that recurs for a new subject (a newly
+	// declared root, say) produces a new ID and notifies again.
+	Dismissed map[string]time.Time `yaml:"dismissed,omitempty"`
+}
+
+// DismissalPath returns the absolute path of the dismissal file.
+func DismissalPath(campaignRoot string) string {
+	return filepath.Join(campaignRoot, filepath.FromSlash(DismissalRelPath))
+}
+
+// LoadDismissals reads the dismissal file. A missing file is an empty set, not
+// an error: no dismissals is the normal starting state.
+func LoadDismissals(campaignRoot string) (*DismissalFile, error) {
+	data, err := os.ReadFile(DismissalPath(campaignRoot))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &DismissalFile{Version: 1, Dismissed: map[string]time.Time{}}, nil
+		}
+		return nil, camperrors.Wrap(err, "read notice dismissals")
+	}
+
+	var f DismissalFile
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return nil, camperrors.Wrap(err, "parse notice dismissals")
+	}
+	if f.Version == 0 {
+		f.Version = 1
+	}
+	if f.Dismissed == nil {
+		f.Dismissed = map[string]time.Time{}
+	}
+	return &f, nil
+}
+
+// Save writes the dismissal file atomically.
+func (f *DismissalFile) Save(campaignRoot string) error {
+	path := DismissalPath(campaignRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return camperrors.Wrap(err, "create .campaign directory")
+	}
+	data, err := yaml.Marshal(f)
+	if err != nil {
+		return camperrors.Wrap(err, "encode notice dismissals")
+	}
+	if err := fsutil.WriteFileAtomically(path, data, 0o644); err != nil {
+		return camperrors.Wrap(err, "write notice dismissals")
+	}
+	return nil
+}
+
+// IsDismissed reports whether a notice ID has been dismissed.
+func (f *DismissalFile) IsDismissed(id string) bool {
+	if f == nil || id == "" {
+		return false
+	}
+	_, ok := f.Dismissed[id]
+	return ok
+}
+
+// Dismiss records a dismissal, reporting whether it changed anything.
+func (f *DismissalFile) Dismiss(id string, at time.Time) bool {
+	if f.Dismissed == nil {
+		f.Dismissed = map[string]time.Time{}
+	}
+	if _, exists := f.Dismissed[id]; exists {
+		return false
+	}
+	f.Dismissed[id] = at.UTC()
+	return true
+}
+
+// FilterDismissed drops notices the user has already dismissed.
+func FilterDismissed(campaignRoot string, notices []Notice) []Notice {
+	f, err := LoadDismissals(campaignRoot)
+	if err != nil {
+		// An unreadable dismissal file must not silence advisories, and must
+		// not fail the command carrying them. Showing a notice the user
+		// dismissed is the recoverable direction; hiding one they never did
+		// is not.
+		return notices
+	}
+	kept := make([]Notice, 0, len(notices))
+	for _, n := range notices {
+		if !f.IsDismissed(n.ID) {
+			kept = append(kept, n)
+		}
+	}
+	return kept
+}

--- a/internal/notice/dismissal_test.go
+++ b/internal/notice/dismissal_test.go
@@ -1,0 +1,110 @@
+package notice
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDismissalFileIsDismissed(t *testing.T) {
+	f := &DismissalFile{Version: 1, Dismissed: map[string]time.Time{
+		"artifact-root-never-synced:videos": time.Now(),
+	}}
+
+	cases := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{name: "empty id is never dismissed", id: "", want: false},
+		{name: "unknown id", id: "something-else", want: false},
+		{name: "dismissed id", id: "artifact-root-never-synced:videos", want: true},
+		{
+			// Per signature, not per kind: a different root is a different id.
+			name: "same kind, different subject",
+			id:   "artifact-root-never-synced:media",
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := f.IsDismissed(tc.id); got != tc.want {
+				t.Errorf("IsDismissed(%q) = %v, want %v", tc.id, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDismissalFileNilIsSafe(t *testing.T) {
+	var f *DismissalFile
+	if f.IsDismissed("anything") {
+		t.Error("nil DismissalFile reported a dismissal")
+	}
+}
+
+func TestDismissalFileDismiss(t *testing.T) {
+	f := &DismissalFile{Version: 1}
+	at := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+
+	if !f.Dismiss("first", at) {
+		t.Fatal("Dismiss() = false for a new id, want true")
+	}
+	if !f.IsDismissed("first") {
+		t.Error("the id should be dismissed after Dismiss()")
+	}
+	if f.Dismiss("first", at) {
+		t.Error("Dismiss() = true for an already-dismissed id, want false")
+	}
+	if !f.Dismiss("second", at) {
+		t.Error("a different id must still be dismissible")
+	}
+}
+
+// Dismissal timestamps are stored in UTC so a file that travels between
+// machines does not appear to shift when read in another zone.
+func TestDismissalFileStoresUTC(t *testing.T) {
+	f := &DismissalFile{Version: 1}
+	zone := time.FixedZone("UTC-7", -7*60*60)
+	f.Dismiss("id", time.Date(2026, 7, 27, 12, 0, 0, 0, zone))
+
+	if got := f.Dismissed["id"].Location(); got != time.UTC {
+		t.Errorf("stored location = %v, want UTC", got)
+	}
+}
+
+func TestDismissalFileFilter(t *testing.T) {
+	notices := []Notice{
+		{ID: "a", Message: "first"},
+		{ID: "b", Message: "second"},
+		{ID: "c", Message: "third"},
+	}
+
+	cases := []struct {
+		name      string
+		dismissed []string
+		wantIDs   []string
+	}{
+		{name: "nothing dismissed keeps all", dismissed: nil, wantIDs: []string{"a", "b", "c"}},
+		{name: "one dismissed", dismissed: []string{"b"}, wantIDs: []string{"a", "c"}},
+		{name: "all dismissed", dismissed: []string{"a", "b", "c"}, wantIDs: nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &DismissalFile{Version: 1, Dismissed: map[string]time.Time{}}
+			for _, id := range tc.dismissed {
+				f.Dismiss(id, time.Now())
+			}
+
+			got := f.Filter(notices)
+			if len(got) != len(tc.wantIDs) {
+				t.Fatalf("Filter() kept %d notices, want %d", len(got), len(tc.wantIDs))
+			}
+			for i, want := range tc.wantIDs {
+				if got[i].ID != want {
+					t.Errorf("Filter()[%d].ID = %q, want %q", i, got[i].ID, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/project/new.go
+++ b/internal/project/new.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git"
 )
 
 // NewOptions configures new project creation.
@@ -94,10 +95,13 @@ func initProjectRepo(ctx context.Context, path, name string) error {
 		return camperrors.Wrap(err, "failed to write README")
 	}
 
-	// git add + commit
-	cmd = exec.CommandContext(ctx, "git", "-C", path, "add", ".")
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return camperrors.Newf("git add failed: %w (output: %s)", err, string(output))
+	// Stage through camp's staging chokepoint rather than a raw `git add .`,
+	// so a new project inherits the staging guard like every other camp
+	// staging path. Today this only stages the README written just above, so
+	// no guard can trip; the point is that a future change to what this
+	// scaffolds cannot become a silently unguarded sweep.
+	if err := git.Stage(ctx, path, nil); err != nil {
+		return camperrors.Wrap(err, "failed to stage initial project files")
 	}
 
 	cmd = exec.CommandContext(ctx, "git", "-C", path, "commit", "-m", "Initial commit")

--- a/internal/scaffold/repair.go
+++ b/internal/scaffold/repair.go
@@ -748,20 +748,9 @@ var campaignGitignoreRequiredRules = []string{
 // operation is append-only and never rewrites the file wholesale.
 func appendGitignoreEntryIfMissing(absDir, entry string) error {
 	gitignorePath := filepath.Join(absDir, config.CampaignDir, ".gitignore")
-	raw, err := os.ReadFile(gitignorePath)
-	if err != nil {
-		return err
-	}
-	if gitignoreHasRule(string(raw), entry) {
-		return nil
-	}
-	suffix := "\n"
-	if len(raw) > 0 && raw[len(raw)-1] != '\n' {
-		suffix = "\n\n"
-	}
-	addition := suffix + campaignGitignoreRuleComment(entry) + "\n" + entry + "\n"
 	// TODO(seq06-lock): concurrent repair runs can still race this read-modify-write append.
-	return fsutil.WriteFileAtomically(gitignorePath, append(raw, []byte(addition)...), 0o644)
+	_, err := fsutil.AppendGitignoreEntryIfMissing(gitignorePath, entry, campaignGitignoreRuleComment(entry))
+	return err
 }
 
 func campaignGitignoreRuleComment(entry string) string {
@@ -781,20 +770,7 @@ func campaignGitignoreRuleComment(entry string) string {
 // like `not-<entry>` or commented-out `# <entry>` do NOT count as
 // present because git would still track the file.
 func gitignoreHasRule(content, entry string) bool {
-	target := strings.TrimSpace(entry)
-	if target == "" {
-		return false
-	}
-	for _, line := range strings.Split(content, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
-			continue
-		}
-		if trimmed == target {
-			return true
-		}
-	}
-	return false
+	return fsutil.HasGitignoreRule(content, entry)
 }
 
 const rootGitignoreWorktreesComment = "# Git worktrees (machine-local)"

--- a/internal/stageguard/check.go
+++ b/internal/stageguard/check.go
@@ -5,6 +5,8 @@ import (
 	"path"
 	"sort"
 	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 
 // dominantPrefixShare is the fraction of a batch one directory must hold to be
@@ -232,6 +234,27 @@ func matchesOne(p, pattern string) bool {
 		}
 	}
 	return false
+}
+
+// ValidateAllow reports the first malformed glob in an allowlist.
+//
+// Matching deliberately ignores pattern errors so one bad entry cannot break
+// evaluation of the rest, which means a typo would otherwise be invisible: the
+// user believes a path is exempt, the guard silently disagrees, and the file
+// gets excluded from their commit anyway. Config resolution calls this so the
+// mistake surfaces where it can be fixed.
+func ValidateAllow(allow []string) error {
+	for _, pattern := range allow {
+		trimmed := strings.TrimSpace(pattern)
+		if trimmed == "" {
+			continue
+		}
+		probe := strings.TrimSuffix(trimmed, "/**")
+		if _, err := path.Match(probe, "probe"); err != nil {
+			return camperrors.Wrapf(err, "invalid allow glob %q", pattern)
+		}
+	}
+	return nil
 }
 
 // SortViolations orders violations for stable reporting: bulk first because it

--- a/internal/stageguard/check.go
+++ b/internal/stageguard/check.go
@@ -1,0 +1,250 @@
+package stageguard
+
+import (
+	"context"
+	"path"
+	"sort"
+	"strings"
+)
+
+// dominantPrefixShare is the fraction of a batch one directory must hold to be
+// called dominant. A vendor tree concentrates almost everything under one
+// path; work spread evenly across a repo does not, and must not block.
+const dominantPrefixShare = 0.9
+
+// CheckStaging enumerates what a stage-everything operation would add in
+// repoPath and returns the violations found under limits. It is stat-only: no
+// file is opened, read, or hashed.
+//
+// It is exported separately from staging so a caller that stages by another
+// route, or wants to preflight without staging, can still consult the guard.
+func CheckStaging(ctx context.Context, repoPath string, limits GuardLimits) ([]GuardViolation, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	candidates, err := Enumerate(ctx, repoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	candidates, err = FilterLFSManaged(ctx, repoPath, candidates)
+	if err != nil {
+		return nil, err
+	}
+	candidates = filterAllowed(candidates, limits.Allow)
+
+	// The per-file guard runs first and the bulk guard counts only what it
+	// leaves behind. Otherwise one auto-handled 512 MB video would also swell
+	// the bulk batch, turning the flagship scenario into a block.
+	violations, remaining := checkPerFile(candidates, limits)
+	if bulk, found := detectBulk(remaining, limits); found {
+		violations = append(violations, bulk)
+	}
+	return violations, nil
+}
+
+// checkPerFile applies the size threshold and returns both the violations and
+// the candidates the bulk guard should still consider.
+func checkPerFile(candidates []Candidate, limits GuardLimits) (violations []GuardViolation, remaining []Candidate) {
+	remaining = make([]Candidate, 0, len(candidates))
+	if limits.LargeFiles == ModeOff {
+		return nil, append(remaining, candidates...)
+	}
+
+	for _, candidate := range candidates {
+		// Size decides, never extension: a 200 KB .mp4 is ordinary content and
+		// a 512 MB .json is not.
+		if candidate.Size <= limits.MaxFileSize {
+			remaining = append(remaining, candidate)
+			continue
+		}
+		if !candidate.Untracked {
+			// A tracked file that grew past the threshold is reported and
+			// committed. Excluding it would leave the stale blob in git while
+			// the new bytes on disk belonged to nothing.
+			violations = append(violations, GuardViolation{
+				Kind: TrackedGrowth,
+				Path: candidate.Path,
+				Size: candidate.Size,
+			})
+			remaining = append(remaining, candidate)
+			continue
+		}
+		violations = append(violations, GuardViolation{
+			Kind: OverThreshold,
+			Path: candidate.Path,
+			Size: candidate.Size,
+		})
+	}
+	return violations, remaining
+}
+
+// detectBulk reports one staging operation adding a very large number of
+// untracked files under a single directory. Tracked modifications never count:
+// editing a thousand existing files is ordinary work, and the pathology being
+// caught is a vendor tree arriving whole.
+func detectBulk(candidates []Candidate, limits GuardLimits) (GuardViolation, bool) {
+	if limits.Bulk == ModeOff || limits.MaxAddedFiles <= 0 {
+		return GuardViolation{}, false
+	}
+
+	untracked := make([]Candidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.Untracked {
+			untracked = append(untracked, candidate)
+		}
+	}
+	if len(untracked) < limits.MaxAddedFiles {
+		return GuardViolation{}, false
+	}
+
+	prefix, count, total := dominantPrefix(untracked)
+	if prefix == "" || count < limits.MaxAddedFiles {
+		return GuardViolation{}, false
+	}
+	return GuardViolation{
+		Kind:         Bulk,
+		CommonPrefix: prefix,
+		Count:        count,
+		// Reported for display only. There is deliberately no total-bytes
+		// trigger: its only unique catch was many medium files, which is
+		// exactly the false positive.
+		TotalBytes: total,
+	}, true
+}
+
+// dominantPrefix finds the deepest directory holding at least
+// dominantPrefixShare of the batch, and returns it with its file count and
+// total size. It returns an empty prefix when the batch is spread across
+// directories, which is the ordinary case that must not block.
+func dominantPrefix(candidates []Candidate) (prefix string, count int, total int64) {
+	threshold := int(float64(len(candidates)) * dominantPrefixShare)
+	current := ""
+
+	for depth := 1; ; depth++ {
+		counts := make(map[string]int)
+		for _, candidate := range candidates {
+			dir, ok := prefixAtDepth(candidate.Path, depth)
+			if !ok || !underPrefix(candidate.Path, current) {
+				continue
+			}
+			counts[dir]++
+		}
+
+		best, bestCount := "", 0
+		for dir, n := range counts {
+			// Ties resolve by name so the result never depends on map order.
+			if n > bestCount || (n == bestCount && dir < best) {
+				best, bestCount = dir, n
+			}
+		}
+		if bestCount < threshold || best == "" {
+			break
+		}
+		current = best
+	}
+
+	if current == "" {
+		return "", 0, 0
+	}
+	for _, candidate := range candidates {
+		if underPrefix(candidate.Path, current) {
+			count++
+			total += candidate.Size
+		}
+	}
+	return current, count, total
+}
+
+// prefixAtDepth returns the first depth segments of a path's directory, or
+// false when the path is not that deep. A file at the repo root has no
+// directory prefix and can never be part of a dominant one.
+func prefixAtDepth(p string, depth int) (string, bool) {
+	segments := strings.Split(p, "/")
+	if len(segments) <= depth {
+		return "", false
+	}
+	return strings.Join(segments[:depth], "/"), true
+}
+
+// underPrefix reports whether p lives beneath prefix. An empty prefix matches
+// everything, which is how the descent starts.
+func underPrefix(p, prefix string) bool {
+	if prefix == "" {
+		return true
+	}
+	return strings.HasPrefix(p, prefix+"/")
+}
+
+// filterAllowed drops candidates matched by an allowlist glob. The allowlist
+// is the one obvious line that makes a legitimate large file permanent, so it
+// is applied before any guard rather than as an exception inside one.
+func filterAllowed(candidates []Candidate, allow []string) []Candidate {
+	if len(allow) == 0 {
+		return candidates
+	}
+	kept := make([]Candidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if MatchesAllow(candidate.Path, allow) {
+			continue
+		}
+		kept = append(kept, candidate)
+	}
+	return kept
+}
+
+// MatchesAllow reports whether a repo-relative path matches any allow glob.
+//
+// Three forms are supported, chosen to match what users already expect from
+// gitignore rather than inventing a syntax:
+//
+//   - an exact path
+//   - "dir/**", matching everything beneath dir
+//   - a glob; one without a slash matches the basename at any depth, so
+//     "*.psd" is not accidentally anchored to the repository root
+func MatchesAllow(p string, allow []string) bool {
+	for _, pattern := range allow {
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" {
+			continue
+		}
+		if matchesOne(p, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesOne(p, pattern string) bool {
+	if p == pattern {
+		return true
+	}
+	if rest, ok := strings.CutSuffix(pattern, "/**"); ok {
+		return p == rest || strings.HasPrefix(p, rest+"/")
+	}
+	if ok, err := path.Match(pattern, p); err == nil && ok {
+		return true
+	}
+	if !strings.Contains(pattern, "/") {
+		if ok, err := path.Match(pattern, path.Base(p)); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// SortViolations orders violations for stable reporting: bulk first because it
+// blocks, then per-file findings by descending size, then by path.
+func SortViolations(violations []GuardViolation) {
+	sort.SliceStable(violations, func(i, j int) bool {
+		a, b := violations[i], violations[j]
+		if (a.Kind == Bulk) != (b.Kind == Bulk) {
+			return a.Kind == Bulk
+		}
+		if a.Size != b.Size {
+			return a.Size > b.Size
+		}
+		return a.Path < b.Path
+	})
+}

--- a/internal/stageguard/check.go
+++ b/internal/stageguard/check.go
@@ -9,11 +9,6 @@ import (
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 
-// dominantPrefixShare is the fraction of a batch one directory must hold to be
-// called dominant. A vendor tree concentrates almost everything under one
-// path; work spread evenly across a repo does not, and must not block.
-const dominantPrefixShare = 0.9
-
 // CheckStaging enumerates what a stage-everything operation would add in
 // repoPath and returns the violations found under limits. It is stat-only: no
 // file is opened, read, or hashed.
@@ -101,8 +96,8 @@ func detectBulk(candidates []Candidate, limits GuardLimits) (GuardViolation, boo
 		return GuardViolation{}, false
 	}
 
-	prefix, count, total := dominantPrefix(untracked)
-	if prefix == "" || count < limits.MaxAddedFiles {
+	prefix, count, total := heaviestPrefix(untracked, limits.MaxAddedFiles)
+	if prefix == "" {
 		return GuardViolation{}, false
 	}
 	return GuardViolation{
@@ -116,12 +111,21 @@ func detectBulk(candidates []Candidate, limits GuardLimits) (GuardViolation, boo
 	}, true
 }
 
-// dominantPrefix finds the deepest directory holding at least
-// dominantPrefixShare of the batch, and returns it with its file count and
-// total size. It returns an empty prefix when the batch is spread across
-// directories, which is the ordinary case that must not block.
-func dominantPrefix(candidates []Candidate) (prefix string, count int, total int64) {
-	threshold := int(float64(len(candidates)) * dominantPrefixShare)
+// heaviestPrefix finds the deepest directory holding at least minCount of the
+// candidates, and returns it with its file count and total size. It returns an
+// empty prefix when no single directory holds that many, which is the ordinary
+// scattered batch that must not block.
+//
+// The test is an absolute count, not a share of the batch. A share can be
+// diluted: 1000 files under vendor/ plus 120 unrelated stragglers is 89% of the
+// batch, so a 90% rule cancels a vendor dump that is exactly what the bulk
+// guard exists to catch. Whether a directory is being dumped into git does not
+// depend on what else the user happened to leave lying around.
+//
+// The descent is kept because it names the reported path: reporting "vendor"
+// when the files are all under "vendor/github.com/pkg" tells the user less
+// about what they are looking at.
+func heaviestPrefix(candidates []Candidate, minCount int) (prefix string, count int, total int64) {
 	current := ""
 
 	for depth := 1; ; depth++ {
@@ -141,7 +145,7 @@ func dominantPrefix(candidates []Candidate) (prefix string, count int, total int
 				best, bestCount = dir, n
 			}
 		}
-		if bestCount < threshold || best == "" {
+		if bestCount < minCount || best == "" {
 			break
 		}
 		current = best

--- a/internal/stageguard/config.go
+++ b/internal/stageguard/config.go
@@ -1,0 +1,225 @@
+package stageguard
+
+import (
+	"context"
+	"math"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// Shipped defaults, applied when config is silent. The campaign figure is low
+// because campaign content is overwhelmingly text, so the exceptions are heavy
+// reference material an artifact root should own. The project figure is higher
+// because the outcome there is a stop rather than a silent fix.
+const (
+	// DefaultMaxFileSize is the campaign-root per-file threshold.
+	DefaultMaxFileSize int64 = 10 << 20 // 10 MiB
+	// DefaultProjectMaxFileSize is the per-file threshold inside a project.
+	DefaultProjectMaxFileSize int64 = 25 << 20 // 25 MiB
+	// DefaultMaxAddedFiles is the bulk trigger count.
+	DefaultMaxAddedFiles = 1000
+)
+
+// ResolveLimits loads the guard policy that applies to repoPath. The stage
+// chokepoint calls it with no config knowledge of its own, which is what lets
+// fest inherit the guard from a version bump with no fest code change.
+//
+// Outside a campaign there is no campaign.yaml, so the project-scope defaults
+// apply: a bare git repo is closer to a project than to a campaign root.
+func ResolveLimits(ctx context.Context, repoPath string) (GuardLimits, error) {
+	if ctx.Err() != nil {
+		return GuardLimits{}, ctx.Err()
+	}
+
+	campaignRoot, err := config.DetectCampaignRoot(ctx, repoPath)
+	if err != nil {
+		if camperrors.Is(err, config.ErrNotInCampaign) {
+			return defaultLimits(true), nil
+		}
+		return GuardLimits{}, camperrors.Wrapf(err, "resolve campaign root for %s", repoPath)
+	}
+
+	cfg, err := config.LoadCampaignConfig(ctx, campaignRoot)
+	if err != nil {
+		return GuardLimits{}, camperrors.Wrapf(err, "load campaign config at %s", campaignRoot)
+	}
+
+	paths := config.DefaultCampaignPaths()
+	if cfg != nil && cfg.Jumps != nil {
+		paths = cfg.Jumps.Paths
+	}
+	scopeProject, projectName := resolveScope(campaignRoot, repoPath, paths)
+	if cfg == nil {
+		return defaultLimits(scopeProject), nil
+	}
+	return applyGuardsConfig(cfg.Commit.Guards, scopeProject, projectName)
+}
+
+// defaultLimits returns the shipped policy for a scope.
+func defaultLimits(scopeProject bool) GuardLimits {
+	maxFileSize := DefaultMaxFileSize
+	if scopeProject {
+		maxFileSize = DefaultProjectMaxFileSize
+	}
+	return GuardLimits{
+		MaxFileSize:   maxFileSize,
+		MaxAddedFiles: DefaultMaxAddedFiles,
+		LargeFiles:    ModeAuto,
+		Bulk:          ModeBlock,
+		ScopeProject:  scopeProject,
+	}
+}
+
+// applyGuardsConfig overlays configured values onto the shipped defaults for a
+// scope. An unset field keeps its default; an invalid one is an error rather
+// than a silent fallback, so a typo never quietly disables a guard.
+func applyGuardsConfig(g config.GuardsConfig, scopeProject bool, projectName string) (GuardLimits, error) {
+	limits := defaultLimits(scopeProject)
+	limits.Allow = g.ResolveAllow(projectName)
+
+	if raw := g.ResolveMaxFileSize(projectName); raw != "" {
+		size, err := ParseByteSize(raw)
+		if err != nil {
+			return GuardLimits{}, camperrors.NewValidation("commit.guards.max_file_size", err.Error(), err)
+		}
+		limits.MaxFileSize = size
+	}
+	if n := g.ResolveMaxAddedFiles(projectName); n > 0 {
+		limits.MaxAddedFiles = n
+	}
+	if raw := g.ResolveGuardMode(projectName); raw != "" {
+		mode := Mode(raw)
+		if !mode.Valid() {
+			return GuardLimits{}, camperrors.NewValidation("commit.guards.large_files",
+				"must be auto, block, or off, got "+strconv.Quote(raw), nil)
+		}
+		limits.LargeFiles = mode
+	}
+	if raw := g.ResolveBulkMode(projectName); raw != "" {
+		mode := Mode(raw)
+		// No auto: camp cannot infer whether a bulk tree wants gitignore or an
+		// artifact root, so offering the mode would promise a decision camp
+		// has no basis to make.
+		if mode != ModeBlock && mode != ModeOff {
+			return GuardLimits{}, camperrors.NewValidation("commit.guards.bulk",
+				"must be block or off, got "+strconv.Quote(raw), nil)
+		}
+		limits.Bulk = mode
+	}
+	return limits, nil
+}
+
+// resolveScope reports whether repoPath is a project rather than the campaign
+// root, and the project name used to key per-project overrides.
+//
+// The projects and worktrees directories are campaign-configurable
+// (.campaign/settings/jumps.yaml), so they are read from paths rather than
+// assumed. Worktrees is checked first because it nests under projects by
+// default, and a worktree keys to the project it belongs to so a per-project
+// override applies to work done in either place.
+func resolveScope(campaignRoot, repoPath string, paths config.CampaignPaths) (scopeProject bool, projectName string) {
+	rootAbs, err := filepath.Abs(campaignRoot)
+	if err != nil {
+		rootAbs = campaignRoot
+	}
+	repoAbs, err := filepath.Abs(repoPath)
+	if err != nil {
+		repoAbs = repoPath
+	}
+
+	rel, err := filepath.Rel(rootAbs, repoAbs)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		// Outside the campaign tree entirely: treat as a bare project.
+		return true, ""
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." {
+		return false, ""
+	}
+
+	for _, container := range []string{paths.Worktrees, paths.Projects} {
+		if name, ok := firstSegmentUnder(rel, container); ok {
+			return true, name
+		}
+	}
+	segments := strings.Split(rel, "/")
+	return true, segments[len(segments)-1]
+}
+
+// firstSegmentUnder returns the first path segment of rel below container, if
+// rel lives there. An empty or "." container never matches, so an unconfigured
+// path cannot swallow the whole campaign.
+func firstSegmentUnder(rel, container string) (string, bool) {
+	container = strings.Trim(strings.TrimSpace(filepath.ToSlash(container)), "/")
+	if container == "" || container == "." {
+		return "", false
+	}
+	if !strings.HasPrefix(rel, container+"/") {
+		return "", false
+	}
+	remainder := strings.TrimPrefix(rel, container+"/")
+	segments := strings.Split(remainder, "/")
+	if segments[0] == "" {
+		return "", false
+	}
+	return segments[0], true
+}
+
+// byteUnits maps a size suffix to its multiplier. Binary (MiB) and decimal
+// (MB) units are both accepted because users write both and the difference at
+// these magnitudes never changes which side of a threshold a file lands on.
+var byteUnits = []struct {
+	suffix string
+	factor int64
+}{
+	{"KIB", 1 << 10}, {"MIB", 1 << 20}, {"GIB", 1 << 30}, {"TIB", 1 << 40},
+	{"KB", 1000}, {"MB", 1000 * 1000}, {"GB", 1000 * 1000 * 1000}, {"TB", 1000 * 1000 * 1000 * 1000},
+	{"K", 1 << 10}, {"M", 1 << 20}, {"G", 1 << 30}, {"T", 1 << 40},
+	{"B", 1},
+}
+
+// ParseByteSize parses a human byte size such as "10MiB", "50MB", or "1024".
+// A bare number is bytes. Parsing is case-insensitive and tolerates a space
+// before the unit.
+func ParseByteSize(raw string) (int64, error) {
+	s := strings.ToUpper(strings.TrimSpace(raw))
+	if s == "" {
+		return 0, camperrors.New("empty byte size")
+	}
+
+	for _, unit := range byteUnits {
+		if !strings.HasSuffix(s, unit.suffix) {
+			continue
+		}
+		digits := strings.TrimSpace(strings.TrimSuffix(s, unit.suffix))
+		value, err := parseSizeNumber(digits, raw)
+		if err != nil {
+			return 0, err
+		}
+		if value > maxSizeValue/unit.factor {
+			return 0, camperrors.Newf("byte size %q overflows int64", raw)
+		}
+		return value * unit.factor, nil
+	}
+	return parseSizeNumber(s, raw)
+}
+
+const maxSizeValue = int64(math.MaxInt64)
+
+func parseSizeNumber(digits, raw string) (int64, error) {
+	if digits == "" {
+		return 0, camperrors.Newf("byte size %q has no number", raw)
+	}
+	value, err := strconv.ParseInt(digits, 10, 64)
+	if err != nil {
+		return 0, camperrors.Wrapf(err, "parse byte size %q", raw)
+	}
+	if value < 0 {
+		return 0, camperrors.Newf("byte size %q must not be negative", raw)
+	}
+	return value, nil
+}

--- a/internal/stageguard/config.go
+++ b/internal/stageguard/config.go
@@ -2,6 +2,7 @@ package stageguard
 
 import (
 	"context"
+	"errors"
 	"math"
 	"path/filepath"
 	"strconv"
@@ -45,6 +46,20 @@ func ResolveLimits(ctx context.Context, repoPath string) (GuardLimits, error) {
 
 	cfg, err := config.LoadCampaignConfig(ctx, campaignRoot)
 	if err != nil {
+		// A .campaign/ directory with no campaign.yaml is a campaign mid-
+		// scaffold, not a broken one. The guard is a safety net, not a
+		// precondition for staging: refusing to stage until the config exists
+		// would break `camp init` and quest scaffolding, which stage files
+		// into a campaign they are still building. Fall back to defaults.
+		//
+		// A malformed or unreadable config is different and still propagates:
+		// there the user has configuration they believe is in effect, and
+		// silently substituting defaults could disable a guard they set.
+		var notFound *camperrors.NotFoundError
+		if errors.As(err, &notFound) {
+			scopeProject, _ := resolveScope(campaignRoot, repoPath, config.DefaultCampaignPaths())
+			return defaultLimits(scopeProject), nil
+		}
 		return GuardLimits{}, camperrors.Wrapf(err, "load campaign config at %s", campaignRoot)
 	}
 
@@ -125,14 +140,15 @@ func applyGuardsConfig(g config.GuardsConfig, scopeProject bool, projectName str
 // default, and a worktree keys to the project it belongs to so a per-project
 // override applies to work done in either place.
 func resolveScope(campaignRoot, repoPath string, paths config.CampaignPaths) (scopeProject bool, projectName string) {
-	rootAbs, err := filepath.Abs(campaignRoot)
-	if err != nil {
-		rootAbs = campaignRoot
-	}
-	repoAbs, err := filepath.Abs(repoPath)
-	if err != nil {
-		repoAbs = repoPath
-	}
+	// Both sides are resolved through symlinks before comparison. Campaign
+	// detection may return a resolved path while the caller holds the logical
+	// one (on macOS /var is a symlink to /private/var, and a campaign under a
+	// symlinked home or /tmp hits the same split). Comparing the two spellings
+	// directly makes filepath.Rel emit "..", which would classify the campaign
+	// root itself as a project and silently apply the higher project threshold
+	// exactly where the lower campaign-root one belongs.
+	rootAbs := resolvePath(campaignRoot)
+	repoAbs := resolvePath(repoPath)
 
 	rel, err := filepath.Rel(rootAbs, repoAbs)
 	if err != nil || strings.HasPrefix(rel, "..") {
@@ -151,6 +167,21 @@ func resolveScope(campaignRoot, repoPath string, paths config.CampaignPaths) (sc
 	}
 	segments := strings.Split(rel, "/")
 	return true, segments[len(segments)-1]
+}
+
+// resolvePath makes a path absolute and resolves symlinks. A path that cannot
+// be resolved (it may not exist yet) keeps its absolute form, which is still
+// better than the raw input for comparison.
+func resolvePath(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		abs = p
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return abs
+	}
+	return resolved
 }
 
 // firstSegmentUnder returns the first path segment of rel below container, if

--- a/internal/stageguard/config.go
+++ b/internal/stageguard/config.go
@@ -80,6 +80,9 @@ func defaultLimits(scopeProject bool) GuardLimits {
 func applyGuardsConfig(g config.GuardsConfig, scopeProject bool, projectName string) (GuardLimits, error) {
 	limits := defaultLimits(scopeProject)
 	limits.Allow = g.ResolveAllow(projectName)
+	if err := ValidateAllow(limits.Allow); err != nil {
+		return GuardLimits{}, camperrors.NewValidation("commit.guards.allow", err.Error(), err)
+	}
 
 	if raw := g.ResolveMaxFileSize(projectName); raw != "" {
 		size, err := ParseByteSize(raw)

--- a/internal/stageguard/config_test.go
+++ b/internal/stageguard/config_test.go
@@ -1,6 +1,9 @@
 package stageguard
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/Obedience-Corp/camp/internal/config"
@@ -370,5 +373,45 @@ func TestApplyGuardsConfigRejectsMalformedAllowGlob(t *testing.T) {
 	guards := config.GuardsConfig{Allow: []string{"docs/[a-.pdf"}}
 	if _, err := applyGuardsConfig(guards, false, ""); err == nil {
 		t.Fatal("applyGuardsConfig() = nil error, want validation error for a bad glob")
+	}
+}
+
+// A .campaign/ directory with no campaign.yaml is a campaign mid-scaffold.
+// Staging into it must still work: camp init and quest scaffolding stage files
+// into a campaign they are still building, and the guard is a safety net
+// rather than a precondition for camp functioning.
+func TestResolveLimitsMissingCampaignConfigFallsBackToDefaults(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".campaign"), 0o755); err != nil {
+		t.Fatalf("create .campaign: %v", err)
+	}
+
+	limits, err := ResolveLimits(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("ResolveLimits() error = %v; a campaign mid-scaffold must not fail staging", err)
+	}
+	if limits.MaxFileSize != DefaultMaxFileSize {
+		t.Errorf("MaxFileSize = %d, want the campaign-root default %d", limits.MaxFileSize, DefaultMaxFileSize)
+	}
+	if limits.LargeFiles != ModeAuto || limits.Bulk != ModeBlock {
+		t.Errorf("modes = (%q, %q), want the shipped defaults", limits.LargeFiles, limits.Bulk)
+	}
+}
+
+// A malformed config is a different case: the user has configuration they
+// believe is in effect, so silently substituting defaults could disable a
+// guard they deliberately set.
+func TestResolveLimitsMalformedCampaignConfigPropagates(t *testing.T) {
+	dir := t.TempDir()
+	campaignDir := filepath.Join(dir, ".campaign")
+	if err := os.MkdirAll(campaignDir, 0o755); err != nil {
+		t.Fatalf("create .campaign: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(campaignDir, "campaign.yaml"), []byte("\tnot: [valid"), 0o644); err != nil {
+		t.Fatalf("write campaign.yaml: %v", err)
+	}
+
+	if _, err := ResolveLimits(context.Background(), dir); err == nil {
+		t.Fatal("ResolveLimits() = nil error for a malformed campaign.yaml, want an error")
 	}
 }

--- a/internal/stageguard/config_test.go
+++ b/internal/stageguard/config_test.go
@@ -363,3 +363,12 @@ func TestResolveScopeEmptyConfiguredPaths(t *testing.T) {
 
 func strPtr(s string) *string { return &s }
 func intPtr(i int) *int       { return &i }
+
+// A malformed glob must fail config resolution rather than silently never
+// matching, which would leave the user believing a path is exempt.
+func TestApplyGuardsConfigRejectsMalformedAllowGlob(t *testing.T) {
+	guards := config.GuardsConfig{Allow: []string{"docs/[a-.pdf"}}
+	if _, err := applyGuardsConfig(guards, false, ""); err == nil {
+		t.Fatal("applyGuardsConfig() = nil error, want validation error for a bad glob")
+	}
+}

--- a/internal/stageguard/config_test.go
+++ b/internal/stageguard/config_test.go
@@ -1,0 +1,365 @@
+package stageguard
+
+import (
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+)
+
+func TestParseByteSizeErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{name: "empty string", raw: ""},
+		{name: "whitespace only", raw: "   "},
+		{name: "unit with no number", raw: "MiB"},
+		{name: "non-numeric", raw: "banana"},
+		{name: "float is not accepted", raw: "1.5MiB"},
+		{name: "negative", raw: "-10MiB"},
+		{name: "unknown unit", raw: "10PiB"},
+		{name: "trailing garbage", raw: "10MiB!"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseByteSize(tc.raw)
+			if err == nil {
+				t.Fatalf("ParseByteSize(%q) = %d, want error", tc.raw, got)
+			}
+		})
+	}
+}
+
+func TestParseByteSize(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want int64
+	}{
+		{name: "bare number is bytes", raw: "1024", want: 1024},
+		{name: "zero", raw: "0", want: 0},
+		{name: "binary mebibyte", raw: "10MiB", want: 10 << 20},
+		{name: "decimal megabyte", raw: "50MB", want: 50 * 1000 * 1000},
+		{name: "case insensitive", raw: "10mib", want: 10 << 20},
+		{name: "space before unit", raw: "10 MiB", want: 10 << 20},
+		{name: "surrounding whitespace", raw: "  25MiB  ", want: 25 << 20},
+		{name: "kibibyte", raw: "512KiB", want: 512 << 10},
+		{name: "gibibyte", raw: "2GiB", want: 2 << 30},
+		{name: "bare B suffix", raw: "900B", want: 900},
+		{name: "short binary suffix", raw: "10M", want: 10 << 20},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseByteSize(tc.raw)
+			if err != nil {
+				t.Fatalf("ParseByteSize(%q) error = %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Errorf("ParseByteSize(%q) = %d, want %d", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyGuardsConfigErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		guards  config.GuardsConfig
+		project string
+	}{
+		{
+			name:   "unknown large_files mode",
+			guards: config.GuardsConfig{LargeFiles: "warn"},
+		},
+		{
+			name:   "bulk rejects auto",
+			guards: config.GuardsConfig{Bulk: "auto"},
+		},
+		{
+			name:   "unparseable max_file_size",
+			guards: config.GuardsConfig{MaxFileSize: "ten megs"},
+		},
+		{
+			name:    "project override mode is validated too",
+			guards:  config.GuardsConfig{Projects: map[string]config.GuardsProjectConfig{"camp": {LargeFiles: strPtr("loud")}}},
+			project: "camp",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scopeProject := tc.project != ""
+			if _, err := applyGuardsConfig(tc.guards, scopeProject, tc.project); err == nil {
+				t.Fatal("applyGuardsConfig() = nil error, want validation error")
+			}
+		})
+	}
+}
+
+func TestApplyGuardsConfigDefaults(t *testing.T) {
+	t.Run("empty config at campaign root", func(t *testing.T) {
+		limits, err := applyGuardsConfig(config.GuardsConfig{}, false, "")
+		if err != nil {
+			t.Fatalf("applyGuardsConfig() error = %v", err)
+		}
+		if limits.MaxFileSize != DefaultMaxFileSize {
+			t.Errorf("MaxFileSize = %d, want %d", limits.MaxFileSize, DefaultMaxFileSize)
+		}
+		if limits.LargeFiles != ModeAuto {
+			t.Errorf("LargeFiles = %q, want %q", limits.LargeFiles, ModeAuto)
+		}
+		if limits.Bulk != ModeBlock {
+			t.Errorf("Bulk = %q, want %q", limits.Bulk, ModeBlock)
+		}
+		if limits.ScopeProject {
+			t.Error("ScopeProject = true, want false at the campaign root")
+		}
+	})
+
+	t.Run("empty config inside a project raises the threshold", func(t *testing.T) {
+		limits, err := applyGuardsConfig(config.GuardsConfig{}, true, "camp")
+		if err != nil {
+			t.Fatalf("applyGuardsConfig() error = %v", err)
+		}
+		if limits.MaxFileSize != DefaultProjectMaxFileSize {
+			t.Errorf("MaxFileSize = %d, want %d", limits.MaxFileSize, DefaultProjectMaxFileSize)
+		}
+		if !limits.ScopeProject {
+			t.Error("ScopeProject = false, want true inside a project")
+		}
+	})
+}
+
+func TestApplyGuardsConfigProjectOverrides(t *testing.T) {
+	guards := config.GuardsConfig{
+		LargeFiles:         "auto",
+		Bulk:               "block",
+		MaxFileSize:        "10MiB",
+		MaxProjectFileSize: "25MiB",
+		MaxAddedFiles:      1000,
+		Allow:              []string{"docs/*.pdf"},
+		Projects: map[string]config.GuardsProjectConfig{
+			"camp": {
+				MaxFileSize:   strPtr("100MiB"),
+				LargeFiles:    strPtr("block"),
+				MaxAddedFiles: intPtr(50),
+				Allow:         []string{"testdata/**"},
+			},
+		},
+	}
+
+	cases := []struct {
+		name              string
+		scopeProject      bool
+		project           string
+		wantMaxFileSize   int64
+		wantMode          Mode
+		wantMaxAddedFiles int
+		wantAllow         []string
+	}{
+		{
+			name:              "campaign root ignores project legs",
+			scopeProject:      false,
+			project:           "",
+			wantMaxFileSize:   10 << 20,
+			wantMode:          ModeAuto,
+			wantMaxAddedFiles: 1000,
+			wantAllow:         []string{"docs/*.pdf"},
+		},
+		{
+			name:              "overridden project wins",
+			scopeProject:      true,
+			project:           "camp",
+			wantMaxFileSize:   100 << 20,
+			wantMode:          ModeBlock,
+			wantMaxAddedFiles: 50,
+			wantAllow:         []string{"testdata/**"},
+		},
+		{
+			name:              "project without an override takes the project default",
+			scopeProject:      true,
+			project:           "fest",
+			wantMaxFileSize:   25 << 20,
+			wantMode:          ModeAuto,
+			wantMaxAddedFiles: 1000,
+			wantAllow:         []string{"docs/*.pdf"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			limits, err := applyGuardsConfig(guards, tc.scopeProject, tc.project)
+			if err != nil {
+				t.Fatalf("applyGuardsConfig() error = %v", err)
+			}
+			if limits.MaxFileSize != tc.wantMaxFileSize {
+				t.Errorf("MaxFileSize = %d, want %d", limits.MaxFileSize, tc.wantMaxFileSize)
+			}
+			if limits.LargeFiles != tc.wantMode {
+				t.Errorf("LargeFiles = %q, want %q", limits.LargeFiles, tc.wantMode)
+			}
+			if limits.MaxAddedFiles != tc.wantMaxAddedFiles {
+				t.Errorf("MaxAddedFiles = %d, want %d", limits.MaxAddedFiles, tc.wantMaxAddedFiles)
+			}
+			if len(limits.Allow) != len(tc.wantAllow) || (len(tc.wantAllow) > 0 && limits.Allow[0] != tc.wantAllow[0]) {
+				t.Errorf("Allow = %v, want %v", limits.Allow, tc.wantAllow)
+			}
+		})
+	}
+}
+
+// An explicit empty project allow list replaces the campaign-wide list rather
+// than inheriting it, so a project can opt out of global exemptions.
+func TestApplyGuardsConfigEmptyProjectAllowReplaces(t *testing.T) {
+	guards := config.GuardsConfig{
+		Allow: []string{"docs/*.pdf"},
+		Projects: map[string]config.GuardsProjectConfig{
+			"camp": {Allow: []string{}},
+		},
+	}
+	limits, err := applyGuardsConfig(guards, true, "camp")
+	if err != nil {
+		t.Fatalf("applyGuardsConfig() error = %v", err)
+	}
+	if len(limits.Allow) != 0 {
+		t.Errorf("Allow = %v, want empty", limits.Allow)
+	}
+}
+
+func TestDefaultLimitsNoCampaignFallsBackToProjectScope(t *testing.T) {
+	// Outside a campaign there is no campaign.yaml; a bare git repo is closer
+	// to a project than to a campaign root, so it takes the higher threshold.
+	limits := defaultLimits(true)
+	if limits.MaxFileSize != DefaultProjectMaxFileSize {
+		t.Errorf("MaxFileSize = %d, want %d", limits.MaxFileSize, DefaultProjectMaxFileSize)
+	}
+	if !limits.ScopeProject {
+		t.Error("ScopeProject = false, want true")
+	}
+	if limits.LargeFiles != ModeAuto || limits.Bulk != ModeBlock {
+		t.Errorf("modes = (%q, %q), want (auto, block)", limits.LargeFiles, limits.Bulk)
+	}
+}
+
+func TestResolveScope(t *testing.T) {
+	const root = "/home/u/campaign"
+
+	cases := []struct {
+		name             string
+		repoPath         string
+		wantScopeProject bool
+		wantProject      string
+	}{
+		{
+			name:             "campaign root itself",
+			repoPath:         root,
+			wantScopeProject: false,
+			wantProject:      "",
+		},
+		{
+			name:             "project submodule",
+			repoPath:         root + "/projects/camp",
+			wantScopeProject: true,
+			wantProject:      "camp",
+		},
+		{
+			name:             "nested path inside a project resolves to the project",
+			repoPath:         root + "/projects/camp/internal/git",
+			wantScopeProject: true,
+			wantProject:      "camp",
+		},
+		{
+			name:             "worktree resolves to the project it belongs to",
+			repoPath:         root + "/projects/worktrees/camp/artifact-commit-guardrails",
+			wantScopeProject: true,
+			wantProject:      "camp",
+		},
+		{
+			name:             "directory outside projects/ is still project scope",
+			repoPath:         root + "/tools/clitest",
+			wantScopeProject: true,
+			wantProject:      "clitest",
+		},
+		{
+			name:             "path outside the campaign entirely",
+			repoPath:         "/home/u/elsewhere/repo",
+			wantScopeProject: true,
+			wantProject:      "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scopeProject, project := resolveScope(root, tc.repoPath, config.DefaultCampaignPaths())
+			if scopeProject != tc.wantScopeProject {
+				t.Errorf("scopeProject = %v, want %v", scopeProject, tc.wantScopeProject)
+			}
+			if project != tc.wantProject {
+				t.Errorf("project = %q, want %q", project, tc.wantProject)
+			}
+		})
+	}
+}
+
+// The projects and worktrees directories are campaign-configurable, so scope
+// resolution must read them rather than assume the defaults.
+func TestResolveScopeHonorsConfiguredPaths(t *testing.T) {
+	const root = "/home/u/campaign"
+	paths := config.CampaignPaths{
+		Projects:  "repos/",
+		Worktrees: "repos/wt/",
+	}
+
+	cases := []struct {
+		name        string
+		repoPath    string
+		wantProject string
+	}{
+		{
+			name:        "configured projects directory",
+			repoPath:    root + "/repos/camp",
+			wantProject: "camp",
+		},
+		{
+			name:        "configured worktrees directory wins over its parent",
+			repoPath:    root + "/repos/wt/camp/some-branch",
+			wantProject: "camp",
+		},
+		{
+			name:        "default layout no longer matches once reconfigured",
+			repoPath:    root + "/projects/camp",
+			wantProject: "camp",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scopeProject, project := resolveScope(root, tc.repoPath, paths)
+			if !scopeProject {
+				t.Error("scopeProject = false, want true")
+			}
+			if project != tc.wantProject {
+				t.Errorf("project = %q, want %q", project, tc.wantProject)
+			}
+		})
+	}
+}
+
+// An unset container path must not match everything, which would key every
+// repository to the wrong project name.
+func TestResolveScopeEmptyConfiguredPaths(t *testing.T) {
+	const root = "/home/u/campaign"
+
+	scopeProject, project := resolveScope(root, root+"/projects/camp", config.CampaignPaths{})
+	if !scopeProject {
+		t.Error("scopeProject = false, want true")
+	}
+	if project != "camp" {
+		t.Errorf("project = %q, want the trailing segment %q", project, "camp")
+	}
+}
+
+func strPtr(s string) *string { return &s }
+func intPtr(i int) *int       { return &i }

--- a/internal/stageguard/deps_test.go
+++ b/internal/stageguard/deps_test.go
@@ -1,0 +1,60 @@
+package stageguard
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// gitPackage is the import path this package must never reach. internal/git
+// imports stageguard, so an edge back would be an import cycle; the compiler
+// would catch it, but only after the wiring in internal/git lands. This test
+// catches it at the moment it is introduced instead.
+const gitPackage = "github.com/Obedience-Corp/camp/internal/git"
+
+func TestStageguardDoesNotDependOnInternalGit(t *testing.T) {
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go toolchain not on PATH")
+	}
+
+	out, err := exec.Command(goBin, "list", "-deps", ".").Output()
+	if err != nil {
+		t.Fatalf("go list -deps . error = %v", err)
+	}
+
+	for dep := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		if strings.TrimSpace(dep) == gitPackage {
+			t.Fatalf("internal/stageguard depends on %s; it is a leaf package and must not, "+
+				"or the import cycle with internal/git returns", gitPackage)
+		}
+	}
+}
+
+// The leaf position also bounds which camp packages stageguard may import
+// directly, so the dependency does not creep back in through a new edge.
+func TestStageguardDirectCampImports(t *testing.T) {
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go toolchain not on PATH")
+	}
+
+	out, err := exec.Command(goBin, "list", "-f", `{{join .Imports "\n"}}`, ".").Output()
+	if err != nil {
+		t.Fatalf("go list -f imports . error = %v", err)
+	}
+
+	allowed := map[string]bool{
+		"github.com/Obedience-Corp/camp/internal/config": true,
+		"github.com/Obedience-Corp/camp/internal/errors": true,
+	}
+	for raw := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		imp := strings.TrimSpace(raw)
+		if !strings.HasPrefix(imp, "github.com/Obedience-Corp/camp/") {
+			continue
+		}
+		if !allowed[imp] {
+			t.Errorf("unexpected camp import %q; stageguard may import only internal/config and internal/errors", imp)
+		}
+	}
+}

--- a/internal/stageguard/enumerate.go
+++ b/internal/stageguard/enumerate.go
@@ -149,6 +149,13 @@ func classifyEntry(entry statusEntry) (untracked, ok bool) {
 		// Ignored; only reachable with --ignored, which this package never passes.
 		return false, false
 	default:
+		// Everything else is in the index, including a file the user staged by
+		// hand that has never been committed ("A "). Such a file has no history
+		// to bifurcate, so the design's tracked-file rationale does not reach
+		// it, but the outcome is the same for a mechanical reason: the guard
+		// excludes by staging everything *except* a path, which cannot un-add
+		// something already in the index. Camp reports it and commits it rather
+		// than silently reversing an explicit git add.
 		return false, true
 	}
 }

--- a/internal/stageguard/enumerate.go
+++ b/internal/stageguard/enumerate.go
@@ -1,0 +1,170 @@
+package stageguard
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// Candidate is one path a stage-everything operation would touch, with the
+// size lstat reports for it. Directories never appear: -uall expands untracked
+// directories into their individual files.
+type Candidate struct {
+	// Path is repo-relative and slash-separated.
+	Path string
+	// Size is the worktree size in bytes. Symlinks report their own size; the
+	// target is never followed.
+	Size int64
+	// Untracked is true for paths git does not yet know about. Tracked paths
+	// are never excluded, so the distinction decides which guard applies.
+	Untracked bool
+}
+
+// Enumerate lists what a stage-everything operation in repoPath would add.
+// It runs its own git status rather than reusing internal/git/porcelain.go:
+// internal/git imports this package, so importing it back would restore the
+// cycle the leaf position exists to break. The duplication is a few lines and
+// is deliberate.
+//
+// Enumeration is stat-only. Nothing is hashed, opened, or read.
+func Enumerate(ctx context.Context, repoPath string) ([]Candidate, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	out, err := statusPorcelain(ctx, repoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := parseStatusPorcelainZ(out)
+	candidates := make([]Candidate, 0, len(entries))
+	for _, entry := range entries {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		candidate, ok := classify(repoPath, entry)
+		if !ok {
+			continue
+		}
+		candidates = append(candidates, candidate)
+	}
+	return candidates, nil
+}
+
+// statusPorcelain runs git status in repoPath. Ignored files are absent by
+// construction, which is why the commit path structurally cannot see content
+// the user gitignored long ago; the doctor bigfiles sweep covers that instead.
+func statusPorcelain(ctx context.Context, repoPath string) ([]byte, error) {
+	args := []string{"-C", repoPath, "status", "--porcelain=v1", "-z", "-uall"}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = gitEnv(os.Environ())
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "git status --porcelain=v1 -z -uall in %s: %s",
+			repoPath, strings.TrimSpace(stderr.String()))
+	}
+	return out, nil
+}
+
+// gitEnv forces the C locale so status codes and any error text stay parseable
+// regardless of the user's locale, matching internal/git's exec setup.
+func gitEnv(base []string) []string {
+	env := make([]string, 0, len(base)+2)
+	for _, item := range base {
+		if strings.HasPrefix(item, "LC_ALL=") || strings.HasPrefix(item, "LANG=") {
+			continue
+		}
+		env = append(env, item)
+	}
+	return append(env, "LC_ALL=C", "LANG=C")
+}
+
+// statusEntry is one record from porcelain v1 -z output.
+type statusEntry struct {
+	// Code is the two-character XY status code, leading space preserved.
+	Code string
+	Path string
+}
+
+// parseStatusPorcelainZ parses NUL-delimited porcelain v1 output. Paths are
+// never quoted or escaped in -z mode, so a path containing spaces, quotes, or
+// non-ASCII bytes arrives verbatim and needs no unquoting.
+func parseStatusPorcelainZ(out []byte) []statusEntry {
+	fields := bytes.Split(bytes.TrimRight(out, "\x00"), []byte{0})
+	entries := make([]statusEntry, 0, len(fields))
+	for i := 0; i < len(fields); i++ {
+		field := fields[i]
+		if len(field) < 4 {
+			continue
+		}
+		code := string(field[:2])
+		entries = append(entries, statusEntry{Code: code, Path: string(field[3:])})
+		if code[0] == 'R' || code[0] == 'C' {
+			// -z emits the source path as a separate trailing field. The
+			// destination is what would be staged, so the source is skipped.
+			i++
+		}
+	}
+	return entries
+}
+
+// classify turns a status entry into a candidate, or reports that it is not
+// one.
+func classify(repoPath string, entry statusEntry) (Candidate, bool) {
+	untracked, ok := classifyEntry(entry)
+	if !ok {
+		return Candidate{}, false
+	}
+	return statCandidate(repoPath, entry.Path, untracked)
+}
+
+// classifyEntry decides whether a status entry is something a stage-everything
+// operation would add, and whether it is untracked. Deletions have nothing to
+// size, and unmerged entries are a conflict state the guard has no business
+// acting on.
+func classifyEntry(entry statusEntry) (untracked, ok bool) {
+	if len(entry.Code) != 2 || entry.Path == "" {
+		return false, false
+	}
+	x, y := entry.Code[0], entry.Code[1]
+
+	switch {
+	case x == '?' && y == '?':
+		return true, true
+	case x == 'U' || y == 'U' || (x == 'A' && y == 'A') || (x == 'D' && y == 'D'):
+		// Unmerged: leave conflict resolution alone.
+		return false, false
+	case x == 'D' || y == 'D':
+		return false, false
+	case x == '!' || y == '!':
+		// Ignored; only reachable with --ignored, which this package never passes.
+		return false, false
+	default:
+		return false, true
+	}
+}
+
+// statCandidate lstats a repo-relative path. A path that vanished between the
+// status call and the stat is dropped rather than erroring: it cannot be
+// staged either, so it is not the guard's problem.
+func statCandidate(repoPath, rel string, untracked bool) (Candidate, bool) {
+	abs := filepath.Join(repoPath, filepath.FromSlash(rel))
+	info, err := os.Lstat(abs)
+	if err != nil || info.IsDir() {
+		return Candidate{}, false
+	}
+	return Candidate{
+		Path:      filepath.ToSlash(rel),
+		Size:      info.Size(),
+		Untracked: untracked,
+	}, true
+}

--- a/internal/stageguard/enumerate_test.go
+++ b/internal/stageguard/enumerate_test.go
@@ -1,0 +1,226 @@
+package stageguard
+
+import (
+	"strings"
+	"testing"
+)
+
+// nulJoin builds porcelain -z output: every record is NUL-terminated.
+func nulJoin(records ...string) []byte {
+	return []byte(strings.Join(records, "\x00") + "\x00")
+}
+
+func TestParseStatusPorcelainZMalformed(t *testing.T) {
+	cases := []struct {
+		name string
+		out  []byte
+	}{
+		{name: "empty output", out: nil},
+		{name: "only NULs", out: []byte("\x00\x00\x00")},
+		{name: "record shorter than a status code", out: nulJoin("?")},
+		{name: "record with a code but no path", out: nulJoin("?? ")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseStatusPorcelainZ(tc.out); len(got) != 0 {
+				t.Errorf("parseStatusPorcelainZ() = %v, want no entries", got)
+			}
+		})
+	}
+}
+
+func TestParseStatusPorcelainZ(t *testing.T) {
+	cases := []struct {
+		name      string
+		out       []byte
+		wantCodes []string
+		wantPaths []string
+	}{
+		{
+			name:      "untracked file",
+			out:       nulJoin("?? videos/footage.mp4"),
+			wantCodes: []string{"??"},
+			wantPaths: []string{"videos/footage.mp4"},
+		},
+		{
+			name:      "worktree modification keeps its leading space",
+			out:       nulJoin(" M internal/git/commit.go"),
+			wantCodes: []string{" M"},
+			wantPaths: []string{"internal/git/commit.go"},
+		},
+		{
+			name:      "staged modification",
+			out:       nulJoin("M  internal/git/commit.go"),
+			wantCodes: []string{"M "},
+			wantPaths: []string{"internal/git/commit.go"},
+		},
+		{
+			name: "rename consumes the trailing source path",
+			// -z emits the destination first, then the source as its own record.
+			out:       nulJoin("R  new/name.go", "old/name.go", "?? after.txt"),
+			wantCodes: []string{"R ", "??"},
+			wantPaths: []string{"new/name.go", "after.txt"},
+		},
+		{
+			name:      "copy also consumes its source path",
+			out:       nulJoin("C  copy.go", "origin.go", "?? after.txt"),
+			wantCodes: []string{"C ", "??"},
+			wantPaths: []string{"copy.go", "after.txt"},
+		},
+		{
+			name:      "mixed records",
+			out:       nulJoin("?? a.txt", " M b.txt", "D  c.txt"),
+			wantCodes: []string{"??", " M", "D "},
+			wantPaths: []string{"a.txt", "b.txt", "c.txt"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entries := parseStatusPorcelainZ(tc.out)
+			if len(entries) != len(tc.wantCodes) {
+				t.Fatalf("parseStatusPorcelainZ() = %v, want %d entries", entries, len(tc.wantCodes))
+			}
+			for i := range entries {
+				if entries[i].Code != tc.wantCodes[i] {
+					t.Errorf("entries[%d].Code = %q, want %q", i, entries[i].Code, tc.wantCodes[i])
+				}
+				if entries[i].Path != tc.wantPaths[i] {
+					t.Errorf("entries[%d].Path = %q, want %q", i, entries[i].Path, tc.wantPaths[i])
+				}
+			}
+		})
+	}
+}
+
+// In -z mode git never quotes or escapes a path, which is the reason this
+// package asks for it. A path that git would render as "\"odd name\"" in the
+// default format arrives here verbatim and must not be unquoted or trimmed.
+func TestParseStatusPorcelainZDoesNotUnquotePaths(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{name: "spaces", path: "my videos/final cut.mp4"},
+		{name: "double quotes", path: `weird/"quoted".txt`},
+		{name: "backslash", path: `weird/back\slash.txt`},
+		{name: "non-ascii", path: "notes/café.md"},
+		{name: "leading dash", path: "-dashfile.txt"},
+		{name: "newline in name", path: "weird/two\nlines.txt"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entries := parseStatusPorcelainZ(nulJoin("?? " + tc.path))
+			if len(entries) != 1 {
+				t.Fatalf("parseStatusPorcelainZ() = %v, want 1 entry", entries)
+			}
+			if entries[0].Path != tc.path {
+				t.Errorf("Path = %q, want %q verbatim", entries[0].Path, tc.path)
+			}
+		})
+	}
+}
+
+func TestClassifyEntry(t *testing.T) {
+	cases := []struct {
+		name          string
+		code          string
+		path          string
+		wantOK        bool
+		wantUntracked bool
+	}{
+		{name: "empty path is not a candidate", code: "??", path: "", wantOK: false},
+		{name: "short code is not a candidate", code: "?", path: "a.txt", wantOK: false},
+		{name: "deleted from worktree", code: " D", path: "a.txt", wantOK: false},
+		{name: "deleted from index", code: "D ", path: "a.txt", wantOK: false},
+		{name: "unmerged both modified", code: "UU", path: "a.txt", wantOK: false},
+		{name: "unmerged both added", code: "AA", path: "a.txt", wantOK: false},
+		{name: "unmerged both deleted", code: "DD", path: "a.txt", wantOK: false},
+		{name: "unmerged added by us", code: "AU", path: "a.txt", wantOK: false},
+		{name: "ignored", code: "!!", path: "a.txt", wantOK: false},
+		{name: "untracked", code: "??", path: "a.txt", wantOK: true, wantUntracked: true},
+		{name: "worktree modification is tracked", code: " M", path: "a.txt", wantOK: true, wantUntracked: false},
+		{name: "staged modification is tracked", code: "M ", path: "a.txt", wantOK: true, wantUntracked: false},
+		{name: "staged and worktree modification is tracked", code: "MM", path: "a.txt", wantOK: true, wantUntracked: false},
+		{name: "added to index is tracked", code: "A ", path: "a.txt", wantOK: true, wantUntracked: false},
+		{name: "rename is tracked", code: "R ", path: "a.txt", wantOK: true, wantUntracked: false},
+		{name: "type change is tracked", code: " T", path: "a.txt", wantOK: true, wantUntracked: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			untracked, ok := classifyEntry(statusEntry{Code: tc.code, Path: tc.path})
+			if ok != tc.wantOK {
+				t.Fatalf("classifyEntry(%q) ok = %v, want %v", tc.code, ok, tc.wantOK)
+			}
+			if ok && untracked != tc.wantUntracked {
+				t.Errorf("classifyEntry(%q) untracked = %v, want %v", tc.code, untracked, tc.wantUntracked)
+			}
+		})
+	}
+}
+
+func TestParseCheckAttrZ(t *testing.T) {
+	cases := []struct {
+		name string
+		out  []byte
+		want map[string]bool
+	}{
+		{name: "empty output", out: nil, want: map[string]bool{}},
+		{name: "truncated triple is ignored", out: nulJoin("a.psd", "filter"), want: map[string]bool{}},
+		{
+			name: "unspecified filter is not lfs",
+			out:  nulJoin("notes.md", "filter", "unspecified"),
+			want: map[string]bool{},
+		},
+		{
+			name: "lfs managed path",
+			out:  nulJoin("assets/a.psd", "filter", "lfs"),
+			want: map[string]bool{"assets/a.psd": true},
+		},
+		{
+			name: "mixed triples",
+			out:  nulJoin("a.psd", "filter", "lfs", "b.md", "filter", "unspecified", "c.bin", "filter", "lfs"),
+			want: map[string]bool{"a.psd": true, "c.bin": true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseCheckAttrZ(tc.out)
+			if len(got) != len(tc.want) {
+				t.Fatalf("parseCheckAttrZ() = %v, want %v", got, tc.want)
+			}
+			for path := range tc.want {
+				if !got[path] {
+					t.Errorf("parseCheckAttrZ() missing %q", path)
+				}
+			}
+		})
+	}
+}
+
+func TestGitEnvForcesCLocale(t *testing.T) {
+	env := gitEnv([]string{"PATH=/usr/bin", "LC_ALL=fr_FR.UTF-8", "LANG=fr_FR.UTF-8", "HOME=/home/u"})
+
+	var sawLCAll, sawLang int
+	for _, item := range env {
+		switch item {
+		case "LC_ALL=C":
+			sawLCAll++
+		case "LANG=C":
+			sawLang++
+		}
+		if strings.HasPrefix(item, "LC_ALL=") && item != "LC_ALL=C" {
+			t.Errorf("gitEnv() kept a non-C locale: %q", item)
+		}
+		if strings.HasPrefix(item, "LANG=") && item != "LANG=C" {
+			t.Errorf("gitEnv() kept a non-C language: %q", item)
+		}
+	}
+	if sawLCAll != 1 || sawLang != 1 {
+		t.Errorf("gitEnv() set LC_ALL %d times and LANG %d times, want 1 each", sawLCAll, sawLang)
+	}
+}

--- a/internal/stageguard/lfs.go
+++ b/internal/stageguard/lfs.go
@@ -1,0 +1,85 @@
+package stageguard
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// lfsFilter is the check-attr value marking a path as git-LFS managed.
+const lfsFilter = "lfs"
+
+// FilterLFSManaged removes paths a `filter=lfs` attribute already covers.
+// The exemption applies in every mode and needs no configuration: a user on
+// git LFS has already solved this problem, and camp interfering would make
+// their setup worse rather than safer.
+//
+// It runs before any violation is recorded, so an LFS-managed path is never
+// reported, never excluded, and never counted toward the bulk trigger.
+func FilterLFSManaged(ctx context.Context, repoPath string, candidates []Candidate) ([]Candidate, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	if len(candidates) == 0 {
+		return candidates, nil
+	}
+
+	managed, err := lfsManagedPaths(ctx, repoPath, candidates)
+	if err != nil {
+		return nil, err
+	}
+	if len(managed) == 0 {
+		return candidates, nil
+	}
+
+	kept := make([]Candidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if managed[candidate.Path] {
+			continue
+		}
+		kept = append(kept, candidate)
+	}
+	return kept, nil
+}
+
+// lfsManagedPaths asks git which candidates carry filter=lfs. Paths go in over
+// stdin so the batch is not bounded by the platform argument limit, which a
+// bulk directory would otherwise blow past.
+func lfsManagedPaths(ctx context.Context, repoPath string, candidates []Candidate) (map[string]bool, error) {
+	var stdin bytes.Buffer
+	for _, candidate := range candidates {
+		stdin.WriteString(candidate.Path)
+		stdin.WriteByte(0)
+	}
+
+	args := []string{"-C", repoPath, "check-attr", "-z", "--stdin", "filter"}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = gitEnv(os.Environ())
+	cmd.Stdin = &stdin
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "git check-attr filter in %s: %s",
+			repoPath, strings.TrimSpace(stderr.String()))
+	}
+	return parseCheckAttrZ(out), nil
+}
+
+// parseCheckAttrZ reads check-attr -z output, which is a flat stream of
+// (path, attribute, value) NUL-terminated triples.
+func parseCheckAttrZ(out []byte) map[string]bool {
+	fields := bytes.Split(bytes.TrimRight(out, "\x00"), []byte{0})
+	managed := make(map[string]bool)
+	for i := 0; i+2 < len(fields); i += 3 {
+		if string(fields[2+i]) == lfsFilter {
+			managed[string(fields[i])] = true
+		}
+	}
+	return managed
+}

--- a/internal/stageguard/stageguard.go
+++ b/internal/stageguard/stageguard.go
@@ -1,0 +1,125 @@
+// Package stageguard decides what camp's stage-everything operations may
+// stage. It is a leaf package: internal/git and pkg/commitkit both import
+// it, so it must import neither.
+//
+// The guard answers one question -- "what would a stage-everything operation
+// add here, and is any of it a mistake" -- and returns the answer as typed
+// data. Rendering that data (error copy, remedy menus, --json shapes) belongs
+// to the CLI layer, and fest renders the same values its own way.
+package stageguard
+
+import "context"
+
+// Mode selects how a guard responds when it finds something.
+type Mode string
+
+const (
+	// ModeAuto declares an artifact root, excludes the file, and reports.
+	// Valid for the large-file guard only.
+	ModeAuto Mode = "auto"
+	// ModeBlock refuses the operation and stages nothing.
+	ModeBlock Mode = "block"
+	// ModeOff disables detection entirely.
+	ModeOff Mode = "off"
+)
+
+// Valid reports whether m is a mode this package recognizes.
+func (m Mode) Valid() bool {
+	switch m {
+	case ModeAuto, ModeBlock, ModeOff:
+		return true
+	}
+	return false
+}
+
+// GuardLimits is the resolved policy for one repository. ResolveLimits builds
+// it from campaign and project config; callers that want to ask "what would
+// happen under these limits" can construct one directly.
+type GuardLimits struct {
+	// MaxFileSize is the per-file threshold in bytes. The campaign root and a
+	// project submodule carry different defaults.
+	MaxFileSize int64
+	// MaxAddedFiles is the bulk trigger: untracked files under a dominant
+	// prefix. There is deliberately no total-bytes leg.
+	MaxAddedFiles int
+	// Allow lists globs exempting paths from every guard, permanently.
+	Allow []string
+	// LargeFiles is the commit.guards.large_files mode.
+	LargeFiles Mode
+	// Bulk is the commit.guards.bulk mode: block or off, never auto.
+	Bulk Mode
+	// ScopeProject is true when the repository is a project rather than the
+	// campaign root. It selects which remedy the CLI offers, since camp never
+	// auto-declares an artifact root inside a project.
+	ScopeProject bool
+}
+
+// ViolationKind distinguishes the guard that produced a violation, because
+// each carries a different remedy.
+type ViolationKind string
+
+const (
+	// OverThreshold is an untracked file above MaxFileSize. At the campaign
+	// root it is an auto-declare candidate; inside a project it is
+	// exclude-and-ask.
+	OverThreshold ViolationKind = "over_threshold"
+	// Bulk is many untracked files under one prefix. It always blocks unless
+	// the bulk mode is off, because camp cannot infer whether the tree wants
+	// gitignore or an artifact root.
+	Bulk ViolationKind = "bulk"
+	// TrackedGrowth is a tracked file whose new content exceeds MaxFileSize.
+	// It is reported every time and excluded never: splitting one file's
+	// history between git and an artifact root is never correct.
+	TrackedGrowth ViolationKind = "tracked_growth"
+)
+
+// GuardViolation is one finding. Prefix, Count, and TotalBytes are set for
+// Bulk only; Path and Size are set for the per-file kinds.
+type GuardViolation struct {
+	Kind ViolationKind
+	// Path is repo-relative and slash-separated.
+	Path string
+	// Size is the file size in bytes, from lstat (symlinks are never followed).
+	Size int64
+	// CommonPrefix is the dominant directory a Bulk violation was found under.
+	CommonPrefix string
+	// Count is how many untracked files a Bulk violation covers.
+	Count int
+	// TotalBytes is the size of a Bulk violation's files. It is reported for
+	// display and is never itself a trigger.
+	TotalBytes int64
+}
+
+// ReportOnly reports whether a violation must never cause exclusion. Tracked
+// growth is always committed; the user is told about it instead.
+func (v GuardViolation) ReportOnly() bool {
+	return v.Kind == TrackedGrowth
+}
+
+// Blocks reports whether a violation stops the operation outright under
+// limits, as opposed to being handled by exclusion or a report.
+func (v GuardViolation) Blocks(limits GuardLimits) bool {
+	switch v.Kind {
+	case Bulk:
+		return limits.Bulk == ModeBlock
+	case OverThreshold:
+		return limits.LargeFiles == ModeBlock
+	default:
+		return false
+	}
+}
+
+// Check resolves limits for repoPath and evaluates the guards against it. It
+// is the entry point for the chokepoint in internal/git.Stage, which has no
+// config knowledge of its own.
+func Check(ctx context.Context, repoPath string) ([]GuardViolation, GuardLimits, error) {
+	limits, err := ResolveLimits(ctx, repoPath)
+	if err != nil {
+		return nil, GuardLimits{}, err
+	}
+	violations, err := CheckStaging(ctx, repoPath, limits)
+	if err != nil {
+		return nil, limits, err
+	}
+	return violations, limits, nil
+}

--- a/internal/stageguard/stageguard_test.go
+++ b/internal/stageguard/stageguard_test.go
@@ -1,0 +1,445 @@
+package stageguard
+
+import (
+	"fmt"
+	"testing"
+)
+
+// testLimits is the shipped campaign-root policy, used unless a case overrides
+// a field.
+func testLimits() GuardLimits {
+	return GuardLimits{
+		MaxFileSize:   DefaultMaxFileSize,
+		MaxAddedFiles: DefaultMaxAddedFiles,
+		LargeFiles:    ModeAuto,
+		Bulk:          ModeBlock,
+	}
+}
+
+func TestCheckPerFileThresholdEdges(t *testing.T) {
+	cases := []struct {
+		name      string
+		size      int64
+		untracked bool
+		wantKinds []ViolationKind
+	}{
+		{
+			name:      "one byte under the threshold is clean",
+			size:      DefaultMaxFileSize - 1,
+			untracked: true,
+			wantKinds: nil,
+		},
+		{
+			name:      "exactly at the threshold is clean",
+			size:      DefaultMaxFileSize,
+			untracked: true,
+			wantKinds: nil,
+		},
+		{
+			name:      "one byte over the threshold is a violation",
+			size:      DefaultMaxFileSize + 1,
+			untracked: true,
+			wantKinds: []ViolationKind{OverThreshold},
+		},
+		{
+			name:      "tracked file at the threshold is clean",
+			size:      DefaultMaxFileSize,
+			untracked: false,
+			wantKinds: nil,
+		},
+		{
+			name:      "tracked file over the threshold reports growth",
+			size:      DefaultMaxFileSize + 1,
+			untracked: false,
+			wantKinds: []ViolationKind{TrackedGrowth},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			candidates := []Candidate{{Path: "asset.bin", Size: tc.size, Untracked: tc.untracked}}
+			violations, _ := checkPerFile(candidates, testLimits())
+			assertKinds(t, violations, tc.wantKinds)
+		})
+	}
+}
+
+// A tracked file that grew past the threshold is reported but stays in the
+// batch: excluding it would leave the stale blob in git while the new bytes on
+// disk belonged to nothing.
+func TestCheckPerFileTrackedGrowthIsNeverExcluded(t *testing.T) {
+	candidates := []Candidate{
+		{Path: "graphs/campaign-graph.png", Size: 13 << 20, Untracked: false},
+		{Path: "footage.mp4", Size: 512 << 20, Untracked: true},
+	}
+
+	violations, remaining := checkPerFile(candidates, testLimits())
+	assertKinds(t, violations, []ViolationKind{TrackedGrowth, OverThreshold})
+
+	if len(remaining) != 1 || remaining[0].Path != "graphs/campaign-graph.png" {
+		t.Fatalf("remaining = %v, want only the tracked file", remaining)
+	}
+}
+
+// Criterion 37: size decides, never extension.
+func TestCheckPerFileSizeDecidesNotExtension(t *testing.T) {
+	cases := []struct {
+		name          string
+		path          string
+		size          int64
+		wantViolation bool
+	}{
+		{name: "200 KB mp4 is ordinary content", path: "clips/teaser.mp4", size: 200 << 10, wantViolation: false},
+		{name: "200 KB mov is ordinary content", path: "clips/teaser.mov", size: 200 << 10, wantViolation: false},
+		{name: "large json is a violation", path: "data/dump.json", size: 512 << 20, wantViolation: true},
+		{name: "large markdown is a violation", path: "notes/huge.md", size: 64 << 20, wantViolation: true},
+		{name: "large mp4 is a violation", path: "clips/footage.mp4", size: 512 << 20, wantViolation: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			candidates := []Candidate{{Path: tc.path, Size: tc.size, Untracked: true}}
+			violations, _ := checkPerFile(candidates, testLimits())
+			if got := len(violations) > 0; got != tc.wantViolation {
+				t.Errorf("violation = %v, want %v (size %d)", got, tc.wantViolation, tc.size)
+			}
+		})
+	}
+}
+
+func TestCheckPerFileModeOffDisablesDetection(t *testing.T) {
+	limits := testLimits()
+	limits.LargeFiles = ModeOff
+
+	candidates := []Candidate{{Path: "footage.mp4", Size: 512 << 20, Untracked: true}}
+	violations, remaining := checkPerFile(candidates, limits)
+
+	if len(violations) != 0 {
+		t.Errorf("violations = %v, want none when large_files is off", violations)
+	}
+	if len(remaining) != 1 {
+		t.Errorf("remaining = %d candidates, want 1", len(remaining))
+	}
+}
+
+func TestDetectBulk(t *testing.T) {
+	cases := []struct {
+		name       string
+		candidates []Candidate
+		limits     func() GuardLimits
+		wantBulk   bool
+		wantPrefix string
+		wantCount  int
+	}{
+		{
+			name:       "999 files under one prefix is under the trigger",
+			candidates: bulkCandidates("node_modules", 999, 1<<10),
+			wantBulk:   false,
+		},
+		{
+			name:       "1000 files under one prefix trips the guard",
+			candidates: bulkCandidates("node_modules", 1000, 1<<10),
+			wantBulk:   true,
+			wantPrefix: "node_modules",
+			wantCount:  1000,
+		},
+		{
+			name: "split across prefixes does not trip",
+			candidates: append(
+				bulkCandidates("src", 600, 1<<10),
+				bulkCandidates("docs", 600, 1<<10)...,
+			),
+			wantBulk: false,
+		},
+		{
+			name: "one dominant prefix among stragglers still trips",
+			candidates: append(
+				bulkCandidates("node_modules", 1200, 1<<10),
+				bulkCandidates("src", 20, 1<<10)...,
+			),
+			wantBulk:   true,
+			wantPrefix: "node_modules",
+			wantCount:  1200,
+		},
+		{
+			name:       "tracked modifications never count toward bulk",
+			candidates: trackedCandidates("src", 2000, 1<<10),
+			wantBulk:   false,
+		},
+		{
+			name:       "bulk off disables the guard",
+			candidates: bulkCandidates("node_modules", 5000, 1<<10),
+			limits: func() GuardLimits {
+				l := testLimits()
+				l.Bulk = ModeOff
+				return l
+			},
+			wantBulk: false,
+		},
+		{
+			name:       "files at the repo root have no prefix to dominate",
+			candidates: rootCandidates(1500, 1<<10),
+			wantBulk:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			limits := testLimits()
+			if tc.limits != nil {
+				limits = tc.limits()
+			}
+			violation, found := detectBulk(tc.candidates, limits)
+			if found != tc.wantBulk {
+				t.Fatalf("detectBulk() found = %v, want %v", found, tc.wantBulk)
+			}
+			if !found {
+				return
+			}
+			if violation.CommonPrefix != tc.wantPrefix {
+				t.Errorf("CommonPrefix = %q, want %q", violation.CommonPrefix, tc.wantPrefix)
+			}
+			if violation.Count != tc.wantCount {
+				t.Errorf("Count = %d, want %d", violation.Count, tc.wantCount)
+			}
+			if violation.TotalBytes != int64(tc.wantCount)*(1<<10) {
+				t.Errorf("TotalBytes = %d, want %d", violation.TotalBytes, int64(tc.wantCount)*(1<<10))
+			}
+		})
+	}
+}
+
+// The per-file guard runs first and the bulk guard counts only what remains.
+// Otherwise one auto-handled 512 MB video would swell the batch back over the
+// trigger and turn the flagship scenario into a block.
+func TestPerFileGuardRunsBeforeBulk(t *testing.T) {
+	candidates := append(
+		[]Candidate{{Path: "videos/footage.mp4", Size: 512 << 20, Untracked: true}},
+		bulkCandidates("videos", 999, 1<<10)...,
+	)
+
+	violations, remaining := checkPerFile(candidates, testLimits())
+	assertKinds(t, violations, []ViolationKind{OverThreshold})
+
+	if _, found := detectBulk(remaining, testLimits()); found {
+		t.Error("detectBulk() tripped on 999 remaining files; the over-threshold file must not count")
+	}
+}
+
+func TestDetectBulkFindsDeepestDominantPrefix(t *testing.T) {
+	candidates := bulkCandidates("projects/webapp/node_modules", 2000, 1<<10)
+
+	violation, found := detectBulk(candidates, testLimits())
+	if !found {
+		t.Fatal("detectBulk() found = false, want true")
+	}
+	if violation.CommonPrefix != "projects/webapp/node_modules" {
+		t.Errorf("CommonPrefix = %q, want the deepest dominant directory", violation.CommonPrefix)
+	}
+}
+
+func TestMatchesAllow(t *testing.T) {
+	allow := []string{
+		"docs/handbook.pdf",
+		"testdata/**",
+		"*.psd",
+		"assets/*.bin",
+	}
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "exact path matches", path: "docs/handbook.pdf", want: true},
+		{name: "exact path does not match a sibling", path: "docs/other.pdf", want: false},
+		{name: "double star matches nested content", path: "testdata/corpus/a/b.tar", want: true},
+		{name: "double star matches the directory itself", path: "testdata", want: true},
+		{name: "double star does not match a prefix sibling", path: "testdata-extra/file.tar", want: false},
+		{name: "unanchored extension glob matches at the root", path: "cover.psd", want: true},
+		{name: "unanchored extension glob matches at depth", path: "art/layers/cover.psd", want: true},
+		{name: "extension glob does not match another extension", path: "art/cover.png", want: false},
+		{name: "anchored glob matches its own directory", path: "assets/blob.bin", want: true},
+		{name: "anchored glob does not match deeper", path: "assets/nested/blob.bin", want: false},
+		{name: "unrelated path", path: "src/main.go", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MatchesAllow(tc.path, allow); got != tc.want {
+				t.Errorf("MatchesAllow(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchesAllowEmptyAndBlankPatterns(t *testing.T) {
+	if MatchesAllow("any/path.bin", nil) {
+		t.Error("MatchesAllow() with no patterns = true, want false")
+	}
+	if MatchesAllow("any/path.bin", []string{"", "   "}) {
+		t.Error("MatchesAllow() with blank patterns = true, want false")
+	}
+}
+
+// An allowlisted file is exempt from every guard, so it is neither reported nor
+// counted toward the bulk trigger.
+func TestFilterAllowedRemovesBeforeAnyGuard(t *testing.T) {
+	candidates := []Candidate{
+		{Path: "releases/camp-darwin-arm64", Size: 60 << 20, Untracked: true},
+		{Path: "notes.md", Size: 4 << 10, Untracked: true},
+	}
+
+	kept := filterAllowed(candidates, []string{"releases/**"})
+	if len(kept) != 1 || kept[0].Path != "notes.md" {
+		t.Fatalf("filterAllowed() = %v, want only notes.md", kept)
+	}
+
+	violations, _ := checkPerFile(kept, testLimits())
+	if len(violations) != 0 {
+		t.Errorf("violations = %v, want none for an allowlisted large file", violations)
+	}
+}
+
+func TestGuardViolationReportOnly(t *testing.T) {
+	cases := []struct {
+		kind ViolationKind
+		want bool
+	}{
+		{kind: TrackedGrowth, want: true},
+		{kind: OverThreshold, want: false},
+		{kind: Bulk, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			if got := (GuardViolation{Kind: tc.kind}).ReportOnly(); got != tc.want {
+				t.Errorf("ReportOnly() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGuardViolationBlocks(t *testing.T) {
+	cases := []struct {
+		name   string
+		kind   ViolationKind
+		limits GuardLimits
+		want   bool
+	}{
+		{
+			name:   "bulk blocks in block mode",
+			kind:   Bulk,
+			limits: GuardLimits{Bulk: ModeBlock},
+			want:   true,
+		},
+		{
+			name:   "over threshold does not block in auto mode",
+			kind:   OverThreshold,
+			limits: GuardLimits{LargeFiles: ModeAuto},
+			want:   false,
+		},
+		{
+			name:   "over threshold blocks in block mode",
+			kind:   OverThreshold,
+			limits: GuardLimits{LargeFiles: ModeBlock},
+			want:   true,
+		},
+		{
+			name:   "tracked growth never blocks",
+			kind:   TrackedGrowth,
+			limits: GuardLimits{LargeFiles: ModeBlock},
+			want:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := (GuardViolation{Kind: tc.kind}).Blocks(tc.limits); got != tc.want {
+				t.Errorf("Blocks() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestModeValid(t *testing.T) {
+	cases := []struct {
+		mode Mode
+		want bool
+	}{
+		{mode: ModeAuto, want: true},
+		{mode: ModeBlock, want: true},
+		{mode: ModeOff, want: true},
+		{mode: Mode(""), want: false},
+		{mode: Mode("warn"), want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.mode), func(t *testing.T) {
+			if got := tc.mode.Valid(); got != tc.want {
+				t.Errorf("Mode(%q).Valid() = %v, want %v", tc.mode, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSortViolations(t *testing.T) {
+	violations := []GuardViolation{
+		{Kind: OverThreshold, Path: "small.bin", Size: 20 << 20},
+		{Kind: Bulk, CommonPrefix: "node_modules", Count: 8000},
+		{Kind: OverThreshold, Path: "big.bin", Size: 512 << 20},
+	}
+
+	SortViolations(violations)
+
+	if violations[0].Kind != Bulk {
+		t.Errorf("first = %v, want the blocking bulk violation", violations[0].Kind)
+	}
+	if violations[1].Path != "big.bin" {
+		t.Errorf("second = %q, want the largest per-file violation", violations[1].Path)
+	}
+}
+
+func assertKinds(t *testing.T, violations []GuardViolation, want []ViolationKind) {
+	t.Helper()
+	if len(violations) != len(want) {
+		t.Fatalf("violations = %v, want %d of kinds %v", violations, len(want), want)
+	}
+	for i, kind := range want {
+		if violations[i].Kind != kind {
+			t.Errorf("violations[%d].Kind = %q, want %q", i, violations[i].Kind, kind)
+		}
+	}
+}
+
+func bulkCandidates(prefix string, n int, size int64) []Candidate {
+	candidates := make([]Candidate, 0, n)
+	for i := range n {
+		candidates = append(candidates, Candidate{
+			Path:      fmt.Sprintf("%s/file%04d.js", prefix, i),
+			Size:      size,
+			Untracked: true,
+		})
+	}
+	return candidates
+}
+
+func trackedCandidates(prefix string, n int, size int64) []Candidate {
+	candidates := bulkCandidates(prefix, n, size)
+	for i := range candidates {
+		candidates[i].Untracked = false
+	}
+	return candidates
+}
+
+func rootCandidates(n int, size int64) []Candidate {
+	candidates := make([]Candidate, 0, n)
+	for i := range n {
+		candidates = append(candidates, Candidate{
+			Path:      fmt.Sprintf("file%04d.js", i),
+			Size:      size,
+			Untracked: true,
+		})
+	}
+	return candidates
+}

--- a/internal/stageguard/stageguard_test.go
+++ b/internal/stageguard/stageguard_test.go
@@ -443,3 +443,32 @@ func rootCandidates(n int, size int64) []Candidate {
 	}
 	return candidates
 }
+
+func TestValidateAllow(t *testing.T) {
+	cases := []struct {
+		name    string
+		allow   []string
+		wantErr bool
+	}{
+		{name: "unclosed character class", allow: []string{"docs/[a-.pdf"}, wantErr: true},
+		{name: "bad pattern among good ones", allow: []string{"*.psd", "[", "docs/**"}, wantErr: true},
+		{name: "nil allowlist", allow: nil, wantErr: false},
+		{name: "blank entries are skipped", allow: []string{"", "   "}, wantErr: false},
+		{name: "exact path", allow: []string{"docs/handbook.pdf"}, wantErr: false},
+		{name: "double star suffix", allow: []string{"testdata/**"}, wantErr: false},
+		{name: "extension glob", allow: []string{"*.psd"}, wantErr: false},
+		{name: "character class", allow: []string{"assets/[abc]*.bin"}, wantErr: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAllow(tc.allow)
+			if tc.wantErr && err == nil {
+				t.Fatal("ValidateAllow() = nil, want error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("ValidateAllow() error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/stageguard/stageguard_test.go
+++ b/internal/stageguard/stageguard_test.go
@@ -238,6 +238,57 @@ func TestDetectBulkFindsDeepestDominantPrefix(t *testing.T) {
 	}
 }
 
+// A vendor dump must block even when unrelated untracked files are sitting
+// alongside it.
+//
+// The share-of-batch rule this replaced could be diluted out of existence:
+// 1000 files under one prefix plus ~120 stragglers is 89% of the batch, so a
+// 90% threshold cancelled exactly the case the bulk guard exists for. Whether a
+// directory is being dumped into git does not depend on what else the user
+// happened to leave lying around.
+func TestDetectBulkIsNotDilutedByUnrelatedFiles(t *testing.T) {
+	candidates := bulkCandidates("vendor", 1000, 1<<10)
+	for i := range 120 {
+		candidates = append(candidates, Candidate{
+			Path: fmt.Sprintf("notes/scratch-%d.md", i),
+			Size: 1 << 8,
+			// Untracked, or detectBulk filters them out before the share is
+			// computed and the dilution this test exists for never happens.
+			Untracked: true,
+		})
+	}
+
+	violation, found := detectBulk(candidates, testLimits())
+	if !found {
+		t.Fatalf("detectBulk() found = false; a 1000-file vendor dump must block "+
+			"even with %d unrelated files alongside it", 120)
+	}
+	if violation.CommonPrefix != "vendor" {
+		t.Errorf("CommonPrefix = %q, want the directory actually being dumped", violation.CommonPrefix)
+	}
+}
+
+// The scattered batch is the ordinary case and must still pass. Making the
+// trigger absolute must not turn "a lot of files" into "blocked" when no single
+// directory is responsible.
+func TestDetectBulkIgnoresAScatteredBatch(t *testing.T) {
+	var candidates []Candidate
+	for dir := range 40 {
+		for f := range 30 {
+			candidates = append(candidates, Candidate{
+				Path:      fmt.Sprintf("area-%d/file-%d.md", dir, f),
+				Size:      1 << 8,
+				Untracked: true,
+			})
+		}
+	}
+
+	if _, found := detectBulk(candidates, testLimits()); found {
+		t.Errorf("detectBulk() blocked %d files spread across 40 directories; "+
+			"no single directory holds enough to be a dump", len(candidates))
+	}
+}
+
 func TestMatchesAllow(t *testing.T) {
 	allow := []string{
 		"docs/handbook.pdf",

--- a/internal/ui/number.go
+++ b/internal/ui/number.go
@@ -1,0 +1,61 @@
+package ui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// byteTiers are ordered largest first so the first match is the right unit.
+// Binary divisors with decimal labels match what the rest of camp's output
+// already does; the distinction never changes a user's decision at these
+// magnitudes, and switching labels mid-tool would be worse than the imprecision.
+var byteTiers = []struct {
+	limit int64
+	unit  string
+}{
+	{limit: 1 << 40, unit: "TB"},
+	{limit: 1 << 30, unit: "GB"},
+	{limit: 1 << 20, unit: "MB"},
+	{limit: 1 << 10, unit: "KB"},
+}
+
+// FormatBytes renders a byte count for humans, e.g. "5.5 GB" or "900 B".
+//
+// Tiers run to TB because artifact roots are routinely gigabytes; a formatter
+// that stops at MB reports a 5 GB video directory as "5632.0 MB", which is
+// the kind of number a reader has to decode rather than read.
+func FormatBytes(b int64) string {
+	if b < 0 {
+		return "0 B"
+	}
+	for _, tier := range byteTiers {
+		if b >= tier.limit {
+			return fmt.Sprintf("%.1f %s", float64(b)/float64(tier.limit), tier.unit)
+		}
+	}
+	return fmt.Sprintf("%d B", b)
+}
+
+// FormatCount renders an integer with thousands separators, e.g. "1,204".
+//
+// File counts are the number a user scans to decide whether a directory is
+// what they think it is, and "1204" versus "8432" is much harder to compare at
+// a glance than "1,204" versus "8,432".
+func FormatCount(n int) string {
+	s := strconv.Itoa(n)
+	negative := strings.HasPrefix(s, "-")
+	s = strings.TrimPrefix(s, "-")
+
+	var out strings.Builder
+	for i, digit := range s {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			out.WriteByte(',')
+		}
+		out.WriteRune(digit)
+	}
+	if negative {
+		return "-" + out.String()
+	}
+	return out.String()
+}

--- a/internal/ui/number_test.go
+++ b/internal/ui/number_test.go
@@ -1,0 +1,57 @@
+package ui_test
+
+import (
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/ui"
+)
+
+func TestFormatBytes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int64
+		want string
+	}{
+		{name: "negative clamps to zero", in: -1, want: "0 B"},
+		{name: "zero", in: 0, want: "0 B"},
+		{name: "bytes below a kibibyte", in: 900, want: "900 B"},
+		{name: "one byte under KB tier", in: 1023, want: "1023 B"},
+		{name: "exactly one kibibyte", in: 1 << 10, want: "1.0 KB"},
+		{name: "exactly one mebibyte", in: 1 << 20, want: "1.0 MB"},
+		{name: "exactly one gibibyte", in: 1 << 30, want: "1.0 GB"},
+		{name: "gigabytes do not render as thousands of MB", in: 5905580032, want: "5.5 GB"},
+		{name: "terabyte tier", in: 1 << 40, want: "1.0 TB"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ui.FormatBytes(tc.in); got != tc.want {
+				t.Errorf("FormatBytes(%d) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatCount(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want string
+	}{
+		{name: "zero", in: 0, want: "0"},
+		{name: "single digit", in: 9, want: "9"},
+		{name: "three digits get no separator", in: 999, want: "999"},
+		{name: "four digits", in: 1000, want: "1,000"},
+		{name: "the node_modules case", in: 8432, want: "8,432"},
+		{name: "seven digits", in: 1234567, want: "1,234,567"},
+		{name: "negative", in: -8432, want: "-8,432"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ui.FormatCount(tc.in); got != tc.want {
+				t.Errorf("FormatCount(%d) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/commitkit/commitkit.go
+++ b/pkg/commitkit/commitkit.go
@@ -161,6 +161,11 @@ func LoadCampaignName(ctx context.Context, campaignRoot string) (string, error) 
 
 // StageAll stages all changes in the repository at repoPath.
 // Uses automatic lock retry with stale lock cleanup.
+//
+// It takes no limits by design. The staging guard runs inside the staging
+// chokepoint and resolves its own thresholds from repoPath, so a caller
+// inherits large-file and bulk protection here without passing anything and
+// without a code change. Use CheckStaging only to preflight.
 func StageAll(ctx context.Context, repoPath string) error {
 	if ctx.Err() != nil {
 		return ctx.Err()

--- a/pkg/commitkit/commitkit.go
+++ b/pkg/commitkit/commitkit.go
@@ -166,20 +166,51 @@ func LoadCampaignName(ctx context.Context, campaignRoot string) (string, error) 
 // chokepoint and resolves its own thresholds from repoPath, so a caller
 // inherits large-file and bulk protection here without passing anything and
 // without a code change. Use CheckStaging only to preflight.
+//
+// It discards what the guard did. When the guard excludes an over-threshold
+// file the stage still succeeds, so a consumer using this form commits without
+// the file and has nothing to tell the user about it. Use StageAllWithOutcome
+// when the consumer renders its own output; a refusal still surfaces here as a
+// *GuardBlockedError.
 func StageAll(ctx context.Context, repoPath string) error {
+	_, err := StageAllWithOutcome(ctx, repoPath)
+	return err
+}
+
+// StageAllWithOutcome is StageAll, returning what the guard decided.
+//
+// The outcome is nil when the guard found nothing worth reporting, which is the
+// ordinary case. A non-nil outcome means the consumer has something to say:
+// files excluded, tracked files flagged, or the guard unable to run at all.
+func StageAllWithOutcome(ctx context.Context, repoPath string) (*StageOutcome, error) {
 	if ctx.Err() != nil {
-		return ctx.Err()
+		return nil, ctx.Err()
 	}
-	return git.StageAll(ctx, repoPath)
+	return git.StageWithGuard(ctx, repoPath, nil)
 }
 
 // StageFiles stages specific files in the repository at repoPath.
 // Uses automatic lock retry with stale lock cleanup.
+//
+// Like StageAll, this discards the guard's outcome; use StageFilesWithOutcome
+// when the consumer renders its own output.
 func StageFiles(ctx context.Context, repoPath string, files ...string) error {
+	_, err := StageFilesWithOutcome(ctx, repoPath, files...)
+	return err
+}
+
+// StageFilesWithOutcome is StageFiles, returning what the guard decided.
+func StageFilesWithOutcome(ctx context.Context, repoPath string, files ...string) (*StageOutcome, error) {
 	if ctx.Err() != nil {
-		return ctx.Err()
+		return nil, ctx.Err()
 	}
-	return git.StageFiles(ctx, repoPath, files...)
+	// An empty list stays an error rather than becoming stage-everything. The
+	// guard path treats no files as "stage the whole tree", which is the
+	// opposite of what a caller passing an empty slice meant.
+	if len(files) == 0 {
+		return nil, git.ErrNoFilesSpecified
+	}
+	return git.StageWithGuard(ctx, repoPath, files)
 }
 
 // HasStagedChanges reports whether there are staged changes ready to commit

--- a/pkg/commitkit/commitkit_test.go
+++ b/pkg/commitkit/commitkit_test.go
@@ -795,3 +795,27 @@ func TestErrNoChanges(t *testing.T) {
 		assert.True(t, errors.Is(commitkit.ErrNoChanges, commitkit.ErrNoChanges))
 	})
 }
+
+// A consumer that wants to report what the guard did must be able to see it.
+//
+// StageAll and StageFiles deliberately discard the outcome for callers that
+// only want the protection, which means an excluded file is invisible to them:
+// the stage succeeds, the commit happens, and nothing says a file the user
+// expected is missing from it. The *WithOutcome forms are how a consumer that
+// renders its own output gets the facts.
+func TestStageWithOutcomeIsAvailableToConsumers(t *testing.T) {
+	t.Parallel()
+
+	// Compile-time contract: the types a consumer needs are reachable from
+	// this package without importing camp's internals.
+	var (
+		_ *commitkit.StageOutcome
+		_ *commitkit.GuardBlockedError
+	)
+
+	// An empty file list stays an error rather than silently becoming
+	// stage-everything, which is the opposite of what the caller meant.
+	if _, err := commitkit.StageFilesWithOutcome(context.Background(), t.TempDir()); err == nil {
+		t.Error("StageFilesWithOutcome with no files returned nil; an empty list must not mean stage everything")
+	}
+}

--- a/pkg/commitkit/guard.go
+++ b/pkg/commitkit/guard.go
@@ -3,6 +3,7 @@ package commitkit
 import (
 	"context"
 
+	"github.com/Obedience-Corp/camp/internal/git"
 	"github.com/Obedience-Corp/camp/internal/stageguard"
 )
 
@@ -59,6 +60,24 @@ const (
 	// one file's history between git and an artifact root is never correct.
 	TrackedGrowth = stageguard.TrackedGrowth
 )
+
+// StageOutcome is what the guard did during a staging operation: which files it
+// kept out of the index, which it staged but flagged, and whether it was able to
+// run at all.
+//
+// A consumer that stages through StageAll or StageFiles gets the protection but
+// not this, which is the silent half: camp excludes a file, the commit succeeds,
+// and nothing in the consumer's output says a file the user expected is not in
+// it. Use StageAllWithOutcome or StageFilesWithOutcome to see it, and render it
+// however suits the consumer.
+type StageOutcome = git.StageOutcome
+
+// GuardBlockedError reports that the guard refused a staging operation.
+//
+// Exported so a consumer can distinguish a refusal from an ordinary git failure
+// with errors.As rather than by matching message text. It carries the
+// violations as typed data for the same reason.
+type GuardBlockedError = git.GuardBlockedError
 
 // Mode is a guard's configured behavior.
 type Mode = stageguard.Mode

--- a/pkg/commitkit/guard.go
+++ b/pkg/commitkit/guard.go
@@ -1,0 +1,105 @@
+package commitkit
+
+import (
+	"context"
+
+	"github.com/Obedience-Corp/camp/internal/stageguard"
+)
+
+// The staging guard's public surface, re-exported for consumers outside this
+// module. fest is a separate module and cannot import camp's internal/
+// packages, so this file is the contract it codes against; only the
+// implementation lives behind it.
+//
+// Almost none of this needs calling. The guard runs inside git.Stage, which
+// every camp staging path funnels through, and it resolves its own thresholds
+// from repoPath. A consumer that stages through Stage, StageAll, StageFiles,
+// or CommitAll therefore inherits the guard from a camp version bump with no
+// code change at all. What is here is for the cases that want to look before
+// staging, or to render violations their own way.
+//
+// Deliberately absent: DrainJobs, which flushes deferred commit jobs. It needs
+// the job queue that phase 002 of this work introduces, so it is added with
+// the queue rather than stubbed here. See the deferred-commits design under
+// workflow/design/camp-artifact-commit-updates-2026-07-25/deferred-commits/.
+
+// GuardLimits is the staging policy for one repository: per-file size
+// threshold, bulk trigger, allowlist, and the mode of each guard.
+//
+// It is an alias rather than a distinct type, so the values a consumer builds
+// and the values the guard returns are the same type and camp never converts
+// between them.
+type GuardLimits = stageguard.GuardLimits
+
+// GuardViolation is one finding from the guard: an over-threshold file, a
+// tracked file that grew past the threshold, or a bulk directory.
+//
+// Violations are data, not an error string to parse. Camp's CLI renders them
+// one way and a consumer is free to render them another; both switch on Kind
+// rather than matching text.
+type GuardViolation = stageguard.GuardViolation
+
+// ViolationKind distinguishes which guard produced a violation. Each kind
+// carries a different remedy, so consumers switch on it to decide what to say.
+type ViolationKind = stageguard.ViolationKind
+
+// The violation kinds a consumer can encounter.
+const (
+	// OverThreshold is an untracked file above the size threshold. At a
+	// campaign root camp declares an artifact root for it and excludes it;
+	// inside a project camp excludes it and asks, because an artifact root
+	// would keep the bytes off the project's remote.
+	OverThreshold = stageguard.OverThreshold
+	// Bulk is many untracked files under one directory. It blocks: camp
+	// cannot tell a vendor tree that wants gitignore from a photo library
+	// that wants an artifact root.
+	Bulk = stageguard.Bulk
+	// TrackedGrowth is a tracked file whose new content crossed the
+	// threshold. It is always reported and never excluded, because splitting
+	// one file's history between git and an artifact root is never correct.
+	TrackedGrowth = stageguard.TrackedGrowth
+)
+
+// Mode is a guard's configured behavior.
+type Mode = stageguard.Mode
+
+// The guard modes. ModeAuto applies to the large-file guard only; the bulk
+// guard accepts ModeBlock or ModeOff, since there is no inference camp could
+// make on its behalf.
+const (
+	ModeAuto  = stageguard.ModeAuto
+	ModeBlock = stageguard.ModeBlock
+	ModeOff   = stageguard.ModeOff
+)
+
+// CheckStaging reports what a stage-everything operation in repoPath would add
+// that the guard would act on. It is stat-only: nothing is opened or hashed.
+//
+// This is a preflight call, and ordinary staging does not need it. Stage,
+// StageAll, and StageFiles already run the guard internally with limits
+// resolved from repoPath, so a consumer that only wants the protection should
+// call nothing. Use CheckStaging to ask "what would happen here" without
+// staging, or to render the findings before deciding.
+//
+// The limits passed here override the ones resolution would produce for
+// repoPath. To ask under the repository's own configured policy, get them from
+// ResolveLimits first.
+func CheckStaging(ctx context.Context, repoPath string, limits GuardLimits) ([]GuardViolation, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return stageguard.CheckStaging(ctx, repoPath, limits)
+}
+
+// ResolveLimits loads the guard policy that applies to repoPath, merging
+// campaign and per-project configuration over camp's shipped defaults. Outside
+// a campaign it returns the project-scope defaults, since a bare git repo is
+// closer to a project than to a campaign root.
+//
+// Pair it with CheckStaging to preflight under the repository's real policy.
+func ResolveLimits(ctx context.Context, repoPath string) (GuardLimits, error) {
+	if ctx.Err() != nil {
+		return GuardLimits{}, ctx.Err()
+	}
+	return stageguard.ResolveLimits(ctx, repoPath)
+}

--- a/pkg/commitkit/guard_test.go
+++ b/pkg/commitkit/guard_test.go
@@ -35,13 +35,18 @@ func TestGuardConstantsMatchStageguard(t *testing.T) {
 	assert.Equal(t, stageguard.ModeOff, commitkit.ModeOff)
 }
 
+// nonexistentRepo is a path that is never created. Every use below is guarded
+// by an already-cancelled context, so nothing should ever reach the disk.
+const nonexistentRepo = "/nonexistent/stageguard-ctx-check"
+
 func TestCheckStagingHonorsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	// A cancelled context short-circuits before git runs, so the path never
-	// has to exist for this to return.
-	_, err := commitkit.CheckStaging(ctx, t.TempDir(), commitkit.GuardLimits{})
+	// A cancelled context short-circuits before any filesystem or git access,
+	// so the path deliberately does not exist: if this ever returns something
+	// other than context.Canceled, the short-circuit regressed.
+	_, err := commitkit.CheckStaging(ctx, nonexistentRepo, commitkit.GuardLimits{})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
 }
@@ -50,7 +55,7 @@ func TestResolveLimitsHonorsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := commitkit.ResolveLimits(ctx, t.TempDir())
+	_, err := commitkit.ResolveLimits(ctx, nonexistentRepo)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
 }
@@ -59,7 +64,7 @@ func TestStageAllHonorsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := commitkit.StageAll(ctx, t.TempDir())
+	err := commitkit.StageAll(ctx, nonexistentRepo)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
 }

--- a/pkg/commitkit/guard_test.go
+++ b/pkg/commitkit/guard_test.go
@@ -1,0 +1,65 @@
+package commitkit_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Obedience-Corp/camp/internal/stageguard"
+	"github.com/Obedience-Corp/camp/pkg/commitkit"
+)
+
+// The re-exports must be aliases, not distinct named types, so a consumer
+// passes and receives exactly the types the guard uses internally and camp
+// never converts between them. These declarations fail to compile if any
+// re-export becomes a separate type, which is the whole assertion: the check
+// is the build, not a runtime comparison.
+var (
+	_ stageguard.GuardLimits    = commitkit.GuardLimits{}
+	_ stageguard.GuardViolation = commitkit.GuardViolation{}
+	_ stageguard.ViolationKind  = commitkit.OverThreshold
+	_ stageguard.Mode           = commitkit.ModeAuto
+
+	// And the reverse direction, so neither side is merely assignable to the
+	// other through an implicit conversion.
+	_ commitkit.GuardLimits    = stageguard.GuardLimits{}
+	_ commitkit.GuardViolation = stageguard.GuardViolation{}
+)
+
+func TestGuardConstantsMatchStageguard(t *testing.T) {
+	assert.Equal(t, stageguard.Bulk, commitkit.Bulk)
+	assert.Equal(t, stageguard.TrackedGrowth, commitkit.TrackedGrowth)
+	assert.Equal(t, stageguard.ModeBlock, commitkit.ModeBlock)
+	assert.Equal(t, stageguard.ModeOff, commitkit.ModeOff)
+}
+
+func TestCheckStagingHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// A cancelled context short-circuits before git runs, so the path never
+	// has to exist for this to return.
+	_, err := commitkit.CheckStaging(ctx, t.TempDir(), commitkit.GuardLimits{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestResolveLimitsHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := commitkit.ResolveLimits(ctx, t.TempDir())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestStageAllHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := commitkit.StageAll(ctx, t.TempDir())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/tests/integration/artifacts_add_gitignore_test.go
+++ b/tests/integration/artifacts_add_gitignore_test.go
@@ -199,3 +199,43 @@ func TestIntegration_ArtifactsAddEmptyRootIsClean(t *testing.T) {
 	gitignore := readGitignore(t, tc, campPath)
 	assert.Equal(t, 1, countRuleLines(gitignore, "empty-root/"))
 }
+
+// --dry-run never reaches File.Add, so path and policy validation has to run
+// before the survey or an impossible declaration would be reported as viable.
+func TestIntegration_ArtifactsAddDryRunStillValidates(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupArtifactsCampaign(t, tc, "artifacts-dryrun-invalid")
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "escaping path",
+			args: []string{"artifacts", "add", "../outside", "--dry-run"},
+			want: "escapes the campaign root",
+		},
+		{
+			name: "path under .campaign",
+			args: []string{"artifacts", "add", ".campaign/cache", "--dry-run"},
+			want: "may not live under .campaign",
+		},
+		{
+			name: "unknown policy",
+			args: []string{"artifacts", "add", "media/renders", "--policy", "sometimes", "--dry-run"},
+			want: "unknown policy",
+		},
+	}
+
+	for _, tc2 := range cases {
+		t.Run(tc2.name, func(t *testing.T) {
+			stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath, tc2.args...)
+			require.NoError(t, err)
+			assert.NotEqual(t, 0, exitCode, "stdout:\n%s", stdout)
+			assert.Contains(t, stdout+stderr, tc2.want)
+			assert.NotContains(t, stdout, "would be declared",
+				"an invalid declaration must not be reported as viable")
+		})
+	}
+}

--- a/tests/integration/artifacts_add_gitignore_test.go
+++ b/tests/integration/artifacts_add_gitignore_test.go
@@ -132,8 +132,12 @@ func TestIntegration_ArtifactsAddMixedRootReportsSplit(t *testing.T) {
 
 	assert.Contains(t, output, "Declared artifact root videos (mixed)")
 	assert.Contains(t, output, "2 git-tracked files stay with git and are excluded from artifact sync")
-	assert.Contains(t, output, "2 untracked files")
-	assert.Contains(t, output, "are the artifact set")
+	// The byte figure must describe the artifact set alone. The fixture's two
+	// tracked files hold 21 bytes and its two untracked files hold 26, so a
+	// report of 47 B would mean tracked content was counted as artifacts.
+	assert.Contains(t, output, "2 untracked files (26 B) are the artifact set")
+	assert.NotContains(t, output, "(47 B) are the artifact set",
+		"the artifact-set size must exclude git-tracked bytes")
 	assert.Contains(t, output, ".gitignore not modified: ignoring this root would hide tracked content")
 
 	assert.Equal(t, before, readGitignore(t, tc, campPath),

--- a/tests/integration/artifacts_add_gitignore_test.go
+++ b/tests/integration/artifacts_add_gitignore_test.go
@@ -1,0 +1,201 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupArtifactsCampaign builds a campaign with one clean media root and one
+// mixed root. Fixtures are constructed in-container: no test may point at the
+// real campaign or at any host media directory.
+func setupArtifactsCampaign(t *testing.T, tc *TestContainer, name string) string {
+	t.Helper()
+
+	path := "/campaigns/" + name
+	_, err := tc.InitCampaign(path, name, "product")
+	require.NoError(t, err)
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p media/renders
+		printf 'render-bytes' > media/renders/frame001.exr
+		printf 'render-bytes' > media/renders/frame002.exr
+
+		mkdir -p videos
+		printf 'script text' > videos/script.md
+		printf 'notes text' > videos/notes.md
+		printf 'footage-bytes' > videos/footage.mov
+		printf 'footage-bytes' > videos/b-roll.mov
+
+		mkdir -p empty-root
+
+		git add videos/script.md videos/notes.md
+		git -c user.email=t@t -c user.name=t commit -q -m "track video scripts"
+	`, path))
+
+	return path
+}
+
+// readGitignore returns the campaign root .gitignore, or "" when absent.
+func readGitignore(t *testing.T, tc *TestContainer, campPath string) string {
+	t.Helper()
+	exists, err := tc.CheckFileExists(campPath + "/.gitignore")
+	require.NoError(t, err)
+	if !exists {
+		return ""
+	}
+	content, err := tc.ReadFile(campPath + "/.gitignore")
+	require.NoError(t, err)
+	return content
+}
+
+// countRuleLines counts active (non-comment) lines exactly equal to rule.
+func countRuleLines(content, rule string) int {
+	n := 0
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) == rule {
+			n++
+		}
+	}
+	return n
+}
+
+// Criterion 22: a clean root gets its ignore rule written, and re-declaring it
+// does not append a second copy.
+func TestIntegration_ArtifactsAddCleanRootWritesGitignore(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupArtifactsCampaign(t, tc, "artifacts-clean")
+
+	output, err := tc.RunCampInDir(campPath, "artifacts", "add", "media/renders")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.Contains(t, output, "Declared artifact root media/renders")
+	assert.Contains(t, output, "Added 'media/renders/' to .gitignore")
+	assert.Contains(t, output, "lives outside git and syncs between your",
+		"clean-root output must state the consequence, not just the edit")
+	assert.Contains(t, output, "Undo: camp artifacts remove media/renders")
+
+	gitignore := readGitignore(t, tc, campPath)
+	require.Equal(t, 1, countRuleLines(gitignore, "media/renders/"),
+		"rule should be present exactly once; got:\n%s", gitignore)
+
+	// git must actually agree the path is ignored now.
+	ignored := tc.Shell(t, fmt.Sprintf(
+		`cd %s && git check-ignore -q media/renders && echo IGNORED || echo VISIBLE`, campPath))
+	assert.Contains(t, ignored, "IGNORED")
+
+	// Re-declaring is append-if-missing, not append-again.
+	_, _ = tc.RunCampInDir(campPath, "artifacts", "add", "media/renders")
+	gitignore = readGitignore(t, tc, campPath)
+	assert.Equal(t, 1, countRuleLines(gitignore, "media/renders/"),
+		"re-running must not duplicate the rule; got:\n%s", gitignore)
+}
+
+// Criterion 22: --no-gitignore declares without writing and keeps the warning.
+func TestIntegration_ArtifactsAddNoGitignoreSkipsWrite(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupArtifactsCampaign(t, tc, "artifacts-nogi")
+
+	before := readGitignore(t, tc, campPath)
+
+	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath,
+		"artifacts", "add", "media/renders", "--no-gitignore")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "stdout:\n%s\nstderr:\n%s", stdout, stderr)
+
+	assert.Contains(t, stdout, "Declared artifact root media/renders")
+	assert.NotContains(t, stdout, "Added 'media/renders/' to .gitignore")
+	assert.Contains(t, stderr, "is not gitignored",
+		"--no-gitignore must retain the existing warning")
+
+	assert.Equal(t, before, readGitignore(t, tc, campPath),
+		".gitignore must be byte-identical after --no-gitignore")
+}
+
+// Criterion 23: a mixed root is declared, never gitignored, and its split is
+// reported with real counts.
+func TestIntegration_ArtifactsAddMixedRootReportsSplit(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupArtifactsCampaign(t, tc, "artifacts-mixed")
+
+	before := readGitignore(t, tc, campPath)
+
+	output, err := tc.RunCampInDir(campPath, "artifacts", "add", "videos")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.Contains(t, output, "Declared artifact root videos (mixed)")
+	assert.Contains(t, output, "2 git-tracked files stay with git and are excluded from artifact sync")
+	assert.Contains(t, output, "2 untracked files")
+	assert.Contains(t, output, "are the artifact set")
+	assert.Contains(t, output, ".gitignore not modified: ignoring this root would hide tracked content")
+
+	assert.Equal(t, before, readGitignore(t, tc, campPath),
+		"a mixed root must never touch .gitignore")
+
+	declared, err := tc.ReadFile(campPath + "/.campaign/artifacts.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, declared, "videos", "the declaration must still be saved")
+}
+
+// Criterion 24: --dry-run reports and writes nothing at all.
+func TestIntegration_ArtifactsAddDryRunWritesNothing(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupArtifactsCampaign(t, tc, "artifacts-dryrun")
+
+	gitignoreBefore := readGitignore(t, tc, campPath)
+	yamlExistsBefore, err := tc.CheckFileExists(campPath + "/.campaign/artifacts.yaml")
+	require.NoError(t, err)
+	var yamlBefore string
+	if yamlExistsBefore {
+		yamlBefore, err = tc.ReadFile(campPath + "/.campaign/artifacts.yaml")
+		require.NoError(t, err)
+	}
+
+	output, err := tc.RunCampInDir(campPath, "artifacts", "add", "videos", "--dry-run")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.Contains(t, output, "videos would be declared as an artifact root (policy: always)")
+	assert.Contains(t, output, "4 files")
+	assert.Contains(t, output, "tracked")
+	assert.Contains(t, output, "untracked")
+	assert.Contains(t, output, "ignored")
+	assert.Contains(t, output, "Nothing was written")
+	assert.NotContains(t, output, "Declared artifact root")
+
+	assert.Equal(t, gitignoreBefore, readGitignore(t, tc, campPath),
+		"--dry-run must leave .gitignore byte-identical")
+
+	yamlExistsAfter, err := tc.CheckFileExists(campPath + "/.campaign/artifacts.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, yamlExistsBefore, yamlExistsAfter,
+		"--dry-run must not create artifacts.yaml")
+	if yamlExistsBefore && yamlExistsAfter {
+		yamlAfter, err := tc.ReadFile(campPath + "/.campaign/artifacts.yaml")
+		require.NoError(t, err)
+		assert.Equal(t, yamlBefore, yamlAfter,
+			"--dry-run must leave artifacts.yaml byte-identical")
+	}
+}
+
+// An empty directory has no tracked files, so it is clean and gets its rule.
+func TestIntegration_ArtifactsAddEmptyRootIsClean(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupArtifactsCampaign(t, tc, "artifacts-empty")
+
+	output, err := tc.RunCampInDir(campPath, "artifacts", "add", "empty-root")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.Contains(t, output, "Declared artifact root empty-root")
+	assert.Contains(t, output, "Added 'empty-root/' to .gitignore")
+	assert.NotContains(t, output, "(mixed)")
+
+	gitignore := readGitignore(t, tc, campPath)
+	assert.Equal(t, 1, countRuleLines(gitignore, "empty-root/"))
+}

--- a/tests/integration/commit_json_test.go
+++ b/tests/integration/commit_json_test.go
@@ -1,0 +1,155 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type commitJSONDoc struct {
+	SchemaVersion string `json:"schema_version"`
+	OK            bool   `json:"ok"`
+	Repo          string `json:"repo"`
+	Commit        string `json:"commit"`
+	Staged        int    `json:"staged"`
+	Excluded      []struct {
+		Path         string `json:"path"`
+		Size         int64  `json:"size"`
+		Reason       string `json:"reason"`
+		ArtifactRoot string `json:"artifact_root"`
+	} `json:"excluded"`
+	ArtifactRootsDeclared []string `json:"artifact_roots_declared"`
+}
+
+// runCommitJSON runs a commit with --json and returns raw stdout plus the
+// parsed document. stdout must be the document and nothing else.
+func runCommitJSON(t *testing.T, tc *TestContainer, dir string, args ...string) (string, commitJSONDoc) {
+	t.Helper()
+	full := append([]string{"commit", "--json"}, args...)
+	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(dir, full...)
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "stdout:\n%s\nstderr:\n%s", stdout, stderr)
+
+	var doc commitJSONDoc
+	require.NoError(t, json.Unmarshal([]byte(stdout), &doc),
+		"stdout must be exactly one JSON document; got:\n%s", stdout)
+	return stdout, doc
+}
+
+// Criterion 15c: --json is synchronous by contract. The document always
+// carries a real hash, and that hash is HEAD.
+func TestIntegration_CommitJSONCarriesRealHash(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "commit-json-hash")
+
+	stdout, doc := runCommitJSON(t, tc, campPath, "-m", "ordinary content")
+
+	assert.Equal(t, "commit/v1alpha1", doc.SchemaVersion)
+	assert.True(t, doc.OK)
+	require.NotEmpty(t, doc.Commit, "the document must carry a real commit hash, never a promise")
+	assert.Len(t, doc.Commit, 40, "machine callers get the full hash, not an abbreviation")
+
+	head := strings.TrimSpace(tc.GitOutput(t, campPath, "rev-parse", "HEAD"))
+	assert.Equal(t, head, doc.Commit, "the reported hash must be HEAD")
+	assert.Greater(t, doc.Staged, 0)
+
+	// Nothing but the document on stdout.
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(stdout), "{"),
+		"stdout must start with the document; got:\n%s", stdout)
+}
+
+// Criterion 15e: empty collections marshal to [], never null. Asserted on raw
+// bytes, because unmarshaling hides the difference and that is exactly how
+// this class of bug reaches consumers.
+func TestIntegration_CommitJSONEmptyArraysAreNotNull(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "commit-json-empty")
+
+	stdout, doc := runCommitJSON(t, tc, campPath, "-m", "nothing excluded")
+
+	assert.Contains(t, stdout, `"excluded": []`,
+		"excluded must serialize as an empty array; got:\n%s", stdout)
+	assert.Contains(t, stdout, `"artifact_roots_declared": []`,
+		"artifact_roots_declared must serialize as an empty array; got:\n%s", stdout)
+	assert.NotContains(t, stdout, "null",
+		"no field may serialize as null; got:\n%s", stdout)
+
+	assert.Empty(t, doc.Excluded)
+	assert.Empty(t, doc.ArtifactRootsDeclared)
+}
+
+// The load-bearing case: a machine caller can see that a file it wrote never
+// entered the commit, and which root now owns it.
+func TestIntegration_CommitJSONReportsExcludedFile(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupMixedRootCampaign(t, tc, "commit-json-excluded")
+
+	_, doc := runCommitJSON(t, tc, campPath, "-m", "rough cut notes")
+
+	require.Len(t, doc.Excluded, 1, "the excluded footage must appear in the document")
+	ex := doc.Excluded[0]
+	assert.Equal(t, "videos/my-video/footage.mp4", ex.Path)
+	assert.Equal(t, int64(3145728), ex.Size)
+	assert.Equal(t, "size_guard", ex.Reason)
+	assert.Equal(t, "videos/my-video", ex.ArtifactRoot)
+
+	assert.Equal(t, []string{"videos/my-video"}, doc.ArtifactRootsDeclared)
+}
+
+// A refusal reports its own reason and declares no root.
+func TestIntegration_CommitJSONReportsRefusalReason(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "commit-json-refusal")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		dd if=/dev/zero of=render.mov bs=1024 count=3072 2>/dev/null
+		printf 'ordinary' > ordinary.md
+	`, campPath))
+
+	_, doc := runCommitJSON(t, tc, campPath, "-m", "root-level media")
+
+	require.Len(t, doc.Excluded, 1)
+	assert.Equal(t, "render.mov", doc.Excluded[0].Path)
+	assert.Equal(t, "needs_root_decision", doc.Excluded[0].Reason)
+	assert.Empty(t, doc.Excluded[0].ArtifactRoot,
+		"a refusal declares nothing, so it names no root")
+	assert.Empty(t, doc.ArtifactRootsDeclared)
+}
+
+// The document must be valid input to a real JSON consumer, not merely
+// parseable by our own unmarshaler.
+func TestIntegration_CommitJSONPipesToJq(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupMixedRootCampaign(t, tc, "commit-json-jq")
+
+	out := tc.Shell(t, fmt.Sprintf(
+		`cd %s && /camp commit --json -m "jq check" 2>/dev/null | jq -r '.excluded[0].reason, .artifact_roots_declared[0]'`,
+		campPath))
+
+	assert.Contains(t, out, "size_guard")
+	assert.Contains(t, out, "videos/my-video")
+}
+
+// Criterion 37c2: the human path is unchanged by the existence of --json.
+func TestIntegration_CommitHumanPathUnchangedWithoutJSON(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "commit-human-baseline")
+
+	stdout, _, exitCode, err := tc.RunCampSplitInDir(campPath, "commit", "-m", "human path")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+
+	assert.Contains(t, stdout, "Changes to be committed:")
+	assert.Contains(t, stdout, "Changes committed successfully")
+	assert.NotContains(t, stdout, "schema_version",
+		"the human path must not emit machine output")
+}

--- a/tests/integration/commit_json_test.go
+++ b/tests/integration/commit_json_test.go
@@ -153,3 +153,60 @@ func TestIntegration_CommitHumanPathUnchangedWithoutJSON(t *testing.T) {
 	assert.NotContains(t, stdout, "schema_version",
 		"the human path must not emit machine output")
 }
+
+// A refusal must still produce a well-formed document. Without one, a machine
+// caller sees exit 1 and empty stdout, and cannot tell a deliberate refusal
+// from a crash.
+func TestIntegration_CommitJSONEmitsDocumentOnRefusal(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "commit-json-refused")
+	writeGuardConfig(t, tc, campPath, "    max_added_files: 50")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p vendor_tree
+		for i in $(seq 1 120); do printf 'x' > vendor_tree/f$i.js; done
+	`, campPath))
+
+	stdout, _, exitCode, err := tc.RunCampSplitInDir(campPath, "commit", "--json", "-m", "vendor")
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, exitCode, "a refusal must still fail the command")
+
+	var doc commitJSONDoc
+	require.NoError(t, json.Unmarshal([]byte(stdout), &doc),
+		"a refusal must still emit one document on stdout; got:\n%s", stdout)
+
+	assert.False(t, doc.OK, "ok must be false when nothing was committed")
+	assert.Empty(t, doc.Commit, "a refusal carries no commit hash")
+	assert.Equal(t, 0, doc.Staged)
+	require.Len(t, doc.Excluded, 1)
+	assert.Equal(t, "vendor_tree", doc.Excluded[0].Path,
+		"a bulk refusal names the directory, not a file")
+	assert.Equal(t, "bulk_guard", doc.Excluded[0].Reason)
+	assert.Empty(t, doc.ArtifactRootsDeclared)
+}
+
+// The same for a large_files: block refusal, which names the file.
+func TestIntegration_CommitJSONEmitsDocumentOnBlockMode(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "commit-json-blocked")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB\n    large_files: block")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p media
+		dd if=/dev/zero of=media/footage.mov bs=1024 count=3072 2>/dev/null
+	`, campPath))
+
+	stdout, _, exitCode, err := tc.RunCampSplitInDir(campPath, "commit", "--json", "-m", "blocked")
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, exitCode)
+
+	var doc commitJSONDoc
+	require.NoError(t, json.Unmarshal([]byte(stdout), &doc), "got:\n%s", stdout)
+
+	assert.False(t, doc.OK)
+	require.Len(t, doc.Excluded, 1)
+	assert.Equal(t, "media/footage.mov", doc.Excluded[0].Path)
+	assert.Equal(t, "size_guard_blocked", doc.Excluded[0].Reason)
+}

--- a/tests/integration/doctor_artifacts_test.go
+++ b/tests/integration/doctor_artifacts_test.go
@@ -1,0 +1,238 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type doctorJSONDoc struct {
+	SchemaVersion string `json:"schema_version"`
+	Success       bool   `json:"success"`
+	Passed        int    `json:"passed"`
+	Warned        int    `json:"warned"`
+	Failed        int    `json:"failed"`
+	Issues        []struct {
+		Severity    any            `json:"severity"`
+		CheckID     string         `json:"check_id"`
+		Description string         `json:"description"`
+		AutoFixable bool           `json:"auto_fixable"`
+		Details     map[string]any `json:"details"`
+	} `json:"issues"`
+}
+
+// declareRoots writes artifacts.yaml directly. Several rows describe states
+// camp itself refuses to create, so they can only be reached by hand-editing
+// the committed declaration file, which is exactly why the check exists.
+func declareRoots(t *testing.T, tc *TestContainer, campPath string, roots ...string) {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("version: 1\nroots:\n")
+	for _, r := range roots {
+		fmt.Fprintf(&b, "  - path: %s\n", r)
+	}
+	require.NoError(t, tc.WriteFile(campPath+"/.campaign/artifacts.yaml", b.String()))
+}
+
+// runDoctorArtifacts runs the check and returns its findings by reason.
+func runDoctorArtifacts(t *testing.T, tc *TestContainer, campPath string, extra ...string) (string, map[string]string) {
+	t.Helper()
+	args := append([]string{"doctor", "-c", "artifacts", "--json"}, extra...)
+	stdout, _, _, err := tc.RunCampSplitInDir(campPath, args...)
+	require.NoError(t, err)
+
+	var doc doctorJSONDoc
+	require.NoError(t, json.Unmarshal([]byte(stdout), &doc),
+		"doctor --json must emit one document; got:\n%s", stdout)
+
+	byReason := make(map[string]string)
+	for _, issue := range doc.Issues {
+		if issue.CheckID != "artifacts" {
+			continue
+		}
+		if reason, ok := issue.Details["reason"].(string); ok {
+			byReason[reason] = issue.Description
+		}
+	}
+	return stdout, byReason
+}
+
+// Criterion 25: a clean root with no ignore rule is an error, and --fix
+// appends the rule exactly once.
+func TestIntegration_DoctorArtifactsCleanRootNotIgnored(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "doctor-clean-root")
+
+	tc.Shell(t, fmt.Sprintf(`cd %s && mkdir -p media/renders && printf 'x' > media/renders/frame.exr`, campPath))
+	declareRoots(t, tc, campPath, "media/renders")
+
+	_, byReason := runDoctorArtifacts(t, tc, campPath)
+	require.Contains(t, byReason, "clean_root_not_gitignored")
+	assert.Contains(t, byReason["clean_root_not_gitignored"], "media/renders")
+
+	// --fix appends the rule.
+	_, _, _, err := tc.RunCampSplitInDir(campPath, "doctor", "-c", "artifacts", "--fix")
+	require.NoError(t, err)
+
+	gitignore := readGitignore(t, tc, campPath)
+	require.Equal(t, 1, countRuleLines(gitignore, "media/renders/"),
+		"the rule must be appended exactly once; got:\n%s", gitignore)
+
+	// Idempotent: a second --fix does not append again, and the finding is gone.
+	_, _, _, err = tc.RunCampSplitInDir(campPath, "doctor", "-c", "artifacts", "--fix")
+	require.NoError(t, err)
+	gitignore = readGitignore(t, tc, campPath)
+	assert.Equal(t, 1, countRuleLines(gitignore, "media/renders/"),
+		"re-running --fix must not duplicate the rule; got:\n%s", gitignore)
+
+	_, byReason = runDoctorArtifacts(t, tc, campPath)
+	assert.NotContains(t, byReason, "clean_root_not_gitignored",
+		"the finding must clear once the rule exists")
+}
+
+// A mixed root is a supported state, so it must never be a finding. Flagging
+// it would train users to ignore this check.
+func TestIntegration_DoctorArtifactsMixedRootIsNotAFinding(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupMixedRootCampaign(t, tc, "doctor-mixed-root")
+	declareRoots(t, tc, campPath, "videos/my-video")
+
+	stdout, byReason := runDoctorArtifacts(t, tc, campPath)
+
+	assert.NotContains(t, byReason, "clean_root_not_gitignored",
+		"a root holding tracked files must not be reported as an un-ignored clean root")
+	assert.NotContains(t, strings.ToLower(stdout), "mixed root",
+		"mixed is informational, never a finding")
+}
+
+// Criterion 26: --fix never untracks a file. A root that has tracked content
+// must keep it, whatever else the fixer does.
+func TestIntegration_DoctorArtifactsFixNeverUntracks(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupMixedRootCampaign(t, tc, "doctor-fix-no-untrack")
+	declareRoots(t, tc, campPath, "videos/my-video")
+
+	before := strings.Fields(tc.GitOutput(t, campPath, "ls-files", "--", "videos/my-video"))
+	require.NotEmpty(t, before, "fixture must have tracked content under the root")
+
+	_, _, _, err := tc.RunCampSplitInDir(campPath, "doctor", "-c", "artifacts", "--fix")
+	require.NoError(t, err)
+
+	after := strings.Fields(tc.GitOutput(t, campPath, "ls-files", "--", "videos/my-video"))
+	assert.Equal(t, before, after, "--fix must never untrack a file")
+
+	gitignore := readGitignore(t, tc, campPath)
+	assert.Equal(t, 0, countRuleLines(gitignore, "videos/my-video/"),
+		"a mixed root must never be gitignored by --fix; got:\n%s", gitignore)
+}
+
+// A declared root absent locally is a warning, not an error: it may live on
+// another machine, which is the reason declarations are committed at all.
+func TestIntegration_DoctorArtifactsMissingRootIsWarning(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "doctor-missing-root")
+	declareRoots(t, tc, campPath, "not/here/yet")
+
+	stdout, byReason := runDoctorArtifacts(t, tc, campPath)
+	require.Contains(t, byReason, "root_missing_locally")
+	assert.Contains(t, byReason["root_missing_locally"], "another machine")
+
+	var doc doctorJSONDoc
+	require.NoError(t, json.Unmarshal([]byte(stdout), &doc))
+	assert.True(t, doc.Success,
+		"a missing root is a warning, so the check must still succeed")
+	assert.Equal(t, 0, doc.Failed, "a warning must not be counted as a failure")
+}
+
+// The remaining rows describe states camp refuses to create; a hand-edited
+// artifacts.yaml is the only way to reach them.
+func TestIntegration_DoctorArtifactsHandEditedBadStates(t *testing.T) {
+	t.Run("nested inside another declared root", func(t *testing.T) {
+		tc := GetSharedContainer(t)
+		campPath := setupGuardCampaign(t, tc, "doctor-nested-root")
+		tc.Shell(t, fmt.Sprintf(`cd %s && mkdir -p videos/inner && printf 'x' > videos/inner/a.bin`, campPath))
+		declareRoots(t, tc, campPath, "videos", "videos/inner")
+
+		_, byReason := runDoctorArtifacts(t, tc, campPath)
+		require.Contains(t, byReason, "root_nested_in_declared_root")
+		assert.Contains(t, byReason["root_nested_in_declared_root"], "videos")
+	})
+
+	t.Run("crosses a submodule boundary", func(t *testing.T) {
+		tc := GetSharedContainer(t)
+		campPath, _, _ := setupFreshCampaignWithSubmodule(t, tc, "doctor-submodule-root")
+		declareRoots(t, tc, campPath, "projects/test-project/media")
+
+		_, byReason := runDoctorArtifacts(t, tc, campPath)
+		require.Contains(t, byReason, "root_crosses_submodule_boundary")
+		desc := byReason["root_crosses_submodule_boundary"]
+		assert.Contains(t, desc, "never reach the submodule's remote")
+		assert.Contains(t, desc, "hand-written",
+			"the finding should say camp cannot create this state")
+	})
+
+	t.Run("escapes the campaign", func(t *testing.T) {
+		tc := GetSharedContainer(t)
+		campPath := setupGuardCampaign(t, tc, "doctor-escaping-root")
+		declareRoots(t, tc, campPath, "../outside")
+
+		_, byReason := runDoctorArtifacts(t, tc, campPath)
+		require.Contains(t, byReason, "root_escapes_campaign")
+	})
+
+	t.Run("also tracked by DVC", func(t *testing.T) {
+		tc := GetSharedContainer(t)
+		campPath := setupGuardCampaign(t, tc, "doctor-dvc-root")
+		tc.Shell(t, fmt.Sprintf(`
+			cd %s
+			mkdir -p datasets
+			printf 'x' > datasets/train.bin
+			printf 'outs:\n- path: datasets\n' > datasets.dvc
+		`, campPath))
+		declareRoots(t, tc, campPath, "datasets")
+
+		_, byReason := runDoctorArtifacts(t, tc, campPath)
+		require.Contains(t, byReason, "root_also_dvc_tracked")
+		assert.Contains(t, byReason["root_also_dvc_tracked"], "DVC")
+	})
+}
+
+// Criterion 28: the check joins doctor --json without breaking its envelope,
+// and every finding carries its row's disposition.
+func TestIntegration_DoctorArtifactsJSONContract(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "doctor-artifacts-json")
+	tc.Shell(t, fmt.Sprintf(`cd %s && mkdir -p media && printf 'x' > media/a.bin`, campPath))
+	declareRoots(t, tc, campPath, "media")
+
+	stdout, _ := runDoctorArtifacts(t, tc, campPath)
+
+	var doc doctorJSONDoc
+	require.NoError(t, json.Unmarshal([]byte(stdout), &doc))
+	assert.Equal(t, "doctor/v1alpha1", doc.SchemaVersion,
+		"the existing doctor envelope must be unchanged")
+
+	var found bool
+	for _, issue := range doc.Issues {
+		if issue.CheckID != "artifacts" {
+			continue
+		}
+		found = true
+		assert.NotEmpty(t, issue.Details["reason"], "every finding must name its row")
+		assert.NotEmpty(t, issue.Details["root"], "every finding must name its root")
+	}
+	assert.True(t, found, "the artifacts check must appear in doctor --json")
+
+	// The document must satisfy a real JSON consumer, not just our unmarshaler.
+	out := tc.Shell(t, fmt.Sprintf(
+		`cd %s && /camp doctor -c artifacts --json 2>/dev/null | jq -r '.issues[] | select(.check_id=="artifacts") | .details.reason'`,
+		campPath))
+	assert.Contains(t, out, "clean_root_not_gitignored")
+}

--- a/tests/integration/doctor_bigfiles_test.go
+++ b/tests/integration/doctor_bigfiles_test.go
@@ -196,3 +196,29 @@ func TestIntegration_DoctorBigFilesFixIsReadOnly(t *testing.T) {
 	assert.Contains(t, stillThere, "media/raw/footage.mov",
 		"the finding must survive --fix; this check only reports")
 }
+
+// Camp's own state tree must never be reported. It is gitignored and claimed
+// by no artifact root, so without an explicit skip the sweep would call it
+// "owned by no system" and suggest `camp artifacts add .campaign` — which
+// ValidateRootPath rejects. A finding whose only remedy is refused teaches the
+// user the check is wrong.
+func TestIntegration_DoctorBigFilesSkipsCampaignState(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupBigFilesCampaign(t, tc, "doctor-bigfiles-state")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p .campaign/cache
+		dd if=/dev/zero of=.campaign/graph.db bs=1024 count=3072 2>/dev/null
+		dd if=/dev/zero of=.campaign/cache/blob.bin bs=1024 count=3072 2>/dev/null
+	`, campPath))
+
+	found := bigFilesFindings(t, tc, campPath)
+	for path := range found {
+		assert.NotContains(t, path, ".campaign",
+			"camp's own state tree must never be reported as unowned user content")
+	}
+
+	// The real findings still fire, so the skip is scoped rather than blunt.
+	assert.Contains(t, found, "media/raw/footage.mov")
+}

--- a/tests/integration/doctor_bigfiles_test.go
+++ b/tests/integration/doctor_bigfiles_test.go
@@ -1,0 +1,198 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupBigFilesCampaign builds one fixture covering every ownership state the
+// sweep must distinguish.
+func setupBigFilesCampaign(t *testing.T, tc *TestContainer, name string) string {
+	t.Helper()
+
+	path := "/campaigns/" + name
+	_, err := tc.InitCampaign(path, name, "product")
+	require.NoError(t, err)
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		cat >> .campaign/campaign.yaml <<'YAML'
+commit:
+  guards:
+    max_file_size: 1MiB
+YAML
+
+		# Tracked and over threshold: already in history, past the guard.
+		mkdir -p tracked
+		dd if=/dev/zero of=tracked/blob.bin bs=1024 count=3072 2>/dev/null
+		git add -f tracked/blob.bin
+		git -c user.email=t@t -c user.name=t commit -q -m "track a large blob"
+
+		# Gitignored and undeclared: owned by no system. The motivating case.
+		mkdir -p media/raw
+		dd if=/dev/zero of=media/raw/footage.mov bs=1024 count=3072 2>/dev/null
+		printf 'media/raw/\n' >> .gitignore
+
+		# Gitignored but inside a declared root: sync owns it, so it must NOT
+		# be reported. Reporting it would tell the user to fix what they fixed.
+		mkdir -p declared
+		dd if=/dev/zero of=declared/asset.bin bs=1024 count=3072 2>/dev/null
+		printf 'declared/\n' >> .gitignore
+		printf 'version: 1\nroots:\n  - path: declared\n' > .campaign/artifacts.yaml
+
+		# LFS-attributed: another system already owns it.
+		mkdir -p lfsdir
+		dd if=/dev/zero of=lfsdir/big.psd bs=1024 count=3072 2>/dev/null
+		printf 'lfsdir/*.psd filter=lfs diff=lfs merge=lfs -text\n' > .gitattributes
+		printf 'lfsdir/\n' >> .gitignore
+	`, path))
+
+	return path
+}
+
+// bigFilesFindings returns the sweep's findings keyed by path.
+func bigFilesFindings(t *testing.T, tc *TestContainer, campPath string) map[string]string {
+	t.Helper()
+	stdout, _, _, err := tc.RunCampSplitInDir(campPath, "doctor", "-c", "bigfiles", "--json")
+	require.NoError(t, err)
+
+	var doc doctorJSONDoc
+	require.NoError(t, json.Unmarshal([]byte(stdout), &doc),
+		"doctor -c bigfiles --json must emit one document; got:\n%s", stdout)
+
+	byPath := make(map[string]string)
+	for _, issue := range doc.Issues {
+		if issue.CheckID != "bigfiles" {
+			continue
+		}
+		p, _ := issue.Details["path"].(string)
+		state, _ := issue.Details["state"].(string)
+		byPath[p] = state
+	}
+	return byPath
+}
+
+// Criteria 29 and 30: the sweep finds what the commit path cannot see, and
+// leaves alone what another system already owns.
+func TestIntegration_DoctorBigFilesOwnership(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupBigFilesCampaign(t, tc, "doctor-bigfiles")
+
+	found := bigFilesFindings(t, tc, campPath)
+
+	assert.Equal(t, "tracked_in_history", found["tracked/blob.bin"],
+		"a large blob already committed must be reported; the guard stops the next one, not the last one")
+	assert.Equal(t, "owned_by_no_system", found["media/raw/footage.mov"],
+		"a gitignored, undeclared large file is the motivating case: it moves by no mechanism")
+
+	assert.NotContains(t, found, "declared/asset.bin",
+		"a file inside a declared artifact root is owned by sync and must not be reported")
+	assert.NotContains(t, found, "lfsdir/big.psd",
+		"an LFS-managed file is owned by LFS and must not be reported")
+}
+
+// Files under the threshold must not appear, whatever their extension. This is
+// the analog of criterion 30's real-campaign result, where the node_modules
+// files sit below the limit and must stay out of the report.
+func TestIntegration_DoctorBigFilesIgnoresUnderThreshold(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupBigFilesCampaign(t, tc, "doctor-bigfiles-small")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p node_modules/pkg
+		for i in $(seq 1 20); do dd if=/dev/zero of=node_modules/pkg/m$i.js bs=1024 count=64 2>/dev/null; done
+		printf 'node_modules/\n' >> .gitignore
+	`, campPath))
+
+	found := bigFilesFindings(t, tc, campPath)
+	for path := range found {
+		assert.NotContains(t, path, "node_modules",
+			"files under the threshold must not appear regardless of directory name")
+	}
+}
+
+// The sweep uses the guard's thresholds, so doctor and commit never disagree
+// about what "large" means.
+func TestIntegration_DoctorBigFilesHonorsConfiguredThreshold(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupBigFilesCampaign(t, tc, "doctor-bigfiles-threshold")
+
+	found := bigFilesFindings(t, tc, campPath)
+	require.Contains(t, found, "media/raw/footage.mov")
+
+	// Raise the limit above the fixture's files; the findings must clear.
+	_, err := tc.RunCampInDir(campPath, "settings", "set", "local.commit.guards.max_file_size", "100MiB")
+	require.NoError(t, err)
+
+	found = bigFilesFindings(t, tc, campPath)
+	assert.NotContains(t, found, "media/raw/footage.mov",
+		"raising the guard's threshold must raise doctor's too")
+}
+
+// Criterion 31e: camp status never surfaces these findings. A deliberate
+// gitignore is not a defect to nag about; doctor is the only surface.
+func TestIntegration_DoctorBigFilesNeverAppearsInStatus(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupBigFilesCampaign(t, tc, "doctor-bigfiles-status")
+
+	output, err := tc.RunCampInDir(campPath, "status")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.NotContains(t, output, "media/raw/footage.mov")
+	assert.NotContains(t, output, "owned by no system")
+	assert.NotContains(t, output, "bigfiles")
+}
+
+// The sweep walks the whole campaign, so it stays out of the default run.
+// Every other check is a git invocation costing milliseconds.
+func TestIntegration_DoctorBigFilesIsOptIn(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupBigFilesCampaign(t, tc, "doctor-bigfiles-optin")
+
+	stdout, _, _, err := tc.RunCampSplitInDir(campPath, "doctor", "--json")
+	require.NoError(t, err)
+
+	var doc doctorJSONDoc
+	require.NoError(t, json.Unmarshal([]byte(stdout), &doc))
+	for _, issue := range doc.Issues {
+		assert.NotEqual(t, "bigfiles", issue.CheckID,
+			"bigfiles must not run in the default doctor pass")
+	}
+
+	// But it is available by name.
+	found := bigFilesFindings(t, tc, campPath)
+	assert.NotEmpty(t, found, "-c bigfiles must run the sweep")
+}
+
+// Detection never remediates: --fix must change nothing here, because both
+// remedies (history rewrite, adopting a directory) are human decisions.
+func TestIntegration_DoctorBigFilesFixIsReadOnly(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupBigFilesCampaign(t, tc, "doctor-bigfiles-readonly")
+
+	gitignoreBefore := readGitignore(t, tc, campPath)
+	declaredBefore, err := tc.ReadFile(campPath + "/.campaign/artifacts.yaml")
+	require.NoError(t, err)
+
+	_, _, _, err = tc.RunCampSplitInDir(campPath, "doctor", "-c", "bigfiles", "--fix")
+	require.NoError(t, err)
+
+	assert.Equal(t, gitignoreBefore, readGitignore(t, tc, campPath),
+		"--fix must not touch .gitignore")
+	declaredAfter, err := tc.ReadFile(campPath + "/.campaign/artifacts.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, declaredBefore, declaredAfter,
+		"--fix must not declare anything")
+
+	stillThere := bigFilesFindings(t, tc, campPath)
+	assert.Contains(t, stillThere, "media/raw/footage.mov",
+		"the finding must survive --fix; this check only reports")
+}

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -243,16 +243,19 @@ func newPooledContainer(ctx context.Context, bins sharedBinaries) (*TestContaine
 		}
 	}
 
-	// Install git (required for project operations)
-	exitCode, output, err := container.Exec(ctx, []string{"apk", "add", "--no-cache", "git"})
+	// Install git (required for project operations) and jq (so --json output
+	// is validated by a real JSON consumer rather than only by our own
+	// unmarshaler, which would accept shapes a caller's parser rejects).
+	// One apk invocation: each one is a container round trip per pool member.
+	exitCode, output, err := container.Exec(ctx, []string{"apk", "add", "--no-cache", "git", "jq"})
 	if err != nil {
 		container.Terminate(ctx)
-		return nil, fmt.Errorf("failed to install git: %w", err)
+		return nil, fmt.Errorf("failed to install container packages: %w", err)
 	}
 	if exitCode != 0 {
 		outputBytes, _ := io.ReadAll(output)
 		container.Terminate(ctx)
-		return nil, fmt.Errorf("apk add git failed with exit code %d: %s", exitCode, string(outputBytes))
+		return nil, fmt.Errorf("apk add git jq failed with exit code %d: %s", exitCode, string(outputBytes))
 	}
 
 	// Configure git (required for submodule operations)

--- a/tests/integration/stage_guard_declare_test.go
+++ b/tests/integration/stage_guard_declare_test.go
@@ -57,7 +57,8 @@ func TestIntegration_GuardAutoDeclaresMixedRoot(t *testing.T) {
 	// Design doc 02's "script.md and notes.md stay with git" line. Without it
 	// the user has been told their directory is now artifact content and has
 	// no way to know the note they just wrote is still versioned.
-	assert.Contains(t, output, "stay with git")
+	assert.Contains(t, output, "stays with git",
+		"one file takes the singular verb")
 	assert.Contains(t, output, "notes.md")
 
 	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")

--- a/tests/integration/stage_guard_declare_test.go
+++ b/tests/integration/stage_guard_declare_test.go
@@ -1,0 +1,271 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupMixedRootCampaign builds the design's flagship fixture: a directory
+// holding a tracked script, an over-threshold "video", and a new small note.
+// The note is criterion 2, the data-loss regression: it must reach git.
+func setupMixedRootCampaign(t *testing.T, tc *TestContainer, name string) string {
+	t.Helper()
+
+	path := "/campaigns/" + name
+	_, err := tc.InitCampaign(path, name, "product")
+	require.NoError(t, err)
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		cat >> .campaign/campaign.yaml <<'YAML'
+commit:
+  guards:
+    max_file_size: 1MiB
+YAML
+		mkdir -p videos/my-video
+		printf 'shot list' > videos/my-video/script.md
+		git add videos/my-video/script.md
+		git -c user.email=t@t -c user.name=t commit -q -m "track the script"
+
+		dd if=/dev/zero of=videos/my-video/footage.mp4 bs=1024 count=3072 2>/dev/null
+		printf 'new note beside the footage' > videos/my-video/notes.md
+	`, path))
+
+	return path
+}
+
+// Criteria 1 and 2: the over-threshold file is excluded and a root declared,
+// while the new small file beside it still reaches git.
+func TestIntegration_GuardAutoDeclaresMixedRoot(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupMixedRootCampaign(t, tc, "guard-declare-mixed")
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "rough cut notes")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.Contains(t, output, "videos/my-video/ is now an artifact root")
+	assert.Contains(t, output, "footage.mp4")
+	assert.Contains(t, output, "Undo: camp artifacts remove videos/my-video",
+		"every message announcing new behavior must carry its undo")
+	assert.Contains(t, output, "syncs with 'camp sync --from <machine>'")
+	// Design doc 02's "script.md and notes.md stay with git" line. Without it
+	// the user has been told their directory is now artifact content and has
+	// no way to know the note they just wrote is still versioned.
+	assert.Contains(t, output, "stay with git")
+	assert.Contains(t, output, "notes.md")
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+
+	// Criterion 2, the data-loss regression. A new small file inside a mixed
+	// root must become git's, not silently reclassified as artifact content.
+	assert.Contains(t, committed, "videos/my-video/notes.md",
+		"a new small file in a MIXED root must land in git")
+	assert.NotContains(t, committed, "videos/my-video/footage.mp4",
+		"the over-threshold file must be excluded")
+
+	// The commit carries its own bookkeeping.
+	assert.Contains(t, committed, ".campaign/artifacts.yaml",
+		"the declaration must land in the same commit that excluded the bytes")
+
+	declared, err := tc.ReadFile(campPath + "/.campaign/artifacts.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, declared, "videos/my-video")
+
+	// A mixed root is never gitignored: the rule would hide tracked content.
+	gitignore := readGitignore(t, tc, campPath)
+	assert.NotContains(t, gitignore, "videos/my-video/",
+		"a mixed root must never get an ignore rule")
+}
+
+// Criterion 9: refusal is per file, not per commit. The commit proceeds and
+// only the refused file is left out.
+func TestIntegration_GuardRefusesCampaignRootFilePerFile(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-refuse-root")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		dd if=/dev/zero of=render.mov bs=1024 count=3072 2>/dev/null
+		printf 'ordinary' > ordinary.md
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "root-level media")
+	require.NoError(t, err, "the commit must still succeed; output:\n%s", output)
+
+	assert.Contains(t, output, "render.mov")
+	assert.Contains(t, output, "sits at the campaign root; camp will not make the campaign an artifact root")
+	assert.Contains(t, output, "camp artifacts add")
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "ordinary.md", "everything else must still commit")
+	assert.NotContains(t, committed, "render.mov")
+
+	// Camp must not have declared anything for a refusal.
+	exists, err := tc.CheckFileExists(campPath + "/.campaign/artifacts.yaml")
+	require.NoError(t, err)
+	if exists {
+		declared, err := tc.ReadFile(campPath + "/.campaign/artifacts.yaml")
+		require.NoError(t, err)
+		assert.NotContains(t, declared, "render.mov")
+	}
+}
+
+// Camp must never turn its own state tree into a user artifact root.
+func TestIntegration_GuardRefusesCampaignStateTree(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-refuse-state")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p .campaign/graphs
+		dd if=/dev/zero of=.campaign/graphs/graph.png bs=1024 count=3072 2>/dev/null
+		printf 'ordinary' > ordinary.md
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "state tree export")
+	require.NoError(t, err, "output:\n%s", output)
+
+	if exists, _ := tc.CheckFileExists(campPath + "/.campaign/artifacts.yaml"); exists {
+		declared, err := tc.ReadFile(campPath + "/.campaign/artifacts.yaml")
+		require.NoError(t, err)
+		assert.NotContains(t, declared, ".campaign/graphs",
+			"camp's own state tree must never become a user artifact root")
+	}
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "ordinary.md")
+}
+
+// A clean root does get its ignore rule, which makes everything landing there
+// later artifact content by construction.
+func TestIntegration_GuardAutoDeclaresCleanRootWithIgnoreRule(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-declare-clean")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p media/renders
+		dd if=/dev/zero of=media/renders/frame.exr bs=1024 count=3072 2>/dev/null
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "renders")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.Contains(t, output, "media/renders/ is now an artifact root")
+	assert.Contains(t, output, "camp sync")
+
+	gitignore := readGitignore(t, tc, campPath)
+	assert.Equal(t, 1, countRuleLines(gitignore, "media/renders/"),
+		"a clean root gets exactly one ignore rule; got:\n%s", gitignore)
+}
+
+// Criterion 10: a second over-threshold file inside an already-declared root
+// reuses it and reports one tally line rather than the full teaching block.
+func TestIntegration_GuardReusesExistingRootWithTallyLine(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupMixedRootCampaign(t, tc, "guard-reuse-root")
+
+	_, err := tc.RunCampInDir(campPath, "commit", "-m", "first cut")
+	require.NoError(t, err)
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		dd if=/dev/zero of=videos/my-video/broll.mp4 bs=1024 count=3072 2>/dev/null
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "b-roll")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.Contains(t, output, "kept out of git",
+		"an existing root should report a tally line")
+	// The b-roll was the only change, so nothing remains staged. Camp must
+	// report that as a clean no-op rather than letting git reject an empty
+	// commit: the excluded file is still an unstaged worktree change, so the
+	// ordinary has-changes check would otherwise say yes.
+	assert.Contains(t, output, "Nothing left to commit")
+	assert.NotContains(t, output, "is now an artifact root",
+		"an already-declared root must not re-teach what an artifact root is")
+
+	declared, err := tc.ReadFile(campPath + "/.campaign/artifacts.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, 1, countRuleLines(declared, "- path: videos/my-video"),
+		"the root must not be declared twice; got:\n%s", declared)
+}
+
+// Criteria 8 and 8b: inside a project camp excludes, asks, and declares nothing.
+func TestIntegration_GuardProjectExcludesAndAsks(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath, projPath, _ := setupFreshCampaignWithSubmodule(t, tc, "guard-project-ask")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		cat >> .campaign/campaign.yaml <<'YAML'
+commit:
+  guards:
+    max_project_file_size: 1MiB
+YAML
+	`, campPath))
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p testdata
+		dd if=/dev/zero of=testdata/corpus.tar bs=1024 count=3072 2>/dev/null
+		printf 'fixture note' > testdata/README.md
+	`, projPath))
+
+	output, err := tc.RunCampInDir(projPath, "project", "commit", "-m", "add fixture")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.Contains(t, output, "testdata/corpus.tar")
+	assert.Contains(t, output, "was left out of this commit")
+	assert.Contains(t, output, "if it is build output")
+	assert.Contains(t, output, "git lfs track")
+	assert.Contains(t, output, "commit.guards.allow")
+
+	// Camp must never declare an artifact root for project content.
+	if exists, _ := tc.CheckFileExists(campPath + "/.campaign/artifacts.yaml"); exists {
+		declared, err := tc.ReadFile(campPath + "/.campaign/artifacts.yaml")
+		require.NoError(t, err)
+		assert.NotContains(t, declared, "testdata",
+			"an artifact root inside a project would keep bytes off its remote")
+	}
+}
+
+// Criteria 7 and 7b: a tracked file over the threshold is committed anyway and
+// reported every time, with the untrack remedy and the allowlist line.
+func TestIntegration_GuardReportsTrackedGrowthButCommitsIt(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-tracked-growth")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p graphs
+		printf 'small' > graphs/graph.png
+		git add graphs/graph.png
+		git -c user.email=t@t -c user.name=t commit -q -m "track the graph"
+
+		dd if=/dev/zero of=graphs/graph.png bs=1024 count=3072 2>/dev/null
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "regenerated graph")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.Contains(t, output, "graphs/graph.png is tracked and now")
+	assert.Contains(t, output, "Tracked files are always committed")
+	assert.Contains(t, output, "git rm --cached graphs/graph.png")
+	assert.Contains(t, output, "commit.guards.allow")
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "graphs/graph.png",
+		"tracked growth is reported, never excluded")
+}

--- a/tests/integration/stage_guard_overrides_test.go
+++ b/tests/integration/stage_guard_overrides_test.go
@@ -1,0 +1,297 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Criterion 14: a bulk directory refuses the whole commit, stages nothing, and
+// prints the three ways forward with the detected prefix interpolated.
+func TestIntegration_GuardBulkRefusalRendersMenu(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-bulk-menu")
+	writeGuardConfig(t, tc, campPath, "    max_added_files: 50")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p vendor_tree
+		for i in $(seq 1 120); do printf 'x' > vendor_tree/f$i.js; done
+	`, campPath))
+
+	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath, "commit", "-m", "vendor")
+	require.NoError(t, err)
+	require.NotEqual(t, 0, exitCode)
+	combined := stdout + stderr
+
+	assert.Contains(t, combined, "untracked files")
+	assert.Contains(t, combined, "would be committed")
+	assert.Contains(t, combined, "vendor_tree")
+	assert.Contains(t, combined, "Nothing was staged")
+
+	// All three ways forward, with the detected prefix interpolated. No
+	// directory name is hardcoded: criterion 36 means shape decides, never a
+	// name camp was taught to recognize.
+	assert.Contains(t, combined, "echo 'vendor_tree/' >> .gitignore")
+	assert.Contains(t, combined, "camp artifacts add vendor_tree")
+	assert.Contains(t, combined, "--commit-large")
+	// Criterion 37d: the message announcing the behavior carries its off switch.
+	assert.Contains(t, combined, "camp settings set local.commit.guards.bulk off")
+
+	assert.Empty(t, stagedPaths(t, tc, campPath), "a refusal must stage nothing")
+}
+
+// Criterion 14b: many medium files are not a bulk trigger. There is no
+// total-bytes leg, precisely because its only unique catch was this case.
+func TestIntegration_GuardPhotoBatchDoesNotBlock(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-photo-batch")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 50MiB\n    max_added_files: 50")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p photos
+		for i in $(seq 1 6); do dd if=/dev/zero of=photos/p$i.jpg bs=1024 count=9216 2>/dev/null; done
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "six photos")
+	require.NoError(t, err, "six 9 MB photos must not block; output:\n%s", output)
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "photos/p1.jpg")
+}
+
+// Criterion 14c: the per-file guard runs first, so an auto-handled large file
+// does not also swell the bulk batch back over the trigger.
+func TestIntegration_GuardLargeFileDoesNotTripBulk(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-order")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB\n    max_added_files: 100")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p media
+		dd if=/dev/zero of=media/footage.mov bs=1024 count=3072 2>/dev/null
+		for i in $(seq 1 99); do printf 'x' > media/small$i.txt; done
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "one big plus ninety-nine small")
+	require.NoError(t, err, "the big file must be taken by the per-file guard, not counted toward bulk; output:\n%s", output)
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "media/small1.txt")
+	assert.NotContains(t, committed, "media/footage.mov")
+}
+
+// Criterion 12: large_files: block refuses, stages nothing, and prints the
+// exact camp artifacts add command for the real directory.
+func TestIntegration_GuardLargeFilesBlockMode(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-block-mode")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB\n    large_files: block")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p media
+		dd if=/dev/zero of=media/footage.mov bs=1024 count=3072 2>/dev/null
+	`, campPath))
+
+	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath, "commit", "-m", "blocked")
+	require.NoError(t, err)
+	require.NotEqual(t, 0, exitCode)
+	combined := stdout + stderr
+
+	assert.Contains(t, combined, "media/footage.mov")
+	assert.Contains(t, combined, "Nothing was staged")
+	assert.Contains(t, combined, "camp artifacts add media")
+	assert.Contains(t, combined, "--commit-large")
+	assert.Contains(t, combined, "camp settings set local.commit.guards.large_files auto")
+
+	assert.Empty(t, stagedPaths(t, tc, campPath), "block mode must leave the index untouched")
+}
+
+// Criterion 3: --commit-large forces the file in and declares nothing.
+func TestIntegration_GuardCommitLargeForcesInclusion(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-commit-large")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p media
+		dd if=/dev/zero of=media/footage.mov bs=1024 count=3072 2>/dev/null
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "--commit-large", "-m", "keep the binary")
+	require.NoError(t, err, "output:\n%s", output)
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "media/footage.mov",
+		"--commit-large must force the file into the commit")
+
+	exists, err := tc.CheckFileExists(campPath + "/.campaign/artifacts.yaml")
+	require.NoError(t, err)
+	if exists {
+		declared, err := tc.ReadFile(campPath + "/.campaign/artifacts.yaml")
+		require.NoError(t, err)
+		assert.NotContains(t, declared, "media",
+			"--commit-large declares nothing; it is an override, not a different handling")
+	}
+	assert.NotContains(t, output, "is now an artifact root")
+}
+
+// --commit-large also overrides a bulk refusal, which is what the bulk menu
+// offers as the third way forward.
+func TestIntegration_GuardCommitLargeOverridesBulk(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-large-bulk")
+	writeGuardConfig(t, tc, campPath, "    max_added_files: 50")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p vendor_tree
+		for i in $(seq 1 120); do printf 'x' > vendor_tree/f$i.js; done
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "--commit-large", "-m", "vendor anyway")
+	require.NoError(t, err, "the bulk menu offers --commit-large, so it must work; output:\n%s", output)
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "vendor_tree/f1.js")
+}
+
+// Criterion 5: an allowlisted file commits normally, with no declaration and
+// no report. An exemption the user configured is not news.
+func TestIntegration_GuardAllowlistIsSilent(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-allow-silent")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB\n    allow:\n      - \"releases/**\"")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p releases
+		dd if=/dev/zero of=releases/camp-darwin bs=1024 count=3072 2>/dev/null
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "release binary")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.NotContains(t, output, "artifact root")
+	assert.NotContains(t, output, "kept out of git")
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "releases/camp-darwin")
+}
+
+// Criterion 35: a per-project override applies to that project only.
+func TestIntegration_GuardProjectOverrideDoesNotAffectSiblings(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath, projPath, _ := setupFreshCampaignWithSubmodule(t, tc, "guard-project-override")
+
+	// alpha raises its own limit; the submodule project keeps the default.
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		cat >> .campaign/campaign.yaml <<'YAML'
+commit:
+  guards:
+    max_project_file_size: 1MiB
+    projects:
+      test-project:
+        max_file_size: 100MiB
+YAML
+	`, campPath))
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p bigdir
+		dd if=/dev/zero of=bigdir/blob.bin bs=1024 count=3072 2>/dev/null
+	`, projPath))
+
+	output, err := tc.RunCampInDir(projPath, "project", "commit", "-m", "override applies here")
+	require.NoError(t, err, "output:\n%s", output)
+
+	committed := tc.GitOutput(t, projPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "bigdir/blob.bin",
+		"the project's own 100MiB override must let a 3 MB file through")
+	assert.NotContains(t, output, "was left out of this commit")
+}
+
+// Criterion 34: camp settings set persists the threshold, and later commits
+// simply honor it with no flags and no output.
+func TestIntegration_GuardSettingsRoundTrip(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-settings")
+
+	out, err := tc.RunCampInDir(campPath, "settings", "set", "local.commit.guards.max_file_size", "100MiB")
+	require.NoError(t, err, "output:\n%s", out)
+
+	got, err := tc.RunCampInDir(campPath, "settings", "get", "local.commit.guards.max_file_size")
+	require.NoError(t, err)
+	assert.Contains(t, got, "100MiB", "the setting must round-trip")
+
+	yaml, err := tc.ReadFile(campPath + "/.campaign/campaign.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, yaml, "100MiB", "the setting must persist to campaign.yaml")
+
+	// A 60 MB file now commits with no flags and no guard output.
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p media
+		dd if=/dev/zero of=media/big.bin bs=1024 count=61440 2>/dev/null
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "under the raised limit")
+	require.NoError(t, err, "output:\n%s", output)
+	assert.NotContains(t, output, "artifact root")
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "media/big.bin")
+}
+
+// Invalid guard settings are rejected at set time, using the same parser the
+// guard uses, so a value accepted here can never be rejected at commit time.
+func TestIntegration_GuardSettingsRejectInvalidValues(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-settings-invalid")
+
+	cases := []struct {
+		name  string
+		key   string
+		value string
+		want  string
+	}{
+		{name: "unparseable size", key: "local.commit.guards.max_file_size", value: "ten megs", want: "10MiB"},
+		{name: "unknown large_files mode", key: "local.commit.guards.large_files", value: "warn", want: "auto, block, or off"},
+		{name: "bulk rejects auto", key: "local.commit.guards.bulk", value: "auto", want: "block or off"},
+		{name: "non-numeric count", key: "local.commit.guards.max_added_files", value: "many", want: "non-negative"},
+	}
+
+	for _, tc2 := range cases {
+		t.Run(tc2.name, func(t *testing.T) {
+			stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath, "settings", "set", tc2.key, tc2.value)
+			require.NoError(t, err)
+			assert.NotEqual(t, 0, exitCode, "stdout:\n%s", stdout)
+			assert.Contains(t, stdout+stderr, tc2.want)
+		})
+	}
+}
+
+// A negative count is rejected too, but it has to be written after a "--"
+// separator: cobra parses a leading-dash value as a flag before any command
+// code sees it. That is generic CLI behavior, not specific to these keys, so
+// the test documents the invocation rather than treating it as a defect.
+func TestIntegration_GuardSettingsRejectNegativeCount(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-settings-negative")
+
+	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath,
+		"settings", "set", "local.commit.guards.max_added_files", "--", "-5")
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, exitCode, "stdout:\n%s", stdout)
+	assert.Contains(t, stdout+stderr, "non-negative")
+}

--- a/tests/integration/stage_guard_test.go
+++ b/tests/integration/stage_guard_test.go
@@ -1,0 +1,235 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupGuardCampaign builds a campaign with ordinary content. Large fixtures
+// are generated in-container per test and never committed to the repo.
+func setupGuardCampaign(t *testing.T, tc *TestContainer, name string) string {
+	t.Helper()
+
+	path := "/campaigns/" + name
+	_, err := tc.InitCampaign(path, name, "product")
+	require.NoError(t, err)
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p notes
+		printf 'first note' > notes/one.md
+		printf 'second note' > notes/two.md
+	`, path))
+
+	return path
+}
+
+// writeGuardConfig sets commit.guards.* in campaign.yaml. Sizes stay small so
+// fixtures are cheap; the guard's logic does not care about magnitude.
+func writeGuardConfig(t *testing.T, tc *TestContainer, campPath, block string) {
+	t.Helper()
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		cat >> .campaign/campaign.yaml <<'YAML'
+commit:
+  guards:
+%s
+YAML
+	`, campPath, block))
+}
+
+// stagedPaths returns the index contents after a staging operation.
+func stagedPaths(t *testing.T, tc *TestContainer, campPath string) []string {
+	t.Helper()
+	out := tc.GitOutput(t, campPath, "diff", "--cached", "--name-only")
+	var paths []string
+	for _, line := range strings.Split(out, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			paths = append(paths, trimmed)
+		}
+	}
+	return paths
+}
+
+// Criterion 4: a repository with nothing over the limits stages exactly as it
+// did before the guard existed, and says nothing extra.
+func TestIntegration_GuardUnderLimitsIsInvisible(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-under-limits")
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "ordinary content")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.NotContains(t, output, "artifact root")
+	assert.NotContains(t, output, "over the size limit")
+	assert.NotContains(t, output, "untracked files")
+
+	committed := tc.GitOutput(t, campPath, "show", "--stat", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "notes/one.md")
+	assert.Contains(t, committed, "notes/two.md")
+}
+
+// Criterion 1 (staging half): an over-threshold untracked file is kept out of
+// the index while everything else goes in.
+func TestIntegration_GuardExcludesOverThresholdFile(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-excludes")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p media
+		dd if=/dev/zero of=media/footage.mov bs=1024 count=3072 2>/dev/null
+		printf 'script' > media/script.md
+	`, campPath))
+
+	_, err := tc.RunCampInDir(campPath, "commit", "-m", "add footage and script")
+	require.NoError(t, err)
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "media/script.md",
+		"small files beside the large one must still be committed")
+	assert.NotContains(t, committed, "media/footage.mov",
+		"the over-threshold file must be kept out of the commit")
+
+	// The bytes are still on disk; the guard excludes, it does not delete.
+	exists, err := tc.CheckFileExists(campPath + "/media/footage.mov")
+	require.NoError(t, err)
+	assert.True(t, exists, "the guard must never remove the user's file")
+}
+
+// Design doc 03 Change 3: an explicit `git add <path>` is an intent, so
+// naming the file stages it regardless of size.
+func TestIntegration_GuardIgnoresExplicitlyNamedFiles(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-explicit")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p media
+		dd if=/dev/zero of=media/footage.mov bs=1024 count=3072 2>/dev/null
+		git add media/footage.mov
+	`, campPath))
+
+	staged := stagedPaths(t, tc, campPath)
+	assert.Contains(t, staged, "media/footage.mov",
+		"an explicitly named path is an intent the guard must not override")
+}
+
+// Criterion 12: a bulk refusal aborts before staging, leaving the index
+// exactly as it was.
+func TestIntegration_GuardBulkBlockLeavesIndexUntouched(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-bulk-block")
+	writeGuardConfig(t, tc, campPath, "    max_added_files: 50\n    bulk: block")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p vendor_tree
+		for i in $(seq 1 120); do printf 'x' > vendor_tree/f$i.js; done
+	`, campPath))
+
+	before := stagedPaths(t, tc, campPath)
+	require.Empty(t, before, "index should start clean")
+
+	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath, "commit", "-m", "vendor tree")
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, exitCode, "bulk block must fail the command; stdout:\n%s", stdout)
+	assert.Contains(t, stdout+stderr, "vendor_tree")
+
+	after := stagedPaths(t, tc, campPath)
+	assert.Empty(t, after,
+		"a bulk refusal must stage nothing at all; index held: %v", after)
+}
+
+// Criterion 13: bulk: off disables detection entirely.
+func TestIntegration_GuardBulkOffDisablesDetection(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-bulk-off")
+	writeGuardConfig(t, tc, campPath, "    max_added_files: 50\n    bulk: \"off\"")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p vendor_tree
+		for i in $(seq 1 120); do printf 'x' > vendor_tree/f$i.js; done
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "vendor tree with guard off")
+	require.NoError(t, err, "output:\n%s", output)
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "vendor_tree/f1.js",
+		"with bulk off the tree must be committed normally")
+}
+
+// large_files: off disables the size guard while leaving bulk alone.
+func TestIntegration_GuardLargeFilesOffStagesBigFile(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-large-off")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB\n    large_files: \"off\"")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p media
+		dd if=/dev/zero of=media/footage.mov bs=1024 count=3072 2>/dev/null
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "big file, guard off")
+	require.NoError(t, err, "output:\n%s", output)
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "media/footage.mov",
+		"with large_files off the file must be committed normally")
+}
+
+// The allowlist exempts a path permanently, in every mode.
+func TestIntegration_GuardAllowlistExemptsPath(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-allowlist")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB\n    allow:\n      - \"releases/**\"")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p releases
+		dd if=/dev/zero of=releases/camp-darwin bs=1024 count=3072 2>/dev/null
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "release binary")
+	require.NoError(t, err, "output:\n%s", output)
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "releases/camp-darwin",
+		"an allowlisted path must be staged despite its size")
+}
+
+// The campaign root always excludes submodule refs, so guard exclusions have
+// to compose with an exclusion list the caller already built.
+func TestIntegration_GuardComposesWithSubmoduleExclusions(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath, _, _ := setupFreshCampaignWithSubmodule(t, tc, "guard-submodule-compose")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p media
+		dd if=/dev/zero of=media/footage.mov bs=1024 count=3072 2>/dev/null
+		printf 'root note' > root-note.md
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "root content beside a big file")
+	require.NoError(t, err, "output:\n%s", output)
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "root-note.md",
+		"ordinary root content must commit with both exclusion sets active")
+	assert.NotContains(t, committed, "media/footage.mov",
+		"the guard exclusion must survive composition with submodule exclusions")
+}

--- a/tests/integration/status_notices_test.go
+++ b/tests/integration/status_notices_test.go
@@ -1,0 +1,147 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// statusStderr returns what camp status writes to stderr, where notices go.
+func statusStderr(t *testing.T, tc *TestContainer, campPath string) string {
+	t.Helper()
+	_, stderr, _, err := tc.RunCampSplitInDir(campPath, "status")
+	require.NoError(t, err)
+	return stderr
+}
+
+// Criterion 31b: a declared root that has never synced is the notice that
+// justifies this surface — declaring moved the bytes out of git's care, and
+// until a sync runs there is one copy of them anywhere.
+func TestIntegration_StatusNoticeNeverSynced(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "notice-never-synced")
+
+	tc.Shell(t, fmt.Sprintf(`cd %s && mkdir -p media/renders && printf 'x' > media/renders/a.bin`, campPath))
+	declareRoots(t, tc, campPath, "media/renders")
+
+	stderr := statusStderr(t, tc, campPath)
+	assert.Contains(t, stderr, "media/renders")
+	assert.Contains(t, stderr, "never synced")
+	assert.Contains(t, stderr, "camp sync --from")
+	assert.Contains(t, stderr, "camp notify dismiss",
+		"every dismissible notice must carry its own dismiss command")
+
+	// A recorded snapshot means it has left this machine; the notice stops.
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p .campaign/cache/peersync/laptop
+		printf '{"version":1,"root":"media/renders","files":[]}' > .campaign/cache/peersync/laptop/media%%2Frenders.json
+	`, campPath))
+
+	stderr = statusStderr(t, tc, campPath)
+	assert.NotContains(t, stderr, "never synced",
+		"the notice must stop after the first successful sync")
+}
+
+// Criterion 31c: a declared root absent locally is one line naming the count.
+func TestIntegration_StatusNoticeMissingLocally(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "notice-missing-local")
+	declareRoots(t, tc, campPath, "not/here", "also/absent")
+
+	stderr := statusStderr(t, tc, campPath)
+	assert.Contains(t, stderr, "2 declared artifact roots are not on this machine")
+	assert.Contains(t, stderr, "camp sync --from")
+}
+
+// Criterion 31d: zero declared roots means zero work and no change to output.
+func TestIntegration_StatusNoticeSilentWithoutRoots(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "notice-no-roots")
+
+	stderr := statusStderr(t, tc, campPath)
+	assert.NotContains(t, stderr, "artifact root")
+	assert.NotContains(t, stderr, "never synced")
+	assert.NotContains(t, stderr, "not on this machine")
+}
+
+// Criterion 31f: dismissal is per signature. Silencing one root must not
+// silence a root declared later.
+func TestIntegration_StatusNoticeDismissalIsPerSignature(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "notice-dismiss")
+
+	tc.Shell(t, fmt.Sprintf(`cd %s && mkdir -p first && printf 'x' > first/a.bin`, campPath))
+	declareRoots(t, tc, campPath, "first")
+
+	stderr := statusStderr(t, tc, campPath)
+	require.Contains(t, stderr, "first")
+
+	out, err := tc.RunCampInDir(campPath, "notify", "dismiss", "artifact-root-never-synced:first")
+	require.NoError(t, err, "output:\n%s", out)
+	assert.Contains(t, out, "Dismissed")
+	assert.Contains(t, out, "Undo: camp notify restore")
+
+	stderr = statusStderr(t, tc, campPath)
+	assert.NotContains(t, stderr, "first is a declared artifact root",
+		"the dismissed root must go quiet")
+
+	// A newly declared root has its own signature and notifies anyway.
+	tc.Shell(t, fmt.Sprintf(`cd %s && mkdir -p second && printf 'x' > second/b.bin`, campPath))
+	declareRoots(t, tc, campPath, "first", "second")
+
+	stderr = statusStderr(t, tc, campPath)
+	assert.Contains(t, stderr, "second",
+		"a newly declared root must notify despite an older dismissal")
+}
+
+// The dismissal is committed, so it travels between machines the same way the
+// declarations it concerns do.
+func TestIntegration_StatusNoticeDismissalIsCommitted(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "notice-dismiss-committed")
+	declareRoots(t, tc, campPath, "somewhere")
+
+	_, err := tc.RunCampInDir(campPath, "notify", "dismiss", "artifact-roots-missing-locally")
+	require.NoError(t, err)
+
+	content, err := tc.ReadFile(campPath + "/.campaign/notices.yaml")
+	require.NoError(t, err, "dismissals must live in a committed file, not cache")
+	assert.Contains(t, content, "artifact-roots-missing-locally")
+
+	// It is inside .campaign/, which is committed, and not under cache/.
+	exists, err := tc.CheckFileExists(campPath + "/.campaign/cache/notices.yaml")
+	require.NoError(t, err)
+	assert.False(t, exists, "dismissals must not live in machine-local cache")
+
+	out, err := tc.RunCampInDir(campPath, "notify", "list")
+	require.NoError(t, err)
+	assert.Contains(t, out, "artifact-roots-missing-locally")
+
+	// Restore brings it back.
+	_, err = tc.RunCampInDir(campPath, "notify", "restore", "artifact-roots-missing-locally")
+	require.NoError(t, err)
+	stderr := statusStderr(t, tc, campPath)
+	assert.Contains(t, stderr, "not on this machine")
+}
+
+// Criterion 31e: the backward-looking case is doctor's, never status's. A
+// deliberate gitignore is not a defect to nag about on every command.
+func TestIntegration_StatusNoticeNeverMentionsUnownedFiles(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupBigFilesCampaign(t, tc, "notice-no-bigfiles")
+
+	stderr := statusStderr(t, tc, campPath)
+	assert.NotContains(t, stderr, "media/raw/footage.mov")
+	assert.NotContains(t, stderr, "owned by no system")
+
+	// doctor still reports it, so the state is discoverable, just not here.
+	found := bigFilesFindings(t, tc, campPath)
+	assert.Contains(t, found, "media/raw/footage.mov",
+		"the state must remain discoverable through doctor")
+}


### PR DESCRIPTION
Implements phase 001 of festival `camp-artifact-commit-guardrails-CA0004`, from the WI-9ad89e design package (`workflow/design/camp-artifact-commit-updates-2026-07-25/`).

**Draft:** sequences 01 and 02 of 4 are complete. 03 (wiring the guard into `internal/git.Stage`) and 04 (doctor checks and notices) land on this branch as work continues.

## What this adds

**`internal/stageguard`** — the guard's detection core, as a leaf package.

- `ResolveLimits(ctx, repoPath)` self-loads thresholds, modes, and the allowlist from campaign and per-project config, so the staging chokepoint needs no config knowledge. This is what lets fest inherit the guard from a version bump with no fest code change.
- `CheckStaging(ctx, repoPath, limits)` enumerates what a stage-everything operation would add and returns typed violations. Stat-only: nothing is opened, read, or hashed.
- Per-file threshold (10 MiB campaign root / 25 MiB project), bulk detection (1000+ untracked files under a dominant prefix, deliberately **no** total-bytes leg), LFS exemption in every mode, allowlist globs.
- Per-file guard runs first; bulk counts only what remains, so one auto-handled 512 MB video cannot swell the batch back over the bulk trigger.
- Tracked files are never violations of the exclusion kind. Over-threshold tracked growth is a distinct `ReportOnly` kind: splitting one file's history between git and an artifact root is never correct.

It imports only `internal/errors` and `internal/config` from camp, and never `internal/git` — `internal/git` will import it in sequence 03, so the reverse edge would be a cycle. That constraint is enforced by a test rather than a one-time manual check.

**`pkg/commitkit`** — the guard surface re-exported for consumers outside the module. Type aliases, not new named types, so fest sees exactly the types the guard returns and camp never converts. `commitkit.StageAll` already existed at the shape the design specified; its godoc now states what a caller inherits for free.

**`camp artifacts add`** — acts on what it already knew instead of warning.

- Clean root: appends the ignore rule and states the consequence (content there lives outside git and syncs with `camp sync`).
- Mixed root: declaration saved, `.gitignore` never touched, tracked/untracked split reported.
- `--dry-run` previews file count, byte total, and the three-way split without writing anything.
- `--no-gitignore` opts out and retains the existing warning.

**Consolidation.** `isGitignored`/`hasTrackedFiles` moved into `internal/artifacts` so the command, doctor, and staging exclusion share one implementation. Gitignore rule editing moved to `internal/fsutil` so camp has one writer; `internal/scaffold` now delegates to it. `ui.FormatBytes`/`ui.FormatCount` added and `cmd/camp/cache` pointed at the former, which also fixes a 5 GB root rendering as "5632.0 MB".

## Notes for review

Three bugs were caught and fixed during the festival's own review gates; each is recorded with its reasoning in the sequence `05_iterate.md` documents.

- **Hardcoded `projects/` and `worktrees/`** in scope resolution. Both are campaign-configurable via `.campaign/settings/jumps.yaml`, so a campaign that renames them would have had every per-project guard override silently keyed to the wrong name. Now reads `config.CampaignPaths`.
- **`--dry-run` skipped validation.** Surveying before declaring moved the work ahead of `File.Add`, where path and policy validation live, so `camp artifacts add ../outside --dry-run` would have printed a confident report for a declaration that could never succeed.
- **Mixed-root report overstated the artifact set.** The design's `(5.5 GB)` qualifies the untracked files; the implementation printed the root's total, including tracked bytes.

One deviation from the design worth flagging: design doc 04 states `commitkit.StageAll` "does not exist yet". It does, at `pkg/commitkit/commitkit.go:164`, in exactly the specified shape — the repo moved since the doc was written. No duplicate was added.

## Verification

- `just gate` green: 3,820 tests (dev profile), 3,781 (stable), 0 lint issues in both profiles.
- Containerized integration suite: 570/570.
- 6 new containerized tests covering acceptance criteria 22, 23, and 24, with fixtures built in-container.
- Porcelain parsing verified against real `git status --porcelain=v1 -z -uall` output rather than only against authored strings — `-z` emits paths verbatim where the default format escapes them, which is why the parser asks for it.

Guard coverage is currently pure-logic only. `Enumerate`, `CheckStaging`, `ResolveLimits`, and the LFS filter have no reachable caller until sequence 03 wires them into `internal/git.Stage`; they get end-to-end coverage through `camp commit` there.

## Known unrelated issue

`internal/fsutil` flakes under full-gate load (1/3781, passes standalone and at `-count=20`). `lock_test.go` asserts on wall-clock budgets while the gate runs the stable suite at 457s CPU in 41s wall. Pre-existing and not caused by this branch — tracked separately.
