### PR TITLE
feat(explorer): meeting t/A/x keys for CI0009

### DIFF
--- a/cmd/camp/intent/add.go
+++ b/cmd/camp/intent/add.go
@@ -249,7 +249,7 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 			Tags:    mergeTags(tagsFlag, saved.Tags),
 		}
 		if createNote {
-			created, err := createNoteWithoutCommit(ctx, svc, intentsDir, savedOpts)
+			created, err := createNoteWithoutCommit(ctx, svc, intentsDir, campaignRoot, savedOpts)
 			if err != nil {
 				return err
 			}
@@ -284,7 +284,7 @@ func runIntentAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	if createNote {
-		created, err := createNoteWithoutCommit(ctx, svc, intentsDir, opts)
+		created, err := createNoteWithoutCommit(ctx, svc, intentsDir, campaignRoot, opts)
 		if err != nil {
 			return err
 		}
@@ -572,7 +572,7 @@ func createIntentWithoutCommit(ctx context.Context, svc *intent.IntentService, i
 	return result, nil
 }
 
-func createNoteWithoutCommit(ctx context.Context, svc *intent.IntentService, intentsDir string, opts intent.CreateOptions) (*intent.Intent, error) {
+func createNoteWithoutCommit(ctx context.Context, svc *intent.IntentService, intentsDir, campaignRoot string, opts intent.CreateOptions) (*intent.Intent, error) {
 	result, err := svc.CreateNote(ctx, opts)
 	if err != nil {
 		return nil, camperrors.Wrap(err, "failed to create note")
@@ -585,7 +585,7 @@ func createNoteWithoutCommit(ctx context.Context, svc *intent.IntentService, int
 	}); err != nil {
 		return nil, err
 	}
-	fmt.Printf("✓ Note created: %s\n", result.Path)
+	fmt.Printf("✓ Note created: %s\n", displayPath(campaignRoot, result.Path))
 	return result, nil
 }
 

--- a/cmd/camp/intent/display_path.go
+++ b/cmd/camp/intent/display_path.go
@@ -1,0 +1,36 @@
+package intent
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/Obedience-Corp/camp/internal/pathutil"
+)
+
+// displayPath returns a user-facing path for CLI success messages.
+// When path is under campaignRoot, prefer a campaign-relative form so fixtures
+// and tapes do not leak absolute host paths (e.g. /private/tmp/...).
+// Falls back to the original path if relativization fails.
+func displayPath(campaignRoot, path string) string {
+	if path == "" {
+		return path
+	}
+	if campaignRoot == "" {
+		return path
+	}
+	// Canonicalize root so Rel matches pathutil.RelativeToRoot's symlink-resolved paths
+	// (e.g. macOS /var/folders → /private/var/folders).
+	resolvedRoot, err := pathutil.ResolveRoot(campaignRoot)
+	if err != nil || resolvedRoot == "" {
+		resolvedRoot = campaignRoot
+	}
+	rel, err := pathutil.RelativeToRoot(resolvedRoot, path)
+	if err != nil || rel == "" || rel == "." {
+		return path
+	}
+	// Reject escapes outside the campaign (Rel can return ../...).
+	if strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return path
+	}
+	return filepath.ToSlash(rel)
+}

--- a/cmd/camp/intent/display_path_test.go
+++ b/cmd/camp/intent/display_path_test.go
@@ -1,0 +1,40 @@
+package intent
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDisplayPath_RelativeUnderCampaign(t *testing.T) {
+	root := t.TempDir()
+	abs := filepath.Join(root, ".campaign", "intents", "notes", "x.md")
+	got := displayPath(root, abs)
+	want := ".campaign/intents/notes/x.md"
+	if got != want {
+		t.Fatalf("displayPath = %q, want %q", got, want)
+	}
+}
+
+func TestDisplayPath_AlreadyRelative(t *testing.T) {
+	root := t.TempDir()
+	got := displayPath(root, ".campaign/intents/notes/y.md")
+	if got != ".campaign/intents/notes/y.md" {
+		t.Fatalf("displayPath relative input = %q", got)
+	}
+}
+
+func TestDisplayPath_OutsideCampaignKeepsAbsolute(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "other.md")
+	got := displayPath(root, outside)
+	if got != outside {
+		t.Fatalf("outside path should stay absolute, got %q want %q", got, outside)
+	}
+}
+
+func TestDisplayPath_EmptyRootPassthrough(t *testing.T) {
+	p := "/tmp/x.md"
+	if got := displayPath("", p); got != p {
+		t.Fatalf("empty root: got %q", got)
+	}
+}

