### PR TITLE
feat(commit): report staged size findings when a commit skips staging

### DIFF
--- a/cmd/camp/cmdutil/stagedreport.go
+++ b/cmd/camp/cmdutil/stagedreport.go
@@ -88,9 +88,19 @@ func stagedGrowth(
 // It names the cause for the same reason GuardUnavailableLine does: the
 // realistic causes need different responses from the user, and a bare "check
 // unavailable" gives them nothing to act on.
+//
+// Every clause is in a tense that is true at the moment it prints, and none of
+// them claims a commit. This runs before the commit object is written, and the
+// flow after it can still end in "nothing to commit", a refusal over
+// pre-staged submodule refs, a deferred message writer, or a git failure.
+// GuardUnavailableLine can afford "Staged without..." because staging really
+// has happened by then; the equivalent past tense here would announce an
+// outcome camp does not yet know, which is the same wrong-by-assertion problem
+// the line exists to avoid.
 func StagedCheckUnavailableLine(cause error) string {
 	return fmt.Sprintf(
-		"Committed without the size check: %v\n"+
-			"  Large files were not checked. Run 'camp doctor -c bigfiles' if you want to look.",
+		"Could not run the size check over the staged files: %v\n"+
+			"  Large files were not checked, and camp does not stop for that.\n"+
+			"  Run 'camp doctor -c bigfiles' if you want to look.",
 		cause)
 }

--- a/cmd/camp/cmdutil/stagedreport.go
+++ b/cmd/camp/cmdutil/stagedreport.go
@@ -1,0 +1,96 @@
+package cmdutil
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/stageguard"
+	"github.com/Obedience-Corp/camp/internal/ui"
+)
+
+// What the user sees when a commit stages nothing.
+//
+// The staging guard lives at the staging chokepoint, so `camp commit
+// --all=false` over an index the user built with git add never reaches it: a
+// 13 MB PNG could enter a commit without camp saying a word. The report below
+// is the whole of the fix.
+//
+// Report-only is the design, not a first increment. Camp's commit default is
+// "commit everything without having to think about it", and a guard that
+// excluded or asked here would turn an index the user assembled deliberately
+// back into a decision point, which is what the default exists to avoid. Acting
+// on the contents would also mean reversing an explicit `git add` -- the one
+// thing the staging guard already refuses to do for hand-staged files, since it
+// excludes by staging around a path and cannot un-add what is already in.
+//
+// So the commit that follows this report is byte-for-byte the commit that would
+// have happened without it. What changes is only that the user is told.
+
+// ReportStagedGrowth writes the guard's findings for an index camp did not
+// stage, and returns them. It excludes nothing, unstages nothing, blocks
+// nothing, and prompts for nothing.
+//
+// commitLarge is the user having already answered this. The staging guard
+// suppresses detection entirely under --commit-large rather than
+// detecting-then-ignoring, and so does this, so the two agree about what the
+// flag means.
+//
+// It is fail-open, like the guard at the staging chokepoint: a repository camp
+// cannot read still commits. The cause is printed rather than swallowed,
+// because the dangerous way to degrade is the quiet one -- a user who is not
+// told assumes the check ran.
+func ReportStagedGrowth(
+	ctx context.Context,
+	out io.Writer,
+	repoPath string,
+	commitLarge bool,
+) []stageguard.GuardViolation {
+	if commitLarge {
+		return nil
+	}
+
+	violations, limits, err := stagedGrowth(ctx, repoPath)
+	if err != nil {
+		_, _ = fmt.Fprintln(out, ui.Warning(StagedCheckUnavailableLine(err)))
+		return nil
+	}
+	// Same renderer as the staging path. A user who hits this over a hand-built
+	// index and a user who hits it through `camp commit` are looking at the same
+	// situation, and must not have to notice that the wording differs.
+	for _, v := range violations {
+		renderTrackedGrowth(out, v, limits)
+	}
+	return violations
+}
+
+// stagedGrowth resolves the repository's guard policy and evaluates the index
+// against it.
+func stagedGrowth(
+	ctx context.Context, repoPath string,
+) ([]stageguard.GuardViolation, stageguard.GuardLimits, error) {
+	limits, err := stageguard.ResolveLimits(ctx, repoPath)
+	if err != nil {
+		return nil, limits, camperrors.Wrapf(err, "resolve staging guard limits for %s", repoPath)
+	}
+	violations, err := stageguard.CheckStagedIndex(ctx, repoPath, limits)
+	if err != nil {
+		return nil, limits, camperrors.Wrapf(err, "evaluate staged files in %s", repoPath)
+	}
+	stageguard.SortViolations(violations)
+	return violations, limits, nil
+}
+
+// StagedCheckUnavailableLine says the size check did not run over an index camp
+// did not stage.
+//
+// It names the cause for the same reason GuardUnavailableLine does: the
+// realistic causes need different responses from the user, and a bare "check
+// unavailable" gives them nothing to act on.
+func StagedCheckUnavailableLine(cause error) string {
+	return fmt.Sprintf(
+		"Committed without the size check: %v\n"+
+			"  Large files were not checked. Run 'camp doctor -c bigfiles' if you want to look.",
+		cause)
+}

