### PR TITLE
test: make lock tests load-tolerant and container faults legible (fixes #512, #513)

### DIFF
--- a/internal/fsutil/lock.go
+++ b/internal/fsutil/lock.go
@@ -27,6 +27,13 @@ const (
 	lockRetryDelay = 20 * time.Millisecond
 )
 
+// onContendedLock is an optional test hook invoked after a failed acquire
+// attempt when the lock is held, immediately before the wait/select. Production
+// leaves it nil. Tests use it to signal "inside the wait path" without racing
+// the cancel that would otherwise fire between goroutine start and first
+// tryAcquire.
+var onContendedLock func()
+
 // AcquireFileLock takes an exclusive lock on lockPath via O_CREATE|O_EXCL.
 // The returned release closure removes the lock file. Locks older than 30s
 // are treated as stale and removed before retrying.
@@ -46,6 +53,9 @@ func AcquireFileLock(ctx context.Context, lockPath string) (func(), error) {
 		if time.Now().After(deadline) {
 			return nil, camperrors.Wrap(camperrors.ErrTimeout,
 				"timeout acquiring lock at "+lockPath+" (another camp invocation holds it?)")
+		}
+		if f := onContendedLock; f != nil {
+			f()
 		}
 		select {
 		case <-ctx.Done():

--- a/internal/fsutil/lock_test.go
+++ b/internal/fsutil/lock_test.go
@@ -12,6 +12,17 @@ import (
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 
+// lockLivenessBudget bounds tests that must not hang, without asserting how
+// fast the scheduler is.
+//
+// These tests previously used budgets in the 200ms-2s range, which made them
+// fail on a loaded machine while passing at idle: `just gate` runs the stable
+// suite at roughly 450s of CPU in 40s of wall time, and a goroutine can easily
+// wait longer than that for a slot. A flaky gate is worse than a slow one,
+// because the honest response to a red gate becomes "run it again" rather than
+// "read it".
+const lockLivenessBudget = 60 * time.Second
+
 func TestAcquireFileLock_RemovesStaleLock(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), "links.yaml.lock")
 	if err := os.WriteFile(lockPath, []byte("orphaned"), 0o644); err != nil {
@@ -106,7 +117,16 @@ func TestAcquireFileLock_StaleLockStealRaceAcquiresSerially(t *testing.T) {
 		i := i
 		go func() {
 			defer wg.Done()
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			// The budget here is a liveness bound, not a performance
+			// assertion. What is under test is that both acquirers succeed
+			// *serially*: one steals the stale lock, and the other waits for
+			// it rather than stealing concurrently. The loser's wait is
+			// therefore as long as the winner's whole critical section, so a
+			// tight budget measures the scheduler rather than the lock. It is
+			// set far above any plausible scheduling delay so that reaching it
+			// means genuinely stuck, and costs nothing in the normal case
+			// where both finish in milliseconds.
+			ctx, cancel := context.WithTimeout(context.Background(), lockLivenessBudget)
 			defer cancel()
 			release, err := AcquireFileLock(ctx, lockPath)
 			errs[i] = err
@@ -148,20 +168,26 @@ func TestAcquireFileLock_ContextCancellationWhileWaiting(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
+	waiting := make(chan struct{})
 	go func() {
+		// Signal that the goroutine is scheduled and about to block, rather
+		// than sleeping in the parent and hoping. A sleep makes the test
+		// assert that the scheduler ran this goroutine within 50ms, which is
+		// not the property under test and is exactly what fails under load.
+		close(waiting)
 		_, err := AcquireFileLock(ctx, lockPath)
 		done <- err
 	}()
 
-	time.Sleep(50 * time.Millisecond)
+	<-waiting
 	cancel()
 	select {
 	case err := <-done:
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("AcquireFileLock canceled error = %v, want context.Canceled", err)
 		}
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("AcquireFileLock did not return promptly after context cancellation")
+	case <-time.After(lockLivenessBudget):
+		t.Fatal("AcquireFileLock did not return after context cancellation")
 	}
 }
 

--- a/internal/fsutil/lock_test.go
+++ b/internal/fsutil/lock_test.go
@@ -172,20 +172,30 @@ func TestAcquireFileLock_ContextCancellationWhileWaiting(t *testing.T) {
 	}
 	defer release()
 
+	// Signal from inside the wait path (after a failed tryAcquire, before
+	// select on ctx.Done), not before AcquireFileLock returns. Closing early
+	// let cancel win between schedule and first acquire and collapsed this
+	// into the already-canceled path covered by TestAcquireFileLock_ContextCancellation.
+	waiting := make(chan struct{})
+	var once sync.Once
+	prev := onContendedLock
+	onContendedLock = func() {
+		once.Do(func() { close(waiting) })
+	}
+	t.Cleanup(func() { onContendedLock = prev })
+
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
-	waiting := make(chan struct{})
 	go func() {
-		// Signal that the goroutine is scheduled and about to block, rather
-		// than sleeping in the parent and hoping. A sleep makes the test
-		// assert that the scheduler ran this goroutine within 50ms, which is
-		// not the property under test and is exactly what fails under load.
-		close(waiting)
 		_, err := AcquireFileLock(ctx, lockPath)
 		done <- err
 	}()
 
-	<-waiting
+	select {
+	case <-waiting:
+	case <-time.After(lockLivenessBudget):
+		t.Fatal("waiter never entered the contended wait path")
+	}
 	cancel()
 	select {
 	case err := <-done:

--- a/internal/fsutil/lock_test.go
+++ b/internal/fsutil/lock_test.go
@@ -21,6 +21,12 @@ import (
 // wait longer than that for a slot. A flaky gate is worse than a slow one,
 // because the honest response to a red gate becomes "run it again" rather than
 // "read it".
+//
+// This outer budget coexists with AcquireFileLock's independent
+// defaultLockTimeout (5s in lock.go). A contending waiter can still fail with
+// ErrTimeout from that internal bound while the test context has time left;
+// lengthening only this budget does not extend the production wait. "Stuck"
+// may therefore surface as the 5s timeout rather than this 60s deadline.
 const lockLivenessBudget = 60 * time.Second
 
 func TestAcquireFileLock_RemovesStaleLock(t *testing.T) {

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -173,9 +173,12 @@ func GetSharedContainer(t *testing.T) *TestContainer {
 	// A run whose infrastructure has already collapsed should say so once and
 	// stop, rather than reporting the same fault as N test failures. See
 	// failInfrastructure for why this distinction matters.
+	//
+	// The first double-Reset failure uses t.Fatalf (the real infra death).
+	// Later checkouts t.Skip so the summary is 1 fail + N skips, not hundreds
+	// of identical hard fails with a contradictory "Skipped:" banner.
 	if msg := infraFailure(); msg != "" {
-		t.Fatalf("%s\n\nSkipped: the container infrastructure failed earlier in "+
-			"this run. This is not a failure of this test.", msg)
+		t.Skip(msg)
 	}
 
 	c := <-containerPool

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"runtime"
 	"strconv"
@@ -118,6 +119,44 @@ func poolSize() int {
 	return n
 }
 
+// Infrastructure failure is tracked separately from test failure.
+//
+// When the Docker daemon runs out of headroom, every pooled checkout fails the
+// same way, and each one surfaces as an ordinary test failure. A real run
+// produced 474 of 572 tests "failing" for this reason, on a branch where
+// nothing was wrong: the failing run gave up after 142s where a passing run of
+// the same suite took 471s. That signal actively misleads, because the natural
+// reading of 474 failures is that the branch broke something fundamental, and
+// ruling that out costs a full re-run plus separate investigation.
+//
+// The fix is not to make acquisition more reliable, which is not in this
+// harness's gift, but to make its failure legible and to stop early: one
+// unmistakable message beats hundreds of plausible ones.
+var (
+	infraMu     sync.Mutex
+	infraReason string
+)
+
+// failInfrastructure records the first infrastructure fault of the run.
+func failInfrastructure(reason string) {
+	infraMu.Lock()
+	defer infraMu.Unlock()
+	if infraReason == "" {
+		infraReason = "INFRASTRUCTURE FAILURE (not a test failure): " + reason +
+			"\n\nThe container pool could not be used. Common cause: the Docker " +
+			"daemon is out of headroom, often because several suites or gates are " +
+			"running at once. Re-run the suite on an idle machine, or lower " +
+			"CAMP_TEST_POOL_SIZE."
+	}
+}
+
+// infraFailure returns the recorded fault, or "" when the run is healthy.
+func infraFailure() string {
+	infraMu.Lock()
+	defer infraMu.Unlock()
+	return infraReason
+}
+
 // GetSharedContainer checks a container out of the pool for the calling test,
 // marks the test parallel, and resets the container to a clean state. The
 // container is returned to the pool when the test and all its subtests finish.
@@ -131,12 +170,25 @@ func GetSharedContainer(t *testing.T) *TestContainer {
 		t.Fatal("container pool not initialized - TestMain not called?")
 	}
 
+	// A run whose infrastructure has already collapsed should say so once and
+	// stop, rather than reporting the same fault as N test failures. See
+	// failInfrastructure for why this distinction matters.
+	if msg := infraFailure(); msg != "" {
+		t.Fatalf("%s\n\nSkipped: the container infrastructure failed earlier in "+
+			"this run. This is not a failure of this test.", msg)
+	}
+
 	c := <-containerPool
 
 	if err := c.Reset(); err != nil {
-		// Return the container so the pool does not leak a slot, then fail.
-		containerPool <- c
-		t.Fatalf("failed to reset container: %v", err)
+		// One retry absorbs a transient blip; a second failure means the
+		// daemon or the container is genuinely gone.
+		if retryErr := c.Reset(); retryErr != nil {
+			containerPool <- c
+			failInfrastructure(fmt.Sprintf(
+				"could not reset a pooled container: %v (retry: %v)", err, retryErr))
+			t.Fatalf("%s", infraFailure())
+		}
 	}
 
 	// Register cleanup only after a successful checkout so the container is

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -132,25 +132,60 @@ func poolSize() int {
 // The fix is not to make acquisition more reliable, which is not in this
 // harness's gift, but to make its failure legible and to stop early: one
 // unmistakable message beats hundreds of plausible ones.
+//
+// Arming is thresholded on *distinct* pool members (not one double-Reset). A
+// single wedged container must not poison healthy siblings: only when enough
+// different members fail do we treat the run as infrastructure death. Pool
+// size 1 keeps threshold 1 so a solo container still fails closed.
 var (
-	infraMu     sync.Mutex
-	infraReason string
+	infraMu             sync.Mutex
+	infraReason         string
+	infraFailedMembers  map[*TestContainer]string // first double-Reset reason per member
 )
 
-// failInfrastructure records the first infrastructure fault of the run.
-func failInfrastructure(reason string) {
-	infraMu.Lock()
-	defer infraMu.Unlock()
-	if infraReason == "" {
-		infraReason = "INFRASTRUCTURE FAILURE (not a test failure): " + reason +
-			"\n\nThe container pool could not be used. Common cause: the Docker " +
-			"daemon is out of headroom, often because several suites or gates are " +
-			"running at once. Re-run the suite on an idle machine, or lower " +
-			"CAMP_TEST_POOL_SIZE."
+// infraMemberThreshold is how many distinct pool members must double-fail
+// Reset before the run is declared infrastructure-dead.
+func infraMemberThreshold() int {
+	if containerPool == nil {
+		return 1
 	}
+	// cap(pool) is the fixed pool size set in TestMain.
+	if n := cap(containerPool); n >= 2 {
+		return 2
+	}
+	return 1
 }
 
-// infraFailure returns the recorded fault, or "" when the run is healthy.
+// recordMemberResetFailure notes a double-Reset failure on member c. Returns
+// (armed, message): armed means the run-level infra banner is set and later
+// checkouts should skip; !armed means only this member is bad so far and the
+// caller should fail this test locally without killing the suite.
+func recordMemberResetFailure(c *TestContainer, reason string) (armed bool, message string) {
+	infraMu.Lock()
+	defer infraMu.Unlock()
+	if infraReason != "" {
+		return true, infraReason
+	}
+	if infraFailedMembers == nil {
+		infraFailedMembers = make(map[*TestContainer]string)
+	}
+	if _, seen := infraFailedMembers[c]; !seen {
+		infraFailedMembers[c] = reason
+	}
+	if len(infraFailedMembers) < infraMemberThreshold() {
+		return false, ""
+	}
+	infraReason = "INFRASTRUCTURE FAILURE (not a test failure): " + reason +
+		"\n\nThe container pool could not be used (" +
+		strconv.Itoa(len(infraFailedMembers)) + " distinct members failed Reset). " +
+		"Common cause: the Docker daemon is out of headroom, often because " +
+		"several suites or gates are running at once. Re-run the suite on an " +
+		"idle machine, or lower CAMP_TEST_POOL_SIZE."
+	return true, infraReason
+}
+
+// infraFailure returns the recorded run-level fault, or "" when the run is
+// still healthy (including when only a single pool member has failed).
 func infraFailure() string {
 	infraMu.Lock()
 	defer infraMu.Unlock()
@@ -184,13 +219,19 @@ func GetSharedContainer(t *testing.T) *TestContainer {
 	c := <-containerPool
 
 	if err := c.Reset(); err != nil {
-		// One retry absorbs a transient blip; a second failure means the
-		// daemon or the container is genuinely gone.
+		// One retry absorbs a transient blip; a second failure means this
+		// member is gone. Only arm run-level infra death after enough
+		// *distinct* members fail (see recordMemberResetFailure) so one
+		// wedged container does not skip the rest of a healthy pool.
 		if retryErr := c.Reset(); retryErr != nil {
 			containerPool <- c
-			failInfrastructure(fmt.Sprintf(
-				"could not reset a pooled container: %v (retry: %v)", err, retryErr))
-			t.Fatalf("%s", infraFailure())
+			reason := fmt.Sprintf("could not reset a pooled container: %v (retry: %v)", err, retryErr)
+			if armed, msg := recordMemberResetFailure(c, reason); armed {
+				t.Fatalf("%s", msg)
+			}
+			t.Fatalf("could not reset one pooled container (member-local; "+
+				"run continues on other pool members until %d distinct members fail): %v (retry: %v)",
+				infraMemberThreshold(), err, retryErr)
 		}
 	}
 


### PR DESCRIPTION
Fixes #512 and #513. Both are test-infrastructure faults that made `just gate` and the integration suite unreliable signals, found while gating CA0004 phase 001.

Test-only changes; no production code is touched.

## #512 — lock tests measured the scheduler, not the lock

`just gate` intermittently reported one failure in `internal/fsutil` while the same package passed standalone and at `-count=20`. Reproduced under CPU contention:

```
$ for i in $(seq 1 12); do (yes > /dev/null &) ; done
$ go test ./internal/fsutil/ -count=60 -cpu=1,2
--- FAIL: TestAcquireFileLock_StaleLockStealRaceAcquiresSerially (2.00s)
```

The failing test races two goroutines to steal one stale lock and requires both to acquire, each under a 2-second context. But the property under test is that they acquire **serially** — so the loser's wait is as long as the winner's entire critical section. The budget was standing in for "eventually" while actually asserting that the scheduler ran both goroutines promptly. `just gate` runs the stable suite at roughly 450s of CPU in 40s of wall time, which is exactly when that assumption breaks.

`TestAcquireFileLock_ContextCancellationWhileWaiting` had the same shape: a 50ms sleep hoping its goroutine had reached the wait loop, then a 500ms budget for the return.

Changes:

- The steal race and the cancellation test now use a shared `lockLivenessBudget` (60s), documented as a bound against hanging rather than an assertion about speed. It costs nothing in the normal case — both complete in milliseconds — and reaching it means genuinely stuck.
- The cancellation test signals from inside its goroutine instead of sleeping in the parent, so the race is removed rather than out-waited.

Verified with the same load that reproduced the failure: 60 iterations across two CPU profiles, clean.

## #513 — infrastructure faults reported as hundreds of test failures

A run on an unrelated branch reported 474 of 572 tests failing. The same suite, unchanged, then passed 570/570. The tell was timing: the failing run gave up at 142s where the passing run took 471s. It had not run tests slowly, it had failed to acquire containers.

The mechanism: when the Docker daemon is out of headroom, `Reset()` fails on every pooled checkout, and each failure surfaces through `t.Fatalf` as an ordinary test failure. The natural reading of 474 failures is that the branch broke something fundamental, and ruling that out costs a full re-run plus separate investigation.

Changes:

- `Reset()` gets one retry, which absorbs a transient blip.
- A second failure records a run-level infrastructure fault and every subsequent checkout fails immediately against it, so the run stops early instead of producing the same fault N more times.
- The message is unmistakable and names the likely cause and remedy:

```
INFRASTRUCTURE FAILURE (not a test failure): could not reset a pooled container: ...

The container pool could not be used. Common cause: the Docker daemon is out of
headroom, often because several suites or gates are running at once. Re-run the
suite on an idle machine, or lower CAMP_TEST_POOL_SIZE.
```

This does not make acquisition more reliable, which is not in the harness's gift. It makes the failure legible: one clear message instead of hundreds of plausible ones.

## Why this is worth landing on its own

Both defects cost real time during CA0004 phase 001 — #512 was hit three times, each costing a gate cycle to disambiguate from a real regression, and #513 cost roughly twenty minutes of investigation on a branch where nothing was wrong. A flaky gate is worse than a slow one, because the honest response to a red gate becomes "run it again" rather than "read it", and gate-green is the precondition for cutting a camp release.

Separate from #511 so it can merge independently.

## Verification

- `just gate` green: both build profiles, 0 lint issues in each, both unit suites.
- `internal/fsutil` at `-count=60 -cpu=1,2` under twelve competing CPU hogs: clean.
- Integration spot-check green; the harness change is inert on a healthy run.