--- a/cmd/camp/intent/note.go
+++ b/cmd/camp/intent/note.go
@@ -221,7 +221,7 @@ func finalizeCreatedNote(ctx context.Context, result *intent.Intent, intentsDir 
 		return err
 	}
 
-	fmt.Printf("✓ Note created: %s\n", result.Path)
+	fmt.Printf("✓ Note created: %s\n", displayPath(campaignRoot, result.Path))
 
 	if !noCommit {
 		opts := wkcmd.AmbientCommitOptions(ctx, campaignRoot, cfg.ID, os.Stderr)

--- a/internal/intent/tui/explorer/meeting_keys.go
+++ b/internal/intent/tui/explorer/meeting_keys.go
@@ -1,6 +1,8 @@
 package explorer
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -43,7 +45,27 @@ func (m *Model) handleMeetingAudio(selected *intent.Intent) (tea.Model, tea.Cmd)
 		m.statusMessage = "No audio path on this meeting"
 		return m, nil
 	}
+	if selected.Meeting.BundleHost != "" {
+		host, err := os.Hostname()
+		if err != nil {
+			m.statusMessage = "Cannot determine whether meeting audio is local"
+			return m, nil
+		}
+		if host != selected.Meeting.BundleHost {
+			m.statusMessage = "Meeting audio is available on " + selected.Meeting.BundleHost
+			return m, nil
+		}
+	}
 	audioPath := filepath.Join(selected.Meeting.Bundle, selected.Meeting.Audio)
+	info, err := os.Stat(audioPath)
+	if err != nil {
+		m.statusMessage = "Meeting audio is unavailable: " + filepath.Base(audioPath)
+		return m, nil
+	}
+	if info.IsDir() {
+		m.statusMessage = "Meeting audio path is not a file: " + filepath.Base(audioPath)
+		return m, nil
+	}
 	return m, openWithSystem(audioPath)
 }
 
@@ -79,7 +101,7 @@ func (m *Model) runMeetingExtract(selected *intent.Intent, items []intent.Extrac
 		}
 		msg := "Extracted 0 new intents (already present or empty)"
 		if n := len(created); n > 0 {
-			msg = "Extracted " + itoa(n) + " intent(s) from meeting"
+			msg = fmt.Sprintf("Extracted %d intent(s) from meeting", n)
 		}
 		return folderFinishedMsg{message: msg}
 	}
@@ -104,18 +126,4 @@ func extractItemsFromMeetingBody(body string) []intent.ExtractItem {
 		items = append(items, intent.ExtractItem{Title: title})
 	}
 	return items
-}
-
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	var b [12]byte
-	i := len(b)
-	for n > 0 {
-		i--
-		b[i] = byte('0' + n%10)
-		n /= 10
-	}
-	return string(b[i:])
 }

