### PR TITLE
fix: preserve divergent default branch during fresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ camp pull all              # Pull all submodules
 camp status                # Show git status of the campaign
 camp status all            # Dashboard of all submodules (branch, dirty/clean, push status, unmerged branches)
 camp status all --view     # Interactive TUI viewer with per-repo detail
-camp fresh                 # Post-merge branch cycling: checkout default, pull, prune, optional new branch
+camp fresh                 # Post-merge branch cycling: fetch, safely sync default, prune, optional new branch
 camp fresh all             # Same cycle across every project in the campaign
 ```
 

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -1292,8 +1292,9 @@ Post-merge branch cycling: sync to default branch and optionally create a new wo
 
 Reset one or more projects to a fresh state after merging a PR.
 
-Performs the post-merge cycle: checkout default branch, pull latest,
-prune merged branches, and optionally create a new working branch.
+Performs the post-merge cycle: checkout the default branch, fetch origin,
+sync to the remote default while preserving local-only commits, prune merged
+branches, and optionally create a new working branch.
 
 Auto-detects the current project from your working directory, or accepts a
 single project name. Use --list to cycle a specific set of projects in one
@@ -1306,7 +1307,7 @@ cycle succeeds. Manage those with 'camp fresh configure'. Inspect the resolved
 sequence with 'camp fresh show-workflow [project-name]'.
 
 Examples:
-  camp fresh                            # Sync current project (checkout default, pull, prune)
+  camp fresh                            # Sync current project (checkout default, fetch, prune)
   camp fresh --branch develop           # Sync and create develop branch
   camp fresh camp -b feat/new-thing     # Sync camp project, create feature branch
   camp fresh --list camp,fest,festival  # Sync a specific set of projects
@@ -1345,7 +1346,7 @@ Run fresh across all project submodules
 
 ### Synopsis
 
-Run the fresh cycle (checkout default, pull, prune, optional branch)
+Run the fresh cycle (fetch and safely sync default, prune, optional branch)
 across every project submodule in the campaign.
 
 Examples:
@@ -1390,7 +1391,7 @@ per-project overrides.
 Run without a subcommand to open the interactive setup for humans, which
 groups the fresh sequence by what you can change about each step:
 
-  Sync        checkout, pull, and safety checks; always runs
+  Sync        checkout, fetch, and safe default-branch realignment; always runs
   Settings    branch, push_upstream, prune, and prune_remote
   Follow-ups  your own commands, run after a successful cycle
 

--- a/docs/cli-reference/camp_fresh.md
+++ b/docs/cli-reference/camp_fresh.md
@@ -6,8 +6,9 @@ Post-merge branch cycling: sync to default branch and optionally create a new wo
 
 Reset one or more projects to a fresh state after merging a PR.
 
-Performs the post-merge cycle: checkout default branch, pull latest,
-prune merged branches, and optionally create a new working branch.
+Performs the post-merge cycle: checkout the default branch, fetch origin,
+sync to the remote default while preserving local-only commits, prune merged
+branches, and optionally create a new working branch.
 
 Auto-detects the current project from your working directory, or accepts a
 single project name. Use --list to cycle a specific set of projects in one
@@ -20,7 +21,7 @@ cycle succeeds. Manage those with 'camp fresh configure'. Inspect the resolved
 sequence with 'camp fresh show-workflow [project-name]'.
 
 Examples:
-  camp fresh                            # Sync current project (checkout default, pull, prune)
+  camp fresh                            # Sync current project (checkout default, fetch, prune)
   camp fresh --branch develop           # Sync and create develop branch
   camp fresh camp -b feat/new-thing     # Sync camp project, create feature branch
   camp fresh --list camp,fest,festival  # Sync a specific set of projects

--- a/docs/cli-reference/camp_fresh_all.md
+++ b/docs/cli-reference/camp_fresh_all.md
@@ -4,7 +4,7 @@ Run fresh across all project submodules
 
 ### Synopsis
 
-Run the fresh cycle (checkout default, pull, prune, optional branch)
+Run the fresh cycle (fetch and safely sync default, prune, optional branch)
 across every project submodule in the campaign.
 
 Examples:

--- a/docs/cli-reference/camp_fresh_configure.md
+++ b/docs/cli-reference/camp_fresh_configure.md
@@ -11,7 +11,7 @@ per-project overrides.
 Run without a subcommand to open the interactive setup for humans, which
 groups the fresh sequence by what you can change about each step:
 
-  Sync        checkout, pull, and safety checks; always runs
+  Sync        checkout, fetch, and safe default-branch realignment; always runs
   Settings    branch, push_upstream, prune, and prune_remote
   Follow-ups  your own commands, run after a successful cycle
 

--- a/internal/commands/fresh/all.go
+++ b/internal/commands/fresh/all.go
@@ -17,7 +17,7 @@ func newAllCommand(freshCmd *cobra.Command) *cobra.Command {
 	return &cobra.Command{
 		Use:   "all",
 		Short: "Run fresh across all project submodules",
-		Long: `Run the fresh cycle (checkout default, pull, prune, optional branch)
+		Long: `Run the fresh cycle (fetch and safely sync default, prune, optional branch)
 across every project submodule in the campaign.
 
 Examples:

--- a/internal/commands/fresh/configure.go
+++ b/internal/commands/fresh/configure.go
@@ -31,7 +31,7 @@ per-project overrides.
 Run without a subcommand to open the interactive setup for humans, which
 groups the fresh sequence by what you can change about each step:
 
-  Sync        checkout, pull, and safety checks; always runs
+  Sync        checkout, fetch, and safe default-branch realignment; always runs
   Settings    branch, push_upstream, prune, and prune_remote
   Follow-ups  your own commands, run after a successful cycle
 

--- a/internal/commands/fresh/configure_tui_update.go
+++ b/internal/commands/fresh/configure_tui_update.go
@@ -97,7 +97,7 @@ func (m *followUpTUIModel) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // activateSelectedStep opens the editor that fits the row under the cursor.
 // Rows with nothing to configure explain themselves rather than failing: the
 // pane already groups them under a header that says so, and a red error for
-// pressing enter on "Pull" would be noise.
+// pressing enter on "Sync default branch" would be noise.
 func (m *followUpTUIModel) activateSelectedStep() (tea.Model, tea.Cmd) {
 	step, ok := m.selectedStep()
 	if !ok {

--- a/internal/commands/fresh/configure_tui_view.go
+++ b/internal/commands/fresh/configure_tui_view.go
@@ -453,7 +453,7 @@ func (m *followUpTUIModel) overlayView() string {
 		}
 		body = []string{
 			freshTUITitleStyle.Render(title + " · " + workflowScopeLabel(scopeProjectName(m.selectedScope()))),
-			freshMuted.Render("This command runs after checkout, pull, prune, and branch setup."),
+			freshMuted.Render("This command runs after default-branch sync, prune, and branch setup."),
 		}
 		if note := m.forkNotice(); note != "" {
 			body = append(body, freshMuted.Render(note))

--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -45,8 +45,9 @@ func NewFreshCommand() *cobra.Command {
 		Short: "Post-merge branch cycling: sync to default branch and optionally create a new working branch",
 		Long: `Reset one or more projects to a fresh state after merging a PR.
 
