### PR TITLE
feat(rail): resident completion, demote to home, and resident doctor checks (WF0001 P3/S4)

### DIFF
--- a/cmd/camp/zz_manifest_annotations.go
+++ b/cmd/camp/zz_manifest_annotations.go
@@ -94,6 +94,7 @@ var manifestAgentAllowedReasons = map[string]string{
 	"workitem list":              "Read-only filtered listing with non-interactive compact and JSON output",
 	"workitem group":             "Non-interactive group update with explicit selector",
 	"workitem priority":          "Non-interactive priority update with explicit selector",
+	"workitem demote":            "Non-interactive demote off the festival rail, fully specified by flags",
 	"workitem promote":           "Non-interactive promote fully specified by --target and flags",
 	"workitem rename":            "Non-interactive rename fully specified by positional args and flags",
 	"workitem repair":            "Idempotent, non-destructive marker repair with --json and --dry-run",

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -7733,6 +7733,43 @@ camp workitem current [selector] [flags]
 ```
 ---
 
+## camp workitem demote
+
+Move a rail resident back to its type root
+
+### Synopsis
+
+Take the workitem identified by [id], by cwd, or by the current pointer off the
+festival rail and back to its original workflow type root.
+
+A resident in festivals/ready or festivals/active returns to
+workflow/<type>/<slug>, where the type comes from its own .workitem marker. Every
+reference is repaired in the same commit, exactly as the rail move does.
+
+This is the escape hatch from the rail, not backward motion along it. It is
+rejected from a dungeon, because restoring a shelved workitem is not a demote,
+and from a workitem already at its type root.
+
+```
+camp workitem demote [id] [flags]
+```
+
+### Options
+
+```
+      --dry-run     Print the planned move, change nothing
+  -h, --help        help for demote
+      --json        Output result as a single JSON object
+      --no-commit   Skip the auto-commit
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+---
+
 ## camp workitem doctor
 
 Report link-registry health issues

--- a/docs/cli-reference/camp_workitem.md
+++ b/docs/cli-reference/camp_workitem.md
@@ -52,6 +52,7 @@ camp workitem [flags]
 * [camp workitem commits](camp_workitem_commits.md)	 - List commits referencing a workitem
 * [camp workitem create](camp_workitem_create.md)	 - Create workitem tracking metadata
 * [camp workitem current](camp_workitem_current.md)	 - Get, set, or clear the current workitem
+* [camp workitem demote](camp_workitem_demote.md)	 - Move a rail resident back to its type root
 * [camp workitem doctor](camp_workitem_doctor.md)	 - Report link-registry health issues
 * [camp workitem group](camp_workitem_group.md)	 - Set or clear the group
 * [camp workitem id](camp_workitem_id.md)	 - Print the identifier of a workitem

--- a/docs/cli-reference/camp_workitem_demote.md
+++ b/docs/cli-reference/camp_workitem_demote.md
@@ -1,0 +1,39 @@
+## camp workitem demote
+
+Move a rail resident back to its type root
+
+### Synopsis
+
+Take the workitem identified by [id], by cwd, or by the current pointer off the
+festival rail and back to its original workflow type root.
+
+A resident in festivals/ready or festivals/active returns to
+workflow/<type>/<slug>, where the type comes from its own .workitem marker. Every
+reference is repaired in the same commit, exactly as the rail move does.
+
+This is the escape hatch from the rail, not backward motion along it. It is
+rejected from a dungeon, because restoring a shelved workitem is not a demote,
+and from a workitem already at its type root.
+
+```
+camp workitem demote [id] [flags]
+```
+
+### Options
+
+```
+      --dry-run     Print the planned move, change nothing
+  -h, --help        help for demote
+      --json        Output result as a single JSON object
+      --no-commit   Skip the auto-commit
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color   disable colored output
+```
+
+### SEE ALSO
+
+* [camp workitem](camp_workitem.md)	 - View active campaign work items

--- a/internal/commands/workitem/demote.go
+++ b/internal/commands/workitem/demote.go
@@ -1,0 +1,147 @@
+package workitem
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	dungeoncmd "github.com/Obedience-Corp/camp/cmd/camp/dungeon"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+// demoteTarget is the audit/ledger target recorded for a demote, so the event
+// stream distinguishes leaving the rail from moving along it.
+const demoteTarget = "home"
+
+type runWorkitemDemoteOptions struct {
+	ID       string
+	DryRun   bool
+	NoCommit bool
+	JSON     bool
+}
+
+func newDemoteCommand() *cobra.Command {
+	var (
+		dryRun   bool
+		noCommit bool
+		jsonOut  bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "demote [id]",
+		Short: "Move a rail resident back to its type root",
+		Long: `Take the workitem identified by [id], by cwd, or by the current pointer off the
+festival rail and back to its original workflow type root.
+
+A resident in festivals/ready or festivals/active returns to
+workflow/<type>/<slug>, where the type comes from its own .workitem marker. Every
+reference is repaired in the same commit, exactly as the rail move does.
+
+This is the escape hatch from the rail, not backward motion along it. It is
+rejected from a dungeon, because restoring a shelved workitem is not a demote,
+and from a workitem already at its type root.`,
+		Args: cobra.RangeArgs(0, 1),
+		Annotations: map[string]string{
+			"agent_allowed": "true",
+			"agent_reason":  "Fully specified by flags; no interactive selection",
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := ""
+			if len(args) == 1 {
+				id = args[0]
+			}
+			return runWorkitemDemote(cmd, runWorkitemDemoteOptions{
+				ID: id, DryRun: dryRun, NoCommit: noCommit, JSON: jsonOut,
+			})
+		},
+	}
+
+	f := cmd.Flags()
+	f.BoolVar(&dryRun, "dry-run", false, "Print the planned move, change nothing")
+	f.BoolVar(&noCommit, "no-commit", false, "Skip the auto-commit")
+	f.BoolVar(&jsonOut, "json", false, "Output result as a single JSON object")
+	return cmd
+}
+
+func runWorkitemDemote(cmd *cobra.Command, opts runWorkitemDemoteOptions) error {
+	ctx := cmd.Context()
+
+	cfg, root, err := config.LoadCampaignConfigFromCwd(ctx)
+	if err != nil {
+		return camperrors.Wrap(err, "not in a campaign directory")
+	}
+
+	loc, err := resolveWorkitem(ctx, root, opts.ID)
+	if err != nil {
+		return err
+	}
+	if err := checkDemotable(railStageOf(loc, root)); err != nil {
+		return err
+	}
+
+	ledgerID, ledgerRef, ledgerTitle := loc.Slug, "", ""
+	if meta, metaErr := wkitem.LoadMetadata(ctx, loc.SourcePath); metaErr == nil && meta != nil {
+		ledgerID, ledgerRef, ledgerTitle = meta.ID, meta.Ref, meta.Title
+	}
+
+	oldRel := filepath.ToSlash(dungeoncmd.RelFromRoot(root, loc.SourcePath))
+	newRel := path.Join("workflow", loc.Type, loc.Slug)
+	result := workitemPromoteResult{
+		ID:     loc.Slug,
+		Type:   loc.Type,
+		Target: demoteTarget,
+		From:   oldRel,
+	}
+
+	if opts.DryRun {
+		result.To = newRel
+		if opts.JSON {
+			return emitPromoteJSON(cmd, result)
+		}
+		_, err := fmt.Fprintf(cmd.OutOrStdout(),
+			"dry-run: would demote workitem %s (%s) from %s to %s\n", loc.Slug, loc.Type, oldRel, newRel)
+		return err
+	}
+
+	destAbs := filepath.Join(root, filepath.FromSlash(newRel))
+	if _, statErr := os.Lstat(destAbs); statErr == nil {
+		return camperrors.Wrapf(camperrors.ErrAlreadyExists,
+			"cannot demote %s: destination %s already exists", loc.Slug, newRel)
+	}
+
+	ci, err := applyWorkitemMove(ctx, root, workitemMove{
+		SourcePath:  loc.SourcePath,
+		DestPath:    destAbs,
+		OldRel:      oldRel,
+		NewRel:      newRel,
+		OldKey:      loc.Type + ":" + oldRel,
+		NewKey:      loc.Type + ":" + newRel,
+		Description: fmt.Sprintf("Demote workitem %s to %s", loc.Slug, newRel),
+	}, &result)
+	if err != nil {
+		return err
+	}
+
+	return finishWorkitemMove(ctx, cmd, cfg, root, ci, &result,
+		ledgerID, ledgerRef, ledgerTitle,
+		"demote to home", "Demoted",
+		moveTailOptions{NoCommit: opts.NoCommit, JSON: opts.JSON})
+}
+
+// checkDemotable allows a demote only from a rail stage. Leaving a dungeon is a
+// restore, and a workitem at its type root is already home.
+func checkDemotable(from string) error {
+	switch from {
+	case railStageReady, railStageActive:
+		return nil
+	case railStageDungeon:
+		return camperrors.New("cannot demote from a dungeon: restoring a shelved workitem is not a demote")
+	default:
+		return camperrors.New("cannot demote: workitem is already at its type root, not on the festival rail")
+	}
+}

--- a/internal/commands/workitem/demote.go
+++ b/internal/commands/workitem/demote.go
@@ -127,10 +127,14 @@ func runWorkitemDemote(cmd *cobra.Command, opts runWorkitemDemoteOptions) error 
 		return err
 	}
 