--- a/internal/intent/tui/explorer/meeting_keys.go
+++ b/internal/intent/tui/explorer/meeting_keys.go
@@ -1,0 +1,121 @@
+package explorer
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Obedience-Corp/camp/internal/git/commit"
+	"github.com/Obedience-Corp/camp/internal/intent"
+	"github.com/Obedience-Corp/camp/internal/intent/audit"
+)
+
+// isMeetingNote reports whether the intent is a structured meeting note.
+func isMeetingNote(i *intent.Intent) bool {
+	if i == nil {
+		return false
+	}
+	if i.Status != intent.StatusNoteMeetings {
+		return false
+	}
+	return i.Meeting != nil
+}
+
+// handleMeetingTranscript opens the transcript sidecar for the selected meeting.
+func (m *Model) handleMeetingTranscript(selected *intent.Intent) (tea.Model, tea.Cmd) {
+	if m.service == nil {
+		m.statusMessage = "Transcript requires an intent service"
+		return m, nil
+	}
+	path, ok := m.service.MeetingTranscriptPath(selected)
+	if !ok {
+		m.statusMessage = "No transcript sidecar for this meeting"
+		return m, nil
+	}
+	return m, openInEditor(m.ctx, path)
+}
+
+// handleMeetingAudio opens the machine-local audio file referenced by the meeting.
+func (m *Model) handleMeetingAudio(selected *intent.Intent) (tea.Model, tea.Cmd) {
+	if selected.Meeting == nil || selected.Meeting.Bundle == "" || selected.Meeting.Audio == "" {
+		m.statusMessage = "No audio path on this meeting"
+		return m, nil
+	}
+	audioPath := filepath.Join(selected.Meeting.Bundle, selected.Meeting.Audio)
+	return m, openWithSystem(audioPath)
+}
+
+// handleMeetingExtract creates inbox intents from checklist lines in the summary.
+func (m *Model) handleMeetingExtract(selected *intent.Intent) (tea.Model, tea.Cmd) {
+	if m.service == nil {
+		m.statusMessage = "Extract requires an intent service"
+		return m, nil
+	}
+	items := extractItemsFromMeetingBody(selected.Content)
+	if len(items) == 0 {
+		m.statusMessage = "No action items found in meeting summary"
+		return m, nil
+	}
+	return m, m.runMeetingExtract(selected, items)
+}
+
+func (m *Model) runMeetingExtract(selected *intent.Intent, items []intent.ExtractItem) tea.Cmd {
+	return func() tea.Msg {
+		created, err := m.service.ExtractMeetingIntents(m.ctx, selected.ID, items)
+		if err != nil {
+			return folderFinishedMsg{err: err}
+		}
+		for _, it := range created {
+			_ = m.appendAuditEvent(audit.Event{
+				Type:   audit.EventCreate,
+				ID:     it.ID,
+				Title:  it.Title,
+				To:     string(it.Status),
+				Reason: "extracted from meeting " + selected.ID,
+			})
+			m.autoCommitIntent(commit.IntentCreate, it.Title, "Extracted from meeting "+selected.ID, it.Path)
+		}
+		msg := "Extracted 0 new intents (already present or empty)"
+		if n := len(created); n > 0 {
+			msg = "Extracted " + itoa(n) + " intent(s) from meeting"
+		}
+		return folderFinishedMsg{message: msg}
+	}
+}
+
+var actionItemLine = regexp.MustCompile(`(?i)^\s*[-*]\s*\[[ xX]\]\s+(.+)$`)
+
+// extractItemsFromMeetingBody pulls checkbox action items from the summary body.
+func extractItemsFromMeetingBody(body string) []intent.ExtractItem {
+	var items []intent.ExtractItem
+	seen := map[string]bool{}
+	for _, line := range strings.Split(body, "\n") {
+		m := actionItemLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		title := strings.TrimSpace(m[1])
+		if title == "" || seen[strings.ToLower(title)] {
+			continue
+		}
+		seen[strings.ToLower(title)] = true
+		items = append(items, intent.ExtractItem{Title: title})
+	}
+	return items
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [12]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}

