### PR TITLE
Fix deferred bookkeeping commits failing on an unborn HEAD

### DIFF
--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -197,14 +197,39 @@ func CopyFile(src, dst string) error {
 }
 
 // ReadTreeIntoTempIndex seeds tmpPath from HEAD.
+//
+// `camp init` creates the .git directory but never commits, so every scoped or
+// blob-captured job enqueued before the user's first commit runs against an
+// unborn branch: HEAD is a ref that does not resolve to any object yet. Seeding
+// from "HEAD" there is not a smaller version of the normal case, it is a
+// different precondition, and `git read-tree HEAD` fails loudly rather than
+// treating the branch as merely empty. Starting from an empty tree instead
+// lets the paths this job stages become the repository's first commit, which
+// is what should happen: the content was captured (or named) when the job was
+// enqueued, and nothing about an unborn branch makes that content less real.
 func ReadTreeIntoTempIndex(ctx context.Context, repoPath, tmpPath string) error {
-	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "read-tree", "HEAD")
+	args := []string{"-C", repoPath, "read-tree", "HEAD"}
+	if !headResolvable(ctx, repoPath) {
+		args = []string{"-C", repoPath, "read-tree", "--empty"}
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Env = append(os.Environ(), "GIT_INDEX_FILE="+tmpPath)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return camperrors.NewGit("read-tree", "", "", strings.TrimSpace(string(out)), err)
 	}
 	return nil
+}
+
+// headResolvable reports whether HEAD points at a real commit.
+//
+// A freshly initialized repository has a HEAD ref but no commit behind it
+// (an unborn branch), and `git read-tree HEAD` treats that as an error rather
+// than an empty tree. This is the one check the temp-index seeding needs to
+// tell the two states apart.
+func headResolvable(ctx context.Context, repoPath string) bool {
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "--verify", "--quiet", "HEAD")
+	return cmd.Run() == nil
 }
 
 // AddPathsToTempIndex stages paths into the provided temp index.

--- a/internal/git/commit_test.go
+++ b/internal/git/commit_test.go
@@ -1124,3 +1124,146 @@ func TestResetPathspecPayloadLimitReservesFixedArgv(t *testing.T) {
 		t.Fatalf("windows budget = %d, want %d", platformCommandLineBudget(), 16*1024)
 	}
 }
