### PR TITLE
fix(jobs): commit deferred work when the message writer fails

### DIFF
--- a/cmd/camp/jobs.go
+++ b/cmd/camp/jobs.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -142,7 +143,11 @@ type jobJSON struct {
 	AgeMs    int64  `json:"age_ms"`
 	Attempts int    `json:"attempts"`
 	Stuck    bool   `json:"stuck"`
-	Summary  string `json:"summary"`
+	// Superseded marks a failed job that retrying can never fix, because
+	// history moved past the commit it was queued against. An agent reading
+	// this queue needs it to pick 'drop' over 'retry' without first failing.
+	Superseded bool   `json:"superseded"`
+	Summary    string `json:"summary"`
 }
 
 func runJobsList(cmd *cobra.Command, _ []string) error {
@@ -157,14 +162,30 @@ func runJobsList(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	superseded := supersededIDs(ctx, campRoot, entries)
 	if jobsOpts.json {
-		return emitJobsJSON(cmd, campRoot, entries)
+		return emitJobsJSON(cmd, campRoot, entries, superseded)
 	}
-	renderJobsHuman(cmd, entries)
+	renderJobsHuman(cmd, entries, superseded)
 	return nil
 }
 
-func emitJobsJSON(cmd *cobra.Command, campRoot string, entries []jobs.Entry) error {
+// supersededIDs marks the failed jobs a retry can never fix.
+//
+// Computed once for both renderers so the human listing and --json cannot
+// disagree, and only for failed jobs, so a queue that is merely busy pays no
+// git calls at all.
+func supersededIDs(ctx context.Context, campRoot string, entries []jobs.Entry) map[string]bool {
+	marked := map[string]bool{}
+	for _, e := range entries {
+		if jobs.Superseded(ctx, campRoot, e) {
+			marked[e.ID] = true
+		}
+	}
+	return marked
+}
+
+func emitJobsJSON(cmd *cobra.Command, campRoot string, entries []jobs.Entry, superseded map[string]bool) error {
 	now := time.Now()
 	payload := jobsPayload{
 		SchemaVersion: JobsJSONVersion,
@@ -191,10 +212,11 @@ func emitJobsJSON(cmd *cobra.Command, campRoot string, entries []jobs.Entry) err
 			Lane:     e.Lane,
 			Kind:     string(e.Kind),
 			Class:    class,
-			AgeMs:    e.Age(now).Milliseconds(),
-			Attempts: e.Attempts,
-			Stuck:    e.Stuck,
-			Summary:  jobs.Describe(e.Job),
+			AgeMs:      e.Age(now).Milliseconds(),
+			Attempts:   e.Attempts,
+			Stuck:      e.Stuck,
+			Superseded: superseded[e.ID],
+			Summary:    jobs.Describe(e.Job),
 		})
 	}
 
@@ -203,7 +225,7 @@ func emitJobsJSON(cmd *cobra.Command, campRoot string, entries []jobs.Entry) err
 	return enc.Encode(payload)
 }
 
