### PR TITLE
fix(jobs,drain): make the attempt count honest and stop reporting commands waiting

### DIFF
--- a/cmd/camp/doctor.go
+++ b/cmd/camp/doctor.go
@@ -106,15 +106,23 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	}
 
 	// Doctor inspects working-tree and commit alignment, so a queued commit
-	// makes it report a discrepancy camp is already fixing. Read-only, so a
-	// slow queue warns and the checks still run.
+	// makes it report a discrepancy camp is already fixing.
+	//
+	// The wait follows what doctor is about to do rather than which command it
+	// is. Reporting proceeds on a notice, because a finding the user can
+	// re-check costs less than holding their terminal. --fix writes, and must
+	// not repair a tree against a view of it camp is still changing.
 	var doctorDrainWaited time.Duration
 	if !doctorOpts.noDrain {
-		waited, err := drain.AllLanes(ctx, campRoot, drain.Read)
-		if err != nil {
+		if doctorOpts.fix {
+			waited, err := drain.AllLanes(ctx, campRoot, drain.Read)
+			if err != nil {
+				return err
+			}
+			doctorDrainWaited = waited
+		} else if _, err := drain.NoteAllLanes(ctx, campRoot); err != nil {
 			return err
 		}
-		doctorDrainWaited = waited
 	}
 
 	// Build doctor with options

--- a/cmd/camp/doctor.go
+++ b/cmd/camp/doctor.go
@@ -110,12 +110,18 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	//
 	// The wait follows what doctor is about to do rather than which command it
 	// is. Reporting proceeds on a notice, because a finding the user can
-	// re-check costs less than holding their terminal. --fix writes, and must
-	// not repair a tree against a view of it camp is still changing.
+	// re-check costs less than holding their terminal.
+	//
+	// --fix writes, so it waits in Write mode and refuses if the queue outlasts
+	// the wait. Read mode would warn and repair anyway, which is the thing this
+	// path must not do: a repair computed against a tree camp is midway through
+	// changing can "fix" what camp was about to commit. A refusal that names
+	// its own way out costs the user a rerun; a wrong repair costs them a
+	// diff they have to understand later.
 	var doctorDrainWaited time.Duration
 	if !doctorOpts.noDrain {
 		if doctorOpts.fix {
-			waited, err := drain.AllLanes(ctx, campRoot, drain.Read)
+			waited, err := drain.AllLanes(ctx, campRoot, drain.Write)
 			if err != nil {
 				return err
 			}

--- a/cmd/camp/doctor.go
+++ b/cmd/camp/doctor.go
@@ -112,16 +112,20 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	// is. Reporting proceeds on a notice, because a finding the user can
 	// re-check costs less than holding their terminal.
 	//
-	// --fix writes, so it waits in Write mode and refuses if the queue outlasts
-	// the wait. Read mode would warn and repair anyway, which is the thing this
-	// path must not do: a repair computed against a tree camp is midway through
-	// changing can "fix" what camp was about to commit. A refusal that names
-	// its own way out costs the user a rerun; a wrong repair costs them a
-	// diff they have to understand later.
+	// --fix writes, so it waits, and on timeout it warns and repairs anyway.
+	//
+	// That last part is deliberate rather than an oversight. Refusing would
+	// buy almost nothing: a deferred job commits content captured at enqueue
+	// (an immutable tree, or blobs), so it never reads the working tree when
+	// it runs, and a repair made while it is queued cannot change what it
+	// commits. Only a job carrying paths and no blobs falls back to the live
+	// tree, which means one written by an older camp or by hand. Refusing
+	// every --fix on a busy queue to cover that would cost more than it saves,
+	// including a --json consumer that would get no report at all.
 	var doctorDrainWaited time.Duration
 	if !doctorOpts.noDrain {
 		if doctorOpts.fix {
-			waited, err := drain.AllLanes(ctx, campRoot, drain.Write)
+			waited, err := drain.AllLanes(ctx, campRoot, drain.Read)
 			if err != nil {
 				return err
 			}

--- a/cmd/camp/drain_matrix_test.go
+++ b/cmd/camp/drain_matrix_test.go
@@ -21,34 +21,60 @@ import (
 // invariant is noticing at compile-and-test time that a history-moving
 // entrypoint has no drain call in it, and that is a question about the code.
 
-// drainMatrixEntry is one history-moving surface and where its drain lives.
+// queueDuty is what a surface owes the deferred queue.
+type queueDuty int
+
+const (
+	// mustDrain is for commands that change or publish history. They wait,
+	// because a queued commit landing in the middle of what they do, or being
+	// left behind by it, is invisible to the user.
+	mustDrain queueDuty = iota
+	// mustNotice is for commands that only report. They do not wait: holding
+	// a user's terminal to make `camp status` marginally fresher is a bad
+	// trade against telling them what is still queued and letting them re-run.
+	// They still have to say so, or a report silently omits work camp has
+	// already promised, which is the confusion deferral must not create.
+	mustNotice
+)
+
+// drainMatrixEntry is one surface and where its queue handling lives.
 type drainMatrixEntry struct {
 	// name is how a failure names the surface, in user terms.
 	name string
-	// file is the source file that must contain the drain call.
+	// file is the source file that must contain the call.
 	file string
-	// fn is the function the drain must appear inside, so moving the call to
-	// an unrelated helper in the same file does not satisfy the test.
+	// fn is the function the call must appear inside, so moving it to an
+	// unrelated helper in the same file does not satisfy the test.
 	fn string
+	// duty is what this surface owes: a wait, or an acknowledgement.
+	duty queueDuty
 }
 
-// The surfaces. Adding a history-moving command means adding a row here; a row
-// with no drain fails, which is the point.
+// The surfaces. Adding a command that reads or writes git history means adding
+// a row here; a row that does neither of its duties fails, which is the point.
 var drainMatrix = []drainMatrixEntry{
-	{name: "camp commit", file: "commit.go", fn: "runCommit"},
-	{name: "camp stage", file: "stage.go", fn: "runStage"},
-	{name: "camp push", file: "push.go", fn: "runPush"},
-	{name: "camp push all", file: "push_all.go", fn: "runPushAllCmd"},
-	{name: "camp pull", file: "pull.go", fn: "runPull"},
-	{name: "camp pull all", file: "pull_all.go", fn: "runPullAllCmd"},
-	{name: "camp status", file: "status.go", fn: "runStatus"},
-	{name: "camp log", file: "log.go", fn: "runLog"},
-	{name: "camp sync", file: "sync.go", fn: "runSync"},
-	{name: "camp doctor", file: "doctor.go", fn: "runDoctor"},
-	{name: "camp p commit", file: "project/commit.go", fn: "runProjectCommit"},
-	{name: "camp worktrees commit", file: "worktrees/commit.go", fn: "runWorktreesCommit"},
-	{name: "camp refs sync", file: "refs/commands.go", fn: "runRefsSync"},
+	{name: "camp commit", file: "commit.go", fn: "runCommit", duty: mustDrain},
+	{name: "camp stage", file: "stage.go", fn: "runStage", duty: mustDrain},
+	{name: "camp push", file: "push.go", fn: "runPush", duty: mustDrain},
+	{name: "camp push all", file: "push_all.go", fn: "runPushAllCmd", duty: mustDrain},
+	{name: "camp pull", file: "pull.go", fn: "runPull", duty: mustDrain},
+	{name: "camp pull all", file: "pull_all.go", fn: "runPullAllCmd", duty: mustDrain},
+	{name: "camp sync", file: "sync.go", fn: "runSync", duty: mustDrain},
+	// doctor --fix repairs a tree, so it waits; plain doctor reports and does
+	// not. The wait follows what the command does, not which command it is.
+	{name: "camp doctor", file: "doctor.go", fn: "runDoctor", duty: mustDrain},
+	{name: "camp p commit", file: "project/commit.go", fn: "runProjectCommit", duty: mustDrain},
+	{name: "camp worktrees commit", file: "worktrees/commit.go", fn: "runWorktreesCommit", duty: mustDrain},
+	{name: "camp refs sync", file: "refs/commands.go", fn: "runRefsSync", duty: mustDrain},
+	{name: "camp status", file: "status.go", fn: "runStatus", duty: mustNotice},
+	{name: "camp log", file: "log.go", fn: "runLog", duty: mustNotice},
 }
+
+// drainCalls are the entrypoints that wait for the queue.
+var drainCalls = []string{"drain.Repo(", "drain.AllLanes(", "drain.CampaignRoot("}
+
+// noticeCalls are the entrypoints that report the queue without waiting.
+var noticeCalls = []string{"drain.Note(", "drain.NoteAllLanes("}
 
 func TestEveryHistoryMovingCommandDrains(t *testing.T) {
 	t.Parallel()
@@ -66,14 +92,28 @@ func TestEveryHistoryMovingCommandDrains(t *testing.T) {
 				t.Fatalf("%s: function %s not found; the matrix is stale",
 					entry.file, entry.fn)
 			}
-			if !strings.Contains(body, "drain.Repo(") &&
-				!strings.Contains(body, "drain.AllLanes(") &&
-				!strings.Contains(body, "drain.CampaignRoot(") {
-				t.Errorf("%s moves git history but never drains the deferred queue.\n"+
-					"A queued commit can then land in the middle of what it does, or be "+
-					"left behind by it.\nAdd a drain in %s (%s), or remove the row from "+
-					"drainMatrix if this command no longer touches history.",
-					entry.name, entry.fn, entry.file)
+			switch entry.duty {
+			case mustDrain:
+				if !containsAny(body, drainCalls) {
+					t.Errorf("%s moves git history but never drains the deferred queue.\n"+
+						"A queued commit can then land in the middle of what it does, or be "+
+						"left behind by it.\nAdd a drain in %s (%s), or remove the row from "+
+						"drainMatrix if this command no longer touches history.",
+						entry.name, entry.fn, entry.file)
+				}
+			case mustNotice:
+				if !containsAny(body, noticeCalls) {
+					t.Errorf("%s reports git history but never mentions the deferred queue.\n"+
+						"It would then omit a commit camp has already promised, with nothing "+
+						"on screen to explain the gap.\nAdd a drain.Note in %s (%s).",
+						entry.name, entry.fn, entry.file)
+				}
+				if containsAny(body, drainCalls) {
+					t.Errorf("%s only reports, so it must not wait for the queue.\n"+
+						"Holding the terminal to make a report marginally fresher is the "+
+						"cost deferral exists to remove; %s (%s) should call drain.Note.",
+						entry.name, entry.fn, entry.file)
+				}
 			}
 		})
 	}
@@ -179,4 +219,14 @@ func TestDrainMatrixCoversEveryPackageWithADrain(t *testing.T) {
 				"add one so the call cannot be removed unnoticed", path)
 		}
 	}
+}
+
+// containsAny reports whether src holds any of the given call sites.
+func containsAny(src string, calls []string) bool {
+	for _, call := range calls {
+		if strings.Contains(src, call) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/camp/drain_matrix_test.go
+++ b/cmd/camp/drain_matrix_test.go
@@ -35,6 +35,13 @@ const (
 	// They still have to say so, or a report silently omits work camp has
 	// already promised, which is the confusion deferral must not create.
 	mustNotice
+	// mustDoBoth is for a command whose duty depends on what it was asked to
+	// do. Only doctor: it reports by default and repairs under --fix, so it
+	// owes a notice on one path and a wait on the other. Requiring only the
+	// wait would let someone make it unconditional again and put a wait back
+	// on every doctor; requiring only the notice would let the repair path
+	// lose its wait. Both strings have to be there.
+	mustDoBoth
 )
 
 // drainMatrixEntry is one surface and where its queue handling lives.
@@ -62,7 +69,7 @@ var drainMatrix = []drainMatrixEntry{
 	{name: "camp sync", file: "sync.go", fn: "runSync", duty: mustDrain},
 	// doctor --fix repairs a tree, so it waits; plain doctor reports and does
 	// not. The wait follows what the command does, not which command it is.
-	{name: "camp doctor", file: "doctor.go", fn: "runDoctor", duty: mustDrain},
+	{name: "camp doctor", file: "doctor.go", fn: "runDoctor", duty: mustDoBoth},
 	{name: "camp p commit", file: "project/commit.go", fn: "runProjectCommit", duty: mustDrain},
 	{name: "camp worktrees commit", file: "worktrees/commit.go", fn: "runWorktreesCommit", duty: mustDrain},
 	{name: "camp refs sync", file: "refs/commands.go", fn: "runRefsSync", duty: mustDrain},
@@ -113,6 +120,20 @@ func TestEveryHistoryMovingCommandDrains(t *testing.T) {
 						"Holding the terminal to make a report marginally fresher is the "+
 						"cost deferral exists to remove; %s (%s) should call drain.Note.",
 						entry.name, entry.fn, entry.file)
+				}
+			case mustDoBoth:
+				if !containsAny(body, drainCalls) {
+					t.Errorf("%s repairs under --fix but never waits for the queue.\n"+
+						"It would repair against a tree camp is still changing.\n"+
+						"Add a blocking drain on the writing path in %s (%s).",
+						entry.name, entry.fn, entry.file)
+				}
+				if !containsAny(body, noticeCalls) {
+					t.Errorf("%s reports by default but never mentions the deferred queue.\n"+
+						"Either the notice was dropped, or the wait became unconditional and "+
+						"every %s now pays for the queue again.\n"+
+						"Both paths must be present in %s (%s).",
+						entry.name, entry.name, entry.fn, entry.file)
 				}
 			}
 		})

--- a/cmd/camp/log.go
+++ b/cmd/camp/log.go
@@ -67,12 +67,13 @@ func runLog(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, ui.Info(fmt.Sprintf("Submodule: %s", target.Name)))
 	}
 