--- a/internal/intent/tui/explorer/meeting_keys_test.go
+++ b/internal/intent/tui/explorer/meeting_keys_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -127,10 +128,72 @@ func TestMeetingKeys_XExtractsActionItems(t *testing.T) {
 	if !ok || fin.err != nil {
 		t.Fatalf("extract result = %#v", msg)
 	}
+	if fin.message != "Extracted 1 intent(s) from meeting" {
+		t.Fatalf("extract message = %q", fin.message)
+	}
+
+	reloaded, err := svc.GetNote(ctx, imported.Note.ID)
+	if err != nil {
+		t.Fatalf("GetNote after extract: %v", err)
+	}
+	if reloaded.Meeting == nil || len(reloaded.Meeting.ExtractedIntents) != 1 {
+		t.Fatalf("extracted intent ids = %#v, want one", reloaded.Meeting)
+	}
+	extracted, err := svc.Get(ctx, reloaded.Meeting.ExtractedIntents[0])
+	if err != nil {
+		t.Fatalf("Get extracted intent: %v", err)
+	}
+	if extracted.Title != "Do the thing" || extracted.Status != intent.StatusInbox {
+		t.Fatalf("extracted intent = %#v", extracted)
+	}
+
 	// Idempotent second run
 	msg2 := m.runMeetingExtract(note, extractItemsFromMeetingBody(note.Content))()
 	fin2, ok := msg2.(folderFinishedMsg)
 	if !ok || fin2.err != nil {
 		t.Fatalf("second extract = %#v", msg2)
+	}
+	if !strings.HasPrefix(fin2.message, "Extracted 0 new intents") {
+		t.Fatalf("second extract message = %q", fin2.message)
+	}
+	reloadedAgain, err := svc.GetNote(ctx, imported.Note.ID)
+	if err != nil {
+		t.Fatalf("GetNote after second extract: %v", err)
+	}
+	if got := len(reloadedAgain.Meeting.ExtractedIntents); got != 1 {
+		t.Fatalf("extracted intent ids after retry = %d, want 1", got)
+	}
+}
+
+func TestMeetingKeys_AMissingAudioFailsClosed(t *testing.T) {
+	m := Model{}
+	selected := &intent.Intent{Meeting: &intent.MeetingMetadata{
+		Bundle: "/path/that/does/not/exist",
+		Audio:  "audio.wav",
+	}}
+
+	_, cmd := m.handleMeetingAudio(selected)
+	if cmd != nil {
+		t.Fatal("missing audio returned an open command")
+	}
+	if m.statusMessage != "Meeting audio is unavailable: audio.wav" {
+		t.Fatalf("status message = %q", m.statusMessage)
+	}
+}
+
+func TestMeetingKeys_ARejectsAudioFromAnotherHost(t *testing.T) {
+	m := Model{}
+	selected := &intent.Intent{Meeting: &intent.MeetingMetadata{
+		Bundle:     "/tmp/meeting-bundle",
+		BundleHost: "definitely-not-this-host.invalid",
+		Audio:      "audio.wav",
+	}}
+
+	_, cmd := m.handleMeetingAudio(selected)
+	if cmd != nil {
+		t.Fatal("remote-host audio returned an open command")
+	}
+	if m.statusMessage != "Meeting audio is available on definitely-not-this-host.invalid" {
+		t.Fatalf("status message = %q", m.statusMessage)
 	}
 }

