### PR TITLE
feat(machine): hop to a campaign from the fleet screen with enter

### DIFF
--- a/cmd/camp/machine.go
+++ b/cmd/camp/machine.go
@@ -88,9 +88,12 @@ server does not run in sandboxed macOS GUI builds, so a mac accepts OpenSSH keys
 instead) and docs/transfer.md for the machine-first transfer grammar.
 
 Run without a subcommand in a terminal to manage the fleet interactively: add,
-discover, edit, and remove machines, and see each one's socket state. The
-subcommands stay the interface for scripts and agents, and remain what a
-non-terminal 'camp machine' prints help for.`,
+discover, edit, and remove machines, see each one's socket state, and press
+enter to pick a campaign on the selected machine and hop to it. Hopping needs
+the shell wrapper ('eval "$(camp shell-init zsh)"'), because no subprocess can
+replace the shell it was run from; without it the screen says so rather than
+appearing to work. The subcommands stay the interface for scripts and agents,
+and remain what a non-terminal 'camp machine' prints help for.`,
 	Args: cobra.NoArgs,
 	RunE: runMachineTUI,
 	Example: `  camp machine
@@ -199,6 +202,11 @@ func init() {
 		"Campaign name on the calling machine (repeatable; names may contain commas)")
 	machineAdoptCmd.Flags().BoolVar(&machineAdoptForce, "force", false,
 		"Skip the reminder that you declined this origin before (never skips the confirmation)")
+
+	// Shared with `camp list`: the TUI writes the chosen destination here and the
+	// shell wrapper acts on it, because a subprocess cannot move its parent shell.
+	machineCmd.Flags().String("path-output", "", "Write the selected hop target to a file (shell integration)")
+	_ = machineCmd.Flags().MarkHidden("path-output")
 
 	machineListCmd.Flags().BoolVar(&machineListJSON, "json", false, "Output as JSON")
 

--- a/cmd/camp/machine_tui.go
+++ b/cmd/camp/machine_tui.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"sort"
 	"strings"
@@ -26,6 +27,7 @@ const (
 	machineDeleteOverlay
 	machineDiscoverOverlay
 	machineHelpOverlay
+	machineHopOverlay
 )
 
 // machineFormField indexes the fields of the add/edit form in the order they
@@ -137,6 +139,15 @@ type machineTUIModel struct {
 	form      machineForm
 	pendingID string
 
+	// hopEnabled reports whether the shell wrapper is there to complete a hop.
+	// It gates the key rather than the screen: the fleet is still worth managing
+	// without shell integration, only the hop cannot be finished.
+	hopEnabled bool
+	// hopSelection is the ssh-hop payload the wrapper acts on, set exactly once
+	// immediately before the final Quit.
+	hopSelection string
+	hop          machineHopState
+
 	// spin animates while a connection test or tailnet scan is out. An ssh
 	// connect can take the full ConnectTimeout before it fails, and a
 	// tailscale status call can sit still just as long; a screen that does
@@ -148,6 +159,37 @@ type machineTUIModel struct {
 	width     int
 	height    int
 	quitting  bool
+}
+
+// machineHopState backs the campaign picker that turns a machine row into a hop
+// target. A hop is machine:campaign, never a bare machine, so choosing the
+// machine is only half the gesture.
+//
+// Campaigns come from the completion cache first, which is what makes the
+// overlay open instantly: the cache is filled by `camp list --remote` pulls and
+// by snapshots other machines push, so the common case never waits on ssh. A
+// live fetch runs only when the cache is cold or the operator asks for one.
+type machineHopState struct {
+	machineID string
+	campaigns []string
+	cursor    int
+	loading   bool
+	err       string
+	// cached records that the list on screen came from the snapshot rather than
+	// a live answer. Worth saying: a pushed entry can be up to 24h old, so a
+	// campaign created since then will not be in it.
+	cached bool
+	// gen drops a late fetch whose overlay has already been closed or reopened
+	// against a different machine.
+	gen uint64
+}
+
+// hopCampaignsMsg carries a live campaign fetch for one machine.
+type hopCampaignsMsg struct {
+	id        string
+	campaigns []string
+	err       error
+	gen       uint64
 }
 
 // socketsMsg carries the result of probing every machine's ControlMaster
@@ -186,11 +228,37 @@ func runMachineTUI(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	program := tea.NewProgram(newMachineTUIModel(ctx, mf), tea.WithContext(ctx), tea.WithAltScreen())
-	if _, err := program.Run(); err != nil {
+	pathOutput, _ := cmd.Flags().GetString("path-output")
+	model := newMachineTUIModel(ctx, mf)
+	// Hop is offered only when the wrapper is there to complete it. Without a
+	// path-output file the key would appear to work and then do nothing, so the
+	// screen says what is missing instead of pretending.
+	model.hopEnabled = pathOutput != ""
+
+	program := tea.NewProgram(model, tea.WithContext(ctx), tea.WithAltScreen())
+	final, err := program.Run()
+	if err != nil {
 		return camperrors.Wrap(err, "running machine TUI")
 	}
-	return nil
+	return writeMachineHopSelection(final, pathOutput)
+}
+
+// writeMachineHopSelection persists the hop the operator chose, in the same
+// ssh-hop:<machine>:<campaign> form `camp list` already writes, so both TUIs
+// hand the shell wrapper one vocabulary rather than two. No-op unless a
+// path-output file was supplied and a hop was actually chosen.
+func writeMachineHopSelection(final tea.Model, pathOutput string) error {
+	m, ok := final.(*machineTUIModel)
+	if !ok || pathOutput == "" || m.hopSelection == "" {
+		return nil
+	}
+	return os.WriteFile(pathOutput, []byte(m.hopSelection), 0o600)
+}
+
+// machineHopSelection builds the path-output payload for a hop to campaign on
+// machine id.
+func machineHopSelection(id, campaign string) string {
+	return "ssh-hop:" + id + ":" + campaign
 }
 
 func newMachineTUIModel(ctx context.Context, mf *machines.File) *machineTUIModel {
@@ -231,10 +299,38 @@ func (m *machineTUIModel) testing() bool {
 	return false
 }
 
-// busy reports whether the spinner should keep ticking: either a connection
-// test or a tailnet scan is in flight.
+// busy reports whether the spinner should keep ticking: a connection test, a
+// tailnet scan, or a live campaign fetch is in flight.
 func (m *machineTUIModel) busy() bool {
-	return m.testing() || m.scanning
+	return m.testing() || m.scanning || m.hop.loading
+}
+
+// listRemoteCampaignsFor is the seam a live campaign fetch resolves through, so
+// the hop picker can be exercised without a live ssh. Production runs the remote
+// machine's own `camp list --json`, which also warms the completion cache — so
+// paying for one fetch here makes the next open of this overlay instant.
+//
+// Not parallel-safe: tests swap this package-level var.
+var listRemoteCampaignsFor = func(ctx context.Context, m *machines.Machine) ([]string, error) {
+	rows, err := enumerateRemoteFor(listFilter{})(ctx, m)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(rows))
+	for _, row := range rows {
+		names = append(names, row.Name)
+	}
+	return names, nil
+}
+
+// fetchHopCampaigns asks a machine for its campaigns in the background, stamped
+// with gen so a late finish against a closed or re-pointed overlay is dropped.
+func (m *machineTUIModel) fetchHopCampaigns(target machines.Machine, gen uint64) tea.Cmd {
+	ctx := m.ctx
+	return func() tea.Msg {
+		names, err := listRemoteCampaignsFor(ctx, &target)
+		return hopCampaignsMsg{id: target.ID, campaigns: names, err: err, gen: gen}
+	}
 }
 
 // tailscaleInstalled reports whether the tailscale CLI is on PATH. Discovery

--- a/cmd/camp/machine_tui_hop_test.go
+++ b/cmd/camp/machine_tui_hop_test.go
@@ -303,6 +303,35 @@ func TestUnreachableMachineReportsRatherThanShowingAnEmptyList(t *testing.T) {
 	}
 }
 
+// A failed refresh replaces the list with the error screen, so the list must
+// really be gone: enter (and j/k) acting on a stale invisible list would hop
+// from a failure screen to a machine that just proved unreachable.
+func TestFailedRefreshClearsTheListSoEnterCannotHop(t *testing.T) {
+	isolateMachineCache(t)
+	writeMachineCacheCampaigns("buildbox", []string{"notes", "platform"})
+
+	m := hopReadyModel(t)
+	m.openHopPicker()
+	m.updateHop(key("down"))
+	m.updateHop(key("r"))
+	m.applyHopCampaigns(hopCampaignsMsg{
+		id:  "buildbox",
+		err: camperrors.New("ssh: connect to host buildbox port 22: no route to host"),
+		gen: m.hop.gen,
+	})
+
+	if len(m.hop.campaigns) != 0 {
+		t.Fatalf("campaigns = %v, want the stale list cleared alongside the error", m.hop.campaigns)
+	}
+	_, cmd := m.updateHop(key("enter"))
+	if m.hopSelection != "" {
+		t.Fatalf("hopSelection = %q, want no hop from a failure screen", m.hopSelection)
+	}
+	if cmd != nil {
+		t.Fatal("enter on a failure screen must not quit into a hop")
+	}
+}
+
 // t and enter are different gestures now. Regression guard: enter used to test
 // the connection, and rebinding it must not have taken the tester with it.
 func TestTestConnectionStillHasItsOwnKey(t *testing.T) {

--- a/cmd/camp/machine_tui_hop_test.go
+++ b/cmd/camp/machine_tui_hop_test.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/machines"
+)
+
+func key(s string) tea.KeyMsg {
+	if len(s) == 1 {
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+	switch s {
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	default:
+		panic("unmapped key " + s)
+	}
+}
+
+// hopReadyModel is a fleet screen with shell integration present and the cursor
+// on a configured machine, which is the state every hop assertion starts from.
+func hopReadyModel(t *testing.T) *machineTUIModel {
+	t.Helper()
+	m := newMachineTUIModel(t.Context(), fleetFile())
+	m.hopEnabled = true
+	m.cursor = 1 // buildbox: ssh-agent auth, so EnsureKeyAuth passes
+	return m
+}
+
+// stubRemoteCampaigns points the live fetch at a fake so no test dials ssh.
+func stubRemoteCampaigns(t *testing.T, names []string, err error) {
+	t.Helper()
+	prev := listRemoteCampaignsFor
+	listRemoteCampaignsFor = func(context.Context, *machines.Machine) ([]string, error) {
+		return names, err
+	}
+	t.Cleanup(func() { listRemoteCampaignsFor = prev })
+}
+
+// isolateMachineCache redirects the completion cache into a temp dir so these
+// tests can neither read a developer's warm cache (which would make a
+// cold-cache assertion pass for the wrong reason) nor write into the real
+// ~/.obey. XDG_CONFIG_HOME is set explicitly rather than relying on the HOME
+// fallback: machineCacheDir prefers XDG when it is set, so a machine that
+// exports it would otherwise route these writes straight at the real cache.
+func isolateMachineCache(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	return home
+}
+
+// The hop is the whole point of the key: the payload has to be the same
+// ssh-hop vocabulary `camp list` already writes, because one shell arm reads both.
+func TestHopSelectionUsesTheSharedSSHHopVocabulary(t *testing.T) {
+	got := machineHopSelection("buildbox", "notes")
+	if want := "ssh-hop:buildbox:notes"; got != want {
+		t.Fatalf("machineHopSelection = %q, want %q", got, want)
+	}
+	if got != gotoSelectionFor(campaignEntry{Machine: "buildbox", Name: "notes"}) {
+		t.Error("the machine screen and the list screen must emit an identical payload")
+	}
+}
+
+// Without the wrapper the key cannot finish, so it must say so rather than
+// appear to work. This is the failure an operator hits on a fresh install.
+func TestHopWithoutShellIntegrationRefusesAndNamesTheFix(t *testing.T) {
+	m := hopReadyModel(t)
+	m.hopEnabled = false
+
+	m.openHopPicker()
+
+	if m.overlay == machineHopOverlay {
+		t.Error("the campaign picker must not open when the hop cannot be completed")
+	}
+	if m.statusKind != statusError {
+		t.Errorf("statusKind = %v, want statusError", m.statusKind)
+	}
+	if !strings.Contains(m.status, "camp shell-init") {
+		t.Errorf("status = %q, want it to name the shell-init fix", m.status)
+	}
+}
+
+// local is this computer. Offering a campaign list for it would produce an ssh
+// hop to itself, which is the one machine an operator is guaranteed to be at.
+func TestHopRefusesTheLocalRow(t *testing.T) {
+	m := hopReadyModel(t)
+	m.cursor = 0
+
+	m.openHopPicker()
+
+	if m.overlay == machineHopOverlay {
+		t.Error("local must not open the campaign picker")
+	}
+	if m.statusKind != statusError {
+		t.Errorf("statusKind = %v, want statusError", m.statusKind)
+	}
+}
+
+// Refuse before opening, not after choosing: a password-auth machine can never
+// be hopped to, so a list of its campaigns leads nowhere.
+func TestHopRefusesPasswordAuthBeforeOpeningTheList(t *testing.T) {
+	m := newMachineTUIModel(t.Context(), &machines.File{
+		Version:  1,
+		Machines: []machines.Machine{{ID: "pw", Host: "pw.example", AuthMethod: machines.AuthSSHPassword}},
+	})
+	m.hopEnabled = true
+	m.cursor = 1
+
+	m.openHopPicker()
+
+	if m.overlay == machineHopOverlay {
+		t.Error("a password-auth machine must not open the campaign picker")
+	}
+	if !strings.Contains(m.status, "password-auth") {
+		t.Errorf("status = %q, want it to name password auth", m.status)
+	}
+}
+
+// The warm cache is what makes the picker open instantly. A cache hit must not
+// dial ssh — that is the difference between a keystroke and an eight-second wait.
+func TestHopOpensFromCacheWithoutDialing(t *testing.T) {
+	isolateMachineCache(t)
+	writeMachineCacheCampaigns("buildbox", []string{"notes", "platform"})
+
+	dialed := false
+	prev := listRemoteCampaignsFor
+	listRemoteCampaignsFor = func(context.Context, *machines.Machine) ([]string, error) {
+		dialed = true
+		return nil, nil
+	}
+	t.Cleanup(func() { listRemoteCampaignsFor = prev })
+
+	m := hopReadyModel(t)
+	_, cmd := m.openHopPicker()
+
+	if m.overlay != machineHopOverlay {
+		t.Fatal("a cache hit must open the campaign picker")
+	}
+	if cmd != nil {
+		t.Error("a cache hit must not schedule a fetch")
+	}
+	if dialed {
+		t.Error("a cache hit must not dial the machine")
+	}
+	if !m.hop.cached {
+		t.Error("the picker must record that the list came from the snapshot")
+	}
+	if strings.Join(m.hop.campaigns, ",") != "notes,platform" {
+		t.Errorf("campaigns = %v, want [notes platform]", m.hop.campaigns)
+	}
+}
+
+// A cold cache is the only case that pays for ssh, and it must actually pay
+// rather than showing an empty list as if the machine had no campaigns.
+func TestHopFetchesWhenTheCacheIsCold(t *testing.T) {
+	isolateMachineCache(t)
+	stubRemoteCampaigns(t, []string{"remote-only"}, nil)
+
+	m := hopReadyModel(t)
+	_, cmd := m.openHopPicker()
+
+	if m.overlay != machineHopOverlay {
+		t.Fatal("a cold cache must still open the picker")
+	}
+	if !m.hop.loading {
+		t.Error("a cold cache must show the fetch as in flight")
+	}
+	if cmd == nil {
+		t.Fatal("a cold cache must schedule a fetch")
+	}
+
+	m.applyHopCampaigns(hopCampaignsMsg{id: "buildbox", campaigns: []string{"remote-only"}, gen: m.hop.gen})
+	if m.hop.loading {
+		t.Error("the fetch result must clear the loading state")
+	}
+	if m.hop.cached {
+		t.Error("a live result must not be labelled as a snapshot")
+	}
+	if strings.Join(m.hop.campaigns, ",") != "remote-only" {
+		t.Errorf("campaigns = %v, want [remote-only]", m.hop.campaigns)
+	}
+}
+
+// Choosing a campaign is what actually produces the hop, and it must quit so the
+// wrapper gets the file. A selection that did not quit would strand the operator.
+func TestChoosingACampaignEmitsTheHopAndQuits(t *testing.T) {
+	isolateMachineCache(t)
+	writeMachineCacheCampaigns("buildbox", []string{"notes", "platform"})
+
+	m := hopReadyModel(t)
+	m.openHopPicker()
+	m.updateHop(key("down"))
+	_, cmd := m.updateHop(key("enter"))
+
+	if want := "ssh-hop:buildbox:platform"; m.hopSelection != want {
+		t.Fatalf("hopSelection = %q, want %q", m.hopSelection, want)
+	}
+	if cmd == nil {
+		t.Fatal("choosing a campaign must quit so the wrapper can act on the file")
+	}
+	if msg := cmd(); msg != tea.Quit() {
+		t.Errorf("expected tea.Quit, got %T", msg)
+	}
+}
+
+// Quitting without choosing must leave the file untouched, or the wrapper would
+// hop somewhere the operator backed out of.
+func TestCancellingTheHopWritesNothing(t *testing.T) {
+	isolateMachineCache(t)
+	writeMachineCacheCampaigns("buildbox", []string{"notes"})
+
+	m := hopReadyModel(t)
+	m.openHopPicker()
+	m.updateHop(key("esc"))
+
+	if m.hopSelection != "" {
+		t.Errorf("hopSelection = %q, want empty after cancel", m.hopSelection)
+	}
+	if m.overlay != machineNoOverlay {
+		t.Error("esc must close the picker")
+	}
+
+	out := filepath.Join(t.TempDir(), "hop")
+	if err := writeMachineHopSelection(m, out); err != nil {
+		t.Fatalf("writeMachineHopSelection: %v", err)
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Error("a cancelled hop must not create the path-output file")
+	}
+}
+
+func TestWriteHopSelectionPersistsTheChosenPayload(t *testing.T) {
+	m := hopReadyModel(t)
+	m.hopSelection = "ssh-hop:buildbox:notes"
+	out := filepath.Join(t.TempDir(), "hop")
+
+	if err := writeMachineHopSelection(m, out); err != nil {
+		t.Fatalf("writeMachineHopSelection: %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read path-output: %v", err)
+	}
+	if string(data) != "ssh-hop:buildbox:notes" {
+		t.Errorf("path-output = %q, want the ssh-hop payload", data)
+	}
+}
+
+// A fetch that lands after its overlay closed (or was re-pointed at another
+// machine) must be dropped, or a slow devbox answer overwrites the buildbox list
+// the operator is looking at.
+func TestStaleFetchResultIsDropped(t *testing.T) {
+	isolateMachineCache(t)
+	stubRemoteCampaigns(t, []string{"late"}, nil)
+
+	m := hopReadyModel(t)
+	m.openHopPicker()
+	stale := m.hop.gen
+
+	m.updateHop(key("esc"))
+	m.openHopPicker()
+
+	m.applyHopCampaigns(hopCampaignsMsg{id: "buildbox", campaigns: []string{"late"}, gen: stale})
+	if strings.Join(m.hop.campaigns, ",") == "late" {
+		t.Error("a superseded fetch must not populate the reopened picker")
+	}
+}
+
+// An unreachable machine must explain and offer the diagnostic, not show an
+// empty list that reads as "this machine has no campaigns".
+func TestUnreachableMachineReportsRatherThanShowingAnEmptyList(t *testing.T) {
+	isolateMachineCache(t)
+	stubRemoteCampaigns(t, nil, camperrors.New("ssh: connect to host buildbox port 22: no route to host"))
+
+	m := hopReadyModel(t)
+	m.openHopPicker()
+	m.applyHopCampaigns(hopCampaignsMsg{
+		id:  "buildbox",
+		err: camperrors.New("ssh: connect to host buildbox port 22: no route to host"),
+		gen: m.hop.gen,
+	})
+
+	if m.hop.err == "" {
+		t.Fatal("an unreachable machine must record the failure")
+	}
+	body := strings.Join(m.hopBody(), "\n")
+	if !strings.Contains(body, "camp machine diagnose buildbox") {
+		t.Errorf("hop body must point at the diagnostic, got:\n%s", body)
+	}
+}
+
+// t and enter are different gestures now. Regression guard: enter used to test
+// the connection, and rebinding it must not have taken the tester with it.
+func TestTestConnectionStillHasItsOwnKey(t *testing.T) {
+	isolateMachines(t)
+	m := hopReadyModel(t)
+
+	m.updateBrowse(key("t"))
+	if m.health["buildbox"].State != healthTesting {
+		t.Error("t must still start a connection test")
+	}
+	if m.overlay == machineHopOverlay {
+		t.Error("t must not open the hop picker")
+	}
+}

--- a/cmd/camp/machine_tui_update.go
+++ b/cmd/camp/machine_tui_update.go
@@ -23,6 +23,8 @@ func (m *machineTUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case devicesMsg:
 		return m.applyDevices(msg)
+	case hopCampaignsMsg:
+		return m.applyHopCampaigns(msg)
 	case spinner.TickMsg:
 		if !m.busy() {
 			return m, nil
@@ -160,7 +162,9 @@ func (m *machineTUIModel) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		return m, m.beginScan(true)
-	case "t", "enter":
+	case "enter":
+		return m.openHopPicker()
+	case "t":
 		return m, m.testSelected()
 	case "e":
 		return m, m.openEditForm()
@@ -175,6 +179,117 @@ func (m *machineTUIModel) updateBrowse(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.overlay = machineHelpOverlay
 	}
 	return m, nil
+}
+
+// openHopPicker turns the highlighted machine into a hop by asking which
+// campaign to land in. It refuses before opening rather than after choosing, so
+// a machine that cannot be hopped to never presents a list that leads nowhere.
+func (m *machineTUIModel) openHopPicker() (tea.Model, tea.Cmd) {
+	row := m.selectedRow()
+	if row.Local {
+		m.setError(camperrors.New("local is this computer; use 'camp list' to open a campaign here"))
+		return m, nil
+	}
+	if !m.hopEnabled {
+		m.setError(camperrors.New("hop needs shell integration: run eval \"$(camp shell-init <shell>)\""))
+		return m, nil
+	}
+	if err := remote.EnsureKeyAuth(row.Machine); err != nil {
+		m.setError(camperrors.New("camp cannot hop to a password-auth machine yet"))
+		return m, nil
+	}
+
+	m.hop.gen++
+	m.hop = machineHopState{machineID: row.Machine.ID, gen: m.hop.gen}
+	m.overlay = machineHopOverlay
+
+	// Cache first: this is the keystroke path, and the snapshot is exactly the
+	// data `csw <id>:<tab>` completes from. A cold cache is the only case that
+	// pays for ssh, and it pays once because the fetch warms the cache too.
+	if names, ok := readMachineCacheCampaigns(row.Machine.ID); ok && len(names) > 0 {
+		m.hop.campaigns = names
+		m.hop.cached = true
+		return m, nil
+	}
+	m.hop.loading = true
+	return m, tea.Batch(m.spin.Tick, m.fetchHopCampaigns(*row.Machine, m.hop.gen))
+}
+
+// updateHop drives the campaign picker. r re-fetches, which is how a stale
+// snapshot gets corrected without leaving the screen.
+func (m *machineTUIModel) updateHop(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+	case "esc", "q":
+		m.overlay = machineNoOverlay
+		m.hop = machineHopState{gen: m.hop.gen}
+		return m, nil
+	case "up", "k":
+		if n := len(m.hop.campaigns); n > 0 {
+			m.hop.cursor = (m.hop.cursor - 1 + n) % n
+		}
+		return m, nil
+	case "down", "j":
+		if n := len(m.hop.campaigns); n > 0 {
+			m.hop.cursor = (m.hop.cursor + 1) % n
+		}
+		return m, nil
+	case "r":
+		if m.hop.loading {
+			return m, nil
+		}
+		m.hop.gen++
+		m.hop.loading = true
+		m.hop.err = ""
+		target, ok := m.machineByID(m.hop.machineID)
+		if !ok {
+			m.hop.loading = false
+			return m, nil
+		}
+		return m, tea.Batch(m.spin.Tick, m.fetchHopCampaigns(target, m.hop.gen))
+	case "enter":
+		if m.hop.loading || len(m.hop.campaigns) == 0 {
+			return m, nil
+		}
+		name := m.hop.campaigns[clampIndex(m.hop.cursor, len(m.hop.campaigns))]
+		// The wrapper resolves this through `camp switch <id>:<name>`, so the
+		// remote registry still decides the path and this never guesses one.
+		m.hopSelection = machineHopSelection(m.hop.machineID, name)
+		m.quitting = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+// applyHopCampaigns folds a live fetch into the overlay, dropping a result whose
+// generation has been superseded by a close, a re-open, or a newer refresh.
+func (m *machineTUIModel) applyHopCampaigns(msg hopCampaignsMsg) (tea.Model, tea.Cmd) {
+	if msg.gen != m.hop.gen || m.overlay != machineHopOverlay {
+		return m, nil
+	}
+	m.hop.loading = false
+	if msg.err != nil {
+		m.hop.err = connectionFailureDetail(msg.err)
+		return m, nil
+	}
+	m.hop.err = ""
+	m.hop.campaigns = msg.campaigns
+	m.hop.cached = false
+	m.hop.cursor = 0
+	return m, nil
+}
+
+// machineByID finds a configured machine by id, copied so a background fetch
+// never reads the slice the fleet list is rebuilt from.
+func (m *machineTUIModel) machineByID(id string) (machines.Machine, bool) {
+	for i := range m.file.Machines {
+		if m.file.Machines[i].ID == id {
+			return m.file.Machines[i], true
+		}
+	}
+	return machines.Machine{}, false
 }
 
 // testSelected runs a connection test against the highlighted machine.
@@ -269,6 +384,8 @@ func (m *machineTUIModel) updateOverlay(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.updateDiscover(msg)
 	case machineFormOverlay:
 		return m.updateForm(msg)
+	case machineHopOverlay:
+		return m.updateHop(msg)
 	default:
 		return m, nil
 	}

--- a/cmd/camp/machine_tui_update.go
+++ b/cmd/camp/machine_tui_update.go
@@ -272,6 +272,12 @@ func (m *machineTUIModel) applyHopCampaigns(msg hopCampaignsMsg) (tea.Model, tea
 	m.hop.loading = false
 	if msg.err != nil {
 		m.hop.err = connectionFailureDetail(msg.err)
+		// The error screen replaces the list, so the list must actually be gone:
+		// keeping the previous campaigns here would let enter act on entries the
+		// operator can no longer see, hopping from a failure screen.
+		m.hop.campaigns = nil
+		m.hop.cached = false
+		m.hop.cursor = 0
 		return m, nil
 	}
 	m.hop.err = ""

--- a/cmd/camp/machine_tui_view.go
+++ b/cmd/camp/machine_tui_view.go
@@ -431,9 +431,9 @@ func (m *machineTUIModel) statusLine() string {
 // equal weight. The action that answers "does this work" comes first, because
 // on a screen full of untested machines it is the one worth pressing.
 func (m *machineTUIModel) footer(width int) string {
-	full := "t test connection  ·  e edit · d remove  ·  a add · s scan tailnet  ·  ? help · q quit"
-	mid := "t test · e edit · d remove · a add · s scan · ? help · q quit"
-	short := "t test · a add · ? help · q quit"
+	full := "enter hop  ·  t test connection  ·  e edit · d remove  ·  a add · s scan tailnet  ·  ? help · q quit"
+	mid := "enter hop · t test · e edit · d remove · a add · s scan · ? help · q quit"
+	short := "enter hop · t test · a add · ? help · q quit"
 	return machineHelpStyle.Render(ui.CollapseHelp(width, full, mid, short, "q: quit"))
 }
 
@@ -450,12 +450,14 @@ func (m *machineTUIModel) overlayView() string {
 			machinePrimary.Render("Once one is listed here you can work on campaigns that"),
 			machinePrimary.Render("live on it, without leaving this terminal:"),
 			"",
-			machineCommand("camp switch devbox:my-campaign", "open one over there"),
+			machineCommand("enter", "pick a campaign and hop there"),
+			machineCommand("camp switch devbox:my-campaign", "the same hop, typed"),
 			machineCommand("camp list --remote", "campaigns everywhere"),
 			"",
 			machineMuted.Render("Nothing runs on a machine until you hop to it."),
 			"",
 			machineTitleStyle.Render("Keys"),
+			machinePrimary.Render("  enter  pick a campaign on the selected machine and hop"),
 			machinePrimary.Render("  t  test whether camp can reach the selected machine"),
 			machinePrimary.Render("  a  add a machine by hand"),
 			machinePrimary.Render("  s  scan your Tailscale network and pick a device"),
@@ -482,6 +484,8 @@ func (m *machineTUIModel) overlayView() string {
 		body = m.discoverBody()
 	case machineFormOverlay:
 		body = m.formBody()
+	case machineHopOverlay:
+		body = m.hopBody()
 	}
 
 	boxWidth := min(max(lay.width-6, 30), 76)
@@ -491,6 +495,64 @@ func (m *machineTUIModel) overlayView() string {
 	canvas := lipgloss.Place(lay.width, lay.height, lipgloss.Center, lipgloss.Center, box,
 		lipgloss.WithWhitespaceBackground(machineTUIPal.BgOverlay))
 	return ui.FitFullscreenView(canvas, lay.height)
+}
+
+// hopBody renders the campaign picker for a hop. It always says where the list
+// came from: a snapshot can be up to 24h old, and an operator who cannot find a
+// campaign they just created needs to know refreshing is the fix rather than
+// concluding the machine is broken.
+func (m *machineTUIModel) hopBody() []string {
+	title := machineTitleStyle.Render("Hop to " + m.hop.machineID)
+
+	if m.hop.loading {
+		return []string{
+			title,
+			"",
+			machineMuted.Render(m.spin.View() + " Asking " + m.hop.machineID + " for its campaigns..."),
+			"",
+			machineHelpStyle.Render("esc cancel"),
+		}
+	}
+
+	body := []string{title}
+	switch {
+	case m.hop.err != "":
+		body = append(body,
+			"",
+			machineErrorStyle.Render("✗ "+m.hop.err),
+			"",
+			machineMuted.Render("'camp machine diagnose "+m.hop.machineID+"' reports auth, probe, and socket state."),
+			"",
+			machineHelpStyle.Render("r retry · esc cancel"),
+		)
+		return body
+	case len(m.hop.campaigns) == 0:
+		body = append(body,
+			"",
+			machineMuted.Render("No campaigns found on "+m.hop.machineID+"."),
+			"",
+			machineHelpStyle.Render("r refresh · esc cancel"),
+		)
+		return body
+	}
+
+	if m.hop.cached {
+		body = append(body, machineMuted.Render("From the last snapshot; press r to ask the machine now."))
+	} else {
+		body = append(body, machineMuted.Render("Live from "+m.hop.machineID+"."))
+	}
+	body = append(body, "")
+
+	for i, name := range m.hop.campaigns {
+		line := "  " + name
+		if i == clampIndex(m.hop.cursor, len(m.hop.campaigns)) {
+			body = append(body, machineSelected.Render("› "+name))
+			continue
+		}
+		body = append(body, machinePrimary.Render(line))
+	}
+
+	return append(body, "", machineHelpStyle.Render("j/k move · enter hop · r refresh · esc cancel"))
 }
 
 func (m *machineTUIModel) discoverBody() []string {

--- a/docs/cli-reference/camp-reference.md
+++ b/docs/cli-reference/camp-reference.md
@@ -3585,9 +3585,12 @@ server does not run in sandboxed macOS GUI builds, so a mac accepts OpenSSH keys
 instead) and docs/transfer.md for the machine-first transfer grammar.
 
 Run without a subcommand in a terminal to manage the fleet interactively: add,
-discover, edit, and remove machines, and see each one's socket state. The
-subcommands stay the interface for scripts and agents, and remain what a
-non-terminal 'camp machine' prints help for.
+discover, edit, and remove machines, see each one's socket state, and press
+enter to pick a campaign on the selected machine and hop to it. Hopping needs
+the shell wrapper ('eval "$(camp shell-init zsh)"'), because no subprocess can
+replace the shell it was run from; without it the screen says so rather than
+appearing to work. The subcommands stay the interface for scripts and agents,
+and remain what a non-terminal 'camp machine' prints help for.
 
 ```
 camp machine [flags]