-	// Read-only, so a slow queue warns rather than refusing. It still drains:
-	// log is one of the two commands people run to check whether something
-	// committed, and showing a log that is missing a commit camp has already
-	// promised is exactly the confusion deferral must not create.
+	// Log reports; it does not wait. It is one of the two commands people run
+	// to check whether something committed, so a log missing a commit camp has
+	// promised is real confusion, and the notice is what resolves it: the
+	// missing commit is named as still queued rather than silently absent.
+	// Naming it costs a directory read; waiting for it costs the terminal.
 	if !noDrain {
-		if _, err := drain.Repo(ctx, target.Path, drain.Read); err != nil {
+		if _, err := drain.Note(ctx, target.Path); err != nil {
 			return err
 		}
 	}

--- a/cmd/camp/status.go
+++ b/cmd/camp/status.go
@@ -48,7 +48,7 @@ func init() {
 	statusCmd.Flags().StringVarP(&statusProject, "project", "p", "", "Status of a specific project path")
 	statusCmd.Flags().BoolVarP(&statusShort, "short", "s", false, "Give output in short format")
 	statusCmd.Flags().BoolVar(&statusShowRefs, "show-refs", false, "Show campaign root submodule ref changes")
-	statusCmd.Flags().BoolVar(&statusNoDrain, "no-drain", false, "Do not wait for camp's queued commits first")
+	statusCmd.Flags().BoolVar(&statusNoDrain, "no-drain", false, "Do not report camp's queued commits first")
 }
 
 func runStatus(cmd *cobra.Command, args []string) error {
@@ -82,11 +82,13 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, ui.Info(fmt.Sprintf("Submodule: %s", target.Name)))
 	}
 