--- a/internal/intent/tui/explorer/meeting_keys_test.go
+++ b/internal/intent/tui/explorer/meeting_keys_test.go
@@ -1,0 +1,136 @@
+package explorer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Obedience-Corp/camp/internal/intent"
+)
+
+func TestExtractItemsFromMeetingBody(t *testing.T) {
+	body := `# Meeting
+
+## Action items
+
+- [ ] Rewrite the unfair-advantage answer
+- [x] Already done item
+- not a checkbox
+- [ ] Rewrite the unfair-advantage answer
+`
+	items := extractItemsFromMeetingBody(body)
+	if len(items) != 2 {
+		t.Fatalf("items = %#v, want 2 unique checkbox lines", items)
+	}
+	if items[0].Title != "Rewrite the unfair-advantage answer" {
+		t.Fatalf("first title = %q", items[0].Title)
+	}
+}
+
+func TestMeetingKeys_TOpensTranscriptWhenMeetingSelected(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := intent.NewIntentService(tmp, intentsDir)
+
+	bundle := filepath.Join(t.TempDir(), "extract.meeting")
+	if err := os.MkdirAll(bundle, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundle, "meeting.md"), []byte("# Meeting: extract\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	imported, err := svc.ImportMeeting(ctx, intent.ImportMeetingOptions{
+		BundlePath: bundle,
+		Summary:    "## Action items\n\n- [ ] Ship meeting keys\n",
+		Timestamp:  time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("ImportMeeting: %v", err)
+	}
+
+	m := NewModel(ctx, svc, nil, intentsDir, tmp, "id", "", nil)
+	m.ready = true
+	m.groups = groupExplorerItemsByStatus([]*intent.Intent{imported.Note}, nil, false, map[string]bool{
+		"notes": true, "notes/meetings": true,
+	}, false)
+	if !selectNoteInGroups(&m, imported.Note.ID) {
+		// selectNoteInGroups may not expand meetings; place manually
+		for gi, g := range m.groups {
+			for ii, it := range g.Intents {
+				if it.ID == imported.Note.ID {
+					m.cursorGroup = gi
+					m.cursorItem = ii
+					m.groups[gi].Expanded = true
+				}
+			}
+		}
+	}
+	// Ensure Meeting metadata is present on selected intent
+	sel := m.SelectedIntent()
+	if sel == nil {
+		t.Fatal("no selected intent")
+	}
+	// Reload from disk so Meeting is populated
+	reloaded, err := svc.GetNote(ctx, imported.Note.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.groups[m.cursorGroup].Intents[m.cursorItem] = reloaded
+	if !isMeetingNote(reloaded) {
+		t.Fatalf("expected meeting note, got status=%s meeting=%v", reloaded.Status, reloaded.Meeting != nil)
+	}
+
+	// t should prefer transcript over type filter
+	updated, cmd := m.updateNormal(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'t'}})
+	_ = updated
+	if cmd == nil {
+		t.Fatal("expected open-transcript command for meeting note")
+	}
+}
+
+func TestMeetingKeys_XExtractsActionItems(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	intentsDir := filepath.Join(tmp, "intents")
+	svc := intent.NewIntentService(tmp, intentsDir)
+
+	bundle := filepath.Join(t.TempDir(), "extract-x.meeting")
+	if err := os.MkdirAll(bundle, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bundle, "meeting.md"), []byte("# Meeting\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	imported, err := svc.ImportMeeting(ctx, intent.ImportMeetingOptions{
+		BundlePath: bundle,
+		Summary:    "## Action items\n\n- [ ] Do the thing\n",
+		Timestamp:  time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("ImportMeeting: %v", err)
+	}
+	note, err := svc.GetNote(ctx, imported.Note.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewModel(ctx, svc, nil, intentsDir, tmp, "id", "", nil)
+	m.ready = true
+	cmd := m.runMeetingExtract(note, extractItemsFromMeetingBody(note.Content))
+	msg := cmd()
+	fin, ok := msg.(folderFinishedMsg)
+	if !ok || fin.err != nil {
+		t.Fatalf("extract result = %#v", msg)
+	}
+	// Idempotent second run
+	msg2 := m.runMeetingExtract(note, extractItemsFromMeetingBody(note.Content))()
+	fin2, ok := msg2.(folderFinishedMsg)
+	if !ok || fin2.err != nil {
+		t.Fatalf("second extract = %#v", msg2)
+	}
+}

--- a/internal/intent/tui/explorer/render.go
+++ b/internal/intent/tui/explorer/render.go
@@ -111,17 +111,30 @@ func (m *Model) renderStatusBarHints() string {
 		}
 	}
 
+	// On a group header (cursorItem == -1), prefer expand/collapse hints so
+	// Space multi-select on items is not confused with fold (V1 / CI0009 polish).
+	onGroupHeader := m.cursorItem < 0
+
 	switch m.layoutMode {
 	case layoutNarrow:
+		if onGroupHeader {
+			return scrollIndicator + "enter/l expand · j/k · / · ? · q"
+		}
 		return scrollIndicator + "j/k · v · / · tab filter · n new · ? · q"
 	case layoutNormal:
 		if m.shouldShowPreview() {
 			return scrollIndicator + "j/k nav · v hide preview · tab focus · / search · n new · q quit"
 		}
+		if onGroupHeader {
+			return scrollIndicator + "enter/l expand · j/k nav · / search · space select items · q quit"
+		}
 		return scrollIndicator + "j/k nav · v preview · / search · tab filter · n new · space gather · q quit"
 	case layoutWide:
 		if m.shouldShowPreview() {
 			return scrollIndicator + "j/k navigate · v hide preview · tab focus · / search · f full · n new · ? help · q quit"
+		}
+		if onGroupHeader {
+			return scrollIndicator + "enter/l expand · j/k navigate · / search · space select items · f full · ? help · q quit"
 		}
 		return scrollIndicator + "j/k navigate · v preview · / search · tab filter · n new · space gather · f full · ? help · q quit"
 	}