--- a/docs/cli-reference/camp_machine.md
+++ b/docs/cli-reference/camp_machine.md
@@ -34,9 +34,12 @@ server does not run in sandboxed macOS GUI builds, so a mac accepts OpenSSH keys
 instead) and docs/transfer.md for the machine-first transfer grammar.
 
 Run without a subcommand in a terminal to manage the fleet interactively: add,
-discover, edit, and remove machines, and see each one's socket state. The
-subcommands stay the interface for scripts and agents, and remain what a
-non-terminal 'camp machine' prints help for.
+discover, edit, and remove machines, see each one's socket state, and press
+enter to pick a campaign on the selected machine and hop to it. Hopping needs
+the shell wrapper ('eval "$(camp shell-init zsh)"'), because no subprocess can
+replace the shell it was run from; without it the screen says so rather than
+appearing to work. The subcommands stay the interface for scripts and agents,
+and remain what a non-terminal 'camp machine' prints help for.
 
 ```
 camp machine [flags]

--- a/docs/machine-mesh.md
+++ b/docs/machine-mesh.md
@@ -86,6 +86,29 @@ $ camp machine adopt
 devbox.example.ts.net is already in your fleet as "devbox"; nothing to adopt
 ```
 
+## Hopping from the fleet screen
+
+`camp machine` lists the fleet; `enter` on a row picks a campaign on that machine
+and hops there. The campaign list comes from the same snapshot completion reads, so
+the picker opens without dialing; `r` refreshes it live when the snapshot is stale.
+
+The hop itself still goes through `camp switch <id>:<campaign>`. The screen writes
+`ssh-hop:<id>:<campaign>` and the shell wrapper turns that into the hop, which is
+the identical path `camp list`'s picker takes. Nothing about the remote resolution
+is duplicated: the far machine's own registry decides the path, exactly as it does
+for a typed `csw devbox:notes`.
+
+This needs the wrapper. A subprocess cannot replace the shell that launched it, so
+without `eval "$(camp shell-init zsh)"` the key reports what is missing instead of
+silently doing nothing:
+
+```
+hop needs shell integration: run eval "$(camp shell-init <shell>)"
+```
+
+`t` remains the connection test — the two are separate gestures, because "can camp
+reach this?" is a question worth asking about a machine you are not about to enter.
+
 ## The hop-back gesture
 
 `csw -` returns to the origin campaign. There is no history file and no daemon: the