-	return finishWorkitemMove(ctx, cmd, cfg, root, ci, &result,
-		ledgerID, ledgerRef, ledgerTitle,
-		"demote to home", "Demoted",
-		moveTailOptions{NoCommit: opts.NoCommit, JSON: opts.JSON})
+	return finishWorkitemMove(ctx, cmd, cfg, root, ci, &result, moveTail{
+		LedgerID:    ledgerID,
+		LedgerRef:   ledgerRef,
+		LedgerTitle: ledgerTitle,
+		Why:         "demote to home",
+		SuccessVerb: "Demoted",
+		Options:     moveTailOptions{NoCommit: opts.NoCommit, JSON: opts.JSON},
+	})
 }
 
 // checkDemotable allows a demote only from a rail stage. Leaving a dungeon is a

--- a/internal/commands/workitem/demote_test.go
+++ b/internal/commands/workitem/demote_test.go
@@ -1,0 +1,181 @@
+package workitem
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
+)
+
+func execDemote(t *testing.T, cwd string, args ...string) (string, string, error) {
+	t.Helper()
+	restore := chdir(t, cwd)
+	defer restore()
+
+	cmd := newDemoteCommand()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+	cmd.SetContext(context.Background())
+	err := cmd.Execute()
+	return out.String(), errOut.String(), err
+}
+
+// A resident returns to its type root, taking its content and marker with it.
+func TestDemoteResidentReturnsHome(t *testing.T) {
+	for _, stage := range []string{"ready", "active"} {
+		t.Run(stage, func(t *testing.T) {
+			root := promoteCampaign(t)
+			src := addResident(t, root, stage, "design", "widget", "Widget")
+
+			if _, _, err := execDemote(t, src, "--no-commit"); err != nil {
+				t.Fatalf("demote from %s: %v", stage, err)
+			}
+
+			home := filepath.Join(root, "workflow", "design", "widget")
+			if _, err := os.Stat(filepath.Join(home, ".workitem")); err != nil {
+				t.Errorf("marker did not travel home: %v", err)
+			}
+			if _, err := os.Stat(filepath.Join(home, "README.md")); err != nil {
+				t.Errorf("content did not travel home: %v", err)
+			}
+			if dirExists(src) {
+				t.Errorf("resident should have left %s", src)
+			}
+		})
+	}
+}
+
+// The type root comes from the marker, not from the folder the resident sat in.
+func TestDemoteUsesMarkerTypeForHome(t *testing.T) {
+	root := promoteCampaign(t)
+	src := addResident(t, root, "active", "explore", "topic", "Topic")
+
+	if _, _, err := execDemote(t, src, "--no-commit"); err != nil {
+		t.Fatalf("demote: %v", err)
+	}
+	if !dirExists(filepath.Join(root, "workflow", "explore", "topic")) {
+		t.Error("explore resident should land under workflow/explore")
+	}
+	if dirExists(filepath.Join(root, "workflow", "design", "topic")) {
+		t.Error("must not land under a type it never belonged to")
+	}
+}
+
+// Demote re-homes path-keyed state, unlike a shelve, because the workitem stays
+// active.
+func TestDemoteRehomesPathState(t *testing.T) {
+	root := promoteCampaign(t)
+	src := addResident(t, root, "active", "design", "widget", "Widget")
+	oldKey := "design:festivals/active/widget"
+	newKey := "design:workflow/design/widget"
+
+	storePath := priority.StorePath(root)
+	if err := priority.WithLock(context.Background(), storePath, func(s *priority.Store) error {
+		priority.Set(s, oldKey, priority.High)
+		return nil
+	}); err != nil {
+		t.Fatalf("seed priority: %v", err)
+	}
+
+	if _, _, err := execDemote(t, src, "--no-commit"); err != nil {
+		t.Fatalf("demote: %v", err)
+	}
+
+	store, err := priority.Load(storePath)
+	if err != nil {
+		t.Fatalf("reload priority: %v", err)
+	}
+	if _, ok := store.ManualPriorities[oldKey]; ok {
+		t.Errorf("old key %q survived the demote", oldKey)
+	}
+	if _, ok := store.ManualPriorities[newKey]; !ok {
+		t.Errorf("priority did not follow the workitem home to %q: %+v", newKey, store.ManualPriorities)
+	}
+}
+
+func TestDemoteRejections(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, root string) string
+		wantErr string
+	}{
+		{
+			name: "already at type root",
+			setup: func(t *testing.T, root string) string {
+				return addWorkitem(t, root, "design", "widget", "Widget", "body")
+			},
+			wantErr: "already at its type root",
+		},
+		{
+			name: "from a dungeon",
+			setup: func(t *testing.T, root string) string {
+				dir := filepath.Join(root, "workflow", "design", "dungeon", "completed", "2026-07-24", "widget")
+				writeFile(t, filepath.Join(dir, ".workitem"),
+					"version: v1alpha8\nkind: workitem\nid: design-widget-fixed\ntype: design\ntitle: Widget\n")
+				return dir
+			},
+			wantErr: "restoring a shelved workitem is not a demote",
+		},
+		{
+			name: "destination occupied",
+			setup: func(t *testing.T, root string) string {
+				addWorkitem(t, root, "design", "widget", "Occupant", "body")
+				return addResident(t, root, "ready", "design", "widget", "Resident")
+			},
+			wantErr: "already exists",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := promoteCampaign(t)
+			src := tc.setup(t, root)
+
+			_, _, err := execDemote(t, src, "--no-commit")
+			if err == nil {
+				t.Fatalf("expected %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+			}
+			if !dirExists(src) {
+				t.Error("a refused demote must leave the source in place")
+			}
+		})
+	}
+}
+
+func TestDemoteDryRunChangesNothing(t *testing.T) {
+	root := promoteCampaign(t)
+	src := addResident(t, root, "active", "design", "widget", "Widget")
+
+	out, _, err := execDemote(t, src, "--dry-run")
+	if err != nil {
+		t.Fatalf("dry-run: %v", err)
+	}
+	if !strings.Contains(out, "would demote") || !strings.Contains(out, "workflow/design/widget") {
+		t.Errorf("dry-run output should name the plan and destination, got %q", out)
+	}
+	if !dirExists(src) {
+		t.Error("dry-run must not move the resident")
+	}
+	if dirExists(filepath.Join(root, "workflow", "design", "widget")) {
+		t.Error("dry-run must not create the destination")
+	}
+}
+
+func TestDemoteIsAgentAllowed(t *testing.T) {
+	cmd := newDemoteCommand()
+	if cmd.Annotations["agent_allowed"] != "true" {
+		t.Errorf("agent_allowed = %q, want true", cmd.Annotations["agent_allowed"])
+	}
+	if cmd.Annotations["agent_reason"] == "" {
+		t.Error("agent_reason must explain why the command is agent-safe")
+	}
+}