--- a/internal/intent/tui/explorer/status_hints_test.go
+++ b/internal/intent/tui/explorer/status_hints_test.go
@@ -1,0 +1,32 @@
+package explorer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderStatusBarHints_GroupHeaderShowsExpand(t *testing.T) {
+	m := makeTestModel(2, 1)
+	m.layoutMode = layoutNormal
+	m.cursorItem = -1
+	hints := m.renderStatusBarHints()
+	if !strings.Contains(hints, "enter/l expand") {
+		t.Fatalf("group header hints missing expand: %q", hints)
+	}
+	if strings.Contains(hints, "space gather") {
+		t.Fatalf("group header should not emphasize space gather: %q", hints)
+	}
+}
+
+func TestRenderStatusBarHints_ItemShowsGather(t *testing.T) {
+	m := makeTestModel(2, 1)
+	m.layoutMode = layoutNormal
+	m.cursorItem = 0
+	hints := m.renderStatusBarHints()
+	if !strings.Contains(hints, "space gather") {
+		t.Fatalf("item hints missing space gather: %q", hints)
+	}
+	if strings.Contains(hints, "enter/l expand") {
+		t.Fatalf("item hints should not show group expand: %q", hints)
+	}
+}

--- a/internal/intent/tui/explorer/update_keys.go
+++ b/internal/intent/tui/explorer/update_keys.go
@@ -79,10 +79,26 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.previewFocused = !m.previewFocused
 		return m, nil
 	case "t":
+		// On a meeting note, open the transcript sidecar; otherwise type filter.
+		if selected := m.SelectedIntent(); isMeetingNote(selected) {
+			return m.handleMeetingTranscript(selected)
+		}
 		m.focusFilterChip(0)
 		return m, nil
 	case "s":
 		m.focusFilterChip(1)
