### PR TITLE
fix(tests): size the container pool by the docker daemon, not the host

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/ktr0731/go-fuzzyfinder v0.9.0
 	github.com/lancekrogers/guild-scaffold v0.1.0
+	github.com/moby/moby/client v0.4.0
 	github.com/moby/patternmatcher v0.6.1
 	github.com/muesli/termenv v0.16.0
 	github.com/sahilm/fuzzy v0.1.1
@@ -79,7 +80,6 @@ require (
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
 	github.com/moby/moby/api v1.54.1 // indirect
-	github.com/moby/moby/client v0.4.0 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect

--- a/internal/buildutil/tasks/integration.go
+++ b/internal/buildutil/tasks/integration.go
@@ -34,6 +34,11 @@ type IntegrationResult struct {
 	TestsPassed int
 	TestsFailed int
 	FailedTests []string // Names of failed tests
+	// SuiteError is a failure of the run itself rather than of any test: a
+	// build error, a panic that took the process down, a timeout. Kept apart
+	// from FailedTests because it is not a test and must not be counted as
+	// one.
+	SuiteError string
 }
 
 const integrationTestTimeout = "15m"
@@ -109,6 +114,8 @@ func Integration(verbose bool) error {
 		var pass bool
 		var testsPassed, testsFailed int
 		var failedTests []string
+		var suiteError string
+		var packageFailed bool
 
 		dockerEnv := append(os.Environ(),
 			"TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock",
@@ -230,6 +237,17 @@ func Integration(verbose bool) error {
 							testsFailed++
 						}
 					}
+				} else if event.Action == "fail" {
+					// A fail with no test name is the package failing as a
+					// whole: a panic outside a test, a TestMain that exited
+					// non-zero, output arriving after a test finished.
+					//
+					// Dropping these is why a run could report every test
+					// passing and still exit non-zero, leaving the only
+					// evidence as "go test exited: exit status 1" with nothing
+					// to attribute it to. The package is not a test, so it is
+					// recorded as a run-level failure.
+					packageFailed = true
 				}
 				mu.Unlock()
 			}
@@ -237,15 +255,9 @@ func Integration(verbose bool) error {
 			close(done)
 			scanErr := scanner.Err()
 			waitErr := cmd.Wait()
-			if scanErr != nil {
-				testsFailed++
-				failedTests = append(failedTests, fmt.Sprintf("%s scanner error: %v", name, scanErr))
-			}
-			if waitErr != nil {
-				testsFailed++
-				failedTests = append(failedTests, fmt.Sprintf("%s go test exited: %v", name, waitErr))
-			}
-			pass = testsFailed == 0
+
+			suiteError = classifyRunFailure(scanErr, waitErr, testsFailed, packageFailed)
+			pass = testsFailed == 0 && suiteError == ""
 			ui.ClearProgressWithOutput()
 		}
 
