### PR TITLE
feat(artifacts): committed per-machine manifests with incremental hashing (CA0004 phase 002/04)

### DIFF
--- a/.justfiles/test.just
+++ b/.justfiles/test.just
@@ -64,7 +64,7 @@ integration-verbose:
     echo "Running container-based integration tests (verbose)..."
     DOCKER_HOST="unix://${HOME}/.colima/default/docker.sock" \
     TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock \
-    go test -v -tags=integration ./tests/integration/... -timeout 10m 2>&1
+    go test -v -tags=integration ./tests/integration/... -timeout 15m 2>&1
 
 # Run a specific integration test
 [no-cd]

--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Obedience-Corp/camp/internal/defercommit"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/jobs"
 
 	"github.com/Obedience-Corp/camp/cmd/camp/cmdutil"
 	"github.com/Obedience-Corp/camp/internal/campaign"
@@ -363,6 +364,20 @@ func runCommit(cmd *cobra.Command, args []string) error {
 		_, festivalRef, workitemRef := resolveCommitContext(ctx, campRoot, commitWorkitem)
 		ledger.NewFromRoot(ctx, campRoot, ledger.WarnTo(cmd.ErrOrStderr())).
 			CommitEvidence(ctx, ledgerkit.Scope{Workitem: workitemRef, Festival: festivalRef}, campRoot, target.Path, sha, message)
+	}
+
+	// Committed artifact manifests: re-queue each declared root's record so
+	// it describes the commit that just landed. Enqueue writes queue files
+	// only; all hashing happens in the worker, so the command returns before
+	// any of it begins. A failure to queue warns rather than failing a commit
+	// that already succeeded: the record is eventually consistent, and the
+	// next commit re-queues it.
+	if !target.IsSubmodule {
+		if n, mErr := jobs.EnqueueManifestsForRoots(ctx, campRoot); mErr != nil {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), ui.Warning("artifact manifest not queued: "+mErr.Error()))
+		} else if n > 0 {
+			defercommit.SpawnWorker(ctx, campRoot, campRoot)
+		}
 	}
 
 	_, _ = fmt.Fprintln(humanOut, ui.Success("Changes committed successfully"))

--- a/internal/artifacts/committed.go
+++ b/internal/artifacts/committed.go
@@ -2,8 +2,12 @@ package artifacts
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
@@ -46,8 +50,15 @@ func CommittedManifestRelPath(machine, rootRel string) string {
 	return filepath.ToSlash(filepath.Join(CommittedRelDir, machine, snapshotSlug(rootRel)+".json"))
 }
 