-Performs the post-merge cycle: checkout default branch, pull latest,
-prune merged branches, and optionally create a new working branch.
+Performs the post-merge cycle: checkout the default branch, fetch origin,
+sync to the remote default while preserving local-only commits, prune merged
+branches, and optionally create a new working branch.
 
 Auto-detects the current project from your working directory, or accepts a
 single project name. Use --list to cycle a specific set of projects in one
@@ -59,7 +60,7 @@ cycle succeeds. Manage those with 'camp fresh configure'. Inspect the resolved
 sequence with 'camp fresh show-workflow [project-name]'.
 
 Examples:
-  camp fresh                            # Sync current project (checkout default, pull, prune)
+  camp fresh                            # Sync current project (checkout default, fetch, prune)
   camp fresh --branch develop           # Sync and create develop branch
   camp fresh camp -b feat/new-thing     # Sync camp project, create feature branch
   camp fresh --list camp,fest,festival  # Sync a specific set of projects
@@ -232,31 +233,12 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 		return err
 	}
 
-	if syncState.detached {
-		note := freshSyncWorktreeNote(syncState)
-		if opts.dryRun {
-			fmt.Printf("%s── Would fetch %-22s %s\n", prefix, "origin",
-				freshStepDim.Render(fmt.Sprintf("(for %s)", syncState.baseRef)))
-			fmt.Printf("%s── Would use %-24s %s\n", prefix, syncState.displayRef,
-				freshStepDim.Render(note))
-		} else {
-			if err := git.FetchRemote(ctx, path, "origin"); err != nil {
-				return camperrors.Wrap(err, "fetch origin")
-			}
-			fmt.Printf("%s── Fetch %-28s %s\n", prefix, "origin", freshStepGreen.Render("done"))
-
-			if err := git.CheckoutDetached(ctx, path, syncState.baseRef); err != nil {
-				return camperrors.Wrapf(err, "checkout detached %s", syncState.baseRef)
-			}
-			fmt.Printf("%s── Checkout %-25s %s\n", prefix, syncState.displayRef,
-				freshStepGreen.Render("done")+" "+freshStepDim.Render(note))
-		}
-	} else if currentBranch == defaultBranch && !syncState.reclaimed {
+	if !syncState.detached && currentBranch == defaultBranch && !syncState.reclaimed {
 		fmt.Printf("%s── Checkout %-24s %s\n", prefix, defaultBranch, freshStepDim.Render("already on it"))
-	} else if opts.dryRun {
+	} else if !syncState.detached && opts.dryRun {
 		fmt.Printf("%s── Would checkout %-19s %s\n", prefix, defaultBranch,
 			freshStepDim.Render(fmt.Sprintf("(currently on %s)", emptyBranchLabel(currentBranch))))
-	} else {
+	} else if !syncState.detached {
 		if err := git.Checkout(ctx, path, defaultBranch); err != nil {
 			// Surface a clearer message than git's raw "already used by worktree".
 			if isBranchInUseByWorktree(err) {
@@ -270,10 +252,10 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 		fmt.Printf("%s── Checkout %-24s %s\n", prefix, defaultBranch, freshStepGreen.Render("done"))
 	}
 
-	// Capture the default branch SHA before the pull so the tier-2 backstop can
+	// Capture the sync base SHA before fetching so the tier-2 backstop can
 	// scan commits newly reachable from the default branch after prune (the
 	// pruned branch refs themselves are gone by the time prune returns).
-	beforeSHAOut, beforeSHAErr := git.Output(ctx, path, "rev-parse", "HEAD")
+	beforeSHAOut, beforeSHAErr := git.Output(ctx, path, "rev-parse", syncState.baseRef)
 	beforeSHA := strings.TrimSpace(beforeSHAOut)
 	if beforeSHAErr != nil || beforeSHA == "" {
 		// Best-effort: without a pre-pull HEAD the tier-2 commit-tag scan is
@@ -283,39 +265,47 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 			"  merged-branch backstop: could not capture pre-pull HEAD for %s; commit-tag scan skipped (%v)", name, beforeSHAErr)))
 	}
 