--- a/internal/shell/machine_wrapper_test.go
+++ b/internal/shell/machine_wrapper_test.go
@@ -1,0 +1,103 @@
+package shell
+
+import (
+	"strings"
+	"testing"
+)
+
+// The machine arm exists so the fleet screen's enter key can finish a hop: the
+// TUI writes ssh-hop:<machine>:<campaign> and the wrapper turns that into the
+// `camp switch --shell-connect` line it evals. A subprocess cannot replace its
+// parent shell, so without this arm the key is inert.
+//
+// Every shell gets the same three guarantees, asserted per shell because the
+// three templates are hand-maintained rather than generated from one source:
+// subcommands pass through untouched, the hop is completed via switch, and the
+// arm never cd's (a machine row is never a local path).
+func TestMachineArm_AllShells(t *testing.T) {
+	for _, sh := range []struct {
+		name        string
+		output      string
+		start, end  string
+		passthrough string
+		hopVia      string
+		tmpFile     string
+	}{
+		{
+			name:        "zsh",
+			output:      generateZsh(),
+			start:       "    machine)",
+			end:         "    festivals)",
+			passthrough: `command camp machine "$@"`,
+			hopVia:      `line=$(command camp switch "$sel" --shell-connect)`,
+			tmpFile:     "camp-machine.XXXXXX",
+		},
+		{
+			name:        "bash",
+			output:      generateBash(),
+			start:       "    machine)",
+			end:         "    festivals)",
+			passthrough: `command camp machine "$@"`,
+			hopVia:      `line=$(command camp switch "$sel" --shell-connect)`,
+			tmpFile:     "camp-machine.XXXXXX",
+		},
+		{
+			name:        "fish",
+			output:      generateFish(),
+			start:       "        case machine",
+			end:         "        case festivals",
+			passthrough: "command camp machine $rest",
+			hopVia:      "command camp switch $sel --shell-connect",
+			tmpFile:     "camp-machine.XXXXXX",
+		},
+	} {
+		t.Run(sh.name, func(t *testing.T) {
+			section := shellWrapperSection(t, sh.output, sh.start, sh.end)
+
+			for _, check := range []struct{ name, content string }{
+				{"path output seam", "--path-output"},
+				{"own temp file", sh.tmpFile},
+				{"subcommand passthrough", sh.passthrough},
+				{"hop completed via switch", sh.hopVia},
+				{"ssh-hop marker", "ssh-hop:"},
+			} {
+				if !strings.Contains(section, check.content) {
+					t.Errorf("%s machine arm missing %s: %q", sh.name, check.name, check.content)
+				}
+			}
+
+			// A machine row resolves to a remote campaign root the far side owns,
+			// never to a local directory. A cd here would mean the arm had
+			// silently grown a second, wrong meaning for the payload.
+			for _, forbidden := range []string{`cd "$dest"`, `cd "$root/$dest"`, "cd $dest"} {
+				if strings.Contains(section, forbidden) {
+					t.Errorf("%s machine arm must not cd: found %q", sh.name, forbidden)
+				}
+			}
+		})
+	}
+}
+
+// The fleet screen takes no positional argument, so a bare first word is always
+// a subcommand and must reach the binary untouched. Without this guard
+// `camp machine list` would be handed --path-output, which it does not define.
+func TestMachineArm_BareWordSubcommandGuard(t *testing.T) {
+	for _, sh := range []struct {
+		name       string
+		output     string
+		start, end string
+		guard      string
+	}{
+		{"zsh", generateZsh(), "    machine)", "    festivals)", `""|-*) ;;`},
+		{"bash", generateBash(), "    machine)", "    festivals)", `""|-*) ;;`},
+		{"fish", generateFish(), "        case machine", "        case festivals",
+			`if test (count $rest) -gt 0; and not string match -qr -- '^-' $rest[1]`},
+	} {
+		t.Run(sh.name, func(t *testing.T) {
+			section := shellWrapperSection(t, sh.output, sh.start, sh.end)
+			if !strings.Contains(section, sh.guard) {
+				t.Errorf("%s machine arm missing bare-word subcommand guard: %q", sh.name, sh.guard)
+			}
+		})
+	}
+}