+
+// `camp init` creates the .git directory but never commits, so a job enqueued
+// before the user's first commit runs against an unborn branch: HEAD is a ref
+// that does not resolve to any object. The tests below cover that precondition
+// for every entry point that seeds a temp index from HEAD.
+
+func TestHeadResolvable(t *testing.T) {
+	tmpDir := initTestRepo(t)
+	ctx := context.Background()
+
+	if headResolvable(ctx, tmpDir) {
+		t.Fatal("headResolvable() = true on a freshly initialized repo with no commits")
+	}
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "seed.txt"), []byte("seed"), 0644); err != nil {
+		t.Fatalf("write seed.txt: %v", err)
+	}
+	if err := StageAll(ctx, tmpDir); err != nil {
+		t.Fatalf("StageAll() error = %v", err)
+	}
+	if err := Commit(ctx, tmpDir, &CommitOptions{Message: "seed commit"}); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+
+	if !headResolvable(ctx, tmpDir) {
+		t.Fatal("headResolvable() = false once a commit exists")
+	}
+}
+
+// The bug this guards: `git read-tree HEAD` fails with "Not a valid object
+// name HEAD" on an unborn branch, which used to fail every deferred
+// bookkeeping job enqueued before the user's first commit.
+func TestReadTreeIntoTempIndex_UnbornHead(t *testing.T) {
+	tmpDir := initTestRepo(t)
+	ctx := context.Background()
+
+	tmpPath, _, err := BuildTempIndexPath(tmpDir)
+	if err != nil {
+		t.Fatalf("BuildTempIndexPath() error = %v", err)
+	}
+	defer RemoveTempIndex(tmpPath)
+
+	if err := ReadTreeIntoTempIndex(ctx, tmpDir, tmpPath); err != nil {
+		t.Fatalf("ReadTreeIntoTempIndex() on an unborn branch error = %v", err)
+	}
+
+	// The seeded index must be usable: staging a path into it and writing a
+	// tree should succeed exactly as it would from a HEAD-seeded index.
+	env := append(os.Environ(), "GIT_INDEX_FILE="+tmpPath)
+	if err := RunWithEnv(ctx, tmpDir, env,
+		"update-index", "--add", "--cacheinfo",
+		"100644,"+emptyBlobSHA(t, tmpDir)+",seeded.txt"); err != nil {
+		t.Fatalf("stage into the empty-seeded temp index: %v", err)
+	}
+	out := runGit(t, "", env, "-C", tmpDir, "ls-files")
+	if !strings.Contains(out, "seeded.txt") {
+		t.Fatalf("temp index seeded from an unborn branch did not accept a staged path; ls-files: %q", out)
+	}
+}
+
+// emptyBlobSHA hashes the empty blob into the object store and returns its
+// SHA, so a test can stage a path without needing real file content on disk.
+func emptyBlobSHA(t *testing.T, repoPath string) string {
+	t.Helper()
+	return runGit(t, "", nil, "-C", repoPath, "hash-object", "-w", "--", os.DevNull)
+}
+
+// CommitScoped is the path a hand-written (path-only, no captured blobs) job
+// takes. It must produce the repository's first commit rather than failing on
+// the temp-index seed.
+func TestCommitScoped_UnbornHead(t *testing.T) {
+	tmpDir := initTestRepo(t)
+	ctx := context.Background()
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "note.md"), []byte("first note\n"), 0644); err != nil {
+		t.Fatalf("write note.md: %v", err)
+	}
+
+	if err := CommitScoped(ctx, tmpDir, []string{"note.md"}, &CommitOptions{
+		Message: "capture: first note",
+	}); err != nil {
+		t.Fatalf("CommitScoped() on an unborn branch error = %v", err)
+	}
+
+	if !headResolvable(ctx, tmpDir) {
+		t.Fatal("CommitScoped() did not create the repository's first commit")
+	}
+	subject := runGit(t, "", nil, "-C", tmpDir, "log", "-1", "--format=%s")
+	if subject != "capture: first note" {
+		t.Fatalf("commit subject = %q, want %q", subject, "capture: first note")
+	}
+	tracked := runGit(t, "", nil, "-C", tmpDir, "ls-tree", "-r", "--name-only", "HEAD")
+	if !strings.Contains(tracked, "note.md") {
+		t.Fatalf("first commit does not contain note.md; tree: %q", tracked)
+	}
+	count := runGit(t, "", nil, "-C", tmpDir, "rev-list", "--count", "HEAD")
+	if count != "1" {
+		t.Fatalf("rev-list --count HEAD = %q, want 1 (exactly one commit)", count)
+	}
+}
+
+// CommitBlobs is the path a bookkeeping job with captured content takes (the
+// worker's real production path for something like `camp intent add`). Content
+// is captured up front and committed without reading the working tree or the
+// real index, so this exercises the exact mechanism the bug report describes.
+func TestCommitBlobs_UnbornHead(t *testing.T) {
+	tmpDir := initTestRepo(t)
+	ctx := context.Background()
+
+	path := filepath.Join(tmpDir, "intents", "idea.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("an idea captured before the first commit\n"), 0644); err != nil {
+		t.Fatalf("write idea.md: %v", err)
+	}
+
+	refs, err := CaptureBlobs(ctx, tmpDir, []string{"intents/idea.md"})
+	if err != nil {
+		t.Fatalf("CaptureBlobs() error = %v", err)
+	}
+
+	if err := CommitBlobs(ctx, tmpDir, refs, &CommitOptions{
+		Message: "capture intent: an idea",
+	}); err != nil {
+		t.Fatalf("CommitBlobs() on an unborn branch error = %v", err)
+	}
+
+	if !headResolvable(ctx, tmpDir) {
+		t.Fatal("CommitBlobs() did not create the repository's first commit")
+	}
+	tracked := runGit(t, "", nil, "-C", tmpDir, "ls-tree", "-r", "--name-only", "HEAD")
+	if !strings.Contains(tracked, "intents/idea.md") {
+		t.Fatalf("first commit does not contain the captured blob; tree: %q", tracked)
+	}
+
+	// The real index must stay untouched: CommitBlobs commits captured content
+	// through a temp index and must never stage the user's working tree.
+	status := runGit(t, "", nil, "-C", tmpDir, "status", "--porcelain")
+	if status != "" {
+		t.Fatalf("CommitBlobs left the real index/working tree dirty: %q", status)
+	}
+}

