### PR TITLE
feat(discovery): reclassify rail residents, bump wi list contract to v1alpha10 (WF0001 P3/S3)

### DIFF
--- a/internal/commands/fresh/merged_backstop.go
+++ b/internal/commands/fresh/merged_backstop.go
@@ -110,8 +110,6 @@ func handleMergedBackstop(ctx context.Context, out io.Writer, root, projectPath 
 // declined item offers a "skip all remaining" shortcut. A cancelled prompt
 // (Ctrl+C) is treated as skip. Every accept goes through the shared promote path
 // with EvidenceMergedBranch; nothing is promoted without an explicit accept.
-// Matches are also de-duplicated by workitem key so a multi-worktree item that
-// somehow still appears more than once is only prompted/promoted once.
 func promoteMergedMatches(ctx context.Context, out io.Writer, cfg *config.CampaignConfig, root string, matches []MergedBackstopMatch) {
 	skipAll := false
 	seen := map[string]bool{}
@@ -257,10 +255,7 @@ func MapMergedBranchesToWorkitems(ctx context.Context, cfg *config.CampaignConfi
 
 	projectScope := projectRelPath(root, projectPath)
 
-	// Signal 1: worktree-scope links, per pruned branch. One workitem often has
-	// several worktree links (stacked PRs / multi-branch designs); once any of
-	// those branches map to it, further branches for the same key are ignored
-	// so promote only runs once.
+	// Signal 1: worktree-scope links, deduped by workitem key.
 	matches, unmatchedBranches, matchedKeys := collectWorktreeLinkMatches(registry.Links, active, prunedBranches)
 
 	// Signal 2: WI- commit tags on commits newly reachable from the default
@@ -285,11 +280,9 @@ func MapMergedBranchesToWorkitems(ctx context.Context, cfg *config.CampaignConfi
 	return matches, nil
 }
 
-// collectWorktreeLinkMatches maps pruned branch names to still-active workitems
-// via worktree-scope link basenames. Each workitem key appears at most once in
-// the returned matches (first pruned branch that hits it wins). Branches with
-// no worktree-link match are returned as unmatched for the commit-tag signal.
-// Pure: no I/O.
+// collectWorktreeLinkMatches maps pruned branches to active workitems via
+// worktree-link basenames, at most once per key. Unmatched branches fall through
+// to the commit-tag signal. Pure.
 func collectWorktreeLinkMatches(all []links.Link, active []wkitem.WorkItem, prunedBranches []string) (matches []MergedBackstopMatch, unmatched []string, matchedKeys map[string]bool) {
 	matchedKeys = map[string]bool{}
 	for _, branch := range prunedBranches {
@@ -299,9 +292,8 @@ func collectWorktreeLinkMatches(all []links.Link, active []wkitem.WorkItem, prun
 			continue
 		}
 		if matchedKeys[wi.Key] {
-			// Same workitem, another of its worktrees just merged. One promote
-			// covers the item; do not re-queue it and do not treat the branch as
-			// unmatched (that would incorrectly open the commit-tag path).
+			// Another worktree of the same item merged. Not unmatched: that would
+			// wrongly open the commit-tag path.
 			continue
 		}
 		matches = append(matches, MergedBackstopMatch{

--- a/internal/commands/workitem/promote_rail.go
+++ b/internal/commands/workitem/promote_rail.go
@@ -19,14 +19,10 @@ import (
 	"github.com/Obedience-Corp/camp/internal/workitem/locate"
 )
 
-// festivalsDir is the campaign-relative folder the rail moves workitems into.
 const festivalsDir = "festivals"
 
-// Rail stages. "root" is a workitem still living under workflow/<type>/; ready
-// and active are the physical festival stages and take their names from the
-// lifecycle vocabulary so the promote target, the stage folder, and
-// StagesByType cannot drift apart; dungeon covers any shelved source, which the
-// rail never accepts as an origin.
+// Stage names come from the lifecycle vocabulary so the promote target, the
+// stage folder, and StagesByType cannot drift apart.
 const (
 	railStageRoot    = "root"
 	railStageReady   = string(wkitem.LifecycleStageReady)
@@ -34,7 +30,7 @@ const (
 	railStageDungeon = "dungeon"
 )
 
-// railStageOf reports which rail stage a resolved location currently occupies.
+// railStageOf reports which rail stage a resolved location occupies.
 func railStageOf(loc *locate.Location, root string) string {
 	if loc.InDungeon {
 		return railStageDungeon
@@ -51,9 +47,6 @@ func railStageOf(loc *locate.Location, root string) string {
 }
 
 // checkRailTransition enforces the forward-only rail: root -> ready -> active.
-// The dungeon case preserves the semantics of the old blanket "active" rejection
-// this replaced: moving a workitem back out of a dungeon is a restore, not a
-// promote, and the rail does not become a loophole for it.
 func checkRailTransition(from, target string) error {
 	switch {
 	case from == railStageDungeon:
@@ -69,13 +62,8 @@ func checkRailTransition(from, target string) error {
 }
 
 // doRailPromote moves a directory workitem onto festivals/<stage>/<slug> and
-// repairs every reference to it, returning commitInputs so the shared promote
-// tail supplies the audit event, ledger emit, and auto-commit unchanged.
-//
-// recordPromotedTo is deliberately not called here. promoted_to records where a
-// shelved source was copied to (the festival and doc targets); a rail move
-// relocates the directory itself, so its stage is its location and a
-// promoted_to pointer would only be able to describe where it already is.
+// repairs every reference to it. recordPromotedTo is intentionally not called:
+// a rail move relocates the directory itself, so its stage is its location.
 func doRailPromote(ctx context.Context, cfg *config.CampaignConfig, root string, loc *locate.Location, stage string, result *workitemPromoteResult) (*commitInputs, error) {
 	if isFile, _ := promoteSourceShape(loc); isFile {
 		return nil, camperrors.New(
@@ -91,10 +79,8 @@ func doRailPromote(ctx context.Context, cfg *config.CampaignConfig, root string,
 			"cannot promote to %s: destination %s already exists", stage, newRel)
 	}
 
-	// Stamp before moving, not after. Resident resolution refuses an unstamped
-	// directory in a lifecycle folder, so a marker written after the move would
-	// strand the workitem where nothing can resolve it if that write failed.
-	// Stamping first leaves every failure recoverable at the original location.
+	// Before the move: resident resolution refuses an unstamped directory, so a
+	// failed stamp must leave the workitem where it can still be resolved.
 	if err := ensureResidentMarker(ctx, cfg, root, oldRel, loc.Type); err != nil {
 		return nil, err
 	}
@@ -126,15 +112,10 @@ func doRailPromote(ctx context.Context, cfg *config.CampaignConfig, root string,
 	}, nil
 }
 
-// migrateRailReferences repairs the priority store, link registry, and current
-// pointer for the resident's new path by reusing the rename migrations verbatim.
-// A rail move is a path change that preserves the type prefix of the workitem
-// key (design:workflow/design/x becomes design:festivals/ready/x), which is
-// exactly the shape those helpers already handle.
-//
-// Returns whether links.yaml changed so the caller can stage it. Each store is
-// best-effort: the move has already landed, so a bookkeeping failure is a
-// warning rather than a reason to strand the moved workitem.
+// migrateRailReferences reuses the rename migrations: a rail move preserves the
+// workitem key's type prefix and changes only the path. Returns whether
+// links.yaml changed so the caller can stage it. Best-effort, since the move has
+// already landed.
 func migrateRailReferences(ctx context.Context, root, oldKey, newKey, oldRel, newRel string, result *workitemPromoteResult) bool {
 	warn := func(format string, args ...any) {
 		result.Warnings = append(result.Warnings, fmt.Sprintf(format, args...))
@@ -155,28 +136,17 @@ func migrateRailReferences(ctx context.Context, root, oldKey, newKey, oldRel, ne
 	return linksChanged
 }
 
-// ensureResidentMarker guarantees the workitem carries a canonical .workitem
-// marker before it enters the rail.
+// ensureResidentMarker makes the source's .workitem marker canonical before it
+// enters the rail. Directory workitems are not uniformly stamped, but resident
+// resolution reads the marker for the type, so a missing one strands the item.
 //
-// Directory workitems are not uniformly stamped: promote tolerates an unmarked
-// directory today (recordPromotedTo skips the stamp when the marker is absent,
-// and the ledger falls back to the slug for the same reason). Resident
-// resolution is stricter, because a resident's parent segment is a lifecycle
-// stage rather than a workflow type and so cannot supply the type. Minting the
-// marker at rail entry is what reconciles the two.
+// An existing marker is repaired, not trusted: the path type is authoritative
+// because migrateRailReferences keys the move on loc.Type while resolution after
+// the move reads the marker, so a disagreeing marker would leave priority,
+// links, and current pointing at a key no rail command resolves. An unparseable
+// marker fails the promote before anything moves.
 //
-// An existing marker is repaired, not trusted. The path type is authoritative
-// here: migrateRailReferences keys the moved workitem on loc.Type, while
-// resident resolution after the move reads the marker, so a marker carrying a
-// different type would leave priority, links, and current pointing at a key no
-// rail command resolves. A marker that cannot be parsed fails the promote
-// before anything moves, so the workitem stays where every repair tool can
-// still reach it.
-//
-// It reuses the camp workitem repair planner so a marker minted or repaired
-// here is byte-identical to the one doctor --fix would write, including id
-// generation and unique-ref derivation. Repair is idempotent: an already
-// canonical marker plans no changes and is not rewritten.
+// Repair goes through the doctor --fix planner and is idempotent.
 func ensureResidentMarker(ctx context.Context, cfg *config.CampaignConfig, root, relPath, typeName string) error {
 	plan, err := planRepair(ctx, root, cfg, relPath, typeName)
 	if err != nil {

--- a/internal/commands/workitem/promote_test.go
+++ b/internal/commands/workitem/promote_test.go
@@ -163,9 +163,8 @@ func TestPromoteResolution(t *testing.T) {
 }
 
 func TestPromoteRejectsBadTargets(t *testing.T) {
-	// "active" is no longer a blanket rejection: it is a rail target, valid from
-	// a workflow root. What stayed rejected (moving out of a dungeon, moving
-	// backward) is covered by TestPromoteRailForwardOnly.
+	// "active" is a rail target now; its rejections live in
+	// TestPromoteRailForwardOnly.
 	cases := []struct {
 		target  string
 		wantErr string
@@ -446,8 +445,7 @@ func TestPromoteFestivalRejectsDest(t *testing.T) {
 	}
 }
 
-// addResident places a stamped workitem directly on a rail stage, standing in
-// for one that got there by an earlier promote.
+// addResident places a stamped workitem directly on a rail stage.
 func addResident(t *testing.T, root, stage, wtype, slug, title string) string {
 	t.Helper()
 	dir := filepath.Join(root, "festivals", stage, slug)
@@ -457,10 +455,8 @@ func addResident(t *testing.T, root, stage, wtype, slug, title string) string {
 	return dir
 }
 
-// TestPromoteRailEntry covers the two rail-entry moves and the ready->active
-// advance. The directory itself relocates, so the source must be gone and the
-// marker must travel with it: a resident that lost its marker cannot be
-// resolved again.
+// The directory itself relocates, so the source must be gone and the marker must
+// travel with it: a resident without a marker cannot be resolved.
 func TestPromoteRailEntry(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -504,9 +500,7 @@ func TestPromoteRailEntry(t *testing.T) {
 	}
 }
 
-// TestPromoteRailForwardOnly locks every rejected transition. The rail only ever
-// moves root -> ready -> active; anything else, including any attempt to leave a
-// dungeon, must error rather than silently relocate a workitem.
+// Every rejected transition must error rather than silently relocate a workitem.
 func TestPromoteRailForwardOnly(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -581,10 +575,7 @@ func TestPromoteRailForwardOnly(t *testing.T) {
 	}
 }
 
-// TestPromoteRailStampsUnmarkedSource is the reason stamping happens at rail
-// entry. Directory workitems are not uniformly marked (promote tolerates an
-// unmarked one), but resident resolution requires a marker, so a workitem that
-// entered the rail unmarked would be unreachable afterward.
+// A workitem entering the rail unmarked would be unreachable afterward.
 func TestPromoteRailStampsUnmarkedSource(t *testing.T) {
 	root := promoteCampaign(t)
 	src := filepath.Join(root, "workflow", "design", "unmarked")
@@ -624,8 +615,7 @@ func TestPromoteRailStampsUnmarkedSource(t *testing.T) {
 	}
 }
 
-// TestPromoteRailRejectsExistingDestination guards against a rail move
-// clobbering a resident that already occupies the slug on that stage.
+// A rail move must not clobber a resident already holding that slug.
 func TestPromoteRailRejectsExistingDestination(t *testing.T) {
 	root := promoteCampaign(t)
 	src := addWorkitem(t, root, "design", "feat", "Feat", "body")

--- a/internal/commands/workitem/sweep_test.go
+++ b/internal/commands/workitem/sweep_test.go
@@ -65,11 +65,7 @@ func TestResolveSweepLocation_WorkflowHome(t *testing.T) {
 	}
 }
 
-// TestResolveSweepLocation_FestivalsHomeRejectsUnstamped is the phase 3 half of
-// what used to be TestResolveSweepLocation_FestivalsHomeNotYetSupported. A
-// festivals/ path is now a resolvable home, but only when the directory carries
-// a .workitem marker: a bare directory sitting in a lifecycle folder is not a
-// resident camp can move, and must say so rather than resolve to a guess.
+// A festivals/ path resolves only when the directory carries a marker.
 func TestResolveSweepLocation_FestivalsHomeRejectsUnstamped(t *testing.T) {
 	root := t.TempDir()
 	itemRel := filepath.Join("festivals", "ready", "foo-item")
@@ -87,9 +83,7 @@ func TestResolveSweepLocation_FestivalsHomeRejectsUnstamped(t *testing.T) {
 	}
 }
 
-// TestResolveSweepLocation_FestivalsResidentHome locks the destination rule that
-// sequence 04 depends on: a stamped resident sweeps into the festival-local
-// dungeon, not back into the dungeon of the workflow type it came from.
+// A stamped resident sweeps into the festival-local dungeon, not its type's.
 func TestResolveSweepLocation_FestivalsResidentHome(t *testing.T) {
 	root := t.TempDir()
 	if resolved, err := filepath.EvalSymlinks(root); err == nil {

--- a/internal/workitem/discover_festivals.go
+++ b/internal/workitem/discover_festivals.go
@@ -28,21 +28,16 @@ type festMetadata struct {
 	CreatedAt    time.Time `yaml:"created_at"`
 }
 
-// lifecycleDirKind classifies a directory sitting in a festivals/ stage folder.
-// The folders hold festivals and, since the rail exists, workitems promoted onto
-// a stage. The .workitem marker is what tells them apart: camp owns the marker,
+// lifecycleDirKind classifies a directory in a festivals/ stage folder. The
+// .workitem marker tells festivals and residents apart: camp owns the marker,
 // fest owns fest.yaml.
 type lifecycleDirKind int
 
 const (
-	// dirIsFestival: no .workitem marker. Emitted as a festival exactly as
-	// before the rail existed, including the marker-less humanized fallback.
 	dirIsFestival lifecycleDirKind = iota
-	// dirIsResident: a stamped workitem living on a rail stage.
 	dirIsResident
-	// dirIsOutOfStageResident: stamped, but sitting in planning, ritual, or
-	// chains, which the v1 resident model does not cover. Emitted as neither: it
-	// is demonstrably camp's directory, so calling it a festival would be wrong.
+	// dirIsOutOfStageResident is stamped but not on a rail stage. Emitted as
+	// neither, since calling camp's own directory a festival would be wrong.
 	dirIsOutOfStageResident
 )
 
@@ -66,8 +61,7 @@ func discoverFestivals(ctx context.Context, campaignRoot string, resolver *paths
 	return items, nil
 }
 
-// discoverFestivalStage scans one lifecycle folder, splitting what it finds into
-// residents and festivals.
+// discoverFestivalStage splits one lifecycle folder into residents and festivals.
 func discoverFestivalStage(ctx context.Context, campaignRoot, festivalsRoot string, stage LifecycleStage) ([]WorkItem, error) {
 	stageDir := filepath.Join(festivalsRoot, string(stage))
 	entries, err := os.ReadDir(stageDir)
@@ -81,8 +75,7 @@ func discoverFestivalStage(ctx context.Context, campaignRoot, festivalsRoot stri
 	var items []WorkItem
 	for _, entry := range entries {
 		name := entry.Name()
-		// The dot-prefix skip also keeps festivals/.dungeon out of this scan;
-		// shelved residents are not active work.
+		// The dot-prefix skip also keeps festivals/.dungeon out of this scan.
 		if !entry.IsDir() || strings.HasPrefix(name, ".") {
 			continue
 		}
@@ -104,20 +97,14 @@ func discoverFestivalStage(ctx context.Context, campaignRoot, festivalsRoot stri
 	return items, nil
 }
 
-// residentFromMarker classifies a lifecycle directory by its .workitem marker and,
-// for a resident on a rail stage, builds the item to emit.
-//
-// A resident is built through buildWorkflowDirItem using the type recorded in its
-// own marker, so it carries the same marker semantics (stable id, tags, projects)
-// and .workflow/ run progress as the identical directory would under
-// workflow/<type>/. Only the lifecycle stage is overridden, to the folder it
-// physically sits in. That is what makes `camp wi --type design` still find a
-// design item that is resident in festivals/active/, with --stage composing on top.
+// residentFromMarker classifies a lifecycle directory by its .workitem marker.
+// A resident is built through buildWorkflowDirItem with its own marker's type, so
+// it inherits marker and .workflow/ semantics from the workflow path; only the
+// stage is overridden to the folder it sits in.
 func residentFromMarker(ctx context.Context, campaignRoot, dirPath string, stage LifecycleStage) (WorkItem, lifecycleDirKind) {
 	meta, err := LoadMetadata(ctx, dirPath)
 	if err != nil {
-		// An unreadable marker still proves the directory is camp's, so it must
-		// not fall through and be emitted as a festival.
+		// Unreadable still proves the directory is camp's; do not emit a festival.
 		slog.Default().Debug("workitem discovery skip",
 			"path", dirPath, "reason", "parse-error", "error", err.Error())
 		return WorkItem{}, dirIsOutOfStageResident
@@ -132,10 +119,8 @@ func residentFromMarker(ctx context.Context, campaignRoot, dirPath string, stage
 		return WorkItem{}, dirIsOutOfStageResident
 	}
 
-	// A directory carrying both markers is an anomaly worth surfacing rather than
-	// silently resolving. Resident wins because .workitem is camp's own record of
-	// a promote it performed, while a leftover fest.yaml proves nothing about the
-	// current owner.
+	// Resident wins: .workitem records a promote camp performed, while a stale
+	// fest.yaml proves nothing about the current owner.
 	if _, statErr := os.Stat(filepath.Join(dirPath, "fest.yaml")); statErr == nil {
 		slog.Default().Warn("lifecycle directory has both .workitem and fest.yaml; classifying as resident",
 			"path", dirPath, "stage", string(stage), "type", meta.Type)
@@ -149,8 +134,8 @@ func residentFromMarker(ctx context.Context, campaignRoot, dirPath string, stage
 	return item, dirIsResident
 }
 
-// festivalItem builds the festival WorkItem for a lifecycle directory. Unchanged
-// from the pre-rail behavior, including the marker-less humanized fallback.
+// festivalItem builds the festival WorkItem, unchanged from pre-rail behavior
+// including the marker-less humanized fallback.
 func festivalItem(ctx context.Context, campaignRoot, dirPath, name string, stage LifecycleStage) (WorkItem, bool) {
 	relPath, err := filepath.Rel(campaignRoot, dirPath)
 	if err != nil {

--- a/internal/workitem/discover_festivals.go
+++ b/internal/workitem/discover_festivals.go
@@ -36,9 +36,10 @@ type lifecycleDirKind int
 const (
 	dirIsFestival lifecycleDirKind = iota
 	dirIsResident
-	// dirIsOutOfStageResident is stamped but not on a rail stage. Emitted as
-	// neither, since calling camp's own directory a festival would be wrong.
-	dirIsOutOfStageResident
+	// dirIsSkipped is camp's directory but not emittable as a resident: not on a
+	// rail stage, or its marker would not load. Emitted as neither, since calling
+	// camp's own directory a festival would be wrong. The slog reason says which.
+	dirIsSkipped
 )
 
 func discoverFestivals(ctx context.Context, campaignRoot string, resolver *paths.Resolver) ([]WorkItem, error) {
@@ -86,7 +87,7 @@ func discoverFestivalStage(ctx context.Context, campaignRoot, festivalsRoot stri
 		case dirIsResident:
 			items = append(items, resident)
 			continue
-		case dirIsOutOfStageResident:
+		case dirIsSkipped:
 			continue
 		}
 
@@ -107,7 +108,7 @@ func residentFromMarker(ctx context.Context, campaignRoot, dirPath string, stage
 		// Unreadable still proves the directory is camp's; do not emit a festival.
 		slog.Default().Debug("workitem discovery skip",
 			"path", dirPath, "reason", "parse-error", "error", err.Error())
-		return WorkItem{}, dirIsOutOfStageResident
+		return WorkItem{}, dirIsSkipped
 	}
 	if meta == nil {
 		return WorkItem{}, dirIsFestival
@@ -116,7 +117,7 @@ func residentFromMarker(ctx context.Context, campaignRoot, dirPath string, stage
 	if stage != LifecycleStageReady && stage != LifecycleStageActive {
 		slog.Default().Debug("workitem discovery skip",
 			"path", dirPath, "reason", "resident-out-of-stage", "stage", string(stage))
-		return WorkItem{}, dirIsOutOfStageResident
+		return WorkItem{}, dirIsSkipped
 	}
 
 	// Resident wins: .workitem records a promote camp performed, while a stale
@@ -128,7 +129,7 @@ func residentFromMarker(ctx context.Context, campaignRoot, dirPath string, stage
 
 	item, ok := buildWorkflowDirItem(ctx, campaignRoot, dirPath, WorkflowType(meta.Type))
 	if !ok {
-		return WorkItem{}, dirIsOutOfStageResident
+		return WorkItem{}, dirIsSkipped
 	}
 	item.LifecycleStage = stage
 	return item, dirIsResident

--- a/internal/workitem/discover_festivals.go
+++ b/internal/workitem/discover_festivals.go
@@ -3,6 +3,7 @@ package workitem
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,6 +28,24 @@ type festMetadata struct {
 	CreatedAt    time.Time `yaml:"created_at"`
 }
 
+// lifecycleDirKind classifies a directory sitting in a festivals/ stage folder.
+// The folders hold festivals and, since the rail exists, workitems promoted onto
+// a stage. The .workitem marker is what tells them apart: camp owns the marker,
+// fest owns fest.yaml.
+type lifecycleDirKind int
+
+const (
+	// dirIsFestival: no .workitem marker. Emitted as a festival exactly as
+	// before the rail existed, including the marker-less humanized fallback.
+	dirIsFestival lifecycleDirKind = iota
+	// dirIsResident: a stamped workitem living on a rail stage.
+	dirIsResident
+	// dirIsOutOfStageResident: stamped, but sitting in planning, ritual, or
+	// chains, which the v1 resident model does not cover. Emitted as neither: it
+	// is demonstrably camp's directory, so calling it a festival would be wrong.
+	dirIsOutOfStageResident
+)
+
 func discoverFestivals(ctx context.Context, campaignRoot string, resolver *paths.Resolver) ([]WorkItem, error) {
 	festivalsRoot := resolver.Festivals()
 	var items []WorkItem
@@ -38,82 +57,157 @@ func discoverFestivals(ctx context.Context, campaignRoot string, resolver *paths
 		LifecycleStageRitual,
 		LifecycleStageChains,
 	} {
-		stageDir := filepath.Join(festivalsRoot, string(stage))
-		entries, err := os.ReadDir(stageDir)
-		if errors.Is(err, os.ErrNotExist) {
+		stageItems, err := discoverFestivalStage(ctx, campaignRoot, festivalsRoot, stage)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, stageItems...)
+	}
+	return items, nil
+}
+
+// discoverFestivalStage scans one lifecycle folder, splitting what it finds into
+// residents and festivals.
+func discoverFestivalStage(ctx context.Context, campaignRoot, festivalsRoot string, stage LifecycleStage) ([]WorkItem, error) {
+	stageDir := filepath.Join(festivalsRoot, string(stage))
+	entries, err := os.ReadDir(stageDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "reading festival stage %s", stage)
+	}
+
+	var items []WorkItem
+	for _, entry := range entries {
+		name := entry.Name()
+		// The dot-prefix skip also keeps festivals/.dungeon out of this scan;
+		// shelved residents are not active work.
+		if !entry.IsDir() || strings.HasPrefix(name, ".") {
 			continue
 		}
-		if err != nil {
-			return nil, camperrors.Wrapf(err, "reading festival stage %s", stage)
+
+		dirPath := filepath.Join(stageDir, name)
+		resident, kind := residentFromMarker(ctx, campaignRoot, dirPath, stage)
+		switch kind {
+		case dirIsResident:
+			items = append(items, resident)
+			continue
+		case dirIsOutOfStageResident:
+			continue
 		}
 
-		for _, entry := range entries {
-			name := entry.Name()
-			if !entry.IsDir() || strings.HasPrefix(name, ".") {
-				continue
-			}
-
-			dirPath := filepath.Join(stageDir, name)
-			relPath, err := filepath.Rel(campaignRoot, dirPath)
-			if err != nil {
-				continue // skip items with unresolvable relative paths
-			}
-
-			var meta festMetadata
-			festPath := filepath.Join(dirPath, "fest.yaml")
-			if data, err := os.ReadFile(festPath); err == nil {
-				var fy festYAML
-				if err := yaml.Unmarshal(data, &fy); err == nil {
-					meta = fy.Metadata
-				}
-			}
-
-			title := meta.Name
-			if title == "" {
-				title = humanizeBasename(name)
-			}
-			if meta.ID != "" {
-				title = title + " (" + meta.ID + ")"
-			}
-
-			primaryDocAbs := findFestivalPrimaryDoc(dirPath)
-			scanEarliest, scanLatest := ScanDirTimestamps(ctx, dirPath)
-			created := meta.CreatedAt
-			if created.IsZero() {
-				created = scanEarliest
-			}
-			updated := scanLatest
-
-			var primaryDocRel string
-			if primaryDocAbs != "" {
-				primaryDocRel, _ = filepath.Rel(campaignRoot, primaryDocAbs)
-			}
-
-			item := WorkItem{
-				Key:            "festival:" + relPath,
-				WorkflowType:   WorkflowTypeFestival,
-				LifecycleStage: stage,
-				Title:          title,
-				RelativePath:   relPath,
-				PrimaryDoc:     primaryDocRel,
-				ItemKind:       ItemKindDirectory,
-				CreatedAt:      created,
-				UpdatedAt:      updated,
-				SourceID:       meta.ID,
-				SourceMetadata: map[string]any{
-					"festival_type": meta.FestivalType,
-				},
-				Tags:     []string{},
-				Projects: []string{},
-			}
-			item.SortTimestamp = DeriveSortTimestamp(item.UpdatedAt, item.CreatedAt)
-			if primaryDocAbs != "" {
-				item.Summary = extractSummaryFromFile(primaryDocAbs, 200)
-			}
+		if item, ok := festivalItem(ctx, campaignRoot, dirPath, name, stage); ok {
 			items = append(items, item)
 		}
 	}
 	return items, nil
+}
+
+// residentFromMarker classifies a lifecycle directory by its .workitem marker and,
+// for a resident on a rail stage, builds the item to emit.
+//
+// A resident is built through buildWorkflowDirItem using the type recorded in its
+// own marker, so it carries the same marker semantics (stable id, tags, projects)
+// and .workflow/ run progress as the identical directory would under
+// workflow/<type>/. Only the lifecycle stage is overridden, to the folder it
+// physically sits in. That is what makes `camp wi --type design` still find a
+// design item that is resident in festivals/active/, with --stage composing on top.
+func residentFromMarker(ctx context.Context, campaignRoot, dirPath string, stage LifecycleStage) (WorkItem, lifecycleDirKind) {
+	meta, err := LoadMetadata(ctx, dirPath)
+	if err != nil {
+		// An unreadable marker still proves the directory is camp's, so it must
+		// not fall through and be emitted as a festival.
+		slog.Default().Debug("workitem discovery skip",
+			"path", dirPath, "reason", "parse-error", "error", err.Error())
+		return WorkItem{}, dirIsOutOfStageResident
+	}
+	if meta == nil {
+		return WorkItem{}, dirIsFestival
+	}
+
+	if stage != LifecycleStageReady && stage != LifecycleStageActive {
+		slog.Default().Debug("workitem discovery skip",
+			"path", dirPath, "reason", "resident-out-of-stage", "stage", string(stage))
+		return WorkItem{}, dirIsOutOfStageResident
+	}
+
+	// A directory carrying both markers is an anomaly worth surfacing rather than
+	// silently resolving. Resident wins because .workitem is camp's own record of
+	// a promote it performed, while a leftover fest.yaml proves nothing about the
+	// current owner.
+	if _, statErr := os.Stat(filepath.Join(dirPath, "fest.yaml")); statErr == nil {
+		slog.Default().Warn("lifecycle directory has both .workitem and fest.yaml; classifying as resident",
+			"path", dirPath, "stage", string(stage), "type", meta.Type)
+	}
+
+	item, ok := buildWorkflowDirItem(ctx, campaignRoot, dirPath, WorkflowType(meta.Type))
+	if !ok {
+		return WorkItem{}, dirIsOutOfStageResident
+	}
+	item.LifecycleStage = stage
+	return item, dirIsResident
+}
+
+// festivalItem builds the festival WorkItem for a lifecycle directory. Unchanged
+// from the pre-rail behavior, including the marker-less humanized fallback.
+func festivalItem(ctx context.Context, campaignRoot, dirPath, name string, stage LifecycleStage) (WorkItem, bool) {
+	relPath, err := filepath.Rel(campaignRoot, dirPath)
+	if err != nil {
+		return WorkItem{}, false // skip items with unresolvable relative paths
+	}
+
+	var meta festMetadata
+	festPath := filepath.Join(dirPath, "fest.yaml")
+	if data, err := os.ReadFile(festPath); err == nil {
+		var fy festYAML
+		if err := yaml.Unmarshal(data, &fy); err == nil {
+			meta = fy.Metadata
+		}
+	}
+
+	title := meta.Name
+	if title == "" {
+		title = humanizeBasename(name)
+	}
+	if meta.ID != "" {
+		title = title + " (" + meta.ID + ")"
+	}
+
+	primaryDocAbs := findFestivalPrimaryDoc(dirPath)
+	scanEarliest, scanLatest := ScanDirTimestamps(ctx, dirPath)
+	created := meta.CreatedAt
+	if created.IsZero() {
+		created = scanEarliest
+	}
+
+	var primaryDocRel string
+	if primaryDocAbs != "" {
+		primaryDocRel, _ = filepath.Rel(campaignRoot, primaryDocAbs)
+	}
+
+	item := WorkItem{
+		Key:            "festival:" + relPath,
+		WorkflowType:   WorkflowTypeFestival,
+		LifecycleStage: stage,
+		Title:          title,
+		RelativePath:   relPath,
+		PrimaryDoc:     primaryDocRel,
+		ItemKind:       ItemKindDirectory,
+		CreatedAt:      created,
+		UpdatedAt:      scanLatest,
+		SourceID:       meta.ID,
+		SourceMetadata: map[string]any{
+			"festival_type": meta.FestivalType,
+		},
+		Tags:     []string{},
+		Projects: []string{},
+	}
+	item.SortTimestamp = DeriveSortTimestamp(item.UpdatedAt, item.CreatedAt)
+	if primaryDocAbs != "" {
+		item.Summary = extractSummaryFromFile(primaryDocAbs, 200)
+	}
+	return item, true
 }
 
 // findFestivalPrimaryDoc returns the best doc file for a festival directory.

--- a/internal/workitem/discover_test.go
+++ b/internal/workitem/discover_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -569,4 +570,247 @@ func TestDiscovery_TagsProjectsNonNilAtConstruction(t *testing.T) {
 		requireNonNil(t, "Tags", items[0].Tags)
 		requireNonNil(t, "Projects", items[0].Projects)
 	})
+}
+
+// stampLifecycleDir writes a directory workitem marker plus a README, the shape a
+// workitem has once it has been promoted onto a rail stage.
+func stampLifecycleDir(t *testing.T, root, relDir, wfType, slug string) string {
+	t.Helper()
+	dir := filepath.Join(root, filepath.FromSlash(relDir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", relDir, err)
+	}
+	writeFile(t, filepath.Join(dir, ".workitem"),
+		"version: v1alpha8\nkind: workitem\nid: "+wfType+"-"+slug+"-fixed\ntype: "+wfType+
+			"\ntitle: "+slug+"\nref: WI-aaaaaa\n")
+	writeFile(t, filepath.Join(dir, "README.md"), "# "+slug+"\n\nBody.\n")
+	return dir
+}
+
+func writeFestivalDir(t *testing.T, root, relDir, id, name string) {
+	t.Helper()
+	dir := filepath.Join(root, filepath.FromSlash(relDir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", relDir, err)
+	}
+	writeFile(t, filepath.Join(dir, "fest.yaml"),
+		"version: \"1.0\"\nmetadata:\n  id: "+id+"\n  name: "+name+"\n  festival_type: implementation\n")
+	writeFile(t, filepath.Join(dir, "FESTIVAL_GOAL.md"), "# Goal\n\nDo the thing.\n")
+}
+
+// byRelPath indexes discovered items so assertions read by path rather than order.
+func byRelPath(items []WorkItem) map[string]WorkItem {
+	m := make(map[string]WorkItem, len(items))
+	for _, it := range items {
+		m[filepath.ToSlash(it.RelativePath)] = it
+	}
+	return m
+}
+
+// TestDiscoverFestivals_SplitsResidentsFromFestivals is the core of the rail's
+// discovery half: a stamped directory in a rail stage is its ORIGINAL workflow
+// type with the folder's stage, while festivals keep behaving exactly as before.
+func TestDiscoverFestivals_SplitsResidentsFromFestivals(t *testing.T) {
+	root, resolver := setupTestCampaign(t)
+
+	stampLifecycleDir(t, root, "festivals/active/resident-design", "design", "resident-design")
+	stampLifecycleDir(t, root, "festivals/ready/resident-explore", "explore", "resident-explore")
+	writeFestivalDir(t, root, "festivals/active/real-fest", "RF0001", "Real Fest")
+
+	items, err := discoverFestivals(context.Background(), root, resolver)
+	if err != nil {
+		t.Fatalf("discoverFestivals: %v", err)
+	}
+	got := byRelPath(items)
+
+	design, ok := got["festivals/active/resident-design"]
+	if !ok {
+		t.Fatal("design resident not discovered")
+	}
+	if design.WorkflowType != WorkflowTypeDesign {
+		t.Errorf("WorkflowType = %q, want design (the marker's type, not festival)", design.WorkflowType)
+	}
+	if design.LifecycleStage != LifecycleStageActive {
+		t.Errorf("LifecycleStage = %q, want active (from the folder)", design.LifecycleStage)
+	}
+	if want := "design:festivals/active/resident-design"; design.Key != want {
+		t.Errorf("Key = %q, want %q", design.Key, want)
+	}
+	if design.StableID != "design-resident-design-fixed" {
+		t.Errorf("StableID = %q, want the marker id", design.StableID)
+	}
+	if design.ItemKind != ItemKindDirectory {
+		t.Errorf("ItemKind = %q, want directory", design.ItemKind)
+	}
+
+	explore, ok := got["festivals/ready/resident-explore"]
+	if !ok {
+		t.Fatal("explore resident not discovered")
+	}
+	if explore.WorkflowType != WorkflowTypeExplore {
+		t.Errorf("WorkflowType = %q, want explore", explore.WorkflowType)
+	}
+	if explore.LifecycleStage != LifecycleStageReady {
+		t.Errorf("LifecycleStage = %q, want ready", explore.LifecycleStage)
+	}
+
+	fest, ok := got["festivals/active/real-fest"]
+	if !ok {
+		t.Fatal("festival not discovered")
+	}
+	if fest.WorkflowType != WorkflowTypeFestival {
+		t.Errorf("festival WorkflowType = %q, want festival", fest.WorkflowType)
+	}
+	if want := "festival:festivals/active/real-fest"; fest.Key != want {
+		t.Errorf("festival Key = %q, want %q", fest.Key, want)
+	}
+	if fest.SourceID != "RF0001" {
+		t.Errorf("festival SourceID = %q, want RF0001", fest.SourceID)
+	}
+}
+
+// TestDiscoverFestivals_ResidentMatchesWorkflowItemShape is the reason the
+// resident is built through buildWorkflowDirItem rather than hand-assembled: an
+// item must not become a different kind of thing by moving onto a stage.
+func TestDiscoverFestivals_ResidentMatchesWorkflowItemShape(t *testing.T) {
+	root, resolver := setupTestCampaign(t)
+	stampLifecycleDir(t, root, "festivals/active/twin", "design", "twin")
+	stampLifecycleDir(t, root, "workflow/design/twin", "design", "twin")
+
+	residents, err := discoverFestivals(context.Background(), root, resolver)
+	if err != nil {
+		t.Fatalf("discoverFestivals: %v", err)
+	}
+	resident := byRelPath(residents)["festivals/active/twin"]
+
+	workflowItems, err := discoverWorkflowDocs(context.Background(), root,
+		filepath.Join(root, "workflow", "design"), WorkflowTypeDesign)
+	if err != nil {
+		t.Fatalf("discoverWorkflowDocs: %v", err)
+	}
+	twin := byRelPath(workflowItems)["workflow/design/twin"]
+	if twin.Key == "" {
+		t.Fatal("workflow twin not discovered; fixture is wrong")
+	}
+
+	if resident.WorkflowType != twin.WorkflowType {
+		t.Errorf("WorkflowType %q != %q", resident.WorkflowType, twin.WorkflowType)
+	}
+	if resident.ItemKind != twin.ItemKind {
+		t.Errorf("ItemKind %q != %q", resident.ItemKind, twin.ItemKind)
+	}
+	if resident.StableID != twin.StableID {
+		t.Errorf("StableID %q != %q", resident.StableID, twin.StableID)
+	}
+	if resident.SourceID != twin.SourceID {
+		t.Errorf("SourceID %q != %q; a resident must not gain a field its workflow twin lacks",
+			resident.SourceID, twin.SourceID)
+	}
+}
+
+// TestDiscoverFestivals_MarkerlessDirStaysAFestival pins the pre-rail fallback:
+// a bare directory with no marker and no fest.yaml is still emitted as a
+// festival with a humanized title.
+func TestDiscoverFestivals_MarkerlessDirStaysAFestival(t *testing.T) {
+	root, resolver := setupTestCampaign(t)
+	dir := filepath.Join(root, "festivals", "active", "bare-thing")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, "NOTES.md"), "# notes\n")
+
+	items, err := discoverFestivals(context.Background(), root, resolver)
+	if err != nil {
+		t.Fatalf("discoverFestivals: %v", err)
+	}
+	got, ok := byRelPath(items)["festivals/active/bare-thing"]
+	if !ok {
+		t.Fatal("marker-less directory should still be discovered as a festival")
+	}
+	if got.WorkflowType != WorkflowTypeFestival {
+		t.Errorf("WorkflowType = %q, want festival", got.WorkflowType)
+	}
+	if got.Title != "Bare Thing" {
+		t.Errorf("Title = %q, want the humanized fallback %q", got.Title, "Bare Thing")
+	}
+}
+
+// TestDiscoverFestivals_MarkedDirOutsideRailStagesIsSkipped covers the v1 scope
+// boundary. planning, ritual, and chains are not rail stages, so a stamped
+// directory there is neither a resident nor a festival: it is demonstrably
+// camp's directory, and calling it a festival would be a lie.
+func TestDiscoverFestivals_MarkedDirOutsideRailStagesIsSkipped(t *testing.T) {
+	for _, stage := range []string{"planning", "ritual", "chains"} {
+		t.Run(stage, func(t *testing.T) {
+			root, resolver := setupTestCampaign(t)
+			rel := "festivals/" + stage + "/stray"
+			stampLifecycleDir(t, root, rel, "design", "stray")
+
+			items, err := discoverFestivals(context.Background(), root, resolver)
+			if err != nil {
+				t.Fatalf("discoverFestivals: %v", err)
+			}
+			if got, ok := byRelPath(items)[rel]; ok {
+				t.Errorf("stamped dir in %s was emitted as %q; want skipped entirely",
+					stage, got.WorkflowType)
+			}
+		})
+	}
+}
+
+// TestDiscoverFestivals_BothMarkersPrefersResident locks the anomaly rule: when a
+// directory carries both .workitem and fest.yaml, camp's own marker wins, because
+// it records a promote camp performed while a leftover fest.yaml proves nothing
+// about the current owner.
+func TestDiscoverFestivals_BothMarkersPrefersResident(t *testing.T) {
+	root, resolver := setupTestCampaign(t)
+	stampLifecycleDir(t, root, "festivals/active/conflicted", "design", "conflicted")
+	writeFile(t, filepath.Join(root, "festivals", "active", "conflicted", "fest.yaml"),
+		"version: \"1.0\"\nmetadata:\n  id: CF0001\n  name: Conflicted\n")
+
+	items, err := discoverFestivals(context.Background(), root, resolver)
+	if err != nil {
+		t.Fatalf("discoverFestivals: %v", err)
+	}
+	got, ok := byRelPath(items)["festivals/active/conflicted"]
+	if !ok {
+		t.Fatal("conflicted directory not discovered at all")
+	}
+	if got.WorkflowType != WorkflowTypeDesign {
+		t.Errorf("WorkflowType = %q, want design (the .workitem marker wins)", got.WorkflowType)
+	}
+	if want := "design:festivals/active/conflicted"; got.Key != want {
+		t.Errorf("Key = %q, want %q", got.Key, want)
+	}
+	// Exactly one item: it must not be emitted as both a resident and a festival.
+	count := 0
+	for _, it := range items {
+		if filepath.ToSlash(it.RelativePath) == "festivals/active/conflicted" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("emitted %d items for one directory, want 1", count)
+	}
+}
+
+// TestDiscoverFestivals_DungeonIsNotScanned guards the dot-prefix skip: shelved
+// residents under festivals/.dungeon are not active work and must never surface.
+func TestDiscoverFestivals_DungeonIsNotScanned(t *testing.T) {
+	root, resolver := setupTestCampaign(t)
+	stampLifecycleDir(t, root, "festivals/.dungeon/completed/2026-07-29/shelved", "design", "shelved")
+	stampLifecycleDir(t, root, "festivals/active/live", "design", "live")
+
+	items, err := discoverFestivals(context.Background(), root, resolver)
+	if err != nil {
+		t.Fatalf("discoverFestivals: %v", err)
+	}
+	for _, it := range items {
+		if strings.Contains(filepath.ToSlash(it.RelativePath), ".dungeon") {
+			t.Errorf("dungeon item leaked into discovery: %s", it.RelativePath)
+		}
+	}
+	if _, ok := byRelPath(items)["festivals/active/live"]; !ok {
+		t.Error("live resident should still be discovered")
+	}
 }

--- a/internal/workitem/discover_test.go
+++ b/internal/workitem/discover_test.go
@@ -572,8 +572,7 @@ func TestDiscovery_TagsProjectsNonNilAtConstruction(t *testing.T) {
 	})
 }
 
-// stampLifecycleDir writes a directory workitem marker plus a README, the shape a
-// workitem has once it has been promoted onto a rail stage.
+// stampLifecycleDir writes the shape a workitem has once promoted onto a stage.
 func stampLifecycleDir(t *testing.T, root, relDir, wfType, slug string) string {
 	t.Helper()
 	dir := filepath.Join(root, filepath.FromSlash(relDir))
@@ -598,7 +597,6 @@ func writeFestivalDir(t *testing.T, root, relDir, id, name string) {
 	writeFile(t, filepath.Join(dir, "FESTIVAL_GOAL.md"), "# Goal\n\nDo the thing.\n")
 }
 
-// byRelPath indexes discovered items so assertions read by path rather than order.
 func byRelPath(items []WorkItem) map[string]WorkItem {
 	m := make(map[string]WorkItem, len(items))
 	for _, it := range items {
@@ -607,9 +605,8 @@ func byRelPath(items []WorkItem) map[string]WorkItem {
 	return m
 }
 
-// TestDiscoverFestivals_SplitsResidentsFromFestivals is the core of the rail's
-// discovery half: a stamped directory in a rail stage is its ORIGINAL workflow
-// type with the folder's stage, while festivals keep behaving exactly as before.
+// A stamped directory on a rail stage is its original type with the folder's
+// stage; festivals are unaffected.
 func TestDiscoverFestivals_SplitsResidentsFromFestivals(t *testing.T) {
 	root, resolver := setupTestCampaign(t)
 
@@ -669,9 +666,7 @@ func TestDiscoverFestivals_SplitsResidentsFromFestivals(t *testing.T) {
 	}
 }
 
-// TestDiscoverFestivals_ResidentMatchesWorkflowItemShape is the reason the
-// resident is built through buildWorkflowDirItem rather than hand-assembled: an
-// item must not become a different kind of thing by moving onto a stage.
+// An item must not become a different kind of thing by moving onto a stage.
 func TestDiscoverFestivals_ResidentMatchesWorkflowItemShape(t *testing.T) {
 	root, resolver := setupTestCampaign(t)
 	stampLifecycleDir(t, root, "festivals/active/twin", "design", "twin")
@@ -708,9 +703,7 @@ func TestDiscoverFestivals_ResidentMatchesWorkflowItemShape(t *testing.T) {
 	}
 }
 
-// TestDiscoverFestivals_MarkerlessDirStaysAFestival pins the pre-rail fallback:
-// a bare directory with no marker and no fest.yaml is still emitted as a
-// festival with a humanized title.
+// Pins the pre-rail fallback for a bare directory.
 func TestDiscoverFestivals_MarkerlessDirStaysAFestival(t *testing.T) {
 	root, resolver := setupTestCampaign(t)
 	dir := filepath.Join(root, "festivals", "active", "bare-thing")
@@ -735,10 +728,8 @@ func TestDiscoverFestivals_MarkerlessDirStaysAFestival(t *testing.T) {
 	}
 }
 
-// TestDiscoverFestivals_MarkedDirOutsideRailStagesIsSkipped covers the v1 scope
-// boundary. planning, ritual, and chains are not rail stages, so a stamped
-// directory there is neither a resident nor a festival: it is demonstrably
-// camp's directory, and calling it a festival would be a lie.
+// planning, ritual, and chains are not rail stages, so a stamped directory there
+// is neither a resident nor a festival.
 func TestDiscoverFestivals_MarkedDirOutsideRailStagesIsSkipped(t *testing.T) {
 	for _, stage := range []string{"planning", "ritual", "chains"} {
 		t.Run(stage, func(t *testing.T) {
@@ -758,10 +749,7 @@ func TestDiscoverFestivals_MarkedDirOutsideRailStagesIsSkipped(t *testing.T) {
 	}
 }
 
-// TestDiscoverFestivals_BothMarkersPrefersResident locks the anomaly rule: when a
-// directory carries both .workitem and fest.yaml, camp's own marker wins, because
-// it records a promote camp performed while a leftover fest.yaml proves nothing
-// about the current owner.
+// With both markers present, camp's own marker wins.
 func TestDiscoverFestivals_BothMarkersPrefersResident(t *testing.T) {
 	root, resolver := setupTestCampaign(t)
 	stampLifecycleDir(t, root, "festivals/active/conflicted", "design", "conflicted")
@@ -782,7 +770,6 @@ func TestDiscoverFestivals_BothMarkersPrefersResident(t *testing.T) {
 	if want := "design:festivals/active/conflicted"; got.Key != want {
 		t.Errorf("Key = %q, want %q", got.Key, want)
 	}
-	// Exactly one item: it must not be emitted as both a resident and a festival.
 	count := 0
 	for _, it := range items {
 		if filepath.ToSlash(it.RelativePath) == "festivals/active/conflicted" {
@@ -794,8 +781,7 @@ func TestDiscoverFestivals_BothMarkersPrefersResident(t *testing.T) {
 	}
 }
 
-// TestDiscoverFestivals_DungeonIsNotScanned guards the dot-prefix skip: shelved
-// residents under festivals/.dungeon are not active work and must never surface.
+// Shelved residents under festivals/.dungeon must never surface.
 func TestDiscoverFestivals_DungeonIsNotScanned(t *testing.T) {
 	root, resolver := setupTestCampaign(t)
 	stampLifecycleDir(t, root, "festivals/.dungeon/completed/2026-07-29/shelved", "design", "shelved")

--- a/internal/workitem/filter_test.go
+++ b/internal/workitem/filter_test.go
@@ -276,3 +276,78 @@ func TestFilterAdvanced_NoFilterOptionsReturnsAllItems(t *testing.T) {
 		t.Fatalf("early-return guard should return all %d items, got %d", len(items), len(got))
 	}
 }
+
+// Residents carry their original type and the folder's stage, so --type and
+// --stage compose over them with no filter-side change.
+func TestFilter_ComposesOverRailResidents(t *testing.T) {
+	items := []WorkItem{
+		// A workflow/ directory item is active by location, so stage alone does not
+		// separate a root item from a rail-active resident; ready does.
+		{Key: "design:workflow/design/root", WorkflowType: WorkflowTypeDesign,
+			LifecycleStage: LifecycleStageActive, RelativePath: "workflow/design/root", Title: "root-design"},
+		{Key: "design:festivals/active/res-a", WorkflowType: WorkflowTypeDesign,
+			LifecycleStage: LifecycleStageActive, RelativePath: "festivals/active/res-a", Title: "active-resident"},
+		{Key: "design:festivals/ready/res-b", WorkflowType: WorkflowTypeDesign,
+			LifecycleStage: LifecycleStageReady, RelativePath: "festivals/ready/res-b", Title: "ready-resident"},
+		{Key: "explore:festivals/active/res-c", WorkflowType: WorkflowTypeExplore,
+			LifecycleStage: LifecycleStageActive, RelativePath: "festivals/active/res-c", Title: "explore-resident"},
+		{Key: "festival:festivals/active/real", WorkflowType: WorkflowTypeFestival,
+			LifecycleStage: LifecycleStageActive, RelativePath: "festivals/active/real", Title: "real-festival"},
+	}
+
+	tests := []struct {
+		name   string
+		types  []string
+		stages []string
+		want   []string
+	}{
+		{"type design finds the residents", []string{"design"}, nil,
+			[]string{"root-design", "active-resident", "ready-resident"}},
+		{"stage active spans types and homes", nil, []string{"active"},
+			[]string{"root-design", "active-resident", "explore-resident", "real-festival"}},
+		{"type and stage compose", []string{"design"}, []string{"active"},
+			[]string{"root-design", "active-resident"}},
+		{"stage ready", []string{"design"}, []string{"ready"},
+			[]string{"ready-resident"}},
+		{"type explore stage active", []string{"explore"}, []string{"active"},
+			[]string{"explore-resident"}},
+		{"stage ready isolates the ready resident", []string{"design"}, []string{"ready"},
+			[]string{"ready-resident"}},
+		{"festival type excludes residents", []string{"festival"}, nil,
+			[]string{"real-festival"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := titlesOf(Filter(items, tc.types, tc.stages, ""))
+			if !sameSet(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func titlesOf(items []WorkItem) []string {
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.Title)
+	}
+	return out
+}
+
+func sameSet(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	seen := make(map[string]int, len(got))
+	for _, g := range got {
+		seen[g]++
+	}
+	for _, w := range want {
+		if seen[w] == 0 {
+			return false
+		}
+		seen[w]--
+	}
+	return true
+}

--- a/internal/workitem/json.go
+++ b/internal/workitem/json.go
@@ -33,7 +33,13 @@ import (
 //     reflects whether that project is the workitem-scope primary link in
 //     links.yaml. See internal/workitem/metadata.go for the marker-level
 //     v1alpha8 schema these are sourced from.
-const SchemaVersion = "workitems/v1alpha9"
+//   - v1alpha10: no new fields. Non-festival types can now report
+//     lifecycle_stage ready/active with a relative_path under festivals/, since a
+//     workitem promoted onto the festival rail lives on a stage while keeping its
+//     type. Field names and vocabularies are unchanged; only the observed
+//     combinations widen. explore gains ready in stage_vocabulary. A campaign
+//     with no residents serializes byte-identically except for this constant.
+const SchemaVersion = "workitems/v1alpha10"
 
 // Payload is the top-level JSON output for camp workitem --json.
 type Payload struct {

--- a/internal/workitem/json_test.go
+++ b/internal/workitem/json_test.go
@@ -154,9 +154,9 @@ func TestWorkItemWorkflow_ZeroValuesAreEmitted(t *testing.T) {
 	}
 }
 
-func TestSchemaVersion_IsV1Alpha9(t *testing.T) {
-	if SchemaVersion != "workitems/v1alpha9" {
-		t.Errorf("SchemaVersion = %q, want workitems/v1alpha9", SchemaVersion)
+func TestSchemaVersion_IsV1Alpha10(t *testing.T) {
+	if SchemaVersion != "workitems/v1alpha10" {
+		t.Errorf("SchemaVersion = %q, want workitems/v1alpha10", SchemaVersion)
 	}
 }
 

--- a/internal/workitem/locate/locate.go
+++ b/internal/workitem/locate/locate.go
@@ -15,23 +15,14 @@ import (
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
 
-// festivalsRoot is the campaign-relative folder holding the festival lifecycle
-// stages. A workitem promoted onto the festival rail physically lives here
-// instead of under workflow/<type>/.
 const festivalsRoot = "festivals"
 
-// festivalDungeonName is the festival-local dungeon. Unlike a workflow type's
-// dungeon, whose on-disk spelling is resolved with spelling.Resolve, this one is
-// the fixed hidden .dungeon, so a resident always completes into
-// festivals/.dungeon/<status>/<date>/<slug> rather than into the dungeon of the
-// workflow type it came from.
+// Fixed, unlike a workflow type's dungeon: no spelling.Resolve, so a resident
+// always completes into festivals/.dungeon rather than its type's dungeon.
 const festivalDungeonName = ".dungeon"
 
-// festivalStages are the rail stages a resident workitem can occupy, named from
-// the lifecycle vocabulary so the folder this resolver accepts cannot drift from
-// the stage a workitem can be promoted to. Promotion onto the rail targets ready
-// and active only; festivals/ also holds folders that are not rail stages
-// (planning, chains, ritual), and those do not resolve.
+// Named from the lifecycle vocabulary so this resolver cannot drift from the
+// stages promote accepts. planning, chains, and ritual are not rail stages.
 var festivalStages = map[string]bool{
 	string(wkitem.LifecycleStageReady):  true,
 	string(wkitem.LifecycleStageActive): true,
@@ -77,9 +68,8 @@ func DetectFromCwd(campaignRoot, cwd string) (*Location, error) {
 	}
 }
 
-// detectWorkflowItem resolves the workflow/<type>/... layouts. The type comes
-// from the path segment, and the dungeon is that type's own dungeon folder in
-// whichever spelling exists on disk.
+// detectWorkflowItem resolves the workflow/<type>/... layouts, taking the type
+// from the path and the dungeon from that type's own folder.
 func detectWorkflowItem(campaignRoot string, parts []string) (*Location, error) {
 	if len(parts) < 3 {
 		return nil, camperrors.New("not inside a workitem; cwd is at workflow root, expected workflow/<type>/<slug>/")
@@ -146,11 +136,9 @@ func workflowDungeon(campaignRoot, typeName string, parts []string) (*Location, 
 	}, nil
 }
 
-// detectFestivalResident resolves a workitem living on the festival rail, either
-// at a working stage (festivals/ready|active/<slug>) or already shelved
-// (festivals/.dungeon/<status>[/<date>]/<slug>). Both shapes report
-// DungeonPath = festivals/.dungeon so the shared move plumbing keeps a resident
-// inside the festival tree instead of sending it back to its workflow type.
+// detectFestivalResident resolves a workitem on the rail, at a working stage or
+// already shelved. Both report DungeonPath = festivals/.dungeon so the shared
+// move plumbing keeps a resident inside the festival tree.
 func detectFestivalResident(campaignRoot string, parts []string) (*Location, error) {
 	if len(parts) < 2 || parts[1] == "" {
 		return nil, camperrors.New("not inside a workitem; cwd is at the festivals root")
@@ -221,11 +209,9 @@ func festivalDungeon(campaignRoot string, parts []string) (*Location, error) {
 	}, nil
 }
 
-// residentType reads a resident's workflow type from its .workitem marker. The
-// path cannot supply it the way workflow/<type>/ does, because a resident's
-// parent segment is a lifecycle stage rather than a type. An unstamped directory
-// in a lifecycle folder is not a resident camp can move, so it is a clear error
-// rather than a guess; camp workitem doctor surfaces these.
+// residentType reads the type from the .workitem marker, since a resident's
+// parent segment is a lifecycle stage rather than a type. Unstamped is an error,
+// not a guess: camp workitem doctor surfaces those.
 func residentType(absDir, relPath string) (string, error) {
 	meta, err := wkitem.LoadMetadata(context.Background(), absDir)
 	if err != nil {

--- a/internal/workitem/locate/locate_test.go
+++ b/internal/workitem/locate/locate_test.go
@@ -206,9 +206,7 @@ func TestDetectFromCwd(t *testing.T) {
 			wantIn:   true,
 			wantStat: "completed",
 		},
-		// Festival rail error paths. These need no fixture on disk: a missing
-		// .workitem reads the same as an unstamped directory, which is exactly
-		// the rejection being asserted.
+		// No fixture needed: a missing .workitem reads as unstamped.
 		{
 			name:    "festivals root",
 			cwd:     "/campaign/festivals",
@@ -286,9 +284,7 @@ func TestDetectFromCwd(t *testing.T) {
 	}
 }
 
-// stampResident creates dir under root and writes a valid .workitem marker with
-// the given workflow type, mirroring what a workitem carries once it has been
-// promoted onto the festival rail.
+// stampResident writes a valid .workitem marker with the given workflow type.
 func stampResident(t *testing.T, root, relDir, typeName string) string {
 	t.Helper()
 	dir := filepath.Join(root, filepath.FromSlash(relDir))
@@ -302,12 +298,8 @@ func stampResident(t *testing.T, root, relDir, typeName string) string {
 	return dir
 }
 
-// TestDetectFromCwd_FestivalResident covers the rail layouts, which unlike the
-// workflow layouts cannot be resolved from the path alone: the parent segment is
-// a lifecycle stage, so Type has to come off the .workitem marker. Every case
-// must report DungeonPath = festivals/.dungeon so the shared move plumbing keeps
-// a resident inside the festival tree instead of returning it to its workflow
-// type's dungeon.
+// Rail layouts cannot be resolved from the path alone; Type comes off the
+// marker. Every case must report DungeonPath = festivals/.dungeon.
 func TestDetectFromCwd_FestivalResident(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -412,9 +404,8 @@ func TestDetectFromCwd_FestivalResident(t *testing.T) {
 	}
 }
 
-// TestDetectFromCwd_FestivalResidentTypeIsNotThePath guards the divergence from
-// the workflow branch: two residents sitting side by side in the same stage
-// folder resolve to different types, which is only possible by reading markers.
+// Two residents in one stage folder resolve to different types, which is only
+// possible by reading markers.
 func TestDetectFromCwd_FestivalResidentTypeIsNotThePath(t *testing.T) {
 	root := t.TempDir()
 	if resolved, err := filepath.EvalSymlinks(root); err == nil {
@@ -439,9 +430,7 @@ func TestDetectFromCwd_FestivalResidentTypeIsNotThePath(t *testing.T) {
 	}
 }
 
-// TestDetectFromCwd_WorkflowUnaffectedByMarker is the regression for requirement
-// 3: a workflow item's Type comes from its path, so a marker that disagrees is
-// ignored and resolution is byte-identical to before the rail existed.
+// A workflow item's Type comes from its path, so a disagreeing marker is ignored.
 func TestDetectFromCwd_WorkflowUnaffectedByMarker(t *testing.T) {
 	root := t.TempDir()
 	if resolved, err := filepath.EvalSymlinks(root); err == nil {

--- a/tests/integration/workitem_json_residents_test.go
+++ b/tests/integration/workitem_json_residents_test.go
@@ -128,3 +128,89 @@ func TestWorkitemJSON_FiltersComposeOverResidents(t *testing.T) {
 	_, ok = itemByPath(ready, resident)
 	assert.False(t, ok, "the active resident must not match --stage ready")
 }
+
+// A stage folder holds both kinds at once: residents classify by their marker,
+// while a real festival and a marker-less directory stay festivals.
+func TestWorkitemJSON_MixedStageFolderSplits(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRailCampaign(t, tc, "wi-json-mixed")
+
+	out, err := tc.RunCampInDir(path, "workitem", "create", "topic",
+		"--type", "explore", "--title", "Topic", "--id", "explore-topic-fixed")
+	require.NoError(t, err, "create explore: %s", out)
+
+	railTo(t, tc, path+"/workflow/design/rail-feature", "active")
+	railTo(t, tc, path+"/workflow/explore/topic", "ready")
+
+	require.NoError(t, tc.WriteFile(path+"/festivals/active/real-fest/fest.yaml",
+		"version: \"1.0\"\nmetadata:\n  id: RF0001\n  name: Real Fest\n  festival_type: implementation\n"))
+	require.NoError(t, tc.WriteFile(path+"/festivals/active/real-fest/FESTIVAL_GOAL.md", "# Goal\n"))
+	require.NoError(t, tc.WriteFile(path+"/festivals/active/bare-dir/NOTES.md", "# notes\n"))
+
+	items := wiList(t, tc, path).Items
+
+	design, ok := itemByPath(items, "festivals/active/rail-feature")
+	require.True(t, ok, "design resident missing: %+v", items)
+	assert.Equal(t, "design", design.WorkflowType)
+	assert.Equal(t, "active", design.LifecycleStage)
+	assert.Equal(t, "design:festivals/active/rail-feature", design.Key)
+	assert.Equal(t, "design-rail-feature-fixed", design.StableID)
+
+	explore, ok := itemByPath(items, "festivals/ready/topic")
+	require.True(t, ok, "explore resident missing: %+v", items)
+	assert.Equal(t, "explore", explore.WorkflowType)
+	assert.Equal(t, "ready", explore.LifecycleStage)
+	assert.Equal(t, "explore:festivals/ready/topic", explore.Key)
+	assert.Equal(t, "explore-topic-fixed", explore.StableID)
+
+	fest, ok := itemByPath(items, "festivals/active/real-fest")
+	require.True(t, ok, "festival missing: %+v", items)
+	assert.Equal(t, "festival", fest.WorkflowType)
+	assert.Equal(t, "festival:festivals/active/real-fest", fest.Key)
+
+	bare, ok := itemByPath(items, "festivals/active/bare-dir")
+	require.True(t, ok, "marker-less dir missing: %+v", items)
+	assert.Equal(t, "festival", bare.WorkflowType, "no marker means it stays a festival")
+}
+
+// A stamped directory in planning is neither a resident nor a festival, so it
+// must not appear at all.
+func TestWorkitemJSON_StampedDirOutsideRailStagesAbsent(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRailCampaign(t, tc, "wi-json-outofstage")
+
+	require.NoError(t, tc.WriteFile(path+"/festivals/planning/stray/.workitem",
+		"version: v1alpha8\nkind: workitem\nid: design-stray-fixed\ntype: design\ntitle: Stray\n"))
+	require.NoError(t, tc.WriteFile(path+"/festivals/planning/stray/README.md", "# Stray\n"))
+
+	items := wiList(t, tc, path).Items
+	_, ok := itemByPath(items, "festivals/planning/stray")
+	assert.False(t, ok, "stamped dir outside a rail stage must not be emitted: %+v", items)
+}
+
+// A festival-only campaign must produce no resident rows: reclassification only
+// triggers on a marker, so nothing under festivals/ changes type without one.
+func TestWorkitemJSON_FestivalOnlyCampaignHasNoResidents(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := "/campaigns/wi-json-festonly"
+	_, err := tc.InitCampaign(path, "wi-json-festonly", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(path+"/festivals/active/f-one/fest.yaml",
+		"version: \"1.0\"\nmetadata:\n  id: F1\n  name: F One\n  festival_type: implementation\n"))
+	require.NoError(t, tc.WriteFile(path+"/festivals/active/f-one/FESTIVAL_GOAL.md", "# Goal\n"))
+	require.NoError(t, tc.WriteFile(path+"/festivals/planning/f-two/fest.yaml",
+		"version: \"1.0\"\nmetadata:\n  id: F2\n  name: F Two\n  festival_type: implementation\n"))
+	require.NoError(t, tc.WriteFile(path+"/festivals/planning/f-two/FESTIVAL_GOAL.md", "# Goal\n"))
+
+	payload := wiList(t, tc, path)
+	assert.Equal(t, "workitems/v1alpha10", payload.SchemaVersion)
+	for _, it := range payload.Items {
+		if strings.HasPrefix(it.RelativePath, "festivals/") {
+			assert.Equal(t, "festival", it.WorkflowType,
+				"%s must stay a festival without a marker", it.RelativePath)
+		}
+	}
+	assert.Equal(t, 2, payload.Counts["festival"])
+	assert.Equal(t, 0, payload.Counts["design"])
+}

--- a/tests/integration/workitem_json_residents_test.go
+++ b/tests/integration/workitem_json_residents_test.go
@@ -1,0 +1,130 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// wiListPayload mirrors only the fields this contract test asserts. Field names
+// come from real command output, not from the Go struct tags.
+type wiListPayload struct {
+	SchemaVersion   string              `json:"schema_version"`
+	Items           []wiListItem        `json:"items"`
+	Counts          map[string]int      `json:"counts"`
+	StageVocabulary map[string][]string `json:"stage_vocabulary"`
+}
+
+type wiListItem struct {
+	Key            string `json:"key"`
+	WorkflowType   string `json:"workflow_type"`
+	LifecycleStage string `json:"lifecycle_stage"`
+	RelativePath   string `json:"relative_path"`
+	StableID       string `json:"stable_id"`
+	ItemKind       string `json:"item_kind"`
+}
+
+func wiList(t *testing.T, tc *TestContainer, path string, args ...string) wiListPayload {
+	t.Helper()
+	out, err := tc.RunCampInDir(path, append([]string{"workitem", "list", "--json"}, args...)...)
+	require.NoError(t, err, "camp workitem list --json: %s", out)
+	var p wiListPayload
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &p), "must parse: %s", out)
+	return p
+}
+
+func itemByPath(items []wiListItem, rel string) (wiListItem, bool) {
+	for _, it := range items {
+		if it.RelativePath == rel {
+			return it, true
+		}
+	}
+	return wiListItem{}, false
+}
+
+func TestWorkitemJSON_SchemaVersionIsV1Alpha10(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := "/campaigns/wi-json-version"
+	_, err := tc.InitCampaign(path, "wi-json-version", "product")
+	require.NoError(t, err)
+
+	assert.Equal(t, "workitems/v1alpha10", wiList(t, tc, path).SchemaVersion)
+}
+
+// The resident row's shape is asserted from real command output so casing is
+// verified rather than assumed.
+func TestWorkitemJSON_ResidentRowShape(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRailCampaign(t, tc, "wi-json-resident")
+	railTo(t, tc, path+"/workflow/design/rail-feature", "active")
+
+	payload := wiList(t, tc, path)
+	assert.Equal(t, "workitems/v1alpha10", payload.SchemaVersion)
+
+	got, ok := itemByPath(payload.Items, "festivals/active/rail-feature")
+	require.True(t, ok, "resident missing from camp wi --json: %+v", payload.Items)
+
+	assert.Equal(t, "design", got.WorkflowType, "resident keeps its original type")
+	assert.Equal(t, "active", got.LifecycleStage, "stage comes from the folder")
+	assert.Equal(t, "design:festivals/active/rail-feature", got.Key)
+	assert.Equal(t, "design-rail-feature-fixed", got.StableID)
+	assert.Equal(t, "directory", got.ItemKind)
+
+	assert.Contains(t, payload.StageVocabulary["explore"], "ready",
+		"explore gains ready in the published vocabulary")
+}
+
+// Counts tally per built-in type, so a design resident increments design, not
+// festival: the rail must not make a workitem look like a festival.
+func TestWorkitemJSON_ResidentCountsAsItsOwnType(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRailCampaign(t, tc, "wi-json-counts")
+
+	before := wiList(t, tc, path).Counts
+	railTo(t, tc, path+"/workflow/design/rail-feature", "active")
+	after := wiList(t, tc, path).Counts
+
+	assert.Equal(t, before["design"], after["design"], "design count survives the move")
+	assert.Equal(t, before["festival"], after["festival"], "resident must not count as a festival")
+	assert.Equal(t, before["total"], after["total"], "total is unchanged; the item moved, it did not multiply")
+}
+
+func TestWorkitemJSON_FiltersComposeOverResidents(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRailCampaign(t, tc, "wi-json-filters")
+
+	out, err := tc.RunCampInDir(path, "workitem", "create", "stay-put",
+		"--type", "design", "--title", "Stay Put", "--id", "design-stay-put-fixed")
+	require.NoError(t, err, "create second design: %s", out)
+	railTo(t, tc, path+"/workflow/design/rail-feature", "active")
+
+	resident := "festivals/active/rail-feature"
+	root := "workflow/design/stay-put"
+
+	byType := wiList(t, tc, path, "--type", "design").Items
+	_, ok := itemByPath(byType, resident)
+	assert.True(t, ok, "--type design must find the resident")
+	_, ok = itemByPath(byType, root)
+	assert.True(t, ok, "--type design must still find the root item")
+
+	// A workflow/ directory item is already "active by location", so --stage
+	// active spans both homes. ready is the value only a resident can hold.
+	composed := wiList(t, tc, path, "--type", "design", "--stage", "active").Items
+	_, ok = itemByPath(composed, resident)
+	assert.True(t, ok, "--type design --stage active must find the resident")
+	_, ok = itemByPath(composed, root)
+	assert.True(t, ok, "root directory items report active by location")
+
+	railTo(t, tc, path+"/workflow/design/stay-put", "ready")
+	ready := wiList(t, tc, path, "--type", "design", "--stage", "ready").Items
+	_, ok = itemByPath(ready, "festivals/ready/stay-put")
+	assert.True(t, ok, "--stage ready must find the ready resident")
+	_, ok = itemByPath(ready, resident)
+	assert.False(t, ok, "the active resident must not match --stage ready")
+}


### PR DESCRIPTION
WF0001 phase 003, sequence 03. `camp`'s festival discovery learns to split what it finds in the lifecycle folders, so a workitem promoted onto the rail (sequence 02, #521) is findable as itself again.

**Stack base:** branches off `main` after #521 merged. Not stacked on an open PR.

## Discovery reclassification

`discoverFestivals` emitted *every* directory under `festivals/` as a festival, so a promoted workitem vanished from its own type and could not be selected by id at all. It now classifies on the `.workitem` marker — camp owns the marker, fest owns `fest.yaml`:

| Directory | Result |
|-----------|--------|
| marker, on `ready`/`active` | resident: its own `workflow_type`, folder `lifecycle_stage`, `festivals/`-relative path and key |
| no marker | festival, exactly as before, including the marker-less humanized fallback |
| marker, in `planning`/`ritual`/`chains` | emitted as neither |

Classification is explicit, never "a directory with no festival markers." A resident is built through `buildWorkflowDirItem` with the type from its own marker, then only `LifecycleStage` is overridden to the folder it sits in. That reuse is the design: residents inherit `ApplyMetadata` (stable id, tags, projects) and `LoadLocalRun` (`.workflow/` run progress) identically to the same directory under `workflow/<type>/`.

The 88-line `discoverFestivals` split into four functions; the festival construction moved verbatim into `festivalItem`.

### Two decisions worth reading

**A stamped directory outside `ready`/`active` is emitted as nothing**, not fallen back to "festival." The marker proves the directory is camp's, and calling it a festival would push a workitem into `camp wi --type festival` and into fest's surfaces — worse than omitting it. An unreadable marker is treated the same way, for the same reason. Both are doctor candidates for sequence 04.

**Both markers present: resident wins**, logged at warn. `.workitem` records a promote camp performed; a leftover `fest.yaml` proves nothing about the current owner. A test asserts exactly one item is emitted, so the directory can never appear twice.

## JSON contract

`SchemaVersion` is now `workitems/v1alpha10` with a changelog entry. No new fields; the only observable change is that non-festival types can report `lifecycle_stage` `ready`/`active` with a `relative_path` under `festivals/`. `explore` gains `ready` in `stage_vocabulary`.

Doc 04 points at `internal/commands/workitem/json_contract.go`; that file holds per-subcommand versions. The list contract is `SchemaVersion` in `internal/workitem/json.go`.

No filter code changed. `--type` filters on `WorkflowType` and `--stage` on `LifecycleStage`, so composition already worked once discovery emitted the right fields. The tests verify that rather than assume it.

### Finding: `--stage active` does not mean "on the rail"

The sequence asked for a test that `--stage active` returns a resident while a root design item "is unaffected". That is false, and the first draft of two tests failed on it. `buildWorkflowDirItem` hardcodes `LifecycleStageActive` — the long-standing "directory workitems are active by location" rule:

```
active   design    festivals/active/x        <- resident
active   design    workflow/design/normal    <- root item
ready    explore   festivals/ready/e
```

So `--stage active` spans both homes; `ready` is the value only a resident can hold, and the real discriminator the rail adds. Pre-existing behavior, nothing to change, but a consumer reading `--stage active` as "on the rail" would be wrong. Both tests now assert reality and the unit fixture no longer misrepresents discovery.

## Verification

Real `camp wi --json` sample with a resident is in the festival results docs; the resident row carries `"workflow_type": "design"`, `"lifecycle_stage": "active"`, `"key": "design:festivals/active/x"`, `"stable_id": "design-x-2026-07-29"`, `"source_id": ""` — identical in shape to its `workflow/` twin.

The no-resident guarantee was verified by building `camp` from `origin/main` (`c3595279`) and from this branch, running both against byte-identical festival-only fixtures, and diffing normalized output:

```
-  "schema_version": "workitems/v1alpha9",
+  "schema_version": "workitems/v1alpha10",

changed lines: 2
```

7 integration tests (all resident assertions parse real command output), 7 filter-composition unit cases, 6 discovery unit tests.

`just gate` green: 3984/3984 unit, 4029/4029 with integration vet. `golangci-lint --new-from-merge-base origin/main`: 0 issues.

## Also here

A comment-density trim across the rail surface from sequence 02 and this one (net ~88 lines): rationale moved to commits and results docs, keeping short doc comments and the non-obvious "why". Includes `merged_backstop.go` from #520, which merged before I could trim it there.
