### PR TITLE
docs(machine): the mesh model, reachability matrix, and transfer grammar

### DIFF
--- a/cmd/camp/machine.go
+++ b/cmd/camp/machine.go
@@ -72,6 +72,21 @@ hops always use BatchMode (agents never hang on password prompts).
 'camp machine diagnose' reports auth mode, a copy-paste ssh probe, and
 ControlMaster socket state (and can clear a stale socket with --reset).
 
+The mesh model, in one paragraph: hopping exports CAMP_HOP_ORIGIN into the
+remote login shell, a single v1 line naming where the shell came from, which is
+what lets 'camp switch -' return without either machine storing state about the
+other. A payload does not register anything: if the origin is unknown here,
+camp names 'camp machine adopt', which previews and asks, requires a TTY, and
+remembers a decline. Reachability need not be symmetric -- a machine you cannot
+dial still appears in completion, because visibility travels as a snapshot
+pushed during a successful enumerate rather than as a live query. Camp will
+never install a key, register a machine unattended, or claim a host is reachable
+on the strength of tailnet membership alone.
+
+See docs/machine-mesh.md for the reachability matrix (notably: the Tailscale SSH
+server does not run in sandboxed macOS GUI builds, so a mac accepts OpenSSH keys
+instead) and docs/transfer.md for the machine-first transfer grammar.
+
 Run without a subcommand in a terminal to manage the fleet interactively: add,
 discover, edit, and remove machines, and see each one's socket state. The
 subcommands stay the interface for scripts and agents, and remain what a

--- a/cmd/camp/transfer.go
+++ b/cmd/camp/transfer.go
@@ -37,6 +37,8 @@ Machine forms (one side only; both-remote is refused):
   machine:campaign:path
                     file on a machine registered in ~/.obey/machines.yaml
 
+See docs/transfer.md for the full grammar, transport, and skew guidance.
+
 At least one side must reference a different campaign or machine. For copies
 within the same campaign on this machine, use 'camp copy' instead.`,
 	Example: `  camp transfer docs/my-doc.md other-campaign:docs/my-doc.md     # local push

--- a/docs/machine-mesh.md
+++ b/docs/machine-mesh.md
@@ -196,11 +196,15 @@ hangs:
   This is common on a fresh fleet member: a stock `go install` puts camp in `~/go/bin`,
   which a non-interactive login shell does not have on its PATH.
 - **Version skew.** If a previous `camp machine diagnose` observed a different camp version
-  on the target, hops warn once, without paying for a probe:
+  on the target, every hop warns, reading that cached result rather than paying for a
+  probe:
   ```
-  camp: camp on devbox is v0.9.1, this machine is v0.10.0; features may not match
-  (run 'camp machine diagnose devbox' to re-check)
+  camp: camp on devbox is v0.9.1, this machine is v0.10.0; features may not match (run 'camp machine diagnose devbox' to re-check)
   ```
+  It repeats on each hop by design — the condition is still true, and a warning that
+  appeared once would be missed by whoever hits the mismatch later. It stops when the
+  cache entry expires (12h) or a fresh `camp machine diagnose` finds the versions agree.
+
   The warning says only that the versions *differ*. Camp does not order them, because the
   remote is as likely to be ahead as behind.
 - **Stale visibility.** A pushed snapshot past its TTL is dropped rather than shown, so