--- a/tests/integration/bookkeeping_defer_test.go
+++ b/tests/integration/bookkeeping_defer_test.go
@@ -272,3 +272,62 @@ func TestIntegration_DroppedBookkeepingJobLeavesTheIntentOnDisk(t *testing.T) {
 	assert.Contains(t, tracked, "survivor.md",
 		"an ordinary commit must pick up what the dropped job would have committed")
 }
+
+// `camp init` creates the .git directory but never commits, so a campaign a
+// user has just created has an unborn HEAD until their first `camp commit`.
+// A deferred bookkeeping job enqueued before that first commit used to die in
+// the worker with "git read-tree: Not a valid object name HEAD" and land in
+// the failed lane silently: `camp jobs drain` still reported success, because
+// draining only waits for a lane to empty, not for its jobs to succeed.
+//
+// This is deliberately NOT setupDrainCampaign: that helper (and InitCampaign
+// underneath it) creates a baseline "Initial campaign setup" commit as a
+// workaround for exactly this bug, so it never exercises an unborn HEAD.
+func TestIntegration_BookkeepingCommitLandsOnUnbornHead(t *testing.T) {
+	tc := GetSharedContainer(t)
+	tc.EnableDeferral()
+
+	campPath := "/campaigns/bk-defer-unborn"
+	_, err := tc.RunCamp("init", campPath, "--name", "bk-defer-unborn",
+		"-d", "Test campaign", "-m", "Test mission", "--type", "product")
+	require.NoError(t, err)
+
+	// Confirm the fixture actually reproduces the precondition: no commit
+	// exists yet. A GitOutput call would fail the test on git's non-zero exit,
+	// so this checks the exit code itself instead.
+	_, exitCode, err := tc.ExecCommand("git", "-C", campPath, "rev-parse", "--verify", "HEAD")
+	require.NoError(t, err)
+	require.NotEqual(t, 0, exitCode, "fixture is not reproducing an unborn HEAD; HEAD already resolves")
+
+	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath, "intent", "add", "captured before first commit")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "stdout:\n%s\nstderr:\n%s", stdout, stderr)
+	assert.Contains(t, stdout+stderr, "queued",
+		"the command must report a queued commit; output:\n%s", stdout+stderr)
+
+	listing := tc.Shell(t, fmt.Sprintf("ls %s/.campaign/intents/inbox/", campPath))
+	assert.Contains(t, listing, "captured-before-first-commit",
+		"the intent file must be written in the foreground; inbox:\n%s", listing)
+
+	drainJobs(t, tc, campPath)
+
+	// The bug's signature: drain reports success even though the job died, so
+	// the assertion that catches it is the failed lane, not the drain's exit
+	// code.
+	assert.Zero(t, pendingJobCount(t, tc, campPath, "failed", rootLane),
+		"the deferred bookkeeping job must not land in the failed lane on an unborn HEAD")
+
+	head := tc.GitOutput(t, campPath, "rev-parse", "HEAD")
+	assert.NotEmpty(t, head, "the deferred job must create the repository's first commit")
+
+	count := strings.TrimSpace(tc.GitOutput(t, campPath, "rev-list", "--count", "HEAD"))
+	assert.Equal(t, "1", count, "the worker must produce exactly one commit, got %s", count)
+
+	tracked := tc.GitOutput(t, campPath, "ls-tree", "-r", "--name-only", "HEAD")
+	assert.Contains(t, tracked, "captured-before-first-commit",
+		"the first commit must contain the captured intent file; tree:\n%s", tracked)
+
+	subject := headSubject(t, tc, campPath)
+	assert.Contains(t, subject, "captured before first commit",
+		"the deferred commit must carry the bookkeeping message; got %q", subject)
+}


### PR DESCRIPTION
## Bug

`camp init` creates the `.git` directory but never commits, so a fresh campaign has an unborn HEAD until the user's first `camp commit`. Any deferred bookkeeping commit enqueued before that (`camp intent add` is the real-world trigger) died in the background worker with:

```
git read-tree: Not a valid object name HEAD
```

and landed in the failed lane silently. `camp jobs drain` still reported success, because draining only waits for a lane to empty, not for its jobs to succeed, so nothing told the user their intent was never committed. This surfaced via CA0004's commit_drain fixture against camp v0.4.0-rc.1, which worked around it by giving the fixture a baseline commit.

## Mechanism of the fix