--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -43,6 +43,8 @@ const (
 	codeProjectNotFound          = "workitem.project.not-found"
 	codeProjectUnvalidatable     = "workitem.project.unvalidatable"
 	codeDeprecatedRelatedProject = "workitem.link.related-project-deprecated"
+	codeUnstampedResident        = "workitem.resident.unstamped"
+	codeResidentMissingHome      = "workitem.resident.missing-home"
 )
 
 const (
@@ -217,6 +219,7 @@ func renderWorkitemDoctorError(cmd *cobra.Command, jsonOut bool, err error) erro
 
 func collectWorkitemFindings(ctx context.Context, root string, registry *links.Links, knownIDs map[string]struct{}, items []wkitem.WorkItem) []docFinding {
 	var findings []docFinding
+	findings = append(findings, collectResidentFindings(root, items)...)
 
 	// Schema-level validation.
 	for _, v := range links.Validate(ctx, registry, links.ValidateOptions{
@@ -668,4 +671,83 @@ func emitDocJSON(w io.Writer, findings []docFinding) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(out)
+}
+
+// collectResidentFindings reports lifecycle directories camp cannot act on: one
+// that is neither a stamped resident nor a festival, and a resident whose type
+// root is gone so demote has nowhere to land.
+func collectResidentFindings(root string, items []wkitem.WorkItem) []docFinding {
+	findings := unclassifiableLifecycleDirs(root)
+	return append(findings, residentsWithoutHome(root, items)...)
+}
+
+func unclassifiableLifecycleDirs(root string) []docFinding {
+	var findings []docFinding
+	for _, stage := range []string{railStageReady, railStageActive} {
+		stageDir := filepath.Join(root, festivalsDir, stage)
+		entries, err := os.ReadDir(stageDir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+				continue
+			}
+			dir := filepath.Join(stageDir, e.Name())
+			if fileExists(filepath.Join(dir, wkitem.MetadataFilename)) || isFestivalDir(dir) {
+				continue
+			}
+			rel := festivalsDir + "/" + stage + "/" + e.Name()
+			findings = append(findings, docFinding{
+				Code:     codeUnstampedResident,
+				Severity: docSeverityWarning,
+				Target:   rel,
+				Message:  rel + " is neither a stamped resident nor a valid festival",
+				FixHint:  "stamp it with camp workitem adopt/create, or add festival markers; --fix does not guess",
+			})
+		}
+	}
+	return findings
+}
+
+func residentsWithoutHome(root string, items []wkitem.WorkItem) []docFinding {
+	var findings []docFinding
+	for _, it := range items {
+		if it.WorkflowType == wkitem.WorkflowTypeFestival {
+			continue
+		}
+		rel := filepath.ToSlash(it.RelativePath)
+		if !strings.HasPrefix(rel, festivalsDir+"/") {
+			continue
+		}
+		typeRoot := filepath.Join(root, "workflow", string(it.WorkflowType))
+		if fileExists(typeRoot) {
+			continue
+		}
+		findings = append(findings, docFinding{
+			Code:     codeResidentMissingHome,
+			Severity: docSeverityWarning,
+			Target:   rel,
+			Message: "resident " + rel + " has no home type root workflow/" +
+				string(it.WorkflowType) + "/ to demote into",
+			FixHint: "recreate workflow/" + string(it.WorkflowType) + "/ or demote to an existing type",
+		})
+	}
+	return findings
+}
+
+// isFestivalDir reports a fest-owned directory by its markers. camp does not
+// import fest, so the marker names are duplicated here deliberately.
+func isFestivalDir(dir string) bool {
+	for _, name := range []string{"fest.yaml", "FESTIVAL_GOAL.md", "FESTIVAL_OVERVIEW.md"} {
+		if fileExists(filepath.Join(dir, name)) {
+			return true
+		}
+	}
+	return false
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }

--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -694,7 +694,7 @@ func unclassifiableLifecycleDirs(root string) []docFinding {
 				continue
 			}
 			dir := filepath.Join(stageDir, e.Name())
-			if fileExists(filepath.Join(dir, wkitem.MetadataFilename)) || isFestivalDir(dir) {
+			if pathExists(filepath.Join(dir, wkitem.MetadataFilename)) || isFestivalDir(dir) {
 				continue
 			}
 			rel := festivalsDir + "/" + stage + "/" + e.Name()
@@ -721,7 +721,7 @@ func residentsWithoutHome(root string, items []wkitem.WorkItem) []docFinding {
 			continue
 		}
 		typeRoot := filepath.Join(root, "workflow", string(it.WorkflowType))
-		if fileExists(typeRoot) {
+		if pathExists(typeRoot) {
 			continue
 		}
 		findings = append(findings, docFinding{
@@ -740,14 +740,14 @@ func residentsWithoutHome(root string, items []wkitem.WorkItem) []docFinding {
 // import fest, so the marker names are duplicated here deliberately.
 func isFestivalDir(dir string) bool {
 	for _, name := range []string{"fest.yaml", "FESTIVAL_GOAL.md", "FESTIVAL_OVERVIEW.md"} {
-		if fileExists(filepath.Join(dir, name)) {
+		if pathExists(filepath.Join(dir, name)) {
 			return true
 		}
 	}
 	return false
 }
 
-func fileExists(path string) bool {
+func pathExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
 }

--- a/internal/commands/workitem/doctor_residents_test.go
+++ b/internal/commands/workitem/doctor_residents_test.go
@@ -1,0 +1,107 @@
+package workitem
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+func codesOf(findings []docFinding) map[string][]string {
+	out := map[string][]string{}
+	for _, f := range findings {
+		out[f.Code] = append(out[f.Code], f.Target)
+	}
+	return out
+}
+
+func TestUnclassifiableLifecycleDirs(t *testing.T) {
+	root := t.TempDir()
+	mk := func(rel string, files map[string]string) {
+		dir := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for name, body := range files {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	mk("festivals/active/mystery", map[string]string{"NOTES.md": "# ?\n"})
+	mk("festivals/active/realfest", map[string]string{"fest.yaml": "version: \"1.0\"\n"})
+	mk("festivals/ready/goalonly", map[string]string{"FESTIVAL_GOAL.md": "# Goal\n"})
+	mk("festivals/ready/overview", map[string]string{"FESTIVAL_OVERVIEW.md": "# Overview\n"})
+	mk("festivals/ready/stamped", map[string]string{".workitem": "type: design\n"})
+	mk("festivals/ready/.hidden", map[string]string{"NOTES.md": "# hidden\n"})
+	// planning is not a rail stage, so it is out of scope for this check.
+	mk("festivals/planning/whatever", map[string]string{"NOTES.md": "# ?\n"})
+
+	got := codesOf(unclassifiableLifecycleDirs(root))
+	targets := got[codeUnstampedResident]
+	if len(targets) != 1 || targets[0] != "festivals/active/mystery" {
+		t.Errorf("flagged %v, want only [festivals/active/mystery]", targets)
+	}
+}
+
+func TestResidentsWithoutHome(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "workflow", "design"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	items := []wkitem.WorkItem{
+		{WorkflowType: wkitem.WorkflowTypeDesign, RelativePath: "festivals/active/has-home"},
+		{WorkflowType: "bug", RelativePath: "festivals/active/no-home"},
+		{WorkflowType: wkitem.WorkflowTypeDesign, RelativePath: "workflow/design/not-a-resident"},
+		{WorkflowType: wkitem.WorkflowTypeFestival, RelativePath: "festivals/active/a-festival"},
+	}
+
+	got := codesOf(residentsWithoutHome(root, items))
+	targets := got[codeResidentMissingHome]
+	if len(targets) != 1 || targets[0] != "festivals/active/no-home" {
+		t.Errorf("flagged %v, want only [festivals/active/no-home]", targets)
+	}
+}
+
+// Neither resident finding is auto-fixable: camp cannot guess a type or invent a
+// type root, so --fix must not touch them.
+func TestResidentFindingsAreNotAutoFixable(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "festivals", "active", "mystery")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	items := []wkitem.WorkItem{{WorkflowType: "bug", RelativePath: "festivals/active/no-home"}}
+
+	for _, f := range collectResidentFindings(root, items) {
+		if f.AutoFixable {
+			t.Errorf("finding %s is auto-fixable; camp must not guess here", f.Code)
+		}
+		if f.Severity != docSeverityWarning {
+			t.Errorf("finding %s severity = %q, want warning", f.Code, f.Severity)
+		}
+		if f.FixHint == "" {
+			t.Errorf("finding %s has no fix hint", f.Code)
+		}
+	}
+}
+
+func TestIsFestivalDir(t *testing.T) {
+	for _, marker := range []string{"fest.yaml", "FESTIVAL_GOAL.md", "FESTIVAL_OVERVIEW.md"} {
+		t.Run(marker, func(t *testing.T) {
+			dir := t.TempDir()
+			if isFestivalDir(dir) {
+				t.Fatal("empty dir should not read as a festival")
+			}
+			if err := os.WriteFile(filepath.Join(dir, marker), []byte("x"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if !isFestivalDir(dir) {
+				t.Errorf("%s should mark a festival directory", marker)
+			}
+		})
+	}
+}

--- a/internal/commands/workitem/move_shared.go
+++ b/internal/commands/workitem/move_shared.go
@@ -1,0 +1,138 @@
+package workitem
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	dungeoncmd "github.com/Obedience-Corp/camp/cmd/camp/dungeon"
+	"github.com/Obedience-Corp/camp/internal/config"
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/mdlinks"
+	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
+	"github.com/Obedience-Corp/camp/internal/statusmove"
+	"github.com/Obedience-Corp/camp/internal/ui"
+	wkaudit "github.com/Obedience-Corp/camp/internal/workitem/audit"
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+// workitemMove describes one physical relocation of a workitem directory that
+// keeps it active: onto a rail stage, or off the rail back to its type root.
+// Shelving is not one of these, because it releases path-keyed state instead of
+// re-homing it.
+type workitemMove struct {
+	SourcePath  string
+	DestPath    string
+	OldRel      string
+	NewRel      string
+	OldKey      string
+	NewKey      string
+	Description string
+}
+
+// applyWorkitemMove performs the move and repairs every reference to it,
+// returning commitInputs for the shared tail. Used by the rail move and by
+// demote so the two cannot drift.
+func applyWorkitemMove(ctx context.Context, root string, mv workitemMove, result *workitemPromoteResult) (*commitInputs, error) {
+	if _, err := statusmove.Move(ctx, mv.SourcePath, mv.DestPath, statusmove.MoveOptions{BoundaryRoot: root}); err != nil {
+		if errors.Is(err, statusmove.ErrAlreadyExists) {
+			return nil, camperrors.Wrapf(camperrors.ErrAlreadyExists,
+				"cannot move %s: destination %s already exists", mv.OldRel, mv.NewRel)
+		}
+		return nil, camperrors.Wrapf(err, "moving %s to %s", mv.OldRel, mv.NewRel)
+	}
+	rewritten, err := mdlinks.RewriteForMove(ctx, root, mv.SourcePath, mv.DestPath)
+	if err != nil {
+		return nil, camperrors.Wrapf(err,
+			"rewriting markdown links after moving %s (move applied; recover with git status)", mv.OldRel)
+	}
+
+	destPaths := []string{mv.DestPath}
+	if migrateRailReferences(ctx, root, mv.OldKey, mv.NewKey, mv.OldRel, mv.NewRel, result) {
+		destPaths = append(destPaths, links.LinksPath(root))
+	}
+
+	result.To = mv.NewRel
+	return &commitInputs{
+		description: mv.Description,
+		sourcePaths: []string{mv.SourcePath},
+		destPaths:   destPaths,
+		rewritten:   rewritten,
+	}, nil
+}
+
+// moveTailOptions carries the flags the shared tail honors.
+type moveTailOptions struct {
+	NoCommit bool
+	JSON     bool
+}
+
+// finishWorkitemMove appends the audit event, emits the ledger transition,
+// auto-commits, invalidates the nav cache, and prints the outcome. Shared by
+// promote and demote so their event streams and commit shape stay identical.
+func finishWorkitemMove(
+	ctx context.Context, cmd *cobra.Command, cfg *config.CampaignConfig, root string,
+	ci *commitInputs, result *workitemPromoteResult,
+	ledgerID, ledgerRef, ledgerTitle, why, successVerb string,
+	opts moveTailOptions,
+) error {
+	appendWorkitemAuditEvent(ctx, cmd, root, wkaudit.Event{
+		Event:      wkaudit.EventPromote,
+		ID:         ledgerID,
+		Ref:        ledgerRef,
+		Title:      ledgerTitle,
+		Type:       result.Type,
+		From:       result.From,
+		To:         result.To,
+		Target:     result.Target,
+		PromotedTo: result.PromotedTo,
+	})
+	ci.destPaths = append(ci.destPaths, auditFilePath(root))
+
+	emitTransitionLedger(ctx, cmd, root, result, why)
+
+	if !opts.NoCommit {
+		if err := commitWorkitemMove(ctx, cmd, cfg, root, ci, result, opts.JSON); err != nil {
+			return err
+		}
+	}
+
+	if navErr := navindex.Delete(root); navErr != nil {
+		msg := fmt.Sprintf("failed to invalidate navigation cache: %v", navErr)
+		result.Warnings = append(result.Warnings, msg)
+		if !opts.JSON {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s %s\n", ui.WarningIcon(), msg)
+		}
+	}
+
+	if opts.JSON {
+		return emitPromoteJSON(cmd, *result)
+	}
+	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s %s workitem %s to %s\n",
+		ui.SuccessIcon(), successVerb, result.ID, result.To); err != nil {
+		return err
+	}
+	return printReleasedLinks(cmd.OutOrStdout(), *result)
+}
+
+func commitWorkitemMove(
+	ctx context.Context, cmd *cobra.Command, cfg *config.CampaignConfig, root string,
+	ci *commitInputs, result *workitemPromoteResult, jsonOut bool,
+) error {
+	outcome := dungeoncmd.StageAndCommitDungeonMove(ctx, &dungeoncmd.DungeonMoveCommit{
+		Config:           cfg,
+		CampaignRoot:     root,
+		Description:      ci.description,
+		SourcePaths:      ci.sourcePaths,
+		DestinationPaths: ci.destPaths,
+		RewrittenFiles:   ci.rewritten,
+	})
+	if !jsonOut {
+		dungeoncmd.PrintDungeonMoveOutcome(cmd.OutOrStdout(), outcome)
+	}
+	result.Committed = outcome.Committed
+	result.CommitMessage = outcome.Message
+	return outcome.Err()
+}

--- a/internal/commands/workitem/move_shared.go
+++ b/internal/commands/workitem/move_shared.go
@@ -69,20 +69,31 @@ type moveTailOptions struct {
 	JSON     bool
 }
 
+// moveTail describes how one move should be recorded and reported. Grouped into
+// a struct because five consecutive string parameters can be transposed without
+// the compiler noticing.
+type moveTail struct {
+	LedgerID    string
+	LedgerRef   string
+	LedgerTitle string
+	Why         string
+	SuccessVerb string
+	Options     moveTailOptions
+}
+
 // finishWorkitemMove appends the audit event, emits the ledger transition,
 // auto-commits, invalidates the nav cache, and prints the outcome. Shared by
 // promote and demote so their event streams and commit shape stay identical.
 func finishWorkitemMove(
 	ctx context.Context, cmd *cobra.Command, cfg *config.CampaignConfig, root string,
-	ci *commitInputs, result *workitemPromoteResult,
-	ledgerID, ledgerRef, ledgerTitle, why, successVerb string,
-	opts moveTailOptions,
+	ci *commitInputs, result *workitemPromoteResult, tail moveTail,
 ) error {
+	opts := tail.Options
 	appendWorkitemAuditEvent(ctx, cmd, root, wkaudit.Event{
 		Event:      wkaudit.EventPromote,
-		ID:         ledgerID,
-		Ref:        ledgerRef,
-		Title:      ledgerTitle,
+		ID:         tail.LedgerID,
+		Ref:        tail.LedgerRef,
+		Title:      tail.LedgerTitle,
 		Type:       result.Type,
 		From:       result.From,
 		To:         result.To,
@@ -91,7 +102,7 @@ func finishWorkitemMove(
 	})
 	ci.destPaths = append(ci.destPaths, auditFilePath(root))
 
-	emitTransitionLedger(ctx, cmd, root, result, why)
+	emitTransitionLedger(ctx, cmd, root, result, tail.Why)
 
 	if !opts.NoCommit {
 		if err := commitWorkitemMove(ctx, cmd, cfg, root, ci, result, opts.JSON); err != nil {
@@ -111,7 +122,7 @@ func finishWorkitemMove(
 		return emitPromoteJSON(cmd, *result)
 	}
 	if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s %s workitem %s to %s\n",
-		ui.SuccessIcon(), successVerb, result.ID, result.To); err != nil {
+		ui.SuccessIcon(), tail.SuccessVerb, result.ID, result.To); err != nil {
 		return err
 	}
 	return printReleasedLinks(cmd.OutOrStdout(), *result)

--- a/internal/commands/workitem/promote.go
+++ b/internal/commands/workitem/promote.go
@@ -26,6 +26,7 @@ import (
 	wkaudit "github.com/Obedience-Corp/camp/internal/workitem/audit"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
 	"github.com/Obedience-Corp/camp/internal/workitem/locate"
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
 	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
 )
 
@@ -55,6 +56,12 @@ type workitemPromoteResult struct {
 	// ReleasedLinks are the links dropped because the workitem is no longer
 	// active. Reported so an automatic removal is never silent.
 	ReleasedLinks []releasedLink `json:"released_links,omitempty"`
+	// ReleasedPriorityKey is the workitem key whose manual priority and
+	// attention entries were dropped on shelve, empty when there were none.
+	ReleasedPriorityKey string `json:"released_priority_key,omitempty"`
+	// ClearedCurrent reports that the current-workitem pointer was cleared
+	// because it referenced the shelved workitem.
+	ClearedCurrent bool `json:"cleared_current,omitempty"`
 }
 
 // releasedLink records a link that promote removed, in enough detail to put it
@@ -282,6 +289,18 @@ func printReleasedLinks(w io.Writer, result workitemPromoteResult) error {
 			return err
 		}
 	}
+	if result.ReleasedPriorityKey != "" {
+		if _, err := fmt.Fprintf(w, "  released priority/attention for %s; %s is no longer active\n",
+			result.ReleasedPriorityKey, result.ID); err != nil {
+			return err
+		}
+	}
+	if result.ClearedCurrent {
+		if _, err := fmt.Fprintf(w, "  cleared the current workitem pointer; %s is no longer active\n",
+			result.ID); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -320,6 +339,9 @@ func doDungeonPromote(ctx context.Context, campaignRoot string, loc *locate.Loca
 	// (`camp p commit` silently stops stamping the ref). So the links go with
 	// the workitem, reported rather than dropped quietly.
 	if err := releaseLinksForShelvedSource(ctx, campaignRoot, oldID, oldKey, ci, result); err != nil {
+		return nil, err
+	}
+	if err := releasePathStateForShelvedSource(ctx, campaignRoot, oldID, oldKey, result); err != nil {
 		return nil, err
 	}
 	return ci, nil
@@ -510,6 +532,9 @@ func doDocPromote(ctx context.Context, opts runWorkitemPromoteOptions, campaignR
 		if err := releaseLinksForShelvedSource(ctx, campaignRoot, oldID, oldKey, ci, result); err != nil {
 			return nil, err
 		}
+		if err := releasePathStateForShelvedSource(ctx, campaignRoot, oldID, oldKey, result); err != nil {
+			return nil, err
+		}
 	}
 	return ci, nil
 }
@@ -528,6 +553,56 @@ func releaseLinksForShelvedSource(ctx context.Context, campaignRoot, oldID, oldK
 		ci.destPaths = append(ci.destPaths, links.LinksPath(campaignRoot))
 		result.ReleasedLinks = append(result.ReleasedLinks, dropped...)
 	}
+	return nil
+}
+
+// releasePathStateForShelvedSource drops the per-machine state keyed on the
+// source's pre-move path. Both stores are gitignored, so neither is staged.
+//
+// A manual priority and an attention stage describe how to rank active work. The
+// key encodes the path, so a shelve strands the entry: nothing resolves it, and
+// Prune only reaches it on a later full discovery pass. Dropping it here is the
+// same call the link release makes for the same reason, so the two cannot
+// disagree about whether a shelved workitem is still active.
+func releasePathStateForShelvedSource(ctx context.Context, campaignRoot, oldID, oldKey string,
+	result *workitemPromoteResult,
+) error {
+	if oldKey != "" {
+		storePath := priority.StorePath(campaignRoot)
+		store, err := priority.Load(storePath)
+		if err != nil {
+			return camperrors.Wrap(err, "load priority store on shelve")
+		}
+		_, hasPriority := store.ManualPriorities[oldKey]
+		_, hasAttention := store.Attention[oldKey]
+		if hasPriority || hasAttention {
+			if err := priority.WithLock(ctx, storePath, func(s *priority.Store) error {
+				priority.Clear(s, oldKey)
+				delete(s.Attention, oldKey)
+				return nil
+			}); err != nil {
+				return camperrors.Wrap(err, "release priority entries on shelve")
+			}
+			result.ReleasedPriorityKey = oldKey
+		}
+	}
+
+	cur, err := links.LoadCurrent(ctx, campaignRoot)
+	if err != nil {
+		return camperrors.Wrap(err, "load current workitem on shelve")
+	}
+	if cur == nil {
+		return nil
+	}
+	if cur.WorkitemID != oldID && cur.WorkitemID != oldKey {
+		return nil
+	}
+	// A current pointer at a shelved workitem is worse than none: the selector
+	// cannot see dungeon items, so camp p commit silently stops stamping the ref.
+	if err := links.SaveCurrent(ctx, campaignRoot, nil); err != nil {
+		return camperrors.Wrap(err, "clear current workitem on shelve")
+	}
+	result.ClearedCurrent = true
 	return nil
 }
 

--- a/internal/commands/workitem/promote.go
+++ b/internal/commands/workitem/promote.go
@@ -18,10 +18,8 @@ import (
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/intent"
 	"github.com/Obedience-Corp/camp/internal/ledger"
-	navindex "github.com/Obedience-Corp/camp/internal/nav/index"
 	"github.com/Obedience-Corp/camp/internal/pathutil"
 	promotepkg "github.com/Obedience-Corp/camp/internal/promote"
-	"github.com/Obedience-Corp/camp/internal/ui"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	wkaudit "github.com/Obedience-Corp/camp/internal/workitem/audit"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
@@ -216,62 +214,10 @@ func runWorkitemPromote(cmd *cobra.Command, opts runWorkitemPromoteOptions) erro
 		return nil
 	}
 
-	appendWorkitemAuditEvent(ctx, cmd, root, wkaudit.Event{
-		Event:      wkaudit.EventPromote,
-		ID:         ledgerID,
-		Ref:        ledgerRef,
-		Title:      ledgerTitle,
-		Type:       result.Type,
-		From:       result.From,
-		To:         result.To,
-		Target:     result.Target,
-		PromotedTo: result.PromotedTo,
-	})
-	ci.destPaths = append(ci.destPaths, filepath.Join(root, ".campaign", "workitems", wkaudit.AuditFile))
-
-	ledger.NewFromRoot(ctx, root, ledger.WarnTo(cmd.ErrOrStderr())).
-		Emit(ctx, ledgerkit.KindTransitioned, ledgerkit.Scope{Workitem: result.ID},
-			ledger.WithWhy("promote to "+opts.Target),
-			ledger.WithPayload(map[string]any{
-				"target": result.Target, "from": result.From,
-				"to": result.To, "promoted_to": result.PromotedTo,
-			}))
-
-	if !opts.NoCommit {
-		outcome := dungeoncmd.StageAndCommitDungeonMove(ctx, &dungeoncmd.DungeonMoveCommit{
-			Config:           cfg,
-			CampaignRoot:     root,
-			Description:      ci.description,
-			SourcePaths:      ci.sourcePaths,
-			DestinationPaths: ci.destPaths,
-			RewrittenFiles:   ci.rewritten,
-		})
-		if !opts.JSON {
-			dungeoncmd.PrintDungeonMoveOutcome(cmd.OutOrStdout(), outcome)
-		}
-		result.Committed = outcome.Committed
-		result.CommitMessage = outcome.Message
-		if cerr := outcome.Err(); cerr != nil {
-			return cerr
-		}
-	}
-
-	if navErr := navindex.Delete(root); navErr != nil {
-		msg := fmt.Sprintf("failed to invalidate navigation cache: %v", navErr)
-		result.Warnings = append(result.Warnings, msg)
-		if !opts.JSON {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s %s\n", ui.WarningIcon(), msg)
-		}
-	}
-
-	if opts.JSON {
-		return emitPromoteJSON(cmd, result)
-	}
-	if _, err = fmt.Fprintf(cmd.OutOrStdout(), "%s Promoted workitem %s to %s\n",
-		ui.SuccessIcon(), result.ID, result.To); err != nil {
-		return err
-	}
-	return printReleasedLinks(cmd.OutOrStdout(), result)
+	return finishWorkitemMove(ctx, cmd, cfg, root, ci, &result,
+		ledgerID, ledgerRef, ledgerTitle,
+		"promote to "+opts.Target, "Promoted",
+		moveTailOptions{NoCommit: opts.NoCommit, JSON: opts.JSON})
 }
 
 // printReleasedLinks names every link promote dropped and how to restore it.
@@ -885,4 +831,18 @@ func locateFromCurrent(ctx context.Context, root string) (*locate.Location, erro
 		return nil, camperrors.New("no current workitem set")
 	}
 	return locateByID(ctx, root, cur.WorkitemID)
+}
+
+func auditFilePath(root string) string {
+	return filepath.Join(root, ".campaign", "workitems", wkaudit.AuditFile)
+}
+
+func emitTransitionLedger(ctx context.Context, cmd *cobra.Command, root string, result *workitemPromoteResult, why string) {
+	ledger.NewFromRoot(ctx, root, ledger.WarnTo(cmd.ErrOrStderr())).
+		Emit(ctx, ledgerkit.KindTransitioned, ledgerkit.Scope{Workitem: result.ID},
+			ledger.WithWhy(why),
+			ledger.WithPayload(map[string]any{
+				"target": result.Target, "from": result.From,
+				"to": result.To, "promoted_to": result.PromotedTo,
+			}))
 }

--- a/internal/commands/workitem/promote.go
+++ b/internal/commands/workitem/promote.go
@@ -214,10 +214,14 @@ func runWorkitemPromote(cmd *cobra.Command, opts runWorkitemPromoteOptions) erro
 		return nil
 	}
 
-	return finishWorkitemMove(ctx, cmd, cfg, root, ci, &result,
-		ledgerID, ledgerRef, ledgerTitle,
-		"promote to "+opts.Target, "Promoted",
-		moveTailOptions{NoCommit: opts.NoCommit, JSON: opts.JSON})
+	return finishWorkitemMove(ctx, cmd, cfg, root, ci, &result, moveTail{
+		LedgerID:    ledgerID,
+		LedgerRef:   ledgerRef,
+		LedgerTitle: ledgerTitle,
+		Why:         "promote to " + opts.Target,
+		SuccessVerb: "Promoted",
+		Options:     moveTailOptions{NoCommit: opts.NoCommit, JSON: opts.JSON},
+	})
 }
 
 // printReleasedLinks names every link promote dropped and how to restore it.

--- a/internal/commands/workitem/promote_rail.go
+++ b/internal/commands/workitem/promote_rail.go
@@ -2,7 +2,6 @@ package workitem
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -12,10 +11,7 @@ import (
 	dungeoncmd "github.com/Obedience-Corp/camp/cmd/camp/dungeon"
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
-	"github.com/Obedience-Corp/camp/internal/mdlinks"
-	"github.com/Obedience-Corp/camp/internal/statusmove"
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
-	"github.com/Obedience-Corp/camp/internal/workitem/links"
 	"github.com/Obedience-Corp/camp/internal/workitem/locate"
 )
 
@@ -85,31 +81,15 @@ func doRailPromote(ctx context.Context, cfg *config.CampaignConfig, root string,
 		return nil, err
 	}
 
-	if _, err := statusmove.Move(ctx, loc.SourcePath, destAbs, statusmove.MoveOptions{BoundaryRoot: root}); err != nil {
-		if errors.Is(err, statusmove.ErrAlreadyExists) {
-			return nil, camperrors.Wrapf(camperrors.ErrAlreadyExists,
-				"cannot promote to %s: destination %s already exists", stage, newRel)
-		}
-		return nil, camperrors.Wrapf(err, "moving %s to %s", oldRel, newRel)
-	}
-	rewritten, err := mdlinks.RewriteForMove(ctx, root, loc.SourcePath, destAbs)
-	if err != nil {
-		return nil, camperrors.Wrapf(err,
-			"rewriting markdown links after moving %s (move applied; recover with git status)", oldRel)
-	}
-
-	destPaths := []string{destAbs}
-	if migrateRailReferences(ctx, root, loc.Type+":"+oldRel, loc.Type+":"+newRel, oldRel, newRel, result) {
-		destPaths = append(destPaths, links.LinksPath(root))
-	}
-
-	result.To = newRel
-	return &commitInputs{
-		description: fmt.Sprintf("Promote workitem %s to %s", loc.Slug, newRel),
-		sourcePaths: []string{loc.SourcePath},
-		destPaths:   destPaths,
-		rewritten:   rewritten,
-	}, nil
+	return applyWorkitemMove(ctx, root, workitemMove{
+		SourcePath:  loc.SourcePath,
+		DestPath:    destAbs,
+		OldRel:      oldRel,
+		NewRel:      newRel,
+		OldKey:      loc.Type + ":" + oldRel,
+		NewKey:      loc.Type + ":" + newRel,
+		Description: fmt.Sprintf("Promote workitem %s to %s", loc.Slug, newRel),
+	}, result)
 }
 
 // migrateRailReferences reuses the rename migrations: a rail move preserves the

--- a/internal/commands/workitem/promote_test.go
+++ b/internal/commands/workitem/promote_test.go
@@ -13,6 +13,7 @@ import (
 	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
 	"github.com/Obedience-Corp/camp/internal/workitem/locate"
+	"github.com/Obedience-Corp/camp/internal/workitem/priority"
 )
 
 func promoteCampaign(t *testing.T) string {
@@ -630,5 +631,92 @@ func TestPromoteRailRejectsExistingDestination(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(src, "README.md")); statErr != nil {
 		t.Errorf("source must be untouched after a refused move: %v", statErr)
+	}
+}
+
+// A resident completes into the festival-local dungeon, in a dated bucket, for
+// every shelve status. Driven entirely by loc.DungeonPath.
+func TestPromoteResidentCompletesIntoFestivalDungeon(t *testing.T) {
+	for _, status := range []string{"completed", "archived", "someday"} {
+		t.Run(status, func(t *testing.T) {
+			root := promoteCampaign(t)
+			src := addResident(t, root, "active", "design", "feat", "Feat")
+
+			if _, _, err := execPromote(t, src, "--target", status, "--no-commit"); err != nil {
+				t.Fatalf("promote resident to %s: %v", status, err)
+			}
+
+			matches, _ := filepath.Glob(filepath.Join(root, "festivals", ".dungeon", status, "*", "feat"))
+			if len(matches) != 1 {
+				t.Fatalf("want one dated bucket under festivals/.dungeon/%s, got %v", status, matches)
+			}
+			if _, err := os.Stat(filepath.Join(matches[0], ".workitem")); err != nil {
+				t.Errorf("marker did not travel into the dungeon: %v", err)
+			}
+			if dirExists(src) {
+				t.Errorf("resident should have left %s", src)
+			}
+			// It must not land in the workflow type's dungeon.
+			if strayed, _ := filepath.Glob(filepath.Join(root, "workflow", "design", "dungeon", status, "*", "feat")); len(strayed) > 0 {
+				t.Errorf("resident landed in the workflow dungeon: %v", strayed)
+			}
+		})
+	}
+}
+
+// Shelving strands path-keyed per-machine state, so promote releases it for the
+// same reason it releases links.
+func TestPromoteShelveReleasesPathState(t *testing.T) {
+	root := promoteCampaign(t)
+	src := addResident(t, root, "active", "design", "feat", "Feat")
+	key := "design:festivals/active/feat"
+
+	storePath := priority.StorePath(root)
+	if err := priority.WithLock(context.Background(), storePath, func(s *priority.Store) error {
+		priority.Set(s, key, priority.High)
+		return nil
+	}); err != nil {
+		t.Fatalf("seed priority: %v", err)
+	}
+	setCurrentPtr(t, root, "design-feat-fixed")
+
+	if _, _, err := execPromote(t, src, "--target", "completed", "--no-commit"); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+
+	store, err := priority.Load(storePath)
+	if err != nil {
+		t.Fatalf("reload priority: %v", err)
+	}
+	if _, ok := store.ManualPriorities[key]; ok {
+		t.Errorf("priority entry for %q survived the shelve; nothing resolves that path now", key)
+	}
+
+	cur, err := links.LoadCurrent(context.Background(), root)
+	if err != nil {
+		t.Fatalf("load current: %v", err)
+	}
+	if cur != nil {
+		t.Errorf("current pointer = %+v, want cleared: the selector cannot see dungeon items", cur)
+	}
+}
+
+// A current pointer at some other workitem must survive.
+func TestPromoteShelveKeepsUnrelatedCurrent(t *testing.T) {
+	root := promoteCampaign(t)
+	src := addWorkitem(t, root, "design", "shelveme", "Shelve Me", "body")
+	addWorkitem(t, root, "design", "other", "Other", "body")
+	setCurrentPtr(t, root, "design-other-fixed")
+
+	if _, _, err := execPromote(t, src, "--target", "completed", "--no-commit"); err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+
+	cur, err := links.LoadCurrent(context.Background(), root)
+	if err != nil {
+		t.Fatalf("load current: %v", err)
+	}
+	if cur == nil || cur.WorkitemID != "design-other-fixed" {
+		t.Errorf("current = %+v, want design-other-fixed untouched", cur)
 	}
 }

--- a/internal/commands/workitem/workitem.go
+++ b/internal/commands/workitem/workitem.go
@@ -151,6 +151,7 @@ Examples:
 	cmd.AddCommand(newStageCommand())
 	cmd.AddCommand(newGroupCommand())
 	cmd.AddCommand(newPromoteCommand())
+	cmd.AddCommand(newDemoteCommand())
 	cmd.AddCommand(newSweepCommand())
 	cmd.AddCommand(newRenameCommand())
 	cmd.AddCommand(newDoctorCommand())

--- a/internal/commands/workitem/workitem_test.go
+++ b/internal/commands/workitem/workitem_test.go
@@ -460,9 +460,9 @@ func TestWorkitemSubcommandsStayRegisteredAndVisible(t *testing.T) {
 	cmd := NewWorkitemCommand()
 
 	want := []string{
-		"adopt", "commit", "commits", "create", "current", "doctor", "group",
-		"id", "link", "links", "list", "priority", "promote", "rename", "repair",
-		"resolve", "stage", "sweep", "unlink", "validate", "worktree",
+		"adopt", "commit", "commits", "create", "current", "demote", "doctor",
+		"group", "id", "link", "links", "list", "priority", "promote", "rename",
+		"repair", "resolve", "stage", "sweep", "unlink", "validate", "worktree",
 	}
 
 	for _, name := range want {

--- a/tests/integration/doctor_intents_festivals_test.go
+++ b/tests/integration/doctor_intents_festivals_test.go
@@ -14,10 +14,12 @@ import (
 )
 
 type doctorFinding struct {
-	Code     string `json:"code"`
-	Severity string `json:"severity"`
-	Target   string `json:"target"`
-	Message  string `json:"message"`
+	Code        string `json:"code"`
+	Severity    string `json:"severity"`
+	Target      string `json:"target"`
+	Message     string `json:"message"`
+	FixHint     string `json:"fix_hint"`
+	AutoFixable bool   `json:"auto_fixable"`
 }
 
 type doctorReport struct {

--- a/tests/integration/doctor_residents_test.go
+++ b/tests/integration/doctor_residents_test.go
@@ -1,0 +1,102 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func residentDoctorFindings(t *testing.T, tc *TestContainer, path string) []doctorFinding {
+	t.Helper()
+	// doctor exits non-zero when it reports findings, so ignore the exit code.
+	stdout, _, _, err := tc.RunCampSplitInDir(path, "workitem", "doctor", "--json")
+	require.NoError(t, err)
+	return doctorFindings(t, stdout)
+}
+
+func findingFor(findings []doctorFinding, code, target string) (doctorFinding, bool) {
+	for _, f := range findings {
+		if f.Code == code && f.Target == target {
+			return f, true
+		}
+	}
+	return doctorFinding{}, false
+}
+
+func TestDoctorResidents_ReportsUnstampedAndHomeless(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := "/campaigns/doctor-residents"
+	_, err := tc.InitCampaign(path, "doctor-residents", "product")
+	require.NoError(t, err)
+
+	// Neither a resident nor a festival.
+	require.NoError(t, tc.WriteFile(path+"/festivals/active/mystery/NOTES.md", "# ?\n"))
+	// A real festival on the same stage: must not be flagged.
+	require.NoError(t, tc.WriteFile(path+"/festivals/active/realfest/fest.yaml",
+		"version: \"1.0\"\nmetadata:\n  id: RF\n  name: Real\n"))
+	// A stamped resident whose type root does not exist.
+	require.NoError(t, tc.WriteFile(path+"/festivals/active/orphan/.workitem",
+		"version: v1alpha8\nkind: workitem\nid: bug-orphan-1\ntype: bug\ntitle: Orphan\nref: WI-aaaaaa\n"))
+	require.NoError(t, tc.WriteFile(path+"/festivals/active/orphan/README.md", "# Orphan\n"))
+	// A stamped resident whose type root does exist: must not be flagged.
+	require.NoError(t, tc.WriteFile(path+"/festivals/ready/good/.workitem",
+		"version: v1alpha8\nkind: workitem\nid: design-good-1\ntype: design\ntitle: Good\nref: WI-bbbbbb\n"))
+	require.NoError(t, tc.WriteFile(path+"/festivals/ready/good/README.md", "# Good\n"))
+	_, _, err = tc.ExecCommand("sh", "-c", "mkdir -p "+path+"/workflow/design")
+	require.NoError(t, err)
+
+	findings := residentDoctorFindings(t, tc, path)
+
+	unstamped, ok := findingFor(findings, "workitem.resident.unstamped", "festivals/active/mystery")
+	require.True(t, ok, "missing unstamped finding: %+v", findings)
+	assert.Equal(t, "warning", unstamped.Severity)
+	assert.False(t, unstamped.AutoFixable, "camp cannot guess a type; --fix must not touch it")
+	assert.NotEmpty(t, unstamped.FixHint)
+
+	homeless, ok := findingFor(findings, "workitem.resident.missing-home", "festivals/active/orphan")
+	require.True(t, ok, "missing homeless finding: %+v", findings)
+	assert.Equal(t, "warning", homeless.Severity)
+	assert.False(t, homeless.AutoFixable, "camp must not invent a type root")
+	assert.Contains(t, homeless.Message, "workflow/bug/")
+
+	_, ok = findingFor(findings, "workitem.resident.unstamped", "festivals/active/realfest")
+	assert.False(t, ok, "a directory with fest.yaml is a festival, not an unstamped resident")
+	_, ok = findingFor(findings, "workitem.resident.unstamped", "festivals/ready/good")
+	assert.False(t, ok, "a stamped resident is not unstamped")
+	_, ok = findingFor(findings, "workitem.resident.missing-home", "festivals/ready/good")
+	assert.False(t, ok, "workflow/design exists, so this resident has a home")
+}
+
+// --fix must leave both findings in place: they are the two cases camp refuses to
+// guess at.
+func TestDoctorResidents_FixDoesNotResolveThem(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := "/campaigns/doctor-residents-fix"
+	_, err := tc.InitCampaign(path, "doctor-residents-fix", "product")
+	require.NoError(t, err)
+
+	require.NoError(t, tc.WriteFile(path+"/festivals/active/mystery/NOTES.md", "# ?\n"))
+	require.NoError(t, tc.WriteFile(path+"/festivals/active/orphan/.workitem",
+		"version: v1alpha8\nkind: workitem\nid: bug-orphan-1\ntype: bug\ntitle: Orphan\nref: WI-aaaaaa\n"))
+	require.NoError(t, tc.WriteFile(path+"/festivals/active/orphan/README.md", "# Orphan\n"))
+
+	_, _, _, err = tc.RunCampSplitInDir(path, "workitem", "doctor", "--fix")
+	require.NoError(t, err)
+
+	findings := residentDoctorFindings(t, tc, path)
+	_, ok := findingFor(findings, "workitem.resident.unstamped", "festivals/active/mystery")
+	assert.True(t, ok, "--fix must not silently resolve an unstamped directory")
+	_, ok = findingFor(findings, "workitem.resident.missing-home", "festivals/active/orphan")
+	assert.True(t, ok, "--fix must not invent workflow/bug/")
+
+	exists, err := tc.CheckFileExists(path + "/festivals/active/mystery/.workitem")
+	require.NoError(t, err)
+	assert.False(t, exists, "--fix must not stamp a directory it cannot classify")
+	exists, err = tc.CheckDirExists(path + "/workflow/bug")
+	require.NoError(t, err)
+	assert.False(t, exists, "--fix must not create a type root")
+}

--- a/tests/integration/intent_add_target_test.go
+++ b/tests/integration/intent_add_target_test.go
@@ -54,10 +54,11 @@ func TestIntentAdd_TargetCampaignWritesToSelectedRoot(t *testing.T) {
 // changes optional-value semantics will be caught.
 //
 // Forms covered:
-//   --campaign <name>   long, space-separated  (the original bug)
-//   --campaign=<name>   long, equals-attached
-//   -c <name>           short, space-separated
-//   -c=<name>           short, equals-attached
+//
+//	--campaign <name>   long, space-separated  (the original bug)
+//	--campaign=<name>   long, equals-attached
+//	-c <name>           short, space-separated
+//	-c=<name>           short, equals-attached
 func TestIntentAdd_TargetCampaignFlagForms(t *testing.T) {
 	tc := GetSharedContainer(t)
 

--- a/tests/integration/jobs_surface_test.go
+++ b/tests/integration/jobs_surface_test.go
@@ -117,7 +117,7 @@ func TestIntegration_JobsDropKeepsContentForTheNextCommit(t *testing.T) {
 
 	writeFailedJob(t, tc, campPath, rootLane, 1, map[string]any{
 		"kind": "commit-paths", "repo": ".",
-		"paths": []string{".campaign/intents/dropped.md"},
+		"paths":   []string{".campaign/intents/dropped.md"},
 		"message": "capture intent: dropped", "attempts": 3,
 	})
 
@@ -151,7 +151,7 @@ func TestIntegration_JobsRetryRunsTheJobToSuccess(t *testing.T) {
 	// fixing the cause, which is exactly what retry is for.
 	writeFailedJob(t, tc, campPath, rootLane, 1, map[string]any{
 		"kind": "commit-paths", "repo": ".",
-		"paths": []string{".campaign/intents/retried.md"},
+		"paths":   []string{".campaign/intents/retried.md"},
 		"message": "capture intent: retried", "attempts": 3,
 	})
 	tc.Shell(t, fmt.Sprintf(`
@@ -305,7 +305,7 @@ func TestIntegration_DoctorReportsBookkeepingLostWithTheCache(t *testing.T) {
 	`, campPath))
 	writeJob(t, tc, campPath, rootLane, 1, map[string]any{
 		"kind": "commit-paths", "repo": ".",
-		"paths": []string{".campaign/intents/orphaned.md"},
+		"paths":   []string{".campaign/intents/orphaned.md"},
 		"message": "capture intent: orphaned",
 	})
 	tc.Shell(t, fmt.Sprintf("rm -rf %s/.campaign/cache", campPath))

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -138,9 +138,9 @@ func poolSize() int {
 // different members fail do we treat the run as infrastructure death. Pool
 // size 1 keeps threshold 1 so a solo container still fails closed.
 var (
-	infraMu             sync.Mutex
-	infraReason         string
-	infraFailedMembers  map[*TestContainer]string // first double-Reset reason per member
+	infraMu            sync.Mutex
+	infraReason        string
+	infraFailedMembers map[*TestContainer]string // first double-Reset reason per member
 )
 
 // infraMemberThreshold is how many distinct pool members must double-fail

--- a/tests/integration/rail_exits_test.go
+++ b/tests/integration/rail_exits_test.go
@@ -1,0 +1,223 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type promoteJSON struct {
+	ID                  string `json:"id"`
+	Type                string `json:"type"`
+	Target              string `json:"target"`
+	From                string `json:"from"`
+	To                  string `json:"to"`
+	Committed           bool   `json:"committed"`
+	ReleasedPriorityKey string `json:"released_priority_key"`
+	ClearedCurrent      bool   `json:"cleared_current"`
+	ReleasedLinks       []struct {
+		ID        string `json:"id"`
+		ScopePath string `json:"scope_path"`
+	} `json:"released_links"`
+}
+
+func runPromoteJSON(t *testing.T, tc *TestContainer, cwd string, args ...string) promoteJSON {
+	t.Helper()
+	out, err := tc.RunCampInDir(cwd, append([]string{"workitem", "promote", "--json"}, args...)...)
+	require.NoError(t, err, "promote --json: %s", out)
+	var p promoteJSON
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &p), "must parse: %s", out)
+	return p
+}
+
+var datedResident = regexp.MustCompile(`^festivals/\.dungeon/[a-z]+/\d{4}-\d{2}-\d{2}/[a-z-]+$`)
+
+// A resident completes into the festival-local dungeon, dated, for each status.
+func TestRailExit_ResidentCompletesIntoFestivalDungeon(t *testing.T) {
+	for _, status := range []string{"completed", "archived", "someday"} {
+		t.Run(status, func(t *testing.T) {
+			tc := GetSharedContainer(t)
+			path := setupRailCampaign(t, tc, "exit-complete-"+status)
+			railTo(t, tc, path+"/workflow/design/rail-feature", "active")
+
+			res := runPromoteJSON(t, tc, path+"/festivals/active/rail-feature", "--target", status)
+			assert.Equal(t, "festivals/active/rail-feature", res.From)
+			assert.Regexp(t, datedResident, res.To, "must land in a dated festival-local bucket")
+			assert.Contains(t, res.To, "festivals/.dungeon/"+status+"/")
+			assert.True(t, res.Committed, "completion should auto-commit")
+
+			exists, err := tc.CheckDirExists(path + "/" + res.To)
+			require.NoError(t, err)
+			assert.True(t, exists, "destination %s should exist", res.To)
+
+			exists, err = tc.CheckDirExists(path + "/festivals/active/rail-feature")
+			require.NoError(t, err)
+			assert.False(t, exists, "resident should have left the stage")
+
+			// It must not have gone to the workflow type's dungeon.
+			strayed, _, err := tc.ExecCommand("sh", "-c",
+				"find "+path+"/workflow/design/dungeon -type d -name rail-feature 2>/dev/null | head -1")
+			require.NoError(t, err)
+			assert.Empty(t, strings.TrimSpace(strayed), "resident must not land in the workflow dungeon")
+
+			audit, err := tc.ReadFile(path + "/.campaign/workitems/.workitems.jsonl")
+			require.NoError(t, err)
+			assert.Contains(t, audit, res.To, "audit event should record the destination")
+
+			status, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git status --porcelain")
+			require.NoError(t, err)
+			assert.Empty(t, strings.TrimSpace(status), "tree should be clean after the auto-commit")
+		})
+	}
+}
+
+// Shelving releases path-keyed state rather than re-homing it, because it ends
+// the workitem's active life. The task text expected "follows into the dungeon";
+// see results/resident-local-dungeon-completion.md for why release is correct.
+func TestRailExit_CompletionReleasesPathState(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRailCampaign(t, tc, "exit-release-state")
+	railTo(t, tc, path+"/workflow/design/rail-feature", "active")
+
+	_, _, err := tc.ExecCommand("sh", "-c", "mkdir -p "+path+"/projects/worktrees/demo")
+	require.NoError(t, err)
+	out, err := tc.RunCampInDir(path, "workitem", "link", "design-rail-feature-fixed",
+		"projects/worktrees/demo", "--role", "primary")
+	require.NoError(t, err, "link: %s", out)
+	out, err = tc.RunCampInDir(path, "workitem", "priority", "design-rail-feature-fixed", "high")
+	require.NoError(t, err, "priority: %s", out)
+	out, err = tc.RunCampInDir(path, "workitem", "current", "design-rail-feature-fixed")
+	require.NoError(t, err, "current: %s", out)
+
+	before, err := tc.ReadFile(path + "/.campaign/settings/workitems.json")
+	require.NoError(t, err)
+	require.Contains(t, before, "design:festivals/active/rail-feature")
+
+	res := runPromoteJSON(t, tc, path+"/festivals/active/rail-feature", "--target", "completed")
+
+	assert.Equal(t, "design:festivals/active/rail-feature", res.ReleasedPriorityKey,
+		"the stranded priority key should be reported, not silently dropped")
+	assert.True(t, res.ClearedCurrent, "a current pointer at a shelved item must be cleared")
+	assert.NotEmpty(t, res.ReleasedLinks, "links should be released on shelve")
+
+	links, err := tc.ReadFile(path + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.NotContains(t, links, "design:festivals/active/rail-feature")
+
+	// Both stores are removed once empty; either absent or without the old key.
+	prio, err := tc.ReadFile(path + "/.campaign/settings/workitems.json")
+	if err == nil {
+		assert.NotContains(t, prio, "design:festivals/active/rail-feature",
+			"priority entry should not survive the shelve")
+	}
+}
+
+func TestRailExit_DemoteReturnsHome(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRailCampaign(t, tc, "exit-demote")
+	railTo(t, tc, path+"/workflow/design/rail-feature", "active")
+
+	out, err := tc.RunCampInDir(path+"/festivals/active/rail-feature", "workitem", "demote", "--json")
+	require.NoError(t, err, "demote: %s", out)
+	var res promoteJSON
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(out)), &res), "must parse: %s", out)
+
+	assert.Equal(t, "festivals/active/rail-feature", res.From)
+	assert.Equal(t, "workflow/design/rail-feature", res.To)
+	assert.Equal(t, "home", res.Target, "the event stream must distinguish a demote")
+	assert.True(t, res.Committed)
+
+	exists, err := tc.CheckFileExists(path + "/workflow/design/rail-feature/.workitem")
+	require.NoError(t, err)
+	assert.True(t, exists, "marker should travel home")
+
+	exists, err = tc.CheckDirExists(path + "/festivals/active/rail-feature")
+	require.NoError(t, err)
+	assert.False(t, exists, "resident should have left the stage")
+
+	gitStatus, _, err := tc.ExecCommand("sh", "-c", "cd "+path+" && git status --porcelain")
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(gitStatus), "demote should auto-commit")
+}
+
+// Unlike a shelve, a demote re-homes path-keyed state, because the workitem stays
+// active.
+func TestRailExit_DemoteRehomesPathState(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupRailCampaign(t, tc, "exit-demote-state")
+	railTo(t, tc, path+"/workflow/design/rail-feature", "active")
+
+	out, err := tc.RunCampInDir(path, "workitem", "priority", "design-rail-feature-fixed", "high")
+	require.NoError(t, err, "priority: %s", out)
+
+	out, err = tc.RunCampInDir(path+"/festivals/active/rail-feature", "workitem", "demote")
+	require.NoError(t, err, "demote: %s", out)
+
+	prio, err := tc.ReadFile(path + "/.campaign/settings/workitems.json")
+	require.NoError(t, err)
+	assert.Contains(t, prio, "design:workflow/design/rail-feature", "priority should follow it home")
+	assert.NotContains(t, prio, "design:festivals/active/rail-feature", "old key must not survive")
+}
+
+func TestRailExit_DemoteRejections(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, tc *TestContainer, path string) string
+		wantErr string
+	}{
+		{
+			name: "from a workflow source",
+			setup: func(t *testing.T, tc *TestContainer, path string) string {
+				return path + "/workflow/design/rail-feature"
+			},
+			wantErr: "already at its type root",
+		},
+		{
+			name: "from a dungeon",
+			setup: func(t *testing.T, tc *TestContainer, path string) string {
+				out, err := tc.RunCampInDir(path+"/workflow/design/rail-feature",
+					"workitem", "promote", "--target", "completed")
+				require.NoError(t, err, "shelve: %s", out)
+				found, _, ferr := tc.ExecCommand("sh", "-c",
+					"find "+path+"/workflow/design/dungeon -type d -name rail-feature | head -1")
+				require.NoError(t, ferr)
+				return strings.TrimSpace(found)
+			},
+			wantErr: "restoring a shelved workitem is not a demote",
+		},
+		{
+			name: "destination occupied",
+			setup: func(t *testing.T, tc *TestContainer, path string) string {
+				railTo(t, tc, path+"/workflow/design/rail-feature", "ready")
+				require.NoError(t, tc.WriteFile(path+"/workflow/design/rail-feature/README.md", "# Occupant\n"))
+				return path + "/festivals/ready/rail-feature"
+			},
+			wantErr: "already exists",
+		},
+	}
+
+	for _, tc2 := range tests {
+		t.Run(tc2.name, func(t *testing.T) {
+			tc := GetSharedContainer(t)
+			path := setupRailCampaign(t, tc, "exit-reject-"+strings.ReplaceAll(tc2.name, " ", "-"))
+			src := tc2.setup(t, tc, path)
+			require.NotEmpty(t, src)
+
+			_, stderr, exitCode, err := tc.RunCampSplitInDir(src, "workitem", "demote")
+			require.NoError(t, err)
+			assert.NotZero(t, exitCode, "a refused demote must exit non-zero")
+			assert.Contains(t, stderr, tc2.wantErr)
+
+			exists, cerr := tc.CheckDirExists(src)
+			require.NoError(t, cerr)
+			assert.True(t, exists, "a refused demote must leave the source in place")
+		})
+	}
+}

--- a/tests/integration/workflow_atomic_writes_test.go
+++ b/tests/integration/workflow_atomic_writes_test.go
@@ -78,4 +78,3 @@ func TestIntegration_WorkflowConfigSaveAtomic_ENOSPC(t *testing.T) {
 	assert.Equal(t, "0", strings.TrimSpace(leftovers),
 		"atomic write must clean up tmp file on rename failure; found leftover tmp files: %s", leftovers)
 }
-


### PR DESCRIPTION
WF0001 phase 003, sequence 04. The two ways a resident leaves the rail: completion into the festival-local dungeon, and demote back to its type root. Plus two doctor checks for the states the rail can leave behind.

**Stack base:** `fest/wf0001-p3s3-discovery-residents` (PR #524). Merge #524 first.

## Completion needed no code, but exposed an older gap

Verified before writing anything: `promote --target completed` on a resident already lands in the right place, because `MoveToDungeon` builds its service from `loc.DungeonPath` and sequence 02's resolver already points that at the festival tree.

```
from: festivals/active/thing
to:   festivals/.dungeon/completed/2026-07-29/thing
```

There is also **no separate phase-001 local-dungeon rule** to reconcile. Searched for one; `loc.DungeonPath` is the single mechanism.

What *was* broken predates the rail. Seeding a priority, a current pointer, and a link on a workitem and then shelving it left:

| Store | After shelve (before this PR) | |
|-------|------|---|
| links | released | correct, #503 |
| priority | **unchanged, keyed on the pre-move path** | orphaned |
| current | **unchanged, aimed at an invisible item** | stale |

The priority entry is keyed on the path, so nothing resolves it after the move and only a later `Prune` reaches it. The current pointer is stored by stable id so it survives any move by design, but pointing at a *shelved* item is the same silent failure #503 fixed for links: the selector cannot see dungeon items, so `camp p commit` quietly stops stamping the ref.

**Released, not re-keyed.** The task text said to re-home this state "matching the rail-move fixups". That predates #503 and contradicts it: a rail move re-homes because the item stays active, whereas a shelve *ends* its active life. A priority re-keyed onto a dungeon path would preserve state no surface reads. So `releasePathStateForShelvedSource` sits next to `releaseLinksForShelvedSource`, and both report rather than acting silently (`released_priority_key`, `cleared_current`).

This fixes every dungeon move, not just residents.

## `camp workitem demote`, not `promote --target home`

Doc 06 item 2 deferred the verb shape to phase 3. Chose a dedicated verb: every other promote target moves a workitem *forward*, so `home` would be the one target that inverts the verb, and it would have to sit inside the forward-only switch where it is the exception.

The duplication that argument was weighed against turned out to be thin, because the extraction was overdue anyway. `doRailPromote` had the move inlined and `runWorkitemPromote` had a 45-line tail inlined — both one copy-paste from drifting. Now:

- `applyWorkitemMove` — move + reference repair
- `finishWorkitemMove` — audit, ledger, commit, nav invalidation, output

Promote and demote both route through them, so they cannot diverge on how a move commits or what event it emits. `promote.go` is smaller than before despite gaining the shelve-release work.

Home is `workflow/<marker.type>/<slug>`: the marker stores a type, not an original path, which is sufficient because the type root is implied-active. Allowed only from `ready`/`active`; a dungeon source is a restore, a `workflow/` source is already home, and collisions are refused with the same `Lstat` guard rail entry uses. Audit/ledger `target` is `home` so the event stream distinguishes it.

Demote **re-homes** path-keyed state, the deliberate mirror of shelve releasing it.

## Doctor checks

`workitem.resident.unstamped` — a directory on a rail stage that is neither stamped nor a festival. `workitem.resident.missing-home` — a resident whose `workflow/<type>/` is gone, so demote has nowhere to land.

Both warnings, neither auto-fixable, and that is tested: camp cannot guess a type or invent a type root. The two read from different sources by necessity — an unstamped directory is never emitted as a resident, so it has to be found by scanning disk. `isFestivalDir` stats the marker names locally rather than importing fest.

## Verification

Every behavior driven against a real binary in throwaway fixtures. Full transcripts in the festival results docs; the demote run shows the directory back at the type root with the markdown cross-reference, link key, and priority key all re-homed, and all four rejection cases erroring with the source intact.

12 new integration tests (7 rail exits, 2 doctor, and the 3 from earlier sequences re-run together), 16 new unit tests.

`just gate` PASSED. `golangci-lint --new-from-merge-base origin/main` 0 issues.

```
$ go test -tags=integration ./tests/integration/ \
    -run "TestRailExit|TestDoctorResidents|TestPromoteRail|TestWorkitemJSON"
ok  	github.com/Obedience-Corp/camp/tests/integration	105.957s
```

## One requirement deliberately not met as written

The testing task asked to assert links/priority "follow a resident into the dungeon". They do not, for the reason above. The tests assert release on shelve and re-home on demote, in the same file, because the pair is what makes the policy legible.
