### PR TITLE
feat(promote): festival rail targets, ready and active (WF0001 P3/S2)

### DIFF
--- a/cmd/camp/promote/selector.go
+++ b/cmd/camp/promote/selector.go
@@ -151,7 +151,9 @@ func targetsForKind(kind promoteKind) []string {
 	case kindIntent:
 		return []string{"ready", "festival", "design"}
 	case kindWorkitem:
-		return []string{"festival", "doc", "completed", "archived", "someday"}
+		// Rail stages lead: they are the forward moves, and a workitem reaches
+		// them far more often than it reaches a festival or the dungeon.
+		return []string{"ready", "active", "festival", "doc", "completed", "archived", "someday"}
 	case kindFestival:
 		return []string{"next", "completed", "archived", "someday"}
 	}

--- a/internal/commands/workitem/promote.go
+++ b/internal/commands/workitem/promote.go
@@ -87,15 +87,21 @@ func newPromoteCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "promote [id] --target <target>",
-		Short: "Promote a workitem to a festival, doc, or dungeon",
+		Short: "Promote a workitem: festival, doc, rail, dungeon",
 		Long: `Promote the workitem identified by [id], by cwd, or by the current pointer.
 
 TARGETS:
   festival    Create a festival from the workitem and shelve the source
   doc         Copy the workitem doc into docs/ and shelve the source
+  ready       Move the workitem onto the festival rail at festivals/ready
+  active      Move the workitem onto the festival rail at festivals/active
   completed   Move the workitem to its local dungeon/completed
   archived    Move the workitem to its local dungeon/archived
-  someday     Move the workitem to its local dungeon/someday`,
+  someday     Move the workitem to its local dungeon/someday
+
+The rail is forward-only: root -> ready -> active. A workitem already on a
+stage cannot move backward, and moving one out of a dungeon is a restore
+rather than a promote.`,
 		Args: cobra.RangeArgs(0, 1),
 		Annotations: map[string]string{
 			"agent_allowed": "true",
@@ -114,7 +120,7 @@ TARGETS:
 	}
 
 	f := cmd.Flags()
-	f.StringVar(&target, "target", "", "Promotion target: festival, doc, completed, archived, someday")
+	f.StringVar(&target, "target", "", "Promotion target: festival, doc, ready, active, completed, archived, someday")
 	f.StringVar(&dest, "dest", "", "Destination path under docs/ for the doc target (must stay within docs/)")
 	f.StringVar(&goal, "goal", "", "Festival goal override (default: first paragraph of the workitem doc)")
 	f.BoolVar(&keep, "keep", false, "On festival/doc, do not move the source workitem to the dungeon")
@@ -130,12 +136,13 @@ func runWorkitemPromote(cmd *cobra.Command, opts runWorkitemPromoteOptions) erro
 
 	switch opts.Target {
 	case "festival", "doc", "completed", "archived", "someday":
-	case "active":
-		return camperrors.New("cannot promote to active: a workitem outside the dungeon is already active; restoring workitems out of the dungeon is not a promote")
+	case railStageReady, railStageActive:
+		// Conditionally valid: the rail is forward-only, so these are checked
+		// against the resolved source location below, once loc is known.
 	case "":
 		return camperrors.New("required flag --target not set")
 	default:
-		return camperrors.New("invalid target: " + opts.Target + " (use festival, doc, completed, archived, someday)")
+		return camperrors.New("invalid target: " + opts.Target + " (use festival, doc, ready, active, completed, archived, someday)")
 	}
 
 	cfg, root, err := config.LoadCampaignConfigFromCwd(ctx)
@@ -146,6 +153,12 @@ func runWorkitemPromote(cmd *cobra.Command, opts runWorkitemPromoteOptions) erro
 	loc, err := resolveWorkitem(ctx, root, opts.ID)
 	if err != nil {
 		return err
+	}
+
+	if opts.Target == railStageReady || opts.Target == railStageActive {
+		if err := checkRailTransition(railStageOf(loc, root), opts.Target); err != nil {
+			return err
+		}
 	}
 
 	// Read .workitem metadata now, before any promote branch runs: festival
@@ -182,6 +195,8 @@ func runWorkitemPromote(cmd *cobra.Command, opts runWorkitemPromoteOptions) erro
 		ci, err = doFestivalPromote(ctx, cmd, opts, root, loc, &result)
 	case "doc":
 		ci, err = doDocPromote(ctx, opts, root, loc, &result)
+	case railStageReady, railStageActive:
+		ci, err = doRailPromote(ctx, cfg, root, loc, opts.Target, &result)
 	case "completed", "archived", "someday":
 		ci, err = doDungeonPromote(ctx, root, loc, opts.Target, &result)
 	default:

--- a/internal/commands/workitem/promote_rail.go
+++ b/internal/commands/workitem/promote_rail.go
@@ -1,0 +1,188 @@
+package workitem
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	dungeoncmd "github.com/Obedience-Corp/camp/cmd/camp/dungeon"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/mdlinks"
+	"github.com/Obedience-Corp/camp/internal/statusmove"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+	"github.com/Obedience-Corp/camp/internal/workitem/locate"
+)
+
+// festivalsDir is the campaign-relative folder the rail moves workitems into.
+const festivalsDir = "festivals"
+
+// Rail stages. "root" is a workitem still living under workflow/<type>/; ready
+// and active are the physical festival stages; dungeon covers any shelved
+// source, which the rail never accepts as an origin.
+const (
+	railStageRoot    = "root"
+	railStageReady   = "ready"
+	railStageActive  = "active"
+	railStageDungeon = "dungeon"
+)
+
+// railStageOf reports which rail stage a resolved location currently occupies.
+func railStageOf(loc *locate.Location, root string) string {
+	if loc.InDungeon {
+		return railStageDungeon
+	}
+	rel := filepath.ToSlash(dungeoncmd.RelFromRoot(root, loc.SourcePath))
+	switch {
+	case strings.HasPrefix(rel, festivalsDir+"/"+railStageReady+"/"):
+		return railStageReady
+	case strings.HasPrefix(rel, festivalsDir+"/"+railStageActive+"/"):
+		return railStageActive
+	default:
+		return railStageRoot
+	}
+}
+
+// checkRailTransition enforces the forward-only rail: root -> ready -> active.
+// The dungeon case preserves the semantics of the old blanket "active" rejection
+// this replaced: moving a workitem back out of a dungeon is a restore, not a
+// promote, and the rail does not become a loophole for it.
+func checkRailTransition(from, target string) error {
+	switch {
+	case from == railStageDungeon:
+		return camperrors.New("cannot promote to " + target +
+			" from a dungeon: restoring workitems out of the dungeon is not a promote")
+	case target == railStageReady && from != railStageRoot:
+		return camperrors.New("cannot promote to ready from " + from +
+			"; the rail is forward-only (root -> ready -> active)")
+	case target == railStageActive && from == railStageActive:
+		return camperrors.New("workitem is already active on the rail")
+	}
+	return nil
+}
+
+// doRailPromote moves a directory workitem onto festivals/<stage>/<slug> and
+// repairs every reference to it, returning commitInputs so the shared promote
+// tail supplies the audit event, ledger emit, and auto-commit unchanged.
+//
+// recordPromotedTo is deliberately not called here. promoted_to records where a
+// shelved source was copied to (the festival and doc targets); a rail move
+// relocates the directory itself, so its stage is its location and a
+// promoted_to pointer would only be able to describe where it already is.
+func doRailPromote(ctx context.Context, cfg *config.CampaignConfig, root string, loc *locate.Location, stage string, result *workitemPromoteResult) (*commitInputs, error) {
+	if isFile, _ := promoteSourceShape(loc); isFile {
+		return nil, camperrors.New(
+			"cannot promote a file workitem onto the rail: a resident is a directory carrying its own " +
+				wkitem.MetadataFilename + " marker")
+	}
+
+	oldRel := filepath.ToSlash(dungeoncmd.RelFromRoot(root, loc.SourcePath))
+	newRel := path.Join(festivalsDir, stage, loc.Slug)
+	destAbs := filepath.Join(root, filepath.FromSlash(newRel))
+	if _, err := os.Lstat(destAbs); err == nil {
+		return nil, camperrors.Wrapf(camperrors.ErrAlreadyExists,
+			"cannot promote to %s: destination %s already exists", stage, newRel)
+	}
+
+	// Stamp before moving, not after. Resident resolution refuses an unstamped
+	// directory in a lifecycle folder, so a marker written after the move would
+	// strand the workitem where nothing can resolve it if that write failed.
+	// Stamping first leaves every failure recoverable at the original location.
+	if err := ensureResidentMarker(ctx, cfg, root, oldRel, loc.Type); err != nil {
+		return nil, err
+	}
+
+	if _, err := statusmove.Move(ctx, loc.SourcePath, destAbs, statusmove.MoveOptions{BoundaryRoot: root}); err != nil {
+		if errors.Is(err, statusmove.ErrAlreadyExists) {
+			return nil, camperrors.Wrapf(camperrors.ErrAlreadyExists,
+				"cannot promote to %s: destination %s already exists", stage, newRel)
+		}
+		return nil, camperrors.Wrapf(err, "moving %s to %s", oldRel, newRel)
+	}
+	rewritten, err := mdlinks.RewriteForMove(ctx, root, loc.SourcePath, destAbs)
+	if err != nil {
+		return nil, camperrors.Wrapf(err,
+			"rewriting markdown links after moving %s (move applied; recover with git status)", oldRel)
+	}
+
+	destPaths := []string{destAbs}
+	if migrateRailReferences(ctx, root, loc.Type+":"+oldRel, loc.Type+":"+newRel, oldRel, newRel, result) {
+		destPaths = append(destPaths, links.LinksPath(root))
+	}
+
+	result.To = newRel
+	return &commitInputs{
+		description: fmt.Sprintf("Promote workitem %s to %s", loc.Slug, newRel),
+		sourcePaths: []string{loc.SourcePath},
+		destPaths:   destPaths,
+		rewritten:   rewritten,
+	}, nil
+}
+
+// migrateRailReferences repairs the priority store, link registry, and current
+// pointer for the resident's new path by reusing the rename migrations verbatim.
+// A rail move is a path change that preserves the type prefix of the workitem
+// key (design:workflow/design/x becomes design:festivals/ready/x), which is
+// exactly the shape those helpers already handle.
+//
+// Returns whether links.yaml changed so the caller can stage it. Each store is
+// best-effort: the move has already landed, so a bookkeeping failure is a
+// warning rather than a reason to strand the moved workitem.
+func migrateRailReferences(ctx context.Context, root, oldKey, newKey, oldRel, newRel string, result *workitemPromoteResult) bool {
+	warn := func(format string, args ...any) {
+		result.Warnings = append(result.Warnings, fmt.Sprintf(format, args...))
+	}
+
+	if _, err := migrateRenamePriority(ctx, root, oldKey, newKey); err != nil {
+		warn("migrate priority entries: %v", err)
+	}
+
+	linksChanged, err := migrateRenameLinks(ctx, root, oldKey, newKey, oldRel, newRel)
+	if err != nil {
+		warn("re-home workitem links: %v", err)
+	}
+
+	if _, err := migrateRenameCurrent(ctx, root, oldKey, newKey); err != nil {
+		warn("update current workitem selection: %v", err)
+	}
+	return linksChanged
+}
+
+// ensureResidentMarker guarantees the workitem carries a .workitem marker before
+// it enters the rail.
+//
+// Directory workitems are not uniformly stamped: promote tolerates an unmarked
+// directory today (recordPromotedTo skips the stamp when the marker is absent,
+// and the ledger falls back to the slug for the same reason). Resident
+// resolution is stricter, because a resident's parent segment is a lifecycle
+// stage rather than a workflow type and so cannot supply the type. Minting the
+// marker at rail entry is what reconciles the two.
+//
+// It reuses the camp workitem repair planner so a marker minted here is byte-
+// identical to the one doctor --fix would write, including id generation and
+// unique-ref derivation.
+func ensureResidentMarker(ctx context.Context, cfg *config.CampaignConfig, root, relPath, typeName string) error {
+	absDir := filepath.Join(root, filepath.FromSlash(relPath))
+	_, err := os.Stat(filepath.Join(absDir, wkitem.MetadataFilename))
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return camperrors.Wrapf(err, "checking %s marker in %s", wkitem.MetadataFilename, relPath)
+	}
+
+	plan, err := planRepair(ctx, root, cfg, relPath, typeName)
+	if err != nil {
+		return camperrors.Wrapf(err, "minting %s marker for %s", wkitem.MetadataFilename, relPath)
+	}
+	if err := writeMarker(absDir, plan.meta); err != nil {
+		return camperrors.Wrapf(err, "writing %s marker for %s", wkitem.MetadataFilename, relPath)
+	}
+	return nil
+}

--- a/internal/commands/workitem/promote_rail.go
+++ b/internal/commands/workitem/promote_rail.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -156,8 +155,8 @@ func migrateRailReferences(ctx context.Context, root, oldKey, newKey, oldRel, ne
 	return linksChanged
 }
 
-// ensureResidentMarker guarantees the workitem carries a .workitem marker before
-// it enters the rail.
+// ensureResidentMarker guarantees the workitem carries a canonical .workitem
+// marker before it enters the rail.
 //
 // Directory workitems are not uniformly stamped: promote tolerates an unmarked
 // directory today (recordPromotedTo skips the stamp when the marker is absent,
@@ -166,23 +165,27 @@ func migrateRailReferences(ctx context.Context, root, oldKey, newKey, oldRel, ne
 // stage rather than a workflow type and so cannot supply the type. Minting the
 // marker at rail entry is what reconciles the two.
 //
-// It reuses the camp workitem repair planner so a marker minted here is byte-
-// identical to the one doctor --fix would write, including id generation and
-// unique-ref derivation.
+// An existing marker is repaired, not trusted. The path type is authoritative
+// here: migrateRailReferences keys the moved workitem on loc.Type, while
+// resident resolution after the move reads the marker, so a marker carrying a
+// different type would leave priority, links, and current pointing at a key no
+// rail command resolves. A marker that cannot be parsed fails the promote
+// before anything moves, so the workitem stays where every repair tool can
+// still reach it.
+//
+// It reuses the camp workitem repair planner so a marker minted or repaired
+// here is byte-identical to the one doctor --fix would write, including id
+// generation and unique-ref derivation. Repair is idempotent: an already
+// canonical marker plans no changes and is not rewritten.
 func ensureResidentMarker(ctx context.Context, cfg *config.CampaignConfig, root, relPath, typeName string) error {
-	absDir := filepath.Join(root, filepath.FromSlash(relPath))
-	_, err := os.Stat(filepath.Join(absDir, wkitem.MetadataFilename))
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, fs.ErrNotExist) {
-		return camperrors.Wrapf(err, "checking %s marker in %s", wkitem.MetadataFilename, relPath)
-	}
-
 	plan, err := planRepair(ctx, root, cfg, relPath, typeName)
 	if err != nil {
-		return camperrors.Wrapf(err, "minting %s marker for %s", wkitem.MetadataFilename, relPath)
+		return camperrors.Wrapf(err, "repairing %s marker for %s", wkitem.MetadataFilename, relPath)
 	}
+	if len(plan.changes) == 0 {
+		return nil
+	}
+	absDir := filepath.Join(root, filepath.FromSlash(relPath))
 	if err := writeMarker(absDir, plan.meta); err != nil {
 		return camperrors.Wrapf(err, "writing %s marker for %s", wkitem.MetadataFilename, relPath)
 	}

--- a/internal/commands/workitem/promote_rail.go
+++ b/internal/commands/workitem/promote_rail.go
@@ -24,12 +24,14 @@ import (
 const festivalsDir = "festivals"
 
 // Rail stages. "root" is a workitem still living under workflow/<type>/; ready
-// and active are the physical festival stages; dungeon covers any shelved
-// source, which the rail never accepts as an origin.
+// and active are the physical festival stages and take their names from the
+// lifecycle vocabulary so the promote target, the stage folder, and
+// StagesByType cannot drift apart; dungeon covers any shelved source, which the
+// rail never accepts as an origin.
 const (
 	railStageRoot    = "root"
-	railStageReady   = "ready"
-	railStageActive  = "active"
+	railStageReady   = string(wkitem.LifecycleStageReady)
+	railStageActive  = string(wkitem.LifecycleStageActive)
 	railStageDungeon = "dungeon"
 )
 

--- a/internal/commands/workitem/promote_test.go
+++ b/internal/commands/workitem/promote_test.go
@@ -163,11 +163,13 @@ func TestPromoteResolution(t *testing.T) {
 }
 
 func TestPromoteRejectsBadTargets(t *testing.T) {
+	// "active" is no longer a blanket rejection: it is a rail target, valid from
+	// a workflow root. What stayed rejected (moving out of a dungeon, moving
+	// backward) is covered by TestPromoteRailForwardOnly.
 	cases := []struct {
 		target  string
 		wantErr string
 	}{
-		{"active", "cannot promote to active"},
 		{"bogus", "invalid target"},
 		{"", "required flag --target not set"},
 	}
@@ -441,5 +443,202 @@ func TestPromoteFestivalRejectsDest(t *testing.T) {
 	_, _, err := execPromote(t, src, "--target", "festival", "--dest", "whatever", "--no-commit")
 	if err == nil || !strings.Contains(err.Error(), "--dest is only valid for --target doc") {
 		t.Fatalf("err = %v, want festival --dest rejection", err)
+	}
+}
+
+// addResident places a stamped workitem directly on a rail stage, standing in
+// for one that got there by an earlier promote.
+func addResident(t *testing.T, root, stage, wtype, slug, title string) string {
+	t.Helper()
+	dir := filepath.Join(root, "festivals", stage, slug)
+	meta := "version: v1alpha8\nkind: workitem\nid: " + wtype + "-" + slug + "-fixed\ntype: " + wtype + "\ntitle: " + title + "\nref: WI-bbbbbb\n"
+	writeFile(t, filepath.Join(dir, ".workitem"), meta)
+	writeFile(t, filepath.Join(dir, "README.md"), "# "+title+"\n")
+	return dir
+}
+
+// TestPromoteRailEntry covers the two rail-entry moves and the ready->active
+// advance. The directory itself relocates, so the source must be gone and the
+// marker must travel with it: a resident that lost its marker cannot be
+// resolved again.
+func TestPromoteRailEntry(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  string
+		fromRes string // rail stage of the source, "" means a workflow root
+		wantTo  string
+	}{
+		{name: "root to ready", target: "ready", wantTo: "festivals/ready/feat"},
+		{name: "root to active", target: "active", wantTo: "festivals/active/feat"},
+		{name: "ready to active", target: "active", fromRes: "ready", wantTo: "festivals/active/feat"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := promoteCampaign(t)
+			var src string
+			if tc.fromRes == "" {
+				src = addWorkitem(t, root, "design", "feat", "Feat", "body")
+			} else {
+				src = addResident(t, root, tc.fromRes, "design", "feat", "Feat")
+			}
+
+			if _, _, err := execPromote(t, src, "--target", tc.target, "--no-commit"); err != nil {
+				t.Fatalf("promote to %s: %v", tc.target, err)
+			}
+
+			dest := filepath.Join(root, filepath.FromSlash(tc.wantTo))
+			if _, err := os.Stat(dest); err != nil {
+				t.Fatalf("destination %s not created: %v", tc.wantTo, err)
+			}
+			if _, err := os.Stat(src); !os.IsNotExist(err) {
+				t.Errorf("source %s still exists after a rail move (err=%v)", src, err)
+			}
+			if _, err := os.Stat(filepath.Join(dest, ".workitem")); err != nil {
+				t.Errorf("marker did not travel with the resident: %v", err)
+			}
+			if _, err := os.Stat(filepath.Join(dest, "README.md")); err != nil {
+				t.Errorf("content did not travel with the resident: %v", err)
+			}
+		})
+	}
+}
+
+// TestPromoteRailForwardOnly locks every rejected transition. The rail only ever
+// moves root -> ready -> active; anything else, including any attempt to leave a
+// dungeon, must error rather than silently relocate a workitem.
+func TestPromoteRailForwardOnly(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  string
+		setup   func(t *testing.T, root string) string
+		wantErr string
+	}{
+		{
+			name:   "active to ready is backward",
+			target: "ready",
+			setup: func(t *testing.T, root string) string {
+				return addResident(t, root, "active", "design", "feat", "Feat")
+			},
+			wantErr: "forward-only",
+		},
+		{
+			name:   "ready to ready is already there",
+			target: "ready",
+			setup: func(t *testing.T, root string) string {
+				return addResident(t, root, "ready", "design", "feat", "Feat")
+			},
+			wantErr: "forward-only",
+		},
+		{
+			name:   "active to active is already there",
+			target: "active",
+			setup: func(t *testing.T, root string) string {
+				return addResident(t, root, "active", "design", "feat", "Feat")
+			},
+			wantErr: "already active on the rail",
+		},
+		{
+			name:   "dungeon to ready is a restore",
+			target: "ready",
+			setup: func(t *testing.T, root string) string {
+				dir := filepath.Join(root, "workflow", "design", "dungeon", "completed", "2026-07-24", "feat")
+				writeFile(t, filepath.Join(dir, ".workitem"),
+					"version: v1alpha8\nkind: workitem\nid: design-feat-fixed\ntype: design\ntitle: Feat\nref: WI-cccccc\n")
+				return dir
+			},
+			wantErr: "restoring workitems out of the dungeon is not a promote",
+		},
+		{
+			name:   "dungeon to active is a restore",
+			target: "active",
+			setup: func(t *testing.T, root string) string {
+				dir := filepath.Join(root, "workflow", "design", "dungeon", "archived", "2026-07-24", "feat")
+				writeFile(t, filepath.Join(dir, ".workitem"),
+					"version: v1alpha8\nkind: workitem\nid: design-feat-fixed\ntype: design\ntitle: Feat\nref: WI-cccccc\n")
+				return dir
+			},
+			wantErr: "restoring workitems out of the dungeon is not a promote",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := promoteCampaign(t)
+			src := tc.setup(t, root)
+
+			_, _, err := execPromote(t, src, "--target", tc.target, "--no-commit")
+			if err == nil {
+				t.Fatalf("expected %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+			}
+			if _, statErr := os.Stat(src); statErr != nil {
+				t.Errorf("rejected promote must leave the source in place: %v", statErr)
+			}
+		})
+	}
+}
+
+// TestPromoteRailStampsUnmarkedSource is the reason stamping happens at rail
+// entry. Directory workitems are not uniformly marked (promote tolerates an
+// unmarked one), but resident resolution requires a marker, so a workitem that
+// entered the rail unmarked would be unreachable afterward.
+func TestPromoteRailStampsUnmarkedSource(t *testing.T) {
+	root := promoteCampaign(t)
+	src := filepath.Join(root, "workflow", "design", "unmarked")
+	writeFile(t, filepath.Join(src, "README.md"), "# Unmarked\n\nbody\n")
+
+	if _, _, err := execPromote(t, src, "--target", "ready", "--no-commit"); err != nil {
+		t.Fatalf("promote unmarked workitem to ready: %v", err)
+	}
+
+	dest := filepath.Join(root, "festivals", "ready", "unmarked")
+	meta, err := wkitem.LoadMetadata(context.Background(), dest)
+	if err != nil {
+		t.Fatalf("LoadMetadata on the new resident: %v", err)
+	}
+	if meta == nil {
+		t.Fatal("resident has no .workitem marker; it would be unresolvable on the rail")
+	}
+	if meta.Type != "design" {
+		t.Errorf("minted marker type = %q, want design", meta.Type)
+	}
+	if meta.ID == "" {
+		t.Error("minted marker has no id")
+	}
+
+	loc, err := locate.DetectFromCwd(root, dest)
+	if err != nil {
+		t.Fatalf("the whole point: a stamped resident must resolve: %v", err)
+	}
+	// DetectFromCwd resolves symlinks, and on macOS the temp root is under
+	// /var -> /private/var, so compare against the resolved root.
+	resolvedRoot := root
+	if r, rerr := filepath.EvalSymlinks(root); rerr == nil {
+		resolvedRoot = r
+	}
+	if want := filepath.Join(resolvedRoot, "festivals", ".dungeon"); loc.DungeonPath != want {
+		t.Errorf("DungeonPath = %q, want %q", loc.DungeonPath, want)
+	}
+}
+
+// TestPromoteRailRejectsExistingDestination guards against a rail move
+// clobbering a resident that already occupies the slug on that stage.
+func TestPromoteRailRejectsExistingDestination(t *testing.T) {
+	root := promoteCampaign(t)
+	src := addWorkitem(t, root, "design", "feat", "Feat", "body")
+	addResident(t, root, "ready", "design", "feat", "Other Feat")
+
+	_, _, err := execPromote(t, src, "--target", "ready", "--no-commit")
+	if err == nil {
+		t.Fatal("expected an already-exists error, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("err = %v, want containing \"already exists\"", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(src, "README.md")); statErr != nil {
+		t.Errorf("source must be untouched after a refused move: %v", statErr)
 	}
 }

--- a/internal/commands/workitem/sweep.go
+++ b/internal/commands/workitem/sweep.go
@@ -28,10 +28,9 @@ import (
 // its RelativePath, reusing locate.DetectFromCwd (which is generic over any
 // path under the item, not literally the process cwd) so the sweep and
 // interactive promote share one notion of "where this item's dungeon lives."
-// Every candidate PlanSweep can produce today has a workflow/<type>/<slug>
-// RelativePath, so this is currently a pass-through onto DetectFromCwd's
-// existing resolution; phase 3 (rail residents in festivals/) extends
-// DetectFromCwd itself, and this function needs no change when that lands.
+// It stays a pass-through: rail residents (festivals/<stage>/<slug>) resolve
+// because DetectFromCwd itself learned that layout, so a swept resident lands in
+// the festival-local dungeon without this function knowing the difference.
 func resolveSweepLocation(campaignRoot string, item wkitem.WorkItem) (*locate.Location, error) {
 	return locate.DetectFromCwd(campaignRoot, filepath.Join(campaignRoot, item.RelativePath))
 }

--- a/internal/commands/workitem/sweep_test.go
+++ b/internal/commands/workitem/sweep_test.go
@@ -65,12 +65,12 @@ func TestResolveSweepLocation_WorkflowHome(t *testing.T) {
 	}
 }
 
-// TestResolveSweepLocation_FestivalsHomeNotYetSupported locks the current
-// error for a festivals/ path. No sweep candidate has such a RelativePath
-// before phase 3 (PlanSweep excludes festivals), so this asserts the baseline
-// that phase 3 must deliberately change when it teaches DetectFromCwd about
-// festivals/ homes. Asserting the exact message catches a silent behavior drift.
-func TestResolveSweepLocation_FestivalsHomeNotYetSupported(t *testing.T) {
+// TestResolveSweepLocation_FestivalsHomeRejectsUnstamped is the phase 3 half of
+// what used to be TestResolveSweepLocation_FestivalsHomeNotYetSupported. A
+// festivals/ path is now a resolvable home, but only when the directory carries
+// a .workitem marker: a bare directory sitting in a lifecycle folder is not a
+// resident camp can move, and must say so rather than resolve to a guess.
+func TestResolveSweepLocation_FestivalsHomeRejectsUnstamped(t *testing.T) {
 	root := t.TempDir()
 	itemRel := filepath.Join("festivals", "ready", "foo-item")
 	if err := os.MkdirAll(filepath.Join(root, itemRel), 0o755); err != nil {
@@ -79,11 +79,47 @@ func TestResolveSweepLocation_FestivalsHomeNotYetSupported(t *testing.T) {
 
 	_, err := resolveSweepLocation(root, wkitem.WorkItem{RelativePath: itemRel})
 	if err == nil {
-		t.Fatal("expected error for festivals/ home, got nil")
+		t.Fatal("expected error for unstamped festivals/ home, got nil")
 	}
-	const want = "not inside a workitem; cwd must be under workflow/<type>/<slug>/"
+	const want = "not a lifecycle resident; festivals/ready/foo-item has no .workitem marker (run camp workitem doctor)"
 	if err.Error() != want {
 		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+// TestResolveSweepLocation_FestivalsResidentHome locks the destination rule that
+// sequence 04 depends on: a stamped resident sweeps into the festival-local
+// dungeon, not back into the dungeon of the workflow type it came from.
+func TestResolveSweepLocation_FestivalsResidentHome(t *testing.T) {
+	root := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
+	itemRel := filepath.Join("festivals", "active", "foo-item")
+	dir := filepath.Join(root, itemRel)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir fixture: %v", err)
+	}
+	marker := "version: v1alpha8\nkind: workitem\nid: design-foo-item-2026-07-24\ntype: design\ntitle: Foo\n"
+	if err := os.WriteFile(filepath.Join(dir, ".workitem"), []byte(marker), 0o644); err != nil {
+		t.Fatalf("write .workitem: %v", err)
+	}
+
+	loc, err := resolveSweepLocation(root, wkitem.WorkItem{RelativePath: itemRel})
+	if err != nil {
+		t.Fatalf("resolveSweepLocation: %v", err)
+	}
+	if loc.Type != "design" {
+		t.Errorf("Type = %q, want design (from the marker, not the path)", loc.Type)
+	}
+	if want := filepath.Join(root, "festivals", "active"); loc.ParentPath != want {
+		t.Errorf("ParentPath = %q, want %q", loc.ParentPath, want)
+	}
+	if want := filepath.Join(root, "festivals", ".dungeon"); loc.DungeonPath != want {
+		t.Errorf("DungeonPath = %q, want %q (residents complete into the festival-local dungeon)", loc.DungeonPath, want)
+	}
+	if loc.InDungeon {
+		t.Error("InDungeon = true, want false for a working-stage resident")
 	}
 }
 

--- a/internal/workitem/locate/locate.go
+++ b/internal/workitem/locate/locate.go
@@ -1,5 +1,6 @@
 // Package locate resolves a workitem's on-disk location from a working
-// directory under workflow/<type>/<slug>/, including dungeon layouts.
+// directory under workflow/<type>/<slug>/ or, for a workitem promoted onto the
+// festival rail, under festivals/<stage>/<slug>/, including dungeon layouts.
 package locate
 
 import (
@@ -11,7 +12,25 @@ import (
 	"github.com/Obedience-Corp/camp/internal/dungeon/spelling"
 	"github.com/Obedience-Corp/camp/internal/dungeon/statuspath"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
+
+// festivalsRoot is the campaign-relative folder holding the festival lifecycle
+// stages. A workitem promoted onto the festival rail physically lives here
+// instead of under workflow/<type>/.
+const festivalsRoot = "festivals"
+
+// festivalDungeonName is the festival-local dungeon. Unlike a workflow type's
+// dungeon, whose on-disk spelling is resolved with spelling.Resolve, this one is
+// the fixed hidden .dungeon, so a resident always completes into
+// festivals/.dungeon/<status>/<date>/<slug> rather than into the dungeon of the
+// workflow type it came from.
+const festivalDungeonName = ".dungeon"
+
+// festivalStages are the rail stages a resident workitem can occupy. Promotion
+// onto the rail targets ready and active only; festivals/ also holds folders
+// that are not rail stages (planning, chains, ritual), and those do not resolve.
+var festivalStages = map[string]bool{"ready": true, "active": true}
 
 type Location struct {
 	Type        string
@@ -43,9 +62,20 @@ func DetectFromCwd(campaignRoot, cwd string) (*Location, error) {
 	}
 
 	parts := strings.Split(rel, "/")
-	if parts[0] != "workflow" {
+	switch parts[0] {
+	case "workflow":
+		return detectWorkflowItem(campaignRoot, parts)
+	case festivalsRoot:
+		return detectFestivalResident(campaignRoot, parts)
+	default:
 		return nil, camperrors.New("not inside a workitem; cwd must be under workflow/<type>/<slug>/")
 	}
+}
+
+// detectWorkflowItem resolves the workflow/<type>/... layouts. The type comes
+// from the path segment, and the dungeon is that type's own dungeon folder in
+// whichever spelling exists on disk.
+func detectWorkflowItem(campaignRoot string, parts []string) (*Location, error) {
 	if len(parts) < 3 {
 		return nil, camperrors.New("not inside a workitem; cwd is at workflow root, expected workflow/<type>/<slug>/")
 	}
@@ -53,25 +83,30 @@ func DetectFromCwd(campaignRoot, cwd string) (*Location, error) {
 	if typeName == "" || spelling.IsDungeonName(typeName) {
 		return nil, camperrors.New(fmt.Sprintf("not inside a workitem; %q is not a valid workflow type", typeName))
 	}
-
 	if !spelling.IsDungeonName(parts[2]) {
-		slug := parts[2]
-		parentRel := filepath.Join("workflow", typeName)
-		sourceRel := filepath.Join("workflow", typeName, slug)
-		resolved, err := spelling.Resolve(context.Background(), filepath.Join(campaignRoot, parentRel))
-		if err != nil {
-			return nil, err
-		}
-		dungeonRel := filepath.Join("workflow", typeName, resolved.Name)
-		return &Location{
-			Type:        typeName,
-			Slug:        slug,
-			ParentPath:  filepath.Join(campaignRoot, parentRel),
-			SourcePath:  filepath.Join(campaignRoot, sourceRel),
-			DungeonPath: filepath.Join(campaignRoot, dungeonRel),
-		}, nil
+		return workflowActive(campaignRoot, typeName, parts[2])
 	}
+	return workflowDungeon(campaignRoot, typeName, parts)
+}
 
+func workflowActive(campaignRoot, typeName, slug string) (*Location, error) {
+	parentRel := filepath.Join("workflow", typeName)
+	sourceRel := filepath.Join("workflow", typeName, slug)
+	resolved, err := spelling.Resolve(context.Background(), filepath.Join(campaignRoot, parentRel))
+	if err != nil {
+		return nil, err
+	}
+	dungeonRel := filepath.Join("workflow", typeName, resolved.Name)
+	return &Location{
+		Type:        typeName,
+		Slug:        slug,
+		ParentPath:  filepath.Join(campaignRoot, parentRel),
+		SourcePath:  filepath.Join(campaignRoot, sourceRel),
+		DungeonPath: filepath.Join(campaignRoot, dungeonRel),
+	}, nil
+}
+
+func workflowDungeon(campaignRoot, typeName string, parts []string) (*Location, error) {
 	dungeonName := parts[2]
 	if len(parts) < 5 {
 		return nil, camperrors.New(fmt.Sprintf("not inside a workitem; cwd is at workflow/%s/%s[/...] without a slug", typeName, dungeonName))
@@ -104,4 +139,95 @@ func DetectFromCwd(campaignRoot, cwd string) (*Location, error) {
 		InDungeon:   true,
 		Status:      status,
 	}, nil
+}
+
+// detectFestivalResident resolves a workitem living on the festival rail, either
+// at a working stage (festivals/ready|active/<slug>) or already shelved
+// (festivals/.dungeon/<status>[/<date>]/<slug>). Both shapes report
+// DungeonPath = festivals/.dungeon so the shared move plumbing keeps a resident
+// inside the festival tree instead of sending it back to its workflow type.
+func detectFestivalResident(campaignRoot string, parts []string) (*Location, error) {
+	if len(parts) < 2 || parts[1] == "" {
+		return nil, camperrors.New("not inside a workitem; cwd is at the festivals root")
+	}
+	if parts[1] == festivalDungeonName {
+		return festivalDungeon(campaignRoot, parts)
+	}
+	return festivalStage(campaignRoot, parts)
+}
+
+func festivalStage(campaignRoot string, parts []string) (*Location, error) {
+	stage := parts[1]
+	if !festivalStages[stage] {
+		return nil, camperrors.New(fmt.Sprintf("not inside a workitem; festivals/%s is not a rail stage (expected festivals/ready/<slug> or festivals/active/<slug>)", stage))
+	}
+	if len(parts) < 3 || parts[2] == "" {
+		return nil, camperrors.New(fmt.Sprintf("not inside a workitem; cwd is at festivals/%s without a slug", stage))
+	}
+
+	slug := parts[2]
+	parentRel := festivalsRoot + "/" + stage
+	sourceRel := parentRel + "/" + slug
+	typeName, err := residentType(filepath.Join(campaignRoot, sourceRel), sourceRel)
+	if err != nil {
+		return nil, err
+	}
+	return &Location{
+		Type:        typeName,
+		Slug:        slug,
+		ParentPath:  filepath.Join(campaignRoot, parentRel),
+		SourcePath:  filepath.Join(campaignRoot, sourceRel),
+		DungeonPath: filepath.Join(campaignRoot, festivalsRoot, festivalDungeonName),
+	}, nil
+}
+
+func festivalDungeon(campaignRoot string, parts []string) (*Location, error) {
+	if len(parts) < 4 || parts[2] == "" {
+		return nil, camperrors.New("not inside a workitem; cwd is at the festivals dungeon root")
+	}
+	status := parts[2]
+
+	var slug string
+	var parentRel string
+	if statuspath.IsDateDir(parts[3]) {
+		if len(parts) < 5 || parts[4] == "" {
+			return nil, camperrors.New(fmt.Sprintf("not inside a workitem; cwd is at festivals/%s/%s/%s without a slug", festivalDungeonName, status, parts[3]))
+		}
+		slug = parts[4]
+		parentRel = festivalsRoot + "/" + festivalDungeonName + "/" + status + "/" + parts[3]
+	} else {
+		slug = parts[3]
+		parentRel = festivalsRoot + "/" + festivalDungeonName + "/" + status
+	}
+
+	sourceRel := parentRel + "/" + slug
+	typeName, err := residentType(filepath.Join(campaignRoot, sourceRel), sourceRel)
+	if err != nil {
+		return nil, err
+	}
+	return &Location{
+		Type:        typeName,
+		Slug:        slug,
+		ParentPath:  filepath.Join(campaignRoot, parentRel),
+		SourcePath:  filepath.Join(campaignRoot, sourceRel),
+		DungeonPath: filepath.Join(campaignRoot, festivalsRoot, festivalDungeonName),
+		InDungeon:   true,
+		Status:      status,
+	}, nil
+}
+
+// residentType reads a resident's workflow type from its .workitem marker. The
+// path cannot supply it the way workflow/<type>/ does, because a resident's
+// parent segment is a lifecycle stage rather than a type. An unstamped directory
+// in a lifecycle folder is not a resident camp can move, so it is a clear error
+// rather than a guess; camp workitem doctor surfaces these.
+func residentType(absDir, relPath string) (string, error) {
+	meta, err := wkitem.LoadMetadata(context.Background(), absDir)
+	if err != nil {
+		return "", err
+	}
+	if meta == nil {
+		return "", camperrors.New(fmt.Sprintf("not a lifecycle resident; %s has no .workitem marker (run camp workitem doctor)", relPath))
+	}
+	return meta.Type, nil
 }

--- a/internal/workitem/locate/locate.go
+++ b/internal/workitem/locate/locate.go
@@ -27,10 +27,15 @@ const festivalsRoot = "festivals"
 // workflow type it came from.
 const festivalDungeonName = ".dungeon"
 
-// festivalStages are the rail stages a resident workitem can occupy. Promotion
-// onto the rail targets ready and active only; festivals/ also holds folders
-// that are not rail stages (planning, chains, ritual), and those do not resolve.
-var festivalStages = map[string]bool{"ready": true, "active": true}
+// festivalStages are the rail stages a resident workitem can occupy, named from
+// the lifecycle vocabulary so the folder this resolver accepts cannot drift from
+// the stage a workitem can be promoted to. Promotion onto the rail targets ready
+// and active only; festivals/ also holds folders that are not rail stages
+// (planning, chains, ritual), and those do not resolve.
+var festivalStages = map[string]bool{
+	string(wkitem.LifecycleStageReady):  true,
+	string(wkitem.LifecycleStageActive): true,
+}
 
 type Location struct {
 	Type        string

--- a/internal/workitem/locate/locate_test.go
+++ b/internal/workitem/locate/locate_test.go
@@ -195,6 +195,55 @@ func TestDetectFromCwd(t *testing.T) {
 			cwd:     "/campaign/workflow/design/dungeon/completed/2026-05-22",
 			wantErr: "without a slug",
 		},
+		{
+			name:     "dungeon dated layout 2026-07-24 regression",
+			cwd:      "/campaign/workflow/design/dungeon/completed/2026-07-24/oldslug",
+			wantType: "design",
+			wantSlug: "oldslug",
+			wantSrc:  "/campaign/workflow/design/dungeon/completed/2026-07-24/oldslug",
+			wantPar:  "/campaign/workflow/design/dungeon/completed/2026-07-24",
+			wantDun:  "/campaign/workflow/design/dungeon",
+			wantIn:   true,
+			wantStat: "completed",
+		},
+		// Festival rail error paths. These need no fixture on disk: a missing
+		// .workitem reads the same as an unstamped directory, which is exactly
+		// the rejection being asserted.
+		{
+			name:    "festivals root",
+			cwd:     "/campaign/festivals",
+			wantErr: "at the festivals root",
+		},
+		{
+			name:    "festivals non-rail stage",
+			cwd:     "/campaign/festivals/planning/some-festival",
+			wantErr: "not a rail stage",
+		},
+		{
+			name:    "festivals stage without slug",
+			cwd:     "/campaign/festivals/ready",
+			wantErr: "without a slug",
+		},
+		{
+			name:    "festivals resident without marker",
+			cwd:     "/campaign/festivals/ready/unstamped",
+			wantErr: "no .workitem marker",
+		},
+		{
+			name:    "festivals dungeon root",
+			cwd:     "/campaign/festivals/.dungeon/completed",
+			wantErr: "at the festivals dungeon root",
+		},
+		{
+			name:    "festivals dungeon date dir no slug",
+			cwd:     "/campaign/festivals/.dungeon/completed/2026-07-24",
+			wantErr: "without a slug",
+		},
+		{
+			name:    "festivals dungeon resident without marker",
+			cwd:     "/campaign/festivals/.dungeon/completed/2026-07-24/unstamped",
+			wantErr: "no .workitem marker",
+		},
 	}
 
 	for _, tc := range tests {
@@ -234,5 +283,183 @@ func TestDetectFromCwd(t *testing.T) {
 				t.Errorf("Status=%q want %q", got.Status, tc.wantStat)
 			}
 		})
+	}
+}
+
+// stampResident creates dir under root and writes a valid .workitem marker with
+// the given workflow type, mirroring what a workitem carries once it has been
+// promoted onto the festival rail.
+func stampResident(t *testing.T, root, relDir, typeName string) string {
+	t.Helper()
+	dir := filepath.Join(root, filepath.FromSlash(relDir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", relDir, err)
+	}
+	marker := "version: v1alpha8\nkind: workitem\nid: " + typeName + "-resident-2026-07-24\ntype: " + typeName + "\ntitle: Resident\n"
+	if err := os.WriteFile(filepath.Join(dir, ".workitem"), []byte(marker), 0o644); err != nil {
+		t.Fatalf("write .workitem in %s: %v", relDir, err)
+	}
+	return dir
+}
+
+// TestDetectFromCwd_FestivalResident covers the rail layouts, which unlike the
+// workflow layouts cannot be resolved from the path alone: the parent segment is
+// a lifecycle stage, so Type has to come off the .workitem marker. Every case
+// must report DungeonPath = festivals/.dungeon so the shared move plumbing keeps
+// a resident inside the festival tree instead of returning it to its workflow
+// type's dungeon.
+func TestDetectFromCwd_FestivalResident(t *testing.T) {
+	tests := []struct {
+		name     string
+		relDir   string
+		cwdRel   string
+		typeName string
+		wantSlug string
+		wantSrc  string
+		wantPar  string
+		wantIn   bool
+		wantStat string
+	}{
+		{
+			name:     "ready stage",
+			relDir:   "festivals/ready/my-item",
+			typeName: "design",
+			wantSlug: "my-item",
+			wantSrc:  "festivals/ready/my-item",
+			wantPar:  "festivals/ready",
+		},
+		{
+			name:     "active stage",
+			relDir:   "festivals/active/my-item",
+			typeName: "design",
+			wantSlug: "my-item",
+			wantSrc:  "festivals/active/my-item",
+			wantPar:  "festivals/active",
+		},
+		{
+			name:     "active stage from a subdir",
+			relDir:   "festivals/active/my-item",
+			cwdRel:   "festivals/active/my-item/notes",
+			typeName: "explore",
+			wantSlug: "my-item",
+			wantSrc:  "festivals/active/my-item",
+			wantPar:  "festivals/active",
+		},
+		{
+			name:     "festival-local dungeon dated layout",
+			relDir:   "festivals/.dungeon/completed/2026-07-24/my-item",
+			typeName: "design",
+			wantSlug: "my-item",
+			wantSrc:  "festivals/.dungeon/completed/2026-07-24/my-item",
+			wantPar:  "festivals/.dungeon/completed/2026-07-24",
+			wantIn:   true,
+			wantStat: "completed",
+		},
+		{
+			name:     "festival-local dungeon flat layout",
+			relDir:   "festivals/.dungeon/archived/my-item",
+			typeName: "design",
+			wantSlug: "my-item",
+			wantSrc:  "festivals/.dungeon/archived/my-item",
+			wantPar:  "festivals/.dungeon/archived",
+			wantIn:   true,
+			wantStat: "archived",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			if resolved, err := filepath.EvalSymlinks(root); err == nil {
+				root = resolved
+			}
+			stampResident(t, root, tc.relDir, tc.typeName)
+
+			cwd := filepath.Join(root, filepath.FromSlash(tc.relDir))
+			if tc.cwdRel != "" {
+				cwd = filepath.Join(root, filepath.FromSlash(tc.cwdRel))
+				if err := os.MkdirAll(cwd, 0o755); err != nil {
+					t.Fatalf("MkdirAll %s: %v", tc.cwdRel, err)
+				}
+			}
+
+			got, err := DetectFromCwd(root, cwd)
+			if err != nil {
+				t.Fatalf("DetectFromCwd(%s): %v", tc.relDir, err)
+			}
+			if got.Type != tc.typeName {
+				t.Errorf("Type=%q want %q (must come from the .workitem marker)", got.Type, tc.typeName)
+			}
+			if got.Slug != tc.wantSlug {
+				t.Errorf("Slug=%q want %q", got.Slug, tc.wantSlug)
+			}
+			if want := filepath.Join(root, filepath.FromSlash(tc.wantSrc)); got.SourcePath != want {
+				t.Errorf("SourcePath=%q want %q", got.SourcePath, want)
+			}
+			if want := filepath.Join(root, filepath.FromSlash(tc.wantPar)); got.ParentPath != want {
+				t.Errorf("ParentPath=%q want %q", got.ParentPath, want)
+			}
+			if want := filepath.Join(root, "festivals", ".dungeon"); got.DungeonPath != want {
+				t.Errorf("DungeonPath=%q want %q", got.DungeonPath, want)
+			}
+			if got.InDungeon != tc.wantIn {
+				t.Errorf("InDungeon=%v want %v", got.InDungeon, tc.wantIn)
+			}
+			if got.Status != tc.wantStat {
+				t.Errorf("Status=%q want %q", got.Status, tc.wantStat)
+			}
+		})
+	}
+}
+
+// TestDetectFromCwd_FestivalResidentTypeIsNotThePath guards the divergence from
+// the workflow branch: two residents sitting side by side in the same stage
+// folder resolve to different types, which is only possible by reading markers.
+func TestDetectFromCwd_FestivalResidentTypeIsNotThePath(t *testing.T) {
+	root := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
+	designDir := stampResident(t, root, "festivals/active/a-design", "design")
+	exploreDir := stampResident(t, root, "festivals/active/an-explore", "explore")
+
+	design, err := DetectFromCwd(root, designDir)
+	if err != nil {
+		t.Fatalf("DetectFromCwd(design resident): %v", err)
+	}
+	explore, err := DetectFromCwd(root, exploreDir)
+	if err != nil {
+		t.Fatalf("DetectFromCwd(explore resident): %v", err)
+	}
+	if design.Type != "design" || explore.Type != "explore" {
+		t.Fatalf("types = %q/%q, want design/explore", design.Type, explore.Type)
+	}
+	if design.ParentPath != explore.ParentPath {
+		t.Errorf("residents in one stage disagree on ParentPath: %q vs %q", design.ParentPath, explore.ParentPath)
+	}
+}
+
+// TestDetectFromCwd_WorkflowUnaffectedByMarker is the regression for requirement
+// 3: a workflow item's Type comes from its path, so a marker that disagrees is
+// ignored and resolution is byte-identical to before the rail existed.
+func TestDetectFromCwd_WorkflowUnaffectedByMarker(t *testing.T) {
+	root := t.TempDir()
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
+	}
+	itemDir := stampResident(t, root, "workflow/design/myslug", "explore")
+
+	loc, err := DetectFromCwd(root, itemDir)
+	if err != nil {
+		t.Fatalf("DetectFromCwd: %v", err)
+	}
+	if loc.Type != "design" {
+		t.Errorf("Type=%q want design (path wins for workflow items, not the marker)", loc.Type)
+	}
+	if want := filepath.Join(root, "workflow", "design", "dungeon"); loc.DungeonPath != want {
+		t.Errorf("DungeonPath=%q want %q", loc.DungeonPath, want)
+	}
+	if loc.InDungeon {
+		t.Error("InDungeon = true, want false")
 	}
 }

--- a/internal/workitem/stage.go
+++ b/internal/workitem/stage.go
@@ -28,6 +28,7 @@ var StagesByType = map[WorkflowType][]LifecycleStage{
 	WorkflowTypeExplore: {
 		LifecycleStageNone,
 		LifecycleStageActive,
+		LifecycleStageReady,
 	},
 	WorkflowTypeFestival: {
 		LifecycleStageNone,

--- a/tests/integration/promote_rail_test.go
+++ b/tests/integration/promote_rail_test.go
@@ -283,6 +283,81 @@ func TestPromoteRail_ExploreAcceptsReady(t *testing.T) {
 	assert.Contains(t, marker, "type: explore", "a resident keeps its original workflow type")
 }
 
+// TestPromoteRail_RepairsMismatchedMarkerType covers a valid marker whose type
+// disagrees with the workflow path. The path type is authoritative: reference
+// migration keys the move on it, while resident resolution afterwards reads the
+// marker, so an unrepaired mismatch would re-home priority onto a key no rail
+// command can resolve. Rail entry must canonicalize the marker before moving.
+func TestPromoteRail_RepairsMismatchedMarkerType(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRailCampaign(t, tc, "rail-mismarked")
+
+	out, err := tc.RunCampInDir(path, "workitem", "priority",
+		"design-rail-feature-fixed", "high")
+	require.NoError(t, err, "priority set should succeed: %s", out)
+
+	_, _, err = tc.ExecCommand("sh", "-c",
+		"sed -i 's/^type: design$/type: explore/' "+path+"/workflow/design/rail-feature/.workitem"+
+			" && cd "+path+" && git add -A && git commit -m 'mismark type'")
+	require.NoError(t, err)
+	fixture, err := tc.ReadFile(path + "/workflow/design/rail-feature/.workitem")
+	require.NoError(t, err)
+	require.Contains(t, fixture, "type: explore", "fixture must start with the mismatched type")
+
+	railTo(t, tc, path+"/workflow/design/rail-feature", "ready")
+
+	marker, err := tc.ReadFile(path + "/festivals/ready/rail-feature/.workitem")
+	require.NoError(t, err)
+	assert.Contains(t, marker, "type: design", "the marker must be repaired to the authoritative path type")
+	assert.NotContains(t, marker, "type: explore", "the mismatched type must not survive rail entry")
+	assert.Contains(t, marker, "id: design-rail-feature-fixed", "repair must preserve the existing id")
+
+	priorities, err := tc.ReadFile(path + "/.campaign/settings/workitems.json")
+	require.NoError(t, err)
+	assert.Contains(t, priorities, "design:festivals/ready/rail-feature",
+		"the migrated priority key and the repaired marker must agree on the type")
+
+	// The proof the fracture is gone: resident resolution reads the repaired
+	// marker, so the same workitem must resolve and advance.
+	railTo(t, tc, path+"/festivals/ready/rail-feature", "active")
+	after, err := tc.ReadFile(path + "/.campaign/settings/workitems.json")
+	require.NoError(t, err)
+	assert.Contains(t, after, "design:festivals/active/rail-feature",
+		"the advance must re-key the same priority entry again")
+}
+
+// TestPromoteRail_MalformedMarkerFailsBeforeMoving covers the marker the repair
+// planner refuses: unparseable YAML. Moving first would strand a resident
+// nothing can resolve, so the promote must fail with the source untouched.
+func TestPromoteRail_MalformedMarkerFailsBeforeMoving(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRailCampaign(t, tc, "rail-malformed")
+
+	require.NoError(t, tc.WriteFile(path+"/workflow/design/rail-feature/.workitem",
+		"kind: [unclosed\n"))
+	_, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git add -A && git commit -m 'corrupt marker'")
+	require.NoError(t, err)
+
+	_, stderr, exitCode, err := tc.RunCampSplitInDir(path+"/workflow/design/rail-feature",
+		"workitem", "promote", "--target", "ready")
+	require.NoError(t, err)
+	assert.NotZero(t, exitCode, "a promote with an unparseable marker must fail")
+	assert.Contains(t, stderr, "cannot parse existing .workitem",
+		"the failure must name the marker so the operator knows what to fix")
+
+	exists, err := tc.CheckDirExists(path + "/workflow/design/rail-feature")
+	require.NoError(t, err)
+	assert.True(t, exists, "failing before the move leaves the workitem in place")
+
+	exists, err = tc.CheckDirExists(path + "/festivals/ready/rail-feature")
+	require.NoError(t, err)
+	assert.False(t, exists, "nothing may land on the stage when the marker cannot be repaired")
+
+	status, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git status --porcelain")
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(status), "a refused promote must not dirty the tree")
+}
+
 // TestPromoteRail_RejectsOccupiedDestination guards against clobbering a
 // resident that already holds the slug on that stage.
 func TestPromoteRail_RejectsOccupiedDestination(t *testing.T) {

--- a/tests/integration/promote_rail_test.go
+++ b/tests/integration/promote_rail_test.go
@@ -1,0 +1,309 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupRailCampaign creates a campaign holding one committed design workitem,
+// the starting point for every rail move.
+func setupRailCampaign(t *testing.T, tc *TestContainer, name string) string {
+	t.Helper()
+
+	path := "/campaigns/" + name
+	_, err := tc.InitCampaign(path, name, "product")
+	require.NoError(t, err)
+
+	out, err := tc.RunCampInDir(path,
+		"workitem", "create", "rail-feature",
+		"--type", "design",
+		"--title", "Rail feature",
+		"--id", "design-rail-feature-fixed",
+	)
+	require.NoError(t, err, "workitem create should succeed: %s", out)
+
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+path+" && git add -A && git commit -m 'add rail workitem'")
+	require.NoError(t, err)
+
+	return path
+}
+
+// railTo promotes the campaign's workitem onto a stage from the given cwd.
+func railTo(t *testing.T, tc *TestContainer, cwd, stage string) string {
+	t.Helper()
+	out, err := tc.RunCampInDir(cwd, "workitem", "promote", "--target", stage)
+	require.NoError(t, err, "promote to %s should succeed: %s", stage, out)
+	return out
+}
+
+// TestPromoteRail_RootToStage covers both rail-entry moves. The directory itself
+// relocates, so the assertions are physical: the destination exists with its
+// content and marker, the source is gone, and the move is committed.
+func TestPromoteRail_RootToStage(t *testing.T) {
+	for _, stage := range []string{"ready", "active"} {
+		t.Run(stage, func(t *testing.T) {
+			tc := GetSharedContainer(t)
+			path := setupRailCampaign(t, tc, "rail-entry-"+stage)
+
+			out := railTo(t, tc, path+"/workflow/design/rail-feature", stage)
+			assert.Contains(t, out, "festivals/"+stage+"/rail-feature")
+
+			exists, err := tc.CheckDirExists(path + "/festivals/" + stage + "/rail-feature")
+			require.NoError(t, err)
+			assert.True(t, exists, "workitem should live on the %s stage", stage)
+
+			exists, err = tc.CheckFileExists(path + "/festivals/" + stage + "/rail-feature/.workitem")
+			require.NoError(t, err)
+			assert.True(t, exists, "marker must travel with the resident or it cannot be resolved again")
+
+			exists, err = tc.CheckDirExists(path + "/workflow/design/rail-feature")
+			require.NoError(t, err)
+			assert.False(t, exists, "source should be gone; the move is the promotion")
+
+			status, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git status --porcelain")
+			require.NoError(t, err)
+			assert.Empty(t, strings.TrimSpace(status), "rail move should auto-commit and leave a clean tree")
+		})
+	}
+}
+
+// TestPromoteRail_ReadyToActiveAdvance exercises the advance, whose source is a
+// resident and therefore depends on resident location resolution.
+func TestPromoteRail_ReadyToActiveAdvance(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRailCampaign(t, tc, "rail-advance")
+
+	railTo(t, tc, path+"/workflow/design/rail-feature", "ready")
+	out := railTo(t, tc, path+"/festivals/ready/rail-feature", "active")
+	assert.Contains(t, out, "festivals/active/rail-feature")
+
+	exists, err := tc.CheckDirExists(path + "/festivals/active/rail-feature")
+	require.NoError(t, err)
+	assert.True(t, exists, "resident should have advanced to active")
+
+	exists, err = tc.CheckDirExists(path + "/festivals/ready/rail-feature")
+	require.NoError(t, err)
+	assert.False(t, exists, "resident should no longer be on ready")
+
+	status, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git status --porcelain")
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(status), "advance should auto-commit")
+}
+
+// TestPromoteRail_ForwardOnlyRejections locks every refused transition. A
+// rejection must change nothing on disk: the workitem stays exactly where it was.
+func TestPromoteRail_ForwardOnlyRejections(t *testing.T) {
+	tests := []struct {
+		name     string
+		stageNow string // rail stage to park the workitem on first, "" = stay at root
+		shelve   bool   // shelve into the dungeon instead
+		target   string
+		wantErr  string
+	}{
+		{name: "active to ready", stageNow: "active", target: "ready", wantErr: "forward-only"},
+		{name: "ready to ready", stageNow: "ready", target: "ready", wantErr: "forward-only"},
+		{name: "active to active", stageNow: "active", target: "active", wantErr: "already active on the rail"},
+		{name: "dungeon to ready", shelve: true, target: "ready", wantErr: "restoring workitems out of the dungeon is not a promote"},
+		{name: "dungeon to active", shelve: true, target: "active", wantErr: "restoring workitems out of the dungeon is not a promote"},
+	}
+
+	for _, tc2 := range tests {
+		t.Run(tc2.name, func(t *testing.T) {
+			tc := GetSharedContainer(t)
+			path := setupRailCampaign(t, tc, "rail-reject-"+strings.ReplaceAll(tc2.name, " ", "-"))
+
+			var srcDir string
+			switch {
+			case tc2.shelve:
+				out, err := tc.RunCampInDir(path+"/workflow/design/rail-feature", "workitem", "promote", "--target", "completed")
+				require.NoError(t, err, "shelve should succeed: %s", out)
+				found, _, ferr := tc.ExecCommand("sh", "-c",
+					"find "+path+"/workflow/design/dungeon -type d -name rail-feature | head -1")
+				require.NoError(t, ferr)
+				srcDir = strings.TrimSpace(found)
+				require.NotEmpty(t, srcDir, "shelved workitem should be findable in the dungeon")
+			case tc2.stageNow != "":
+				railTo(t, tc, path+"/workflow/design/rail-feature", tc2.stageNow)
+				srcDir = path + "/festivals/" + tc2.stageNow + "/rail-feature"
+			default:
+				srcDir = path + "/workflow/design/rail-feature"
+			}
+
+			_, stderr, exitCode, err := tc.RunCampSplitInDir(srcDir, "workitem", "promote", "--target", tc2.target)
+			require.NoError(t, err)
+			assert.NotZero(t, exitCode, "a refused rail move must exit non-zero")
+			assert.Contains(t, stderr, tc2.wantErr)
+
+			exists, cerr := tc.CheckDirExists(srcDir)
+			require.NoError(t, cerr)
+			assert.True(t, exists, "a refused promote must leave the workitem where it was")
+
+			status, _, serr := tc.ExecCommand("sh", "-c", "cd "+path+" && git status --porcelain")
+			require.NoError(t, serr)
+			assert.Empty(t, strings.TrimSpace(status), "a refused promote must not dirty the tree")
+		})
+	}
+}
+
+// TestPromoteRail_RepairsReferences asserts the fixup surface doc 04 rule 3
+// requires: the links registry re-homes onto the new path, markdown
+// cross-references are rewritten, and an audit event is appended.
+func TestPromoteRail_RepairsReferences(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRailCampaign(t, tc, "rail-references")
+
+	require.NoError(t, tc.WriteFile(path+"/docs/index.md",
+		"# Index\n\nSee [the item](../workflow/design/rail-feature/README.md).\n"))
+	// The link scope must exist on disk before it can be linked.
+	_, _, err := tc.ExecCommand("sh", "-c", "mkdir -p "+path+"/projects/worktrees/demo")
+	require.NoError(t, err)
+	out, err := tc.RunCampInDir(path, "workitem", "link", "design-rail-feature-fixed",
+		"projects/worktrees/demo", "--role", "primary")
+	require.NoError(t, err, "link should succeed: %s", out)
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+path+" && git add -A && git commit -m 'add refs'")
+	require.NoError(t, err)
+
+	railTo(t, tc, path+"/workflow/design/rail-feature", "ready")
+
+	linksBody, err := tc.ReadFile(path + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, linksBody, "design:festivals/ready/rail-feature",
+		"link key should re-home onto the resident path")
+	assert.NotContains(t, linksBody, "design:workflow/design/rail-feature",
+		"the old key must not survive")
+	assert.Contains(t, linksBody, "projects/worktrees/demo",
+		"the link's scope must be preserved, only its key moves")
+
+	indexBody, err := tc.ReadFile(path + "/docs/index.md")
+	require.NoError(t, err)
+	assert.Contains(t, indexBody, "../festivals/ready/rail-feature/README.md",
+		"markdown cross-reference should follow the move")
+
+	audit, err := tc.ReadFile(path + "/.campaign/workitems/.workitems.jsonl")
+	require.NoError(t, err)
+	assert.Contains(t, audit, "festivals/ready/rail-feature", "a promote event should record the destination")
+}
+
+// TestPromoteRail_PriorityStoreRekeyedNotStaged mirrors the rename expectation:
+// .campaign/settings/workitems.json is gitignored per-machine state, so a rail
+// move must re-key it on disk without dragging it into the commit.
+func TestPromoteRail_PriorityStoreRekeyedNotStaged(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRailCampaign(t, tc, "rail-priority")
+
+	out, err := tc.RunCampInDir(path, "workitem", "priority",
+		"design-rail-feature-fixed", "high")
+	require.NoError(t, err, "priority set should succeed: %s", out)
+
+	before, err := tc.ReadFile(path + "/.campaign/settings/workitems.json")
+	require.NoError(t, err)
+	require.Contains(t, before, "design:workflow/design/rail-feature",
+		"priority store should be keyed on the pre-move path")
+
+	railTo(t, tc, path+"/workflow/design/rail-feature", "ready")
+
+	after, err := tc.ReadFile(path + "/.campaign/settings/workitems.json")
+	require.NoError(t, err)
+	assert.Contains(t, after, "design:festivals/ready/rail-feature",
+		"priority store should be re-keyed onto the resident path")
+	assert.NotContains(t, after, "design:workflow/design/rail-feature",
+		"the old priority key must not survive")
+
+	files := tc.GitOutput(t, path, "show", "--name-only", "--format=", "HEAD")
+	assert.NotContains(t, files, ".campaign/settings/workitems.json",
+		"the priority store is gitignored machine state and must not be staged")
+}
+
+// TestPromoteRail_StampsUnmarkedSource is why stamping happens at rail entry.
+// Directory workitems are not uniformly marked, but a resident without a marker
+// cannot be resolved, so entering the rail unmarked would strand it.
+func TestPromoteRail_StampsUnmarkedSource(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := "/campaigns/rail-unmarked"
+	_, err := tc.InitCampaign(path, "rail-unmarked", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(path+"/workflow/design/bare/README.md", "# Bare\n\nNo marker.\n"))
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+path+" && git add -A && git commit -m 'add bare dir'")
+	require.NoError(t, err)
+
+	exists, err := tc.CheckFileExists(path + "/workflow/design/bare/.workitem")
+	require.NoError(t, err)
+	require.False(t, exists, "fixture must start without a marker")
+
+	railTo(t, tc, path+"/workflow/design/bare", "ready")
+
+	marker, err := tc.ReadFile(path + "/festivals/ready/bare/.workitem")
+	require.NoError(t, err, "rail entry must mint a marker")
+	assert.Contains(t, marker, "type: design", "minted marker keeps the source's workflow type")
+	assert.Contains(t, marker, "kind: workitem")
+	assert.Regexp(t, `(?m)^id: .+$`, marker, "minted marker must carry an id")
+
+	// The marker is what makes the resident resolvable, so a second rail move
+	// off it must work.
+	railTo(t, tc, path+"/festivals/ready/bare", "active")
+	exists, err = tc.CheckDirExists(path + "/festivals/active/bare")
+	require.NoError(t, err)
+	assert.True(t, exists, "a stamped resident must be able to advance")
+}
+
+// TestPromoteRail_ExploreAcceptsReady confirms an explore workitem reaches the
+// ready stage. Reclassification in camp wi is sequence 03; this asserts only that
+// the promote succeeds and the directory lands on the stage.
+func TestPromoteRail_ExploreAcceptsReady(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := "/campaigns/rail-explore"
+	_, err := tc.InitCampaign(path, "rail-explore", "product")
+	require.NoError(t, err)
+
+	out, err := tc.RunCampInDir(path,
+		"workitem", "create", "explore-topic",
+		"--type", "explore",
+		"--title", "Explore topic",
+		"--id", "explore-topic-fixed",
+	)
+	require.NoError(t, err, "explore create should succeed: %s", out)
+	_, _, err = tc.ExecCommand("sh", "-c", "cd "+path+" && git add -A && git commit -m 'add explore'")
+	require.NoError(t, err)
+
+	railTo(t, tc, path+"/workflow/explore/explore-topic", "ready")
+
+	exists, err := tc.CheckDirExists(path + "/festivals/ready/explore-topic")
+	require.NoError(t, err)
+	assert.True(t, exists, "explore workitem should reach the ready stage")
+
+	marker, err := tc.ReadFile(path + "/festivals/ready/explore-topic/.workitem")
+	require.NoError(t, err)
+	assert.Contains(t, marker, "type: explore", "a resident keeps its original workflow type")
+}
+
+// TestPromoteRail_RejectsOccupiedDestination guards against clobbering a
+// resident that already holds the slug on that stage.
+func TestPromoteRail_RejectsOccupiedDestination(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRailCampaign(t, tc, "rail-occupied")
+
+	require.NoError(t, tc.WriteFile(path+"/festivals/ready/rail-feature/README.md", "# Squatter\n"))
+	require.NoError(t, tc.WriteFile(path+"/festivals/ready/rail-feature/.workitem",
+		"version: v1alpha8\nkind: workitem\nid: design-squatter-fixed\ntype: design\ntitle: Squatter\n"))
+
+	_, stderr, exitCode, err := tc.RunCampSplitInDir(path+"/workflow/design/rail-feature",
+		"workitem", "promote", "--target", "ready")
+	require.NoError(t, err)
+	assert.NotZero(t, exitCode, "promoting onto an occupied slug must fail")
+	assert.Contains(t, stderr, "already exists")
+
+	body, err := tc.ReadFile(path + "/festivals/ready/rail-feature/README.md")
+	require.NoError(t, err)
+	assert.Contains(t, body, "Squatter", "the occupant must be untouched")
+
+	exists, err := tc.CheckDirExists(path + "/workflow/design/rail-feature")
+	require.NoError(t, err)
+	assert.True(t, exists, "the refused source must stay in place")
+}


### PR DESCRIPTION
**Stack base:** branches off `main` at `3643af24` (PR #516). Not stacked on any open PR; #520 (sweep link release) is independent and touches different files.

**Review fixes applied on this branch** after the staff review: the interactive `camp promote` picker now offers the rail targets (`targetsForKind` omitted them), and the rail stage names now derive from the `LifecycleStage` constants instead of being spelled three separate ways.

---

WF0001 phase 003, sequence 02. Adds the festival rail: `camp workitem promote --target ready|active` physically moves a directory workitem onto `festivals/<stage>/<slug>`. The move IS the promotion, so the rail is a real kanban on disk rather than a status field.

Three commits, each self-contained:

## 1. Resident location resolution (`internal/workitem/locate`)

`DetectFromCwd` hard-required a `workflow/` first segment, so a workitem on the rail could not be located at all and none of the shared promote plumbing could touch it. It now dispatches on the first path segment:

| Path | `Type` | `ParentPath` | `DungeonPath` |
|------|--------|--------------|---------------|
| `workflow/<type>/...` | path segment | unchanged | `workflow/<type>/<dungeon>` |
| `festivals/{ready,active}/<slug>` | `.workitem` marker | the stage folder | `festivals/.dungeon` |
| `festivals/.dungeon/<status>[/<date>]/<slug>` | `.workitem` marker | the bucket | `festivals/.dungeon` |

`DungeonPath = festivals/.dungeon` is the point: `MoveToDungeon` builds its dungeon service straight off `loc.DungeonPath`, so a resident completes into the festival-local dungeon with no change to the move code. Sequence 04 depends on this.

The workflow branch was extracted into helpers verbatim; a regression test asserts a `workflow/design/<slug>` item carrying a marker that says `explore` still resolves as `design`, because for workflow items the path wins.

`locate` now imports `internal/workitem` for `LoadMetadata`. The task anticipated an import cycle; `go list -deps` confirms the parent package does not reach `locate`, so no minimal inline YAML parse was needed and residents get the same schema validation as every other marker read.

## 2. Rail targets (`internal/commands/workitem`)

The blanket `cannot promote to active` rejection is replaced by a transition check against the resolved source. `root -> ready -> active` is allowed; backward moves and any attempt to leave a dungeon are refused, which preserves what the old rejection actually protected.

`doRailPromote` returns `*commitInputs`, so the shared promote tail supplies the audit event, ledger emit, and auto-commit unchanged. Reference repair reuses the rename migrations verbatim (`migrateRenamePriority`, `migrateRenameLinks`, `migrateRenameCurrent`) because a rail move only changes the path half of the workitem key: `design:workflow/design/x` becomes `design:festivals/ready/x`. No helper bodies were duplicated and `applyRename` is not called.

**The marker is stamped at rail entry, before the move rather than after.** The task sketch put it after. Directory workitems are *not* uniformly stamped today (`recordPromotedTo` skips when the marker is absent; the ledger falls back to the slug for the same reason), but resident resolution *requires* a marker. Stamping after a successful move would strand the workitem where nothing can resolve it if that write failed. Stamping first means a failure leaves it at `workflow/<type>/<slug>`, fully recoverable. Minting goes through the `camp workitem repair` planner, so the marker matches what `doctor --fix` would write.

`recordPromotedTo` is deliberately not called for a rail move: `promoted_to` records where a shelved source was *copied*, and a rail move relocates the directory itself, so the field could only restate the workitem's own location.

File workitems are rejected: they keep identity in their own frontmatter and have nowhere to put the sidecar resident resolution reads.

Explore gains `ready` in `StagesByType`.

## 3. Tests

Eight containerized integration tests plus unit coverage. Every rejection asserts more than the error message: the workitem is still where it was and the tree is still clean, so a refused promote cannot half-apply.

## Known limitation (planned, not a defect)

A resident is **not yet selectable by id** — discovery does not produce residents until sequence 03, so `ready -> active` currently works from inside the resident directory (cwd) but not via `camp workitem promote <id>`:

```
$ camp workitem promote design-idfeature-2026-07-29 --target active
Error: no workitem matched selector design-idfeature-2026-07-29: ... not found
```

This is the planned sequence order (task 01 notes `wi.RelativePath` for a resident is "produced by sequence 03 discovery"), but it is a real usability cliff until that lands, so it should not be mistaken for finished.

## Deviation from a stated acceptance criterion

The sequence asked that `promote.go` stay under 500 lines. It was **798 lines before this work** and is 813 now, so that criterion was never satisfiable as written. The substantive half was honored: the rail move lives entirely in `promote_rail.go` (188 lines) and `promote.go` gained only the target switch, the guard, the dispatch case, and help text. Reducing it is a real but separate refactor. Flagging rather than silently claiming it.

Every function added here is under 50 lines (`doRailPromote` is the largest at 49).

## Verification

`just gate` green: 3837/3837 unit, 3882/3882 with integration vet. `golangci-lint --new-from-merge-base origin/main`: 0 issues. Both ratchets clean.

Driven end to end against throwaway fixture campaigns with a binary built from this branch — all six transitions, the marker mint, the `--json` envelope, link re-homing, and markdown rewriting. Full transcripts in the festival results docs.