-	// Read-only, so a slow queue warns rather than refusing. Status is the
-	// first thing a user runs to ask "did that commit?", so reporting a tree
-	// camp is midway through changing is a correctness bug, not a nicety.
+	// Status reports; it does not wait. It is the first thing a user runs to
+	// ask "did that commit?", and the honest answer to that while the queue is
+	// still working is the count, given now, not the same answer given thirty
+	// seconds later. A tree camp is midway through changing still has to be
+	// declared, which is what the notice does.
 	if !statusNoDrain {
-		if _, err := drain.Repo(ctx, target.Path, drain.Read); err != nil {
+		if _, err := drain.Note(ctx, target.Path); err != nil {
 			return err
 		}
 	}

--- a/internal/drain/drain.go
+++ b/internal/drain/drain.go
@@ -142,16 +142,17 @@ func noteAllTo(ctx context.Context, w io.Writer, campaignRoot string) (int, erro
 }
 
 // pendingNotice is what a reporting command prints instead of waiting.
+//
+// It does not reuse countPhrase, whose "1 queued commit" reads correctly in a
+// refusal ("1 queued commit not completed after 30s") but stutters here into
+// "1 queued commit still queued". This line prints on ordinary commands rather
+// than only on failures, so it is the one a user sees most and the one least
+// able to afford reading like a template.
 func pendingNotice(n int) string {
-	return fmt.Sprintf("%s still queued; what follows may not include %s (camp jobs)",
-		countPhrase(n), itOrThem(n))
-}
-
-func itOrThem(n int) string {
 	if n == 1 {
-		return "it"
+		return "1 commit still queued; what follows may not include it (camp jobs)"
 	}
-	return "them"
+	return fmt.Sprintf("%d commits still queued; what follows may not include them (camp jobs)", n)
 }
 
 // CampaignRoot waits for the campaign root's lane. Commands that operate

--- a/internal/drain/drain.go
+++ b/internal/drain/drain.go
@@ -69,6 +69,91 @@ func Repo(ctx context.Context, repoPath string, mode Mode) (time.Duration, error
 	return drainRepoTo(ctx, os.Stderr, repoPath, mode)
 }
 
+// Note reports repoPath's outstanding commits without waiting for any of them.
+//
+// For commands that only report. Waiting made those commands pay the queue's
+// full cost to buy a marginally fresher read: `camp status` is the thing a user
+// runs constantly and often twice in a row, and holding it for up to
+// DrainTimeout so its answer can be slightly more current is a bad trade
+// against just saying how many commits are still on their way. The user re-runs
+// it; that is what the command is for.
+//
+// The caveat the wait was protecting is kept, because it was the real point:
+// the user is told the tree is mid-change, so a status that looks stale is
+// explained rather than merely wrong. What changes is that they are told
+// immediately instead of thirty seconds later.
+//
+// Returns the number of outstanding commits. Outside a campaign, or with an
+// empty queue, it is one directory read and returns zero.
+func Note(ctx context.Context, repoPath string) (int, error) {
+	return noteTo(ctx, os.Stderr, repoPath)
+}
+
+func noteTo(ctx context.Context, w io.Writer, repoPath string) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	campaignRoot, err := campaign.DetectCached(ctx)
+	if err != nil {
+		// Not in a campaign: no queue, nothing to report. Campaign detection
+		// problems belong to the command's own work, not to this notice.
+		return 0, nil
+	}
+	repo := jobs.RepoForPath(campaignRoot, repoPath)
+	if repo == "" {
+		return 0, nil
+	}
+	outstanding, err := jobs.Outstanding(campaignRoot, repo)
+	if err != nil {
+		// A notice that cannot be computed must not fail the command it was
+		// going to annotate.
+		return 0, nil
+	}
+	if len(outstanding) == 0 {
+		return 0, nil
+	}
+	// Report, but still kick the queue. Spawning is the cheap half of a drain
+	// and the half that makes progress inevitable; waiting is the half that
+	// costs the user their terminal. Taking only the second away would leave a
+	// user whose worker died watching the same jobs sit there every time they
+	// ran status.
+	jobs.EnsureServed(ctx, campaignRoot, outstanding)
+	_, _ = fmt.Fprintln(w, ui.Dim(pendingNotice(len(outstanding))))
+	return len(outstanding), nil
+}
+
+// NoteAllLanes reports every lane's outstanding commits without waiting, for
+// reporting commands that look at the whole campaign.
+func NoteAllLanes(ctx context.Context, campaignRoot string) (int, error) {
+	return noteAllTo(ctx, os.Stderr, campaignRoot)
+}
+
+func noteAllTo(ctx context.Context, w io.Writer, campaignRoot string) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	outstanding, err := jobs.OutstandingAll(campaignRoot)
+	if err != nil || len(outstanding) == 0 {
+		return 0, nil
+	}
+	jobs.EnsureServed(ctx, campaignRoot, outstanding)
+	_, _ = fmt.Fprintln(w, ui.Dim(pendingNotice(len(outstanding))))
+	return len(outstanding), nil
+}
+
+// pendingNotice is what a reporting command prints instead of waiting.
+func pendingNotice(n int) string {
+	return fmt.Sprintf("%s still queued; what follows may not include %s (camp jobs)",
+		countPhrase(n), itOrThem(n))
+}
+
+func itOrThem(n int) string {
+	if n == 1 {
+		return "it"
+	}
+	return "them"
+}
+
 // CampaignRoot waits for the campaign root's lane. Commands that operate
 // on the campaign itself rather than a specific repository use it.
 func CampaignRoot(ctx context.Context, campaignRoot string, mode Mode) (time.Duration, error) {

--- a/internal/drain/drain_internal_test.go
+++ b/internal/drain/drain_internal_test.go
@@ -2,6 +2,7 @@ package drain
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -213,5 +214,79 @@ func TestSuccessfulDrainIsSilent(t *testing.T) {
 	}
 	if waited != 0 || out.Len() != 0 {
 		t.Errorf("a drain with nothing to wait for must be silent; got %q", out.String())
+	}
+}
+
+// A reporting command says what is queued and returns. This is the half of the
+// decision that used to be a wait: `camp status` held the terminal for up to
+// DrainTimeout so its answer could be slightly fresher, which is the cost
+// deferral exists to remove. The caveat survives, the wait does not.
+func TestPendingNoticeSaysWhatIsQueuedAndWhereToLook(t *testing.T) {
+	t.Parallel()
+
+	notice := pendingNotice(1)
+	if !strings.Contains(notice, "1 queued commit") {
+		t.Errorf("notice did not count the work:\n%s", notice)
+	}
+	if !strings.Contains(notice, "still queued") {
+		t.Errorf("notice did not say the report may be incomplete:\n%s", notice)
+	}
+	if !strings.Contains(notice, "camp jobs") {
+		t.Errorf("notice did not name where to look:\n%s", notice)
+	}
+	// Nothing about waiting: a user told to wait by a command that did not
+	// wait learns to distrust both statements.
+	for _, forbidden := range []string{"waiting", "after 30s", "timed out"} {
+		if strings.Contains(notice, forbidden) {
+			t.Errorf("notice mentions %q but nothing waited:\n%s", forbidden, notice)
+		}
+	}
+}
+
+// Singular and plural both have to read correctly, because this line is
+// printed constantly and a "1 queued commits" is the kind of wrong that makes
+// a user stop reading camp's output.
+func TestPendingNoticeAgreesInNumber(t *testing.T) {
+	t.Parallel()
+
+	if got := pendingNotice(1); !strings.Contains(got, "1 queued commit ") ||
+		!strings.Contains(got, "include it") {
+		t.Errorf("pendingNotice(1) = %q, want singular throughout", got)
+	}
+	if got := pendingNotice(3); !strings.Contains(got, "3 queued commits") ||
+		!strings.Contains(got, "include them") {
+		t.Errorf("pendingNotice(3) = %q, want plural throughout", got)
+	}
+}
+
+// An empty queue is silent. A notice on every status in a campaign with
+// nothing pending is noise, and noise is how a warning stops being read.
+func TestNoticeIsSilentWithAnEmptyQueue(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	n, err := noteAllTo(context.Background(), &out, t.TempDir())
+	if err != nil {
+		t.Fatalf("noteAllTo() error = %v", err)
+	}
+	if n != 0 {
+		t.Errorf("counted %d outstanding commits in an empty campaign, want 0", n)
+	}
+	if out.String() != "" {
+		t.Errorf("an empty queue printed %q, want silence", out.String())
+	}
+}
+
+// A cancelled context stops the notice like anything else, rather than doing
+// filesystem work nobody is waiting for.
+func TestNoticeHonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var out bytes.Buffer
+	if _, err := noteAllTo(ctx, &out, t.TempDir()); err == nil {
+		t.Error("noteAllTo() with a cancelled context returned nil, want the context error")
 	}
 }