`ReadTreeIntoTempIndex` (`internal/git/commit.go`) unconditionally ran `git read-tree HEAD` to seed the worker's temp index. On an unborn branch HEAD is a ref with no object behind it, so that read fails outright — it's a different precondition from a normal, non-empty repository, not a smaller version of it.

The fix checks whether HEAD resolves (`git rev-parse --verify --quiet HEAD`) and, when it does not, seeds the temp index with `git read-tree --empty` instead. The job's captured paths then stage into that empty index exactly as before, and the resulting commit becomes the repository's first commit. This one function is shared by both worker paths that build a temp index from HEAD (`CommitScoped`, for hand-written path-only jobs, and `CommitBlobs`, the production path a captured-content bookkeeping job like `camp intent add` takes), so both are fixed by the same change.

I audited the rest of the worker's temp-index mechanism for the same class of HEAD-resolution assumption, since an unborn branch breaks any code that assumes HEAD exists:

- `IsGitlink` (`git ls-tree HEAD`) and `FirstParentChainContains` (`git log HEAD`) already return their safe default (`false`) on error, which is the correct answer on an unborn branch — nothing can already be a gitlink or already applied when there is no history yet.
- `ExpandTrackedPathsFromTempIndex`/`ExpandTrackedPaths` (`git diff --cached`) already work: git natively diffs an unborn HEAD against the empty tree, verified directly.
- `ResetIndexToHead` and the plain `git commit` (`executeCommit`) only run after the worker's own commit has landed, at which point HEAD is no longer unborn regardless of how the job started.
- `git.FullHash`, used by the separate `KindCommitTree` job path (`--auto-write` deferred commits, not bookkeeping), does fail on an unborn HEAD, but `TryDeferAutoWrite` already has a pre-existing, intentional fallback for exactly this: a failed `Enqueue` degrades to a synchronous commit with a warning, so it doesn't lose the commit — it just doesn't defer on someone's very first `camp commit --auto-write`. That's a pre-existing design, not something I added, and I left it alone.

None of those needed a change. `camp init` is untouched on purpose — it must stay side-effect-light, and the fix belongs in the mechanism that assumed history exists, not in preventing the state where it doesn't.

## Tests

- `internal/git/commit_test.go`: `TestHeadResolvable`, `TestReadTreeIntoTempIndex_UnbornHead`, `TestCommitScoped_UnbornHead`, `TestCommitBlobs_UnbornHead` — host-git unit tests (this package's existing convention, no container) against a freshly `git init`'d repo with zero commits. Confirmed each fails with the exact reported error when the fix is reverted, and passes with it applied.
- `tests/integration/bookkeeping_defer_test.go`: `TestIntegration_BookkeepingCommitLandsOnUnbornHead` — containerized end-to-end repro: raw `camp init` (no baseline commit, unlike `setupDrainCampaign`/`InitCampaign` which paper over this bug), `camp intent add`, drain, then assert the job is not in the failed lane, HEAD now resolves, exactly one commit exists, and it contains the captured intent file. Confirmed this fails against the pre-fix code with `-count=1` (job lands in `failed/`, HEAD stays unresolved) and passes with the fix.

## Test commands run

- `go build ./...` — clean
- `go test ./internal/git/...` — pass (30.6s, includes the 4 new unit tests)
- `go test ./internal/jobs/... ./internal/defercommit/...` — pass
- `go test -tags integration ./tests/integration/ -run 'TestIntegration_Bookkeeping|TestIntegration_Drain|TestIntegration_CampNoDefer|TestIntegration_DeferredCommit' -count=1` — 16/16 pass (Docker via Colima)
- `go test -tags integration ./tests/integration/ -run 'TestIntegration_.*Job|TestIntegration_.*Scope|TestIntegration_.*Commit' -count=1` — 103/103 pass
- `just gate` — PASSED (stable+dev build, vet stable+dev+integration, lint stable clean including the errcheck ratchet, 113 packages / 4001 unit tests passed)

## Caveats

- The `git.FullHash`/`KindCommitTree` gap noted above is real (an unborn-HEAD `--auto-write` commit prints an unnecessary "Could not queue this commit" warning before falling back to synchronous) but does not fail or lose work, and reworking that job's `Parent` field to mean "no parent" would be a larger, separate change to that job schema's validation (`executeCommitTree` currently treats an empty `Parent` as a malformed job). Left out of scope; flagging here in case it's worth its own follow-up.
- No new dependencies, no changes to `camp init`, no synchronous fallback added — this fixes the temp-index mechanism itself, per the task brief.