-	// Step 2: Pull (ff-only)
-	if !syncState.detached {
+	// Step 2: Fetch once, then either sync detached at origin/<default> or
+	// reconcile the checked-out local default branch. When local commits exist,
+	// reconciliation first creates a recovery branch and only then resets.
+	if err := fetchFreshRemote(ctx, path, opts.prune); err != nil {
+		return camperrors.Wrap(err, "fetch origin")
+	}
+	fetchDetail := freshStepGreen.Render("done")
+	if opts.dryRun {
+		fetchDetail += " " + freshStepDim.Render("(remote refs only)")
+	}
+	fmt.Printf("%s── Fetch %-28s %s\n", prefix, "origin", fetchDetail)
+
+	if syncState.detached {
+		note := freshSyncWorktreeNote(syncState)
 		if opts.dryRun {
-			fmt.Printf("%s── Would pull (ff-only)\n", prefix)
+			fmt.Printf("%s── Would use %-24s %s\n", prefix, syncState.displayRef,
+				freshStepDim.Render(note))
 		} else {
-			output, err := git.PullFFOnly(ctx, path)
-			if err != nil {
-				return camperrors.Wrapf(err, "pull failed — resolve manually")
+			if err := git.CheckoutDetached(ctx, path, syncState.baseRef); err != nil {
+				return camperrors.Wrapf(err, "checkout detached %s", syncState.baseRef)
 			}
-			detail := "up-to-date"
-			if !strings.Contains(output, "Already up to date") {
-				detail = "updated"
-			}
-			fmt.Printf("%s── Pull (ff-only)                  %s\n", prefix, freshStepGreen.Render(detail))
+			fmt.Printf("%s── Checkout %-25s %s\n", prefix, syncState.displayRef,
+				freshStepGreen.Render("done")+" "+freshStepDim.Render(note))
+		}
+	} else {
+		if err := reconcileFreshDefault(ctx, path, defaultBranch, opts.dryRun, prefix); err != nil {
+			return err
 		}
 	}
 
 	// Step 3: Prune merged and gone-upstream branches.
-	// Prune flow itself refreshes remote tracking (RefreshRemote below),
-	// so squash-merged PRs show up here without requiring the user to run
-	// 'git fetch --prune' first.
+	// Step 2 already refreshed and pruned remote tracking refs, so prune does
+	// not perform a second network fetch.
 	if opts.prune {
 		pruneOpts := prune.Options{
-			DryRun:       opts.dryRun,
-			Force:        true,  // Skip confirmation — fresh is deliberate
-			DiscardDirty: false, // preserve dirty worktrees (new guard); fresh should not destroy uncommitted work
-			Remote:       opts.pruneRemote,
-			// Refresh even on dry-run: 'git fetch --prune' only updates
-			// remote-tracking refs, not the worktree, so the dry-run
-			// preview must include it or squash-merged branches stay
-			// invisible until the user fetches manually.
+			DryRun:        opts.dryRun,
+			Force:         true,  // Skip confirmation — fresh is deliberate
+			DiscardDirty:  false, // preserve dirty worktrees (new guard); fresh should not destroy uncommitted work
+			Remote:        opts.pruneRemote,
 			BaseRef:       syncState.baseRef,
-			RefreshRemote: true,
+			RefreshRemote: false,
 		}
 		// Reclaiming the default branch detaches its former worktree. Preserve
 		// that exact worktree during this prune pass: fresh created the detached
@@ -418,7 +408,7 @@ func executeFresh(ctx context.Context, name, path string, opts freshOptions) err
 	// Summary
 	fmt.Println()
 	if opts.dryRun {
-		fmt.Println(freshStepDim.Render("  (dry-run — no changes made)"))
+		fmt.Println(freshStepDim.Render("  (dry-run — remote refs refreshed; no local branches or files changed)"))
 	} else if branchCreated {
 		fmt.Printf("  %s Ready to work on %s.\n", freshStepGreen.Render("Fresh!"), ui.Value(opts.branch))
 	} else if syncState.detached {

--- a/internal/commands/fresh/reconcile.go
+++ b/internal/commands/fresh/reconcile.go
@@ -1,0 +1,139 @@
+package fresh
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git"
+)
+
+const (
+	freshRecoveryPrefix = "camp-fresh-recovery-"
+	freshRecoverySHALen = 12
+)
+
+// fetchFreshRemote refreshes origin once for both default-branch sync and the
+// later prune pass. A dry-run intentionally refreshes remote-tracking refs so
+// its plan is based on current remote truth; it still does not move local refs.
+func fetchFreshRemote(ctx context.Context, path string, pruneEnabled bool) error {
+	if pruneEnabled {
+		return git.FetchRemotePrune(ctx, path, "origin")
+	}
+	return git.FetchRemote(ctx, path, "origin")
+}
+
+// reconcileFreshDefault makes a checked-out local default branch match its
+// fetched origin ref. Local-only commits are first anchored by a recovery
+// branch, which makes the subsequent hard reset lossless and reversible.
+func reconcileFreshDefault(ctx context.Context, path, defaultBranch string, dryRun bool, prefix string) error {
+	localRef := "refs/heads/" + defaultBranch
+	remoteRef := "refs/remotes/origin/" + defaultBranch
+
+	if _, err := git.Output(ctx, path, "rev-parse", "--verify", remoteRef); err != nil {
+		return camperrors.Wrapf(err, "verify %s", remoteRef)
+	}
+
+	divergence, err := git.CompareRefs(ctx, path, localRef, remoteRef)
+	if err != nil {
+		return camperrors.Wrap(err, "compare local and remote default branches")
+	}
+
+	if divergence.Ahead == 0 {
+		if divergence.Behind == 0 {
+			fmt.Printf("%s── Sync %-29s %s\n", prefix, defaultBranch+" <- origin/"+defaultBranch,
+				freshStepDim.Render("up-to-date"))
+			return nil
+		}
+		if dryRun {
+			fmt.Printf("%s── Would fast-forward %-19s %s\n", prefix, defaultBranch,
+				freshStepDim.Render(fmt.Sprintf("(%d commit(s) from origin/%s)", divergence.Behind, defaultBranch)))
+			return nil
+		}
+		if err := git.FastForwardTo(ctx, path, remoteRef); err != nil {
+			return camperrors.Wrapf(err, "fast-forward %s to origin/%s", defaultBranch, defaultBranch)
+		}
+		fmt.Printf("%s── Sync %-29s %s\n", prefix, defaultBranch+" <- origin/"+defaultBranch,
+			freshStepGreen.Render(fmt.Sprintf("updated %d commit(s)", divergence.Behind)))
+		return nil
+	}
+
+	oldTip, err := git.Output(ctx, path, "rev-parse", "--verify", localRef)
+	if err != nil {
+		return camperrors.Wrapf(err, "resolve local %s tip", defaultBranch)
+	}
+	recoveryBranch, reuse, err := selectFreshRecoveryBranch(ctx, path, oldTip)
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		action := "Would preserve"
+		if reuse {
+			action = "Recovery exists"
+		}
+		fmt.Printf("%s── %-14s %-21s %s\n", prefix, action, recoveryBranch,
+			freshStepDim.Render(fmt.Sprintf("(%d local-only commit(s))", divergence.Ahead)))
+		fmt.Printf("%s── Would realign %-22s %s\n", prefix, defaultBranch,
+			freshStepDim.Render("to origin/"+defaultBranch))
+		return nil
+	}
+
+	if !reuse {
+		if err := git.CreateBranchRef(ctx, path, recoveryBranch, oldTip); err != nil {
+			return camperrors.Wrapf(err, "preserve local %s at %s", defaultBranch, recoveryBranch)
+		}
+	}
+	status := freshStepGreen.Render("done")
+	if reuse {
+		status = freshStepDim.Render("already preserved")
+	}
+	fmt.Printf("%s── Preserve %-25s %s %s\n", prefix, recoveryBranch, status,
+		freshStepDim.Render(fmt.Sprintf("(%d local-only commit(s))", divergence.Ahead)))
+
+	if err := git.ResetHardTo(ctx, path, remoteRef); err != nil {
+		return camperrors.Wrapf(err,
+			"realign %s to origin/%s; local commits remain at %s", defaultBranch, defaultBranch, recoveryBranch)
+	}
+	fmt.Printf("%s── Realign %-26s %s\n", prefix, defaultBranch+" -> origin/"+defaultBranch,
+		freshStepGreen.Render("done"))
+	fmt.Printf("%s   %s\n", prefix, freshStepDim.Render(freshRecoveryUndo(defaultBranch, recoveryBranch)))
+	return nil
+}
+
+// selectFreshRecoveryBranch returns a deterministic available recovery branch.
+// If the base candidate already points to oldTip it is reused, making retries
+// idempotent. A conflicting candidate receives a numeric suffix.
+func selectFreshRecoveryBranch(ctx context.Context, path, oldTip string) (branch string, reuse bool, err error) {
+	base := freshRecoveryBranchBase(oldTip)
+	for suffix := 1; suffix <= 1000; suffix++ {
+		candidate := base
+		if suffix > 1 {
+			candidate = fmt.Sprintf("%s-%d", base, suffix)
+		}
+		if !git.BranchExists(ctx, path, candidate) {
+			return candidate, false, nil
+		}
+		tip, resolveErr := git.Output(ctx, path, "rev-parse", "--verify", "refs/heads/"+candidate)
+		if resolveErr != nil {
+			return "", false, camperrors.Wrapf(resolveErr, "resolve recovery branch %s", candidate)
+		}
+		if strings.TrimSpace(tip) == strings.TrimSpace(oldTip) {
+			return candidate, true, nil
+		}
+	}
+	return "", false, camperrors.New("could not allocate a recovery branch after 1000 attempts")
+}
+
+func freshRecoveryBranchBase(sha string) string {
+	sha = strings.TrimSpace(sha)
+	if len(sha) > freshRecoverySHALen {
+		sha = sha[:freshRecoverySHALen]
+	}
+	return freshRecoveryPrefix + sha
+}
+
+func freshRecoveryUndo(defaultBranch, recoveryBranch string) string {
+	return fmt.Sprintf("Undo: git switch %s && git reset --hard %s", defaultBranch, recoveryBranch)
+}

--- a/internal/commands/fresh/sync_state_test.go
+++ b/internal/commands/fresh/sync_state_test.go
@@ -6,6 +6,21 @@ import (
 	"testing"
 )
 
+func TestFreshRecoveryBranchBase(t *testing.T) {
+	got := freshRecoveryBranchBase("1c00a37a0247b1474ee2c5a4f3ccd13c7d876909")
+	if want := "camp-fresh-recovery-1c00a37a0247"; got != want {
+		t.Fatalf("freshRecoveryBranchBase() = %q, want %q", got, want)
+	}
+}
+
+func TestFreshRecoveryUndo(t *testing.T) {
+	got := freshRecoveryUndo("main", "camp-fresh-recovery-1c00a37a0247")
+	want := "Undo: git switch main && git reset --hard camp-fresh-recovery-1c00a37a0247"
+	if got != want {
+		t.Fatalf("freshRecoveryUndo() = %q, want %q", got, want)
+	}
+}
+
 func TestSameWorktreePath(t *testing.T) {
 	if !sameWorktreePath("/a/b", "/a/b") {
 		t.Error("identical paths should match")

--- a/internal/commands/fresh/workflow.go
+++ b/internal/commands/fresh/workflow.go
@@ -104,7 +104,7 @@ func buildFreshWorkflow(cfg *config.FreshConfig, projectName string) []freshWork
 	steps := []freshWorkflowStep{
 		{Title: "Safety checks", Detail: "no merge/rebase in progress; worktree is clean", Enabled: true},
 		{Title: "Checkout default branch", Detail: "reclaim default branch from a clean worktree if needed, then check it out (detached origin/ fallback when dirty)", Enabled: true},
-		{Title: "Pull", Detail: "fast-forward only", Enabled: true},
+		{Title: "Sync default branch", Detail: "fetch origin; preserve local-only commits before realigning", Enabled: true},
 	}
 
 	steps = append(steps,

--- a/internal/git/reconcile.go
+++ b/internal/git/reconcile.go
@@ -1,0 +1,51 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// RefDivergence reports how many commits are unique to each side of a ref
+// comparison. Ahead is unique to localRef; Behind is unique to remoteRef.
+type RefDivergence struct {
+	Ahead  int
+	Behind int
+}
+
+// CompareRefs compares two refs without changing either one.
+func CompareRefs(ctx context.Context, repoPath, localRef, remoteRef string) (RefDivergence, error) {
+	output, err := RunGitCmd(ctx, repoPath, "rev-list", "--left-right", "--count", localRef+"..."+remoteRef)
+	if err != nil {
+		return RefDivergence{}, err
+	}
+
+	var divergence RefDivergence
+	if _, err := fmt.Sscanf(output, "%d %d", &divergence.Ahead, &divergence.Behind); err != nil {
+		return RefDivergence{}, camperrors.Wrapf(err,
+			"parse divergence between %s and %s: %s", localRef, remoteRef, strings.TrimSpace(output))
+	}
+	return divergence, nil
+}
+
+// CreateBranchRef creates a local branch at startPoint without checking it out.
+func CreateBranchRef(ctx context.Context, repoPath, branch, startPoint string) error {
+	_, err := RunGitCmd(ctx, repoPath, "branch", branch, startPoint)
+	return err
+}
+
+// FastForwardTo advances the checked-out branch to ref without creating a
+// merge commit or reconciling divergent history.
+func FastForwardTo(ctx context.Context, repoPath, ref string) error {
+	_, err := RunGitCmd(ctx, repoPath, "merge", "--ff-only", ref)
+	return err
+}
+
+// ResetHardTo makes the checked-out branch and worktree match ref. Callers
+// must establish their own clean-worktree and recovery-ref safety guarantees.
+func ResetHardTo(ctx context.Context, repoPath, ref string) error {
+	_, err := RunGitCmd(ctx, repoPath, "reset", "--hard", ref)
+	return err
+}

--- a/tests/integration/fresh_test.go
+++ b/tests/integration/fresh_test.go
@@ -157,6 +157,168 @@ func skipIfShort(t *testing.T) {
 	}
 }
 
+func advanceFreshRemote(t *testing.T, tc *TestContainer, name, bareDir, filename string) string {
+	t.Helper()
+	peerDir := "/test/" + name + "-peer"
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+git clone %[1]s %[2]s
+git -C %[2]s config user.email peer@test.com
+git -C %[2]s config user.name Peer
+printf 'remote update\n' > %[2]s/%[3]s
+git -C %[2]s add %[3]s
+git -C %[2]s commit -m 'Remote update'
+git -C %[2]s push origin main
+`, bareDir, peerDir, filename))
+	return tc.GitOutput(t, bareDir, "rev-parse", "refs/heads/main")
+}
+
+func TestFresh_FastForwardsBehindDefaultBranch(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-behind-default"
+	_, projectDir, bareDir := setupFreshCampaignWithSubmodule(t, tc, name)
+	remoteTip := advanceFreshRemote(t, tc, name, bareDir, "remote.txt")
+
+	output, err := tc.RunCampInDir(projectDir, "fresh", "--no-branch", "--no-push", "--no-follow-up", "--no-prune")
+	require.NoError(t, err, "camp fresh should fast-forward a behind-only default branch:\n%s", output)
+	assert.Equal(t, remoteTip, tc.GitOutput(t, projectDir, "rev-parse", "main"))
+	assert.Contains(t, output, "updated 1 commit(s)")
+	assert.Empty(t, tc.GitOutput(t, projectDir, "for-each-ref", "--format=%(refname:short)", "refs/heads/camp-fresh-recovery-*"))
+}
+
+func TestFresh_PreservesAndRealignsAheadOnlyDefaultBranch(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-ahead-default"
+	_, projectDir, _ := setupFreshCampaignWithSubmodule(t, tc, name)
+
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+printf 'local work\n' > %[1]s/local.txt
+git -C %[1]s add local.txt
+git -C %[1]s commit -m 'Local main work'
+`, projectDir))
+	oldTip := tc.GitOutput(t, projectDir, "rev-parse", "main")
+	recovery := freshRecoveryPrefixForTest(oldTip)
+
+	output, err := tc.RunCampInDir(projectDir, "fresh", "--no-branch", "--no-push", "--no-follow-up", "--no-prune")
+	require.NoError(t, err, "camp fresh should preserve and realign ahead-only main:\n%s", output)
+	assert.Equal(t, tc.GitOutput(t, projectDir, "rev-parse", "origin/main"), tc.GitOutput(t, projectDir, "rev-parse", "main"))
+	assert.Equal(t, oldTip, tc.GitOutput(t, projectDir, "rev-parse", recovery))
+	assert.Contains(t, output, recovery)
+	assert.Contains(t, output, "1 local-only commit(s)")
+	assert.Contains(t, output, "Undo: git switch main && git reset --hard "+recovery)
+
+	// Retrying the same recovery state is idempotent: reuse the existing ref
+	// instead of allocating a suffixed duplicate.
+	tc.Shell(t, fmt.Sprintf("git -C %s reset --hard %s", projectDir, recovery))
+	retryOutput, err := tc.RunCampInDir(projectDir, "fresh", "--no-branch", "--no-push", "--no-follow-up", "--no-prune")
+	require.NoError(t, err, "camp fresh should reuse an existing matching recovery branch:\n%s", retryOutput)
+	assert.Contains(t, retryOutput, "already preserved")
+	assert.Empty(t, tc.GitOutput(t, projectDir, "for-each-ref", "--format=%(refname:short)", "refs/heads/"+recovery+"-2"))
+}
+
+func TestFresh_PreservesAndRealignsDivergedDefaultBranch(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-diverged-default"
+	_, projectDir, bareDir := setupFreshCampaignWithSubmodule(t, tc, name)
+
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+printf 'local work\n' > %[1]s/local.txt
+git -C %[1]s add local.txt
+git -C %[1]s commit -m 'Local main work'
+`, projectDir))
+	oldTip := tc.GitOutput(t, projectDir, "rev-parse", "main")
+	remoteTip := advanceFreshRemote(t, tc, name, bareDir, "remote.txt")
+	recovery := freshRecoveryPrefixForTest(oldTip)
+
+	output, err := tc.RunCampInDir(projectDir, "fresh", "--no-branch", "--no-push", "--no-follow-up", "--no-prune")
+	require.NoError(t, err, "camp fresh should preserve and realign diverged main:\n%s", output)
+	assert.Equal(t, remoteTip, tc.GitOutput(t, projectDir, "rev-parse", "main"))
+	assert.Equal(t, oldTip, tc.GitOutput(t, projectDir, "rev-parse", recovery))
+	assert.Equal(t, "main", tc.GitOutput(t, projectDir, "rev-parse", "--abbrev-ref", "HEAD"))
+	assert.Empty(t, tc.GitOutput(t, projectDir, "status", "--porcelain"))
+	assert.Contains(t, output, "Realign")
+}
+
+func TestFresh_DryRunReportsDivergenceWithoutMovingLocalRefs(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-diverged-dry-run"
+	_, projectDir, bareDir := setupFreshCampaignWithSubmodule(t, tc, name)
+
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+printf 'local work\n' > %[1]s/local.txt
+git -C %[1]s add local.txt
+git -C %[1]s commit -m 'Local main work'
+`, projectDir))
+	oldTip := tc.GitOutput(t, projectDir, "rev-parse", "main")
+	_ = advanceFreshRemote(t, tc, name, bareDir, "remote.txt")
+	recovery := freshRecoveryPrefixForTest(oldTip)
+
+	output, err := tc.RunCampInDir(projectDir, "fresh", "--dry-run", "--no-branch", "--no-push", "--no-follow-up", "--no-prune")
+	require.NoError(t, err, "camp fresh dry-run should report the divergence plan:\n%s", output)
+	assert.Equal(t, oldTip, tc.GitOutput(t, projectDir, "rev-parse", "main"))
+	assert.Empty(t, tc.GitOutput(t, projectDir, "for-each-ref", "--format=%(refname:short)", "refs/heads/camp-fresh-recovery-*"))
+	assert.Contains(t, output, "Would preserve")
+	assert.Contains(t, output, recovery)
+	assert.Contains(t, output, "Would realign")
+}
+
+func TestFresh_RecoveryBranchCollisionUsesSuffix(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-recovery-collision"
+	_, projectDir, _ := setupFreshCampaignWithSubmodule(t, tc, name)
+
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+printf 'local work\n' > %[1]s/local.txt
+git -C %[1]s add local.txt
+git -C %[1]s commit -m 'Local main work'
+`, projectDir))
+	oldTip := tc.GitOutput(t, projectDir, "rev-parse", "main")
+	baseRecovery := freshRecoveryPrefixForTest(oldTip)
+	tc.Shell(t, fmt.Sprintf("git -C %s branch %s HEAD^", projectDir, baseRecovery))
+
+	output, err := tc.RunCampInDir(projectDir, "fresh", "--no-branch", "--no-push", "--no-follow-up", "--no-prune")
+	require.NoError(t, err, "camp fresh should suffix a colliding recovery branch:\n%s", output)
+	assert.NotEqual(t, oldTip, tc.GitOutput(t, projectDir, "rev-parse", baseRecovery))
+	assert.Equal(t, oldTip, tc.GitOutput(t, projectDir, "rev-parse", baseRecovery+"-2"))
+	assert.Contains(t, output, baseRecovery+"-2")
+}
+
+func TestFresh_MissingRemoteDefaultDoesNotMoveLocalMain(t *testing.T) {
+	skipIfShort(t)
+	tc := GetSharedContainer(t)
+	const name = "fresh-missing-remote-default"
+	_, projectDir, bareDir := setupFreshCampaignWithSubmodule(t, tc, name)
+
+	tc.Shell(t, fmt.Sprintf(`
+set -e
+printf 'local work\n' > %[1]s/local.txt
+git -C %[1]s add local.txt
+git -C %[1]s commit -m 'Local main work'
+git --git-dir %[2]s update-ref -d refs/heads/main
+git -C %[1]s update-ref -d refs/remotes/origin/main
+`, projectDir, bareDir))
+	oldTip := tc.GitOutput(t, projectDir, "rev-parse", "main")
+
+	output, err := tc.RunCampInDir(projectDir, "fresh", "--no-branch", "--no-push", "--no-follow-up", "--no-prune")
+	require.Error(t, err, "camp fresh should fail when origin has no default ref:\n%s", output)
+	assert.Equal(t, oldTip, tc.GitOutput(t, projectDir, "rev-parse", "main"))
+	assert.Empty(t, tc.GitOutput(t, projectDir, "for-each-ref", "--format=%(refname:short)", "refs/heads/camp-fresh-recovery-*"))
+	assert.Contains(t, output, "refs/remotes/origin/main")
+}
+
+func freshRecoveryPrefixForTest(sha string) string {
+	return "camp-fresh-recovery-" + sha[:12]
+}
+
 func TestFresh_CreatesAndPushesNewBranch(t *testing.T) {
 	skipIfShort(t)
 	tc := GetSharedContainer(t)


### PR DESCRIPTION
## Summary

- fetch `origin` before synchronizing the default branch
- preserve local-only commits on a deterministic `camp-fresh-recovery-<sha>` branch before realigning to `origin/<default>`
- fast-forward behind-only branches and keep retries idempotent, with collision-safe recovery names
- make dry-run report divergence without moving local branches or files
- document the recovery behavior and explicit undo command

## Root cause

`camp fresh` used `git pull --ff-only` after checking out the default branch. A clean branch with both local-only and remote-only commits therefore stopped at Git's divergence error and required the user to choose a merge or rebase policy manually. That contradicts Fresh's post-merge cleanup contract and adds a decision point even though Camp can preserve the local tip before safely realigning.

## User impact

A divergent clean default branch now completes automatically without losing work. Camp anchors the old tip locally, reports exactly what it did, and prints the command that restores it. Recovery branches are never pushed by Fresh.

## Validation

- `just gate`
- full container integration suite: 576/576 tests passed
- real `camp fresh obey --dry-run --no-prune --no-follow-up --no-branch --no-push` smoke test