### PR TITLE
docs(help,dungeon): document the rail and surface workitem types in triage (WF0001 P5/S2)

### DIFF
--- a/cmd/camp/dungeon/list.go
+++ b/cmd/camp/dungeon/list.go
@@ -165,20 +165,24 @@ func outputDungeonSimple(items []intdungeon.DungeonItem) error {
 }
 
 func outputDungeonJSON(items []intdungeon.DungeonItem) error {
+	// This remaps rather than marshalling DungeonItem directly, so a new field on
+	// that struct does not reach --json until it is added here too.
 	type jsonItem struct {
-		Name    string `json:"name"`
-		Path    string `json:"path"`
-		Type    string `json:"type"`
-		ModTime string `json:"mod_time"`
+		Name         string `json:"name"`
+		Path         string `json:"path"`
+		Type         string `json:"type"`
+		ModTime      string `json:"mod_time"`
+		WorkitemType string `json:"workitem_type,omitempty"`
 	}
 
 	output := make([]jsonItem, 0, len(items))
 	for _, item := range items {
 		output = append(output, jsonItem{
-			Name:    item.Name,
-			Path:    item.Path,
-			Type:    string(item.Type),
-			ModTime: item.ModTime.Format(time.RFC3339),
+			Name:         item.Name,
+			Path:         item.Path,
+			Type:         string(item.Type),
+			ModTime:      item.ModTime.Format(time.RFC3339),
+			WorkitemType: item.WorkitemType,
 		})
 	}
 

--- a/cmd/camp/dungeon/list_test.go
+++ b/cmd/camp/dungeon/list_test.go
@@ -1,6 +1,13 @@
 package dungeon
 
-import "testing"
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	intdungeon "github.com/Obedience-Corp/camp/internal/dungeon"
+)
 
 func TestBuildDungeonListContextLine(t *testing.T) {
 	tests := []struct {
@@ -71,4 +78,57 @@ func TestDungeonListJSONAliasRegistered(t *testing.T) {
 	if dungeonListCmd.Flags().Lookup("json") == nil {
 		t.Fatal("camp dungeon list missing --json alias")
 	}
+}
+
+// outputDungeonJSON remaps into a local struct, so a field added to DungeonItem
+// does not reach --json on its own. This locks the mapping.
+func TestOutputDungeonJSON_IncludesWorkitemType(t *testing.T) {
+	items := []intdungeon.DungeonItem{
+		{Name: "resident", Path: "/c/workflow/design/resident", Type: intdungeon.ItemTypeDirectory, WorkitemType: "design"},
+		{Name: "plaindir", Path: "/c/workflow/design/plaindir", Type: intdungeon.ItemTypeDirectory},
+		{Name: "loose.md", Path: "/c/workflow/design/loose.md", Type: intdungeon.ItemTypeFile},
+	}
+
+	out := captureDungeonStdout(t, func() {
+		if err := outputDungeonJSON(items); err != nil {
+			t.Fatalf("outputDungeonJSON: %v", err)
+		}
+	})
+
+	var decoded []map[string]any
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, out)
+	}
+	if len(decoded) != 3 {
+		t.Fatalf("want 3 items, got %d", len(decoded))
+	}
+	if got := decoded[0]["workitem_type"]; got != "design" {
+		t.Errorf("resident workitem_type = %v, want design", got)
+	}
+	// omitempty: absent, not empty-string, for non-workitems.
+	if _, ok := decoded[1]["workitem_type"]; ok {
+		t.Error("plain directory must not carry workitem_type")
+	}
+	if _, ok := decoded[2]["workitem_type"]; ok {
+		t.Error("file must not carry workitem_type")
+	}
+}
+
+func captureDungeonStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
 }

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -1313,6 +1313,21 @@ follow-up command workflows (install, build, bootstrap, ...) to run once the
 cycle succeeds. Manage those with 'camp fresh configure'. Inspect the resolved
 sequence with 'camp fresh show-workflow [project-name]'.
 