--- a/internal/drain/drain_internal_test.go
+++ b/internal/drain/drain_internal_test.go
@@ -225,7 +225,7 @@ func TestPendingNoticeSaysWhatIsQueuedAndWhereToLook(t *testing.T) {
 	t.Parallel()
 
 	notice := pendingNotice(1)
-	if !strings.Contains(notice, "1 queued commit") {
+	if !strings.Contains(notice, "1 commit") {
 		t.Errorf("notice did not count the work:\n%s", notice)
 	}
 	if !strings.Contains(notice, "still queued") {
@@ -249,13 +249,17 @@ func TestPendingNoticeSaysWhatIsQueuedAndWhereToLook(t *testing.T) {
 func TestPendingNoticeAgreesInNumber(t *testing.T) {
 	t.Parallel()
 
-	if got := pendingNotice(1); !strings.Contains(got, "1 queued commit ") ||
+	if got := pendingNotice(1); !strings.Contains(got, "1 commit still queued") ||
 		!strings.Contains(got, "include it") {
 		t.Errorf("pendingNotice(1) = %q, want singular throughout", got)
 	}
-	if got := pendingNotice(3); !strings.Contains(got, "3 queued commits") ||
+	if got := pendingNotice(3); !strings.Contains(got, "3 commits still queued") ||
 		!strings.Contains(got, "include them") {
 		t.Errorf("pendingNotice(3) = %q, want plural throughout", got)
+	}
+	// The stutter this line used to have, from reusing the refusal's phrasing.
+	if got := pendingNotice(1); strings.Contains(got, "queued commit still queued") {
+		t.Errorf("pendingNotice(1) = %q, want it to read like a sentence", got)
 	}
 }
 

--- a/internal/jobs/attempts_internal_test.go
+++ b/internal/jobs/attempts_internal_test.go
@@ -3,6 +3,8 @@ package jobs
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -142,5 +144,77 @@ func TestParkingAnExhaustedJobDoesNotCountAnotherAttempt(t *testing.T) {
 	if failed[0].Attempts != MaxAttempts {
 		t.Errorf("Attempts = %d, want %d: parking is not a run",
 			failed[0].Attempts, MaxAttempts)
+	}
+}
+
+// Parking must always empty running/, even when the job cannot be parsed.
+//
+// Reclaim skips what it cannot read, so anything left behind here sits in
+// running/ with nothing ever coming for it. Recording the attempt is the part
+// that may fail; leaving the lane is not optional.
+func TestParkingAnUnreadableJobStillLeavesRunning(t *testing.T) {
+	root := testCampaign(t)
+
+	runningDir := laneDir(root, stateRunning, ".")
+	if err := os.MkdirAll(runningDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const name = "0000001.json"
+	path := filepath.Join(runningDir, name)
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := parkFailedJob(root, ".", path, name); err != nil {
+		t.Fatalf("parkFailedJob() error = %v; an unparseable job must still be parked", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("the job is still in running/; nothing will ever pick it up again")
+	}
+	if _, err := os.Stat(filepath.Join(laneDir(root, stateFailed, "."), name)); err != nil {
+		t.Errorf("the job did not reach failed/: %v", err)
+	}
+}
+
+// The incremented job is written to failed/ rather than edited in place, so an
+// interrupted park cannot leave unparseable JSON in running/.
+//
+// Asserted through the file that is left behind: an in-place implementation
+// writes the count to the running path before moving it, and this checks that
+// the running path is never the thing carrying the new count.
+func TestParkingWritesTheCountToItsDestination(t *testing.T) {
+	root := testCampaign(t)
+	ctx := context.Background()
+
+	if _, err := Enqueue(ctx, root, Job{
+		Kind: KindCommitPaths, Repo: ".", Paths: []string{"a.md"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Claim(ctx, root, "."); err != nil {
+		t.Fatal(err)
+	}
+
+	runningDir := laneDir(root, stateRunning, ".")
+	names, err := sortedJobFiles(runningDir)
+	if err != nil || len(names) != 1 {
+		t.Fatalf("setup: want one claimed job in running/, got %v (%v)", names, err)
+	}
+	name := names[0]
+	runningPath := filepath.Join(runningDir, name)
+	if err := parkFailedJob(root, ".", runningPath, name); err != nil {
+		t.Fatalf("parkFailedJob() error = %v", err)
+	}
+
+	if _, err := os.Stat(runningPath); !os.IsNotExist(err) {
+		t.Error("running/ still holds the job after parking")
+	}
+	parked, err := readJob(filepath.Join(laneDir(root, stateFailed, "."), name))
+	if err != nil {
+		t.Fatalf("read the parked job: %v", err)
+	}
+	if parked.Attempts != 1 {
+		t.Errorf("parked Attempts = %d, want 1", parked.Attempts)
 	}
 }

--- a/internal/jobs/attempts_internal_test.go
+++ b/internal/jobs/attempts_internal_test.go
@@ -1,0 +1,146 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+var errJobFailed = errors.New("the job failed")
+
+// A parked job must report the same number of tries however you ask.
+//
+// The listing and --json read the same job document, so a job that ran and
+// failed without recording the run made them contradict each other: the text
+// said "gave up after 1 attempt" beside a field that said 0. An agent reading
+// the queue could not tell a failure that had been retried from one that never
+// was, and both are shown identically.
+func TestExecutionFailureRecordsTheAttempt(t *testing.T) {
+	withFastTiming(t, time.Millisecond, time.Millisecond)
+	root := testCampaign(t)
+	ctx := context.Background()
+
+	origExecute := executeJob
+	executeJob = func(context.Context, string, *Job) error { return errJobFailed }
+	t.Cleanup(func() { executeJob = origExecute })
+
+	job, err := Enqueue(ctx, root, Job{
+		Kind: KindCommitPaths, Repo: ".", Paths: []string{"a.md"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Run(ctx, root); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	failed, err := List(root, stateFailed, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(failed) != 1 || failed[0].ID != job.ID {
+		t.Fatalf("failed lane = %+v, want the job that failed (%s)", failed, job.ID)
+	}
+	if failed[0].Attempts != 1 {
+		t.Errorf("Attempts = %d, want 1: a job that ran once and failed has "+
+			"used one attempt", failed[0].Attempts)
+	}
+
+	// The contradiction this fixes, stated as the invariant it broke: the
+	// count the user reads and the count a script reads are the same count.
+	note := AttemptNote(failed[0].Attempts, true)
+	if note != "gave up after 1 attempt" {
+		t.Errorf("AttemptNote(%d, true) = %q, want it to agree with the "+
+			"recorded count", failed[0].Attempts, note)
+	}
+}
+
+// Reclaims and executions both count, because both are a job that started and
+// did not finish. A job abandoned twice and then failed has tried three times.
+func TestReclaimAndExecutionAttemptsAccumulate(t *testing.T) {
+	withFastTiming(t, time.Millisecond, time.Millisecond)
+	root := testCampaign(t)
+	ctx := context.Background()
+
+	if _, err := Enqueue(ctx, root, Job{
+		Kind: KindCommitPaths, Repo: ".", Paths: []string{"a.md"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two workers die mid-job.
+	for range 2 {
+		if _, _, err := Claim(ctx, root, "."); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(2 * time.Millisecond)
+		if _, err := Reclaim(ctx, root, ".", laneLiveness); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	origExecute := executeJob
+	executeJob = func(context.Context, string, *Job) error { return errJobFailed }
+	t.Cleanup(func() { executeJob = origExecute })
+
+	if err := Run(ctx, root); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	failed, err := List(root, stateFailed, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(failed) != 1 {
+		t.Fatalf("failed lane holds %d jobs, want 1", len(failed))
+	}
+	if failed[0].Attempts != 3 {
+		t.Errorf("Attempts = %d, want 3: two abandoned runs plus one that "+
+			"failed", failed[0].Attempts)
+	}
+}
+
+// Parking an exhausted job must not invent a run it never had.
+//
+// parkExhausted moves a job that has already burned its attempts out of
+// pending. It did not run here, so counting one would push the total past
+// MaxAttempts and make the listing claim a try that never happened.
+func TestParkingAnExhaustedJobDoesNotCountAnotherAttempt(t *testing.T) {
+	withFastTiming(t, time.Millisecond, time.Millisecond)
+	root := testCampaign(t)
+	ctx := context.Background()
+
+	if _, err := Enqueue(ctx, root, Job{
+		Kind: KindCommitPaths, Repo: ".", Paths: []string{"a.md"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for range MaxAttempts {
+		if _, _, err := Claim(ctx, root, "."); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(2 * time.Millisecond)
+		if _, err := Reclaim(ctx, root, ".", laneLiveness); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := parkExhausted(root, "."); err != nil {
+		t.Fatalf("parkExhausted() error = %v", err)
+	}
+
+	failed, err := List(root, stateFailed, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(failed) != 1 {
+		t.Fatalf("failed lane holds %d jobs, want 1", len(failed))
+	}
+	if failed[0].Attempts != MaxAttempts {
+		t.Errorf("Attempts = %d, want %d: parking is not a run",
+			failed[0].Attempts, MaxAttempts)
+	}
+}

--- a/internal/jobs/drain.go
+++ b/internal/jobs/drain.go
@@ -320,6 +320,19 @@ func OutstandingAll(campaignRoot string) ([]Job, error) {
 // be waiting on two lanes at once (the root's own and a submodule's follow-up
 // parent), and waiting on a lane nobody serves is the failure this exists to
 // prevent.
+// EnsureServed starts a worker for any lane in blocking that has none, without
+// waiting for the work to finish.
+//
+// Exported for the reporting commands, which announce the queue rather than
+// waiting for it. They still owe it a kick: spawning is what makes "a queued
+// job is always eventually served" true, and it is the cheap half of a drain.
+// A user whose worker died and who only ever runs `camp status` would
+// otherwise watch the same jobs sit there forever, being told about them each
+// time and never seeing them move.
+func EnsureServed(ctx context.Context, campaignRoot string, blocking []Job) []string {
+	return spawnForJobs(ctx, campaignRoot, blocking)
+}
+
 func spawnForJobs(ctx context.Context, campaignRoot string, blocking []Job) []string {
 	seen := make(map[string]struct{}, len(blocking))
 	var spawned []string

--- a/internal/jobs/queue.go
+++ b/internal/jobs/queue.go
@@ -208,10 +208,7 @@ func Claim(ctx context.Context, campaignRoot, repo string) (*Job, func(error) er
 func completionFor(campaignRoot, repo, runningPath, name string) func(error) error {
 	return func(jobErr error) error {
 		if jobErr != nil {
-			// The run is recorded before the job is parked, so the count
-			// survives into failed/ where a user and an agent both read it.
-			recordAttempt(runningPath)
-			return failJobFile(campaignRoot, repo, runningPath, name)
+			return parkFailedJob(campaignRoot, repo, runningPath, name)
 		}
 		if err := os.Remove(runningPath); err != nil && !os.IsNotExist(err) {
 			return camperrors.Wrapf(err, "complete job %s", runningPath)
@@ -220,7 +217,7 @@ func completionFor(campaignRoot, repo, runningPath, name string) func(error) err
 	}
 }
 
-// recordAttempt increments a job's attempt count in place.
+// parkFailedJob records the run and moves the job to failed/.
 //
 // An attempt is a job that started and did not finish, and until now only one
 // of the two ways that happens was counted. Reclaim counted the worker that
@@ -230,21 +227,39 @@ func completionFor(campaignRoot, repo, runningPath, name string) func(error) err
 // and an agent reading --json could not tell a failure that had been retried
 // from one that never was.
 //
-// Best effort: this runs on the way to failed/, and a job that cannot be
-// re-read or rewritten must still be parked. Losing the count costs a wrong
-// number in a listing, while returning early here would strand the job in
-// running/ with no worker coming for it.
-func recordAttempt(path string) {
-	job, err := readJob(path)
+// The incremented copy is written to the destination and the source removed
+// after, never edited in place. Reclaim skips a job it cannot parse, so an
+// interrupted in-place write would leave unreadable JSON in running/ that
+// nothing ever picks up again: the one failure this queue treats as
+// unforgivable. Written this way a crash in the window leaves the job in both
+// lanes instead, and reclaim resolves that by running it again. Duplicating a
+// job is recoverable; stranding one is not.
+//
+// A job that cannot be read or marshalled is still parked, without a count.
+// It has to leave running/ either way, and a wrong number in a listing costs
+// less than a job nobody is coming for.
+func parkFailedJob(campaignRoot, repo, runningPath, name string) error {
+	job, err := readJob(runningPath)
 	if err != nil {
-		return
+		return failJobFile(campaignRoot, repo, runningPath, name)
 	}
 	job.Attempts++
 	data, err := json.MarshalIndent(job, "", "  ")
 	if err != nil {
-		return
+		return failJobFile(campaignRoot, repo, runningPath, name)
 	}
-	_ = os.WriteFile(path, data, 0o644)
+
+	failedDir := laneDir(campaignRoot, stateFailed, repo)
+	if err := os.MkdirAll(failedDir, 0o755); err != nil {
+		return camperrors.Wrapf(err, "create failed lane %s", failedDir)
+	}
+	if err := os.WriteFile(filepath.Join(failedDir, name), data, 0o644); err != nil {
+		return camperrors.Wrapf(err, "park job %s", runningPath)
+	}
+	if err := os.Remove(runningPath); err != nil && !os.IsNotExist(err) {
+		return camperrors.Wrapf(err, "park job %s", runningPath)
+	}
+	return nil
 }
 
 // failJobFile moves a running job to the failed lane, keeping it for

--- a/internal/jobs/queue.go
+++ b/internal/jobs/queue.go
@@ -208,6 +208,9 @@ func Claim(ctx context.Context, campaignRoot, repo string) (*Job, func(error) er
 func completionFor(campaignRoot, repo, runningPath, name string) func(error) error {
 	return func(jobErr error) error {
 		if jobErr != nil {
+			// The run is recorded before the job is parked, so the count
+			// survives into failed/ where a user and an agent both read it.
+			recordAttempt(runningPath)
 			return failJobFile(campaignRoot, repo, runningPath, name)
 		}
 		if err := os.Remove(runningPath); err != nil && !os.IsNotExist(err) {
@@ -215,6 +218,33 @@ func completionFor(campaignRoot, repo, runningPath, name string) func(error) err
 		}
 		return nil
 	}
+}
+
+// recordAttempt increments a job's attempt count in place.
+//
+// An attempt is a job that started and did not finish, and until now only one
+// of the two ways that happens was counted. Reclaim counted the worker that
+// died; a job that ran and returned an error counted nothing, so it was parked
+// still reading Attempts: 0 while the listing beside it said the job had
+// already been tried and given up on. The two disagreed in the same output,
+// and an agent reading --json could not tell a failure that had been retried
+// from one that never was.
+//
+// Best effort: this runs on the way to failed/, and a job that cannot be
+// re-read or rewritten must still be parked. Losing the count costs a wrong
+// number in a listing, while returning early here would strand the job in
+// running/ with no worker coming for it.
+func recordAttempt(path string) {
+	job, err := readJob(path)
+	if err != nil {
+		return
+	}
+	job.Attempts++
+	data, err := json.MarshalIndent(job, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(path, data, 0o644)
 }
 
 // failJobFile moves a running job to the failed lane, keeping it for

--- a/tests/integration/jobs_drain_test.go
+++ b/tests/integration/jobs_drain_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -198,14 +199,17 @@ func TestIntegration_ManifestJobNeverBlocksAPush(t *testing.T) {
 		"a manifest job must not make a push wait; stderr:\n%s", stderr)
 }
 
-// A read-only command warns and proceeds when the queue outlasts it. Refusing
-// to show status because a commit is slow is worse than showing status with a
-// caveat, and status is the command people run to ask whether something
-// committed.
+// A read-only command reports the queue and returns, without waiting for it.
+//
+// Status is the command people run to ask whether something committed, and
+// often twice in a row. Holding it so its answer can be marginally fresher
+// spends the exact cost deferral exists to remove; the honest answer while the
+// queue is working is the count, given immediately. The user re-runs it.
 //
 // The lane is wedged deliberately: a fresh lock says a worker holds it, and the
-// job names a path that does not exist so nothing can ever complete it.
-func TestIntegration_StatusWarnsAndProceedsOnAWedgedLane(t *testing.T) {
+// job names a path that does not exist so nothing can ever complete it. Before
+// this behavior existed, that setup made status sit for DrainTimeout.
+func TestIntegration_StatusReportsTheQueueWithoutWaiting(t *testing.T) {
 	tc := GetSharedContainer(t)
 	tc.EnableDeferral()
 	campPath, _ := setupDrainCampaign(t, tc, "drain-status-wedged")
@@ -216,23 +220,32 @@ func TestIntegration_StatusWarnsAndProceedsOnAWedgedLane(t *testing.T) {
 		"paths":   []string{"does/not/exist.md"},
 		"message": "capture intent: wedged",
 	})
-	// A fresh lane lock stands in for a live worker, so the drain does not
-	// spawn one and simply waits.
+	// A fresh lane lock stands in for a live worker, so nothing spawns and
+	// nothing completes: any wait here would run to its full timeout.
 	tc.Shell(t, fmt.Sprintf(`
 		cd %s/.campaign/cache/jobs
 		printf '99999\n' > worker-%s.lock
 	`, campPath, rootLane))
 
+	started := time.Now()
 	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath,
 		"status", "--short")
+	elapsed := time.Since(started)
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, exitCode,
-		"status must proceed despite a slow queue; stdout:\n%s\nstderr:\n%s", stdout, stderr)
+		"status must proceed despite a busy queue; stdout:\n%s\nstderr:\n%s", stdout, stderr)
+	// The wedged job can never complete, so anything close to the drain
+	// timeout means status waited on it.
+	assert.Less(t, elapsed, 15*time.Second,
+		"status must not wait for the queue; it took %s against a lane that "+
+			"can never finish", elapsed)
 	assert.Contains(t, stderr, "still queued",
-		"status must say the report may be out of date; stderr:\n%s", stderr)
+		"status must say the report may be incomplete; stderr:\n%s", stderr)
 	assert.Contains(t, stderr, "camp jobs",
-		"the warning must name the command that shows what is stuck; stderr:\n%s", stderr)
+		"the notice must name the command that shows what is stuck; stderr:\n%s", stderr)
+	assert.NotContains(t, stderr, "waiting on",
+		"status must not claim to be waiting when it is not; stderr:\n%s", stderr)
 }
 
 // A write command refuses rather than proceeding into a half-correct state,

--- a/tests/integration/jobs_drain_test.go
+++ b/tests/integration/jobs_drain_test.go
@@ -281,10 +281,10 @@ func TestIntegration_StatusReportsTheQueueWithoutWaiting(t *testing.T) {
 // Doctor's duty follows what it was asked to do, and both halves are real
 // behavior rather than two branches that merely exist.
 //
-// Plain doctor reports, so it takes the notice and returns. --fix repairs, so
-// it waits and refuses when the queue outlasts the wait: a repair computed
-// against a tree camp is midway through changing can undo what camp was about
-// to commit, and that is worse than making the user rerun.
+// Plain doctor reports, so it takes the notice and returns immediately. --fix
+// repairs, so it still waits for the queue. Source matching can prove both
+// calls exist but not that they sit on the paths they claim to; only the
+// timing separates them, which is what this measures.
 //
 // One wedged lane serves both: a fresh lock says a worker holds it and the job
 // names a path that does not exist, so nothing can ever complete it.
@@ -306,7 +306,7 @@ func TestIntegration_DoctorWaitsOnlyWhenItRepairs(t *testing.T) {
 
 	// Reporting: notice, no wait.
 	started := time.Now()
-	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath, "doctor")
+	stdout, stderr, _, err := tc.RunCampSplitInDir(campPath, "doctor")
 	elapsed := time.Since(started)
 	require.NoError(t, err)
 
@@ -318,18 +318,23 @@ func TestIntegration_DoctorWaitsOnlyWhenItRepairs(t *testing.T) {
 	assert.NotContains(t, stdout+stderr, "would leave them behind",
 		"plain doctor reports and must not refuse; stdout:\n%s\nstderr:\n%s", stdout, stderr)
 
-	// Repairing: wait, then refuse rather than fix against a stale tree.
-	stdout, stderr, exitCode, err = tc.RunCampSplitInDir(campPath, "doctor", "--fix")
+	// Repairing: wait. It proceeds afterwards, which is deliberate (a deferred
+	// job commits content captured at enqueue, so a repair made while it is
+	// queued cannot change what it commits), but it does wait first, and that
+	// is what separates this path from the reporting one.
+	started = time.Now()
+	stdout, stderr, _, err = tc.RunCampSplitInDir(campPath, "doctor", "--fix")
+	fixElapsed := time.Since(started)
 	require.NoError(t, err)
 
-	assert.NotEqual(t, 0, exitCode,
-		"doctor --fix must refuse on a wedged queue rather than repair against "+
-			"a stale tree; stdout:\n%s\nstderr:\n%s", stdout, stderr)
+	assert.Greater(t, fixElapsed, 20*time.Second,
+		"doctor --fix must wait for the queue; it returned in %s, which means "+
+			"it took the reporting path", fixElapsed)
+	assert.Greater(t, fixElapsed, elapsed,
+		"the repairing path must wait where the reporting path does not; "+
+			"report took %s, repair took %s", elapsed, fixElapsed)
 	assert.Contains(t, stdout+stderr, "camp jobs",
-		"the refusal must name where to look; stdout:\n%s\nstderr:\n%s", stdout, stderr)
-	assert.Contains(t, stdout+stderr, "--no-drain",
-		"the refusal must offer the escape the command actually has; stdout:\n%s\nstderr:\n%s",
-		stdout, stderr)
+		"the warning must name where to look; stdout:\n%s\nstderr:\n%s", stdout, stderr)
 }
 
 // A write command refuses rather than proceeding into a half-correct state,

--- a/tests/integration/jobs_drain_test.go
+++ b/tests/integration/jobs_drain_test.go
@@ -165,12 +165,42 @@ func TestIntegration_DrainSpawnsAWorkerForAnUnservedLane(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode, "stdout:\n%s\nstderr:\n%s", stdout, stderr)
 
-	assert.Zero(t, pendingJobCount(t, tc, campPath, "pending", rootLane),
-		"a drain must spawn a worker for an unserved lane rather than time out")
+	// Status spawns and returns, so the lane is not expected to be empty the
+	// instant it exits. Asserting that directly would pass or fail on how fast
+	// the container scheduled a detached worker.
+	//
+	// The property is that the lane drains at all. Nothing below runs a camp
+	// command, and no worker existed before status: if status had not spawned
+	// one, nothing in the system would, and this waits out its deadline.
+	require.True(t, laneDrains(t, tc, campPath, rootLane, 30*time.Second),
+		"status must spawn a worker for an unserved lane; the lane never emptied")
 
 	log := tc.GitOutput(t, campPath, "log", "--oneline", "-5")
 	assert.Contains(t, log, "unserved lane",
 		"the spawned worker must have committed the job; git log:\n%s", log)
+}
+
+// laneDrains polls until a lane holds no pending or running jobs.
+//
+// Polled in the test's own goroutine rather than through require.Eventually,
+// because the count is read with a container shell whose helper fails the test
+// on error, and that is not valid from the goroutine Eventually would run it
+// in. It also deliberately runs no camp command: a test proving that some
+// earlier command spawned a worker cannot invoke something that would spawn
+// one itself.
+func laneDrains(t *testing.T, tc *TestContainer, campPath, laneSlug string, within time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		if pendingJobCount(t, tc, campPath, "pending", laneSlug) == 0 &&
+			pendingJobCount(t, tc, campPath, "running", laneSlug) == 0 {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
 }
 
 // Manifest jobs are exempt from every drain. Blocking a push on a first-pass
@@ -246,6 +276,60 @@ func TestIntegration_StatusReportsTheQueueWithoutWaiting(t *testing.T) {
 		"the notice must name the command that shows what is stuck; stderr:\n%s", stderr)
 	assert.NotContains(t, stderr, "waiting on",
 		"status must not claim to be waiting when it is not; stderr:\n%s", stderr)
+}
+
+// Doctor's duty follows what it was asked to do, and both halves are real
+// behavior rather than two branches that merely exist.
+//
+// Plain doctor reports, so it takes the notice and returns. --fix repairs, so
+// it waits and refuses when the queue outlasts the wait: a repair computed
+// against a tree camp is midway through changing can undo what camp was about
+// to commit, and that is worse than making the user rerun.
+//
+// One wedged lane serves both: a fresh lock says a worker holds it and the job
+// names a path that does not exist, so nothing can ever complete it.
+func TestIntegration_DoctorWaitsOnlyWhenItRepairs(t *testing.T) {
+	tc := GetSharedContainer(t)
+	tc.EnableDeferral()
+	campPath, _ := setupDrainCampaign(t, tc, "drain-doctor-duty")
+
+	writeJob(t, tc, campPath, rootLane, 1, map[string]any{
+		"kind":    "commit-paths",
+		"repo":    ".",
+		"paths":   []string{"does/not/exist.md"},
+		"message": "capture intent: wedged",
+	})
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s/.campaign/cache/jobs
+		printf '99999\n' > worker-%s.lock
+	`, campPath, rootLane))
+
+	// Reporting: notice, no wait.
+	started := time.Now()
+	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath, "doctor")
+	elapsed := time.Since(started)
+	require.NoError(t, err)
+
+	assert.Less(t, elapsed, 15*time.Second,
+		"plain doctor must not wait for the queue; it took %s against a lane "+
+			"that can never finish", elapsed)
+	assert.Contains(t, stderr, "still queued",
+		"plain doctor must say its findings may be incomplete; stderr:\n%s", stderr)
+	assert.NotContains(t, stdout+stderr, "would leave them behind",
+		"plain doctor reports and must not refuse; stdout:\n%s\nstderr:\n%s", stdout, stderr)
+
+	// Repairing: wait, then refuse rather than fix against a stale tree.
+	stdout, stderr, exitCode, err = tc.RunCampSplitInDir(campPath, "doctor", "--fix")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, 0, exitCode,
+		"doctor --fix must refuse on a wedged queue rather than repair against "+
+			"a stale tree; stdout:\n%s\nstderr:\n%s", stdout, stderr)
+	assert.Contains(t, stdout+stderr, "camp jobs",
+		"the refusal must name where to look; stdout:\n%s\nstderr:\n%s", stdout, stderr)
+	assert.Contains(t, stdout+stderr, "--no-drain",
+		"the refusal must offer the escape the command actually has; stdout:\n%s\nstderr:\n%s",
+		stdout, stderr)
 }
 
 // A write command refuses rather than proceeding into a half-correct state,


### PR DESCRIPTION
Follow-up to #534. Two more queue defects from the same live-campaign diagnosis.

## The attempt count contradicted itself

`camp jobs` and `camp jobs --json` described the same job two incompatible ways:

```
failed  job-20260803T185441Z-3a0b  commit-tree  writing a commit message in . (gave up after 1 attempt)
```
```json
{ "id": "job-20260803T185441Z-3a0b", "state": "failed", "attempts": 0 }
```

Only reclaim incremented `Attempts`. A job that ran and returned an error went straight to `failed/` recording nothing, so it was parked reading 0 beside copy saying it had already been tried and given up on. An agent reading `--json` could not tell a failure that had been retried from one that never was, and the two are shown identically.

An attempt is now a job that started and did not finish, whichever way that happened: the worker died (reclaim, as before) or the job returned an error (new). Parking an already-exhausted job still counts nothing, because parking is not a run and counting it would push the total past `MaxAttempts` and claim a try that never happened.

## Reporting commands no longer wait on the queue

`camp status` held the terminal for up to `DrainTimeout` (30s) so its answer could be marginally fresher. That is the exact cost deferral exists to remove, spent on the command people run constantly and often twice in a row.

It now prints what is still queued and returns:

```
1 commit still queued; what follows may not include it (camp jobs)
```

The caveat survives because it was the real point. A tree camp is midway through changing still has to be declared, so a status that looks stale is explained rather than merely wrong. What changes is that the user is told immediately instead of thirty seconds later, and re-runs when they want a fresh read. That is what the command is for.

**The notice still spawns workers for unserved lanes.** Spawning is the cheap half of a drain and the half that makes "a queued job is always eventually served" true; only the wait is gone. Dropping it would leave a user whose worker died, and who only ever runs `camp status`, being told about the same jobs forever and never seeing them move. `TestIntegration_DrainSpawnsAWorkerForAnUnservedLane` covers this, rewritten to poll rather than depend on status having blocked (see review round below).

`camp log` gets the same treatment for the same reason.

`camp doctor` waits only under `--fix`; plain `doctor` reports and does not wait. The rule is now that the wait follows what a command does rather than which command it is. The `--fix` path keeps today's `Read` mode, so on timeout it warns and repairs anyway. That is deliberate, and the reasoning is in the code: a deferred job commits content captured at enqueue (an immutable tree, or blobs), so it never reads the working tree when it runs, and a repair made while a job is queued cannot change what that job commits. Refusing would have cost `doctor --fix --json` its report on any busy queue to guard a case that does not arise.

`--no-drain` is unchanged as a flag and still suppresses the queue interaction on these commands; its help text on `camp status` now says "report" rather than "wait".

## The guard was strengthened, not weakened

`TestEveryHistoryMovingCommandDrains` previously required a `drain.Repo`/`AllLanes`/`CampaignRoot` call in every listed command, which `status` and `log` would now fail. Rather than dropping those rows, the matrix gained a duty per surface:

- `mustDrain` for history-movers: must wait, as before.
- `mustNotice` for reporters: must call `drain.Note`, **and must not** call a blocking drain.
- `mustDoBoth` for doctor, the one dual-duty surface: must have both, so the wait cannot quietly become unconditional again (a 30s wait back on every doctor) and the notice branch cannot be dropped.

So a reporting command that ignores the queue fails, one that reintroduces a wait fails, and doctor losing either half fails. Before, only the first was caught.

Source matching still cannot prove which call sits under which branch, so doctor's duty is asserted behaviorally as well, in the integration test below.

## Verification

- `just gate`: build, vet across stable/dev/integration, lint 0 issues both profiles, 4095 + 4050 unit tests pass. The new timing-sensitive tests were stressed at -count=25 and the jobs package at -count=6, clean.
- New: `TestIntegration_StatusReportsTheQueueWithoutWaiting` wedges a lane that can never complete (fresh lock, job naming a nonexistent path) and asserts status returns well inside the drain timeout, says what is queued, names `camp jobs`, and does not claim to be waiting. Under the old behavior that setup sat for the full 30s.
- New: `TestIntegration_DoctorWaitsOnlyWhenItRepairs` wedges a lane and asserts plain doctor returns promptly with the notice while `--fix` waits and refuses with its escapes. It runs 35s because the `--fix` path genuinely waits out the timeout.
- Unit: attempt recording on execution failure, reclaim and execution accumulating together, parking not counting a run, parking an unparseable job still emptying `running/`, the count landing on the destination file rather than the source, notice copy including singular/plural agreement, silence on an empty queue, and context cancellation.
- Ran the doctor, workitem, dungeon, shell-init and rename integration groups in isolation; all pass.

The full integration suite reports 2/734 failing. That is pre-existing: unmodified `main` at dc258b42 fails the identical 2/734, one of them `TestLeverage_ConfigValidationPeople`. Not introduced here and not addressed here.

## Review round

Three findings from obey-agent, all correct, fixed in fb0fa80b:

1. `TestIntegration_DrainSpawnsAWorkerForAnUnservedLane` was racing. Its assertions were guaranteed by status *blocking*, and this PR removed the block while leaving them. It now polls for the lane to drain while running no camp command, so if status had not spawned a worker the poll times out.
2. `doctor --fix` used `Read` mode, which warns and proceeds, contradicting the comment above it. Correct finding; I first fixed the wrong side of it by switching to `Write` (refuse on timeout), then reverted in 1dda5870 and corrected the comment instead. The claim in that comment was false: deferred jobs commit captured content and never read the working tree at execution, so the repair cannot affect what a queued job commits. Refusing would have cost `--json` consumers their report to guard a case that does not arise.
3. The drain matrix only half-guarded doctor. It now carries a dual duty requiring both call sites, verified by reintroducing the unconditional wait and confirming the matrix fails on it.

Two further defects found on my own re-read, fixed in 4d6d64a0:

4. The attempt count was written **in place** into the running job file before the move. An interrupted write there leaves unparseable JSON in `running/`, and `Reclaim` skips what it cannot read, so the job would strand with nothing coming for it. Nothing else in the package edits a running job in place and `Reclaim` already had the safe shape. Parking now writes the incremented copy to its destination and removes the source after, so a crash duplicates a job rather than corrupting one.
5. The notice read `1 queued commit still queued`. It reused `countPhrase`, whose wording is built for a refusal and stutters here. This line prints on ordinary commands, so it is the one users see most.
