### PR TITLE
fix(jobs): stop deferred capture from walking into nested repositories

### DIFF
--- a/internal/defercommit/defercommit.go
+++ b/internal/defercommit/defercommit.go
@@ -11,6 +11,7 @@ package defercommit
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 
@@ -160,8 +161,25 @@ func EnqueuePaths(ctx context.Context, campaignRoot, repoPath, message string, p
 	// committing at all, and the failure is a repository camp could not read.
 	// Degrading silently is not an option, so the worker log records it; the
 	// job itself also shows it, since a captured job carries blobs.
+	//
+	// A nested repository is the exception, because there the degraded job is
+	// wrong rather than merely coarser. See the refusal below.
 	blobs, err := git.CaptureBlobs(ctx, repoPath, paths)
-	if err != nil {
+	switch {
+	case errors.Is(err, git.ErrNestedRepo):
+		// A submodule cannot be deferred at all, so this is the one capture
+		// failure that refuses the job rather than degrading it. Git records
+		// the path as a gitlink pointing at the nested HEAD, which is neither
+		// something the enqueuer can snapshot nor something a job may commit
+		// from an execution-time read: `camp project add` would publish
+		// whatever that submodule's HEAD had become by the time the worker
+		// ran. Returning an error puts the caller back on the synchronous
+		// path, where `git add` records the pointer the user just created.
+		jobs.LogEvent(campaignRoot,
+			"capture-refused repo=%s paths=%d err=%v; committing synchronously instead",
+			jobs.RepoForPath(campaignRoot, repoPath), len(paths), err)
+		return nil, err
+	case err != nil:
 		jobs.LogEvent(campaignRoot,
 			"capture-degraded repo=%s paths=%d err=%v; the job will commit execution-time content",
 			jobs.RepoForPath(campaignRoot, repoPath), len(paths), err)

--- a/internal/git/commit/commit.go
+++ b/internal/git/commit/commit.go
@@ -162,8 +162,9 @@ func stageAndCommit(ctx context.Context, opts Options, message string) error {
 			defercommit.SpawnWorker(ctx, opts.CampaignRoot, opts.CampaignRoot)
 			return errDeferred
 		}
-		// A queue that cannot be written must not cost the user their commit.
-		// Fall through to the synchronous path exactly as before.
+		// A queue that cannot be written, or a set of paths that must not be
+		// deferred at all, must not cost the user their commit. Fall through
+		// to the synchronous path exactly as before.
 	}
 
 	commitScope := append(append([]string{}, opts.Files...), opts.PreStaged...)

--- a/internal/git/commit_test.go
+++ b/internal/git/commit_test.go
@@ -1374,3 +1374,65 @@ func TestCommitBlobs_UnbornHead(t *testing.T) {
 		t.Fatalf("CommitBlobs left the real index/working tree dirty: %q", status)
 	}
 }
+
+// CaptureBlobs must refuse a nested repository rather than walk into it.
+//
+// Walking would hash the nested checkout as ordinary blobs, including a
+// projects/<name>/.git path that git rejects on every CommitBlobs attempt, so
+// the job could never drain. A .git file (submodule gitdir pointer) and a
+// .git directory (embedded clone) both count as a boundary.
+func TestCaptureBlobs_NestedRepoBoundary(t *testing.T) {
+	ctx := context.Background()
+	tmpDir := initTestRepo(t)
+
+	// Ordinary nested content without a .git boundary still expands.
+	ordinary := filepath.Join(tmpDir, "notes")
+	if err := os.MkdirAll(filepath.Join(ordinary, "deep"), 0o755); err != nil {
+		t.Fatalf("mkdir ordinary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ordinary, "deep", "idea.md"), []byte("ok\n"), 0o644); err != nil {
+		t.Fatalf("write ordinary: %v", err)
+	}
+	refs, err := CaptureBlobs(ctx, tmpDir, []string{"notes"})
+	if err != nil {
+		t.Fatalf("CaptureBlobs ordinary dir: %v", err)
+	}
+	if len(refs) != 1 || refs[0].Path != "notes/deep/idea.md" {
+		t.Fatalf("ordinary capture = %+v, want notes/deep/idea.md", refs)
+	}
+
+	// Submodule-style: .git is a file, not a directory.
+	subFile := filepath.Join(tmpDir, "projects", "Cap")
+	if err := os.MkdirAll(subFile, 0o755); err != nil {
+		t.Fatalf("mkdir submodule: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subFile, ".git"), []byte("gitdir: ../.git/modules/Cap\n"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subFile, "README.md"), []byte("nested\n"), 0o644); err != nil {
+		t.Fatalf("write nested file: %v", err)
+	}
+	if !isRepoBoundary(subFile) {
+		t.Fatal("isRepoBoundary must treat a .git file as a boundary")
+	}
+	_, err = CaptureBlobs(ctx, tmpDir, []string{"projects/Cap"})
+	if !errors.Is(err, ErrNestedRepo) {
+		t.Fatalf("submodule-style capture error = %v, want ErrNestedRepo", err)
+	}
+
+	// Embedded-clone style: .git is a directory.
+	subDir := filepath.Join(tmpDir, "projects", "embedded")
+	if err := os.MkdirAll(filepath.Join(subDir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir embedded .git: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("write embedded file: %v", err)
+	}
+	if !isRepoBoundary(subDir) {
+		t.Fatal("isRepoBoundary must treat a .git directory as a boundary")
+	}
+	_, err = CaptureBlobs(ctx, tmpDir, []string{"projects/embedded"})
+	if !errors.Is(err, ErrNestedRepo) {
+		t.Fatalf("embedded-clone capture error = %v, want ErrNestedRepo", err)
+	}
+}

--- a/internal/git/errors.go
+++ b/internal/git/errors.go
@@ -148,6 +148,12 @@ var (
 	// ErrNoFilesSpecified indicates an empty file list was provided for staging.
 	ErrNoFilesSpecified = camperrors.Wrap(camperrors.ErrInvalidInput, "no files specified for staging")
 
+	// ErrNestedRepo indicates a capture reached a repository boundary. The
+	// files below one belong to that repository, and git records the boundary
+	// as a gitlink rather than as the tree beneath it, which is a pointer to
+	// whatever HEAD is at commit time and so cannot be captured in advance.
+	ErrNestedRepo = errors.New("path contains a nested git repository")
+
 	// ErrRemoteNotReachable indicates the remote host could not be contacted.
 	ErrRemoteNotReachable = camperrors.Wrap(camperrors.ErrGitFailed, "remote not reachable")
 

--- a/internal/git/tree.go
+++ b/internal/git/tree.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -306,24 +307,52 @@ func CaptureBlobs(ctx context.Context, repoPath string, paths []string) ([]BlobR
 }
 
 // captureDir captures every file under a directory.
+//
+// The walk stops at a nested repository rather than descending into it. Git
+// records such a directory as a gitlink, so its files are not part of this
+// repository's tree at all, and capturing them would both commit another
+// project's checkout inline and produce a `<dir>/.git` entry that git rejects
+// on every attempt, leaving a job that can never drain.
 func captureDir(ctx context.Context, repoPath, dir string) ([]BlobRef, error) {
 	var paths []string
 	root := filepath.Join(repoPath, filepath.FromSlash(dir))
 	err := filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
+		if err != nil {
 			return err
 		}
 		rel, relErr := filepath.Rel(repoPath, p)
 		if relErr != nil {
 			return relErr
 		}
+		if d.IsDir() {
+			if isRepoBoundary(p) {
+				return camperrors.Wrapf(ErrNestedRepo, "%s", filepath.ToSlash(rel))
+			}
+			return nil
+		}
 		paths = append(paths, filepath.ToSlash(rel))
 		return nil
 	})
 	if err != nil {
+		// The boundary error already names the repository it found, which is
+		// not always the directory the walk started from.
+		if errors.Is(err, ErrNestedRepo) {
+			return nil, err
+		}
 		return nil, camperrors.Wrapf(err, "capture directory %s", dir)
 	}
 	return CaptureBlobs(ctx, repoPath, paths)
+}
+
+// isRepoBoundary reports whether an absolute path is its own git repository.
+//
+// A submodule's `.git` is a file holding a gitdir pointer and an embedded
+// clone's is a directory, so presence is the test and its kind is not. The
+// walk root is included deliberately: `camp project add` captures the
+// submodule directory itself, which is the case this exists for.
+func isRepoBoundary(abs string) bool {
+	_, err := os.Lstat(filepath.Join(abs, ".git"))
+	return err == nil
 }
 
 // blobMode returns the git mode for a file.

--- a/tests/integration/project_add_defer_test.go
+++ b/tests/integration/project_add_defer_test.go
@@ -1,0 +1,131 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// `camp project add` is the one bookkeeping commit whose paths name a nested
+// repository, and the rest of the project-add coverage runs with deferral off,
+// so the deferred form of it had no test at all.
+//
+// The deferred path captures content by walking the paths it was given. A
+// submodule directory walked as ordinary files yields the whole checkout as
+// blobs, `projects/<name>/.git` among them, and git refuses that path forever:
+// the job cannot succeed on this attempt or any retry.
+
+// The commit must record the submodule pointer, exactly as the synchronous
+// path's `git add` would, and must not carry a single file from inside it.
+func TestIntegration_ProjectAddDeferredCommitsThePointerNotTheCheckout(t *testing.T) {
+	tc := GetSharedContainer(t)
+	tc.EnableDeferral()
+	campPath, _ := setupDrainCampaign(t, tc, "proj-add-defer")
+
+	source := "/test/proj-add-defer-src"
+	name := "proj-add-defer-src"
+	require.NoError(t, tc.CreateGitRepo(source))
+
+	// A file below the top level: a walk that descends at all picks this up,
+	// so its absence from the commit is what proves the boundary held.
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p src
+		echo 'package main' > src/main.go
+		git add -A
+		git commit -q -m 'add source file'
+	`, source))
+
+	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(
+		campPath, "project", "add", source, "--local", source)
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "stdout:\n%s\nstderr:\n%s", stdout, stderr)
+
+	drainJobs(t, tc, campPath)
+
+	// The bookkeeping commit camp promised has to exist. A queue that dropped
+	// it silently would leave the user's newly added project uncommitted.
+	entry := strings.TrimSpace(tc.GitOutput(t, campPath, "ls-tree", "HEAD", "--", "projects/"+name))
+	require.NotEmpty(t, entry,
+		"the deferred project-add commit never landed; projects/%s is absent from HEAD", name)
+	assert.True(t, strings.HasPrefix(entry, "160000 commit"),
+		"projects/%s must be committed as a submodule pointer, got %q", name, entry)
+
+	// The failure this test exists for: the checkout committed as ordinary
+	// files. `.git` is the entry git rejects outright, but any of them is wrong.
+	tree := tc.GitOutput(t, campPath, "ls-tree", "-r", "--name-only", "HEAD")
+	for line := range strings.SplitSeq(tree, "\n") {
+		path := strings.TrimSpace(line)
+		assert.False(t, strings.HasPrefix(path, "projects/"+name+"/"),
+			"the commit must not contain files from inside the submodule, found %q", path)
+	}
+
+	assert.Contains(t, tc.GitOutput(t, campPath, "ls-tree", "HEAD", "--name-only"), ".gitmodules",
+		"the submodule declaration must land in the same commit as the pointer")
+}
+
+// A failed job is not self-clearing: it sits in the queue and nags on every
+// later command. This one could never drain, because the path git rejected is
+// baked into the captured content, so `camp jobs retry` reproduced the same
+// failure indefinitely.
+func TestIntegration_ProjectAddDeferredLeavesNoUndrainableJob(t *testing.T) {
+	tc := GetSharedContainer(t)
+	tc.EnableDeferral()
+	campPath, _ := setupDrainCampaign(t, tc, "proj-add-defer-queue")
+
+	source := "/test/proj-add-defer-queue-src"
+	require.NoError(t, tc.CreateGitRepo(source))
+
+	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(
+		campPath, "project", "add", source, "--local", source)
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "stdout:\n%s\nstderr:\n%s", stdout, stderr)
+
+	drainJobs(t, tc, campPath)
+
+	// The notice is the user-visible symptom: it repeats on unrelated commands
+	// until the job is resolved, and here it never could be.
+	_, statusErr, _, err := tc.RunCampSplitInDir(campPath, "status", "--short")
+	require.NoError(t, err)
+	assert.NotContains(t, statusErr, "deferred commit failed",
+		"adding a project must not leave a failed job behind; stderr:\n%s", statusErr)
+
+	failed := tc.Shell(t, fmt.Sprintf(
+		"ls %s/.campaign/cache/jobs/failed/*/ 2>/dev/null || true", campPath))
+	assert.Empty(t, strings.TrimSpace(failed),
+		"the failed lane must be empty after a project add drains; found:\n%s", failed)
+}
+
+// `camp project new` commits the same two paths as `camp project add`, so it
+// reaches the same capture through a second command. Covered separately
+// because a fix that only special-cased the add path would leave this one
+// producing the same undrainable job.
+func TestIntegration_ProjectNewDeferredCommitsThePointerNotTheCheckout(t *testing.T) {
+	tc := GetSharedContainer(t)
+	tc.EnableDeferral()
+	campPath, _ := setupDrainCampaign(t, tc, "proj-new-defer")
+
+	name := "demo-app"
+	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath, "project", "new", name)
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "stdout:\n%s\nstderr:\n%s", stdout, stderr)
+
+	drainJobs(t, tc, campPath)
+
+	entry := strings.TrimSpace(tc.GitOutput(t, campPath, "ls-tree", "HEAD", "--", "projects/"+name))
+	require.NotEmpty(t, entry,
+		"the deferred project-new commit never landed; projects/%s is absent from HEAD", name)
+	assert.True(t, strings.HasPrefix(entry, "160000 commit"),
+		"projects/%s must be committed as a submodule pointer, got %q", name, entry)
+
+	_, statusErr, _, err := tc.RunCampSplitInDir(campPath, "status", "--short")
+	require.NoError(t, err)
+	assert.NotContains(t, statusErr, "deferred commit failed",
+		"creating a project must not leave a failed job behind; stderr:\n%s", statusErr)
+}


### PR DESCRIPTION
## The bug

`camp project add` and `camp project new` both queue a bookkeeping commit of two paths: `.gitmodules` and the new project directory. With deferral on (the default), that commit fails immediately and no retry can ever make it succeed.

```
STATE     ID                        LANE   KIND           AGE  WHAT
failed    job-20260804T215858Z-a9b5 .      commit-paths   25s  [mytools:8a57dff6] Add: Cap (gave up after 1 attempt)
```

From `worker.log`:

```
failed lane=. seq=1 id=job-20260804T215858Z-a9b5
  err=stage captured projects/Cap/.git: git update-index --add --cacheinfo
  100644,acb2cc304e1550139bf193879546ea8071457c36,projects/Cap/.git:
  error: Invalid path 'projects/Cap/.git'
fatal: git update-index: --cacheinfo cannot add projects/Cap/.git: exit status 128
```

## Root cause

Deferred jobs snapshot content at enqueue time, so the commit means what its message says even if the tree changes before the worker runs. `CaptureBlobs` hands a directory path to `captureDir` (`internal/git/tree.go`), which was a plain `filepath.WalkDir` with no notion of a repository boundary.

Handed a freshly added submodule, it walked the entire checkout and hashed every file as an ordinary blob: 3347 of them in the reported job, `projects/Cap/.git` among them. A submodule's `.git` is a 40-byte file holding a gitdir pointer, so the walk saw an ordinary file and captured it as mode `100644`. Git refuses any path with a `.git` component, so `CommitBlobs` died at exit 128.

The rejected path is baked into the job document on disk, which is what makes it permanent: `camp jobs retry` replays the identical `update-index` call and gets the identical rejection.

The synchronous path never had this bug. It stages with `git add`, which records a submodule as a gitlink and never descends into it.

Setting the `.git` entry aside, the captured job was wrong anyway: it would have inlined 3346 of the submodule's files into the parent repo instead of a one-line pointer. The hard failure is the loud symptom of a wrong capture, not the whole defect.

## Why it was not caught

Every existing `project add` and `project new` integration test runs with deferral disabled, so all of them exercise the synchronous path.

## The fix

- `captureDir` stops at a repository boundary and returns `ErrNestedRepo` naming it. A submodule's `.git` is a file and an embedded clone's is a directory, so presence is the test and its kind is not.
- `EnqueuePaths` treats that one capture failure as a refusal rather than degrading it to a path-only job. Every other capture failure degrades exactly as before.
- The caller's existing fall-through then takes the synchronous path, where `git add` records the gitlink the user just created.

A gitlink is not something a fixed capture could snapshot in the first place: its value is the nested repository's HEAD at commit time. That is why `checkGitlinkCarveOut` already forbids a non-follow-up job from committing one. That check reads `HEAD`, so a brand-new submodule was invisible to it and the job got through.

## Tests

`tests/integration/project_add_defer_test.go`. All three verified failing before the fix and passing after:

- `project add` commits the pointer as `160000 commit` and no file from inside the submodule
- `project add` leaves no failed job and no "deferred commit failed" notice
- `project new`, the second command with the same two paths, does the same

Gate status: builds (stable and dev), vet (stable, dev, integration), lint (stable and dev, 0 issues), the `fmt.Errorf` ratchet, and unit tests on both profiles (4129 dev, 4084 stable) all pass.

`just gate` itself stops earlier, at `lint-no-host-fs-tests`, on a violation that is already on `main` and unrelated to this change: `internal/git/tree_empty_test.go` arrived in #538 and is not on the allowlist, so the gate is red on a clean `origin/main` checkout too. Verified by stashing this branch's changes and re-running the recipe. Not touched here; worth its own migration to `tests/integration/` rather than growing the allowlist.

## For anyone already stuck

This prevents new undrainable jobs; it does not clear one already queued. Drop it and commit normally:

```
camp jobs drop <id>
```

Nothing is lost. The real index already holds the correct gitlink, so an ordinary commit records it.
