### PR TITLE
feat(commitkit): export StageAllWithOptions for consumer commit-large flags

### DIFF
--- a/pkg/commitkit/commitkit.go
+++ b/pkg/commitkit/commitkit.go
@@ -190,6 +190,19 @@ func StageAllWithOutcome(ctx context.Context, repoPath string) (*StageOutcome, e
 	return git.StageWithGuard(ctx, repoPath, nil)
 }
 
+// StageAllWithOptions is StageAllWithOutcome with per-invocation overrides of
+// the guard's decision. It exists for the consumer flag that means "commit it
+// anyway": fest's --commit-large forwards here exactly as camp's own
+// --commit-large reaches the guard, so the override behaves identically in
+// both tools.
+func StageAllWithOptions(ctx context.Context, repoPath string, opts StageOptions) (*StageOutcome, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	drainQuietly(ctx, repoPath)
+	return git.StageWithGuardOptions(ctx, repoPath, nil, opts)
+}
+
 // StageFiles stages specific files in the repository at repoPath.
 // Uses automatic lock retry with stale lock cleanup.
 //

--- a/pkg/commitkit/guard.go
+++ b/pkg/commitkit/guard.go
@@ -80,6 +80,15 @@ type StageOutcome = git.StageOutcome
 // violations as typed data for the same reason.
 type GuardBlockedError = git.GuardBlockedError
 
+// StageOptions carries per-invocation overrides of the guard's decision.
+//
+// CommitLarge is the consumer-facing "no, this file belongs in git": camp's
+// own commit command threads --commit-large through this same override, and a
+// consumer's equivalent flag arrives here via StageAllWithOptions. An alias
+// for the same reason as every type above: the override a consumer builds is
+// the override the guard reads, with no conversion between them.
+type StageOptions = git.StageOptions
+
 // Mode is a guard's configured behavior.
 type Mode = stageguard.Mode
 

--- a/pkg/commitkit/guard_test.go
+++ b/pkg/commitkit/guard_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Obedience-Corp/camp/internal/git"
 	"github.com/Obedience-Corp/camp/internal/stageguard"
 	"github.com/Obedience-Corp/camp/pkg/commitkit"
 )
@@ -26,6 +27,13 @@ var (
 	// other through an implicit conversion.
 	_ commitkit.GuardLimits    = stageguard.GuardLimits{}
 	_ commitkit.GuardViolation = stageguard.GuardViolation{}
+)
+
+// StageOptions must alias the internal override type the same way: the
+// CommitLarge a consumer sets is the CommitLarge the guard reads.
+var (
+	_ git.StageOptions       = commitkit.StageOptions{CommitLarge: true}
+	_ commitkit.StageOptions = git.StageOptions{}
 )
 
 func TestGuardConstantsMatchStageguard(t *testing.T) {
@@ -56,6 +64,15 @@ func TestResolveLimitsHonorsCanceledContext(t *testing.T) {
 	cancel()
 
 	_, err := commitkit.ResolveLimits(ctx, nonexistentRepo)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestStageAllWithOptionsHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := commitkit.StageAllWithOptions(ctx, nonexistentRepo, commitkit.StageOptions{CommitLarge: true})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
 }


### PR DESCRIPTION
## What

Exports the staging guard's per-invocation override through pkg/commitkit: `StageOptions` (alias of the internal type, like every other guard re-export) and `StageAllWithOptions`, which is `StageAllWithOutcome` plus the override, wired to the same internal path camp's own `--commit-large` uses.

## Why

Fest's commitkit integration (CA0004 phase 003) adds `fest commit --commit-large`, mirroring camp's flag. The override existed only inside the module: `StageAllWithOutcome` takes no options, so a consumer had no way to say "commit it anyway" without reimplementing staging. This is the smallest export that closes the gap.

## Testing

- Alias compile-checks in both directions (same pattern as the file's other re-exports), so the override a consumer builds is the override the guard reads with no conversion.
- Cancelled-context short-circuit test for the new function.
- `just gate-fast` green (lint 0 issues, full unit suite both profiles).

Once merged this ships as v0.4.0-rc.2 so fest can bump from rc.1 and thread the flag.