### PR TITLE
feat(commitkit): export StageFilesWithOptions for file-list commit-large

### DIFF
--- a/pkg/commitkit/commitkit.go
+++ b/pkg/commitkit/commitkit.go
@@ -228,6 +228,24 @@ func StageFilesWithOutcome(ctx context.Context, repoPath string, files ...string
 	return git.StageWithGuard(ctx, repoPath, files)
 }
 
+// StageFilesWithOptions is StageFilesWithOutcome with per-invocation overrides
+// of the guard's decision. It exists for the consumer flag that means "commit
+// it anyway": fest's --commit-large forwards here exactly as camp's own
+// --commit-large reaches the guard, so the override behaves identically in
+// both tools on the file-list path, not just the stage-all path.
+func StageFilesWithOptions(ctx context.Context, repoPath string, opts StageOptions, files ...string) (*StageOutcome, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	// Same reasoning as StageFilesWithOutcome: an empty list stays an error
+	// rather than silently becoming stage-everything.
+	if len(files) == 0 {
+		return nil, git.ErrNoFilesSpecified
+	}
+	drainQuietly(ctx, repoPath)
+	return git.StageWithGuardOptions(ctx, repoPath, files, opts)
+}
+
 // HasStagedChanges reports whether there are staged changes ready to commit
 // in the repository at repoPath.
 func HasStagedChanges(ctx context.Context, repoPath string) (bool, error) {

--- a/pkg/commitkit/commitkit_test.go
+++ b/pkg/commitkit/commitkit_test.go
@@ -577,6 +577,52 @@ func TestStageFiles(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// StageFilesWithOptions
+// ---------------------------------------------------------------------------
+
+func TestStageFilesWithOptions(t *testing.T) {
+	t.Run("zero options behaves identically to StageFilesWithOutcome", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a\n"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "b.txt"), []byte("b\n"), 0644))
+
+		outcome, err := commitkit.StageFilesWithOptions(context.Background(), dir, commitkit.StageOptions{}, "a.txt")
+		require.NoError(t, err)
+		assert.Nil(t, outcome, "a zero-options file-list stage has nothing for the guard to report")
+
+		out, err := exec.Command("git", "-C", dir, "diff", "--cached", "--name-only").Output()
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "a.txt")
+		assert.NotContains(t, string(out), "b.txt")
+	})
+
+	t.Run("empty file list is an error, not stage-everything", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		// Same reasoning as StageFilesWithOutcome (see
+		// TestStageWithOutcomeIsAvailableToConsumers): an empty list must not
+		// silently become stage-everything.
+		if _, err := commitkit.StageFilesWithOptions(context.Background(), dir, commitkit.StageOptions{}); err == nil {
+			t.Error("StageFilesWithOptions with no files returned nil; an empty list must not mean stage everything")
+		}
+	})
+
+	t.Run("returns error on cancelled context", func(t *testing.T) {
+		dir := t.TempDir()
+		makeGitRepo(t, dir)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		_, err := commitkit.StageFilesWithOptions(ctx, dir, commitkit.StageOptions{CommitLarge: true}, "file.txt")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+// ---------------------------------------------------------------------------
 // HasStagedChanges
 // ---------------------------------------------------------------------------
 

--- a/pkg/commitkit/guard_test.go
+++ b/pkg/commitkit/guard_test.go
@@ -77,6 +77,15 @@ func TestStageAllWithOptionsHonorsCanceledContext(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
+func TestStageFilesWithOptionsHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := commitkit.StageFilesWithOptions(ctx, nonexistentRepo, commitkit.StageOptions{CommitLarge: true}, "file.txt")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 func TestStageAllHonorsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()


### PR DESCRIPTION
## The gap

`pkg/commitkit` exports `StageFilesWithOutcome(ctx, repoPath, files...)` but no options-taking form, so a consumer cannot pass `StageOptions{CommitLarge: true}` when staging an explicit file list. PR #523 closed this for the stage-all path (`StageAllWithOptions`); the file-list path stayed behind.

The concrete consequence lives in fest: its file-list commit branches must print `camp commit --commit-large` as the retry command instead of `fest commit --commit-large`, because fest cannot honor its own flag on that path (campaign intent `camp-commitkit-exports-no-options-20260730-125402`).

## The change

`StageFilesWithOptions(ctx, repoPath string, opts StageOptions, files ...string)` in `pkg/commitkit/commitkit.go`, mirroring `StageAllWithOptions` exactly: the same ctx short-circuit, the same `drainQuietly`, delegating to the internal `git.StageWithGuardOptions` with the file list.

One deliberate divergence from the lower layer: an empty file list returns `git.ErrNoFilesSpecified`, matching `StageFilesWithOutcome`, rather than falling through to the internal path where no files means "stage the whole tree". A caller who passed an empty slice did not mean stage-everything.

## Tests

- `TestStageFilesWithOptions`: zero options behaves identically to `StageFilesWithOutcome` (stages the named file, not its neighbor); empty file list is an error, not stage-everything; cancelled context returns `context.Canceled`.
- `TestStageFilesWithOptionsHonorsCanceledContext` in `guard_test.go`, matching the existing `StageAllWithOptions` cancellation test placement.

## Gates

- `go test ./pkg/commitkit/...`: pass (6.5s)
- `just gate`: PASSED (stable and dev builds, vet stable/dev/integration, lint stable and dev clean, 3997 unit tests passed)

## Follow-up

Once this ships in a release fest can pin, fest's file-list retry copy can flip from `camp commit --commit-large` to `fest commit --commit-large` and wire the flag through `StageFilesWithOptions`. That consumption change is fest-side and separate.