--- a/internal/shell/templates/bash.sh.tmpl
+++ b/internal/shell/templates/bash.sh.tmpl
@@ -174,6 +174,63 @@ camp() {
         rm -f "$tmp"
       fi
       ;;
+    machine)
+      shift
+      # A machine subcommand (list, add, remove, diagnose, adopt, ...) is always
+      # the first token and is a bare word; the interactive fleet screen takes no
+      # positional argument. Only that screen understands --path-output, so pass
+      # any subcommand invocation through verbatim. This is forward-compatible:
+      # new subcommands need no wrapper regeneration.
+      case "${1:-}" in
+        ""|-*) ;;
+        *)
+          command camp machine "$@"
+          return
+          ;;
+      esac
+      local arg passthrough cmd_status tmp dest line sel
+      passthrough=0
+      for arg in "$@"; do
+        case "$arg" in
+          --help|-h)
+            passthrough=1
+            break
+            ;;
+        esac
+      done
+      if [ "$passthrough" -eq 1 ]; then
+        command camp machine "$@"
+        return
+      fi
+      if ! [ -t 0 ] || ! [ -t 1 ]; then
+        command camp machine "$@"
+        return
+      fi
+
+      tmp=$(mktemp "${TMPDIR:-/tmp}/camp-machine.XXXXXX") || return 1
+      command camp machine "$@" --path-output "$tmp"
+      cmd_status=$?
+      if [ "$cmd_status" -ne 0 ]; then
+        rm -f "$tmp"
+        return "$cmd_status"
+      fi
+
+      if [ -s "$tmp" ]; then
+        dest=$(cat "$tmp")
+        rm -f "$tmp"
+        # The fleet screen only ever writes ssh-hop:<machine>:<campaign>; hop via
+        # switch so the remote registry still resolves the path.
+        case "$dest" in
+          ssh-hop:*)
+            sel="${dest#ssh-hop:}"
+            line=$(command camp switch "$sel" --shell-connect) || return $?
+            eval "$line"
+            ;;
+        esac
+      else
+        rm -f "$tmp"
+      fi
+      ;;
     festivals)
       shift
       local arg passthrough cmd_status tmp