--- a/docs/machine-mesh.md
+++ b/docs/machine-mesh.md
@@ -1,0 +1,221 @@
+# The Machine Mesh
+
+Camp can move you between machines the same way it moves you between campaigns:
+`csw devbox:notes` opens a shell in the `notes` campaign on `devbox`. This document
+describes the model that makes that safe, and what each piece degrades to when the
+network or the far machine does not cooperate.
+
+The short version: **camp never registers a machine for you, never installs a key, and
+never claims reachability it has not observed.** Everything below follows from that.
+
+## The fleet file
+
+Machines live in `~/.obey/machines.yaml`:
+
+```yaml
+version: 1
+machines:
+    - id: devbox
+      label: Dev Box
+      host: devbox.example.ts.net
+      auth_method: tailscale-ssh      # or ssh-agent
+      ssh_user: alex
+```
+
+`id` is what you type. `host` is what ssh dials. They are separate so a machine can be
+renamed without rewriting every command you have in muscle memory.
+
+## The origin payload
+
+When you hop, camp exports one environment variable into the remote login shell:
+
+```
+CAMP_HOP_ORIGIN=v1;host=devbox.example.ts.net;user=alex;campaign=notes;id=devbox
+```
+
+A single line, percent-encoded values, `v1` prefix. It answers exactly one question on
+the far side: *where did this shell come from?* That is what makes `csw -` possible
+without either machine keeping state about the other.
+
+Fields:
+
+| Field | Meaning | Absent when |
+| --- | --- | --- |
+| `host` | the origin's reachable name | never |
+| `user` | ssh user on the origin | never |
+| `campaign` | campaign the hop started in | the hop did not start inside a campaign |
+| `id` | the id derived from the origin's own reachable name | the name is empty, or the field was dropped for size |
+
+`campaign` is genuinely optional, and its absence is meaningful. Hop from your home
+directory and `csw -` will refuse, because there is no campaign to return to:
+
+```
+$ csw -
+Error: camp switch -: origin campaign unknown (the outbound hop did not start inside a
+campaign); hop back with 'camp switch <machine>:<campaign>'
+```
+
+That is the payload being honest rather than guessing.
+
+## Consent: adopt is always yours
+
+A payload tells the far machine where you came from. It does **not** register you
+there, and hop-back does not require registration — an unknown origin still works,
+built from the payload.
+
+Registration matters when the hop *fails*. Camp phrases the failure by whether it
+has a fleet row to point you at:
+
+```
+# origin is registered here
+Error: run 'camp machine diagnose devbox' to check reachability: <cause>
+
+# origin is not registered here
+Error: the origin is not registered here, probe it with: ssh -o BatchMode=yes alex@devbox.example.ts.net true; 'camp machine adopt' registers it so future hops know the way back: <cause>
+```
+
+`camp machine adopt` reads the payload, shows a preview, and asks. It requires a TTY:
+the confirm-and-write path refuses non-interactive stdin on purpose, so no script and no
+agent can add a machine to your fleet on your behalf. Declining is remembered, and the
+hint stops.
+
+Adopting a machine you already have is a no-op that says so:
+
+```
+$ camp machine adopt
+devbox.example.ts.net is already in your fleet as "devbox"; nothing to adopt
+```
+
+## The hop-back gesture
+
+`csw -` returns to the origin campaign. There is no history file and no daemon: the
+gesture is stateless by construction, which is why it survives a machine reboot on
+either end and why it cannot drift.
+
+It is registration-*independent*, not fleet-blind. Camp looks for a `machines.yaml` row
+whose host matches the payload's, so your own `ssh_user`, `identity_file`, and
+`auth_method` win when you have registered that machine; with no match it builds a
+transient machine from the payload alone.
+
+If the origin is unreachable, the failure explains and points at the diagnostic rather
+than reporting a bare exit code:
+
+```
+$ csw -
+Error: run 'camp machine diagnose devbox' to check reachability: could not resolve
+"notes" on devbox: ... SSH permission denied (publickey) — check ssh-agent keys
+(`ssh-add -l`), identity_file, remote authorized_keys, and ssh_user …
+```
+
+(Abbreviated; the live classification continues with Tailscale SSH guidance.)
+
+## Self-reference resolves locally
+
+`csw devbox:notes` *on devbox* does not ssh to itself. Camp derives an id from this
+machine's own reachable name — character for character the derivation that fills the
+payload's `id` field — and resolves locally when it matches the selector:
+
+```
+$ camp switch devbox:no --print
+Matched: no -> notes
+/home/alex/campaigns/notes
+```
+
+A registered machine still wins: if the selector's id is in your `machines.yaml`, camp
+honors that mapping and hops, on the principle that an explicit operator entry outranks
+detection. Listing your own machine under its real id therefore suppresses local
+resolution — `local` is the implicit id for this machine and does not belong in the file.
+
+This matters more than it looks. Without it, a command that is correct everywhere becomes
+a hang or a self-ssh on exactly one machine in your fleet, which is the machine you are
+most likely to be sitting at.
+
+## Visibility without reachability
+
+The mesh does not require symmetric SSH. A machine that can reach you but that you cannot
+reach still shows up usefully, because visibility travels as a **pushed snapshot** rather
+than a live query.
+
+When machine A successfully enumerates machine B, it also pushes its own campaign-name
+list to B. B can then complete `csw A:<tab>` without ever dialing A:
+
+```
+$ camp __complete switch devbox:no
+devbox:notes
+devbox:notebook
+```
+
+Pushed entries carry `source=push` and a 24h TTL. A live-queried entry gets 60s, because
+it can be refreshed on demand and a pushed one cannot.
+
+## Reachability matrix
+
+Rows are the transport on the *target* machine. "Forward hop" is you dialing it;
+"reverse hop" is it dialing you; "visibility" is whether its campaign names appear in
+your completion.
+
+| Target transport | Target platform | Forward hop | Reverse hop | Visibility |
+| --- | --- | --- | --- | --- |
+| Tailscale SSH | Linux | yes | yes | live query |
+| Tailscale SSH | macOS | **no** — see below | yes | pushed snapshot only |
+| OpenSSH + key | Linux | yes, once the key is installed | yes | live query |
+| OpenSSH + key | macOS | yes, once the key is installed | yes | live query |
+| any | offline / asleep | fails, bounded | n/a | last snapshot, until TTL |
+
+**The macOS Tailscale SSH cell is the one that surprises people.** The Tailscale SSH
+*server* does not run in sandboxed Tailscale GUI builds, which is what the App Store and
+standard macOS app are:
+
+```
+$ tailscale set --ssh
+The Tailscale SSH server does not run in sandboxed Tailscale GUI builds.
+```
+
+So a mac can Tailscale-SSH *out* but cannot accept Tailscale SSH *in*. To reach a mac you
+either install standalone `tailscaled`, or add a key to its `~/.ssh/authorized_keys` and
+use `auth_method: ssh-agent`. Camp will diagnose this and refuse to fix it: installing a
+credential on a machine is your explicit act.
+
+Until you do, the mesh still works in the direction that is available, and the mac's
+campaign names still reach the other machine by push.
+
+## Degradation
+
+Every cell above that says "no" degrades to something that explains, not something that
+hangs:
+
+- **Unreachable target.** Bounded probe, then the diagnose pointer. `camp machine diagnose`
+  reports the socket state, the exact probe command it ran, whether camp is present on the
+  far side, and whether *this* machine is accepting connections.
+- **camp missing on the far side.** Named explicitly, with the variable that fixes it:
+  ```
+  remote camp not found on devbox (tried "camp" via sh -lc, i.e. the machine's
+  login-shell PATH); if camp lives outside that PATH, set CAMP_REMOTE_CAMP_PATH to its
+  exact path on that machine
+  ```
+  This is common on a fresh fleet member: a stock `go install` puts camp in `~/go/bin`,
+  which a non-interactive login shell does not have on its PATH.
+- **Version skew.** If a previous `camp machine diagnose` observed a different camp version
+  on the target, hops warn once, without paying for a probe:
+  ```
+  camp: camp on devbox is v0.9.1, this machine is v0.10.0; features may not match
+  (run 'camp machine diagnose devbox' to re-check)
+  ```
+  The warning says only that the versions *differ*. Camp does not order them, because the
+  remote is as likely to be ahead as behind.
+- **Stale visibility.** A pushed snapshot past its TTL is dropped rather than shown, so
+  completion is never confidently wrong.
+
+## What camp will not do
+
+- Install, copy, or generate an SSH key.
+- Register a machine without an interactive confirmation.
+- Enable a remote login service.
+- Claim a machine is reachable on the strength of tailnet membership. Being on the same
+  tailnet is not being logged in, and camp says so in its hints.
+
+## See also
+
+- `camp machine --help` — the command surface
+- `camp machine diagnose <id>` — the one command to run when a hop fails
+- [transfer.md](./transfer.md) — moving files across the mesh

