### PR TITLE
test: label Docker transport faults so they stop reading as test failures

### DIFF
--- a/tests/integration/exec_classify_test.go
+++ b/tests/integration/exec_classify_test.go
@@ -5,6 +5,7 @@ package integration
 
 import (
 	"errors"
+	"io"
 	"strings"
 	"testing"
 )
@@ -48,5 +49,38 @@ func TestClassifyExecError(t *testing.T) {
 
 	if classifyExecError(nil) != nil {
 		t.Error("classifyExecError(nil) must stay nil")
+	}
+}
+
+// failingReader stands in for the hijacked exec stream dying mid-read: Exec
+// itself returned nil, and the transport fault surfaces from ReadAll.
+type failingReader struct{ err error }
+
+func (r failingReader) Read([]byte) (int, error) { return 0, r.err }
+
+// Transport loss on the second error channel, the read of the live stream,
+// must be labelled exactly as loss reported by Exec itself is.
+func TestReadExecOutputClassifiesMidReadTransportLoss(t *testing.T) {
+	t.Parallel()
+
+	_, err := readExecOutput(failingReader{err: io.ErrUnexpectedEOF})
+	if err == nil || !strings.Contains(err.Error(), "INFRASTRUCTURE FAILURE (not a test failure)") {
+		t.Errorf("mid-read transport loss was not labelled as infrastructure:\n%v", err)
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Error("the label must wrap the original so the cause survives")
+	}
+
+	// An ordinary read error is not infrastructure and must pass through
+	// unchanged, or real corruption would hide behind a re-run suggestion.
+	plain := errors.New("short buffer")
+	if _, err := readExecOutput(failingReader{err: plain}); err != plain {
+		t.Errorf("a non-transport read error was relabelled: %v", err)
+	}
+
+	// The success path returns the bytes untouched.
+	data, err := readExecOutput(strings.NewReader("output"))
+	if err != nil || string(data) != "output" {
+		t.Errorf("clean read altered: data=%q err=%v", data, err)
 	}
 }

--- a/tests/integration/exec_classify_test.go
+++ b/tests/integration/exec_classify_test.go
@@ -1,0 +1,52 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A Docker transport fault must never read as a failure of whatever test
+// happened to be running when the daemon dropped the stream.
+func TestClassifyExecError(t *testing.T) {
+	t.Parallel()
+
+	transport := []string{
+		"container exec attach: unexpected EOF",
+		"read tcp 127.0.0.1:1234: connection reset by peer",
+		"write unix /var/run/docker.sock: broken pipe",
+		"Error response from daemon: Container abc123 is not running",
+		"Cannot connect to the Docker daemon at unix:///var/run/docker.sock",
+	}
+	for _, msg := range transport {
+		got := classifyExecError(errors.New(msg))
+		if !strings.Contains(got.Error(), "INFRASTRUCTURE FAILURE (not a test failure)") {
+			t.Errorf("classifyExecError(%q) was not labelled as infrastructure:\n%s", msg, got)
+		}
+		if !errors.Is(got, errors.Unwrap(got)) {
+			t.Errorf("classifyExecError(%q) must wrap the original so the cause survives", msg)
+		}
+	}
+
+	// A command that ran and reported something is not an infrastructure
+	// fault. Labelling those would hide real failures behind a re-run
+	// suggestion, which is worse than the noise it removes.
+	real := []string{
+		"exit status 1",
+		"fatal: not a git repository",
+		"camp: unknown command",
+	}
+	for _, msg := range real {
+		err := errors.New(msg)
+		if got := classifyExecError(err); got != err {
+			t.Errorf("classifyExecError(%q) relabelled a real failure as infrastructure:\n%s", msg, got)
+		}
+	}
+
+	if classifyExecError(nil) != nil {
+		t.Error("classifyExecError(nil) must stay nil")
+	}
+}

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -250,7 +249,7 @@ func newPooledContainer(ctx context.Context, bins sharedBinaries) (*TestContaine
 		return nil, fmt.Errorf("failed to install git: %w", err)
 	}
 	if exitCode != 0 {
-		outputBytes, _ := io.ReadAll(output)
+		outputBytes, _ := readExecOutput(output)
 		container.Terminate(ctx)
 		return nil, fmt.Errorf("apk add git failed with exit code %d: %s", exitCode, string(outputBytes))
 	}