--- a/internal/shell/templates/fish.sh.tmpl
+++ b/internal/shell/templates/fish.sh.tmpl
@@ -199,6 +199,68 @@ function camp --description "Camp CLI wrapper with directory-changing support"
             else
                 rm -f "$tmp"
             end
+        case machine
+            set -l rest $argv[2..-1]
+            # A machine subcommand (list, add, remove, diagnose, adopt, ...) is
+            # always the first token and is a bare word; the interactive fleet
+            # screen takes no positional argument. Only that screen understands
+            # --path-output, so pass any subcommand invocation through verbatim.
+            # This is forward-compatible: new subcommands need no wrapper
+            # regeneration.
+            if test (count $rest) -gt 0; and not string match -qr -- '^-' $rest[1]
+                command camp machine $rest
+                return $status
+            end
+            set -l passthrough 0
+            for arg in $rest
+                switch "$arg"
+                    case --help -h
+                        set passthrough 1
+                        break
+                end
+            end
+            if test "$passthrough" -eq 1
+                command camp machine $rest
+                return $status
+            end
+            if not isatty stdin; or not isatty stdout
+                command camp machine $rest
+                return $status
+            end
+
+            set -l tmpdir /tmp
+            if set -q TMPDIR
+                set tmpdir $TMPDIR
+            end
+            set -l tmp (mktemp "$tmpdir/camp-machine.XXXXXX" 2>/dev/null)
+            if test -z "$tmp"
+                return 1
+            end
+
+            command camp machine $rest --path-output "$tmp"
+            set -l cmd_status $status
+            if test "$cmd_status" -ne 0
+                rm -f "$tmp"
+                return $cmd_status
+            end
+
+            if test -s "$tmp"
+                set -l dest (cat "$tmp")
+                rm -f "$tmp"
+                # The fleet screen only ever writes ssh-hop:<machine>:<campaign>;
+                # hop via switch so the remote registry still resolves the path.
+                if string match -q 'ssh-hop:*' -- $dest
+                    set -l sel (string replace -r '^ssh-hop:' '' -- $dest)
+                    set -l line (command camp switch $sel --shell-connect)
+                    set -l hop_status $status
+                    if test "$hop_status" -ne 0
+                        return $hop_status
+                    end
+                    eval "$line"
+                end
+            else
+                rm -f "$tmp"
+            end
         case festivals
             set -l rest $argv[2..-1]
             set -l passthrough 0