+WORKITEM COMPLETION
+
+Two fresh.yaml settings decide what happens to workitems whose work looks done:
+
+  completed_runs     Tier 1, once per run, campaign-root scoped. "sweep"
+                     (default) promotes every workitem whose workflow run
+                     completed, "report" prints a read-only banner, "off" skips
+                     it. This is the same sweep 'camp workitem sweep' performs.
+  merged_workitems   Tier 2, per project. A workitem whose branch merged is
+                     inferred evidence, so it never auto-promotes: "prompt"
+                     asks on a TTY and reports otherwise, "report" prints the
+                     exact promote commands to run, "off" skips it.
+
+Both are configured in fresh.yaml, not by flags. See 'camp fresh configure'.
+
 Examples:
   camp fresh                            # Sync current project (checkout default, fetch, prune)
   camp fresh --branch develop           # Sync and create develop branch
@@ -8063,7 +8078,12 @@ TARGETS:
 
 The rail is forward-only: root -> ready -> active. A workitem already on a
 stage cannot move backward, and moving one out of a dungeon is a restore
-rather than a promote.
+rather than a promote. To leave the rail entirely, use 'camp workitem demote',
+which returns the workitem to its original workflow type root.
+
+A workitem on the rail keeps its original type: a design item promoted to
+active is still a design item, now living at festivals/active/<slug>, and
+'camp wi --type design' still finds it.
 
 ```
 camp workitem promote [id] --target <target> [flags]

--- a/docs/cli-reference/camp_fresh.md
+++ b/docs/cli-reference/camp_fresh.md
@@ -20,6 +20,21 @@ follow-up command workflows (install, build, bootstrap, ...) to run once the
 cycle succeeds. Manage those with 'camp fresh configure'. Inspect the resolved
 sequence with 'camp fresh show-workflow [project-name]'.
 
+WORKITEM COMPLETION
+
+Two fresh.yaml settings decide what happens to workitems whose work looks done:
+
+  completed_runs     Tier 1, once per run, campaign-root scoped. "sweep"
+                     (default) promotes every workitem whose workflow run
+                     completed, "report" prints a read-only banner, "off" skips
+                     it. This is the same sweep 'camp workitem sweep' performs.
+  merged_workitems   Tier 2, per project. A workitem whose branch merged is
+                     inferred evidence, so it never auto-promotes: "prompt"
+                     asks on a TTY and reports otherwise, "report" prints the
+                     exact promote commands to run, "off" skips it.
+
+Both are configured in fresh.yaml, not by flags. See 'camp fresh configure'.
+
 Examples:
   camp fresh                            # Sync current project (checkout default, fetch, prune)
   camp fresh --branch develop           # Sync and create develop branch

--- a/docs/cli-reference/camp_workitem_promote.md
+++ b/docs/cli-reference/camp_workitem_promote.md
@@ -17,7 +17,12 @@ TARGETS:
 
 The rail is forward-only: root -> ready -> active. A workitem already on a
 stage cannot move backward, and moving one out of a dungeon is a restore
-rather than a promote.
+rather than a promote. To leave the rail entirely, use 'camp workitem demote',
+which returns the workitem to its original workflow type root.
+
+A workitem on the rail keeps its original type: a design item promoted to
+active is still a design item, now living at festivals/active/<slug>, and
+'camp wi --type design' still finds it.
 
 ```
 camp workitem promote [id] --target <target> [flags]

--- a/internal/commands/fresh/fresh.go
+++ b/internal/commands/fresh/fresh.go
@@ -61,6 +61,21 @@ follow-up command workflows (install, build, bootstrap, ...) to run once the
 cycle succeeds. Manage those with 'camp fresh configure'. Inspect the resolved
 sequence with 'camp fresh show-workflow [project-name]'.
 
+WORKITEM COMPLETION
+
+Two fresh.yaml settings decide what happens to workitems whose work looks done:
+
+  completed_runs     Tier 1, once per run, campaign-root scoped. "sweep"
+                     (default) promotes every workitem whose workflow run
+                     completed, "report" prints a read-only banner, "off" skips
+                     it. This is the same sweep 'camp workitem sweep' performs.
+  merged_workitems   Tier 2, per project. A workitem whose branch merged is
+                     inferred evidence, so it never auto-promotes: "prompt"
+                     asks on a TTY and reports otherwise, "report" prints the
+                     exact promote commands to run, "off" skips it.
+
+Both are configured in fresh.yaml, not by flags. See 'camp fresh configure'.
+
 Examples:
   camp fresh                            # Sync current project (checkout default, fetch, prune)
   camp fresh --branch develop           # Sync and create develop branch

