### PR TITLE
test(workitem): assert the v1alpha10 list contract in the filter test

### DIFF
--- a/tests/integration/workitem_list_filter_test.go
+++ b/tests/integration/workitem_list_filter_test.go
@@ -40,7 +40,7 @@ func TestIntegration_WorkitemListFiltersNonTTYAndJSON(t *testing.T) {
 		} `json:"items"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(raw[start:]), &payload))
-	assert.Equal(t, "workitems/v1alpha9", payload.SchemaVersion)
+	assert.Equal(t, "workitems/v1alpha10", payload.SchemaVersion)
 	require.NotEmpty(t, payload.Items)
 	for _, item := range payload.Items {
 		assert.True(t, item.AttentionStage == "active" || item.LifecycleStage == "active")


### PR DESCRIPTION
## Summary
- Align the workitem filter-test schema assertion with `workitems/v1alpha10` after the schema bump in 7daf8c1c.
- The suite is behind the integration build tag and needs Docker, so pre-push gates never exercised this path.

## Context
Draft PR for visibility and CI. Worktree had unpushed commits only.

## Test plan
- [ ] Integration/filter suite with Docker if available
- [ ] Confirm assertion matches current SchemaVersion