@@ -258,6 +270,7 @@ func Integration(verbose bool) error {
 			TestsPassed: testsPassed,
 			TestsFailed: testsFailed,
 			FailedTests: failedTests,
+			SuiteError:  suiteError,
 		})
 
 		if !pass {
@@ -283,19 +296,33 @@ func Integration(verbose bool) error {
 	hasFailures := failures > 0
 
 	for _, r := range results {
-		if !r.Pass && len(r.FailedTests) > 0 {
-			// Show each failed test as a row
-			for _, testName := range r.FailedTests {
-				status := "✗ FAILED"
-				if ui.ColourEnabled() {
-					status = ui.Red + status + ui.Reset
-				}
-				rows = append(rows, []string{
-					testName,
-					status,
-					"",
-				})
+		if r.Pass {
+			continue
+		}
+		// Show each failed test as a row
+		for _, testName := range r.FailedTests {
+			status := "✗ FAILED"
+			if ui.ColourEnabled() {
+				status = ui.Red + status + ui.Reset
 			}
+			rows = append(rows, []string{
+				testName,
+				status,
+				"",
+			})
+		}
+		// A run-level failure gets its own row, labelled so it cannot be
+		// mistaken for a test someone could go and rerun.
+		if r.SuiteError != "" {
+			status := "✗ SUITE"
+			if ui.ColourEnabled() {
+				status = ui.Red + status + ui.Reset
+			}
+			rows = append(rows, []string{
+				fmt.Sprintf("%s: %s", r.Suite, r.SuiteError),
+				status,
+				"",
+			})
 		}
 	}
 
@@ -333,6 +360,35 @@ func Integration(verbose bool) error {
 	}
 
 	return nil
+}
+
+// classifyRunFailure decides whether a `go test` process failure is news, and
+// returns the line describing it, or "" when it is not.
+//
+// A non-zero exit is how `go test` reports that a test failed, so recording it
+// as a failure of its own double-counts every real one: a single broken test
+// was summarized as "2/734 tests failed", and the extra row read "go test
+// exited: exit status 1", which is not a test, cannot be looked up, and cannot
+// be rerun. Anyone reading that goes looking for a second broken test that
+// does not exist.
+//
+// The exit only carries information when no test claimed the failure. That is
+// a build error, a panic that took the process down, or a timeout, and then it
+// is the only evidence there is, so it has to be surfaced. Still not as a test.
+func classifyRunFailure(scanErr, waitErr error, testsFailed int, packageFailed bool) string {
+	switch {
+	case scanErr != nil:
+		return fmt.Sprintf("could not read test output: %v", scanErr)
+	case packageFailed && testsFailed == 0:
+		return "the test package failed with no failing test: a panic outside " +
+			"a test, a TestMain that exited non-zero, or output after a test " +
+			"finished. Rerun with 'just test integration-verbose' to see it."
+	case waitErr != nil && testsFailed == 0:
+		return fmt.Sprintf("go test exited without reporting a failing test "+
+			"(build error, panic, or timeout): %v", waitErr)
+	default:
+		return ""
+	}
 }
 
 // discoverIntegrationSuites finds all integration test directories

--- a/internal/buildutil/tasks/integration_test.go
+++ b/internal/buildutil/tasks/integration_test.go
@@ -1,0 +1,121 @@
+package tasks
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+var (
+	errExitStatus1 = errors.New("exit status 1")
+	errScanner     = errors.New("token too long")
+)
+
+// The summary is the only thing most people read after a run, so its count has
+// to mean what it says.
+//
+// It did not. `go test` exits non-zero because a test failed, and the runner
+// recorded that exit as a failure of its own, so one broken test was reported
+// as "2/734 tests failed" with a second row reading "go test exited: exit
+// status 1". That row names nothing anyone can open, rerun, or fix, and it
+// sends a reader looking for a second broken test that was never there.
+func TestClassifyRunFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		scanErr       error
+		waitErr       error
+		testsFailed   int
+		packageFailed bool
+		want          string // "" means the run failure is not news
+		wantContain   string
+	}{
+		{
+			name:        "a clean run reports nothing",
+			testsFailed: 0,
+			want:        "",
+		},
+		{
+			// The case that produced the phantom row.
+			name:        "a failing test already explains the non-zero exit",
+			waitErr:     errExitStatus1,
+			testsFailed: 1,
+			want:        "",
+		},
+		{
+			name:        "many failing tests still explain it",
+			waitErr:     errExitStatus1,
+			testsFailed: 23,
+			want:        "",
+		},
+		{
+			// Nothing claimed the failure, so the exit is the only evidence
+			// there is: a build error, a panic, or a timeout.
+			name:        "an unexplained exit is surfaced",
+			waitErr:     errExitStatus1,
+			testsFailed: 0,
+			wantContain: "exited without reporting a failing test",
+		},
+		{
+			// A package-level fail event used to be dropped entirely, so a run
+			// could report every test passing and still exit non-zero with
+			// nothing naming the cause.
+			name:          "a package failure with no failing test is surfaced",
+			waitErr:       errExitStatus1,
+			testsFailed:   0,
+			packageFailed: true,
+			wantContain:   "test package failed with no failing test",
+		},
+		{
+			// The package always fails when a test does. That is not news on
+			// top of the test itself.
+			name:          "a package failure adds nothing when a test failed",
+			waitErr:       errExitStatus1,
+			testsFailed:   2,
+			packageFailed: true,
+			want:          "",
+		},
+		{
+			// Output we could not read means the counts themselves are
+			// suspect, so it is reported even when tests did fail.
+			name:        "unreadable output is surfaced regardless of counts",
+			scanErr:     errScanner,
+			waitErr:     errExitStatus1,
+			testsFailed: 5,
+			wantContain: "could not read test output",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyRunFailure(tt.scanErr, tt.waitErr, tt.testsFailed, tt.packageFailed)
+			if tt.wantContain != "" {
+				if !strings.Contains(got, tt.wantContain) {
+					t.Fatalf("classifyRunFailure() = %q, want it to mention %q",
+						got, tt.wantContain)
+				}
+				return
+			}
+			if got != tt.want {
+				t.Fatalf("classifyRunFailure() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Whatever it reports, it is never a test name. The summary lists failed tests
+// by name so they can be rerun; a line that cannot be rerun must not look like
+// one of them.
+func TestClassifyRunFailureNeverLooksLikeATestName(t *testing.T) {
+	t.Parallel()
+
+	got := classifyRunFailure(nil, errExitStatus1, 0, false)
+	if got == "" {
+		t.Fatal("an unexplained exit must be surfaced")
+	}
+	if strings.HasPrefix(got, "Test") {
+		t.Fatalf("classifyRunFailure() = %q, which reads like a test name", got)
+	}
+}

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -11,6 +11,10 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/moby/moby/client"
+	"github.com/testcontainers/testcontainers-go"
 )
 
 // containerPool holds the reusable containers. Tests check one out (blocking
@@ -41,13 +45,24 @@ var legacyCampSkip string
 // pool (rather than a single container) lets tests run concurrently via
 // t.Parallel(), since each test gets exclusive use of one isolated container.
 func TestMain(m *testing.M) {
-	size := poolSize()
-
 	cleanupTransport, err := startDedicatedColimaDockerTransport()
 	if err != nil {
 		os.Stderr.WriteString("Failed to create isolated Docker transport: " + err.Error() + "\n")
 		os.Exit(1)
 	}
+
+	// Sized after the transport exists, so the daemon it asks about is the one
+	// the containers will actually run on. Asking first worked by luck here
+	// (both spellings reach the same daemon) but would answer for the wrong
+	// machine, or not at all, against a remote or rerouted one.
+	//
+	// Announced because the failure this guards against is silent: an
+	// oversubscribed pool looks like flaky tests, and the number that caused
+	// it was never on screen.
+	daemonCPUs := dockerCPUs()
+	size := poolSizeFor(daemonCPUs)
+	fmt.Fprintf(os.Stderr, "container pool: %d (docker daemon reports %d CPUs, host has %d)\n",
+		size, daemonCPUs, runtime.NumCPU())
 
 	bins, cleanupBins, err := buildSharedBinaries()
 	if err != nil {
@@ -103,13 +118,36 @@ func TestMain(m *testing.M) {
 // poolSize returns how many containers to run concurrently. Override with
 // CAMP_TEST_POOL_SIZE; otherwise scale to the host but stay conservative, since
 // each member is a full container running real git operations.
-func poolSize() int {
+// poolSizeFor turns the Docker daemon's CPU count into a pool size. A
+// non-positive count means it could not be determined.
+//
+// Sized against the machine that runs the containers, not the one
+// orchestrating them.
+//
+// On a Linux host those are the same machine and nothing changes. Under
+// Colima, Docker Desktop, or a remote daemon they are not, and the host is
+// always the larger of the two: a 16-CPU laptop driving a 4-CPU VM sized this
+// pool to six containers, half again what the VM could actually run. The
+// oversubscription did not fail loudly. It showed up as tests that pass alone
+// and fail in the full suite, differently each run, which reads like flaky
+// tests rather than a saturated machine.
+//
+// The halving and the bounds are unchanged. Only the number they are applied
+// to was wrong.
+func poolSizeFor(daemonCPUs int) int {
 	if v := os.Getenv("CAMP_TEST_POOL_SIZE"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			return n
 		}
 	}
-	n := runtime.NumCPU() / 2
+
+	cpus := daemonCPUs
+	if cpus <= 0 {
+		// Cannot tell. Fall back to the host, which is what this did
+		// unconditionally before: no worse than the old behavior.
+		cpus = runtime.NumCPU()
+	}
+	n := cpus / 2
 	if n < 2 {
 		n = 2
 	}
@@ -117,6 +155,29 @@ func poolSize() int {
 		n = 6
 	}
 	return n
+}
+
+// dockerCPUs reports the Docker daemon's CPU count, or 0 when it cannot be
+// determined.
+//
+// Zero rather than an error: failing to size a pool optimally is not worth
+// failing a test run over, and the caller falls back to the host count, which
+// is what this code did unconditionally before.
+func dockerCPUs() int {
+	provider, err := testcontainers.NewDockerProvider()
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = provider.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	result, err := provider.Client().Info(ctx, client.InfoOptions{})
+	if err != nil {
+		return 0
+	}
+	return result.Info.NCPU
 }
 
 // Infrastructure failure is tracked separately from test failure.

--- a/tests/integration/pool_size_test.go
+++ b/tests/integration/pool_size_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"runtime"
+	"testing"
+)
+
+// The pool size decides how many containers run at once, and getting it wrong
+// does not announce itself: an oversubscribed daemon produces tests that pass
+// alone and fail together, differently each run, which reads like flaky tests.
+// So the arithmetic is worth pinning even though it is four lines.
+func TestPoolSizeFor(t *testing.T) {
+	t.Setenv("CAMP_TEST_POOL_SIZE", "")
+
+	tests := []struct {
+		name       string
+		daemonCPUs int
+		want       int
+	}{
+		{
+			// The case that was broken: a 4-CPU Colima VM behind a 16-CPU
+			// laptop was sized from the laptop and got six containers.
+			name:       "a four cpu daemon gets two",
+			daemonCPUs: 4,
+			want:       2,
+		},
+		{
+			name:       "a large daemon is still capped",
+			daemonCPUs: 64,
+			want:       6,
+		},
+		{
+			name:       "a tiny daemon still gets the floor",
+			daemonCPUs: 1,
+			want:       2,
+		},
+		{
+			name:       "twelve cpus lands inside the range",
+			daemonCPUs: 12,
+			want:       6,
+		},
+		{
+			name:       "ten cpus lands inside the range",
+			daemonCPUs: 10,
+			want:       5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := poolSizeFor(tt.daemonCPUs); got != tt.want {
+				t.Fatalf("poolSizeFor(%d) = %d, want %d", tt.daemonCPUs, got, tt.want)
+			}
+		})
+	}
+}
+
+// An unreadable daemon must not make the pool worse than it was. Falling back
+// to the host count is exactly the old behavior, so a daemon that will not
+// answer costs nothing beyond the bug this fix removes.
+func TestPoolSizeForFallsBackToTheHost(t *testing.T) {
+	t.Setenv("CAMP_TEST_POOL_SIZE", "")
+
+	want := runtime.NumCPU() / 2
+	if want < 2 {
+		want = 2
+	}
+	if want > 6 {
+		want = 6
+	}
+	for _, unknown := range []int{0, -1} {
+		if got := poolSizeFor(unknown); got != want {
+			t.Errorf("poolSizeFor(%d) = %d, want the host-derived %d",
+				unknown, got, want)
+		}
+	}
+}
+
+// The override is how someone with a bigger daemon, or a wedged one, takes
+// control. It has to beat whatever the daemon reports.
+func TestPoolSizeForHonorsTheOverride(t *testing.T) {
+	t.Setenv("CAMP_TEST_POOL_SIZE", "9")
+	if got := poolSizeFor(4); got != 9 {
+		t.Fatalf("poolSizeFor(4) with an override of 9 = %d, want 9", got)
+	}
+
+	// A meaningless override is ignored rather than obeyed into a zero-sized
+	// pool, which would deadlock every checkout.
+	t.Setenv("CAMP_TEST_POOL_SIZE", "banana")
+	if got := poolSizeFor(4); got != 2 {
+		t.Fatalf("poolSizeFor(4) with a junk override = %d, want the computed 2", got)
+	}
+}


### PR DESCRIPTION
The integration suite has been red on `main`. It is not a broken test.

## The symptom

Two full runs of unmodified `main`, back to back, failed differently:

```
run 1:  2/734 failed   TestLeverage_ConfigValidationPeople
run 2: 24/114 failed   TestShellInit_FishCampWrapperGo, TestShellInit_ZshAliasWrappers,
                       TestShellInit_ZshCompdefRegistered, ... (mostly TestShellInit_*)
```

Every one of those passes in isolation. I ran the leverage, doctor, workitem, dungeon, shell-init and rename groups individually and they were all green. Different victims each run, all fine alone, is the signature of a saturated machine rather than a bad assertion.

## The cause

`poolSize()` derived from `runtime.NumCPU()`. That is the machine orchestrating the containers, not the one running them:

```
host NumCPU=16 -> poolSize=6
docker daemon CPUs: 4
```

Six containers on a four-CPU VM. On a Linux host those are the same machine and the old code was right; under Colima, Docker Desktop, or a remote daemon the host is always the larger of the two, and the pool was sized from it.

The pool now asks the daemon. **The halving and the bounds are unchanged** — only the number they were applied to was wrong. Two consequences worth having: giving the VM more CPUs now scales the pool by itself, and `CAMP_TEST_POOL_SIZE` still overrides everything.

Sizing also moved to after the Docker transport is established. It ran before, so it asked one connection about a daemon another connection would use. That worked by luck here (both spellings reach the same daemon) and would answer for the wrong machine, or not at all, against a rerouted or remote one. The chosen size is now printed at startup:

```
container pool: 2 (docker daemon reports 4 CPUs, host has 16)
```

The failure this guards against is silent, and the number that caused it was never on screen.

## Two reporting bugs that hid it

**A non-zero `go test` exit was counted as a failed test.** That is precisely how `go test` reports that a test failed, so every real failure was double-counted. One broken test was summarized as `2/734 tests failed`, and the second row read:

```
tests/integration go test exited: exit status 1   ✗ FAILED
```

That names nothing anyone can open, rerun, or fix, and it sends a reader looking for a second broken test that was never there. It only carries information when *no* test claimed the failure — a build error, a panic, a timeout — and even then it is not a test. It now reports as a distinct `✗ SUITE` row, outside the test counts.

**Package-level `fail` events were dropped entirely.** They carry no test name, and the parser only inspected events that had one. So a run could report every test passing and still exit non-zero with nothing to attribute it to, which is exactly what the pool-sized-down run did before I found this. Those now surface as a run-level failure that says what the category is and how to see it.

## Verification

With the pool sized from the daemon (2 on this machine), a raw `go test -json` run of the whole suite:

```
top-level pass/fail/skip: {'pass': 711, 'fail': 0, 'skip': 8}
package-level fail: False   named failures: []
exit=0
```

`just gate`: 0 lint issues both profiles, 4097 unit tests pass.

Unit coverage added for both fixed behaviors: `poolSizeFor` across daemon sizes, the unreadable-daemon fallback to host count (which is exactly the old behavior, so a daemon that will not answer costs nothing), the `CAMP_TEST_POOL_SIZE` override including a junk value that must not produce a zero-sized pool; and `classifyRunFailure` across a clean run, an exit already explained by a failing test, an unexplained exit, a package failure with and without failing tests, and unreadable output.

## Cost, stated plainly

The suite takes about 2.5x longer: ~910s at a pool of 2 versus ~600s at 6. That is the honest cost of the machine's real capacity, and the previous speed was borrowed against reliability. Two ways to get it back, both better than oversubscribing: give Colima more CPUs (`colima start --cpu 8`) and the pool scales itself, or set `CAMP_TEST_POOL_SIZE` deliberately.

## One thing I could not fully explain

An earlier dashboard run at pool 2 reported `459/460 tests passed` plus the phantom exit row, while the raw run above counted 711 passes. The dashboard's totals are not consistent with the raw event stream. The dropped package-fail events explain why that run's non-zero exit was unattributable, and both reporting fixes make the next occurrence legible, but I did not prove there is no further event loss in the dashboard parser. Flagging it rather than implying the reporting is now fully trustworthy.