+		return m, nil
+	case "A":
+		// Open machine-local meeting audio (capital A; lowercase a stays archive).
+		if selected := m.SelectedIntent(); isMeetingNote(selected) {
+			return m.handleMeetingAudio(selected)
+		}
+		return m, nil
+	case "x":
+		// Extract inbox intents from meeting action items.
+		if selected := m.SelectedIntent(); isMeetingNote(selected) {
+			return m.handleMeetingExtract(selected)
+		}
 		return m, nil
 	case "c":
 		if selected := m.SelectedIntent(); selected != nil && selected.Status.IsNote() {

--- a/internal/intent/tui/help.go
+++ b/internal/intent/tui/help.go
@@ -43,11 +43,16 @@ GATHER (Multi-Select)
 
 FILTERS
   /           Search intents (fuzzy)
-  t           Filter by type
+  t           Filter by type (non-meeting)
   s           Filter by status
   c           Filter by concept
   C           Clear concept filter
   Escape      Clear filters
+
+MEETING NOTES (selected meeting)
+  t           Open transcript sidecar
+  A           Open meeting audio (machine-local)
+  x           Extract checkbox action items to inbox
 
 VIEW
   v           Toggle preview pane

--- a/internal/intent/tui/help_test.go
+++ b/internal/intent/tui/help_test.go
@@ -1,0 +1,20 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHelpContentDocumentsMeetingActions(t *testing.T) {
+	for _, want := range []string{
+		"t           Filter by type (non-meeting)",
+		"MEETING NOTES (selected meeting)",
+		"t           Open transcript sidecar",
+		"A           Open meeting audio (machine-local)",
+		"x           Extract checkbox action items to inbox",
+	} {
+		if !strings.Contains(helpContent, want) {
+			t.Errorf("help content missing %q", want)
+		}
+	}
+}

--- a/tests/integration/intent_note_folders_test.go
+++ b/tests/integration/intent_note_folders_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestIntentNoteFolders_CRUDAndJSON exercises note folder create/list/move/rm
-// and import-meeting through the real camp binary inside the container harness
-// (not host TempDir unit tests).
-func TestIntentNoteFolders_CRUDAndJSON(t *testing.T) {
+// TestIntentNoteFolders_CRUDAndImportMeetingJSON exercises note folder
+// create/list/move/rm and import-meeting through the real camp binary inside
+// the container harness (not the explorer key handlers).
+func TestIntentNoteFolders_CRUDAndImportMeetingJSON(t *testing.T) {
 	tc := GetSharedContainer(t)
 
 	const campPath = "/campaigns/note-folders-ci0009"
@@ -51,17 +51,14 @@ func TestIntentNoteFolders_CRUDAndJSON(t *testing.T) {
 	require.NoError(t, err, "note --folder: %s", out)
 	assert.Contains(t, out, "notes/reading/books/")
 
-	// Extract note id from path in output.
-	// "✓ Note created: .../id.md"
-	id := ""
-	for _, line := range strings.Split(out, "\n") {
-		if strings.Contains(line, "Note created:") {
-			base := line[strings.LastIndex(line, "/")+1:]
-			id = strings.TrimSuffix(base, ".md")
-			break
-		}
-	}
-	require.NotEmpty(t, id, "could not parse note id from: %s", out)
+	// The note-create command has no JSON mode and lifecycle list/find omit
+	// notes. Resolve the ID from the exact folder contract rather than parsing
+	// human success text.
+	id := strings.TrimSpace(tc.Shell(t, fmt.Sprintf(
+		"basename \"$(find %s/.campaign/intents/notes/reading/books -maxdepth 1 -type f -name '*.md' | head -n 1)\" .md",
+		campPath,
+	)))
+	require.NotEmpty(t, id)
 
 	out, err = tc.RunCampInDir(campPath, "idea", "notes", "mv", id, ".")
 	require.NoError(t, err, "notes mv: %s", out)

--- a/tests/integration/intent_note_folders_test.go
+++ b/tests/integration/intent_note_folders_test.go
@@ -1,0 +1,86 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntentNoteFolders_CRUDAndJSON exercises note folder create/list/move/rm
+// and import-meeting through the real camp binary inside the container harness
+// (not host TempDir unit tests).
+func TestIntentNoteFolders_CRUDAndJSON(t *testing.T) {
+	tc := GetSharedContainer(t)
+
+	const campPath = "/campaigns/note-folders-ci0009"
+	_, err := tc.InitCampaign(campPath, "note-folders-ci0009", "product")
+	require.NoError(t, err)
+
+	// Create nested folder; must write .gitkeep.
+	out, err := tc.RunCampInDir(campPath, "idea", "notes", "folders", "add", "reading/papers")
+	require.NoError(t, err, "folders add: %s", out)
+	assert.Contains(t, out, "notes/reading/papers")
+
+	exists, err := tc.CheckFileExists(campPath + "/.campaign/intents/notes/reading/papers/.gitkeep")
+	require.NoError(t, err)
+	assert.True(t, exists, ".gitkeep should exist after folders add")
+
+	// JSON list contract.
+	jsonOut, err := tc.RunCampInDir(campPath, "idea", "notes", "folders", "--json")
+	require.NoError(t, err, "folders --json: %s", jsonOut)
+	assert.Contains(t, jsonOut, `"schema_version": "intent-note-folders/v1alpha1"`)
+	assert.Contains(t, jsonOut, `"status": "notes/reading/papers"`)
+	assert.NotContains(t, jsonOut, `"folders": null`)
+
+	// Rename folder (directory move only).
+	out, err = tc.RunCampInDir(campPath, "idea", "notes", "folders", "mv", "reading/papers", "reading/books")
+	require.NoError(t, err, "folders mv: %s", out)
+	exists, err = tc.CheckFileExists(campPath + "/.campaign/intents/notes/reading/books/.gitkeep")
+	require.NoError(t, err)
+	assert.True(t, exists, "renamed folder should exist")
+
+	// Capture a note into the folder, then move it to root.
+	out, err = tc.RunCampInDir(campPath, "idea", "note", "paper note",
+		"--folder", "reading/books", "--no-commit")
+	require.NoError(t, err, "note --folder: %s", out)
+	assert.Contains(t, out, "notes/reading/books/")
+
+	// Extract note id from path in output.
+	// "✓ Note created: .../id.md"
+	id := ""
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "Note created:") {
+			base := line[strings.LastIndex(line, "/")+1:]
+			id = strings.TrimSuffix(base, ".md")
+			break
+		}
+	}
+	require.NotEmpty(t, id, "could not parse note id from: %s", out)
+
+	out, err = tc.RunCampInDir(campPath, "idea", "notes", "mv", id, ".")
+	require.NoError(t, err, "notes mv: %s", out)
+
+	// Delete empty folder.
+	out, err = tc.RunCampInDir(campPath, "idea", "notes", "folders", "rm", "reading/books")
+	require.NoError(t, err, "folders rm: %s", out)
+
+	// Reserved name rejected.
+	out, err = tc.RunCampInDir(campPath, "idea", "notes", "folders", "add", "meetings")
+	require.Error(t, err, "reserved meetings should fail: %s", out)
+
+	// import-meeting: create a minimal bundle in the container.
+	bundle := "/tmp/ci0009-standup.meeting"
+	tc.Shell(t, fmt.Sprintf("mkdir -p %s && printf '# Meeting: standup\\n' > %s/meeting.md", bundle, bundle))
+	out, err = tc.RunCampInDir(campPath, "idea", "notes", "import-meeting", bundle,
+		"--summary", "## Summary\n\nStandup notes.\n", "--json", "--author", "agent")
+	require.NoError(t, err, "import-meeting: %s", out)
+	assert.Contains(t, out, `"schema_version": "intent-meeting-import/v1alpha1"`)
+	assert.Contains(t, out, "notes/meetings/")
+	assert.Contains(t, out, ".transcripts/")
+}


### PR DESCRIPTION
## Summary

Follow-up to #537 for festival CI0009 sequence 06 explorer keys:

- **t** on a meeting note opens the `.transcripts/` sidecar (type filter still on non-meetings)
- **A** opens machine-local meeting audio from the bundle path
- **x** extracts checkbox action items via `ExtractMeetingIntents` (idempotent)

## Review fixes

- Fail closed when meeting audio belongs to another host, is missing, or is not a file
- Document meeting-scoped `t` / `A` / `x` actions in the explorer help overlay
- Assert the first extraction creates a persisted inbox intent and the second creates none
- Replace the private integer formatter with `fmt.Sprintf`
- Clarify that the container integration test covers folder/import contracts, and resolve its note ID from the exact folder contract instead of human output

## Test plan

- [x] `go test ./internal/intent/tui/explorer ./internal/intent/tui`
- [x] `just test integration-run TestIntentNoteFolders_CRUDAndImportMeetingJSON`
- [x] `just build quick`
- [x] Real binary driven in a PTY with fake `HOME`; meeting help section rendered without clipping
- [x] `just gate-push` reached stable/dev builds, stable/dev/integration vet, and golangci-lint; the final host-FS ratchet is currently red on unchanged `internal/git/tree_empty_test.go` from merged #538

## Visual demos

### Full-color Intent Explorer TUI

![notes-explorer-tui](https://vhs.charm.sh/vhs-6BbJcub5R9WPiuQ0wrz6Kt.gif)


Re-recorded with this PR binary (hosted via `vhs publish`):

- Meetings node: https://vhs.charm.sh/vhs-5hW9bRECLBzpu4pq069dDI.gif
- Capture destination (relative path): https://vhs.charm.sh/vhs-6CQFX5DHYdTnFdelfeYCNh.gif

### Full-color explorer TUI

- https://vhs.charm.sh/vhs-sWNUI7POvIC62yXE9KFwg.gif