--- a/internal/shell/templates/zsh.sh.tmpl
+++ b/internal/shell/templates/zsh.sh.tmpl
@@ -169,6 +169,61 @@ camp() {
         rm -f "$tmp"
       fi
       ;;
+    machine)
+      shift
+      # A machine subcommand (list, add, remove, diagnose, adopt, ...) is always
+      # the first token and is a bare word; the interactive fleet screen takes no
+      # positional argument. Only that screen understands --path-output, so pass
+      # any subcommand invocation through verbatim. This is forward-compatible:
+      # new subcommands need no wrapper regeneration.
+      case "${1:-}" in
+        ""|-*) ;;
+        *)
+          command camp machine "$@"
+          return
+          ;;
+      esac
+      local arg passthrough tmp dest cmd_status line sel
+      passthrough=0
+      for arg in "$@"; do
+        case "$arg" in
+          --help|-h)
+            passthrough=1
+            break
+            ;;
+        esac
+      done
+      if [[ "$passthrough" -eq 1 ]]; then
+        command camp machine "$@"
+        return
+      fi
+      if [[ ! -t 0 || ! -t 1 ]]; then
+        command camp machine "$@"
+        return
+      fi
+
+      tmp=$(mktemp "${TMPDIR:-/tmp}/camp-machine.XXXXXX") || return 1
+      command camp machine "$@" --path-output "$tmp"
+      cmd_status=$?
+      if [[ "$cmd_status" -ne 0 ]]; then
+        rm -f "$tmp"
+        return "$cmd_status"
+      fi
+
+      if [[ -s "$tmp" ]]; then
+        dest=$(cat "$tmp")
+        rm -f "$tmp"
+        # The fleet screen only ever writes ssh-hop:<machine>:<campaign>; hop via
+        # switch so the remote registry still resolves the path.
+        if [[ "$dest" == ssh-hop:* ]]; then
+          sel="${dest#ssh-hop:}"
+          line=$(command camp switch "$sel" --shell-connect) || return $?
+          eval "$line"
+        fi
+      else
+        rm -f "$tmp"
+      fi
+      ;;
     festivals)
       shift
       local arg passthrough tmp dest cmd_status