-func renderJobsHuman(cmd *cobra.Command, entries []jobs.Entry) {
+func renderJobsHuman(cmd *cobra.Command, entries []jobs.Entry, superseded map[string]bool) {
 	out := cmd.OutOrStdout()
 	if len(entries) == 0 {
 		_, _ = fmt.Fprintln(out, ui.Dim("No deferred commits queued."))
@@ -223,7 +245,14 @@ func renderJobsHuman(cmd *cobra.Command, entries []jobs.Entry) {
 			state = "stuck"
 		}
 		what := jobs.Describe(e.Job)
-		if note := jobs.AttemptNote(e.Attempts, e.State == "failed"); note != "" {
+		note := jobs.AttemptNote(e.Attempts, e.State == "failed")
+		if superseded[e.ID] {
+			// The row carries it too, not only the footer: with a mix of
+			// retryable and superseded jobs the footer can say how many but
+			// not which, and "which" is what the user has to act on.
+			note = strings.TrimPrefix(note+", cannot retry", ", ")
+		}
+		if note != "" {
 			what = fmt.Sprintf("%s (%s)", what, note)
 		}
 		fmt.Fprintf(&b, "%-9s %-25s %-22s %-14s %6s  %s\n",
@@ -233,11 +262,14 @@ func renderJobsHuman(cmd *cobra.Command, entries []jobs.Entry) {
 
 	// Every state that needs a decision names the command that makes it, so
 	// the listing is actionable rather than merely informative.
-	failed, stuck := 0, 0
+	failed, stuck, stale := 0, 0, 0
 	for _, e := range entries {
 		switch {
 		case e.State == "failed":
 			failed++
+			if superseded[e.ID] {
+				stale++
+			}
 		case e.Stuck:
 			stuck++
 		}
@@ -246,8 +278,27 @@ func renderJobsHuman(cmd *cobra.Command, entries []jobs.Entry) {
 	// which would style the newline and emit a line of trailing spaces.
 	if failed > 0 {
 		_, _ = fmt.Fprintln(out)
-		_, _ = fmt.Fprintln(out, ui.Dim(
-			"Retry them with 'camp jobs retry all', or give up with 'camp jobs drop <id>'."))
+		// Retry is only offered when retrying could actually work. A job
+		// whose parent is no longer HEAD fails identically every time, so
+		// naming the command that does that would send the user around a
+		// loop with no exit.
+		switch stale {
+		case 0:
+			_, _ = fmt.Fprintln(out, ui.Dim(
+				"Retry them with 'camp jobs retry all', or give up with 'camp jobs drop <id>'."))
+		case failed:
+			_, _ = fmt.Fprintln(out, ui.Dim(
+				"Retrying will not help: history moved past the commit these were queued"))
+			_, _ = fmt.Fprintln(out, ui.Dim(
+				"against. Drop them with 'camp jobs drop <id>'."))
+		default:
+			_, _ = fmt.Fprintln(out, ui.Dim(
+				"Retry them with 'camp jobs retry all', or give up with 'camp jobs drop <id>'."))
+			_, _ = fmt.Fprintln(out, ui.Dim(fmt.Sprintf(
+				"The %d marked 'cannot retry' will not come back: history moved past the", stale)))
+			_, _ = fmt.Fprintln(out, ui.Dim(
+				"commit they were queued against. Drop those."))
+		}
 		_, _ = fmt.Fprintln(out, ui.Dim(
 			"Dropping keeps the files on disk; your next commit picks them up."))
 	}

--- a/internal/autowrite/autowrite.go
+++ b/internal/autowrite/autowrite.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -43,6 +44,70 @@ hooks:
 // ErrCommitMessageHookEmptyOutput is returned when the hook succeeds but writes
 // no commit message to stdout.
 var ErrCommitMessageHookEmptyOutput = errors.New("auto-write commit message command produced no message")
+
+// WriterError is a commit message writer that ran and did not produce a
+// message.
+//
+// It exists so callers can act on the writer's own diagnostic without parsing
+// a formatted error string. The deferred-commit worker needs exactly that: it
+// commits anyway when the writer fails and puts the reason in the commit
+// message, and a message built by scraping err.Error() would carry camp's
+// wrapping and the writer's ANSI codes into git history.
+type WriterError struct {
+	// Command is the configured writer, as written in campaign.yaml.
+	Command string
+	// Reason is the writer's own last diagnostic line: sanitized, single
+	// line, bounded. Empty when the writer said nothing.
+	Reason string
+	// Err is the underlying failure.
+	Err error
+}
+
+func (e *WriterError) Error() string {
+	if e.Reason == "" {
+		return "auto-write commit message command failed"
+	}
+	return "auto-write commit message command failed: " + e.Reason
+}
+
+func (e *WriterError) Unwrap() error { return e.Err }
+
+// maxWriterReasonBytes bounds the writer diagnostic camp repeats.
+//
+// A writer that fails by printing its own usage emits a screenful, and every
+// byte of it would otherwise land twice in the worker log and, for a degraded
+// commit, permanently in git history. The operative line is the last one.
+const maxWriterReasonBytes = 300
+
+// ansiEscape matches the CSI sequences a writer emits when it renders help
+// text to a pipe. Broader than a fixed list of color constants on purpose: the
+// point is that nothing an arbitrary user-configured tool prints can reach a
+// commit message as an escape code.
+var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
+
+// writerReason reduces a writer's stderr to the one line worth repeating.
+//
+// The last non-empty line, because tools print their diagnosis after their
+// usage, not before it. Sanitized and truncated because this string is
+// embedded in text camp writes on the user's behalf.
+func writerReason(stderr string) string {
+	cleaned := strings.TrimSpace(ansiEscape.ReplaceAllString(stderr, ""))
+	if cleaned == "" {
+		return ""
+	}
+	lines := strings.Split(cleaned, "\n")
+	reason := ""
+	for i := len(lines) - 1; i >= 0; i-- {
+		if trimmed := strings.TrimSpace(lines[i]); trimmed != "" {
+			reason = trimmed
+			break
+		}
+	}
+	if len(reason) > maxWriterReasonBytes {
+		reason = reason[:maxWriterReasonBytes] + "..."
+	}
+	return reason
+}
 
 // commitAmendEnv is the Camp-to-writer amend signal.
 const commitAmendEnv = "CAMP_COMMIT_AMEND=1"
@@ -159,16 +224,24 @@ func runCommitMessageCommandWithEnv(
 		if ctx.Err() != nil {
 			return "", ctx.Err()
 		}
-		msg := strings.TrimSpace(stderr.String())
-		if msg != "" {
-			return "", camperrors.Wrapf(err, "auto-write commit message command failed: %s", msg)
+		// Only the reason reaches the error. The full stderr was already
+		// streamed live to diagnosticOut, so repeating it here would render a
+		// failing writer's help text twice in the same log with nothing to
+		// distinguish the copies.
+		return "", &WriterError{
+			Command: command,
+			Reason:  writerReason(stderr.String()),
+			Err:     err,
 		}
-		return "", camperrors.Wrap(err, "auto-write commit message command failed")
 	}
 
 	message := strings.TrimSpace(stdout.String())
 	if message == "" {
-		return "", ErrCommitMessageHookEmptyOutput
+		return "", &WriterError{
+			Command: command,
+			Reason:  "the writer exited cleanly without printing a message",
+			Err:     ErrCommitMessageHookEmptyOutput,
+		}
 	}
 
 	return message, nil

--- a/internal/autowrite/autowrite_internal_test.go
+++ b/internal/autowrite/autowrite_internal_test.go
@@ -19,13 +19,14 @@ func TestRunCommitMessageCommandForwardsDiagnostics(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name             string
-		command          string
-		extraEnv         []string
-		wantMessage      string
-		wantErr          bool
-		wantDiagContains []string
-		wantErrContains  []string
+		name               string
+		command            string
+		extraEnv           []string
+		wantMessage        string
+		wantErr            bool
+		wantDiagContains   []string
+		wantErrContains    []string
+		wantErrNotContains []string
 	}{
 		{
 			name:        "success forwards stderr and returns stdout",
@@ -44,7 +45,13 @@ func TestRunCommitMessageCommandForwardsDiagnostics(t *testing.T) {
 		{
 			// MultiWriter dual-path contract: live forward AND error wrapping.
 			// A future refactor must not break either side independently.
-			name:    "failure forwards diagnostics and keeps stderr in wrapped error",
+			//
+			// The two sides carry different amounts on purpose. The live
+			// stream is the full diagnostic record; the error is the one line
+			// worth repeating next to it, because a writer that fails by
+			// printing its usage would otherwise render a screenful twice in
+			// the same log.
+			name:    "failure forwards all diagnostics but keeps only the reason in the error",
 			command: "printf 'ob: generating...\\n' >&2; printf 'hook boom\\n' >&2; exit 1",
 			wantErr: true,
 			wantDiagContains: []string{
@@ -52,9 +59,25 @@ func TestRunCommitMessageCommandForwardsDiagnostics(t *testing.T) {
 				"hook boom",
 			},
 			wantErrContains: []string{
-				"ob: generating...",
 				"hook boom",
 				"auto-write commit message command failed",
+			},
+			wantErrNotContains: []string{
+				"ob: generating...",
+			},
+		},
+		{
+			// Escape codes must not survive into the error, because the same
+			// reason is embedded verbatim in a commit message when a deferred
+			// commit degrades.
+			name:    "strips ANSI from the reason",
+			command: "printf '\\033[1;38;5;230mdaemon not running\\033[0m\\n' >&2; exit 1",
+			wantErr: true,
+			wantErrContains: []string{
+				"daemon not running",
+			},
+			wantErrNotContains: []string{
+				"\x1b[",
 			},
 		},
 	}
@@ -84,6 +107,11 @@ func TestRunCommitMessageCommandForwardsDiagnostics(t *testing.T) {
 						t.Fatalf("error = %q, want substring %q", err.Error(), want)
 					}
 				}
+				for _, unwanted := range tt.wantErrNotContains {
+					if strings.Contains(err.Error(), unwanted) {
+						t.Fatalf("error = %q, want it to omit %q", err.Error(), unwanted)
+					}
+				}
 			} else {
 				if err != nil {
 					t.Fatalf("runCommitMessageCommandWithEnv() error = %v", err)
@@ -100,5 +128,73 @@ func TestRunCommitMessageCommandForwardsDiagnostics(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// writerReason is the only part of a failing writer's output that camp repeats
+// on the user's behalf: it goes in the error and, when a deferred commit
+// degrades, verbatim into a commit message. Everything it must guarantee is
+// therefore a guarantee about text that ends up in git history.
+func TestWriterReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		stderr string
+		want   string
+	}{
+		{
+			name:   "empty stderr yields no reason",
+			stderr: "",
+			want:   "",
+		},
+		{
+			name:   "whitespace only yields no reason",
+			stderr: "\n\n   \n",
+			want:   "",
+		},
+		{
+			// Tools print their diagnosis after their usage, so the last line
+			// is the one that says what went wrong.
+			name:   "takes the last meaningful line",
+			stderr: "Usage:\n  ob commit [flags]\n\nconnect to daemon: ob: daemon not running\n",
+			want:   "connect to daemon: ob: daemon not running",
+		},
+		{
+			name:   "ignores trailing blank lines",
+			stderr: "the real reason\n\n\n",
+			want:   "the real reason",
+		},
+		{
+			// 256-color sequences, not just the handful of constants camp
+			// itself emits: the writer is an arbitrary user-configured tool.
+			name:   "strips 256-color escapes",
+			stderr: "\x1b[1;38;5;230mdaemon not running\x1b[0m",
+			want:   "daemon not running",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := writerReason(tt.stderr); got != tt.want {
+				t.Fatalf("writerReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A writer that dumps an unbounded blob must not put an unbounded blob in a
+// commit message.
+func TestWriterReasonIsBounded(t *testing.T) {
+	t.Parallel()
+
+	reason := writerReason(strings.Repeat("x", maxWriterReasonBytes*3))
+	if len(reason) > maxWriterReasonBytes+3 {
+		t.Fatalf("writerReason() length = %d, want at most %d",
+			len(reason), maxWriterReasonBytes+3)
+	}
+	if !strings.HasSuffix(reason, "...") {
+		t.Fatalf("writerReason() = %q, want a truncation marker", reason)
 	}
 }

--- a/internal/git/tree.go
+++ b/internal/git/tree.go
@@ -133,6 +133,41 @@ func FirstParentChainContains(ctx context.Context, repoPath, tree, parent string
 	return false
 }
 
+// TreeChangedPaths lists the paths that differ between two trees.
+//
+// It exists to describe a deferred commit whose message writer was
+// unavailable. The tree pair is the whole description available at that point,
+// and it is the accurate one: it names what the commit contains rather than
+// what the working tree looks like by the time the worker runs.
+func TreeChangedPaths(ctx context.Context, repoPath, from, to string) ([]string, error) {
+	out, err := Output(ctx, repoPath,
+		"diff-tree", "-r", "--name-only", "--no-commit-id", from, to)
+	if err != nil {
+		return nil, camperrors.Wrap(err, "list the paths a deferred commit changes")
+	}
+	var paths []string
+	for line := range strings.SplitSeq(out, "\n") {
+		if p := strings.TrimSpace(line); p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths, nil
+}
+
+// HeadSHA returns the commit HEAD points at, or "" when HEAD is unborn or
+// unreadable.
+//
+// Empty rather than an error because both callers treat "cannot tell" and
+// "nothing there" the same way, and neither is exceptional: a campaign's first
+// commit runs against an unborn HEAD by definition.
+func HeadSHA(ctx context.Context, repoPath string) string {
+	out, err := Output(ctx, repoPath, "rev-parse", "HEAD")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}
+
 // StagedFileCount returns how many paths are staged, for the line a deferred
 // commit prints in place of a hash.
 func StagedFileCount(ctx context.Context, repoPath string) (int, error) {

--- a/internal/jobs/execute.go
+++ b/internal/jobs/execute.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -223,13 +224,36 @@ func messageForTree(ctx context.Context, campaignRoot, repoPath string, job *Job
 		}
 		return job.Message, nil
 	}
+
 	message, err := writeMessage(ctx, campaignRoot, repoPath, job)
-	if err != nil {
-		return "", err
-	}
-	if strings.TrimSpace(message) == "" {
+	if err == nil && strings.TrimSpace(message) == "" {
 		return "", camperrors.Newf("the commit message writer produced no message for job %s", job.ID)
 	}
+	if errors.Is(err, autowrite.ErrCommitMessageHookEmptyOutput) {
+		// A writer that exits zero and prints nothing has not failed, it has
+		// declined, and camp does not overrule a writer's own verdict on
+		// itself. Only a writer that reports failure gets compensated for
+		// below. Keeping this case a failure also keeps the decision the
+		// user's: they configured the tool, so an empty message is a
+		// conversation with their own script, not with camp.
+		return "", err
+	}
+	if err != nil {
+		// A writer outage must not be able to cost the user a commit.
+		//
+		// The tree is the user's work and the message is decoration, so
+		// failing the job here parks a commit camp already promised. It also
+		// decays: every minute the job sits in failed/ raises the chance
+		// someone commits over its parent, and once HEAD has moved the job can
+		// never be retried at all (executeCommitTree refuses to rebase it), so
+		// the only remaining recovery is to drop it and commit again by hand.
+		// A message camp writes itself is strictly better than that, and the
+		// commit is where it says so: this worker is detached, so nothing else
+		// it prints is guaranteed to reach anyone.
+		logWorker(campaignRoot, "writer-degraded lane=%s id=%s err=%v", job.Repo, job.ID, err)
+		message = fallbackMessage(ctx, repoPath, job, err)
+	}
+
 	// The tag goes on the subject line, which is why it is prepended here
 	// rather than composed into the writer's prompt: the writer owns the
 	// message, camp owns the tag, and a deferred commit has to end up with the
@@ -238,6 +262,89 @@ func messageForTree(ctx context.Context, campaignRoot, repoPath string, job *Job
 		return job.MessagePrefix + " " + message, nil
 	}
 	return message, nil
+}
+
+// FallbackSubjectMarker tags the subject of a commit camp had to describe
+// itself, so `git log --oneline | grep` finds every one of them.
+//
+// Exported because it is a promise to the user rather than an implementation
+// detail: the whole value of a degraded commit landing is that the user can
+// find it later and reword it.
+const FallbackSubjectMarker = "(writer unavailable)"
+
+// maxFallbackSubject bounds the generated subject, leaving room for the
+// campaign tag camp prepends afterwards.
+const maxFallbackSubject = 60
+
+// fallbackMessage describes a commit whose message writer did not produce one.
+//
+// Deterministic by necessity: it runs precisely when the configured writer is
+// unavailable, so it may use only what git already knows. The body names the
+// cause because a background worker has no other way to tell anyone, and a
+// commit the user cannot explain later is its own small mystery.
+func fallbackMessage(ctx context.Context, repoPath string, job *Job, writerErr error) string {
+	var b strings.Builder
+	b.WriteString(fallbackSubject(ctx, repoPath, job))
+	b.WriteString("\n\ncamp wrote this message itself: the configured commit message\n")
+	b.WriteString("writer did not return one.\n")
+	if reason := writerFailureReason(writerErr); reason != "" {
+		b.WriteString("\n  ")
+		b.WriteString(reason)
+		b.WriteString("\n")
+	}
+	b.WriteString("\nReword it with: git commit --amend\n")
+	return b.String()
+}
+
+// fallbackSubject names what the commit contains, in the shape a person scans.
+func fallbackSubject(ctx context.Context, repoPath string, job *Job) string {
+	paths, err := git.TreeChangedPaths(ctx, repoPath, job.Parent, job.Tree)
+	if err != nil {
+		// A subject is still owed even when git cannot say what changed. The
+		// commit is landing either way, and one that says nothing is better
+		// than no commit at all.
+		return fallbackSubjectFor(nil)
+	}
+	return fallbackSubjectFor(paths)
+}
+
+// fallbackSubjectFor renders the subject for a set of changed paths.
+//
+// One changed path is worth naming outright; several are not, because a
+// subject listing them is longer than the terminal and less informative than
+// the count. A path long enough to blow the subject line degrades to the count
+// form rather than being truncated into something that reads like a real path
+// but is not one.
+//
+// Split from its git call so the shape of the subject, which is the part a
+// user sees forever, is testable without a repository behind it.
+func fallbackSubjectFor(paths []string) string {
+	switch len(paths) {
+	case 0:
+		return "Deferred commit " + FallbackSubjectMarker
+	case 1:
+		subject := "Update " + paths[0] + " " + FallbackSubjectMarker
+		if len(subject) <= maxFallbackSubject {
+			return subject
+		}
+		return "Update 1 file " + FallbackSubjectMarker
+	default:
+		return fmt.Sprintf("Update %d files %s", len(paths), FallbackSubjectMarker)
+	}
+}
+
+// writerFailureReason returns the writer's own diagnostic when the failure
+// came from the writer, and nothing when it did not.
+//
+// Only a *autowrite.WriterError carries a reason that is safe to embed: it has
+// been stripped of escape codes and bounded. Any other error is camp's own and
+// its text is not written into git history.
+func writerFailureReason(err error) string {
+	var writerErr *autowrite.WriterError
+	if errors.As(err, &writerErr) {
+		return writerErr.Reason
+	}
+	return ""
 }
 
 // writeMessage runs the configured writer against the job's captured tree.

--- a/internal/jobs/fallback_message_internal_test.go
+++ b/internal/jobs/fallback_message_internal_test.go
@@ -1,0 +1,106 @@
+package jobs
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/autowrite"
+)
+
+// errNotAWriterFailure stands in for any error that did not come from the
+// configured writer.
+var errNotAWriterFailure = errors.New("camp could not materialize the tree")
+
+// The fallback subject is permanent. It is written when the configured writer
+// is unavailable, and unlike a queue file it stays in git history for as long
+// as the repository exists, so its shape is a contract with the user rather
+// than an implementation detail.
+func TestFallbackSubjectFor(t *testing.T) {
+	t.Parallel()
+
+	longPath := "projects/camp/internal/" + strings.Repeat("deep/", 12) + "file.go"
+
+	tests := []struct {
+		name  string
+		paths []string
+		want  string
+	}{
+		{
+			// git could not say what changed. The commit still lands, so it
+			// still needs a subject.
+			name:  "no paths",
+			paths: nil,
+			want:  "Deferred commit (writer unavailable)",
+		},
+		{
+			name:  "one path is named outright",
+			paths: []string{".campaign/intents/inbox/idea.md"},
+			want:  "Update .campaign/intents/inbox/idea.md (writer unavailable)",
+		},
+		{
+			// Truncating would produce something that reads like a path and is
+			// not one, which is worse than saying less.
+			name:  "a path too long for a subject degrades to the count",
+			paths: []string{longPath},
+			want:  "Update 1 file (writer unavailable)",
+		},
+		{
+			name:  "several paths become a count",
+			paths: []string{"a.md", "b.md", "c.md"},
+			want:  "Update 3 files (writer unavailable)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := fallbackSubjectFor(tt.paths)
+			if got != tt.want {
+				t.Fatalf("fallbackSubjectFor() = %q, want %q", got, tt.want)
+			}
+			if !strings.Contains(got, FallbackSubjectMarker) {
+				t.Fatalf("subject %q must carry the marker that makes these commits findable", got)
+			}
+		})
+	}
+}
+
+// Every generated subject stays inside the budget, so the campaign tag camp
+// prepends afterwards cannot push the subject line past what git log shows.
+func TestFallbackSubjectForStaysWithinBudget(t *testing.T) {
+	t.Parallel()
+
+	cases := [][]string{
+		nil,
+		{"short.md"},
+		{strings.Repeat("x/", 200) + "file.go"},
+		{"a", "b", "c", "d", "e"},
+	}
+	for _, paths := range cases {
+		if got := fallbackSubjectFor(paths); len(got) > maxFallbackSubject {
+			t.Fatalf("fallbackSubjectFor(%v) = %q, length %d exceeds the %d budget",
+				paths, got, len(got), maxFallbackSubject)
+		}
+	}
+}
+
+// Only a writer's own diagnostic is repeated into a commit message. Camp's
+// internal error text is not, because it describes camp's plumbing rather than
+// anything the user configured or can act on.
+func TestWriterFailureReasonOnlyReportsTheWriter(t *testing.T) {
+	t.Parallel()
+
+	writerErr := &autowrite.WriterError{Reason: "daemon not running"}
+	if got := writerFailureReason(writerErr); got != "daemon not running" {
+		t.Fatalf("writerFailureReason(WriterError) = %q, want the writer's reason", got)
+	}
+
+	if got := writerFailureReason(errNotAWriterFailure); got != "" {
+		t.Fatalf("writerFailureReason(other) = %q, want empty", got)
+	}
+
+	if got := writerFailureReason(nil); got != "" {
+		t.Fatalf("writerFailureReason(nil) = %q, want empty", got)
+	}
+}

--- a/internal/jobs/inspect.go
+++ b/internal/jobs/inspect.go
@@ -5,9 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+	"github.com/Obedience-Corp/camp/internal/git"
 )
 
 // The read side of the queue: what `camp jobs`, the failed-job notice, and the
@@ -99,6 +101,39 @@ func stateRank(state string) int {
 	default:
 		return 2
 	}
+}
+
+// Superseded reports whether a failed job can never succeed on a retry because
+// history moved past the commit it was queued against.
+//
+// executeCommitTree refuses to replay a captured tree onto a parent the user
+// did not choose, so a commit-tree job whose parent is no longer HEAD is not
+// waiting for a better moment: retrying it is guaranteed to fail again, every
+// time, forever. Telling a user to retry that job sends them around a loop
+// with no exit, which is worse than telling them nothing.
+//
+// A job whose commit already landed is deliberately not superseded. Retry is
+// the right action there: it recognizes its own work and clears the queue.
+//
+// Best effort by design. Anything unreadable answers false, because the cost
+// of a wrong "cannot retry" (a user drops recoverable work) is higher than the
+// cost of a wrong "try it" (they retry once and see it fail).
+func Superseded(ctx context.Context, campaignRoot string, e Entry) bool {
+	if e.State != stateFailed || e.Kind != KindCommitTree {
+		return false
+	}
+	if strings.TrimSpace(e.Parent) == "" || strings.TrimSpace(e.Tree) == "" {
+		return false
+	}
+	repoPath, err := resolveRepoPath(campaignRoot, e.Repo)
+	if err != nil {
+		return false
+	}
+	head := git.HeadSHA(ctx, repoPath)
+	if head == "" || head == e.Parent {
+		return false
+	}
+	return !git.FirstParentChainContains(ctx, repoPath, e.Tree, e.Parent)
 }
 
 // FailedCount reports how many jobs are parked in failed/.

--- a/tests/integration/autowrite_defer_test.go
+++ b/tests/integration/autowrite_defer_test.go
@@ -48,6 +48,14 @@ sleep 3
 echo "deferred: the slow writer finished"`,
 	"empty": `#!/bin/sh
 exit 0`,
+	// Shaped like the real failure that motivated the fallback: a writer whose
+	// backing daemon is down prints its whole usage and exits non-zero, so the
+	// operative line is the last one rather than the first.
+	"broken": `#!/bin/sh
+echo "Usage:" >&2
+echo "  writer [flags]" >&2
+echo "connect to daemon: writer: daemon not running" >&2
+exit 1`,
 }
 
 // drainJobs waits for the queue so an assertion does not race the worker.
@@ -406,4 +414,114 @@ func TestIntegration_EmptyWriterOutputFailsTheJob(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "failed",
 		"the failure must be kept as evidence; camp jobs:\n%s", stdout)
+}
+
+// A writer outage costs the message, never the commit.
+//
+// This is the failure that motivated the fallback. The writer's daemon was
+// down, so the job was parked; by the time anyone looked, HEAD had moved past
+// its parent and the job could no longer be retried at all, leaving work
+// staged and uncommitted with no way back except dropping the job. Every
+// assertion here is a step on that road that must no longer exist.
+func TestIntegration_WriterFailureStillCommits(t *testing.T) {
+	tc := GetSharedContainer(t)
+	tc.EnableDeferral()
+	campPath, _ := setupDrainCampaign(t, tc, "aw-defer-broken")
+	configureWriter(t, tc, campPath, "broken")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		printf 'rescued\n' > rescued.md
+	`, campPath))
+
+	before := strings.TrimSpace(tc.GitOutput(t, campPath, "rev-parse", "HEAD"))
+
+	_, stderr, exitCode, err := tc.RunCampSplitInDir(campPath, "commit", "--auto-write")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "stderr:\n%s", stderr)
+
+	drainJobs(t, tc, campPath)
+
+	after := strings.TrimSpace(tc.GitOutput(t, campPath, "rev-parse", "HEAD"))
+	assert.NotEqual(t, before, after,
+		"a writer that failed must not cost the user the commit camp already captured")
+
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "rescued.md",
+		"the degraded commit must contain the captured tree; commit contained:\n%s", committed)
+
+	// The subject says the message is camp's, so `git log` shows which commits
+	// are worth rewording once the writer is back.
+	subject := headSubject(t, tc, campPath)
+	assert.Contains(t, subject, "writer unavailable",
+		"a machine-written subject must say so; subject: %q", subject)
+	// It still describes the commit: a named path when there is one, a count
+	// when naming them all would be longer than the line.
+	assert.Regexp(t, `Update (\d+ files?|\S+) \(writer unavailable\)`, subject,
+		"the subject must describe what changed; subject: %q", subject)
+
+	// The campaign tag survives degradation: a deferred commit ends up with
+	// the same subject shape a synchronous one would.
+	assert.Contains(t, subject, "[",
+		"the campaign tag must still be prepended; subject: %q", subject)
+
+	// The body carries the writer's own diagnosis. A detached worker has no
+	// other channel that reliably reaches the user.
+	body := tc.GitOutput(t, campPath, "log", "-1", "--format=%b")
+	assert.Contains(t, body, "daemon not running",
+		"the commit must record why the writer did not run; body:\n%s", body)
+	assert.NotContains(t, body, "Usage:",
+		"only the operative line belongs in git history, not the writer's usage; body:\n%s", body)
+
+	// Nothing is parked, so nothing can rot into an unretryable job.
+	stdout, _, _, err := tc.RunCampSplitInDir(campPath, "jobs")
+	require.NoError(t, err)
+	assert.NotContains(t, stdout, "failed",
+		"a degraded commit must leave an empty queue; camp jobs:\n%s", stdout)
+}
+
+// A failed job that can never be retried must not be advertised as retryable.
+//
+// The queue's advice is the only thing standing between a user and a loop with
+// no exit: retrying a job whose parent moved fails identically every time.
+func TestIntegration_SupersededJobIsNotOfferedForRetry(t *testing.T) {
+	tc := GetSharedContainer(t)
+	tc.EnableDeferral()
+	campPath, _ := setupDrainCampaign(t, tc, "aw-defer-superseded")
+	configureWriter(t, tc, campPath, "slow")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		printf 'queued\n' > queued.md
+	`, campPath))
+
+	_, stderr, exitCode, err := tc.RunCampSplitInDir(campPath, "commit", "--auto-write")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "stderr:\n%s", stderr)
+
+	// Someone commits directly, moving HEAD past the queued job's parent.
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		printf 'interloper\n' > interloper.md
+		git add interloper.md
+		git commit -q -m "committed directly while the job was queued"
+	`, campPath))
+
+	_, _, _, err = tc.RunCampSplitInDir(campPath, "jobs", "drain")
+	require.NoError(t, err)
+
+	stdout, _, _, err := tc.RunCampSplitInDir(campPath, "jobs")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "cannot retry",
+		"the row must say the job is beyond retry; camp jobs:\n%s", stdout)
+	assert.NotContains(t, stdout, "camp jobs retry all",
+		"camp must not name a command that cannot work; camp jobs:\n%s", stdout)
+	assert.Contains(t, stdout, "camp jobs drop",
+		"the listing must name the action that does work; camp jobs:\n%s", stdout)
+
+	// Agents read the queue as JSON and need the same fact without parsing prose.
+	jsonOut, _, _, err := tc.RunCampSplitInDir(campPath, "jobs", "--json")
+	require.NoError(t, err)
+	assert.Contains(t, jsonOut, `"superseded": true`,
+		"--json must carry the retryability of a failed job; output:\n%s", jsonOut)
 }


### PR DESCRIPTION
## The failure

Found in a live campaign. Two deferred `--auto-write` commits sat in `failed/` for half an hour:

```
STATE     ID                        LANE   KIND          AGE  WHAT
failed    job-20260803T185441Z-3a0b .      commit-tree   27m  writing a commit message in . (gave up after 1 attempt)
failed    job-20260803T185514Z-6905 .      commit-tree   27m  writing a commit message in . (gave up after 1 attempt)
```

The cause was outside camp entirely. The configured writer was `ob commit`, and its daemon was down:

```
connect to daemon: ob: daemon not running - start with: obey serve
```

Camp had everything it needed to make the commit: an immutable tree, a valid parent, its own campaign tag. Only the prose was missing, and it threw the commit away for it.

Worse, the failure decayed. `executeCommitTree` refuses to replay a captured tree onto a parent the user did not choose (correctly, it must never rebase over someone else's commit). By the time anyone looked, a later job had committed and moved HEAD past the queued parent, so the job could not be retried at all. The listing still said to retry it. Following that advice was a loop with no exit; the only real recovery was `drop`, which nothing suggested.

So a transient outage in an unrelated process turned into permanently parked work, silently, on a timer.

## What changes

**A writer that fails no longer costs the commit.** The tree is the user's work; the message is decoration. A writer that reports failure now degrades to a message camp writes itself:

```
[jobsearch:c46efcc1] Update 2 files (writer unavailable)

camp wrote this message itself: the configured commit message
writer did not return one.

  connect to daemon: ob: daemon not running - start with: obey serve

Reword it with: git commit --amend
```

The subject marker is exported as `jobs.FallbackSubjectMarker` so `git log --oneline | grep` finds every one of them. The body carries the writer's own diagnostic because the worker is detached and the commit is the only channel that reliably reaches anyone.

This also removes the decay entirely: the commit lands while its parent is still HEAD, so it can never rot into an unretryable job.

**The queue stops advertising a retry that cannot work.** `camp jobs` now marks a failed commit-tree job whose parent is no longer reachable, and names the action that does work:

```
STATE     ID                        LANE   KIND          AGE  WHAT
failed    job-20260803T200112Z-6a71 .      commit-tree    3s  writing a commit message in . (gave up after 1 attempt, cannot retry)

Retrying will not help: history moved past the commit these were queued
against. Drop them with 'camp jobs drop <id>'.
Dropping keeps the files on disk; your next commit picks them up.
```

`--json` carries the same fact as a new `superseded` field, since agents read this queue and should not have to fail once to learn it. Additive only.

**Writer stderr is bounded and sanitized.** `ob` prints its full usage on failure, and the wrapped error embedded all of it next to the live copy already streamed to the log, so `worker.log` held two complete `--help` dumps. The error now carries the last meaningful line, ANSI stripped. This matters more than log tidiness now: the same string goes into commit messages, and nothing an arbitrary user-configured tool prints should reach git history as an escape sequence.

## Scope decisions

**Empty writer output still fails the job.** A writer that exits non-zero has reported its own failure and camp compensates. A writer that exits zero and prints nothing has declined, and camp does not overrule a writer's verdict on itself. `TestIntegration_EmptyWriterOutputFailsTheJob` asserts the old behavior and still passes unchanged.

**No retry-with-backoff for exec failures.** Worth noting that `MaxAttempts` is reclaim-only accounting: a job that runs and returns an error goes straight to `failed/` with no retry, which is where "gave up after 1 attempt" comes from. I did not add general retry here. For the writer case it is now moot, and the remaining exec failures are deterministic git errors that a retry would not fix. Adding it would risk cycling genuinely poisoned jobs for no gain in this failure class.

**The synchronous path is untouched.** `camp commit --auto-write` in the foreground still fails loudly when the writer fails, which is correct: the user is there, nothing was queued, and nothing decays. The asymmetry is the point.

**Not fixed, filed separately:** `camp jobs --json` reports `"attempts": 0` on a job the human listing describes as "gave up after 1 attempt". Both are defensible in isolation (the field counts reclaims, the text counts runs) but they disagree in the same output. Changing either is a contract change and did not belong in this PR.

## Verification

- `just gate`: build, vet across stable/dev/integration, lint 0 issues both profiles, 4071 + 4026 unit tests pass.
- Full deferral integration group, 17 tests, all pass, including the two whose contracts this touches (`EmptyWriterOutputFailsTheJob`, `DeferredCommitFailsWhenHeadMoved`).
- New tests: `TestIntegration_WriterFailureStillCommits` drives a writer shaped like the real one (usage to stderr, non-zero exit) and asserts the commit lands with the captured tree, a marked and descriptive subject, the reason in the body, no usage text in history, and an empty queue. `TestIntegration_SupersededJobIsNotOfferedForRetry` asserts the listing and `--json` both refuse to recommend retry. Unit coverage for the subject shapes, the subject-length budget, reason extraction, ANSI stripping, and truncation.

One existing unit test changed deliberately: `TestRunCommitMessageCommandForwardsDiagnostics` asserted the full stderr appears in the wrapped error. It now asserts the live stream keeps everything and the error keeps only the operative line, which is the contract change above.