@@ -274,7 +273,7 @@ func newPooledContainer(ctx context.Context, bins sharedBinaries) (*TestContaine
 		return nil, fmt.Errorf("failed to check camp binary: %w", err)
 	}
 	if exitCode != 0 {
-		outputBytes, _ := io.ReadAll(output)
+		outputBytes, _ := readExecOutput(output)
 		container.Terminate(ctx)
 		return nil, fmt.Errorf("camp binary not found, ls output: %s", string(outputBytes))
 	}

--- a/tests/integration/helpers_container.go
+++ b/tests/integration/helpers_container.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -12,6 +13,65 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+// exec runs a command in the container, classifying transport faults.
+//
+// Every container command in this file goes through here rather than calling
+// container.Exec directly, so a Docker transport failure is labelled once,
+// where it happens.
+//
+// The failure it exists for looks like this:
+//
+//	--- FAIL: TestFresh_ListRejectsPositionalArg
+//	    failed to init git repo: container exec attach: unexpected EOF
+//
+// That names a test about positional arguments, so the reader goes and studies
+// argument handling. Nothing is wrong with the code under test: the Docker
+// daemon dropped the exec stream, usually because several suites are running
+// at once. A harness that reports its own infrastructure as a failure of
+// whatever test happened to be running costs more time than the flake does.
+//
+// This is the same distinction the pool's Reset latch already draws
+// (failInfrastructure in main_test.go); that one is scoped to pool checkout,
+// and every other exec in the suite could still produce the misleading form.
+func (tc *TestContainer) exec(ctx context.Context, cmd []string) (int, io.Reader, error) {
+	exitCode, reader, err := tc.container.Exec(ctx, cmd)
+	if err != nil {
+		return exitCode, reader, classifyExecError(err)
+	}
+	return exitCode, reader, nil
+}
+
+// execTransportSignatures are the Docker-side failures that mean the daemon or
+// the exec stream died, rather than the command reporting something.
+var execTransportSignatures = []string{
+	"exec attach",
+	"unexpected EOF",
+	"connection reset by peer",
+	"broken pipe",
+	"is not running",
+	"No such container",
+	"Cannot connect to the Docker daemon",
+}
+
+// classifyExecError labels a transport fault so it cannot be read as a test
+// failure. Anything else is returned unchanged.
+func classifyExecError(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	for _, sig := range execTransportSignatures {
+		if strings.Contains(msg, sig) {
+			return fmt.Errorf(
+				"INFRASTRUCTURE FAILURE (not a test failure): container exec did not complete: %w"+
+					"\n\nThe Docker daemon dropped the exec stream. Common cause: several "+
+					"suites or gates running at once. Re-run on an idle machine, or lower "+
+					"CAMP_TEST_POOL_SIZE", err)
+		}
+	}
+	return err
+}
 
 // Reset clears container state between tests.
 // This removes all test artifacts while keeping the container and binary intact.