--- a/docs/transfer.md
+++ b/docs/transfer.md
@@ -1,0 +1,129 @@
+# Transfer
+
+`camp transfer` copies a file between campaigns, including campaigns on another machine.
+
+```
+camp transfer <source> <destination> [--force]
+```
+
+Both endpoints use the same grammar, and either one may be remote — but not both.
+
+## The grammar
+
+An endpoint is up to three colon-separated parts:
+
+```
+                    notes.md              # a path in the current campaign
+           mycampaign:notes.md            # a path in another local campaign
+   devbox:mycampaign:notes.md             # a path in a campaign on another machine
+```
+
+Camp reads the leading segment as a **machine id first**, and only if that id is in your
+`~/.obey/machines.yaml`. On a machine with no fleet configured the machine reading is
+unreachable, so every pre-existing form keeps its old meaning exactly.
+
+A machine endpoint requires all three parts. Naming a machine without a campaign is an
+error rather than a guess:
+
+```
+$ camp transfer devbox:notes.md .
+Error: "devbox" is a machine; use machine:campaign:path (for example devbox:<campaign>:notes.md)
+```
+
+### Shadowing, and the `local:` escape
+
+If a campaign happens to share a name with a registered machine, the machine wins — and
+camp tells you, every time, because the ambiguity is in the command you just typed:
+
+```
+$ camp transfer devbox:notes:file.md .
+camp: devbox is a registered machine; reading it as machine:campaign:path (use local:devbox:... for the campaign)
+```
+
+`local:` forces the campaign reading:
+
+```
+$ camp transfer local:devbox:file.md .
+```
+
+The note fires on every invocation rather than once per session. A silently different
+reading on the second run is precisely what it exists to prevent.
+
+## Copy semantics
+
+Transfer is a **copy**. The source is never modified, moved, or removed.
+
+**The destination is never overwritten without `--force`.** This holds on every path,
+including the scp fallback described below:
+
+```
+$ camp transfer notes.md devbox:mycampaign:notes.md
+Transferred notes.md -> devbox:mycampaign:notes.md
+
+$ camp transfer notes.md devbox:mycampaign:notes.md
+Error: destination exists on devbox, not overwritten (use --force)
+
+$ camp transfer notes.md devbox:mycampaign:notes.md --force
+Transferred notes.md -> devbox:mycampaign:notes.md
+```
+
+Camp reports "Transferred" only when bytes actually moved. A skipped copy is never
+reported as a success.
+
+## Transport
+
+Remote transfers prefer **rsync over ssh**, reusing the same ControlMaster socket the rest
+of camp uses, so a transfer right after a hop costs no new handshake. rsync gives the
+no-clobber guarantee directly via `--ignore-existing`.
+
+If the far machine has no rsync, camp falls back to **scp**. scp has no portable
+no-clobber flag, so camp looks before it copies: a stat for a local destination, one
+`ssh … test -e` for a remote one. A probe that fails for any reason other than "not there"
+is an error, never permission to overwrite.
+
+If neither is available the error names both:
+
+```
+Error: rsync not found on devbox and scp not found locally; install rsync on both
+machines, or scp on this one
+```
+
+Transfers are bounded by a stall timeout rather than a wall-clock deadline. A slow link on
+a large file is still making progress; a dead connection is not, and that is the distinction
+worth acting on.
+
+## Both endpoints remote
+
+Refused:
+
+```
+$ camp transfer devbox:a:f.md buildhost:b:f.md
+Error: at most one endpoint may be on another machine (got devbox and buildhost)
+```
+
+Brokering the copy would need the two far machines to reach each other, which camp
+cannot observe from here and therefore will not promise. Run the transfer from one
+of them.
+
+## Version skew
+
+If a previous `camp machine diagnose` saw a different camp version on the far machine,
+transfers and hops warn:
+
+```
+camp: camp on devbox is v0.9.1, this machine is v0.10.0; features may not match (run 'camp machine diagnose devbox' to re-check)
+```
+
+(One line on stderr; wrapped here only if your terminal is narrow.)
+
+Endpoint grammar is parsed **locally**, so a skewed remote does not change how your command
+is read. What can differ is the remote's own behavior once camp there takes over — which is
+why the warning points at `diagnose` rather than trying to reconcile anything itself.
+
+Update the far machine when you see this. There is no automatic remote update: camp does not
+install software on your machines.
+
+## See also
+
+- [machine-mesh.md](./machine-mesh.md) — the mesh model, consent, and the reachability matrix
+- `camp machine diagnose <id>` — when a transfer fails on reachability