--- a/cmd/camp/cmdutil/stagedreport_test.go
+++ b/cmd/camp/cmdutil/stagedreport_test.go
@@ -1,0 +1,56 @@
+package cmdutil
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// --commit-large is the user having already answered the question, so the pass
+// must not even ask git. A repository path that cannot be read proves it
+// returned before running anything.
+func TestReportStagedGrowthCommitLargeSuppressesEverything(t *testing.T) {
+	var out bytes.Buffer
+
+	violations := ReportStagedGrowth(context.Background(), &out, "/nonexistent/repo", true)
+
+	if len(violations) != 0 {
+		t.Errorf("ReportStagedGrowth() = %+v, want none under --commit-large", violations)
+	}
+	if out.Len() != 0 {
+		t.Errorf("output = %q, want nothing under --commit-large", out.String())
+	}
+}
+
+// Fail-open, but never quietly: a repository camp cannot read still commits,
+// and the user is told the check did not run. The silent version is the
+// dangerous one, because it leaves them believing they were checked.
+func TestReportStagedGrowthFailsOpenAndSaysSo(t *testing.T) {
+	var out bytes.Buffer
+
+	// An empty directory is not a git repository, so the diff fails the way a
+	// broken or mid-scaffold repository would.
+	violations := ReportStagedGrowth(context.Background(), &out, t.TempDir(), false)
+
+	if len(violations) != 0 {
+		t.Errorf("ReportStagedGrowth() = %+v, want none when the check cannot run", violations)
+	}
+	if !strings.Contains(out.String(), "Committed without the size check") {
+		t.Errorf("output = %q, want it to say the check did not run", out.String())
+	}
+}
+
+func TestStagedCheckUnavailableLineNamesTheCause(t *testing.T) {
+	line := StagedCheckUnavailableLine(camperrors.New("git exploded"))
+
+	if !strings.Contains(line, "git exploded") {
+		t.Errorf("line = %q, want the cause named", line)
+	}
+	// A user told only that a check was skipped has nothing to do about it.
+	if !strings.Contains(line, "camp doctor -c bigfiles") {
+		t.Errorf("line = %q, want a way to look for large files", line)
+	}
+}

--- a/cmd/camp/cmdutil/stagedreport_test.go
+++ b/cmd/camp/cmdutil/stagedreport_test.go
@@ -38,7 +38,7 @@ func TestReportStagedGrowthFailsOpenAndSaysSo(t *testing.T) {
 	if len(violations) != 0 {
 		t.Errorf("ReportStagedGrowth() = %+v, want none when the check cannot run", violations)
 	}
-	if !strings.Contains(out.String(), "Committed without the size check") {
+	if !strings.Contains(out.String(), "Could not run the size check") {
 		t.Errorf("output = %q, want it to say the check did not run", out.String())
 	}
 }
@@ -52,5 +52,20 @@ func TestStagedCheckUnavailableLineNamesTheCause(t *testing.T) {
 	// A user told only that a check was skipped has nothing to do about it.
 	if !strings.Contains(line, "camp doctor -c bigfiles") {
 		t.Errorf("line = %q, want a way to look for large files", line)
+	}
+}
+
+// The line prints before the commit object exists, and the flow after it can
+// still end in "nothing to commit", a refusal over pre-staged submodule refs, a
+// deferred message writer, or a git failure. Past tense would assert an outcome
+// camp does not know yet, which is the same wrong-by-assertion problem the line
+// exists to avoid.
+func TestStagedCheckUnavailableLineClaimsNoCommit(t *testing.T) {
+	line := StagedCheckUnavailableLine(camperrors.New("git exploded"))
+
+	for _, claim := range []string{"Committed", "committed", "Commit succeeded"} {
+		if strings.Contains(line, claim) {
+			t.Errorf("line = %q, must not claim a commit happened (found %q)", line, claim)
+		}
 	}
 }

--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -257,6 +257,11 @@ func runCommit(cmd *cobra.Command, args []string) error {
 			cmdutil.ReportNothingLeftToCommit(humanOut)
 			return commitJSONNoop(cmd, jsonResult)
 		}
+	} else {
+		// Nothing was staged here, so the guard at the staging chokepoint never
+		// ran: the index is whatever the user built with git add. Report what it
+		// holds, and only report -- the commit below is unchanged.
+		cmdutil.ReportStagedGrowth(ctx, humanOut, target.Path, commitLarge)
 	}
 
 	// Show what will be committed

--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -189,6 +189,10 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 			cmdutil.ReportNothingLeftToCommit(cmd.OutOrStdout())
 			return nil
 		}
+	} else {
+		// No staging means the guard never ran. Report what the index already
+		// holds; nothing here changes the commit.
+		cmdutil.ReportStagedGrowth(ctx, cmd.OutOrStdout(), resolvedPath, projectCommitLarge)
 	}
 
 	// Check for changes

--- a/cmd/camp/worktrees/commit.go
+++ b/cmd/camp/worktrees/commit.go
@@ -147,6 +147,10 @@ func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 			cmdutil.ReportNothingLeftToCommit(cmd.OutOrStdout())
 			return nil
 		}
+	} else {
+		// No staging means the guard never ran. Report what the index already
+		// holds; nothing here changes the commit.
+		cmdutil.ReportStagedGrowth(ctx, cmd.OutOrStdout(), wtCtx.WorktreePath, wtCommitLarge)
 	}
 
 	// Check for changes