--- a/internal/commands/workitem/promote.go
+++ b/internal/commands/workitem/promote.go
@@ -106,7 +106,12 @@ TARGETS:
 
 The rail is forward-only: root -> ready -> active. A workitem already on a
 stage cannot move backward, and moving one out of a dungeon is a restore
-rather than a promote.`,
+rather than a promote. To leave the rail entirely, use 'camp workitem demote',
+which returns the workitem to its original workflow type root.
+
+A workitem on the rail keeps its original type: a design item promoted to
+active is still a design item, now living at festivals/active/<slug>, and
+'camp wi --type design' still finds it.`,
 		Args: cobra.RangeArgs(0, 1),
 		Annotations: map[string]string{
 			"agent_allowed": "true",

--- a/internal/dungeon/crawl.go
+++ b/internal/dungeon/crawl.go
@@ -162,7 +162,13 @@ func runCrawlWithPrompt(ctx context.Context, svc *Service, prompt crawl.Prompt) 
 
 // buildInfoString creates a human-readable info string for display.
 func buildInfoString(item DungeonItem, stats *ItemStats) string {
-	info := fmt.Sprintf("Type: %s | Modified: %s", item.Type, item.ModTime.Format("2006-01-02"))
+	// The workitem type goes in parens beside the generic label rather than
+	// replacing it, so a plain directory's line is unchanged.
+	typeLabel := string(item.Type)
+	if item.WorkitemType != "" {
+		typeLabel = fmt.Sprintf("%s (%s)", item.Type, item.WorkitemType)
+	}
+	info := fmt.Sprintf("Type: %s | Modified: %s", typeLabel, item.ModTime.Format("2006-01-02"))
 
 	if stats != nil {
 		if stats.Files > 0 {

--- a/internal/dungeon/service_list.go
+++ b/internal/dungeon/service_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -12,6 +13,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/dungeon/statuspath"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/workflow"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 )
 
 // ListStatusDirs scans the dungeon for all subdirectories, counts items in each
@@ -142,11 +144,13 @@ func (s *Service) ListParentItems(ctx context.Context, parentPath string) ([]Dun
 			itemType = ItemTypeDirectory
 		}
 
+		itemPath := filepath.Join(parentPath, name)
 		items = append(items, DungeonItem{
-			Name:    name,
-			Path:    filepath.Join(parentPath, name),
-			Type:    itemType,
-			ModTime: info.ModTime(),
+			Name:         name,
+			Path:         itemPath,
+			Type:         itemType,
+			ModTime:      info.ModTime(),
+			WorkitemType: workitemTypeOf(ctx, itemPath, entry.IsDir()),
 		})
 	}
 
@@ -242,4 +246,24 @@ func (e parentItemExcluder) excludes(parentPath, name string, isDir bool) bool {
 	}
 
 	return false
+}
+
+// workitemTypeOf reads the workflow type from a directory's .workitem marker.
+// Best-effort: an absent marker is the common case, and an unreadable one leaves
+// the field empty rather than failing the listing, matching how the rest of this
+// package treats markers.
+func workitemTypeOf(ctx context.Context, path string, isDir bool) string {
+	if !isDir {
+		return ""
+	}
+	meta, err := wkitem.LoadMetadata(ctx, path)
+	if err != nil {
+		slog.Default().Warn("unreadable workitem marker during triage",
+			"path", path, "error", err.Error())
+		return ""
+	}
+	if meta == nil {
+		return ""
+	}
+	return meta.Type
 }

--- a/internal/dungeon/triage_workitem_test.go
+++ b/internal/dungeon/triage_workitem_test.go
@@ -1,0 +1,101 @@
+package dungeon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeMarker(t *testing.T, dir, wfType string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "version: v1alpha8\nkind: workitem\nid: " + wfType + "-thing-1\ntype: " + wfType + "\ntitle: Thing\n"
+	if err := os.WriteFile(filepath.Join(dir, ".workitem"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func itemsByName(items []DungeonItem) map[string]DungeonItem {
+	out := make(map[string]DungeonItem, len(items))
+	for _, it := range items {
+		out[it.Name] = it
+	}
+	return out
+}
+
+// Triage over a parent shows a directory workitem's real type. A plain directory
+// and a loose file must be untouched, since the field is additive.
+func TestListParentItems_PopulatesWorkitemType(t *testing.T) {
+	parent := t.TempDir()
+	writeMarker(t, filepath.Join(parent, "resident"), "design")
+	if err := os.MkdirAll(filepath.Join(parent, "plaindir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, "loose.md"), []byte("# x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewService(parent, filepath.Join(parent, "dungeon"))
+	items, err := svc.ListParentItems(context.Background(), parent)
+	if err != nil {
+		t.Fatalf("ListParentItems: %v", err)
+	}
+	got := itemsByName(items)
+
+	res, ok := got["resident"]
+	if !ok {
+		t.Fatalf("resident not listed: %+v", items)
+	}
+	if res.WorkitemType != "design" {
+		t.Errorf("WorkitemType = %q, want design", res.WorkitemType)
+	}
+	if res.Type != ItemTypeDirectory {
+		t.Errorf("Type = %q, want directory: the generic label must not be replaced", res.Type)
+	}
+
+	if plain, ok := got["plaindir"]; ok && plain.WorkitemType != "" {
+		t.Errorf("plain directory got WorkitemType %q, want empty", plain.WorkitemType)
+	}
+	if loose, ok := got["loose.md"]; ok && loose.WorkitemType != "" {
+		t.Errorf("file got WorkitemType %q, want empty", loose.WorkitemType)
+	}
+}
+
+// An unreadable marker must not fail the listing.
+func TestListParentItems_UnreadableMarkerIsNotFatal(t *testing.T) {
+	parent := t.TempDir()
+	broken := filepath.Join(parent, "broken")
+	if err := os.MkdirAll(broken, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(broken, ".workitem"), []byte("kind: workitem\n\tbad: [\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewService(parent, filepath.Join(parent, "dungeon"))
+	items, err := svc.ListParentItems(context.Background(), parent)
+	if err != nil {
+		t.Fatalf("an unreadable marker must not fail the listing: %v", err)
+	}
+	if item, ok := itemsByName(items)["broken"]; !ok {
+		t.Error("directory with a broken marker should still be listed")
+	} else if item.WorkitemType != "" {
+		t.Errorf("WorkitemType = %q, want empty for an unreadable marker", item.WorkitemType)
+	}
+}
+
+func TestBuildInfoString_WorkitemType(t *testing.T) {
+	plain := DungeonItem{Name: "d", Type: ItemTypeDirectory}
+	if got := buildInfoString(plain, nil); got[:16] != "Type: directory " {
+		t.Errorf("plain directory line changed: %q", got)
+	}
+
+	resident := DungeonItem{Name: "d", Type: ItemTypeDirectory, WorkitemType: "design"}
+	got := buildInfoString(resident, nil)
+	if want := "Type: directory (design) | Modified: "; got[:len(want)] != want {
+		t.Errorf("got %q, want prefix %q", got, want)
+	}
+}

--- a/internal/dungeon/types.go
+++ b/internal/dungeon/types.go
@@ -34,6 +34,10 @@ type DungeonItem struct {
 	Path    string    `json:"path"`
 	Type    ItemType  `json:"type"`
 	ModTime time.Time `json:"mod_time"`
+	// WorkitemType is the workflow type from the directory's .workitem marker,
+	// empty when it carries none. Populated by parent triage so a directory
+	// workitem shows what it is instead of a bare "directory".
+	WorkitemType string `json:"workitem_type,omitempty"`
 }
 
 // ItemStats contains statistics gathered from scc or fest count.

--- a/tests/integration/dungeon_triage_workitem_test.go
+++ b/tests/integration/dungeon_triage_workitem_test.go
@@ -1,0 +1,105 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type triageItem struct {
+	Name         string `json:"name"`
+	Type         string `json:"type"`
+	WorkitemType string `json:"workitem_type"`
+}
+
+func triageJSON(t *testing.T, tc *TestContainer, dir string) map[string]triageItem {
+	t.Helper()
+	out, err := tc.RunCampInDir(dir, "dungeon", "list", "--triage", "--json")
+	require.NoError(t, err, "triage list: %s", out)
+
+	start := strings.Index(out, "[")
+	require.GreaterOrEqual(t, start, 0, "no JSON array in output: %s", out)
+	var items []triageItem
+	require.NoError(t, json.Unmarshal([]byte(out[start:]), &items), "must parse: %s", out)
+
+	byName := make(map[string]triageItem, len(items))
+	for _, it := range items {
+		byName[it.Name] = it
+	}
+	return byName
+}
+
+func writeWorkitemDir(t *testing.T, tc *TestContainer, dir, wfType, slug string) {
+	t.Helper()
+	body := "version: v1alpha8\nkind: workitem\nid: " + wfType + "-" + slug + "-1\n" +
+		"type: " + wfType + "\ntitle: " + slug + "\nref: WI-aaaaaa\n"
+	require.NoError(t, tc.WriteFile(dir+"/.workitem", body))
+	require.NoError(t, tc.WriteFile(dir+"/README.md", "# "+slug+"\n"))
+}
+
+// Triage never reaches festivals/. The excluder lists "festivals" by name
+// (internal/dungeon/service_list.go), and `camp dungeon add` from inside festivals/
+// resolves the campaign-root dungeon rather than creating one there, so the parent
+// under triage is the campaign root, where festivals/ is excluded outright.
+//
+// This extends the discrepancy recorded in task 02: doc 04 asks for resident
+// awareness "in the inner crawl of festivals/.dungeon/", and neither that crawl nor
+// a triage view over festivals/ exists. Type-local triage is the one real surface,
+// covered by the next test.
+func TestDungeonTriage_FestivalsIsNotATriageParent(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupDungeonCampaign(t, tc, "triage-wi-festivals")
+
+	writeWorkitemDir(t, tc, path+"/festivals/marked", "design", "marked")
+	require.NoError(t, tc.WriteFile(path+"/festivals/plaindir/NOTES.md", "# nothing\n"))
+
+	out, err := tc.RunCampInDir(path+"/festivals", "dungeon", "list", "--triage")
+	require.NoError(t, err, "triage list: %s", out)
+	assert.Contains(t, out, "No parent items eligible for triage",
+		"festivals/ is excluded from triage, so nothing under it is a candidate")
+
+	got := triageJSON(t, tc, path+"/festivals")
+	assert.Empty(t, got, "no triage candidates resolve from festivals/: %+v", got)
+}
+
+// The same field appears in a type-local triage context, because ListParentItems is
+// shared. Recorded as a deliberate consequence rather than special-cased by path.
+func TestDungeonTriage_WorkitemTypeInTypeLocalParent(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupDungeonCampaign(t, tc, "triage-wi-typelocal")
+
+	out, err := tc.RunCampInDir(path, "workitem", "create", "real-design",
+		"--type", "design", "--title", "Real Design", "--id", "design-real-design-fixed")
+	require.NoError(t, err, "workitem create: %s", out)
+	require.NoError(t, tc.WriteFile(path+"/workflow/design/plaindir/NOTES.md", "# nothing\n"))
+
+	got := triageJSON(t, tc, path+"/workflow/design")
+
+	item, ok := got["real-design"]
+	require.True(t, ok, "design workitem missing: %+v", got)
+	assert.Equal(t, "design", item.WorkitemType)
+
+	plain, ok := got["plaindir"]
+	require.True(t, ok, "plain directory missing: %+v", got)
+	assert.Empty(t, plain.WorkitemType)
+}
+
+// A file must never carry the field, and its row is otherwise unchanged.
+func TestDungeonTriage_FilesUnaffected(t *testing.T) {
+	tc := GetSharedContainer(t)
+	path := setupDungeonCampaign(t, tc, "triage-wi-files")
+
+	require.NoError(t, tc.WriteFile(path+"/workflow/design/loose.md", "# loose\n"))
+
+	got := triageJSON(t, tc, path+"/workflow/design")
+	loose, ok := got["loose.md"]
+	require.True(t, ok, "loose file missing: %+v", got)
+	assert.Equal(t, "file", loose.Type)
+	assert.Empty(t, loose.WorkitemType)
+}


### PR DESCRIPTION
WF0001 phase 005, sequence 02 (camp half). Documentation plus dungeon triage resident awareness. Base `main`.

The fest half is [fest#312](https://github.com/Obedience-Corp/fest/pull/312) — independent, either can merge first.

## Help text

`camp fresh --help` gains a `WORKITEM COMPLETION` section. The two settings that decide what happens to finished workitems were only discoverable by reading `settings.go`:

```
  completed_runs     Tier 1, once per run, campaign-root scoped. "sweep"
                     (default) promotes every workitem whose workflow run
                     completed, "report" prints a read-only banner, "off" skips
                     it. This is the same sweep 'camp workitem sweep' performs.
  merged_workitems   Tier 2, per project. A workitem whose branch merged is
                     inferred evidence, so it never auto-promotes: "prompt"
                     asks on a TTY and reports otherwise, "report" prints the
                     exact promote commands to run, "off" skips it.
```

Values and the "inferred evidence never auto-promotes" rule come from the doc comments at `settings.go:214-224`, verified rather than assumed.

`camp workitem promote --help` already listed `ready`/`active` from phase 3. Added the two things it lacked: `camp workitem demote` as the way off the rail, and the property that makes the rail safe to adopt — a workitem on a stage keeps its original type, so `camp wi --type design` still finds it.

## Dungeon triage shows a workitem's type

`DungeonItem.WorkitemType` is populated during parent triage from camp's own `.workitem` marker, and rendered beside the generic label rather than replacing it, so a non-workitem directory's line is byte-identical:

```
Type: directory (design) | Modified: 2026-07-30
```

**A gap the unit tests did not catch:** `outputDungeonJSON` remaps into a *local* struct, so a field added to `DungeonItem` never reaches `--json`. The unit tests passed while the real command still omitted it; only running the binary surfaced that. Fixed, commented at the struct so the next person sees why, and locked with a test.

`ListParentItems` is shared, so type-local triage (`workflow/design/`) gains the same field. Every directory workitem already carries a marker, so scoping this to `festivals/` would mean special-casing by path. Recorded deliberately.

## Two discrepancies with doc 04, both recorded rather than papered over

Doc 04 asks that "the inner crawl of `festivals/.dungeon/` present residents correctly when reviewing." Tracing current source shows **no such surface exists**:

1. `ListItems` skips every subdirectory (`service_list.go:75-79`), so the crawl never walks the dated status buckets where a completed resident lands. `Discover()` also excludes anything under a `dungeon/` segment, so completed items never resurface in `camp wi` either.
2. Triage does not reach `festivals/` either: the excluder lists `"festivals"` by name (`service_list.go:181`), and `camp dungeon add` from inside it resolves the campaign-root dungeon rather than creating one there. Real output from the fixture:

```
triage context from festivals/: No parent items eligible for triage (context: dungeon).
```

So type-local triage is the one real resident-touching surface, and that is where this lands. If a future phase adds a genuine "browse the completed bucket" command, that command is the one that should consume `WorkitemType`.

The integration test for the festivals case asserts this actual behavior rather than forcing a fixture onto a path that does not exist.

## Docs regen isolated

Two commits: help-text edits, then `docs: regenerate CLI reference` containing only `docs/cli-reference/*` (verified with `git show --stat`), per the campaign's rule that a regen must never hide unrelated drift inside a feature diff.

## Gate

`just gate` PASSED. Integration: `go test -tags=integration -run TestDungeonTriage_` ok.