### PR DESCRIPTION
Closes the documentation half of MN0001's 007_DOCS_CLOSE. Stacked on #509.

## What

- `docs/machine-mesh.md` — origin payload, the consent model behind `camp machine adopt`, the hop-back gesture, self-reference, visibility-without-reachability, and the reachability matrix with a degradation story per cell.
- `docs/transfer.md` — machine-first grammar, the shadowing note and `local:` escape, copy-only semantics, rsync/scp transport and the no-clobber contract, both-remote refusal, skew guidance.
- `camp machine` long help — the model in one paragraph, pointing at both.

## Written against observed behavior, not the specs

Every claim comes from the 006_FLEET_GATE run on a real two-machine fleet at `mesh-gate 775d0eab`. Two findings the specs did not predict are now documented:

**The Tailscale SSH server does not run in sandboxed macOS GUI builds.**

```
$ tailscale set --ssh
The Tailscale SSH server does not run in sandboxed Tailscale GUI builds.
```

So a mac Tailscale-SSHes *out* but cannot accept it *in*; reaching a mac means an OpenSSH key. That cell is in the matrix rather than left for the next person to rediscover.

**A stock `go install` leaves camp off the non-interactive login PATH** on both macOS zsh and Arch bash, so every cross-machine call fails until `CAMP_REMOTE_CAMP_PATH` is set. Documented under degradation, with camp's own error quoted since it names the fix.

## Conventions

No real fleet ids or personal campaigns; examples use `devbox`/`notes` per campaign standards.

## Verification

`just lint` 0 issues, `cmd/camp` tests pass, `camp machine --help` renders correctly.