--- a/internal/stageguard/staged.go
+++ b/internal/stageguard/staged.go
@@ -1,0 +1,241 @@
+package stageguard
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// The guard's second attachment point: an index camp did not build.
+//
+// Everything in check.go answers "what would a stage-everything operation add
+// here". A commit that stages nothing never asks it, so `camp commit
+// --all=false` over an index the user assembled with git add says nothing about
+// what is in it. This file answers the other question -- "what is in the index
+// already" -- so that commit can report the same findings.
+//
+// Sizes come from the index, not from lstat. The blob is what actually enters
+// the repository, so it is the more correct number: content filters have
+// already run. git-LFS is the case that matters, since it replaces a large file
+// with a pointer of a few hundred bytes; an LFS-managed path therefore falls
+// under any threshold by construction, and needs none of the check-attr call
+// that FilterLFSManaged makes on the worktree side.
+
+// CheckStagedIndex returns what the index already holds that the per-file
+// threshold flags. It is header-only: no file and no object is read.
+//
+// Every finding is TrackedGrowth, because everything in an index is tracked by
+// definition. That is also the conclusion the staging guard reaches for a file
+// the user staged by hand (see classifyEntry in enumerate.go), which is what
+// lets both paths share one report and one remedy.
+//
+// The bulk guard deliberately does not run here. Bulk blocks, and a caller that
+// has not staged anything must not: it would be refusing an index the user
+// built deliberately. Reporting bulk instead would need remedy copy for a
+// situation camp has already allowed to happen, which is a design question
+// rather than the silence this closes.
+func CheckStagedIndex(ctx context.Context, repoPath string, limits GuardLimits) ([]GuardViolation, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	if limits.LargeFiles == ModeOff {
+		return nil, nil
+	}
+
+	candidates, err := EnumerateStaged(ctx, repoPath)
+	if err != nil {
+		return nil, err
+	}
+	violations, _ := checkPerFile(filterAllowed(candidates, limits.Allow), limits)
+	return violations, nil
+}
+
+// EnumerateStaged lists the regular files the index holds relative to HEAD,
+// each with the size of the blob it would commit.
+//
+// Two git processes, whatever the file count: one diff to name the entries and
+// their object ids, one batched cat-file to size them. Neither scales with how
+// large the staged content is.
+func EnumerateStaged(ctx context.Context, repoPath string) ([]Candidate, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	out, err := diffCachedRaw(ctx, repoPath)
+	if err != nil {
+		return nil, err
+	}
+	entries := parseDiffRawZ(out)
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	sizes, err := blobSizes(ctx, repoPath, entries)
+	if err != nil {
+		return nil, err
+	}
+
+	candidates := make([]Candidate, 0, len(entries))
+	for _, entry := range entries {
+		size, ok := sizes[entry.OID]
+		if !ok {
+			// An object this repository does not have. Nothing to size, and
+			// nothing camp should guess at.
+			continue
+		}
+		// Untracked stays false: an index entry is tracked, which is what makes
+		// every finding here report-only.
+		candidates = append(candidates, Candidate{Path: entry.Path, Size: size})
+	}
+	return candidates, nil
+}
+
+// stagedEntry is one index entry a commit would write: its path and the object
+// id of the blob that path points at.
+type stagedEntry struct {
+	Path string
+	OID  string
+}
+
+// diffCachedRaw asks git what the index holds relative to HEAD.
+//
+// `git diff --cached` rather than `git diff-index HEAD`, because it is the form
+// that works before the first commit: an unborn HEAD diffs against the empty
+// tree instead of failing on an unknown revision, and a campaign's first commit
+// is exactly when a user is most likely to add something large.
+//
+// --no-renames keeps every record to one path and one object id. Rename
+// detection would pay for a similarity scan and buy nothing, since the
+// destination blob is the only thing being sized. --no-abbrev gives whole
+// object ids whatever hash algorithm the repository uses, so nothing downstream
+// has to resolve an ambiguous prefix.
+func diffCachedRaw(ctx context.Context, repoPath string) ([]byte, error) {
+	args := []string{"-C", repoPath, "diff", "--cached", "--raw", "-z", "--no-renames", "--no-abbrev"}
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = gitEnv(os.Environ())
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "git diff --cached --raw in %s: %s",
+			repoPath, strings.TrimSpace(stderr.String()))
+	}
+	return out, nil
+}
+
+// parseDiffRawZ parses `git diff --raw -z` output.
+//
+// Each record is ":<src-mode> <dst-mode> <src-oid> <dst-oid> <status>", a NUL,
+// then the path. Paths are never quoted or escaped in -z mode, so one holding a
+// space, a quote, or a newline arrives verbatim and needs no unquoting.
+func parseDiffRawZ(out []byte) []stagedEntry {
+	fields := bytes.Split(bytes.TrimRight(out, "\x00"), []byte{0})
+	entries := make([]stagedEntry, 0, len(fields)/2)
+	for i := 0; i+1 < len(fields); i += 2 {
+		entry, ok := parseDiffRawRecord(string(fields[i]), string(fields[i+1]))
+		if !ok {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+// parseDiffRawRecord turns one metadata/path pair into an entry, or reports
+// that it is not one worth sizing.
+func parseDiffRawRecord(meta, path string) (stagedEntry, bool) {
+	if path == "" || !strings.HasPrefix(meta, ":") {
+		return stagedEntry{}, false
+	}
+	parts := strings.Fields(meta[1:])
+	if len(parts) < 4 || !isRegularFileMode(parts[1]) {
+		return stagedEntry{}, false
+	}
+	return stagedEntry{Path: path, OID: parts[3]}, true
+}
+
+// isRegularFileMode reports whether a record's destination is an ordinary file.
+//
+// The three modes it rejects each have a reason. 000000 is a deletion, which
+// has no destination content to size. 160000 is a submodule gitlink, whose
+// object id names a commit in the submodule's object database rather than this
+// repository's, so asking for its size here is meaningless. 120000 is a
+// symlink, whose blob is the target path rather than the target's bytes.
+func isRegularFileMode(mode string) bool {
+	return mode == "100644" || mode == "100755"
+}
+
+// blobSizes asks git for the size of each object, in one process.
+//
+// Object ids go in over stdin: they are hex and cannot contain a newline, so
+// the line-delimited batch protocol is safe for them in a way it would not be
+// for paths. Ids are deduplicated first, which also collapses the identical
+// copies a large staged batch tends to carry.
+//
+// --batch-check reads object headers. Nothing is inflated or streamed, so a
+// staged gigabyte costs the same as a staged kilobyte.
+func blobSizes(ctx context.Context, repoPath string, entries []stagedEntry) (map[string]int64, error) {
+	var stdin bytes.Buffer
+	for _, oid := range uniqueOIDs(entries) {
+		stdin.WriteString(oid)
+		stdin.WriteByte('\n')
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "cat-file", "--batch-check")
+	cmd.Env = gitEnv(os.Environ())
+	cmd.Stdin = &stdin
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, camperrors.Wrapf(err, "git cat-file --batch-check in %s: %s",
+			repoPath, strings.TrimSpace(stderr.String()))
+	}
+	return parseBatchCheck(out), nil
+}
+
+// uniqueOIDs returns each object id once, in the order first seen. Two paths
+// holding identical bytes share a blob, so a batch that copied a directory asks
+// git about far fewer objects than it has entries.
+func uniqueOIDs(entries []stagedEntry) []string {
+	seen := make(map[string]struct{}, len(entries))
+	oids := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if _, ok := seen[entry.OID]; ok {
+			continue
+		}
+		seen[entry.OID] = struct{}{}
+		oids = append(oids, entry.OID)
+	}
+	return oids
+}
+
+// parseBatchCheck reads `git cat-file --batch-check` output: one
+// "<oid> <type> <size>" line per input id.
+//
+// An object the repository does not have answers "<oid> missing" and is left
+// out of the map rather than recorded as zero bytes, so a caller can tell "not
+// there" from "empty" instead of silently sizing an absent object at nothing.
+func parseBatchCheck(out []byte) map[string]int64 {
+	lines := strings.Split(string(out), "\n")
+	sizes := make(map[string]int64, len(lines))
+	for _, line := range lines {
+		parts := strings.Fields(line)
+		if len(parts) != 3 || parts[1] != "blob" {
+			continue
+		}
+		size, err := strconv.ParseInt(parts[2], 10, 64)
+		if err != nil {
+			continue
+		}
+		sizes[parts[0]] = size
+	}
+	return sizes
+}

--- a/internal/stageguard/staged_test.go
+++ b/internal/stageguard/staged_test.go
@@ -1,0 +1,252 @@
+package stageguard
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// rawRecord builds one `git diff --raw -z` record: metadata, NUL, path, NUL.
+func rawRecord(srcMode, dstMode, srcOID, dstOID, status, path string) string {
+	return ":" + srcMode + " " + dstMode + " " + srcOID + " " + dstOID + " " + status +
+		"\x00" + path + "\x00"
+}
+
+const (
+	oidA = "b6fc4c620b67d95f953a5c1c1230aaab5db5a1b0"
+	oidB = "dc984463190c2b199b6003bd2e7589251742ea05"
+	oidZ = "0000000000000000000000000000000000000000"
+)
+
+func TestParseDiffRawZ(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want []stagedEntry
+	}{
+		{
+			name: "modification and addition",
+			out: rawRecord("100644", "100644", oidA, oidB, "M", "notes/one.md") +
+				rawRecord("000000", "100644", oidZ, oidA, "A", "notes/two.md"),
+			want: []stagedEntry{
+				{Path: "notes/one.md", OID: oidB},
+				{Path: "notes/two.md", OID: oidA},
+			},
+		},
+		{
+			name: "an executable file is still a regular file",
+			out:  rawRecord("000000", "100755", oidZ, oidA, "A", "bin/run.sh"),
+			want: []stagedEntry{{Path: "bin/run.sh", OID: oidA}},
+		},
+		{
+			// A deletion has no destination content to size.
+			name: "deletion is skipped",
+			out:  rawRecord("100644", "000000", oidA, oidZ, "D", "gone.md"),
+			want: []stagedEntry{},
+		},
+		{
+			// The gitlink's object id names a commit in the submodule's object
+			// database, not this repository's. Sizing it here is meaningless,
+			// and the campaign root stages these routinely.
+			name: "submodule gitlink is skipped",
+			out:  rawRecord("000000", "160000", oidZ, oidA, "A", "projects/camp"),
+			want: []stagedEntry{},
+		},
+		{
+			// A symlink's blob is the target path, not the target's bytes.
+			name: "symlink is skipped",
+			out:  rawRecord("000000", "120000", oidZ, oidA, "A", "link"),
+			want: []stagedEntry{},
+		},
+		{
+			// -z output never quotes or escapes, so awkward names arrive whole.
+			name: "path with a space and a quote survives verbatim",
+			out:  rawRecord("000000", "100644", oidZ, oidA, "A", `my notes/it's "here".md`),
+			want: []stagedEntry{{Path: `my notes/it's "here".md`, OID: oidA}},
+		},
+		{
+			name: "empty output",
+			out:  "",
+			want: []stagedEntry{},
+		},
+		{
+			name: "record with no leading colon is skipped",
+			out:  "100644 100644 " + oidA + " " + oidB + " M\x00notes/one.md\x00",
+			want: []stagedEntry{},
+		},
+		{
+			name: "truncated record is skipped",
+			out:  ":100644 100644\x00notes/one.md\x00",
+			want: []stagedEntry{},
+		},
+		{
+			name: "empty path is skipped",
+			out:  rawRecord("000000", "100644", oidZ, oidA, "A", ""),
+			want: []stagedEntry{},
+		},
+		{
+			// One unusable record must not desynchronize the ones after it.
+			name: "a skipped record does not lose the next one",
+			out: rawRecord("000000", "160000", oidZ, oidA, "A", "projects/camp") +
+				rawRecord("000000", "100644", oidZ, oidB, "A", "notes/two.md"),
+			want: []stagedEntry{{Path: "notes/two.md", OID: oidB}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseDiffRawZ([]byte(tt.out))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseDiffRawZ() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseBatchCheck(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want map[string]int64
+	}{
+		{
+			name: "sizes are read per object",
+			out:  oidA + " blob 31\n" + oidB + " blob 13891584\n",
+			want: map[string]int64{oidA: 31, oidB: 13891584},
+		},
+		{
+			// Absent is not zero. Recording it as zero bytes would silently
+			// size an object camp cannot see, and it would pass every check.
+			name: "a missing object is left out, not sized zero",
+			out:  oidA + " missing\n" + oidB + " blob 40\n",
+			want: map[string]int64{oidB: 40},
+		},
+		{
+			name: "non-blob objects are ignored",
+			out:  oidA + " commit 214\n" + oidB + " tree 96\n",
+			want: map[string]int64{},
+		},
+		{
+			name: "an unparseable size is ignored",
+			out:  oidA + " blob notanumber\n",
+			want: map[string]int64{},
+		},
+		{
+			name: "empty output",
+			out:  "",
+			want: map[string]int64{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseBatchCheck([]byte(tt.out))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseBatchCheck() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUniqueOIDs(t *testing.T) {
+	entries := []stagedEntry{
+		{Path: "a.md", OID: oidA},
+		{Path: "b.md", OID: oidB},
+		{Path: "copy-of-a.md", OID: oidA},
+		{Path: "another-copy.md", OID: oidA},
+	}
+
+	got := uniqueOIDs(entries)
+	want := []string{oidA, oidB}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("uniqueOIDs() = %v, want %v", got, want)
+	}
+}
+
+func TestUniqueOIDsEmpty(t *testing.T) {
+	if got := uniqueOIDs(nil); len(got) != 0 {
+		t.Errorf("uniqueOIDs(nil) = %v, want empty", got)
+	}
+}
+
+// The mode gate is what keeps a configured-off guard from paying for two git
+// processes on every scoped commit. It must return before touching the
+// repository at all, which a path that does not exist proves.
+func TestCheckStagedIndexModeOffRunsNothing(t *testing.T) {
+	limits := GuardLimits{MaxFileSize: 1, LargeFiles: ModeOff, Bulk: ModeBlock}
+
+	violations, err := CheckStagedIndex(context.Background(), "/nonexistent/repo", limits)
+	if err != nil {
+		t.Fatalf("CheckStagedIndex() error = %v, want nil", err)
+	}
+	if len(violations) != 0 {
+		t.Errorf("CheckStagedIndex() = %+v, want no violations", violations)
+	}
+}
+
+func TestCheckStagedIndexHonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	limits := GuardLimits{MaxFileSize: 1, LargeFiles: ModeAuto, Bulk: ModeBlock}
+	if _, err := CheckStagedIndex(ctx, "/nonexistent/repo", limits); err == nil {
+		t.Fatal("CheckStagedIndex() error = nil, want a cancellation error")
+	}
+
+	if _, err := EnumerateStaged(ctx, "/nonexistent/repo"); err == nil {
+		t.Fatal("EnumerateStaged() error = nil, want a cancellation error")
+	}
+}
+
+// Everything an index holds is tracked, which is the whole reason this pass can
+// only ever report. If a staged entry could arrive as untracked, checkPerFile
+// would classify it OverThreshold and the caller would exclude a file the user
+// staged on purpose.
+func TestStagedCandidatesAreAlwaysTrackedGrowth(t *testing.T) {
+	limits := GuardLimits{MaxFileSize: 1 << 20, LargeFiles: ModeAuto, Bulk: ModeOff}
+	candidates := []Candidate{
+		{Path: "media/big.png", Size: 13 << 20},
+		{Path: "notes/small.md", Size: 12},
+	}
+
+	violations, remaining := checkPerFile(candidates, limits)
+	if len(violations) != 1 {
+		t.Fatalf("checkPerFile() = %+v, want exactly one violation", violations)
+	}
+	if violations[0].Kind != TrackedGrowth {
+		t.Errorf("violation kind = %q, want %q", violations[0].Kind, TrackedGrowth)
+	}
+	if !violations[0].ReportOnly() {
+		t.Error("a staged entry's violation must be report-only")
+	}
+	if len(remaining) != len(candidates) {
+		t.Errorf("remaining = %d, want %d: a reported entry is still committed",
+			len(remaining), len(candidates))
+	}
+}
+
+// The allowlist is the one line that makes a legitimate large file permanent,
+// and it has to reach this pass too or a user who allowed a path still gets
+// told about it on every scoped commit.
+func TestStagedCandidatesRespectAllowlist(t *testing.T) {
+	limits := GuardLimits{
+		MaxFileSize: 1 << 20,
+		LargeFiles:  ModeAuto,
+		Bulk:        ModeOff,
+		Allow:       []string{"*.psd"},
+	}
+	candidates := []Candidate{
+		{Path: "art/cover.psd", Size: 40 << 20},
+		{Path: "art/cover.png", Size: 13 << 20},
+	}
+
+	violations, _ := checkPerFile(filterAllowed(candidates, limits.Allow), limits)
+	if len(violations) != 1 {
+		t.Fatalf("checkPerFile() = %+v, want exactly one violation", violations)
+	}
+	if !strings.HasSuffix(violations[0].Path, ".png") {
+		t.Errorf("violation path = %q, want the file the allowlist does not cover",
+			violations[0].Path)
+	}
+}

--- a/tests/integration/stage_guard_scoped_commit_test.go
+++ b/tests/integration/stage_guard_scoped_commit_test.go
@@ -1,0 +1,264 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The gap these cover: camp's size guard lives at the staging chokepoint, so a
+// commit that stages nothing never reaches it. A user who ran `git add` by hand
+// and then committed with --all=false could put a 13 MB PNG into git without
+// camp saying a word.
+//
+// What the fix is allowed to do is report. The commit must land byte-for-byte
+// as it would have without the check, so every case below asserts the file is
+// committed as well as reported.
+
+// stagePreStagedLargeFile builds the reported scenario: a file over the
+// threshold placed in the index by raw git add, with an ordinary file beside it
+// so the commit has more than one thing in it.
+func stagePreStagedLargeFile(t *testing.T, tc *TestContainer, campPath string) {
+	t.Helper()
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p media
+		dd if=/dev/zero of=media/diagram.png bs=1024 count=3072 2>/dev/null
+		printf 'a caption' > media/caption.md
+		git add media/diagram.png media/caption.md
+	`, campPath))
+}
+
+// The reported incident, end to end: pre-staged over-threshold content is
+// reported, and still committed.
+func TestIntegration_ScopedCommitReportsPreStagedGrowth(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "scoped-commit-report")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB")
+	stagePreStagedLargeFile(t, tc, campPath)
+
+	output, err := tc.RunCampInDir(campPath, "commit", "--all=false", "-m", "hand-staged diagram")
+	require.NoError(t, err, "output:\n%s", output)
+
+	// The staging path's copy, verbatim. A user must not have to notice that
+	// the wording changes with who did the staging.
+	assert.Contains(t, output, "media/diagram.png is tracked and now")
+	assert.Contains(t, output, "Tracked files are always committed")
+	assert.Contains(t, output, "git rm --cached media/diagram.png")
+	assert.Contains(t, output, "camp artifacts add media")
+	assert.Contains(t, output, "commit.guards.allow")
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
+	assert.Contains(t, committed, "media/diagram.png",
+		"the report must not change what is committed")
+	assert.Contains(t, committed, "media/caption.md",
+		"everything else in the index commits as usual")
+
+	// Report-only means report only. Nothing may be declared, excluded, or
+	// gitignored on the user's behalf.
+	exists, err := tc.CheckFileExists(campPath + "/.campaign/artifacts.yaml")
+	require.NoError(t, err)
+	if exists {
+		declared, readErr := tc.ReadFile(campPath + "/.campaign/artifacts.yaml")
+		require.NoError(t, readErr)
+		assert.NotContains(t, declared, "media",
+			"a scoped commit must never declare an artifact root")
+	}
+	assert.NotContains(t, readGitignore(t, tc, campPath), "media/",
+		"a scoped commit must never write an ignore rule")
+}
+
+// The other half of the contract: an ordinary scoped commit stays quiet. A
+// report on every commit would be noise, and noise is what makes a real report
+// easy to miss.
+func TestIntegration_ScopedCommitStaysSilentUnderThreshold(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "scoped-commit-quiet")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p media
+		printf 'well under the limit' > media/note.md
+		git add media/note.md
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "--all=false", "-m", "small note")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.NotContains(t, output, "is tracked and now",
+		"an under-threshold scoped commit must say nothing about size")
+	assert.NotContains(t, output, "Committed without the size check",
+		"the check must have run rather than degrading")
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
+	assert.Contains(t, committed, "media/note.md")
+}
+
+// --commit-large is the user having already answered. It suppresses detection
+// on the staging path; it has to mean the same thing here, or the flag would
+// silence camp in one command and not the other.
+func TestIntegration_ScopedCommitLargeSuppressesTheReport(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "scoped-commit-large")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB")
+	stagePreStagedLargeFile(t, tc, campPath)
+
+	output, err := tc.RunCampInDir(campPath,
+		"commit", "--all=false", "--commit-large", "-m", "yes, it belongs in git")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.NotContains(t, output, "is tracked and now")
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
+	assert.Contains(t, committed, "media/diagram.png")
+}
+
+// The allowlist is the one line that makes a legitimate large file permanent.
+// If it did not reach this pass, a user who had already allowed a path would be
+// told about it on every scoped commit, with no way to stop it.
+func TestIntegration_ScopedCommitRespectsAllowlist(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "scoped-commit-allow")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB\n    allow:\n      - \"*.png\"")
+	stagePreStagedLargeFile(t, tc, campPath)
+
+	output, err := tc.RunCampInDir(campPath, "commit", "--all=false", "-m", "allowed diagram")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.NotContains(t, output, "is tracked and now",
+		"an allowlisted path must not be reported")
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
+	assert.Contains(t, committed, "media/diagram.png")
+}
+
+// The report is human output, so under --json it belongs on stderr with the
+// rest of it. stdout carries one document and nothing else, which is the whole
+// reason a machine caller can parse it without a filter.
+func TestIntegration_ScopedCommitJSONStdoutStaysPure(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "scoped-commit-json")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB")
+	stagePreStagedLargeFile(t, tc, campPath)
+
+	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath,
+		"commit", "--json", "--all=false", "-m", "hand-staged diagram")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "stdout:\n%s\nstderr:\n%s", stdout, stderr)
+
+	var doc commitJSONDoc
+	require.NoError(t, json.Unmarshal([]byte(stdout), &doc),
+		"stdout must be exactly one JSON document; got:\n%s", stdout)
+	assert.True(t, doc.OK)
+	assert.NotContains(t, stdout, "is tracked and now",
+		"the report must not leak into the document stream")
+
+	assert.Contains(t, stderr, "media/diagram.png is tracked and now",
+		"a person watching a scripted run still has to see it; stderr:\n%s", stderr)
+
+	// Nothing was kept out, so the document says nothing was.
+	assert.Empty(t, doc.Excluded)
+	assert.Empty(t, doc.ArtifactRootsDeclared)
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", doc.Commit)
+	assert.Contains(t, committed, "media/diagram.png")
+}
+
+// A submodule gitlink is staged at the campaign root routinely, and its object
+// id names a commit that lives in the submodule rather than the parent. Asking
+// git to size it there would be meaningless; the pass has to skip it without
+// falling over, and without losing the ordinary files beside it.
+func TestIntegration_ScopedCommitSkipsStagedSubmoduleRefs(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "scoped-commit-gitlink")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB")
+
+	// A gitlink written straight into the index, pointing at an object the
+	// campaign repository does not have. This is the shape `git add` leaves
+	// behind for a submodule, without the cost of building one.
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p media
+		dd if=/dev/zero of=media/diagram.png bs=1024 count=3072 2>/dev/null
+		git add media/diagram.png
+		git update-index --add --cacheinfo 160000,0000000000000000000000000000000000000001,vendor/thing
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "--all=false", "-m", "diagram plus a gitlink")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.Contains(t, output, "media/diagram.png is tracked and now",
+		"a gitlink in the index must not cost the report the files beside it")
+	assert.NotContains(t, output, "Committed without the size check",
+		"an unreachable gitlink object must not fail the check")
+	assert.NotContains(t, output, "vendor/thing is tracked and now",
+		"a gitlink has no blob size to report")
+}
+
+// Everything above runs at the campaign root. A project has its own threshold
+// and its own remedy, and it is a separate command; the report has to reach it
+// too or the gap simply moves.
+func TestIntegration_ScopedProjectCommitReportsPreStagedGrowth(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath, projPath, _ := setupFreshCampaignWithSubmodule(t, tc, "scoped-project-report")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		cat >> .campaign/campaign.yaml <<'YAML'
+commit:
+  guards:
+    max_project_file_size: 1MiB
+YAML
+	`, campPath))
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p testdata
+		dd if=/dev/zero of=testdata/corpus.tar bs=1024 count=3072 2>/dev/null
+		git add testdata/corpus.tar
+	`, projPath))
+
+	output, err := tc.RunCampInDir(projPath,
+		"project", "commit", "--all=false", "--no-sync", "-m", "hand-staged fixture")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.Contains(t, output, "testdata/corpus.tar is tracked and now")
+	assert.Contains(t, output, "Tracked files are always committed")
+
+	committed := tc.GitOutput(t, projPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "testdata/corpus.tar",
+		"the report must not change what a project commit contains")
+}
+
+// A wide index is the case that would expose a per-file design: 400 staged
+// paths cost two git processes here, not 400. The assertion is that the commit
+// is still whole and still silent, since nothing in it crosses the threshold.
+func TestIntegration_ScopedCommitHandlesAWideIndex(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "scoped-commit-cost")
+	writeGuardConfig(t, tc, campPath, "    max_file_size: 1MiB")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p bulk
+		for i in $(seq 1 400); do printf 'entry %%s' "$i" > bulk/file-$i.md; done
+		git add bulk
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "--all=false", "-m", "four hundred small files")
+	require.NoError(t, err, "output:\n%s", output)
+	assert.NotContains(t, output, "is tracked and now",
+		"nothing here crosses the threshold, so nothing may be reported")
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
+	assert.Contains(t, committed, "bulk/file-1.md")
+	assert.Contains(t, committed, "bulk/file-400.md",
+		"a wide scoped commit still commits everything it was given")
+}

--- a/tests/integration/stage_guard_scoped_commit_test.go
+++ b/tests/integration/stage_guard_scoped_commit_test.go
@@ -94,7 +94,7 @@ func TestIntegration_ScopedCommitStaysSilentUnderThreshold(t *testing.T) {
 
 	assert.NotContains(t, output, "is tracked and now",
 		"an under-threshold scoped commit must say nothing about size")
-	assert.NotContains(t, output, "Committed without the size check",
+	assert.NotContains(t, output, "Could not run the size check",
 		"the check must have run rather than degrading")
 
 	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", latestUserCommit(t, tc, campPath))
@@ -196,7 +196,7 @@ func TestIntegration_ScopedCommitSkipsStagedSubmoduleRefs(t *testing.T) {
 
 	assert.Contains(t, output, "media/diagram.png is tracked and now",
 		"a gitlink in the index must not cost the report the files beside it")
-	assert.NotContains(t, output, "Committed without the size check",
+	assert.NotContains(t, output, "Could not run the size check",
 		"an unreachable gitlink object must not fail the check")
 	assert.NotContains(t, output, "vendor/thing is tracked and now",
 		"a gitlink has no blob size to report")


### PR DESCRIPTION
## The gap

camp's size and bulk guard lives at the **staging** chokepoint (`internal/git`, the `StageWithGuard` family). A commit that stages nothing never reaches it.

So this sequence is silent:

```
git add media/diagram.png      # 13.25 MB, staged by hand
camp commit --all=false -m "..."
```

The commit lands with the file in it and camp prints no report line: no tracked-growth warning, no threshold named, no remedy. The same file committed through the default `camp commit` path produces the full report. The raw-`git add` gap is designed (design doc 05 open question 4 defers a pre-commit hook for it), but a scoped commit going completely quiet about it is not.

## The fix: a commit-time report-only pass

When a commit skips staging, camp now evaluates the existing index against the same guard thresholds and prints the same tracked-growth report lines the staging path emits.

It **only reports**. It never excludes, unstages, blocks, or prompts, and it never declares an artifact root or writes a gitignore rule. The commit that follows is byte-for-byte the commit that would have happened without the check.

That is not a first increment; it is the design, and it follows from the friction-free principle in CLAUDE.md section 7:

- **"Never reintroduce curation friction into the normal path."** An index the user assembled with `git add` is a deliberate act. A guard that excluded or asked here would convert it back into a decision point, which is exactly what camp's commit default exists to avoid.
- **"When something must protect the user, camp handles it and reports."** Here camp cannot handle it, because handling would mean reversing an explicit instruction. So it does the other half: it reports.
- Excluding is also mechanically wrong at this point. The staging guard excludes by staging *around* a path, which cannot un-add something already in the index. `internal/stageguard/enumerate.go:151-160` already documents this for a hand-staged file reached through the normal path, and reaches the same conclusion: report it and commit it. This change makes the two paths agree instead of leaving one silent.

Everything the pass finds is therefore `TrackedGrowth`, which is *defined* as report-and-commit. The existing `renderTrackedGrowth` is reused verbatim, so a user hitting this over a hand-built index reads the same copy as a user hitting it through `camp commit`.

Wired into all three commit surfaces that have an `--all` flag: `camp commit`, `camp project commit`, `camp worktrees commit`.

## Cost

Latency is friction too, so the check is two git processes regardless of how many files are staged: `git diff --cached --raw -z --no-renames --no-abbrev` to name the entries and their object ids, then one batched `git cat-file --batch-check` to size them. Nothing is opened, read, or hashed; `--batch-check` reads object headers, so a staged gigabyte costs what a staged kilobyte costs.

Measured on macOS, 100 iterations per figure, git 2.54:

| staged entries | added pass |
| --- | --- |
| 1 | 6.75 ms |
| 400 | 7.43 ms |
| 5000 | 9.35 ms |

Two reference points on the same 400-entry fixture:

- `git status --porcelain=v1 -z -uall`, which the **default** commit path already runs on every commit: **7.26 ms**. The added pass costs about what one call camp already makes costs.
- One `git cat-file -s` spawn per staged file, i.e. what a naive per-file design would cost: **2688 ms**. That is the 360x reason for the batching.

The near-flat curve is the point: cost is dominated by two process spawns, not by file count.

## Design details worth reviewing

**Sizes come from the index, not from `lstat`.** The blob is what actually enters the repository, so it is the more correct number: content filters have already run. This has a useful consequence. git-LFS replaces a large file with a pointer of a few hundred bytes, so an LFS-managed path falls under any threshold by construction, and this pass needs none of the `git check-attr` call `FilterLFSManaged` makes on the worktree side.

**Non-blob index entries are filtered by destination mode.** Deletions (`000000`) have no destination content. Submodule gitlinks (`160000`) name a commit in the submodule's object database rather than the parent's, which matters because the campaign root stages these routinely; there is a test for it. Symlinks (`120000`) store their target path, not the target's bytes.

**`git diff --cached` rather than `git diff-index HEAD`.** The former works before the first commit (an unborn HEAD diffs against the empty tree), and a campaign's first commit is exactly when someone is likely to add something large.

**Fail-open, never silently.** A repository camp cannot read still commits; the cause is printed. Same stance as `GuardUnavailableLine` on the staging path, and for the same reason: a user who is not told assumes the check ran.

**`--commit-large` suppresses detection entirely**, matching the staging path, so the flag means one thing across both.

## Tradeoffs and things deliberately left out

- **The bulk guard does not run in this pass.** Bulk *blocks*, and a pass that stages nothing must not. Reporting bulk instead would need new remedy copy for a situation camp has already allowed to happen, and its entire existing vocabulary is a refusal ("Nothing was staged, here are your three choices"), which would be false here. That is a design question rather than the silence this closes.
- **No `--json` schema change.** Tracked growth has never appeared in `commit/v1alpha1` (`applyGuardHandling` folds in exclusions and declared roots only), and surfacing it for the scoped path alone would make the document inconsistent about the same finding. The report is human output and goes where the rest of the human output goes: `humanOut`, which is stderr under `--json`. There is a test asserting stdout stays exactly one JSON document while the report appears on stderr. Adding a tracked-growth field to the schema is a separate, deliberate decision.
- **`renderTrackedGrowth` suggests `camp artifacts add <dir>` even in project scope**, where camp otherwise refuses to auto-declare roots. That is pre-existing on the staging path, which renders tracked growth identically regardless of scope; reusing the copy inherits it rather than introducing it. Changing shared copy felt like the wrong scope for this PR.
- `--amend` without an explicit `--all` resolves to not staging, so it now runs the pass. A plain amend has an empty index diff and reports nothing; content actually staged for the amend is reported, which is correct. A file already in HEAD is not re-reported, since the comparison is index against HEAD.

## Tests

Unit, `internal/stageguard/staged_test.go`, pure parsing and policy logic:
- `parseDiffRawZ` across modification, addition, executable mode, deletion, gitlink, symlink, a path with a space and a quote, a malformed record, and a skipped record not desynchronizing the next one.
- `parseBatchCheck`, including that a `missing` object is left out of the map rather than recorded as zero bytes (zero would pass every check).
- `uniqueOIDs` deduplication.
- The mode-off gate returning before touching the repository, and context cancellation on both entry points.
- That a staged candidate always classifies as `TrackedGrowth` and stays in the commit, and that the allowlist reaches this pass.

Unit, `cmd/camp/cmdutil/stagedreport_test.go`: `--commit-large` suppressing everything without running git, fail-open printing its cause, and the unavailable line naming both cause and next step.

Integration, containerized, `tests/integration/stage_guard_scoped_commit_test.go` (8 tests):
- The reported incident: `git add` an over-threshold file, `camp commit --all=false`, assert the report **and** that the file is committed, and that nothing was declared or gitignored.
- Under threshold: no report line at all.
- `--commit-large`: no report, file committed.
- Allowlisted path: no report, file committed.
- `--json`: stdout parses as exactly one document, report on stderr, `excluded` and `artifact_roots_declared` both empty.
- A staged submodule gitlink does not fail the check or cost the report the files beside it.
- `camp project commit --all=false` reports too, so the gap does not just move to project scope.
- A 400-entry index commits whole and stays silent.

## Gates

- `just gate` (build, vet stable/dev/integration, lint stable/dev, ratchets, unit tests dev and stable): **PASSED**. 4053/4053 dev, 4008/4008 stable, 0 lint issues, no new host-FS-test or `fmt.Errorf` violators.
- `just test integration-run 'TestIntegration_ScopedCommit|TestIntegration_ScopedProjectCommit'`: **8/8 PASS** (Docker via colima).

No new dependencies. `camperrors` throughout, `context.Context` first on every I/O path, all functions under 50 lines.