@@ -29,7 +89,7 @@ func (tc *TestContainer) Reset() error {
 	// Remove all test artifacts and recreate clean directories. Include both
 	// current and legacy config homes so registry/global settings never leak
 	// between tests that share a pooled container.
-	exitCode, _, err := tc.container.Exec(tc.ctx, []string{
+	exitCode, _, err := tc.exec(tc.ctx, []string{
 		"sh", "-c",
 		"rm -rf /test /campaigns /root/.obey /root/.config/camp /root/.camp /tmp/create-* 2>/dev/null; " +
 			"mkdir -p /test /campaigns /root/.config/camp /root/.obey/campaign; sync; " +
@@ -55,7 +115,7 @@ func (tc *TestContainer) Cleanup() {
 func (tc *TestContainer) RunCamp(args ...string) (string, error) {
 	cmd := append([]string{"/camp"}, args...)
 
-	exitCode, reader, err := tc.container.Exec(tc.ctx, cmd)
+	exitCode, reader, err := tc.exec(tc.ctx, cmd)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute camp: %w", err)
 	}
@@ -88,7 +148,7 @@ func (tc *TestContainer) RunCampInDir(dir string, args ...string) (string, error
 	cmdStr := fmt.Sprintf("cd %s && /camp %s 2>&1", dir, strings.Join(quotedArgs, " "))
 	cmd := []string{"sh", "-c", cmdStr}
 
-	exitCode, reader, err := tc.container.Exec(tc.ctx, cmd)
+	exitCode, reader, err := tc.exec(tc.ctx, cmd)
 	if err != nil {
 		return "", fmt.Errorf("failed to execute camp: %w", err)
 	}
@@ -118,7 +178,7 @@ func (tc *TestContainer) RunLegacyCampInDir(dir string, args ...string) (string,
 		quotedArgs[i] = "'" + escaped + "'"
 	}
 	cmdStr := fmt.Sprintf("cd %s && /camp-legacy %s 2>&1", dir, strings.Join(quotedArgs, " "))
-	exitCode, reader, err := tc.container.Exec(tc.ctx, []string{"sh", "-c", cmdStr})
+	exitCode, reader, err := tc.exec(tc.ctx, []string{"sh", "-c", cmdStr})
 	if err != nil {
 		return "", fmt.Errorf("failed to execute legacy camp: %w", err)
 	}
@@ -146,7 +206,7 @@ func (tc *TestContainer) InitCampaign(path, name, campType string) (string, erro
 
 	// Initialize campaign as git repo (required for submodule operations)
 	cmdStr := fmt.Sprintf("cd %s && git init && git add . && git commit -m 'Initial campaign setup'", path)
-	exitCode, reader, gitErr := tc.container.Exec(tc.ctx, []string{"sh", "-c", cmdStr})
+	exitCode, reader, gitErr := tc.exec(tc.ctx, []string{"sh", "-c", cmdStr})
 	if gitErr != nil {
 		return output, fmt.Errorf("failed to init git repo: %w", gitErr)
 	}
@@ -160,7 +220,7 @@ func (tc *TestContainer) InitCampaign(path, name, campType string) (string, erro
 
 // ReadFile reads a file from the container
 func (tc *TestContainer) ReadFile(path string) (string, error) {
-	exitCode, reader, err := tc.container.Exec(tc.ctx, []string{"cat", path})
+	exitCode, reader, err := tc.exec(tc.ctx, []string{"cat", path})
 	if err != nil {
 		return "", fmt.Errorf("failed to read file: %w", err)
 	}
@@ -183,13 +243,13 @@ func (tc *TestContainer) ReadFile(path string) (string, error) {
 func (tc *TestContainer) WriteFile(path, content string) error {
 	// Ensure parent directory exists
 	dir := filepath.Dir(path)
-	exitCode, _, err := tc.container.Exec(tc.ctx, []string{"mkdir", "-p", dir})
+	exitCode, _, err := tc.exec(tc.ctx, []string{"mkdir", "-p", dir})
 	if err != nil || exitCode != 0 {
 		return fmt.Errorf("failed to create parent directory: %w", err)
 	}
 
 	// Write content using printf to handle special characters
-	exitCode, _, err = tc.container.Exec(tc.ctx, []string{
+	exitCode, _, err = tc.exec(tc.ctx, []string{
 		"sh", "-c",
 		fmt.Sprintf("printf '%%s' '%s' > %s", strings.ReplaceAll(content, "'", "'\\''"), path),
 	})
@@ -202,7 +262,7 @@ func (tc *TestContainer) WriteFile(path, content string) error {
 
 // CheckFileExists checks if a file exists in the container
 func (tc *TestContainer) CheckFileExists(path string) (bool, error) {
-	exitCode, _, err := tc.container.Exec(tc.ctx, []string{"test", "-f", path})
+	exitCode, _, err := tc.exec(tc.ctx, []string{"test", "-f", path})
 	if err != nil {
 		return false, fmt.Errorf("failed to check file: %w", err)
 	}
@@ -211,7 +271,7 @@ func (tc *TestContainer) CheckFileExists(path string) (bool, error) {
 
 // CheckDirExists checks if a directory exists in the container
 func (tc *TestContainer) CheckDirExists(path string) (bool, error) {
-	exitCode, _, err := tc.container.Exec(tc.ctx, []string{"test", "-d", path})
+	exitCode, _, err := tc.exec(tc.ctx, []string{"test", "-d", path})
 	if err != nil {
 		return false, fmt.Errorf("failed to check directory: %w", err)
 	}
@@ -220,7 +280,7 @@ func (tc *TestContainer) CheckDirExists(path string) (bool, error) {
 
 // ListDirectory lists files in a container directory
 func (tc *TestContainer) ListDirectory(path string) ([]string, error) {
-	exitCode, reader, err := tc.container.Exec(tc.ctx, []string{"find", path, "-type", "f"})
+	exitCode, reader, err := tc.exec(tc.ctx, []string{"find", path, "-type", "f"})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list directory: %w", err)
 	}
@@ -250,13 +310,13 @@ func (tc *TestContainer) ListDirectory(path string) ([]string, error) {
 // CreateGitRepo initializes a git repository at the given path
 func (tc *TestContainer) CreateGitRepo(path string) error {
 	// Create directory
-	exitCode, _, err := tc.container.Exec(tc.ctx, []string{"mkdir", "-p", path})
+	exitCode, _, err := tc.exec(tc.ctx, []string{"mkdir", "-p", path})
 	if err != nil || exitCode != 0 {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
 	// Initialize git repo
-	exitCode, output, err := tc.container.Exec(tc.ctx, []string{"git", "init", path})
+	exitCode, output, err := tc.exec(tc.ctx, []string{"git", "init", path})
 	if err != nil {
 		return fmt.Errorf("failed to init git repo: %w", err)
 	}
@@ -267,7 +327,7 @@ func (tc *TestContainer) CreateGitRepo(path string) error {
 
 	// Create an initial commit so the repo is valid
 	cmdStr := fmt.Sprintf("cd %s && touch .gitkeep && git add . && git commit -m 'Initial commit'", path)
-	exitCode, output, err = tc.container.Exec(tc.ctx, []string{"sh", "-c", cmdStr})
+	exitCode, output, err = tc.exec(tc.ctx, []string{"sh", "-c", cmdStr})
 	if err != nil {
 		return fmt.Errorf("failed to create initial commit: %w", err)
 	}
@@ -281,7 +341,7 @@ func (tc *TestContainer) CreateGitRepo(path string) error {
 
 // ExecCommand executes an arbitrary command in the container
 func (tc *TestContainer) ExecCommand(args ...string) (string, int, error) {
-	exitCode, reader, err := tc.container.Exec(tc.ctx, args)
+	exitCode, reader, err := tc.exec(tc.ctx, args)
 	if err != nil {
 		return "", -1, fmt.Errorf("failed to execute command: %w", err)
 	}

--- a/tests/integration/helpers_container.go
+++ b/tests/integration/helpers_container.go
@@ -73,6 +73,20 @@ func classifyExecError(err error) error {
 	return err
 }
 
+// readExecOutput consumes an exec stream, classifying transport loss that
+// surfaces mid-read. Exec hands back a live hijacked connection, so the daemon
+// dropping it after Exec returned nil reports here, from the read, as an
+// ordinary "unexpected EOF". Without classification on this second channel the
+// consumers wrap it as "failed to read output" and recreate exactly the
+// misleading test failure this file exists to remove.
+func readExecOutput(reader io.Reader) ([]byte, error) {
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return data, classifyExecError(err)
+	}
+	return data, nil
+}
+
 // Reset clears container state between tests.
 // This removes all test artifacts while keeping the container and binary intact.
 // The trailing `sync` ensures filesystem buffers are flushed before the next test
@@ -120,7 +134,7 @@ func (tc *TestContainer) RunCamp(args ...string) (string, error) {
 		return "", fmt.Errorf("failed to execute camp: %w", err)
 	}
 
-	rawOutput, err := io.ReadAll(reader)
+	rawOutput, err := readExecOutput(reader)
 	if err != nil {
 		return "", fmt.Errorf("failed to read output: %w", err)
 	}
@@ -153,7 +167,7 @@ func (tc *TestContainer) RunCampInDir(dir string, args ...string) (string, error
 		return "", fmt.Errorf("failed to execute camp: %w", err)
 	}
 
-	rawOutput, err := io.ReadAll(reader)
+	rawOutput, err := readExecOutput(reader)
 	if err != nil {
 		return "", fmt.Errorf("failed to read output: %w", err)
 	}
@@ -182,7 +196,7 @@ func (tc *TestContainer) RunLegacyCampInDir(dir string, args ...string) (string,
 	if err != nil {
 		return "", fmt.Errorf("failed to execute legacy camp: %w", err)
 	}
-	rawOutput, err := io.ReadAll(reader)
+	rawOutput, err := readExecOutput(reader)
 	if err != nil {
 		return "", fmt.Errorf("failed to read output: %w", err)
 	}
@@ -211,7 +225,7 @@ func (tc *TestContainer) InitCampaign(path, name, campType string) (string, erro
 		return output, fmt.Errorf("failed to init git repo: %w", gitErr)
 	}
 	if exitCode != 0 {
-		rawOutput, _ := io.ReadAll(reader)
+		rawOutput, _ := readExecOutput(reader)
 		return output, fmt.Errorf("git init failed: %s", string(demuxDockerOutput(rawOutput)))
 	}
 
@@ -225,7 +239,7 @@ func (tc *TestContainer) ReadFile(path string) (string, error) {
 		return "", fmt.Errorf("failed to read file: %w", err)
 	}
 
-	rawOutput, err := io.ReadAll(reader)
+	rawOutput, err := readExecOutput(reader)
 	if err != nil {
 		return "", fmt.Errorf("failed to read output: %w", err)
 	}
@@ -289,7 +303,7 @@ func (tc *TestContainer) ListDirectory(path string) ([]string, error) {
 		return nil, fmt.Errorf("find command failed with exit code %d", exitCode)
 	}
 
-	rawOutput, err := io.ReadAll(reader)
+	rawOutput, err := readExecOutput(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read output: %w", err)
 	}
@@ -321,7 +335,7 @@ func (tc *TestContainer) CreateGitRepo(path string) error {
 		return fmt.Errorf("failed to init git repo: %w", err)
 	}
 	if exitCode != 0 {
-		outputBytes, _ := io.ReadAll(output)
+		outputBytes, _ := readExecOutput(output)
 		return fmt.Errorf("git init failed: %s", string(outputBytes))
 	}
 
@@ -332,7 +346,7 @@ func (tc *TestContainer) CreateGitRepo(path string) error {
 		return fmt.Errorf("failed to create initial commit: %w", err)
 	}
 	if exitCode != 0 {
-		outputBytes, _ := io.ReadAll(output)
+		outputBytes, _ := readExecOutput(output)
 		return fmt.Errorf("initial commit failed: %s", string(outputBytes))
 	}
 
@@ -346,7 +360,7 @@ func (tc *TestContainer) ExecCommand(args ...string) (string, int, error) {
 		return "", -1, fmt.Errorf("failed to execute command: %w", err)
 	}
 
-	rawOutput, err := io.ReadAll(reader)
+	rawOutput, err := readExecOutput(reader)
 	if err != nil {
 		return "", exitCode, fmt.Errorf("failed to read output: %w", err)
 	}


### PR DESCRIPTION
## What

A dropped Docker exec stream surfaced as an ordinary test failure:

```
--- FAIL: TestFresh_ListRejectsPositionalArg
    failed to init git repo: container exec attach: unexpected EOF
```

That names a test about positional arguments, so the reader goes and studies argument handling. Nothing was wrong with the code under test — the daemon dropped the exec stream, in this case because a gate and the integration suite were running at once.

## Change

Every container command in `helpers_container.go` (15 call sites) now goes through one wrapper that recognizes the transport signatures and labels them `INFRASTRUCTURE FAILURE (not a test failure)`, with the likely cause and what to do.

This is the same distinction #514's Reset latch draws. That one is scoped to pool checkout, so every other exec in the suite could still produce the misleading form. Found while running the suite for CA0004.

## Not relabelled

Real command failures (`exit status 1`, `fatal: not a git repository`) pass through unchanged, asserted by test. Labelling those would hide genuine failures behind a re-run suggestion, which is worse than the noise it removes.

## Verification

- `TestClassifyExecError` covers both directions, including that the original error stays wrapped so the cause survives.
- `TestFresh_*` and `TestWorktreesList_*` (the tests that surfaced the fault) pass.