### PR TITLE
fix(git): return ErrNoChanges for untracked-only and unstaged no-op commits

### DIFF
--- a/internal/git/commit_test.go
+++ b/internal/git/commit_test.go
@@ -442,6 +442,113 @@ func TestCommit_NoChanges(t *testing.T) {
 	// Note: ErrNoChanges is returned
 }
 
+func TestCommit_NoChanges_UntrackedOnly(t *testing.T) {
+	tmpDir := initTestRepo(t)
+
+	// Create initial commit so we have a HEAD.
+	if err := os.WriteFile(filepath.Join(tmpDir, "init.txt"), []byte("init"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, tmpDir, nil, "add", ".")
+	runGit(t, tmpDir, nil, "commit", "-m", "init")
+
+	// Only an untracked file exists; nothing is staged.
+	if err := os.WriteFile(filepath.Join(tmpDir, "untracked.txt"), []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	err := Commit(ctx, tmpDir, &CommitOptions{Message: "should not commit"})
+
+	if !errors.Is(err, ErrNoChanges) {
+		t.Fatalf("Commit() error = %v, want ErrNoChanges", err)
+	}
+}
+
+func TestCommit_NoChanges_TrackedModifiedButUnstaged(t *testing.T) {
+	tmpDir := initTestRepo(t)
+
+	// Create and commit a tracked file.
+	trackedPath := filepath.Join(tmpDir, "tracked.txt")
+	if err := os.WriteFile(trackedPath, []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, tmpDir, nil, "add", ".")
+	runGit(t, tmpDir, nil, "commit", "-m", "init")
+
+	// Modify the tracked file without staging the change.
+	if err := os.WriteFile(trackedPath, []byte("modified"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	err := Commit(ctx, tmpDir, &CommitOptions{Message: "should not commit"})
+
+	if !errors.Is(err, ErrNoChanges) {
+		t.Fatalf("Commit() error = %v, want ErrNoChanges", err)
+	}
+}
+
+func TestCommit_StagedChangeCommitsFine(t *testing.T) {
+	tmpDir := initTestRepo(t)
+
+	// Create initial commit so we have a HEAD.
+	if err := os.WriteFile(filepath.Join(tmpDir, "init.txt"), []byte("init"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, tmpDir, nil, "add", ".")
+	runGit(t, tmpDir, nil, "commit", "-m", "init")
+
+	// Stage a genuine change alongside an untracked file, mirroring the
+	// mixed working tree where the untracked-only matcher must not
+	// misfire on a repo that also has real staged content.
+	if err := os.WriteFile(filepath.Join(tmpDir, "staged.txt"), []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "untracked.txt"), []byte("other"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, tmpDir, nil, "add", "staged.txt")
+
+	ctx := context.Background()
+	err := Commit(ctx, tmpDir, &CommitOptions{Message: "staged commit"})
+	if err != nil {
+		t.Fatalf("Commit() error = %v, want success", err)
+	}
+
+	cmd := exec.Command("git", "-C", tmpDir, "log", "--oneline", "-1")
+	output, _ := cmd.Output()
+	if !strings.Contains(string(output), "staged commit") {
+		t.Error("Commit message not found in git log")
+	}
+}
+
+func TestCommit_DifferentGitFailureNotMappedToNoChanges(t *testing.T) {
+	tmpDir := initTestRepo(t)
+
+	// Stage a change so the no-changes paths are not what triggers the
+	// failure; force a distinct git error (bad author format) instead.
+	if err := os.WriteFile(filepath.Join(tmpDir, "test.txt"), []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := StageAll(context.Background(), tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	err := Commit(ctx, tmpDir, &CommitOptions{
+		Message: "test",
+		Author:  "not-a-valid-author-string",
+	})
+
+	if err == nil {
+		t.Fatal("Commit() error = nil, want a git failure")
+	}
+	if errors.Is(err, ErrNoChanges) {
+		t.Fatalf("Commit() error = %v, should not be classified as ErrNoChanges", err)
+	}
+}
+
 func TestCommit_WithAmend(t *testing.T) {
 	tmpDir := initTestRepo(t)
 

--- a/internal/git/errors.go
+++ b/internal/git/errors.go
@@ -163,7 +163,8 @@ func ClassifyGitError(stderr string, exitCode int) GitErrorType {
 	case strings.Contains(lower, "index.lock"):
 		return GitErrorLock
 	case strings.Contains(lower, "nothing to commit"),
-		strings.Contains(lower, "no changes added to commit"):
+		strings.Contains(lower, "no changes added to commit"),
+		strings.Contains(lower, "nothing added to commit but untracked files present"):
 		return GitErrorNoChanges
 	case strings.Contains(lower, "not a git repository"):
 		return GitErrorNotRepo

--- a/internal/git/errors_test.go
+++ b/internal/git/errors_test.go
@@ -57,6 +57,12 @@ func TestClassifyGitError(t *testing.T) {
 			want:     GitErrorNoChanges,
 		},
 		{
+			name:     "untracked files only, nothing staged",
+			stderr:   "nothing added to commit but untracked files present (use \"git add\" to track)",
+			exitCode: 1,
+			want:     GitErrorNoChanges,
+		},
+		{
 			name:     "not a git repository",
 			stderr:   "fatal: not a git repository (or any of the parent directories): .git",
 			exitCode: 128,


### PR DESCRIPTION
## Bug

`commitkit.Commit` documents "Returns ErrNoChanges if there is nothing to commit," but that contract broke down for one specific shape of no-op: a repo whose only changes were untracked files (nothing staged). Git refuses that commit with:

```
nothing added to commit but untracked files present (use "git add" to track)
```

`internal/git.ClassifyGitError` (internal/git/errors.go) only matched `nothing to commit` and `no changes added to commit`, so this phrasing fell through to `GitErrorUnknown` and `Commit` returned a raw wrapped git failure instead of `ErrNoChanges`. Fest's CA0004 exclude-everything test hit this directly and had to work around it by calling `HasStagedChanges` before `Commit`.

## Fix

Extended the existing string-matcher switch in `ClassifyGitError` with the untracked-only phrasing:

```go
case strings.Contains(lower, "nothing to commit"),
    strings.Contains(lower, "no changes added to commit"),
    strings.Contains(lower, "nothing added to commit but untracked files present"):
    return GitErrorNoChanges
```

I audited git's other no-op phrasings while I was in there:
- `nothing to commit, working tree clean` (truly nothing changed) — already matched.
- `no changes added to commit (use "git add" and/or "git commit -a")` (tracked file modified but unstaged) — already matched.
- `nothing added to commit but untracked files present (use "git add" to track)` (untracked files only, nothing staged) — newly matched by this PR.

This keeps the matcher conservative and string-based, matching the existing idiom in this file rather than introducing a different detection strategy (e.g. checking staged state structurally). A structural check was available (`HasStagedChanges`) but the existing code already classifies git's stderr for every other no-op case, so extending the same switch keeps the contract enforcement in one place instead of splitting it between a string matcher and a separate pre-check.

## Tests

All in `internal/git`, following the package's existing host-git convention (`initTestRepo` with `t.TempDir()` and real `git` invocations, matching every other test in `commit_test.go`):

- `TestClassifyGitError/untracked_files_only,_nothing_staged` (errors_test.go) — direct unit coverage of the new matcher branch.
- `TestCommit_NoChanges_UntrackedOnly` (commit_test.go) — end-to-end: only an untracked file exists, `Commit` returns `ErrNoChanges`. I confirmed this test fails against the pre-fix code (reproduces the exact bug) and passes after the fix.
- `TestCommit_NoChanges_TrackedModifiedButUnstaged` — a tracked file is modified but not staged, `Commit` returns `ErrNoChanges` (already covered by the existing "no changes added to commit" branch; added as an explicit regression guard).
- `TestCommit_StagedChangeCommitsFine` — a real staged change alongside an unrelated untracked file still commits normally (guards against the new branch over-matching a mixed working tree).
- `TestCommit_DifferentGitFailureNotMappedToNoChanges` — a genuinely different git failure (malformed `--author`) is not misclassified as `ErrNoChanges`.

## Gate

Ran `just gate` from the worktree root (stable + dev build, vet, lint stable/dev, dev + stable test suites):

```
=== gate-fast: stable build ===  BUILD SUCCESSFUL (50.80s)
=== gate-fast: dev build ===     BUILD SUCCESSFUL (66.67s)
=== gate-fast: vet stable/dev/integration === clean
=== gate-fast: lint stable ===   0 issues
=== gate-fast: lint dev ===      0 issues
=== gate-fast: unit tests dev ===    116 packages, 4046/4046 tests passed (47.97s)
=== gate: unit tests stable ===      113 packages, 4001/4001 tests passed (53.16s)
=== gate: PASSED ===
```

No `tests/integration/` coverage was touched or added: the existing integration suite (stage-guard and commit-worktree scenarios) doesn't cover the no-changes commit contract, and this behavior is a pure string-classification path already well covered by this package's host-git unit test convention, so I followed that instead of inventing a new pattern.

## Caveats

- The fix is intentionally still string-matching on git's English stderr output (same as the rest of `ClassifyGitError`); it will not recognize a localized git installation's untracked-files message, same limitation the existing branches already have (see `TestClassifyGitErrorLocale`).
- I did not touch `internal/git/commit` (the higher-level `stageAndCommit`/`doCommit` orchestration) — every path there that reaches `git.Commit` without staging first already has a structural pre-check (`ExpandTrackedPathsFromTempIndex` returning empty, or `HasStagedChanges` inside `CommitAll`), so the raw-error-string gap only affected direct callers of the exported `git.Commit`, like fest.