-// LoadCommitted reads one machine's committed manifest for a root. A missing
-// file is (nil, "", nil): no record yet, which callers treat as a first pass.
+// LoadCommitted reads one machine's committed manifest for a root from the
+// working tree. A missing file is (nil, "", nil): no record yet, which
+// callers treat as a first pass.
+//
+// This is the status-path variant for the drift surfaces, where one file read
+// per root is the cost contract. The worker's correctness decisions use
+// LoadCommittedAtHead instead: the working-tree file may be a crashed
+// attempt's uncommitted write, and treating that as the record would let a
+// retry skip the commit forever.
 func LoadCommitted(campaignRoot, machine, rootRel string) (*Manifest, string, error) {
 	path := filepath.Join(campaignRoot, filepath.FromSlash(CommittedManifestRelPath(machine, rootRel)))
 	data, err := os.ReadFile(path)
@@ -57,13 +68,54 @@ func LoadCommitted(campaignRoot, machine, rootRel string) (*Manifest, string, er
 	if err != nil {
 		return nil, "", camperrors.Wrapf(err, "read committed manifest for %s", rootRel)
 	}
+	return decodeCommitted(data, rootRel)
+}
+
+// LoadCommittedAtHead reads the record as git has it at HEAD, which is the
+// only baseline a manifest job may trust: it proves the previous record
+// actually landed in history rather than merely reaching the filesystem.
+func LoadCommittedAtHead(ctx context.Context, campaignRoot, machine, rootRel string) (*Manifest, string, error) {
+	rel := CommittedManifestRelPath(machine, rootRel)
+	show := exec.CommandContext(ctx, "git", "-C", campaignRoot, "show", "HEAD:"+rel)
+	out, err := show.Output()
+	if err != nil {
+		// Not in HEAD: no committed record yet, a first pass.
+		return nil, "", nil
+	}
+	return decodeCommitted(out, rootRel)
+}
+
+// decodeCommitted parses a committed record, refusing one whose embedded root
+// is not the root that was asked for: queue files and manifests are
+// hand-editable, and a mismatched record must degrade to a first pass rather
+// than carry another root's hashes forward.
+func decodeCommitted(data []byte, rootRel string) (*Manifest, string, error) {
 	var c committedManifest
 	if err := json.Unmarshal(data, &c); err != nil {
-		// An unreadable record degrades to a first pass rather than wedging
-		// the manifest job forever: the next write replaces it.
+		return nil, "", nil
+	}
+	if c.Root != NormalizeRootPath(rootRel) {
 		return nil, "", nil
 	}
 	return &Manifest{Version: c.Version, Root: c.Root, Files: c.Files}, c.DescribesCommit, nil
+}
+
+// ValidateMachineSegment rejects a machine identity that could escape the
+// committed manifest tree. Same rules as peer ids, which face the same join.
+func ValidateMachineSegment(machine string) error {
+	return ValidatePeerID(machine)
+}
+
+// FingerprintFiles is a stat-level fingerprint of a file list: one hash over
+// every (path, size, mtime, kind) tuple, in sorted order. It exists so a
+// manifest job can prove at execution that the root still holds what it held
+// at enqueue, without reading a single content byte at enqueue time.
+func FingerprintFiles(files []FileEntry) string {
+	h := sha256.New()
+	for _, f := range files {
+		_, _ = fmt.Fprintf(h, "%s\x00%d\x00%d\x00%t\x00", f.Path, f.Size, f.MTime, f.Symlink)
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // WriteCommitted durably writes one machine's committed manifest for a root

--- a/internal/artifacts/committed.go
+++ b/internal/artifacts/committed.go
@@ -1,6 +1,7 @@
 package artifacts
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -75,14 +76,62 @@ func LoadCommitted(campaignRoot, machine, rootRel string) (*Manifest, string, er
 // only baseline a manifest job may trust: it proves the previous record
 // actually landed in history rather than merely reaching the filesystem.
 func LoadCommittedAtHead(ctx context.Context, campaignRoot, machine, rootRel string) (*Manifest, string, error) {
+	out, ok, err := CommittedAtHeadBytes(ctx, campaignRoot, machine, rootRel)
+	if err != nil || !ok {
+		return nil, "", err
+	}
+	return decodeCommitted(out, rootRel)
+}
+
+// CommittedAtHeadBytes returns one machine's committed record for a root
+// exactly as git has it at HEAD, and whether HEAD carries it at all. Raw bytes
+// rather than a decoded manifest because the reconcile path compares and
+// restores the file byte for byte; re-serializing a decoded record could differ
+// from what history holds.
+func CommittedAtHeadBytes(ctx context.Context, campaignRoot, machine, rootRel string) ([]byte, bool, error) {
 	rel := CommittedManifestRelPath(machine, rootRel)
 	show := exec.CommandContext(ctx, "git", "-C", campaignRoot, "show", "HEAD:"+rel)
 	out, err := show.Output()
 	if err != nil {
 		// Not in HEAD: no committed record yet, a first pass.
-		return nil, "", nil
+		return nil, false, nil
 	}
-	return decodeCommitted(out, rootRel)
+	return out, true, nil
+}
+
+// ReconcileCommittedToHead puts the working-tree record back to the bytes HEAD
+// carries, reporting whether it had to change anything.
+//
+// It exists for the skip-commit path. Proving the artifact root matches the
+// record in HEAD does not prove the working-tree file matches HEAD too: a
+// crashed attempt writes its record before its commit, so the file on disk can
+// hold output that history never accepted. Status reads that file through
+// LoadCommitted, and a later broad commit would sweep it into history as though
+// it were the record. Restoring costs one small read and makes the skip
+// truthful.
+//
+// Only the working tree is touched, never the index. The worker stages through
+// camp's temp-index path, so a crashed attempt leaves its write unstaged by
+// construction, and repairing the file is enough to make git see nothing to
+// commit.
+func ReconcileCommittedToHead(ctx context.Context, campaignRoot, machine, rootRel string) (bool, error) {
+	want, ok, err := CommittedAtHeadBytes(ctx, campaignRoot, machine, rootRel)
+	if err != nil || !ok {
+		return false, err
+	}
+	rel := CommittedManifestRelPath(machine, rootRel)
+	abs := filepath.Join(campaignRoot, filepath.FromSlash(rel))
+	got, readErr := os.ReadFile(abs)
+	if readErr == nil && bytes.Equal(got, want) {
+		return false, nil
+	}
+	if readErr != nil && !os.IsNotExist(readErr) {
+		return false, camperrors.Wrapf(readErr, "read committed manifest for %s", rootRel)
+	}
+	if _, err := writeCommittedBytes(campaignRoot, rel, want); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // decodeCommitted parses a committed record, refusing one whose embedded root
@@ -122,32 +171,39 @@ func FingerprintFiles(files []FileEntry) string {
 // and returns its campaign-relative path. Temp file plus rename, the same
 // crash discipline the queue uses.
 func WriteCommitted(campaignRoot, machine string, m *Manifest, describesCommit string) (string, error) {
-	rel := CommittedManifestRelPath(machine, m.Root)
-	abs := filepath.Join(campaignRoot, filepath.FromSlash(rel))
-	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
-		return "", camperrors.Wrapf(err, "create committed manifest dir for %s", m.Root)
-	}
 	data, err := m.CommittedJSON(describesCommit)
 	if err != nil {
 		return "", err
 	}
+	return writeCommittedBytes(campaignRoot, CommittedManifestRelPath(machine, m.Root), data)
+}
+
+// writeCommittedBytes durably places exact bytes at a campaign-relative
+// manifest path: temp file plus rename, the same crash discipline the queue
+// uses. Shared by the record writer and the reconcile path so both leave the
+// same guarantee behind.
+func writeCommittedBytes(campaignRoot, rel string, data []byte) (string, error) {
+	abs := filepath.Join(campaignRoot, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		return "", camperrors.Wrapf(err, "create committed manifest dir for %s", rel)
+	}
 	tmp, err := os.CreateTemp(filepath.Dir(abs), ".manifest-*")
 	if err != nil {
-		return "", camperrors.Wrapf(err, "stage committed manifest for %s", m.Root)
+		return "", camperrors.Wrapf(err, "stage committed manifest for %s", rel)
 	}
 	tmpName := tmp.Name()
 	if _, err := tmp.Write(data); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmpName)
-		return "", camperrors.Wrapf(err, "write committed manifest for %s", m.Root)
+		return "", camperrors.Wrapf(err, "write committed manifest for %s", rel)
 	}
 	if err := tmp.Close(); err != nil {
 		_ = os.Remove(tmpName)
-		return "", camperrors.Wrapf(err, "close committed manifest for %s", m.Root)
+		return "", camperrors.Wrapf(err, "close committed manifest for %s", rel)
 	}
 	if err := os.Rename(tmpName, abs); err != nil {
 		_ = os.Remove(tmpName)
-		return "", camperrors.Wrapf(err, "place committed manifest for %s", m.Root)
+		return "", camperrors.Wrapf(err, "place committed manifest for %s", rel)
 	}
 	return rel, nil
 }

--- a/internal/artifacts/committed.go
+++ b/internal/artifacts/committed.go
@@ -1,0 +1,155 @@
+package artifacts
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/machines"
+)
+
+// Committed manifests are the record half of design doc 08: camp never
+// versions artifact content, it commits what the artifact set was. One file
+// per (machine, root) under a committed directory, so two machines
+// legitimately holding different content never conflict: distinct paths by
+// construction.
+
+// CommittedRelDir is the committed manifest tree, campaign-relative.
+const CommittedRelDir = ".campaign/artifacts/manifests"
+
+// EnvMachineName overrides the machine identity component. It exists for
+// containerized tests that must simulate two machines against one filesystem,
+// and for hosts whose hostname is not a stable identity.
+const EnvMachineName = "CAMP_MACHINE_NAME"
+
+// MachineName is this machine's identity component in committed manifest
+// paths. It reuses the machines file's hostname normalization rather than
+// inventing a second identity: the same string a peer sees in the mesh is the
+// directory their manifests appear under.
+func MachineName() (string, error) {
+	if v := os.Getenv(EnvMachineName); v != "" {
+		return machines.NormalizeHost(v), nil
+	}
+	host, err := os.Hostname()
+	if err != nil {
+		return "", camperrors.Wrap(err, "resolve hostname for manifest identity")
+	}
+	return machines.NormalizeHost(host), nil
+}
+
+// CommittedManifestRelPath is the campaign-relative path of one machine's
+// committed manifest for one root. The root is slugged with the same
+// injective encoding peersync snapshots use, so distinct roots stay distinct.
+func CommittedManifestRelPath(machine, rootRel string) string {
+	return filepath.ToSlash(filepath.Join(CommittedRelDir, machine, snapshotSlug(rootRel)+".json"))
+}
+
+// LoadCommitted reads one machine's committed manifest for a root. A missing
+// file is (nil, "", nil): no record yet, which callers treat as a first pass.
+func LoadCommitted(campaignRoot, machine, rootRel string) (*Manifest, string, error) {
+	path := filepath.Join(campaignRoot, filepath.FromSlash(CommittedManifestRelPath(machine, rootRel)))
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, "", nil
+	}
+	if err != nil {
+		return nil, "", camperrors.Wrapf(err, "read committed manifest for %s", rootRel)
+	}
+	var c committedManifest
+	if err := json.Unmarshal(data, &c); err != nil {
+		// An unreadable record degrades to a first pass rather than wedging
+		// the manifest job forever: the next write replaces it.
+		return nil, "", nil
+	}
+	return &Manifest{Version: c.Version, Root: c.Root, Files: c.Files}, c.DescribesCommit, nil
+}
+
+// WriteCommitted durably writes one machine's committed manifest for a root
+// and returns its campaign-relative path. Temp file plus rename, the same
+// crash discipline the queue uses.
+func WriteCommitted(campaignRoot, machine string, m *Manifest, describesCommit string) (string, error) {
+	rel := CommittedManifestRelPath(machine, m.Root)
+	abs := filepath.Join(campaignRoot, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		return "", camperrors.Wrapf(err, "create committed manifest dir for %s", m.Root)
+	}
+	data, err := m.CommittedJSON(describesCommit)
+	if err != nil {
+		return "", err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(abs), ".manifest-*")
+	if err != nil {
+		return "", camperrors.Wrapf(err, "stage committed manifest for %s", m.Root)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return "", camperrors.Wrapf(err, "write committed manifest for %s", m.Root)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return "", camperrors.Wrapf(err, "close committed manifest for %s", m.Root)
+	}
+	if err := os.Rename(tmpName, abs); err != nil {
+		_ = os.Remove(tmpName)
+		return "", camperrors.Wrapf(err, "place committed manifest for %s", m.Root)
+	}
+	return rel, nil
+}
+
+// SameFiles reports whether two file lists record the same artifact state:
+// same paths, sizes, mtimes, kinds, and hashes, in the same (sorted) order.
+// It is the skip-commit decision: equal files mean the committed record is
+// already correct and nothing is rewritten.
+func SameFiles(a, b []FileEntry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Drift is one working-tree divergence from the committed record.
+type Drift struct {
+	Path   string // slash-separated, relative to the root
+	Reason string // "changed", "missing", or "extra"
+}
+
+// DetectDrift compares a root's working tree against its committed manifest,
+// stat-level only: size or nanosecond mtime moved means changed, an entry
+// with no file means missing, a file with no entry means extra. It reports
+// and never resolves; hashing is deliberately absent so the comparison is
+// cheap enough for a status-path notice detector.
+func DetectDrift(ctx context.Context, campaignRoot string, committed *Manifest) ([]Drift, error) {
+	current, err := BuildManifest(ctx, campaignRoot, committed.Root)
+	if err != nil {
+		return nil, err
+	}
+	base := committed.Index()
+	seen := make(map[string]bool, len(current.Files))
+	var drifts []Drift
+	for _, f := range current.Files {
+		seen[f.Path] = true
+		b, ok := base[f.Path]
+		if !ok {
+			drifts = append(drifts, Drift{Path: f.Path, Reason: "extra"})
+			continue
+		}
+		if b.Size != f.Size || b.MTime != f.MTime || b.Symlink != f.Symlink {
+			drifts = append(drifts, Drift{Path: f.Path, Reason: "changed"})
+		}
+	}
+	for _, b := range committed.Files {
+		if !seen[b.Path] {
+			drifts = append(drifts, Drift{Path: b.Path, Reason: "missing"})
+		}
+	}
+	return drifts, nil
+}

--- a/internal/artifacts/hash.go
+++ b/internal/artifacts/hash.go
@@ -104,21 +104,34 @@ func hashFile(ctx context.Context, path string, done *int64, progress func(int64
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
-// CommittedJSON is the manifest's committed serialization: deterministic
-// bytes that are identical whenever the contents are identical, so an
-// unchanged root produces no diff commit after commit.
+// committedManifest is the committed serialization shape. GeneratedAt is
+// deliberately absent: it stamps every build, which is right for
+// machine-local derived state and wrong for a committed record, where it
+// would churn the file on every commit with nothing changed.
 //
-// GeneratedAt is deliberately absent. It stamps every build, which is right
-// for machine-local derived state and wrong for a committed record: it would
-// churn the file on every commit with nothing changed. The committed record's
-// time anchor is the commit that carries it.
-func (m *Manifest) CommittedJSON() ([]byte, error) {
-	committed := struct {
-		Version int         `json:"version"`
-		Root    string      `json:"root"`
-		Files   []FileEntry `json:"files"`
-	}{m.Version, m.Root, m.Files}
+// DescribesCommit is the SHA whose artifact state the manifest captures. The
+// carrier commit is usually later, because the manifest is written by a
+// deferred job; recording the described commit explicitly keeps the record
+// correct no matter when it lands. When contents have not changed the file is
+// not rewritten at all, so the field keeps naming the commit that last
+// changed the root, and an unchanged root stays byte-identical.
+type committedManifest struct {
+	Version         int         `json:"version"`
+	Root            string      `json:"root"`
+	DescribesCommit string      `json:"describes_commit"`
+	Files           []FileEntry `json:"files"`
+}
 
+// CommittedJSON is the manifest's committed serialization: deterministic
+// bytes that are identical whenever the contents and described commit are
+// identical.
+func (m *Manifest) CommittedJSON(describesCommit string) ([]byte, error) {
+	committed := committedManifest{
+		Version:         m.Version,
+		Root:            m.Root,
+		DescribesCommit: describesCommit,
+		Files:           m.Files,
+	}
 	data, err := json.MarshalIndent(committed, "", "  ")
 	if err != nil {
 		return nil, camperrors.Wrapf(err, "encode committed manifest for %s", m.Root)

--- a/internal/artifacts/hash.go
+++ b/internal/artifacts/hash.go
@@ -18,12 +18,33 @@ import (
 // no faster non-cryptographic hash offers. The cost only shows on the first
 // pass; steady state re-hashes nothing.
 
+// HashOutcome reports what a hash pass could not pin down.
+//
+// Unsettled names the files whose bytes were still moving while they were read,
+// so no single observation of them exists to record. Their entries carry the
+// latest stat with an unknown hash; the caller surfaces them, because "the
+// record could not describe these files" is operational news, not a detail.
+type HashOutcome struct {
+	Unsettled []string
+}
+
+// settleAttempts is how many times one file is re-read while it keeps moving
+// under the reader. A file still changing after three passes is being actively
+// written, and waiting longer inside a manifest job does not make it stop.
+const settleAttempts = 3
+
 // HashManifest fills m's content hashes, re-reading only what moved.
 //
 // prev is the previous manifest for this root, nil on the first pass. An entry
 // whose size, nanosecond mtime, and kind all match prev inherits prev's hash
 // without a read, so the steady-state cost of a multi-hundred-GB root is a
 // stat walk. Everything else is read and hashed.
+//
+// Each hashed entry is re-statted around its read and takes the stat that
+// describes the bytes actually hashed, which may be newer than the walk's. An
+// entry whose size and mtime came from the walk but whose hash came from a read
+// minutes later would describe a state that never existed at any single moment,
+// and a record of a state that never existed is worse than no record.
 //
 // progress, when non-nil, receives the cumulative bytes hashed, at least once
 // per chunk, so a worker heartbeat stays live through a first pass over a
@@ -32,9 +53,9 @@ import (
 // A file that vanished between the walk and the read keeps an empty hash
 // rather than failing the manifest: the record is of what the walk saw, and
 // the next manifest will not include the file at all.
-func HashManifest(ctx context.Context, campaignRoot string, m *Manifest, prev *Manifest, progress func(bytesHashed int64)) error {
+func HashManifest(ctx context.Context, campaignRoot string, m *Manifest, prev *Manifest, progress func(bytesHashed int64)) (*HashOutcome, error) {
 	if ctx.Err() != nil {
-		return ctx.Err()
+		return nil, ctx.Err()
 	}
 	var base map[string]FileEntry
 	if prev != nil {
@@ -42,10 +63,11 @@ func HashManifest(ctx context.Context, campaignRoot string, m *Manifest, prev *M
 	}
 	rootAbs := filepath.Join(campaignRoot, filepath.FromSlash(m.Root))
 
+	outcome := &HashOutcome{}
 	var done int64
 	for i := range m.Files {
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return nil, ctx.Err()
 		}
 		entry := &m.Files[i]
 		if entry.Symlink {
@@ -55,17 +77,64 @@ func HashManifest(ctx context.Context, campaignRoot string, m *Manifest, prev *M
 			entry.HashSHA256 = b.HashSHA256
 			continue
 		}
-		sum, err := hashFile(ctx, filepath.Join(rootAbs, filepath.FromSlash(entry.Path)), &done, progress)
+		read, err := hashSettledFile(ctx, filepath.Join(rootAbs, filepath.FromSlash(entry.Path)), &done, progress)
 		if os.IsNotExist(err) {
 			entry.HashSHA256 = ""
 			continue
 		}
 		if err != nil {
-			return err
+			return nil, err
 		}
-		entry.HashSHA256 = sum
+		entry.Size, entry.MTime, entry.HashSHA256 = read.size, read.mtime, read.sum
+		if !read.settled {
+			outcome.Unsettled = append(outcome.Unsettled, entry.Path)
+		}
 	}
-	return nil
+	return outcome, nil
+}
+
+// settledRead is one file's hash together with the stat that describes the
+// bytes it was computed from.
+type settledRead struct {
+	sum     string
+	size    int64
+	mtime   int64
+	settled bool
+}
+
+// hashSettledFile hashes path and returns the hash paired with a stat taken
+// around the read, retrying while the file moves under the reader.
+//
+// When the file will not settle, the read returns the latest stat and NO hash.
+// An unknown hash is a state the format already carries (a pre-hashing record
+// unmarshals the same way) and the next pass re-reads it; a hash paired with a
+// stat it does not belong to would be indistinguishable from a true record.
+func hashSettledFile(ctx context.Context, path string, done *int64, progress func(int64)) (settledRead, error) {
+	for attempt := 0; attempt < settleAttempts; attempt++ {
+		if ctx.Err() != nil {
+			return settledRead{}, ctx.Err()
+		}
+		before, err := os.Lstat(path)
+		if err != nil {
+			return settledRead{}, err
+		}
+		sum, err := hashFile(ctx, path, done, progress)
+		if err != nil {
+			return settledRead{}, err
+		}
+		after, err := os.Lstat(path)
+		if err != nil {
+			return settledRead{}, err
+		}
+		if before.Size() == after.Size() && before.ModTime().UnixNano() == after.ModTime().UnixNano() {
+			return settledRead{sum: sum, size: after.Size(), mtime: after.ModTime().UnixNano(), settled: true}, nil
+		}
+	}
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return settledRead{}, err
+	}
+	return settledRead{size: fi.Size(), mtime: fi.ModTime().UnixNano()}, nil
 }
 
 // hashFile reads one file through SHA-256, reporting cumulative progress per

--- a/internal/artifacts/hash.go
+++ b/internal/artifacts/hash.go
@@ -1,0 +1,127 @@
+package artifacts
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// SHA-256 is the manifest content hash. Nothing else in camp standardizes a
+// content hash to defer to, and the record exists for external verification:
+// a backup tool restoring a root checks it with plain `shasum -a 256`, which
+// no faster non-cryptographic hash offers. The cost only shows on the first
+// pass; steady state re-hashes nothing.
+
+// HashManifest fills m's content hashes, re-reading only what moved.
+//
+// prev is the previous manifest for this root, nil on the first pass. An entry
+// whose size, nanosecond mtime, and kind all match prev inherits prev's hash
+// without a read, so the steady-state cost of a multi-hundred-GB root is a
+// stat walk. Everything else is read and hashed.
+//
+// progress, when non-nil, receives the cumulative bytes hashed, at least once
+// per chunk, so a worker heartbeat stays live through a first pass over a
+// large file rather than being declared stale mid-read.
+//
+// A file that vanished between the walk and the read keeps an empty hash
+// rather than failing the manifest: the record is of what the walk saw, and
+// the next manifest will not include the file at all.
+func HashManifest(ctx context.Context, campaignRoot string, m *Manifest, prev *Manifest, progress func(bytesHashed int64)) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	var base map[string]FileEntry
+	if prev != nil {
+		base = prev.Index()
+	}
+	rootAbs := filepath.Join(campaignRoot, filepath.FromSlash(m.Root))
+
+	var done int64
+	for i := range m.Files {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		entry := &m.Files[i]
+		if entry.Symlink {
+			continue
+		}
+		if b, ok := base[entry.Path]; ok && sameEntry(b, *entry) && b.HashSHA256 != "" {
+			entry.HashSHA256 = b.HashSHA256
+			continue
+		}
+		sum, err := hashFile(ctx, filepath.Join(rootAbs, filepath.FromSlash(entry.Path)), &done, progress)
+		if os.IsNotExist(err) {
+			entry.HashSHA256 = ""
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		entry.HashSHA256 = sum
+	}
+	return nil
+}
+
+// hashFile reads one file through SHA-256, reporting cumulative progress per
+// chunk via done/progress.
+func hashFile(ctx context.Context, path string, done *int64, progress func(int64)) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", err
+		}
+		return "", camperrors.Wrapf(err, "open %s for hashing", path)
+	}
+	defer func() { _ = f.Close() }()
+
+	h := sha256.New()
+	buf := make([]byte, 1<<20)
+	for {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		n, readErr := f.Read(buf)
+		if n > 0 {
+			_, _ = h.Write(buf[:n])
+			*done += int64(n)
+			if progress != nil {
+				progress(*done)
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return "", camperrors.Wrapf(readErr, "read %s for hashing", path)
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// CommittedJSON is the manifest's committed serialization: deterministic
+// bytes that are identical whenever the contents are identical, so an
+// unchanged root produces no diff commit after commit.
+//
+// GeneratedAt is deliberately absent. It stamps every build, which is right
+// for machine-local derived state and wrong for a committed record: it would
+// churn the file on every commit with nothing changed. The committed record's
+// time anchor is the commit that carries it.
+func (m *Manifest) CommittedJSON() ([]byte, error) {
+	committed := struct {
+		Version int         `json:"version"`
+		Root    string      `json:"root"`
+		Files   []FileEntry `json:"files"`
+	}{m.Version, m.Root, m.Files}
+
+	data, err := json.MarshalIndent(committed, "", "  ")
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "encode committed manifest for %s", m.Root)
+	}
+	return append(data, '\n'), nil
+}

--- a/internal/artifacts/hash_test.go
+++ b/internal/artifacts/hash_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func buildHashedManifest(t *testing.T, campaignRoot, rootRel string, prev *Manifest) *Manifest {
@@ -17,7 +18,7 @@ func buildHashedManifest(t *testing.T, campaignRoot, rootRel string, prev *Manif
 	if err != nil {
 		t.Fatalf("build manifest: %v", err)
 	}
-	if err := HashManifest(context.Background(), campaignRoot, m, prev, nil); err != nil {
+	if _, err := HashManifest(context.Background(), campaignRoot, m, prev, nil); err != nil {
 		t.Fatalf("hash manifest: %v", err)
 	}
 	return m
@@ -60,7 +61,7 @@ func TestHashManifestCarriesForwardWithoutReading(t *testing.T) {
 		{Path: "steady.bin", Size: 9, MTime: 1234},
 	}}
 
-	if err := HashManifest(context.Background(), t.TempDir(), m, prev, nil); err != nil {
+	if _, err := HashManifest(context.Background(), t.TempDir(), m, prev, nil); err != nil {
 		t.Fatalf("hash manifest: %v", err)
 	}
 	if got := m.Files[0].HashSHA256; got != "cafe" {
@@ -152,7 +153,7 @@ func TestHashManifestReportsProgressAndHonorsCancellation(t *testing.T) {
 	}
 	var last int64
 	calls := 0
-	err = HashManifest(context.Background(), root, m, nil, func(done int64) {
+	_, err = HashManifest(context.Background(), root, m, nil, func(done int64) {
 		if done < last {
 			t.Errorf("progress went backwards: %d after %d", done, last)
 		}
@@ -168,7 +169,7 @@ func TestHashManifestReportsProgressAndHonorsCancellation(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if err := HashManifest(ctx, root, m, nil, nil); err == nil {
+	if _, err := HashManifest(ctx, root, m, nil, nil); err == nil {
 		t.Error("cancelled context must stop the hash pass with an error")
 	}
 }
@@ -190,11 +191,168 @@ func TestHashManifestToleratesAVanishedFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := HashManifest(context.Background(), root, m, nil, nil); err != nil {
+	if _, err := HashManifest(context.Background(), root, m, nil, nil); err != nil {
 		t.Fatalf("a vanished file must not fail the manifest: %v", err)
 	}
 	if got := m.Index()["gone.bin"].HashSHA256; got != "" {
 		t.Errorf("vanished file hash = %q, want unknown", got)
+	}
+}
+
+// A manifest entry must never pair a stat from before the read with a hash from
+// after it: that record describes a state that never existed at any single
+// moment, and nothing downstream can tell it apart from a true one. The
+// progress callback fires mid-read, which is the one place a test can reach
+// inside the hash window.
+func TestHashManifestEntryStatDescribesTheBytesItHashed(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "media")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "growing.bin")
+	original := bytes.Repeat([]byte("a"), 4096)
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := BuildManifest(context.Background(), root, "media")
+	if err != nil {
+		t.Fatal(err)
+	}
+	walked := m.Index()["growing.bin"]
+
+	// Grow the file once, from inside the first read.
+	grown := append(bytes.Repeat([]byte("a"), 4096), bytes.Repeat([]byte("b"), 4096)...)
+	var mutated bool
+	outcome, err := HashManifest(context.Background(), root, m, nil, func(int64) {
+		if mutated {
+			return
+		}
+		mutated = true
+		if werr := os.WriteFile(path, grown, 0o644); werr != nil {
+			t.Errorf("mutate during hash: %v", werr)
+		}
+	})
+	if err != nil {
+		t.Fatalf("hash manifest: %v", err)
+	}
+	if !mutated {
+		t.Fatal("the progress callback never fired, so the hash window was never exercised")
+	}
+
+	entry := m.Index()["growing.bin"]
+	if entry.Size == walked.Size && entry.MTime == walked.MTime {
+		t.Fatal("entry kept the pre-read stat after the file changed under the reader")
+	}
+
+	// Whatever the entry ended up claiming, its stat and its hash must describe
+	// one observation. An unknown hash is the honest answer for a file that
+	// would not settle; a hash present must be the hash of the bytes the stat
+	// describes.
+	if entry.HashSHA256 == "" {
+		if len(outcome.Unsettled) != 1 || outcome.Unsettled[0] != "growing.bin" {
+			t.Errorf("an unhashed entry must be reported as unsettled, got %v", outcome.Unsettled)
+		}
+		return
+	}
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := sha256.Sum256(onDisk)
+	if entry.HashSHA256 != hex.EncodeToString(want[:]) {
+		t.Errorf("hash = %q, want the hash of the bytes the entry's stat describes", entry.HashSHA256)
+	}
+	if int64(len(onDisk)) != entry.Size {
+		t.Errorf("entry size = %d, want the size of the hashed bytes %d", entry.Size, len(onDisk))
+	}
+}
+
+// A file under continuous write never settles. The record must then say the
+// hash is unknown rather than pair a stat with a hash it does not belong to,
+// and it must say so out loud instead of looking complete.
+func TestHashManifestReportsAFileItCouldNotPinDown(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "media")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "streaming.bin")
+	if err := os.WriteFile(path, bytes.Repeat([]byte("a"), 2048), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := BuildManifest(context.Background(), root, "media")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Rewrite in place on every read, so every settle attempt observes a file
+	// that moved under it. The size stays fixed and the mtime is stamped
+	// explicitly: a growing file would outrun the reader and never reach EOF,
+	// and a same-size rewrite is the harder case anyway (only the mtime betrays
+	// it). One callback fires per read here, the content being far under the
+	// 1MiB chunk.
+	stamp := time.Now()
+	rewrites := 0
+	outcome, err := HashManifest(context.Background(), root, m, nil, func(int64) {
+		rewrites++
+		if werr := os.WriteFile(path, bytes.Repeat([]byte("b"), 2048), 0o644); werr != nil {
+			t.Errorf("mutate during hash: %v", werr)
+			return
+		}
+		stamp = stamp.Add(time.Second)
+		if werr := os.Chtimes(path, stamp, stamp); werr != nil {
+			t.Errorf("stamp mtime during hash: %v", werr)
+		}
+	})
+	if err != nil {
+		t.Fatalf("a file under continuous write must not fail the manifest: %v", err)
+	}
+	if rewrites < settleAttempts {
+		t.Fatalf("only %d read(s) happened; the settle loop was not exhausted", rewrites)
+	}
+	if got := m.Index()["streaming.bin"].HashSHA256; got != "" {
+		t.Errorf("hash = %q, want unknown for a file that never settled", got)
+	}
+	if len(outcome.Unsettled) != 1 || outcome.Unsettled[0] != "streaming.bin" {
+		t.Errorf("Unsettled = %v, want the file that never settled", outcome.Unsettled)
+	}
+}
+
+// The settled path must leave the ordinary contract alone: one read, the walk's
+// stat preserved, and nothing reported.
+func TestHashManifestReportsNothingWhenTheRootIsStill(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "media")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "still.bin"), []byte("stable bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := BuildManifest(context.Background(), root, "media")
+	if err != nil {
+		t.Fatal(err)
+	}
+	walked := m.Index()["still.bin"]
+
+	outcome, err := HashManifest(context.Background(), root, m, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(outcome.Unsettled) != 0 {
+		t.Errorf("Unsettled = %v, want nothing for a still root", outcome.Unsettled)
+	}
+	entry := m.Index()["still.bin"]
+	if entry.Size != walked.Size || entry.MTime != walked.MTime {
+		t.Errorf("a still file's stat moved: walked %+v, recorded %+v", walked, entry)
+	}
+	want := sha256.Sum256([]byte("stable bytes"))
+	if entry.HashSHA256 != hex.EncodeToString(want[:]) {
+		t.Errorf("hash = %q, want the file's sha256", entry.HashSHA256)
 	}
 }
 

--- a/internal/artifacts/hash_test.go
+++ b/internal/artifacts/hash_test.go
@@ -197,3 +197,23 @@ func TestHashManifestToleratesAVanishedFile(t *testing.T) {
 		t.Errorf("vanished file hash = %q, want unknown", got)
 	}
 }
+
+func TestDecodeCommittedRefusesAMismatchedRoot(t *testing.T) {
+	data := []byte(`{"version":1,"root":"other","describes_commit":"abc","files":[{"path":"f","size":1,"mtime_unix_nano":1,"hash_sha256":"aa"}]}`)
+	m, describes, err := decodeCommitted(data, "media")
+	if err != nil || m != nil || describes != "" {
+		t.Errorf("a record embedding another root must degrade to first pass, got m=%v describes=%q err=%v", m, describes, err)
+	}
+}
+
+func TestFingerprintFilesChangesWithStatState(t *testing.T) {
+	a := []FileEntry{{Path: "f", Size: 1, MTime: 10}}
+	same := []FileEntry{{Path: "f", Size: 1, MTime: 10}}
+	moved := []FileEntry{{Path: "f", Size: 1, MTime: 11}}
+	if FingerprintFiles(a) != FingerprintFiles(same) {
+		t.Error("identical stat state must fingerprint identically")
+	}
+	if FingerprintFiles(a) == FingerprintFiles(moved) {
+		t.Error("a moved mtime must change the fingerprint")
+	}
+}

--- a/internal/artifacts/hash_test.go
+++ b/internal/artifacts/hash_test.go
@@ -1,0 +1,193 @@
+package artifacts
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func buildHashedManifest(t *testing.T, campaignRoot, rootRel string, prev *Manifest) *Manifest {
+	t.Helper()
+	m, err := BuildManifest(context.Background(), campaignRoot, rootRel)
+	if err != nil {
+		t.Fatalf("build manifest: %v", err)
+	}
+	if err := HashManifest(context.Background(), campaignRoot, m, prev, nil); err != nil {
+		t.Fatalf("hash manifest: %v", err)
+	}
+	return m
+}
+
+func TestHashManifestHashesRegularFilesAndSkipsSymlinks(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "media")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("the bytes a backup tool must reproduce")
+	if err := os.WriteFile(filepath.Join(dir, "clip.bin"), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("clip.bin", filepath.Join(dir, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	m := buildHashedManifest(t, root, "media", nil)
+
+	want := sha256.Sum256(content)
+	byPath := m.Index()
+	if got := byPath["clip.bin"].HashSHA256; got != hex.EncodeToString(want[:]) {
+		t.Errorf("clip.bin hash = %q, want the file's sha256", got)
+	}
+	if got := byPath["link"].HashSHA256; got != "" {
+		t.Errorf("symlink carried a content hash %q; its identity is kind+path", got)
+	}
+}
+
+func TestHashManifestCarriesForwardWithoutReading(t *testing.T) {
+	// The entries exist only in the manifests; no file backs them. A
+	// carry-forward that read from disk would fail loudly here, which is the
+	// point: an unchanged entry must inherit its hash from prev with no read.
+	prev := &Manifest{Root: "media", Files: []FileEntry{
+		{Path: "steady.bin", Size: 9, MTime: 1234, HashSHA256: "cafe"},
+	}}
+	m := &Manifest{Root: "media", Files: []FileEntry{
+		{Path: "steady.bin", Size: 9, MTime: 1234},
+	}}
+
+	if err := HashManifest(context.Background(), t.TempDir(), m, prev, nil); err != nil {
+		t.Fatalf("hash manifest: %v", err)
+	}
+	if got := m.Files[0].HashSHA256; got != "cafe" {
+		t.Errorf("unchanged entry hash = %q, want carried-forward %q", got, "cafe")
+	}
+}
+
+func TestHashManifestRehashesWhatMoved(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "media")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "clip.bin")
+	if err := os.WriteFile(path, []byte("before"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	first := buildHashedManifest(t, root, "media", nil)
+
+	if err := os.WriteFile(path, []byte("after, and longer"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	second := buildHashedManifest(t, root, "media", first)
+
+	want := sha256.Sum256([]byte("after, and longer"))
+	if got := second.Index()["clip.bin"].HashSHA256; got != hex.EncodeToString(want[:]) {
+		t.Errorf("changed entry hash = %q, want re-hashed content", got)
+	}
+
+	// A pre-hashing manifest degrades to re-hash: same shape, hash absent.
+	var legacy Manifest
+	if err := json.Unmarshal([]byte(`{"version":1,"root":"media","files":[{"path":"clip.bin","size":6,"mtime_unix_nano":1}]}`), &legacy); err != nil {
+		t.Fatal(err)
+	}
+	if legacy.Files[0].HashSHA256 != "" {
+		t.Error("a manifest written before hashing existed must unmarshal to hash unknown")
+	}
+}
+
+func TestCommittedJSONIsByteIdenticalWhenNothingChanged(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "media")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "clip.bin"), []byte("stable"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	first := buildHashedManifest(t, root, "media", nil)
+	second := buildHashedManifest(t, root, "media", first)
+
+	a, err := first.CommittedJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := second.CommittedJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Errorf("unchanged root produced differing committed bytes:\n%s\n---\n%s", a, b)
+	}
+	if bytes.Contains(a, []byte("generated_at")) {
+		t.Error("committed form must not carry generated_at; it would churn every commit")
+	}
+}
+
+func TestHashManifestReportsProgressAndHonorsCancellation(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "media")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := bytes.Repeat([]byte("x"), 4096)
+	if err := os.WriteFile(filepath.Join(dir, "clip.bin"), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := BuildManifest(context.Background(), root, "media")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var last int64
+	calls := 0
+	err = HashManifest(context.Background(), root, m, nil, func(done int64) {
+		if done < last {
+			t.Errorf("progress went backwards: %d after %d", done, last)
+		}
+		last = done
+		calls++
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls == 0 || last != int64(len(content)) {
+		t.Errorf("progress calls=%d last=%d, want coverage of all %d bytes", calls, last, len(content))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := HashManifest(ctx, root, m, nil, nil); err == nil {
+		t.Error("cancelled context must stop the hash pass with an error")
+	}
+}
+
+func TestHashManifestToleratesAVanishedFile(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "media")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "gone.bin"), []byte("temp"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := BuildManifest(context.Background(), root, "media")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(dir, "gone.bin")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := HashManifest(context.Background(), root, m, nil, nil); err != nil {
+		t.Fatalf("a vanished file must not fail the manifest: %v", err)
+	}
+	if got := m.Index()["gone.bin"].HashSHA256; got != "" {
+		t.Errorf("vanished file hash = %q, want unknown", got)
+	}
+}

--- a/internal/artifacts/hash_test.go
+++ b/internal/artifacts/hash_test.go
@@ -113,11 +113,11 @@ func TestCommittedJSONIsByteIdenticalWhenNothingChanged(t *testing.T) {
 	first := buildHashedManifest(t, root, "media", nil)
 	second := buildHashedManifest(t, root, "media", first)
 
-	a, err := first.CommittedJSON()
+	a, err := first.CommittedJSON("abc123")
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := second.CommittedJSON()
+	b, err := second.CommittedJSON("abc123")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,6 +126,12 @@ func TestCommittedJSONIsByteIdenticalWhenNothingChanged(t *testing.T) {
 	}
 	if bytes.Contains(a, []byte("generated_at")) {
 		t.Error("committed form must not carry generated_at; it would churn every commit")
+	}
+	if !bytes.Contains(a, []byte(`"describes_commit": "abc123"`)) {
+		t.Error("committed form must record the commit it describes")
+	}
+	if !SameFiles(first.Files, second.Files) {
+		t.Error("unchanged root must compare as same files; this is the skip-commit decision")
 	}
 }
 

--- a/internal/artifacts/manifest.go
+++ b/internal/artifacts/manifest.go
@@ -40,6 +40,12 @@ type FileEntry struct {
 	// followed) so a local symlink participates in conflict protection instead
 	// of being invisible to it.
 	Symlink bool `json:"symlink,omitempty"`
+	// HashSHA256 is the hex content hash of a regular file. The key is
+	// versioned the way mtime_unix_nano is: a manifest written before hashing
+	// existed unmarshals with this empty, which reads as "unknown, re-hash",
+	// never as a wrong hash. Symlinks carry no hash; their recorded identity
+	// is kind plus path, and their content lives at the target.
+	HashSHA256 string `json:"hash_sha256,omitempty"`
 }
 
 // BuildManifest walks the artifact root and records every regular file and

--- a/internal/buildutil/tasks/integration.go
+++ b/internal/buildutil/tasks/integration.go
@@ -36,7 +36,7 @@ type IntegrationResult struct {
 	FailedTests []string // Names of failed tests
 }
 
-const integrationTestTimeout = "10m"
+const integrationTestTimeout = "15m"
 
 // Integration runs integration tests
 func Integration(verbose bool) error {

--- a/internal/doctor/checks/artifacts.go
+++ b/internal/doctor/checks/artifacts.go
@@ -99,11 +99,31 @@ func (c *ArtifactsCheck) Run(ctx context.Context, repoRoot string) (*doctor.Chec
 		result.Issues = append(result.Issues, issues...)
 	}
 
-	// Criterion 27 lives in this check but needs committed manifests, which
-	// phase 002 introduces. Recorded as a skip rather than omitted so the
-	// check's coverage gap is visible rather than silently absent.
-	result.Details["skipped_rows"] = []string{reasonManifestDrift}
-	result.Details["skipped_reason"] = "manifest drift requires committed manifests (phase 002)"
+	// Criterion 27: manifest drift. Stat-level only, deliberately: the row
+	// compares size, nanosecond mtime, and presence against this machine's
+	// committed record. It reports and never resolves; the manifest is a
+	// record of what was, and only a commit updates it.
+	if machine, mErr := artifacts.MachineName(); mErr == nil {
+		for _, root := range cfg.Roots {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			committed, describes, lErr := artifacts.LoadCommitted(repoRoot, machine, root.Path)
+			if lErr != nil || committed == nil {
+				continue // no committed record yet; nothing to drift from
+			}
+			drifts, dErr := artifacts.DetectDrift(ctx, repoRoot, committed)
+			if dErr != nil || len(drifts) == 0 {
+				continue
+			}
+			result.Issues = append(result.Issues, artifactIssue(
+				c.ID(), root.Path, reasonManifestDrift, doctor.SeverityWarning,
+				fmt.Sprintf("%s has drifted from its committed manifest (%d paths; record describes %s)",
+					root.Path, len(drifts), shortCommit(describes)),
+				"camp commit",
+			))
+		}
+	}
 
 	for _, issue := range result.Issues {
 		if issue.Severity == doctor.SeverityError {
@@ -298,4 +318,12 @@ func dvcGoverned(repoRoot, normalized string) (string, bool) {
 		dir = parent
 	}
 	return "", false
+}
+
+// shortCommit abbreviates a SHA for a doctor row a human reads.
+func shortCommit(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
 }

--- a/internal/git/commit/commit.go
+++ b/internal/git/commit/commit.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/config"
 	"github.com/Obedience-Corp/camp/internal/defercommit"
 	"github.com/Obedience-Corp/camp/internal/git"
+	"github.com/Obedience-Corp/camp/internal/jobs"
 )
 
 // Result contains the outcome of a commit attempt.
@@ -170,7 +171,11 @@ func stageAndCommit(ctx context.Context, opts Options, message string) error {
 		if opts.SelectiveOnly {
 			return git.ErrNoChanges
 		}
-		return git.CommitAll(ctx, opts.CampaignRoot, message)
+		if err := git.CommitAll(ctx, opts.CampaignRoot, message); err != nil {
+			return err
+		}
+		enqueueManifestRecords(ctx, opts.CampaignRoot)
+		return nil
 	}
 
 	tmpPath, realIndex, err := git.BuildTempIndexPath(opts.CampaignRoot)
@@ -207,5 +212,18 @@ func stageAndCommit(ctx context.Context, opts Options, message string) error {
 	}); err != nil {
 		return err
 	}
+	enqueueManifestRecords(ctx, opts.CampaignRoot)
 	return git.ResetIndexToHead(ctx, opts.CampaignRoot, expandedScope)
+}
+
+// enqueueManifestRecords re-queues each declared root's committed manifest so
+// it describes the bookkeeping commit that just landed on the synchronous
+// path. The deferred path needs no twin: the worker re-queues after every
+// campaign-root job it completes. Failure is deliberately swallowed; the
+// record is eventually consistent and a bookkeeping commit must not fail
+// because the queue directory could not be written.
+func enqueueManifestRecords(ctx context.Context, campaignRoot string) {
+	if n, err := jobs.EnqueueManifestsForRoots(ctx, campaignRoot); err == nil && n > 0 {
+		defercommit.SpawnWorker(ctx, campaignRoot, campaignRoot)
+	}
 }

--- a/internal/jobs/execute.go
+++ b/internal/jobs/execute.go
@@ -44,6 +44,8 @@ func execute(ctx context.Context, campaignRoot string, job *Job) error {
 		return executeCommitPaths(ctx, repoPath, job)
 	case KindCommitTree:
 		return executeCommitTree(ctx, campaignRoot, repoPath, job)
+	case KindManifest:
+		return executeManifest(ctx, campaignRoot, repoPath, job)
 	default:
 		return camperrors.Newf("unknown job kind %q in job %s", job.Kind, job.ID)
 	}

--- a/internal/jobs/job.go
+++ b/internal/jobs/job.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Obedience-Corp/camp/internal/artifacts"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 )
 
@@ -182,6 +183,13 @@ type Job struct {
 	// serves whatever is in the lane, and one spawned under another
 	// environment must not write this machine's record under its own name.
 	Machine string `json:"machine,omitempty"`
+	// StateFingerprint is the stat-level fingerprint of the root at enqueue
+	// (artifacts.FingerprintFiles). The worker recomputes it before hashing:
+	// a mismatch means the root moved after the described commit, the
+	// pre-edit bytes are unrecoverable, and the record is relabelled to the
+	// commit current at observation rather than silently claiming to
+	// describe state it never saw.
+	StateFingerprint string `json:"state_fingerprint,omitempty"`
 	// CreatedAt is the enqueuing process's clock, RFC3339 with millis.
 	CreatedAt string `json:"created_at"`
 	// Attempts counts how many times this job has been claimed.
@@ -279,17 +287,19 @@ func (j *Job) Validate() error {
 				"commit-tree requires a message or auto_write", nil)
 		}
 	case KindManifest:
-		if strings.TrimSpace(j.ManifestRoot) == "" {
-			return camperrors.NewValidation("manifest_root",
-				"a manifest job requires the declared root it records", nil)
+		// Queue files are hand-editable, so both path components are
+		// re-validated wherever they are read, not only where camp wrote
+		// them: an edited root or machine must never walk or write outside
+		// the campaign's trees.
+		if err := artifacts.ValidateRootPath(j.ManifestRoot); err != nil {
+			return camperrors.NewValidation("manifest_root", err.Error(), err)
 		}
 		if strings.TrimSpace(j.DescribesCommit) == "" {
 			return camperrors.NewValidation("describes_commit",
 				"a manifest job requires the commit it describes; without it the record is ambiguous", nil)
 		}
-		if strings.TrimSpace(j.Machine) == "" {
-			return camperrors.NewValidation("machine",
-				"a manifest job requires the machine identity captured at enqueue", nil)
+		if err := artifacts.ValidateMachineSegment(j.Machine); err != nil {
+			return camperrors.NewValidation("machine", err.Error(), err)
 		}
 		if j.Class != ClassManifest {
 			return camperrors.NewValidation("class",

--- a/internal/jobs/job.go
+++ b/internal/jobs/job.go
@@ -41,11 +41,17 @@ const (
 	// Running a plain `git commit` later would sweep in anything staged in the
 	// meantime by another terminal.
 	KindCommitTree Kind = "commit-tree"
+	// KindManifest is a committed artifact manifest: the worker hashes the
+	// declared root incrementally, writes the machine's committed record, and
+	// commits it. There is no snapshot to capture at enqueue; the record
+	// describes DescribesCommit whenever it lands, which is why manifest jobs
+	// are the one class exempt from drains.
+	KindManifest Kind = "manifest"
 )
 
 // Valid reports whether k is a kind this package executes.
 func (k Kind) Valid() bool {
-	return k == KindCommitPaths || k == KindCommitTree
+	return k == KindCommitPaths || k == KindCommitTree || k == KindManifest
 }
 
 // Class says whether a drain waits for a job.
@@ -164,6 +170,13 @@ type Job struct {
 	// the commit the parent made. Narrow on purpose, and enforced at execution
 	// rather than by convention.
 	FollowUp bool `json:"follow_up,omitempty"`
+	// ManifestRoot is the declared artifact root a KindManifest job records,
+	// campaign-relative and normalized.
+	ManifestRoot string `json:"manifest_root,omitempty"`
+	// DescribesCommit is the campaign-root SHA whose artifact state a
+	// KindManifest job captures. The carrier commit is usually later; this
+	// field is what keeps the record unambiguous.
+	DescribesCommit string `json:"describes_commit,omitempty"`
 	// CreatedAt is the enqueuing process's clock, RFC3339 with millis.
 	CreatedAt string `json:"created_at"`
 	// Attempts counts how many times this job has been claimed.
@@ -259,6 +272,27 @@ func (j *Job) Validate() error {
 		if strings.TrimSpace(j.Message) == "" && !j.AutoWrite {
 			return camperrors.NewValidation("message",
 				"commit-tree requires a message or auto_write", nil)
+		}
+	case KindManifest:
+		if strings.TrimSpace(j.ManifestRoot) == "" {
+			return camperrors.NewValidation("manifest_root",
+				"a manifest job requires the declared root it records", nil)
+		}
+		if strings.TrimSpace(j.DescribesCommit) == "" {
+			return camperrors.NewValidation("describes_commit",
+				"a manifest job requires the commit it describes; without it the record is ambiguous", nil)
+		}
+		if j.Class != ClassManifest {
+			return camperrors.NewValidation("class",
+				"a manifest job must carry class manifest; anything else would let it block drains", nil)
+		}
+		if normalizeRepo(j.Repo) != "." {
+			return camperrors.NewValidation("repo",
+				"manifest records are campaign-root files; the job's lane is \".\"", nil)
+		}
+		if j.Then != nil || j.FollowUp || len(j.Paths) != 0 {
+			return camperrors.NewValidation("manifest",
+				"a manifest job carries no paths, follow-up, or chain", nil)
 		}
 	}
 	return nil

--- a/internal/jobs/job.go
+++ b/internal/jobs/job.go
@@ -177,6 +177,11 @@ type Job struct {
 	// KindManifest job captures. The carrier commit is usually later; this
 	// field is what keeps the record unambiguous.
 	DescribesCommit string `json:"describes_commit,omitempty"`
+	// Machine is the identity whose committed manifest a KindManifest job
+	// writes. Captured at enqueue rather than read at execution: a worker
+	// serves whatever is in the lane, and one spawned under another
+	// environment must not write this machine's record under its own name.
+	Machine string `json:"machine,omitempty"`
 	// CreatedAt is the enqueuing process's clock, RFC3339 with millis.
 	CreatedAt string `json:"created_at"`
 	// Attempts counts how many times this job has been claimed.
@@ -281,6 +286,10 @@ func (j *Job) Validate() error {
 		if strings.TrimSpace(j.DescribesCommit) == "" {
 			return camperrors.NewValidation("describes_commit",
 				"a manifest job requires the commit it describes; without it the record is ambiguous", nil)
+		}
+		if strings.TrimSpace(j.Machine) == "" {
+			return camperrors.NewValidation("machine",
+				"a manifest job requires the machine identity captured at enqueue", nil)
 		}
 		if j.Class != ClassManifest {
 			return camperrors.NewValidation("class",

--- a/internal/jobs/manifest.go
+++ b/internal/jobs/manifest.go
@@ -1,0 +1,111 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/Obedience-Corp/camp/internal/artifacts"
+	"github.com/Obedience-Corp/camp/internal/git"
+)
+
+// Committed artifact manifests ride the queue as their own kind because they
+// invert the usual promise. A commit job must land exactly what was captured;
+// a manifest job must land whatever the root holds when it runs, labelled
+// with the commit it describes. Late is correct here, which is why the class
+// is exempt from every drain.
+
+// executeManifest builds the incremental manifest for one root, writes the
+// machine's committed record, and commits it. An unchanged root writes and
+// commits nothing: the committed record is already correct, and rewriting it
+// would churn a byte-identical file through history.
+func executeManifest(ctx context.Context, campaignRoot, repoPath string, job *Job) error {
+	machine, err := artifacts.MachineName()
+	if err != nil {
+		return err
+	}
+	prev, _, err := artifacts.LoadCommitted(campaignRoot, machine, job.ManifestRoot)
+	if err != nil {
+		return err
+	}
+	m, err := artifacts.BuildManifest(ctx, campaignRoot, job.ManifestRoot)
+	if err != nil {
+		return err
+	}
+	// The heartbeat goroutine on the lane lock keeps the worker alive through
+	// a long first-pass hash; no progress plumbing is needed for liveness.
+	if err := artifacts.HashManifest(ctx, campaignRoot, m, prev, nil); err != nil {
+		return err
+	}
+	if prev != nil && artifacts.SameFiles(prev.Files, m.Files) {
+		return nil
+	}
+	rel, err := artifacts.WriteCommitted(campaignRoot, machine, m, job.DescribesCommit)
+	if err != nil {
+		return err
+	}
+	err = git.CommitScoped(ctx, repoPath, []string{rel}, &git.CommitOptions{
+		Message: "manifest: " + job.ManifestRoot + " at " + shortSHA(job.DescribesCommit),
+	})
+	if errors.Is(err, git.ErrNoChanges) {
+		return nil // a drain or ordinary commit already carried the file
+	}
+	return err
+}
+
+// EnqueueManifest queues one root's manifest job, dropping any pending
+// manifest job for the same root first. Only the newest record matters: a
+// pending job for an older commit would build the same bytes and label them
+// with a stale SHA, so the dedupe keeps the latest describes_commit and the
+// queue from accumulating one job per keystroke.
+func EnqueueManifest(ctx context.Context, campaignRoot, rootRel, describesCommit string) error {
+	pending, err := List(campaignRoot, statePending, ".")
+	if err == nil {
+		for _, j := range pending {
+			if j.Kind == KindManifest && j.ManifestRoot == artifacts.NormalizeRootPath(rootRel) {
+				// A claim racing this remove wins the rename and the remove
+				// sees ENOENT; both jobs then run and the newer record lands
+				// last. Duplicate work, never a wrong record.
+				_ = os.Remove(filepath.Join(laneDir(campaignRoot, statePending, "."), jobFilename(j.Seq)))
+			}
+		}
+	}
+	_, err = Enqueue(ctx, campaignRoot, Job{
+		Kind:            KindManifest,
+		Class:           ClassManifest,
+		Repo:            ".",
+		ManifestRoot:    artifacts.NormalizeRootPath(rootRel),
+		DescribesCommit: describesCommit,
+	})
+	return err
+}
+
+// EnqueueManifestsForRoots queues a manifest job per declared root, recording
+// the campaign root's current HEAD as the described commit. A campaign with
+// no declared roots does nothing at all, which is the zero cost everyone else
+// pays for this feature.
+func EnqueueManifestsForRoots(ctx context.Context, campaignRoot string) (int, error) {
+	cfg, err := artifacts.Load(campaignRoot)
+	if err != nil {
+		return 0, err
+	}
+	if len(cfg.Roots) == 0 {
+		return 0, nil
+	}
+	head, err := git.FullHash(ctx, campaignRoot)
+	if err != nil {
+		return 0, err
+	}
+	enqueued := 0
+	for _, r := range cfg.Roots {
+		if ctx.Err() != nil {
+			return enqueued, ctx.Err()
+		}
+		if err := EnqueueManifest(ctx, campaignRoot, r.Path, head); err != nil {
+			return enqueued, err
+		}
+		enqueued++
+	}
+	return enqueued, nil
+}

--- a/internal/jobs/manifest.go
+++ b/internal/jobs/manifest.go
@@ -21,10 +21,10 @@ import (
 // commits nothing: the committed record is already correct, and rewriting it
 // would churn a byte-identical file through history.
 func executeManifest(ctx context.Context, campaignRoot, repoPath string, job *Job) error {
-	machine, err := artifacts.MachineName()
-	if err != nil {
-		return err
-	}
+	// The identity was captured at enqueue; a worker spawned under any other
+	// environment still writes the enqueuer's record under the enqueuer's
+	// name.
+	machine := job.Machine
 	prev, _, err := artifacts.LoadCommitted(campaignRoot, machine, job.ManifestRoot)
 	if err != nil {
 		return err
@@ -60,10 +60,14 @@ func executeManifest(ctx context.Context, campaignRoot, repoPath string, job *Jo
 // with a stale SHA, so the dedupe keeps the latest describes_commit and the
 // queue from accumulating one job per keystroke.
 func EnqueueManifest(ctx context.Context, campaignRoot, rootRel, describesCommit string) error {
+	machine, err := artifacts.MachineName()
+	if err != nil {
+		return err
+	}
 	pending, err := List(campaignRoot, statePending, ".")
 	if err == nil {
 		for _, j := range pending {
-			if j.Kind == KindManifest && j.ManifestRoot == artifacts.NormalizeRootPath(rootRel) {
+			if j.Kind == KindManifest && j.ManifestRoot == artifacts.NormalizeRootPath(rootRel) && j.Machine == machine {
 				// A claim racing this remove wins the rename and the remove
 				// sees ENOENT; both jobs then run and the newer record lands
 				// last. Duplicate work, never a wrong record.
@@ -77,6 +81,7 @@ func EnqueueManifest(ctx context.Context, campaignRoot, rootRel, describesCommit
 		Repo:            ".",
 		ManifestRoot:    artifacts.NormalizeRootPath(rootRel),
 		DescribesCommit: describesCommit,
+		Machine:         machine,
 	})
 	return err
 }

--- a/internal/jobs/manifest.go
+++ b/internal/jobs/manifest.go
@@ -23,9 +23,16 @@ import (
 func executeManifest(ctx context.Context, campaignRoot, repoPath string, job *Job) error {
 	// The identity was captured at enqueue; a worker spawned under any other
 	// environment still writes the enqueuer's record under the enqueuer's
-	// name.
+	// name. Both path components were validated at claim, and the root is
+	// re-checked at the moment of use because the walk is about to happen.
 	machine := job.Machine
-	prev, _, err := artifacts.LoadCommitted(campaignRoot, machine, job.ManifestRoot)
+	if _, err := artifacts.EnsureRootWithin(campaignRoot, job.ManifestRoot); err != nil {
+		return err
+	}
+	// The baseline is the record as git has it, never the working-tree file:
+	// a crashed attempt leaves its write uncommitted, and comparing against
+	// that would let the retry skip the commit forever.
+	prev, _, err := artifacts.LoadCommittedAtHead(ctx, campaignRoot, machine, job.ManifestRoot)
 	if err != nil {
 		return err
 	}
@@ -33,6 +40,23 @@ func executeManifest(ctx context.Context, campaignRoot, repoPath string, job *Jo
 	if err != nil {
 		return err
 	}
+
+	// The stat fingerprint captured at enqueue is what ties the observation
+	// to the described commit. If the root moved between the commit and this
+	// run, the pre-edit bytes are gone and no record of them can be made;
+	// the truthful record is the observed state anchored to the newest
+	// commit at observation time, said out loud in the worker log.
+	describes := job.DescribesCommit
+	if job.StateFingerprint != "" && artifacts.FingerprintFiles(m.Files) != job.StateFingerprint {
+		head, headErr := git.FullHash(ctx, repoPath)
+		if headErr != nil {
+			return headErr
+		}
+		logWorker(campaignRoot, "manifest-relabel root=%s described=%s now=%s: the root changed after enqueue; the record reflects the observed state",
+			job.ManifestRoot, shortSHA(job.DescribesCommit), shortSHA(head))
+		describes = head
+	}
+
 	// The heartbeat goroutine on the lane lock keeps the worker alive through
 	// a long first-pass hash; no progress plumbing is needed for liveness.
 	if err := artifacts.HashManifest(ctx, campaignRoot, m, prev, nil); err != nil {
@@ -41,12 +65,12 @@ func executeManifest(ctx context.Context, campaignRoot, repoPath string, job *Jo
 	if prev != nil && artifacts.SameFiles(prev.Files, m.Files) {
 		return nil
 	}
-	rel, err := artifacts.WriteCommitted(campaignRoot, machine, m, job.DescribesCommit)
+	rel, err := artifacts.WriteCommitted(campaignRoot, machine, m, describes)
 	if err != nil {
 		return err
 	}
 	err = git.CommitScoped(ctx, repoPath, []string{rel}, &git.CommitOptions{
-		Message: "manifest: " + job.ManifestRoot + " at " + shortSHA(job.DescribesCommit),
+		Message: "manifest: " + job.ManifestRoot + " at " + shortSHA(describes),
 	})
 	if errors.Is(err, git.ErrNoChanges) {
 		return nil // a drain or ordinary commit already carried the file
@@ -64,6 +88,20 @@ func EnqueueManifest(ctx context.Context, campaignRoot, rootRel, describesCommit
 	if err != nil {
 		return err
 	}
+	// artifacts.yaml is hand-editable; a root that escapes the campaign is
+	// refused before it can become a queued promise to walk it.
+	if err := artifacts.ValidateRootPath(rootRel); err != nil {
+		return err
+	}
+	if _, err := artifacts.EnsureRootWithin(campaignRoot, rootRel); err != nil {
+		return err
+	}
+	// One stat walk, no content reads: the fingerprint is what lets the
+	// worker prove the root still holds what it held at this commit.
+	snapshot, err := artifacts.BuildManifest(ctx, campaignRoot, rootRel)
+	if err != nil {
+		return err
+	}
 	pending, err := List(campaignRoot, statePending, ".")
 	if err == nil {
 		for _, j := range pending {
@@ -76,12 +114,13 @@ func EnqueueManifest(ctx context.Context, campaignRoot, rootRel, describesCommit
 		}
 	}
 	_, err = Enqueue(ctx, campaignRoot, Job{
-		Kind:            KindManifest,
-		Class:           ClassManifest,
-		Repo:            ".",
-		ManifestRoot:    artifacts.NormalizeRootPath(rootRel),
-		DescribesCommit: describesCommit,
-		Machine:         machine,
+		Kind:             KindManifest,
+		Class:            ClassManifest,
+		Repo:             ".",
+		ManifestRoot:     artifacts.NormalizeRootPath(rootRel),
+		DescribesCommit:  describesCommit,
+		Machine:          machine,
+		StateFingerprint: artifacts.FingerprintFiles(snapshot.Files),
 	})
 	return err
 }

--- a/internal/jobs/manifest.go
+++ b/internal/jobs/manifest.go
@@ -41,30 +41,65 @@ func executeManifest(ctx context.Context, campaignRoot, repoPath string, job *Jo
 		return err
 	}
 
-	// The stat fingerprint captured at enqueue is what ties the observation
-	// to the described commit. If the root moved between the commit and this
-	// run, the pre-edit bytes are gone and no record of them can be made;
-	// the truthful record is the observed state anchored to the newest
-	// commit at observation time, said out loud in the worker log.
-	describes := job.DescribesCommit
-	if job.StateFingerprint != "" && artifacts.FingerprintFiles(m.Files) != job.StateFingerprint {
-		head, headErr := git.FullHash(ctx, repoPath)
-		if headErr != nil {
-			return headErr
-		}
-		logWorker(campaignRoot, "manifest-relabel root=%s described=%s now=%s: the root changed after enqueue; the record reflects the observed state",
-			job.ManifestRoot, shortSHA(job.DescribesCommit), shortSHA(head))
-		describes = head
-	}
-
 	// The heartbeat goroutine on the lane lock keeps the worker alive through
 	// a long first-pass hash; no progress plumbing is needed for liveness.
-	if err := artifacts.HashManifest(ctx, campaignRoot, m, prev, nil); err != nil {
+	outcome, err := artifacts.HashManifest(ctx, campaignRoot, m, prev, nil)
+	if err != nil {
 		return err
 	}
+
 	if prev != nil && artifacts.SameFiles(prev.Files, m.Files) {
+		// HEAD already records this exact artifact state, so there is nothing
+		// new to commit. The working-tree file can still hold a crashed
+		// attempt's write, which HEAD never accepted: status reads that file,
+		// and a later broad commit would sweep it into history as the record.
+		// Put it back before calling the job done.
+		restored, rErr := artifacts.ReconcileCommittedToHead(ctx, campaignRoot, machine, job.ManifestRoot)
+		if rErr != nil {
+			return rErr
+		}
+		if restored {
+			logWorker(campaignRoot, "manifest-restore root=%s: discarded a working-tree record HEAD does not carry",
+				job.ManifestRoot)
+		}
 		return nil
 	}
+
+	// The stat fingerprint captured at enqueue is what ties the observation to
+	// the described commit, and it is compared against a walk taken AFTER the
+	// hash pass. A comparison made before hashing proves nothing about the
+	// record actually written: the hash pass reads every changed byte and can
+	// run for minutes on a first pass, and an entry whose hash was carried
+	// forward from prev is never re-read at all, so only a fresh walk can tell
+	// that its file has since moved. If the root moved, the pre-edit bytes are
+	// gone and no record of them can be made; the truthful record is the
+	// observed state anchored to the newest commit at observation time, said out
+	// loud in the worker log.
+	describes := job.DescribesCommit
+	if job.StateFingerprint != "" {
+		observed, oErr := artifacts.BuildManifest(ctx, campaignRoot, job.ManifestRoot)
+		if oErr != nil {
+			return oErr
+		}
+		if artifacts.FingerprintFiles(observed.Files) != job.StateFingerprint {
+			head, headErr := git.FullHash(ctx, repoPath)
+			if headErr != nil {
+				return headErr
+			}
+			logWorker(campaignRoot, "manifest-relabel root=%s described=%s now=%s: the root changed after enqueue; the record reflects the observed state",
+				job.ManifestRoot, shortSHA(job.DescribesCommit), shortSHA(head))
+			describes = head
+		}
+	}
+
+	// A file being written while it was hashed has no single set of bytes to
+	// record, so its entry carries an unknown hash and the next pass re-reads
+	// it. Silence here would look identical to a complete record.
+	if len(outcome.Unsettled) > 0 {
+		logWorker(campaignRoot, "manifest-unsettled root=%s files=%d first=%s: written while being hashed; recorded with hash unknown",
+			job.ManifestRoot, len(outcome.Unsettled), outcome.Unsettled[0])
+	}
+
 	rel, err := artifacts.WriteCommitted(campaignRoot, machine, m, describes)
 	if err != nil {
 		return err

--- a/internal/jobs/manifest_validate_internal_test.go
+++ b/internal/jobs/manifest_validate_internal_test.go
@@ -1,0 +1,45 @@
+package jobs
+
+import (
+	"strings"
+	"testing"
+)
+
+// Queue files are hand-editable, so the manifest job's path components are
+// re-validated at the claim boundary. An edited root or machine must never
+// become a promise to walk or write outside the campaign's trees.
+func TestManifestJobValidationRefusesEscapes(t *testing.T) {
+	base := Job{
+		Kind:            KindManifest,
+		Class:           ClassManifest,
+		Repo:            ".",
+		ManifestRoot:    "media",
+		DescribesCommit: "cafebabecafebabecafebabecafebabecafebabe",
+		Machine:         "machine-a",
+	}
+	if err := base.Validate(); err != nil {
+		t.Fatalf("the valid baseline must validate: %v", err)
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*Job)
+		want   string
+	}{
+		{"escaping root", func(j *Job) { j.ManifestRoot = "../../outside" }, "manifest_root"},
+		{"absolute root", func(j *Job) { j.ManifestRoot = "/etc" }, "manifest_root"},
+		{"machine with separator", func(j *Job) { j.Machine = "evil/../../tmp" }, "machine"},
+		{"machine dot-prefixed", func(j *Job) { j.Machine = ".." }, "machine"},
+		{"empty machine", func(j *Job) { j.Machine = "" }, "machine"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			j := base
+			tc.mutate(&j)
+			err := j.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("Validate() = %v, want refusal naming %s", err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/jobs/worker.go
+++ b/internal/jobs/worker.go
@@ -151,6 +151,18 @@ func runLane(ctx context.Context, campaignRoot, repo string) (served bool) {
 			if err := complete(cmp.Or(execErr, followErr)); err != nil {
 				logWorker(campaignRoot, "complete-error lane=%s id=%s err=%v", repo, job.ID, err)
 			}
+			// A worker-made commit in the campaign root moves the history the
+			// manifest record ties artifact state to, so it re-queues the
+			// record like a foreground commit would. Manifest jobs themselves
+			// are excluded: an unchanged root skips its commit, so without
+			// the exclusion the one that did commit would re-queue forever.
+			// Enqueue failure is logged, not fatal: the record is eventually
+			// consistent, and the next commit re-queues it.
+			if execErr == nil && followErr == nil && job.Kind != KindManifest && normalizeRepo(job.Repo) == "." {
+				if _, err := EnqueueManifestsForRoots(ctx, campaignRoot); err != nil {
+					logWorker(campaignRoot, "manifest-enqueue-error lane=%s id=%s err=%v", repo, job.ID, err)
+				}
+			}
 		}
 
 		lock.release()

--- a/internal/notice/artifacts.go
+++ b/internal/notice/artifacts.go
@@ -123,15 +123,52 @@ func ArtifactRootsMissingLocally(ctx context.Context, campaignRoot string) (*Not
 // ArtifactRootDrift reports a declared root whose contents no longer match its
 // committed manifest.
 //
-// Registered now and deliberately silent: the comparison needs committed
-// manifests, which phase 002 introduces. Wiring the detector in ahead of its
-// data keeps the notice surface's shape visible and means the later change is
-// one function body rather than another round of plumbing.
+// Stat-level by contract: size, nanosecond mtime, and presence, bounded by the
+// declared-root list, no hashing on the status path. The notice reports and
+// never resolves; the manifest is a record of what was, and the next commit is
+// what updates it.
 func ArtifactRootDrift(ctx context.Context, campaignRoot string) (*Notice, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
-	// manifests: phase 002 sequence 04 fills this in.
+	cfg, err := artifacts.Load(campaignRoot)
+	if err != nil || len(cfg.Roots) == 0 {
+		return nil, err
+	}
+	machine, err := artifacts.MachineName()
+	if err != nil {
+		return nil, nil // no identity, no record to compare against
+	}
+	dismissals, err := LoadDismissals(campaignRoot)
+	if err != nil {
+		dismissals = &DismissalFile{}
+	}
+
+	for _, root := range cfg.Roots {
+		rel := artifacts.NormalizeRootPath(root.Path)
+		if rel == "" || !rootExists(campaignRoot, rel) {
+			continue
+		}
+		if dismissals.IsDismissed(manifestDriftIDPrefix + rel) {
+			continue
+		}
+		committed, _, err := artifacts.LoadCommitted(campaignRoot, machine, rel)
+		if err != nil || committed == nil {
+			continue // no committed record yet; never-synced covers the gap
+		}
+		drifts, err := artifacts.DetectDrift(ctx, campaignRoot, committed)
+		if err != nil || len(drifts) == 0 {
+			continue
+		}
+		id := manifestDriftIDPrefix + rel
+		return &Notice{
+			ID: id,
+			Message: fmt.Sprintf(
+				"%s has drifted from its committed manifest (%d paths); the record no longer matches this machine",
+				rel, len(drifts)),
+			Command: "camp commit   (dismiss: camp notify dismiss " + id + ")",
+		}, nil
+	}
 	return nil, nil
 }
 
@@ -151,3 +188,7 @@ func hasAnySnapshot(campaignRoot string, peers []string, rel string) bool {
 	}
 	return false
 }
+
+// manifestDriftIDPrefix keys drift dismissals per root, so silencing one
+// root's drift does not silence the next root that drifts.
+const manifestDriftIDPrefix = "artifact-manifest-drift:"

--- a/tests/integration/manifests_test.go
+++ b/tests/integration/manifests_test.go
@@ -236,3 +236,92 @@ func latestUserCommit(t *testing.T, tc *TestContainer, repoPath string) string {
 	t.Fatal("no non-manifest commit in recent history")
 	return ""
 }
+
+// Review finding 1: a crash after WriteCommitted but before the commit left
+// the record on disk and uncommitted. Comparing against the working-tree file
+// made the retry skip the commit forever; the baseline must be HEAD.
+func TestIntegration_ManifestCrashRetryStillCommits(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := "/campaigns/manifest-crash"
+	_, err := tc.InitCampaign(campPath, "manifest-crash", "product")
+	require.NoError(t, err)
+	const machine = "machine-a"
+
+	tc.Shell(t, fmt.Sprintf(`cd %s && mkdir -p media && printf 'crash-content' > media/f.bin`, campPath))
+	campAs(t, tc, machine, campPath, "artifacts add media")
+	campAs(t, tc, machine, campPath, `commit -m "declare"`)
+	settleJobs(t, tc, machine, campPath)
+
+	// The crash state, exactly: the carrier commit undone, the written record
+	// still on disk. A crafted retry job stands in for the reclaimed one.
+	described := strings.TrimSpace(tc.Shell(t, fmt.Sprintf(
+		`cd %s && git show HEAD:.campaign/artifacts/manifests/%s/media.json | grep describes_commit | cut -d'"' -f4`,
+		campPath, machine)))
+	require.NotEmpty(t, described)
+	tc.Shell(t, fmt.Sprintf(`
+		set -e
+		cd %[1]s
+		git reset -q --soft HEAD~1
+		LANE=.campaign/cache/jobs/pending/%%2E
+		mkdir -p "$LANE"
+		cat > "$LANE/0000009.json" <<JSON
+{
+  "id": "job-crash-retry",
+  "seq": 9,
+  "kind": "manifest",
+  "class": "manifest",
+  "repo": ".",
+  "manifest_root": "media",
+  "describes_commit": "%[2]s",
+  "machine": "%[3]s",
+  "created_at": "2026-07-29T00:00:00.000Z",
+  "attempts": 1
+}
+JSON
+	`, campPath, described, machine))
+	settleJobs(t, tc, machine, campPath)
+
+	inHead := tc.Shell(t, fmt.Sprintf(
+		`cd %s && git show HEAD:.campaign/artifacts/manifests/%s/media.json 2>/dev/null | grep -c describes_commit || true`,
+		campPath, machine))
+	assert.Equal(t, "1", strings.TrimSpace(inHead),
+		"the retry of a crashed attempt must commit the record, not skip because the file already exists")
+}
+
+// Review finding 3: an artifact edit between the described commit and the
+// worker's read used to be silently absorbed under the earlier SHA. The
+// enqueue-time stat fingerprint detects it; the record then reflects the
+// observed state, relabelled to the commit current at observation, and the
+// divergence is said out loud in the worker log.
+func TestIntegration_ManifestDetectsPostCommitArtifactEdit(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := "/campaigns/manifest-race"
+	_, err := tc.InitCampaign(campPath, "manifest-race", "product")
+	require.NoError(t, err)
+	const machine = "machine-a"
+
+	tc.Shell(t, fmt.Sprintf(`cd %s && mkdir -p media && printf 'original-bytes' > media/f.bin`, campPath))
+	campAs(t, tc, machine, campPath, "artifacts add media")
+	campAs(t, tc, machine, campPath, `commit -m "declare"`)
+	settleJobs(t, tc, machine, campPath)
+
+	// Pin the lane so the job cannot run, commit, then edit the root: the
+	// exact race the fingerprint exists to catch.
+	tc.Shell(t, fmt.Sprintf(`touch "%s/.campaign/cache/jobs/worker-%%2E.lock"`, campPath))
+	tc.Shell(t, fmt.Sprintf(`cd %s && printf 'raced change\n' >> README.md && printf 'grow media' >> media/f.bin`, campPath))
+	campAs(t, tc, machine, campPath, `commit -m "commit before the edit"`)
+	tc.Shell(t, fmt.Sprintf(`cd %s && printf 'edited-after-commit' > media/f.bin`, campPath))
+	tc.Shell(t, fmt.Sprintf(`rm -f "%s/.campaign/cache/jobs/worker-%%2E.lock"`, campPath))
+	settleJobs(t, tc, machine, campPath)
+
+	logOut := tc.Shell(t, fmt.Sprintf(`grep -c manifest-relabel %s/.campaign/cache/jobs/worker.log || true`, campPath))
+	assert.NotEqual(t, "0", strings.TrimSpace(logOut),
+		"the divergence must be detected and said out loud in the worker log")
+
+	wantHash := strings.TrimSpace(tc.Shell(t, fmt.Sprintf(
+		`cd %s && sha256sum media/f.bin | cut -d' ' -f1`, campPath)))
+	record := tc.Shell(t, fmt.Sprintf(
+		`cd %s && git show HEAD:.campaign/artifacts/manifests/%s/media.json`, campPath, machine))
+	assert.Contains(t, record, wantHash,
+		"the record must truthfully hash the observed bytes, never claim state it did not see")
+}

--- a/tests/integration/manifests_test.go
+++ b/tests/integration/manifests_test.go
@@ -325,3 +325,137 @@ func TestIntegration_ManifestDetectsPostCommitArtifactEdit(t *testing.T) {
 	assert.Contains(t, record, wantHash,
 		"the record must truthfully hash the observed bytes, never claim state it did not see")
 }
+
+// Re-review finding 1: proving the artifact root matches the record in HEAD
+// does not prove the working-tree file matches HEAD too. A crashed attempt
+// writes its record before its commit, so the file on disk can hold output
+// history never accepted. The skip-commit path used to return success on the
+// root comparison alone and leave that file in place, where status reads it and
+// a later broad commit sweeps it into history as though it were the record.
+func TestIntegration_ManifestSkipRestoresAnUncommittedRecord(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := "/campaigns/manifest-stale-record"
+	_, err := tc.InitCampaign(campPath, "manifest-stale-record", "product")
+	require.NoError(t, err)
+	const machine = "machine-a"
+
+	tc.Shell(t, fmt.Sprintf(`cd %s && mkdir -p media && printf 'recorded-bytes' > media/f.bin`, campPath))
+	campAs(t, tc, machine, campPath, "artifacts add media")
+	campAs(t, tc, machine, campPath, `commit -m "declare"`)
+	settleJobs(t, tc, machine, campPath)
+
+	record := fmt.Sprintf(".campaign/artifacts/manifests/%s/media.json", machine)
+	committed := tc.Shell(t, fmt.Sprintf(`cd %s && git show HEAD:%s`, campPath, record))
+	require.Contains(t, committed, "describes_commit", "the baseline record must be in HEAD")
+
+	// The crash state: HEAD holds the real record, the working tree holds an
+	// attempt's output that was never committed. The root is untouched, so the
+	// job takes the skip-commit path.
+	tc.Shell(t, fmt.Sprintf(`cd %s && cat > %s <<'JSON'
+{
+  "version": 1,
+  "root": "media",
+  "describes_commit": "0000000000000000000000000000000000000000",
+  "files": [
+    {
+      "path": "f.bin",
+      "size": 999999,
+      "mtime_unix_nano": 1,
+      "hash_sha256": "deadbeef"
+    }
+  ]
+}
+JSON`, campPath, record))
+
+	tc.Shell(t, fmt.Sprintf(`
+		set -e
+		cd %[1]s
+		LANE=.campaign/cache/jobs/pending/%%2E
+		mkdir -p "$LANE"
+		cat > "$LANE/0000009.json" <<JSON
+{
+  "id": "job-stale-record-retry",
+  "seq": 9,
+  "kind": "manifest",
+  "class": "manifest",
+  "repo": ".",
+  "manifest_root": "media",
+  "describes_commit": "%[2]s",
+  "machine": "%[3]s",
+  "created_at": "2026-07-29T00:00:00.000Z",
+  "attempts": 1
+}
+JSON
+	`, campPath, strings.Repeat("a", 40), machine))
+	settleJobs(t, tc, machine, campPath)
+
+	after := tc.Shell(t, fmt.Sprintf(`cd %s && cat %s`, campPath, record))
+	assert.Equal(t, strings.TrimSpace(committed), strings.TrimSpace(after),
+		"the skip path must restore the working-tree record to the bytes HEAD carries")
+	assert.NotContains(t, after, "deadbeef",
+		"an uncommitted attempt's record must not survive the skip path")
+
+	dirty := strings.TrimSpace(tc.Shell(t, fmt.Sprintf(
+		`cd %s && git status --porcelain -- %s`, campPath, record)))
+	assert.Empty(t, dirty,
+		"after restoring, git must see nothing to commit for the record; otherwise a broad commit sweeps it in")
+
+	logOut := tc.Shell(t, fmt.Sprintf(`grep -c manifest-restore %s/.campaign/cache/jobs/worker.log || true`, campPath))
+	assert.NotEqual(t, "0", strings.TrimSpace(logOut),
+		"discarding a record HEAD does not carry must be said out loud in the worker log")
+}
+
+// Re-review finding 2, at the worker boundary: an artifact edit that lands
+// while the hash pass is reading must still relabel the record. The fingerprint
+// is therefore compared against a stat walk taken after hashing, not before it.
+func TestIntegration_ManifestRelabelsWhenTheRootMovesDuringHashing(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := "/campaigns/manifest-hash-window"
+	_, err := tc.InitCampaign(campPath, "manifest-hash-window", "product")
+	require.NoError(t, err)
+	const machine = "machine-a"
+
+	tc.Shell(t, fmt.Sprintf(`cd %s && mkdir -p media && printf 'original-bytes' > media/f.bin`, campPath))
+	campAs(t, tc, machine, campPath, "artifacts add media")
+	campAs(t, tc, machine, campPath, `commit -m "declare"`)
+	settleJobs(t, tc, machine, campPath)
+
+	// A hand-written job whose fingerprint names a state the root no longer
+	// holds stands in for the enqueue-then-edit window, with the edit landing
+	// where only a post-hash walk can see it.
+	tc.Shell(t, fmt.Sprintf(`cd %s && printf 'edited-after-enqueue' > media/f.bin`, campPath))
+	head := strings.TrimSpace(tc.GitOutput(t, campPath, "rev-parse", "HEAD"))
+	tc.Shell(t, fmt.Sprintf(`
+		set -e
+		cd %[1]s
+		LANE=.campaign/cache/jobs/pending/%%2E
+		mkdir -p "$LANE"
+		cat > "$LANE/0000009.json" <<JSON
+{
+  "id": "job-hash-window",
+  "seq": 9,
+  "kind": "manifest",
+  "class": "manifest",
+  "repo": ".",
+  "manifest_root": "media",
+  "describes_commit": "%[2]s",
+  "machine": "%[3]s",
+  "state_fingerprint": "%[4]s",
+  "created_at": "2026-07-29T00:00:00.000Z",
+  "attempts": 1
+}
+JSON
+	`, campPath, head, machine, strings.Repeat("b", 64)))
+	settleJobs(t, tc, machine, campPath)
+
+	logOut := tc.Shell(t, fmt.Sprintf(`grep -c manifest-relabel %s/.campaign/cache/jobs/worker.log || true`, campPath))
+	assert.NotEqual(t, "0", strings.TrimSpace(logOut),
+		"a root that moved out from under the described commit must be relabelled and logged")
+
+	wantHash := strings.TrimSpace(tc.Shell(t, fmt.Sprintf(
+		`cd %s && sha256sum media/f.bin | cut -d' ' -f1`, campPath)))
+	stored := tc.Shell(t, fmt.Sprintf(
+		`cd %s && git show HEAD:.campaign/artifacts/manifests/%s/media.json`, campPath, machine))
+	assert.Contains(t, stored, wantHash,
+		"the record must hash the bytes it observed")
+}

--- a/tests/integration/manifests_test.go
+++ b/tests/integration/manifests_test.go
@@ -220,3 +220,19 @@ func TestIntegration_DrainNeverWaitsOnAManifestHash(t *testing.T) {
 	assert.Contains(t, subjects, "manifest: media at "+described[:8],
 		"the manifest still lands after the drain, naming the right commit")
 }
+
+// latestUserCommit returns the newest commit that is not a manifest carrier.
+// Committed manifests land asynchronously, so "the commit this test just
+// made" and HEAD can differ by the time the test reads it.
+func latestUserCommit(t *testing.T, tc *TestContainer, repoPath string) string {
+	t.Helper()
+	out := tc.GitOutput(t, repoPath, "log", "--format=%H %s", "-8")
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		sha, subject, ok := strings.Cut(line, " ")
+		if ok && !strings.HasPrefix(subject, "manifest: ") {
+			return sha
+		}
+	}
+	t.Fatal("no non-manifest commit in recent history")
+	return ""
+}

--- a/tests/integration/manifests_test.go
+++ b/tests/integration/manifests_test.go
@@ -1,0 +1,222 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Committed artifact manifests, criteria 16, 17, 19, 21, 21b, 21c, and 27.
+// Every camp invocation pins CAMP_MACHINE_NAME so the manifest identity is
+// deterministic regardless of the container's hostname, and jobs are served
+// by an explicit worker run under the same identity.
+
+func campAs(t *testing.T, tc *TestContainer, machine, campPath, args string) string {
+	t.Helper()
+	return tc.Shell(t, fmt.Sprintf(
+		`cd %s && CAMP_MACHINE_NAME=%s /camp %s 2>&1 || true`, campPath, machine, args))
+}
+
+// settleJobs serves every queued job under one identity and waits for the
+// queue to empty, so a later phase can switch identity without an earlier
+// phase's worker picking up its jobs.
+func settleJobs(t *testing.T, tc *TestContainer, machine, campPath string) {
+	t.Helper()
+	deadline := time.Now().Add(90 * time.Second)
+	for {
+		campAs(t, tc, machine, campPath, "jobs run --campaign "+campPath)
+		left := strings.TrimSpace(tc.Shell(t, fmt.Sprintf(
+			`find %s/.campaign/cache/jobs/pending %s/.campaign/cache/jobs/running -name '*.json' 2>/dev/null | wc -l`,
+			campPath, campPath)))
+		if left == "0" || left == "" {
+			failed := strings.TrimSpace(tc.Shell(t, fmt.Sprintf(
+				`find %s/.campaign/cache/jobs/failed -name '*.json' 2>/dev/null | wc -l`, campPath)))
+			if failed != "0" && failed != "" {
+				log := tc.Shell(t, fmt.Sprintf(
+					`tail -20 %s/.campaign/cache/jobs/worker.log 2>/dev/null; find %s/.campaign/cache/jobs/failed -name '*.json' -exec cat {} \;`,
+					campPath, campPath))
+				t.Fatalf("jobs failed while settling:\n%s", log)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("queue did not settle; %s jobs left", left)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// shaBySubject resolves the commit whose subject matches exactly, so a test
+// never mistakes an asynchronously landed manifest carrier for the commit it
+// just made.
+func shaBySubject(t *testing.T, tc *TestContainer, campPath, subject string) string {
+	t.Helper()
+	out := tc.GitOutput(t, campPath, "log", "--format=%H %s")
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		sha, rest, ok := strings.Cut(line, " ")
+		if ok && strings.HasSuffix(rest, subject) {
+			return sha
+		}
+	}
+	t.Fatalf("no commit with subject %q in:\n%s", subject, out)
+	return ""
+}
+
+func TestIntegration_ManifestRecordsArtifactStatePerCommit(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := "/campaigns/manifest-record"
+	_, err := tc.InitCampaign(campPath, "manifest-record", "product")
+	require.NoError(t, err)
+	const machine = "machine-a"
+
+	// Declare the root, then let the declaration's own bookkeeping and any
+	// first manifest settle before the commit under test.
+	tc.Shell(t, fmt.Sprintf(`
+		set -e
+		cd %s
+		mkdir -p media
+		printf 'seed-content-v1' > media/seed.bin
+	`, campPath))
+	campAs(t, tc, machine, campPath, "artifacts add media")
+	campAs(t, tc, machine, campPath, `commit -m "declare media root"`)
+	settleJobs(t, tc, machine, campPath)
+
+	// The commit under test changes the root's contents.
+	tc.Shell(t, fmt.Sprintf(`
+		set -e
+		cd %s
+		printf 'seed-content-v2-now-longer' > media/seed.bin
+		printf 'second-file-content' > media/extra.bin
+		printf 'tracked change\n' >> README.md
+	`, campPath))
+	campAs(t, tc, machine, campPath, `commit -m "change media"`)
+	head1 := shaBySubject(t, tc, campPath, "change media")
+
+	// Criterion 21c, structurally: the commit that changed the root does not
+	// itself carry the manifest. The record rides a later carrier commit;
+	// nothing hashed on the command the user waited for.
+	head1Files := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", head1)
+	assert.NotContains(t, head1Files, ".campaign/artifacts/manifests",
+		"the described commit must not carry its own manifest (hashing is deferred)")
+
+	settleJobs(t, tc, machine, campPath)
+
+	// Criterion 16: the record exists, is committed, and ties history to
+	// artifact state: path, size, mtime, hash, and the described commit.
+	manifestRel := ".campaign/artifacts/manifests/" + machine + "/media.json"
+	manifest := tc.Shell(t, fmt.Sprintf(`cd %s && git show HEAD:%s 2>/dev/null || cat %s`,
+		campPath, manifestRel, manifestRel))
+	for _, want := range []string{
+		`"path": "seed.bin"`, `"path": "extra.bin"`,
+		`"mtime_unix_nano"`, `"hash_sha256"`,
+		fmt.Sprintf(`"describes_commit": "%s"`, head1),
+	} {
+		assert.Contains(t, manifest, want, "committed manifest must carry %s", want)
+	}
+	subjects := tc.GitOutput(t, campPath, "log", "--format=%s")
+	assert.Contains(t, subjects, "manifest: media at "+head1[:8],
+		"the carrier commit names the root and the described commit")
+
+	// Criterion 17: a commit that does not touch the root re-commits nothing.
+	manifestCommits := strings.Count(subjects, "manifest: media at ")
+	tc.Shell(t, fmt.Sprintf(`cd %s && printf 'unrelated\n' >> README.md`, campPath))
+	campAs(t, tc, machine, campPath, `commit -m "unrelated change"`)
+	settleJobs(t, tc, machine, campPath)
+	subjects = tc.GitOutput(t, campPath, "log", "--format=%s")
+	assert.Equal(t, manifestCommits, strings.Count(subjects, "manifest: media at "),
+		"an unchanged root must not produce a new manifest commit")
+	manifestAfter := tc.Shell(t, fmt.Sprintf(`cd %s && git show HEAD:%s`, campPath, manifestRel))
+	assert.Contains(t, manifestAfter, head1,
+		"the record keeps describing the commit that last changed the root")
+
+	// Criterion 21: camp stores no copy of artifact content anywhere.
+	leaked := strings.TrimSpace(tc.Shell(t, fmt.Sprintf(
+		`grep -rl 'seed-content-v2-now-longer' %s/.campaign 2>/dev/null || true`, campPath)))
+	assert.Empty(t, leaked, "no camp-managed directory may hold artifact content bytes")
+
+	// Criterion 27: drift is reported on doctor and status, and never fixed.
+	tc.Shell(t, fmt.Sprintf(`cd %s && printf 'drifted-content-edit' > media/seed.bin`, campPath))
+	doctorOut := campAs(t, tc, machine, campPath, "doctor -c artifacts --json")
+	assert.Contains(t, doctorOut, "manifest_drift", "doctor must report the drift row")
+	statusOut := campAs(t, tc, machine, campPath, "status")
+	assert.Contains(t, statusOut, "drifted from its committed manifest",
+		"status must surface the drift notice")
+	content := tc.Shell(t, fmt.Sprintf(`cat %s/media/seed.bin`, campPath))
+	assert.Equal(t, "drifted-content-edit", strings.TrimSpace(content),
+		"drift is reported, never resolved: the working tree is untouched")
+
+	// The next commit updates the record and the drift clears.
+	tc.Shell(t, fmt.Sprintf(`cd %s && printf 'clear drift\n' >> README.md`, campPath))
+	campAs(t, tc, machine, campPath, `commit -m "carry drifted media"`)
+	settleJobs(t, tc, machine, campPath)
+	doctorOut = campAs(t, tc, machine, campPath, "doctor -c artifacts --json")
+	assert.NotContains(t, doctorOut, "manifest_drift",
+		"a committed record matching the tree is not drift")
+}
+
+func TestIntegration_ManifestTwoMachinesNeverCollide(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := "/campaigns/manifest-machines"
+	_, err := tc.InitCampaign(campPath, "manifest-machines", "product")
+	require.NoError(t, err)
+
+	tc.Shell(t, fmt.Sprintf(`cd %s && mkdir -p media && printf 'shared' > media/f.bin`, campPath))
+	campAs(t, tc, "machine-a", campPath, "artifacts add media")
+	campAs(t, tc, "machine-a", campPath, `commit -m "declare on a"`)
+	settleJobs(t, tc, "machine-a", campPath)
+
+	tc.Shell(t, fmt.Sprintf(`cd %s && printf 'b-view' > media/f.bin && printf 'b change\n' >> README.md`, campPath))
+	campAs(t, tc, "machine-b", campPath, `commit -m "change on b"`)
+	settleJobs(t, tc, "machine-b", campPath)
+
+	// Criterion 19: distinct paths by construction; both records coexist in
+	// one history with no conflict to resolve.
+	tree := tc.GitOutput(t, campPath, "ls-tree", "-r", "--name-only", "HEAD")
+	assert.Contains(t, tree, ".campaign/artifacts/manifests/machine-a/media.json")
+	assert.Contains(t, tree, ".campaign/artifacts/manifests/machine-b/media.json")
+}
+
+func TestIntegration_DrainNeverWaitsOnAManifestHash(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := "/campaigns/manifest-drain"
+	_, err := tc.InitCampaign(campPath, "manifest-drain", "product")
+	require.NoError(t, err)
+	const machine = "machine-a"
+
+	tc.Shell(t, fmt.Sprintf(`cd %s && mkdir -p media && printf 'small' > media/f.bin`, campPath))
+	campAs(t, tc, machine, campPath, "artifacts add media")
+	campAs(t, tc, machine, campPath, `commit -m "declare"`)
+	settleJobs(t, tc, machine, campPath)
+
+	// Hold the root lane's worker lock so nothing can serve the queue: the
+	// manifest job is pinned pending, and the only way the drain below can
+	// return is by not waiting for it. This is the deterministic form of "a
+	// multi-gigabyte first pass is still running".
+	tc.Shell(t, fmt.Sprintf(
+		`touch "%s/.campaign/cache/jobs/worker-%%2E.lock"`, campPath))
+	tc.Shell(t, fmt.Sprintf(`cd %s && printf 'moved' > media/f.bin && printf 'busy change\n' >> README.md`, campPath))
+	campAs(t, tc, machine, campPath, `commit -m "change while lane is busy"`)
+
+	// Criterion 21b: the drain every history-moving command uses returns while
+	// the manifest job cannot possibly have run. Blocking jobs only.
+	campAs(t, tc, machine, campPath, "jobs drain")
+	left := strings.TrimSpace(tc.Shell(t, fmt.Sprintf(
+		`find %s/.campaign/cache/jobs/pending -name '*.json' 2>/dev/null | wc -l`, campPath)))
+	assert.NotEqual(t, "0", left,
+		"the manifest job must still be pending when the drain returns; drains wait for blocking jobs only")
+
+	// Release the lane; the record still lands and names the right commit.
+	tc.Shell(t, fmt.Sprintf(`rm -f "%s/.campaign/cache/jobs/worker-%%2E.lock"`, campPath))
+	described := shaBySubject(t, tc, campPath, "change while lane is busy")
+	settleJobs(t, tc, machine, campPath)
+	subjects := tc.GitOutput(t, campPath, "log", "--format=%s")
+	assert.Contains(t, subjects, "manifest: media at "+described[:8],
+		"the manifest still lands after the drain, naming the right commit")
+}

--- a/tests/integration/stage_guard_declare_test.go
+++ b/tests/integration/stage_guard_declare_test.go
@@ -61,7 +61,7 @@ func TestIntegration_GuardAutoDeclaresMixedRoot(t *testing.T) {
 		"one file takes the singular verb")
 	assert.Contains(t, output, "notes.md")
 
-	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
 
 	// Criterion 2, the data-loss regression. A new small file inside a mixed
 	// root must become git's, not silently reclassified as artifact content.
@@ -104,7 +104,7 @@ func TestIntegration_GuardRefusesCampaignRootFilePerFile(t *testing.T) {
 	assert.Contains(t, output, "sits at the campaign root; camp will not make the campaign an artifact root")
 	assert.Contains(t, output, "camp artifacts add")
 
-	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
 	assert.Contains(t, committed, "ordinary.md", "everything else must still commit")
 	assert.NotContains(t, committed, "render.mov")
 
@@ -141,7 +141,7 @@ func TestIntegration_GuardRefusesCampaignStateTree(t *testing.T) {
 			"camp's own state tree must never become a user artifact root")
 	}
 
-	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
 	assert.Contains(t, committed, "ordinary.md")
 }
 
@@ -266,7 +266,7 @@ func TestIntegration_GuardReportsTrackedGrowthButCommitsIt(t *testing.T) {
 	assert.Contains(t, output, "git rm --cached graphs/graph.png")
 	assert.Contains(t, output, "commit.guards.allow")
 
-	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
 	assert.Contains(t, committed, "graphs/graph.png",
 		"tracked growth is reported, never excluded")
 }

--- a/tests/integration/stage_guard_overrides_test.go
+++ b/tests/integration/stage_guard_overrides_test.go
@@ -62,7 +62,7 @@ func TestIntegration_GuardPhotoBatchDoesNotBlock(t *testing.T) {
 	output, err := tc.RunCampInDir(campPath, "commit", "-m", "six photos")
 	require.NoError(t, err, "six 9 MB photos must not block; output:\n%s", output)
 
-	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
 	assert.Contains(t, committed, "photos/p1.jpg")
 }
 
@@ -83,7 +83,7 @@ func TestIntegration_GuardLargeFileDoesNotTripBulk(t *testing.T) {
 	output, err := tc.RunCampInDir(campPath, "commit", "-m", "one big plus ninety-nine small")
 	require.NoError(t, err, "the big file must be taken by the per-file guard, not counted toward bulk; output:\n%s", output)
 
-	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
 	assert.Contains(t, committed, "media/small1.txt")
 	assert.NotContains(t, committed, "media/footage.mov")
 }
@@ -130,7 +130,7 @@ func TestIntegration_GuardCommitLargeForcesInclusion(t *testing.T) {
 	output, err := tc.RunCampInDir(campPath, "commit", "--commit-large", "-m", "keep the binary")
 	require.NoError(t, err, "output:\n%s", output)
 
-	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
 	assert.Contains(t, committed, "media/footage.mov",
 		"--commit-large must force the file into the commit")
 
@@ -161,7 +161,7 @@ func TestIntegration_GuardCommitLargeOverridesBulk(t *testing.T) {
 	output, err := tc.RunCampInDir(campPath, "commit", "--commit-large", "-m", "vendor anyway")
 	require.NoError(t, err, "the bulk menu offers --commit-large, so it must work; output:\n%s", output)
 
-	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
 	assert.Contains(t, committed, "vendor_tree/f1.js")
 }
 
@@ -184,7 +184,7 @@ func TestIntegration_GuardAllowlistIsSilent(t *testing.T) {
 	assert.NotContains(t, output, "artifact root")
 	assert.NotContains(t, output, "kept out of git")
 
-	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
 	assert.Contains(t, committed, "releases/camp-darwin")
 }
 
@@ -215,7 +215,7 @@ YAML
 	output, err := tc.RunCampInDir(projPath, "project", "commit", "-m", "override applies here")
 	require.NoError(t, err, "output:\n%s", output)
 
-	committed := tc.GitOutput(t, projPath, "show", "--name-only", "--format=", "HEAD")
+	committed := tc.GitOutput(t, projPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, projPath))
 	assert.Contains(t, committed, "bigdir/blob.bin",
 		"the project's own 100MiB override must let a 3 MB file through")
 	assert.NotContains(t, output, "was left out of this commit")
@@ -249,7 +249,7 @@ func TestIntegration_GuardSettingsRoundTrip(t *testing.T) {
 	require.NoError(t, err, "output:\n%s", output)
 	assert.NotContains(t, output, "artifact root")
 
-	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
 	assert.Contains(t, committed, "media/big.bin")
 }
 


### PR DESCRIPTION
## What

Design doc 08 (`workflow/design/camp-artifact-commit-updates-2026-07-25/08-artifact-manifests.md`): camp records what the artifact set was at each commit, and never stores old copies.

- **Incremental hashing** (`internal/artifacts/hash.go`): `FileEntry` gains `hash_sha256` under a versioned key so pre-hashing manifests degrade to re-hash, never misread. Only entries whose size or nanosecond mtime moved are re-read; unchanged entries inherit their hash without a read (proven by a test whose files do not exist on disk). SHA-256 for external verifiability (`shasum -a 256`).
- **Committed record** (`internal/artifacts/committed.go`): one file per (machine, root) at `.campaign/artifacts/manifests/<machine>/<root-slug>.json`, carrying `describes_commit`. GeneratedAt is absent from the committed form; an unchanged root serializes byte-identically and the job commits nothing.
- **Machine identity**: `NormalizeHost` over the hostname, `CAMP_MACHINE_NAME` override; captured at enqueue on the job so a worker spawned under any environment writes the enqueuer's record.
- **Queue integration** (`internal/jobs/manifest.go`): new `manifest` kind, always `class: manifest` so it is exempt from every drain; enqueued at each campaign-root commit tail (foreground, synchronous bookkeeping, worker completions), deduped per (root, machine) keeping the newest `describes_commit`.
- **Drift surfaces**: the doctor `artifacts` check replaces its phase-002 skip with the real `manifest_drift` row; the pre-wired `ArtifactRootDrift` status notice gets its live body. Stat-level only; report, never resolve.

## Semantics worth noting

Artifact-only edits produce no commit and therefore no record update, by design: the record ties artifact state to git history, and drift covers the window until the next real commit. Manifest carrier commits land asynchronously, so tests that read HEAD right after committing were re-anchored (`latestUserCommit`).

## Verification

- Full containerized integration suite: **691/691 green** (753s), including new criteria tests for 16, 17, 19, 21, 21b, 21c, 27. The 21b test is deterministic: with the lane lock held so nothing can serve the queue, `camp jobs drain` still returns with the manifest job pending.
- `just gate` green; `GOOS=windows` unaffected (no platform code touched).
- The suite outgrew its 10m go test cap during this work (timeout panic with zero failing tests); the budget is raised to 15m in the buildtool and verbose recipe.