### PR DESCRIPTION
## Why

`camp machine` listed the fleet but had no way into it. The only pointer to `camp switch <id>:<campaign>` lived in the `?` overlay, so an operator who opened the screen looking for a way onto a machine found the fleet, the socket state, a connection tester, and no door.

## What

`enter` on a machine row opens a campaign picker for that machine and hops there.

```
╭──────────────────────────────────────────────────────────────────────╮
│  Hop to buildbox                                                     │
│  From the last snapshot; press r to ask the machine now.             │
│                                                                      │
│  › notes                                                             │
│    obey-campaign                                                     │
│    platform                                                          │
│                                                                      │
│  j/k move · enter hop · r refresh · esc cancel                       │
╰──────────────────────────────────────────────────────────────────────╯
```

**Nothing about the hop is new.** The screen writes `ssh-hop:<machine>:<campaign>` to `--path-output` and the shell wrapper turns that into `camp switch <sel> --shell-connect` — byte-for-byte the path `camp list`'s picker already takes. The far machine's own registry still resolves the root; no remote resolution is duplicated here.

Campaign names come from the completion snapshot first, which is what makes the picker open without dialing. `r` refreshes live; a cold cache pays for one fetch, and that fetch warms the cache so the next open is instant.

## Decisions worth reviewing

