### PR TITLE
fix(commit): say nothing staged when worktree is still dirty

### DIFF
--- a/cmd/camp/cmdutil/nothing_staged.go
+++ b/cmd/camp/cmdutil/nothing_staged.go
@@ -1,0 +1,28 @@
+package cmdutil
+
+import (
+	"context"
+
+	"github.com/Obedience-Corp/camp/internal/git"
+)
+
+// NothingStagedLine is the no-op message after a staged-only commit gate finds
+// nothing to commit.
+//
+// The gate checks staged changes only, so claiming "working tree clean" is
+// wrong when unstaged or untracked dirt remains (common at campaign root with
+// excluded submodule pointers). scope is a trailing place qualifier such as
+// " in project" or " in worktree"; empty for campaign-root commit.
+func NothingStagedLine(ctx context.Context, repoPath, scope string) string {
+	// hasStaged is already known false by the caller. HasChanges here is
+	// unstaged + untracked only in practice, and is the same dirt the user
+	// still sees in git status.
+	dirty, err := git.HasChanges(ctx, repoPath)
+	if err != nil || dirty {
+		return "Nothing staged to commit" + scope
+	}
+	if scope == "" {
+		return "Nothing to commit, working tree clean"
+	}
+	return "Nothing to commit" + scope
+}

--- a/cmd/camp/cmdutil/nothing_staged_test.go
+++ b/cmd/camp/cmdutil/nothing_staged_test.go
@@ -1,0 +1,71 @@
+package cmdutil
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNothingStagedLine(t *testing.T) {
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init")
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "a.txt")
+	run("commit", "-m", "init")
+
+	ctx := context.Background()
+
+	got := NothingStagedLine(ctx, dir, "")
+	if got != "Nothing to commit, working tree clean" {
+		t.Fatalf("clean tree: got %q", got)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "b.txt"), []byte("b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got = NothingStagedLine(ctx, dir, "")
+	if got != "Nothing staged to commit" {
+		t.Fatalf("untracked dirt: got %q", got)
+	}
+
+	got = NothingStagedLine(ctx, dir, " in project")
+	if got != "Nothing staged to commit in project" {
+		t.Fatalf("scoped dirty: got %q", got)
+	}
+
+	// Stage then unstage via reset so we have unstaged tracked changes.
+	run("add", "b.txt")
+	run("reset", "HEAD", "--", "b.txt")
+	// b.txt is now untracked again after reset of a never-committed add...
+	// Write over a tracked file instead for a true unstaged modification.
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got = NothingStagedLine(ctx, dir, "")
+	if !strings.Contains(got, "Nothing staged to commit") {
+		t.Fatalf("unstaged tracked change: got %q", got)
+	}
+
+	// Clean project-scoped message when nothing is dirty.
+	run("checkout", "--", "a.txt")
+	_ = os.Remove(filepath.Join(dir, "b.txt"))
+	got = NothingStagedLine(ctx, dir, " in worktree")
+	if got != "Nothing to commit in worktree" {
+		t.Fatalf("clean scoped: got %q", got)
+	}
+}

--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -302,7 +302,9 @@ func runCommit(cmd *cobra.Command, args []string) error {
 				return commitJSONNoop(cmd, jsonResult)
 			}
 		}
-		_, _ = fmt.Fprintln(humanOut, ui.Success("Nothing to commit, working tree clean"))
+		// Staged-only gate: do not claim the worktree is clean when unstaged
+		// or untracked dirt remains (e.g. excluded submodule pointers).
+		_, _ = fmt.Fprintln(humanOut, ui.Success(cmdutil.NothingStagedLine(ctx, target.Path, "")))
 		return commitJSONNoop(cmd, jsonResult)
 	}
 

--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -202,7 +202,7 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if !hasStaged && !projectCommitAmend {
-		fmt.Println(ui.Success("Nothing to commit in project"))
+		fmt.Println(ui.Success(cmdutil.NothingStagedLine(ctx, resolvedPath, " in project")))
 		return nil
 	}
 

--- a/cmd/camp/worktrees/commit.go
+++ b/cmd/camp/worktrees/commit.go
@@ -160,7 +160,7 @@ func runWorktreesCommit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if !hasStaged && !wtCommitAmend {
-		fmt.Println(ui.Success("Nothing to commit in worktree"))
+		fmt.Println(ui.Success(cmdutil.NothingStagedLine(ctx, wtCtx.WorktreePath, " in worktree")))
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #538 review suggestion: after the staged-only commit gate, do not print “Nothing to commit, working tree clean” when unstaged/untracked dirt is still present.

- Clean tree → `Nothing to commit, working tree clean` (unchanged)
- Dirt present but nothing staged → `Nothing staged to commit`
- Same wording for project (`… in project`) and worktree (`… in worktree`)

## Test plan

- [x] `go test ./cmd/camp/cmdutil/ -run NothingStaged`
- [x] `go test ./cmd/camp/ ./cmd/camp/project/ ./cmd/camp/worktrees/`
- [ ] Manual: dirty submodule pointers only at campaign root → `camp commit -aw` should not claim the worktree is clean