**`enter` was bound to test-connection.** It now hops; `t` keeps the tester. This is the one user-visible regression in the set — anyone with muscle memory on `enter`-to-test gets a campaign picker instead. `enter` is the universal "go there" and the footer already led with `t test connection`, so this seemed the right way round, but it is a live rebinding and worth a second opinion.

**Hopping needs the wrapper, and says so when it is missing.** No subprocess can replace the shell that launched it. Without `--path-output` the key reports `hop needs shell integration: run eval "$(camp shell-init <shell>)"` rather than appearing to work — the same shape `camp list` uses for the same reason.

**Refusals happen before the list opens, not after a choice.** `local` (this computer) and password-auth machines are rejected at `enter`, so no picker ever leads nowhere.

**Unreachable ≠ empty.** A failed fetch shows the error and points at `camp machine diagnose <id>`. An empty list would read as "this machine has no campaigns", which is a different and wrong claim.

## Verification

Green tests do not verify a TUI, so this was driven in a real pty (`pyte`) against a fixture `XDG_CONFIG_HOME`, reading the rendered screen:

- fleet screen renders, footer reads `enter hop · t test connection · …`
- `enter` on `local` → `✗ local is this computer; use 'camp list' to open a campaign here`
- `enter` on `buildbox` → picker above, from the snapshot, no ssh dialed
- `down down` + `enter` → `--path-output` file contains exactly `ssh-hop:buildbox:platform`
- without `--path-output` → `✗ hop needs shell integration: run eval "$(camp shell-init <shell>)"`

Wrapper arms driven end-to-end in a pty with a stub `camp` on PATH:

| invocation | zsh | bash |
| --- | --- | --- |
| `camp machine` | hops via switch | hops via switch |
| `camp machine list` | passthrough | passthrough |
| `camp machine add devbox --host x` | passthrough | passthrough |
| `camp machine diagnose devbox` | passthrough | passthrough |
| `camp machine --help` | passthrough | passthrough |

`just gate`: 4080 dev + 4035 stable tests pass, lint clean. `just docs` regenerated only the two machine reference files.

## Gaps

- **fish is asserted but not executed.** fish is not installed on this machine, so its arm is covered by the generator test and shape-matched against the existing `list` arm, not run. `TestGenerateFish_ValidSyntax` skips for the same reason and will cover it on a box that has fish.
- **No integration test performs a real hop.** The seam is `camp switch`, which is already covered; this PR tests up to the payload and the wrapper's handling of it.

## Note for reviewers

The first version of the wrapper test file was named `machine_arm_test.go`, which Go silently excluded from the package — `_arm` reads as a `GOARCH=arm` build constraint. It reported `ok` with zero tests running. Renamed to `machine_wrapper_test.go`. Worth knowing generally: a `_test.go` file whose name ends in `_<goarch>` or `_<goos>` disappears without warning.
