### PR TITLE
fix(workitem): resolve intents to bare ids so they can primary-link to worktrees [intent: intents-cannot-be-primary-linked-20260803-184438]

### DIFF
--- a/cmd/camp/project/worktree/add.go
+++ b/cmd/camp/project/worktree/add.go
@@ -172,7 +172,7 @@ func runProjectWorktreeAdd(cmd *cobra.Command, args []string) error {
 			return camperrors.Wrap(lerr, "worktree created but workitem link failed")
 		}
 		fmt.Printf("  Workitem: %s (%s)\n", ui.Value(link.WorkitemID), ui.Dim(link.WorkitemKey))
-		fmt.Println(ui.Dim("  camp p commit in this worktree will include WI-* in the campaign tag"))
+		fmt.Println(ui.Dim("  " + wkitem.WorktreeLinkCommitNote(linkTarget)))
 	}
 
 	// Project campaign skills into the worktree so Grok/Claude sessions whose

--- a/cmd/camp/worktrees/create.go
+++ b/cmd/camp/worktrees/create.go
@@ -176,7 +176,7 @@ func runWorktreesCreate(cmd *cobra.Command, args []string) error {
 			return camperrors.Wrap(lerr, "worktree created but workitem link failed")
 		}
 		fmt.Printf("  Workitem: %s (%s)\n", ui.Value(link.WorkitemID), ui.Dim(link.WorkitemKey))
-		fmt.Println(ui.Dim("  camp p commit in this worktree will include WI-* in the campaign tag"))
+		fmt.Println(ui.Dim("  " + wkitem.WorktreeLinkCommitNote(linkTarget)))
 	}
 
 	projected, err := intskills.ProjectIntoWorktreeBestEffort(ctx, campRoot, result.Path)

--- a/internal/commands/fresh/merged_backstop.go
+++ b/internal/commands/fresh/merged_backstop.go
@@ -186,10 +186,7 @@ func backstopPromoteCommand(wi wkitem.WorkItem) string {
 }
 
 func backstopWorkitemID(wi wkitem.WorkItem) string {
-	if wi.StableID != "" {
-		return wi.StableID
-	}
-	return wi.Key
+	return wkitem.LinkWorkitemID(&wi)
 }
 
 func backstopWorkitemLabel(wi wkitem.WorkItem) string {
@@ -352,12 +349,9 @@ func projectRelPath(root, projectPath string) string {
 // resolveLinkedActiveItem resolves a link to a still-active workitem by stable
 // id or key, matching worktree.go's linkMatchesWorkitem.
 func resolveLinkedActiveItem(link links.Link, active []wkitem.WorkItem) (wkitem.WorkItem, bool) {
-	for _, wi := range active {
-		if wi.StableID != "" && link.WorkitemID == wi.StableID {
-			return wi, true
-		}
-		if wi.Key != "" && link.WorkitemKey == wi.Key {
-			return wi, true
+	for i := range active {
+		if wkitem.LinkMatchesWorkitem(&active[i], link.WorkitemID, link.WorkitemKey) {
+			return active[i], true
 		}
 	}
 	return wkitem.WorkItem{}, false
@@ -452,10 +446,7 @@ func HasOpenWork(root string, registry *links.Links, wi wkitem.WorkItem, mergedS
 }
 
 func linkMatchesBackstopItem(link links.Link, wi wkitem.WorkItem) bool {
-	if wi.StableID != "" && link.WorkitemID == wi.StableID {
-		return true
-	}
-	return wi.Key != "" && link.WorkitemKey == wi.Key
+	return wkitem.LinkMatchesWorkitem(&wi, link.WorkitemID, link.WorkitemKey)
 }
 
 func worktreeDirExists(root, scopePath string) bool {

--- a/internal/commands/workitem/doctor.go
+++ b/internal/commands/workitem/doctor.go
@@ -512,11 +512,12 @@ func workitemIDsOnDisk(ctx context.Context, root string) (map[string]struct{}, [
 		if item.Key != "" {
 			set[item.Key] = struct{}{}
 		}
-		// Festivals are first-class link targets addressed by their fest.yaml
-		// id (e.g. SC0001); keep that id "present on disk" so a link migrated
-		// onto a festival by promote is not reported as broken.
-		if item.WorkflowType == wkitem.WorkflowTypeFestival && item.SourceID != "" {
-			set[item.SourceID] = struct{}{}
+		// Festivals and intents are first-class link targets addressed by the id
+		// declared in their own source document (a fest.yaml id such as SC0001,
+		// an intent's frontmatter id); keep those ids "present on disk" so a
+		// link written against one is not reported as broken.
+		if id := wkitem.SourceDeclaredID(&item); id != "" {
+			set[id] = struct{}{}
 		}
 	}
 	return set, items, nil

--- a/internal/commands/workitem/id.go
+++ b/internal/commands/workitem/id.go
@@ -110,24 +110,34 @@ type idKind string
 const (
 	idKindStable   idKind = "stable"
 	idKindFestival idKind = "festival"
+	idKindIntent   idKind = "intent"
 	idKindKey      idKind = "key"
 )
 
 // durableID returns the single-segment identifier the selector can resolve back
 // to wi, plus which form it is. The value is delegated to LinkWorkitemID so the
 // id printed here and the id stored on a link cannot drift; the kind is derived
-// from the same precedence (stable .workitem id, then a festival's fest.yaml id,
-// then the path-derived key fallback).
+// from the same precedence (stable .workitem id, then the id the source document
+// declares, then the path-derived key fallback).
 func durableID(wi *wkitem.WorkItem) (string, idKind) {
 	id := wkitem.LinkWorkitemID(wi)
 	switch {
 	case wi.StableID != "" && id == wi.StableID:
 		return id, idKindStable
-	case wi.WorkflowType == wkitem.WorkflowTypeFestival && wi.SourceID != "" && id == wi.SourceID:
-		return id, idKindFestival
+	case id != "" && id == wkitem.SourceDeclaredID(wi):
+		return id, sourceIDKind(wi.WorkflowType)
 	default:
 		return id, idKindKey
 	}
+}
+
+// sourceIDKind names which source document declared the id, so --json consumers
+// can tell a festival's fest.yaml id from an intent's frontmatter id.
+func sourceIDKind(t wkitem.WorkflowType) idKind {
+	if t == wkitem.WorkflowTypeIntent {
+		return idKindIntent
+	}
+	return idKindFestival
 }
 
 // selectorFromArg translates a positional argument into a selector string. An

--- a/internal/commands/workitem/id.go
+++ b/internal/commands/workitem/id.go
@@ -34,19 +34,22 @@ func newIDCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "id [selector-or-path]",
 		Short: "Print the identifier of a workitem",
-		Long: `Print the stable identifier of a workitem.
+		Long: `Print the durable single-segment identifier of a workitem.
 
 With no argument, the workitem is detected from the current context using the
 same tiered resolution as ` + "`camp workitem resolve`" + ` (explicit selector, cwd
 ancestor, linked scope, festival, current-workitem pointer). With an argument,
 the workitem is resolved through the shared selector family: workitem ref,
-stable id, key, campaign-relative path, directory slug, or festival id. A
-filesystem path (absolute or relative to the current directory) is accepted and
-translated to the campaign-relative form the selector expects.
+stable id, key, campaign-relative path, directory slug, festival id, or intent
+frontmatter id. A filesystem path (absolute or relative to the current directory)
+is accepted and translated to the campaign-relative form the selector expects.
 
-The bare stable id is written to stdout for shell scripting; it is the id sibling
-of ` + "`camp workitem --print`" + `, which prints a path. Use --key for the
-path-derived key instead, or --json for a structured object.
+Stdout is the bare durable id for shell scripting — stable .workitem id when
+present, otherwise a source-declared id (festival fest.yaml id or intent
+frontmatter id), otherwise the path-derived key. It is the id sibling of
+` + "`camp workitem --print`" + `, which prints a path. Use --key for the
+path-derived key instead, or --json for a structured object (id_kind is
+stable / festival / intent / key).
 
 Examples:
   camp workitem id                       # id of the workitem for the cwd
@@ -133,11 +136,18 @@ func durableID(wi *wkitem.WorkItem) (string, idKind) {
 
 // sourceIDKind names which source document declared the id, so --json consumers
 // can tell a festival's fest.yaml id from an intent's frontmatter id.
+// Only festival and intent currently declare a single-segment source id
+// (SourceDeclaredID); anything else falls through to idKindKey so a future
+// type cannot silently inherit "festival".
 func sourceIDKind(t wkitem.WorkflowType) idKind {
-	if t == wkitem.WorkflowTypeIntent {
+	switch t {
+	case wkitem.WorkflowTypeIntent:
 		return idKindIntent
+	case wkitem.WorkflowTypeFestival:
+		return idKindFestival
+	default:
+		return idKindKey
 	}
-	return idKindFestival
 }
 
 // selectorFromArg translates a positional argument into a selector string. An

--- a/internal/commands/workitem/id_test.go
+++ b/internal/commands/workitem/id_test.go
@@ -204,6 +204,63 @@ func TestID_FestivalDurableIDIsFestivalMetadataID(t *testing.T) {
 	}
 }
 
+// TestID_IntentDurableIDIsFrontmatterID pins the stdout contract that makes an
+// intent linkable: `camp workitem id <intent>` must print the bare frontmatter
+// id, since that is what workitem_id stores and the links validator accepts.
+func TestID_IntentDurableIDIsFrontmatterID(t *testing.T) {
+	root, relPath := intentTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	for _, selectorArg := range []string{intentTestID, relPath, "intent:" + relPath} {
+		out, err := runIDCmd(t, context.Background(), []string{selectorArg}, idOptions{})
+		if err != nil {
+			t.Fatalf("runID intent %q: %v", selectorArg, err)
+		}
+		if strings.TrimSpace(out) != intentTestID {
+			t.Fatalf("id for %q = %q, want %q", selectorArg, strings.TrimSpace(out), intentTestID)
+		}
+	}
+
+	out, err := runIDCmd(t, context.Background(), []string{intentTestID}, idOptions{Key: true})
+	if err != nil {
+		t.Fatalf("runID intent --key: %v", err)
+	}
+	if want := "intent:" + relPath; strings.TrimSpace(out) != want {
+		t.Fatalf("key = %q, want %q", strings.TrimSpace(out), want)
+	}
+}
+
+func TestID_IntentJSONReportsIntentIDKind(t *testing.T) {
+	root, relPath := intentTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	out, err := runIDCmd(t, context.Background(), []string{intentTestID}, idOptions{JSON: true})
+	if err != nil {
+		t.Fatalf("runID intent --json: %v", err)
+	}
+	var payload struct {
+		ID           string `json:"id"`
+		IDKind       string `json:"id_kind"`
+		Key          string `json:"key"`
+		StableID     string `json:"stable_id"`
+		RelativePath string `json:"relative_path"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\nraw=%s", err, out)
+	}
+	if payload.ID != intentTestID || payload.IDKind != string(idKindIntent) {
+		t.Fatalf("id/id_kind = %q/%q, want %q/intent", payload.ID, payload.IDKind, intentTestID)
+	}
+	if payload.Key != "intent:"+relPath || payload.RelativePath != relPath {
+		t.Fatalf("key/relative_path = %q/%q", payload.Key, payload.RelativePath)
+	}
+	if payload.StableID != "" {
+		t.Fatalf("stable_id = %q, want empty for an unadopted intent", payload.StableID)
+	}
+}
+
 func TestID_JSONShape(t *testing.T) {
 	root := linkTestCampaign(t)
 	restore := chdir(t, root)
@@ -283,6 +340,8 @@ func TestDurableID_MatchesLinkTarget(t *testing.T) {
 	}{
 		{"stable", wkitem.WorkItem{StableID: "design-x-2026-05-24", Key: "design:workflow/design/x"}, idKindStable},
 		{"festival", wkitem.WorkItem{WorkflowType: wkitem.WorkflowTypeFestival, SourceID: "SC0001", Key: "festival:festivals/active/x"}, idKindFestival},
+		{"intent", wkitem.WorkItem{WorkflowType: wkitem.WorkflowTypeIntent, SourceID: "idea-20260101-000000", Key: "intent:.campaign/intents/inbox/idea-20260101-000000.md"}, idKindIntent},
+		{"intent_without_frontmatter_id", wkitem.WorkItem{WorkflowType: wkitem.WorkflowTypeIntent, Key: "intent:.campaign/intents/inbox/x.md"}, idKindKey},
 		{"key_only", wkitem.WorkItem{Key: "design:workflow/design/plain"}, idKindKey},
 	}
 	for _, tc := range cases {

--- a/internal/commands/workitem/link.go
+++ b/internal/commands/workitem/link.go
@@ -143,6 +143,14 @@ func runLink(ctx context.Context, cmd *cobra.Command, opts linkOptions) error {
 	}
 
 	if !opts.AllowMissing {
+		// An unadopted design/explore directory has no single-segment id of its
+		// own, so the row would fail the workitem_id validator on a key the user
+		// never typed. `camp project worktree add` already refuses these up
+		// front; say the same thing here instead of leaking the path-segment
+		// complaint.
+		if wkitem.NeedsAdoption(wi) {
+			return wkitem.NotAdoptedError(wi.RelativePath)
+		}
 		if err := quest.ValidateLinkPath(root, scope.Path); err != nil {
 			return camperrors.Wrap(err, "scope path")
 		}
@@ -307,12 +315,14 @@ func inferScopeKind(rel string) links.ScopeKind {
 	}
 }
 
+// workitemIDForLink is LinkWorkitemID plus the one case it cannot answer.
+// LinkWorkitemID falls back to the slash-bearing key when a workitem declares no
+// single-segment id of its own; under --allow-missing that workitem may have
+// been synthesized from the raw selector, and the selector the user typed is a
+// better identity than a key camp invented for it.
 func workitemIDForLink(wi *wkitem.WorkItem, opts linkOptions) string {
-	if wi.StableID != "" {
-		return wi.StableID
-	}
-	if wi.WorkflowType == wkitem.WorkflowTypeFestival && wi.SourceID != "" {
-		return wi.SourceID
+	if id := wkitem.LinkWorkitemID(wi); id != wi.Key {
+		return id
 	}
 	if opts.AllowMissing {
 		return opts.Selector

--- a/internal/commands/workitem/link_intent_test.go
+++ b/internal/commands/workitem/link_intent_test.go
@@ -1,0 +1,210 @@
+package workitem
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Obedience-Corp/camp/internal/workitem/links"
+)
+
+const (
+	intentTestID    = "intents-cannot-be-primary-linked-20260803-184438"
+	intentTestStage = "inbox"
+)
+
+// intentTestCampaign extends linkTestCampaign with one intent whose frontmatter
+// carries intentTestID, plus a worktree directory to link it to.
+func intentTestCampaign(t *testing.T) (root, relPath string) {
+	t.Helper()
+	root = linkTestCampaign(t)
+
+	relPath = ".campaign/intents/" + intentTestStage + "/" + intentTestID + ".md"
+	body := "---\nid: " + intentTestID +
+		"\ntitle: Intents cannot be primary-linked to a worktree\nstatus: " + intentTestStage +
+		"\ncreated_at: 2026-08-03T18:44:38Z\ntype: bug\n---\n\n# Intents cannot be primary-linked\n"
+	writeTestFile(t, filepath.Join(root, filepath.FromSlash(relPath)), body)
+
+	if err := os.MkdirAll(filepath.Join(root, "projects", "worktrees", "camp", "intent-links"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root, relPath
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestLink_IntentRejectsUnknownSelector keeps the error case first: a selector
+// that names no intent must fail before any link row is written.
+func TestLink_IntentRejectsUnknownSelector(t *testing.T) {
+	root, _ := intentTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	err := runLink(context.Background(), newCmd(), linkOptions{
+		Selector: "no-such-intent-20260101-000000",
+		Worktree: "camp/intent-links",
+	})
+	if err == nil {
+		t.Fatal("runLink with an unknown intent selector must fail")
+	}
+	registry, lerr := links.Load(context.Background(), root)
+	if lerr != nil {
+		t.Fatal(lerr)
+	}
+	if len(registry.Links) != 0 {
+		t.Fatalf("failed link must not write a row, got %d", len(registry.Links))
+	}
+}
+
+// TestLink_UnadoptedDocTypeAsksForAdoptionInsteadOfLeakingTheValidator covers
+// the neighbouring path-keyed case: a design/explore directory with no
+// .workitem marker has no single-segment id anywhere on disk, so linking it
+// must point at `camp workitem adopt` rather than reporting a workitem_id the
+// user never chose.
+func TestLink_UnadoptedDocTypeAsksForAdoptionInsteadOfLeakingTheValidator(t *testing.T) {
+	root, _ := intentTestCampaign(t)
+	unadopted := filepath.Join(root, "workflow", "explore", "unadopted-topic")
+	if err := os.MkdirAll(unadopted, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, filepath.Join(unadopted, "README.md"), "# Unadopted\n")
+	restore := chdir(t, root)
+	defer restore()
+
+	err := runLink(context.Background(), newCmd(), linkOptions{
+		Selector: "unadopted-topic",
+		Worktree: "camp/intent-links",
+	})
+	if err == nil {
+		t.Fatal("linking an unadopted explore directory must fail")
+	}
+	if !strings.Contains(err.Error(), "camp workitem adopt") {
+		t.Fatalf("error should name the adopt command, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "must not contain") {
+		t.Fatalf("error should not leak the path-segment validator, got: %v", err)
+	}
+}
+
+// TestLink_IntentPrimaryLinksByEverySelectorForm is the regression for the
+// intent-link defect: every form that names the intent must produce a link whose
+// workitem_id is the bare frontmatter id and whose workitem_key is the key form.
+func TestLink_IntentPrimaryLinksByEverySelectorForm(t *testing.T) {
+	_, relPath := intentTestCampaign(t)
+	wantKey := "intent:" + relPath
+
+	tests := []struct {
+		name     string
+		selector string
+	}{
+		{"frontmatter id", intentTestID},
+		{"key form", wantKey},
+		{"relative path", relPath},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root, _ := intentTestCampaign(t)
+			restore := chdir(t, root)
+			defer restore()
+
+			if err := runLink(context.Background(), newCmd(), linkOptions{
+				Selector: tt.selector,
+				Worktree: "camp/intent-links",
+			}); err != nil {
+				t.Fatalf("runLink(%q): %v", tt.selector, err)
+			}
+
+			registry, err := links.Load(context.Background(), root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(registry.Links) != 1 {
+				t.Fatalf("expected 1 link, got %d", len(registry.Links))
+			}
+			link := registry.Links[0]
+			if link.WorkitemID != intentTestID {
+				t.Errorf("workitem_id = %q, want the bare frontmatter id %q", link.WorkitemID, intentTestID)
+			}
+			if link.WorkitemKey != wantKey {
+				t.Errorf("workitem_key = %q, want %q", link.WorkitemKey, wantKey)
+			}
+			if link.Scope.Kind != links.ScopeWorktree ||
+				link.Scope.Path != "projects/worktrees/camp/intent-links" {
+				t.Errorf("scope = %#v", link.Scope)
+			}
+			if link.Role != links.RolePrimary {
+				t.Errorf("role = %s, want primary", link.Role)
+			}
+		})
+	}
+}
+
+// TestLinks_IntentLinkIsListedBySelector covers the read-back half: once an
+// intent is linked, `camp workitem links <intent>` must find its own row.
+func TestLinks_IntentLinkIsListedBySelector(t *testing.T) {
+	root, _ := intentTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	ctx := context.Background()
+	if err := runLink(ctx, newCmd(), linkOptions{
+		Selector: intentTestID,
+		Worktree: "camp/intent-links",
+	}); err != nil {
+		t.Fatalf("runLink: %v", err)
+	}
+
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	if err := runLinks(ctx, cmd, intentTestID, false); err != nil {
+		t.Fatalf("runLinks: %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, intentTestID) {
+		t.Fatalf("camp workitem links %s did not list the intent's own link:\n%s", intentTestID, got)
+	}
+}
+
+// TestUnlink_IntentRemovesItsOwnLink covers the teardown half: an intent must be
+// able to drop the link it was just able to create.
+func TestUnlink_IntentRemovesItsOwnLink(t *testing.T) {
+	root, _ := intentTestCampaign(t)
+	restore := chdir(t, root)
+	defer restore()
+
+	ctx := context.Background()
+	if err := runLink(ctx, newCmd(), linkOptions{
+		Selector: intentTestID,
+		Worktree: "camp/intent-links",
+	}); err != nil {
+		t.Fatalf("runLink: %v", err)
+	}
+	if err := runUnlink(ctx, newCmd(), unlinkOptions{
+		Selector: intentTestID,
+		Worktree: "camp/intent-links",
+	}); err != nil {
+		t.Fatalf("runUnlink: %v", err)
+	}
+
+	registry, err := links.Load(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(registry.Links) != 0 {
+		t.Fatalf("expected the intent link to be removed, got %d rows", len(registry.Links))
+	}
+}

--- a/internal/commands/workitem/links.go
+++ b/internal/commands/workitem/links.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Obedience-Corp/camp/internal/config"
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/jsoncontract"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
 )
 
@@ -65,7 +66,7 @@ func runLinks(ctx context.Context, cmd *cobra.Command, selectorArg string, jsonO
 		}
 		var matched []links.Link
 		for _, link := range registry.Links {
-			if link.WorkitemID == wi.StableID {
+			if wkitem.LinkMatchesWorkitem(wi, link.WorkitemID, link.WorkitemKey) {
 				matched = append(matched, link)
 			}
 		}

--- a/internal/commands/workitem/staging_branches.go
+++ b/internal/commands/workitem/staging_branches.go
@@ -220,7 +220,7 @@ func pickPrimaryProjectScopePath(ctx context.Context, root string, wi *wkitem.Wo
 		}
 	}
 	return "", camperrors.NewValidation("link",
-		"no primary project link points at workitem "+wi.StableID, nil)
+		"no primary project link points at workitem "+wkitem.LinkWorkitemID(wi), nil)
 }
 
 func primaryFestivalScopePath(ctx context.Context, root string, wi *wkitem.WorkItem, festivalID string) string {

--- a/internal/commands/workitem/staging_branches.go
+++ b/internal/commands/workitem/staging_branches.go
@@ -211,7 +211,7 @@ func pickPrimaryProjectScopePath(ctx context.Context, root string, wi *wkitem.Wo
 		if link.Role != links.RolePrimary {
 			continue
 		}
-		if link.WorkitemID != wi.StableID && link.WorkitemID != wi.Key {
+		if !wkitem.LinkMatchesWorkitem(wi, link.WorkitemID, link.WorkitemKey) {
 			continue
 		}
 		switch link.Scope.Kind {
@@ -244,7 +244,7 @@ func selectPrimaryFestivalScope(registry *links.Links, wi *wkitem.WorkItem, fest
 		if link.Role != links.RolePrimary || link.Scope.Kind != links.ScopeFestival {
 			continue
 		}
-		if link.WorkitemID != wi.StableID && link.WorkitemID != wi.Key {
+		if !wkitem.LinkMatchesWorkitem(wi, link.WorkitemID, link.WorkitemKey) {
 			continue
 		}
 		if festivalID != "" {

--- a/internal/commands/workitem/unlink.go
+++ b/internal/commands/workitem/unlink.go
@@ -14,6 +14,7 @@ import (
 	camperrors "github.com/Obedience-Corp/camp/internal/errors"
 	"github.com/Obedience-Corp/camp/internal/jsoncontract"
 	"github.com/Obedience-Corp/camp/internal/ledger"
+	wkitem "github.com/Obedience-Corp/camp/internal/workitem"
 	"github.com/Obedience-Corp/camp/internal/workitem/links"
 	"github.com/Obedience-Corp/camp/pkg/ledgerkit"
 )
@@ -100,7 +101,7 @@ func runUnlink(ctx context.Context, cmd *cobra.Command, opts unlinkOptions) erro
 			if err != nil {
 				return err
 			}
-			matches := matchUnlinkCandidates(registry, wi.StableID, opts)
+			matches := matchUnlinkCandidates(registry, wi, opts)
 			if len(matches) == 0 {
 				return camperrors.NewValidation("selector",
 					"no links matched selector "+opts.Selector, nil)
@@ -136,11 +137,11 @@ func runUnlink(ctx context.Context, cmd *cobra.Command, opts unlinkOptions) erro
 	return emitUnlinkHuman(cmd.OutOrStdout(), removed)
 }
 
-func matchUnlinkCandidates(registry *links.Links, workitemID string, opts unlinkOptions) []links.Link {
+func matchUnlinkCandidates(registry *links.Links, wi *wkitem.WorkItem, opts unlinkOptions) []links.Link {
 	scopeFilter, useScope := unlinkScopeFilter(opts)
 	var out []links.Link
 	for _, link := range registry.Links {
-		if link.WorkitemID != workitemID {
+		if !wkitem.LinkMatchesWorkitem(wi, link.WorkitemID, link.WorkitemKey) {
 			continue
 		}
 		if useScope {

--- a/internal/commands/workitem/worktree.go
+++ b/internal/commands/workitem/worktree.go
@@ -254,10 +254,7 @@ func existingWorktreeLink(registry *links.Links, wi *wkitem.WorkItem) (string, b
 }
 
 func linkMatchesWorkitem(link links.Link, wi *wkitem.WorkItem) bool {
-	if wi.StableID != "" && link.WorkitemID == wi.StableID {
-		return true
-	}
-	return wi.Key != "" && link.WorkitemKey == wi.Key
+	return wkitem.LinkMatchesWorkitem(wi, link.WorkitemID, link.WorkitemKey)
 }
 
 // attachWorktreeLink primary-links the worktree so the resolver (and therefore
@@ -342,7 +339,7 @@ func emitWorktree(cmd *cobra.Command, printOnly bool, relPath, branch string, wi
 		if branch != "" {
 			lines = append(lines, fmt.Sprintf("  Branch:   %s", ui.Value(branch)))
 		}
-		lines = append(lines, ui.Dim("  camp p commit in this worktree will include WI-* in the campaign tag"))
+		lines = append(lines, ui.Dim("  "+wkitem.WorktreeLinkCommitNote(wi)))
 	}
 	lines = append(lines, ui.Dim(fmt.Sprintf("To navigate: cd %s", relPath)))
 

--- a/internal/workitem/link_target.go
+++ b/internal/workitem/link_target.go
@@ -1,15 +1,41 @@
 package workitem
 
+// SourceDeclaredID returns the single-segment id a workitem type declares inside
+// its own source document, or "" for types that declare none.
+//
+// Festivals declare it in fest.yaml (e.g. SC0001) and intents in their markdown
+// frontmatter (e.g. add-dark-mode-toggle-20260119-153412); discovery lands both
+// on SourceID. Types whose identity instead comes from an adopted .workitem
+// marker are absent here because that id is StableID.
+//
+// This is the shared rule behind "which single-segment string names this
+// workitem": LinkWorkitemID stores it and the selector resolves it, so an id
+// that can be written to a link can always be read back.
+func SourceDeclaredID(wi *WorkItem) string {
+	if wi == nil {
+		return ""
+	}
+	switch wi.WorkflowType {
+	case WorkflowTypeFestival, WorkflowTypeIntent:
+		return wi.SourceID
+	default:
+		return ""
+	}
+}
+
 // LinkWorkitemID returns the identifier to store as a link's workitem_id for
 // wi. It is the single-segment id the selector can resolve back to wi:
 //   - an adopted workitem's stable .workitem id, when present;
-//   - a festival's fest.yaml id (e.g. SC0001), which is how a festival becomes
-//     a first-class link target after `camp workitem promote --target festival`;
+//   - the source-declared id for types that carry one (see SourceDeclaredID),
+//     which is how a festival becomes a first-class link target after
+//     `camp workitem promote --target festival` and how an intent becomes one
+//     without being adopted;
 //   - otherwise the workitem key.
 //
 // The links validator requires workitem_id to be a single path segment, so a
-// festival's slash-bearing key ("festival:festivals/...") is never a valid id;
-// its fest.yaml id is.
+// slash-bearing key ("festival:festivals/...", "intent:.campaign/intents/...")
+// is never a valid id; the source-declared id is. The key form belongs in
+// workitem_key.
 func LinkWorkitemID(wi *WorkItem) string {
 	if wi == nil {
 		return ""
@@ -17,8 +43,27 @@ func LinkWorkitemID(wi *WorkItem) string {
 	if wi.StableID != "" {
 		return wi.StableID
 	}
-	if wi.WorkflowType == WorkflowTypeFestival && wi.SourceID != "" {
-		return wi.SourceID
+	if id := SourceDeclaredID(wi); id != "" {
+		return id
 	}
 	return wi.Key
+}
+
+// LinkMatchesWorkitem reports whether a link's stored workitem_id/workitem_key
+// pair addresses wi.
+//
+// It accepts the id LinkWorkitemID mints today plus the forms an earlier camp
+// may have written, so recognizing an existing link never requires a registry
+// migration: a row saved under the path-derived key still matches the workitem
+// it names, on either field.
+func LinkMatchesWorkitem(wi *WorkItem, workitemID, workitemKey string) bool {
+	if wi == nil {
+		return false
+	}
+	if workitemID != "" {
+		if workitemID == LinkWorkitemID(wi) || workitemID == wi.StableID || workitemID == wi.Key {
+			return true
+		}
+	}
+	return workitemKey != "" && workitemKey == wi.Key
 }

--- a/internal/workitem/link_target_test.go
+++ b/internal/workitem/link_target_test.go
@@ -20,8 +20,32 @@ func TestLinkWorkitemID(t *testing.T) {
 			"SC0001",
 		},
 		{
+			"intent uses its frontmatter id, never its slash-bearing key",
+			&WorkItem{
+				WorkflowType: WorkflowTypeIntent,
+				SourceID:     "fest-phase-gate-templates-give-20260727-123326",
+				Key:          "intent:.campaign/intents/active/fest-phase-gate-templates-give-20260727-123326.md",
+			},
+			"fest-phase-gate-templates-give-20260727-123326",
+		},
+		{
+			"intent with no frontmatter id falls back to key",
+			&WorkItem{WorkflowType: WorkflowTypeIntent, Key: "intent:.campaign/intents/inbox/x.md"},
+			"intent:.campaign/intents/inbox/x.md",
+		},
+		{
+			"stable id wins over a source-declared id",
+			&WorkItem{WorkflowType: WorkflowTypeIntent, StableID: "adopted-id", SourceID: "frontmatter-id", Key: "intent:x.md"},
+			"adopted-id",
+		},
+		{
 			"id-less non-festival falls back to key",
 			&WorkItem{WorkflowType: WorkflowTypeDesign, Key: "design:workflow/design/x"},
+			"design:workflow/design/x",
+		},
+		{
+			"design source_id is not an addressable id",
+			&WorkItem{WorkflowType: WorkflowTypeDesign, SourceID: "not-addressable", Key: "design:workflow/design/x"},
 			"design:workflow/design/x",
 		},
 	}
@@ -29,6 +53,67 @@ func TestLinkWorkitemID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := LinkWorkitemID(tt.wi); got != tt.want {
 				t.Fatalf("LinkWorkitemID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSourceDeclaredID(t *testing.T) {
+	tests := []struct {
+		name string
+		wi   *WorkItem
+		want string
+	}{
+		{"nil", nil, ""},
+		{"festival", &WorkItem{WorkflowType: WorkflowTypeFestival, SourceID: "SC0001"}, "SC0001"},
+		{"intent", &WorkItem{WorkflowType: WorkflowTypeIntent, SourceID: "idea-20260101-000000"}, "idea-20260101-000000"},
+		{"design carries no source-declared id", &WorkItem{WorkflowType: WorkflowTypeDesign, SourceID: "x"}, ""},
+		{"explore carries no source-declared id", &WorkItem{WorkflowType: WorkflowTypeExplore, SourceID: "x"}, ""},
+		{"custom type carries no source-declared id", &WorkItem{WorkflowType: "code_reviews", SourceID: "x"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SourceDeclaredID(tt.wi); got != tt.want {
+				t.Fatalf("SourceDeclaredID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLinkMatchesWorkitem(t *testing.T) {
+	intent := &WorkItem{
+		WorkflowType: WorkflowTypeIntent,
+		SourceID:     "idea-20260101-000000",
+		Key:          "intent:.campaign/intents/inbox/idea-20260101-000000.md",
+	}
+	design := &WorkItem{
+		WorkflowType: WorkflowTypeDesign,
+		StableID:     "design-x-2026-07-17",
+		Key:          "design:workflow/design/x",
+	}
+
+	tests := []struct {
+		name        string
+		wi          *WorkItem
+		workitemID  string
+		workitemKey string
+		want        bool
+	}{
+		{"nil workitem never matches", nil, "anything", "anything", false},
+		{"empty link fields never match", design, "", "", false},
+		{"unrelated id does not match", design, "design-other", "design:workflow/design/other", false},
+		{"key of another workitem does not match", intent, "", "intent:.campaign/intents/inbox/other.md", false},
+		{"intent matches its frontmatter id", intent, intent.SourceID, "", true},
+		{"intent matches a legacy row keyed by workitem_id", intent, intent.Key, "", true},
+		{"intent matches a row carrying only workitem_key", intent, "", intent.Key, true},
+		{"design matches its stable id", design, design.StableID, design.Key, true},
+		{"design matches a legacy row keyed by workitem_id", design, design.Key, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := LinkMatchesWorkitem(tt.wi, tt.workitemID, tt.workitemKey); got != tt.want {
+				t.Fatalf("LinkMatchesWorkitem(%q, %q) = %v, want %v",
+					tt.workitemID, tt.workitemKey, got, tt.want)
 			}
 		})
 	}

--- a/internal/workitem/ref_commit.go
+++ b/internal/workitem/ref_commit.go
@@ -21,17 +21,37 @@ func RefOf(wi *WorkItem) string {
 	return ""
 }
 
+// CarriesCommitRef reports whether wi can carry a WI- ref in a campaign commit
+// tag. A ref is stored in a directory's .workitem marker, so only a
+// directory-kind item with a stable id has somewhere to keep one; intents and
+// festivals identify themselves from their own source document and have no
+// marker to write to. Callers use this to avoid promising a WI- segment that
+// EnsureRefForCommit will not produce.
+func CarriesCommitRef(wi *WorkItem) bool {
+	return wi != nil && wi.ItemKind == ItemKindDirectory && wi.StableID != ""
+}
+
+// WorktreeLinkCommitNote is the one-line note printed after a worktree is
+// primary-linked to wi, describing what a commit from inside it will actually
+// carry. Only a ref-carrying workitem gets a WI- segment; for the rest the link
+// still supplies workitem context, and saying so beats promising a tag that
+// never appears.
+func WorktreeLinkCommitNote(wi *WorkItem) string {
+	if CarriesCommitRef(wi) {
+		return "camp p commit in this worktree will include WI-* in the campaign tag"
+	}
+	return "camp p commit in this worktree will resolve to this workitem " +
+		"(no WI-* segment: only adopted workitems carry a ref)"
+}
+
 // EnsureRefForCommit returns the workitem's ref, auto-backfilling the
-// .workitem marker on disk if the field is empty and the workitem is a
-// directory-kind item with a stable id. Intents/festivals and unresolved
+// .workitem marker on disk if the field is empty and the workitem can carry a
+// ref at all (see CarriesCommitRef). Intents/festivals and unresolved
 // workitems return "" with no side effect. Failures during backfill fall
 // back to "" with a louder stderr warning so the commit can still proceed
 // without a WI- segment.
 func EnsureRefForCommit(ctx context.Context, root string, wi *WorkItem, errw io.Writer) (string, error) {
-	if wi == nil {
-		return "", nil
-	}
-	if wi.ItemKind != ItemKindDirectory || wi.StableID == "" {
+	if !CarriesCommitRef(wi) {
 		return "", nil
 	}
 	if v := RefOf(wi); v != "" {

--- a/internal/workitem/ref_commit_test.go
+++ b/internal/workitem/ref_commit_test.go
@@ -1,0 +1,58 @@
+package workitem
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCarriesCommitRef(t *testing.T) {
+	tests := []struct {
+		name string
+		wi   *WorkItem
+		want bool
+	}{
+		{"nil", nil, false},
+		{"file kind without stable id", &WorkItem{ItemKind: ItemKindFile}, false},
+		{
+			"intent identifies itself but has no marker to hold a ref",
+			&WorkItem{WorkflowType: WorkflowTypeIntent, ItemKind: ItemKindFile, SourceID: "idea-20260101-000000"},
+			false,
+		},
+		{
+			"festival identifies itself but has no marker to hold a ref",
+			&WorkItem{WorkflowType: WorkflowTypeFestival, ItemKind: ItemKindDirectory, SourceID: "SC0001"},
+			false,
+		},
+		{
+			"directory without a stable id has nothing to hash",
+			&WorkItem{WorkflowType: WorkflowTypeDesign, ItemKind: ItemKindDirectory},
+			false,
+		},
+		{
+			"adopted directory workitem carries a ref",
+			&WorkItem{WorkflowType: WorkflowTypeDesign, ItemKind: ItemKindDirectory, StableID: "design-x-2026-07-17"},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CarriesCommitRef(tt.wi); got != tt.want {
+				t.Fatalf("CarriesCommitRef() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestWorktreeLinkCommitNote guards the honesty of the post-link message: it may
+// only promise a WI- segment for a workitem that can actually mint one.
+func TestWorktreeLinkCommitNote(t *testing.T) {
+	intent := &WorkItem{WorkflowType: WorkflowTypeIntent, ItemKind: ItemKindFile, SourceID: "idea-20260101-000000"}
+	if note := WorktreeLinkCommitNote(intent); strings.Contains(note, "will include WI-*") {
+		t.Fatalf("intent note promises a WI- segment it cannot mint: %q", note)
+	}
+
+	adopted := &WorkItem{WorkflowType: WorkflowTypeDesign, ItemKind: ItemKindDirectory, StableID: "design-x-2026-07-17"}
+	if note := WorktreeLinkCommitNote(adopted); !strings.Contains(note, "will include WI-*") {
+		t.Fatalf("adopted workitem note should promise a WI- segment, got %q", note)
+	}
+}

--- a/internal/workitem/resolver/intent_link_test.go
+++ b/internal/workitem/resolver/intent_link_test.go
@@ -1,0 +1,97 @@
+package resolver
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/workitem"
+)
+
+const resolverIntentID = "intents-cannot-be-primary-linked-20260803-184438"
+
+// writeIntentLinkedWorktree lays down a campaign with one intent, a worktree
+// directory, and a primary worktree link that addresses the intent by the given
+// workitem_id/workitem_key pair. It returns the campaign root and the absolute
+// worktree path.
+func writeIntentLinkedWorktree(t *testing.T, workitemID, workitemKey string) (root, worktree string) {
+	t.Helper()
+	root = t.TempDir()
+	writeMinimalCampaign(t, root)
+
+	intentRel := ".campaign/intents/inbox/" + resolverIntentID + ".md"
+	body := "---\nid: " + resolverIntentID +
+		"\ntitle: Intents cannot be primary-linked\nstatus: inbox" +
+		"\ncreated_at: 2026-08-03T18:44:38Z\ntype: bug\n---\n\n# Intent\n"
+	mustWriteFile(t, filepath.Join(root, filepath.FromSlash(intentRel)), body)
+
+	worktree = filepath.Join(root, "projects", "worktrees", "camp", "intent-links")
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := `version: workitem-links/v1alpha1
+links:
+  - id: lnk_20260803_aaaaaa
+    workitem_id: ` + workitemID + `
+    workitem_key: ` + workitemKey + `
+    scope:
+      kind: worktree
+      path: projects/worktrees/camp/intent-links
+    role: primary
+    created_at: 2026-08-03T18:44:38Z
+    created_by: camp_workitem_link
+`
+	mustWriteFile(t, filepath.Join(root, ".campaign", "workitems", "links.yaml"), registry)
+	return root, worktree
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestResolve_IntentWorktreeLinkResolvesFromInsideTheWorktree is the round-trip
+// the fix exists for: the bare id a link stores for an intent must resolve back
+// to that intent from inside the linked worktree, which is how camp p commit
+// picks up workitem context there.
+func TestResolve_IntentWorktreeLinkResolvesFromInsideTheWorktree(t *testing.T) {
+	intentKey := "intent:.campaign/intents/inbox/" + resolverIntentID + ".md"
+
+	tests := []struct {
+		name        string
+		workitemID  string
+		workitemKey string
+	}{
+		{"bare frontmatter id", resolverIntentID, intentKey},
+		{"id written without a key", resolverIntentID, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root, worktree := writeIntentLinkedWorktree(t, tt.workitemID, tt.workitemKey)
+
+			got, err := Resolve(context.Background(), root, Options{Cwd: worktree})
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if got.Source != SourceLink {
+				t.Fatalf("Source = %q, want %q; trace=%+v", got.Source, SourceLink, got.Trace)
+			}
+			if got.Workitem == nil {
+				t.Fatal("Workitem is nil; the worktree link did not resolve")
+			}
+			if got.Workitem.SourceID != resolverIntentID {
+				t.Fatalf("resolved source_id = %q, want %q", got.Workitem.SourceID, resolverIntentID)
+			}
+			if got.Workitem.WorkflowType != workitem.WorkflowTypeIntent {
+				t.Fatalf("resolved workflow_type = %q, want intent", got.Workitem.WorkflowType)
+			}
+		})
+	}
+}

--- a/internal/workitem/selector/intent_test.go
+++ b/internal/workitem/selector/intent_test.go
@@ -1,0 +1,79 @@
+package selector
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	testIntentID    = "fest-phase-gate-templates-give-20260727-123326"
+	testIntentStage = "active"
+)
+
+// writeCampaignWithIntent lays down a minimal campaign containing one intent in
+// the given stage whose frontmatter carries id, and returns the campaign root.
+func writeCampaignWithIntent(t *testing.T, stage, id string) string {
+	t.Helper()
+	root := t.TempDir()
+
+	campaignYAML := "version: campaign/v1\nid: testcampaign\nname: test\ntype: product\n"
+	mustWrite(t, filepath.Join(root, ".campaign", "campaign.yaml"), campaignYAML)
+
+	body := "---\nid: " + id + "\ntitle: Fest phase gate templates\nstatus: " + stage +
+		"\ncreated_at: 2026-07-27T12:33:26Z\ntype: bug\n---\n\n# Fest phase gate templates\n"
+	mustWrite(t, filepath.Join(root, ".campaign", "intents", stage, id+".md"), body)
+	return root
+}
+
+func TestResolve_IntentMatchesEverySelectorForm(t *testing.T) {
+	root := writeCampaignWithIntent(t, testIntentStage, testIntentID)
+	relPath := ".campaign/intents/" + testIntentStage + "/" + testIntentID + ".md"
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{"frontmatter id", testIntentID},
+		{"frontmatter id uppercase", "FEST-PHASE-GATE-TEMPLATES-GIVE-20260727-123326"},
+		{"key", "intent:" + relPath},
+		{"relative path", relPath},
+		{"filename slug", testIntentID + ".md"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wi, err := Resolve(context.Background(), root, tt.query, ResolveOptions{})
+			if err != nil {
+				t.Fatalf("Resolve(%q) returned error: %v", tt.query, err)
+			}
+			if wi.SourceID != testIntentID {
+				t.Fatalf("Resolve(%q) matched source_id %q, want %q", tt.query, wi.SourceID, testIntentID)
+			}
+		})
+	}
+}
+
+func TestResolve_UnknownIntentIDIsNotFound(t *testing.T) {
+	root := writeCampaignWithIntent(t, testIntentStage, testIntentID)
+
+	_, err := Resolve(context.Background(), root, "no-such-intent-20260101-000000", ResolveOptions{})
+	if !errors.Is(err, ErrSelectorNotFound) {
+		t.Fatalf("Resolve(unknown intent id) error = %v, want ErrSelectorNotFound", err)
+	}
+}
+
+// TestResolve_AmbiguousIntentIDReportsBothKeys guards the tier semantics: two
+// intents hand-edited to share an id must report ambiguity rather than silently
+// picking whichever the directory walk saw first.
+func TestResolve_AmbiguousIntentIDReportsBothKeys(t *testing.T) {
+	root := writeCampaignWithIntent(t, testIntentStage, testIntentID)
+	body := "---\nid: " + testIntentID + "\ntitle: Duplicate\nstatus: inbox\n" +
+		"created_at: 2026-07-27T12:33:26Z\ntype: bug\n---\n\n# Duplicate\n"
+	mustWrite(t, filepath.Join(root, ".campaign", "intents", "inbox", "duplicate.md"), body)
+
+	_, err := Resolve(context.Background(), root, testIntentID, ResolveOptions{})
+	if !errors.Is(err, ErrSelectorAmbiguous) {
+		t.Fatalf("Resolve(duplicate intent id) error = %v, want ErrSelectorAmbiguous", err)
+	}
+}

--- a/internal/workitem/selector/selector.go
+++ b/internal/workitem/selector/selector.go
@@ -40,7 +40,9 @@ var (
 //  3. exact key (`<type>:<path>`)
 //  4. exact RelativePath
 //  5. exact directory-base slug
-//  6. exact festival id (`fest.yaml` metadata id, e.g. SC0001)
+//  6. exact source-declared id (a festival's `fest.yaml` id such as SC0001, or
+//     an intent's frontmatter id): the same id LinkWorkitemID stores, so every
+//     workitem_id a link can hold resolves back here
 //  7. fuzzy substring on key or title (only when opts.AllowFuzzy)
 func Resolve(ctx context.Context, root string, query string, opts ResolveOptions) (*workitem.WorkItem, error) {
 	if err := ctx.Err(); err != nil {
@@ -69,8 +71,9 @@ func Resolve(ctx context.Context, root string, query string, opts ResolveOptions
 		{"key", func(w workitem.WorkItem) bool { return strings.EqualFold(w.Key, query) }},
 		{"path", func(w workitem.WorkItem) bool { return w.RelativePath == strings.TrimRight(query, "/") }},
 		{"slug", func(w workitem.WorkItem) bool { return strings.EqualFold(filepath.Base(w.RelativePath), query) }},
-		{"festival_id", func(w workitem.WorkItem) bool {
-			return w.WorkflowType == workitem.WorkflowTypeFestival && w.SourceID != "" && strings.EqualFold(w.SourceID, query)
+		{"source_id", func(w workitem.WorkItem) bool {
+			id := workitem.SourceDeclaredID(&w)
+			return id != "" && strings.EqualFold(id, query)
 		}},
 	}
 	for _, m := range matchers {

--- a/tests/integration/workitem_intent_links_test.go
+++ b/tests/integration/workitem_intent_links_test.go
@@ -1,0 +1,149 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedIntent captures an intent through the real CLI and returns the bare
+// frontmatter id `camp workitem id` reports for it.
+func seedIntent(t *testing.T, tc *TestContainer, dir, title string) string {
+	t.Helper()
+	out, err := tc.RunCampInDir(dir, "intent", "add", title, "--no-commit")
+	require.NoError(t, err, "intent add: %s", out)
+
+	listed, err := tc.RunCampInDir(dir, "workitem", "--json")
+	require.NoError(t, err, "workitem --json: %s", listed)
+	var payload struct {
+		Items []struct {
+			WorkflowType string `json:"workflow_type"`
+			SourceID     string `json:"source_id"`
+			Title        string `json:"title"`
+		} `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(listed), &payload), "raw=%s", listed)
+	for _, wi := range payload.Items {
+		if wi.WorkflowType == "intent" && wi.Title == title {
+			require.NotEmpty(t, wi.SourceID, "intent must expose its frontmatter id")
+			return wi.SourceID
+		}
+	}
+	t.Fatalf("no intent titled %q in workitem --json: %s", title, listed)
+	return ""
+}
+
+// TestIntegration_IntentPrimaryLinkLifecycle is the containerized regression for
+// the intent-link defect: an intent must link to a worktree scope by its bare
+// frontmatter id, survive on disk with the key form in workitem_key, resolve
+// back from inside that scope, pass doctor, and unlink again.
+func TestIntegration_IntentPrimaryLinkLifecycle(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/workitem-intent-links"
+	initLinksCampaign(t, tc, dir)
+
+	const title = "Intents cannot be primary-linked"
+	intentID := seedIntent(t, tc, dir, title)
+
+	// `camp workitem id` must print the bare id, not the "intent:<path>" key:
+	// the key form is what the links validator rejects.
+	idOut, err := tc.RunCampInDir(dir, "workitem", "id", intentID)
+	require.NoError(t, err, "workitem id: %s", idOut)
+	assert.Equal(t, intentID, strings.TrimSpace(idOut))
+	assert.NotContains(t, idOut, "intent:", "stdout id must be the bare id")
+
+	keyOut, err := tc.RunCampInDir(dir, "workitem", "id", "--key", intentID)
+	require.NoError(t, err, "workitem id --key: %s", keyOut)
+	assert.Contains(t, keyOut, "intent:.campaign/intents/")
+
+	worktreeScope := "projects/worktrees/camp/intent-links"
+	_, _, err = tc.ExecCommand("mkdir", "-p", dir+"/"+worktreeScope)
+	require.NoError(t, err)
+
+	out, err := tc.RunCampInDir(dir, "workitem", "link", intentID, "--worktree", "camp/intent-links")
+	require.NoError(t, err, "workitem link intent: %s", out)
+	assert.Contains(t, out, intentID)
+
+	linksYAML, err := tc.ReadFile(dir + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, linksYAML, "workitem_id: "+intentID,
+		"workitem_id must hold the bare id")
+	assert.Contains(t, linksYAML, "workitem_key: intent:.campaign/intents/",
+		"workitem_key must hold the path-derived key form")
+
+	// The link must be findable by the intent that owns it.
+	out, err = tc.RunCampInDir(dir, "workitem", "links", intentID)
+	require.NoError(t, err, "workitem links <intent>: %s", out)
+	assert.Contains(t, out, worktreeScope)
+
+	// Round-trip: from inside the linked scope the resolver must land back on
+	// the intent, which is what gives camp p commit its workitem context there.
+	out, err = tc.RunCampInDir(dir+"/"+worktreeScope, "workitem", "resolve", "--json")
+	require.NoError(t, err, "resolve inside linked worktree: %s", out)
+	src, resolution := extractResolveSource(t, out)
+	assert.Equal(t, "link", src, "linked worktree should resolve via the link tier")
+	wi, _ := resolution["workitem"].(map[string]any)
+	require.NotNil(t, wi, "resolution must carry a workitem: %s", out)
+	assert.Equal(t, "intent", wi["workflow_type"])
+	assert.Equal(t, intentID, wi["source_id"])
+
+	// A link camp itself wrote must not be a doctor finding.
+	out, err = tc.RunCampInDir(dir, "workitem", "doctor")
+	require.NoError(t, err, "doctor: %s", out)
+	assert.NotContains(t, out, intentID, "intent link must not be reported broken: %s", out)
+
+	out, err = tc.RunCampInDir(dir, "workitem", "unlink", intentID, "--worktree", "camp/intent-links")
+	require.NoError(t, err, "unlink intent: %s", out)
+	out, err = tc.RunCampInDir(dir, "workitem", "links")
+	require.NoError(t, err, "links post-unlink: %s", out)
+	assert.Contains(t, out, "no links")
+}
+
+// TestIntegration_WorktreeAdd_IntentLinksNotDangles is the sibling of
+// TestIntegration_WorktreeAdd_UnadoptedDesignDirErrors and covers the exact
+// failure the intent reported: the link error arrived only after the worktree
+// existed, so `camp project worktree add --workitem <intent>` left an unlinked
+// worktree behind. An intent carries its own id, so the link must now succeed.
+func TestIntegration_WorktreeAdd_IntentLinksNotDangles(t *testing.T) {
+	tc := GetSharedContainer(t)
+	dir := "/test/worktree-add-intent"
+	initCommitTagsCampaign(t, tc, dir)
+
+	_, err := tc.RunCampInDir(dir, "project", "new", "demo-app")
+	require.NoError(t, err, "camp project new")
+
+	intentID := seedIntent(t, tc, dir, "Intent drives a worktree")
+
+	out, err := tc.RunCampInDir(dir, "project", "worktree", "add", "intent-wt",
+		"--project", "demo-app", "--workitem", intentID)
+	require.NoError(t, err, "worktree add --workitem <intent>: %s", out)
+	assert.NotContains(t, out, "must not contain",
+		"the workitem_id path-segment rule must not surface here: %s", out)
+
+	wtRel := "projects/worktrees/demo-app/intent-wt"
+	exists, err := tc.CheckDirExists(dir + "/" + wtRel)
+	require.NoError(t, err)
+	require.True(t, exists, "worktree should exist at %s; output:\n%s", wtRel, out)
+
+	linksYAML, err := tc.ReadFile(dir + "/.campaign/workitems/links.yaml")
+	require.NoError(t, err)
+	assert.Contains(t, linksYAML, "workitem_id: "+intentID,
+		"the created worktree must be linked to the intent, not left dangling")
+	assert.Contains(t, linksYAML, wtRel)
+
+	// The link must be live from inside the worktree, which is what gives
+	// camp p commit its workitem context there.
+	resolveOut, err := tc.RunCampInDir(dir+"/"+wtRel, "workitem", "resolve", "--json")
+	require.NoError(t, err, "resolve inside intent worktree: %s", resolveOut)
+	src, resolution := extractResolveSource(t, resolveOut)
+	assert.Equal(t, "link", src)
+	wi, _ := resolution["workitem"].(map[string]any)
+	require.NotNil(t, wi, "resolution must carry a workitem: %s", resolveOut)
+	assert.Equal(t, intentID, wi["source_id"])
+}

--- a/tests/integration/workitem_intent_links_test.go
+++ b/tests/integration/workitem_intent_links_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// seedIntent captures an intent through the real CLI and returns the bare
-// frontmatter id `camp workitem id` reports for it.
+// seedIntent captures an intent through the real CLI and returns its bare
+// frontmatter id, read back from `camp workitem --json` rather than parsed out
+// of the create output.
 func seedIntent(t *testing.T, tc *TestContainer, dir, title string) string {
 	t.Helper()
 	out, err := tc.RunCampInDir(dir, "intent", "add", title, "--no-commit")


### PR DESCRIPTION
## Source intent

- **id**: `intents-cannot-be-primary-linked-20260803-184438`
- **title**: Intents cannot be primary-linked to a worktree: resolver returns key form, workitem_id validator rejects it
- **file**: `.campaign/intents/active/intents-cannot-be-primary-linked-20260803-184438.md`

## The bug (verified live on this branch before any change)

An intent had no string that could satisfy both the selector and the links validator, so `camp workitem link <intent> --worktree ...` and `camp project worktree add --workitem <intent>` were both impossible.

The selector rejected the bare frontmatter id and suggested the key form:

```
Resolve("intents-cannot-be-primary-linked-20260803-184438") returned error:
no workitem matched selector intents-cannot-be-primary-linked-20260803-184438;
did you mean: intent:.campaign/intents/inbox/intents-cannot-be-primary-linked-20260803-184438.md
```

...and the links validator rejected exactly the key form the selector had just suggested:

```
validation error on workitem_id: invalid workitem_id
intent:.campaign/intents/inbox/intents-cannot-be-primary-linked-20260803-184438.md:
must not be empty, must not contain '/', '\', whitespace, or control characters,
must not start with '.' or '-', max 80 chars
```

Two defects met in the middle:

1. `internal/workitem/link_target.go` promoted `SourceID` to `workitem_id` only for festivals, so an intent fell through to `wi.Key`, which always contains a slash and can never pass `pathutil.ValidateSegment`.
2. `internal/workitem/selector/selector.go` had a `festival_id` match tier gated on `WorkflowType == festival`, so an intent's frontmatter id resolved to nothing. The intent's own id was sitting in `SourceID`, unused by either side.

## What changed

**The id rule is now one function, shared by writer and reader.** `SourceDeclaredID` names the types that carry a single-segment id inside their own source document (festival `fest.yaml` id, intent frontmatter id). `LinkWorkitemID` stores it; the selector's match tier (renamed `festival_id` to `source_id`) resolves it. An id that can be written to a link can now always be read back, which was the invariant the two sides disagreed about.

Consequential changes needed to make the round-trip real:

- `workitemIDsOnDisk` (doctor) registers source-declared ids, so a link camp itself wrote is not then reported as pointing at a workitem that is not on disk.
- `camp workitem id` prints the bare id for intents, with the key form still behind `--key`. `--json` gains `id_kind: "intent"` alongside the existing `stable` / `festival` / `key` (additive; `workitem-id/v1alpha1` unchanged).
- `link.go`'s `workitemIDForLink` had its own copy of the id precedence. It now delegates to `LinkWorkitemID`, keeping only the `--allow-missing` case that has no workitem to ask.
- New `LinkMatchesWorkitem(wi, workitem_id, workitem_key)` replaces five hand-rolled `link.WorkitemID == wi.StableID` comparisons in `links.go`, `unlink.go`, `staging_branches.go` (x2), `worktree.go`, and `merged_backstop.go` (x2). Without this an intent could be linked but not listed by `camp workitem links <intent>` and not removed by `camp workitem unlink <intent>`, since `wi.StableID` is empty for an intent. The helper still accepts the stable id and the key form, so registries written by an older camp keep matching with no migration.

**Two honesty fixes found while tracing the path:**

- `camp workitem link` on an unadopted design/explore directory leaked the raw path-segment validator error. `camp project worktree add` already refused those up front with a "run camp workitem adopt" message; the standalone link command now says the same thing.
- All three worktree-link success paths printed "camp p commit in this worktree will include WI-* in the campaign tag". That is false for an intent: `EnsureRefForCommit` only mints a ref for a directory-kind item with a `.workitem` marker to write it into. `WorktreeLinkCommitNote` now tells the truth for both cases, and `CarriesCommitRef` gives that rule one home instead of an inlined condition.

## Other path-keyed types (checked, not assumed)

Ran each through the real binary against a throwaway fixture campaign:

| Type | Finding |
| --- | --- |
| `intent` | The bug. Had a perfectly good bare id in frontmatter that nothing used. Fixed. |
| `code_reviews`, `website`, other custom types | Not affected. A custom type is only discovered as a workitem when it carries a `.workitem` marker, which supplies `StableID`. Linking an adopted `code_reviews` item already worked and still does. |
| `design`, `explore` (unadopted dirs) | Hit the same validator wall but for a different reason: there is no bare id anywhere on disk to use. The designed remedy is `camp workitem adopt`, which mints one. Not the same defect, so not changed. Only the error message improved, as above. |

## Bonus durability, worth knowing

Because the id is path-independent, an intent link now survives an intent lifecycle move. Promoting a linked intent from `inbox` to `active` leaves `workitem_key` pointing at the old `inbox/` path, but the link still resolves via the id:

```
source   = link
reason   = via link lnk_20260805_4947e8 on worktree:projects/worktrees/camp/wt1
source_id= promote-me-to-a-festival-20260805-030012
rel_path = .campaign/intents/active/promote-me-to-a-festival-20260805-030012.md
```

`camp workitem doctor` reports 0 findings in that state. The stale `workitem_key` is cosmetic (the id is the authority and the key is only a legacy matcher), but see follow-ups.

## Tests

Error cases first, table-driven where the cases vary along one axis.

- `internal/workitem/link_target_test.go`: `LinkWorkitemID` (8 cases incl. stable-id-wins and design-`SourceID`-is-not-addressable), `SourceDeclaredID` (6), `LinkMatchesWorkitem` (9, starting with nil/empty/unrelated).
- `internal/workitem/ref_commit_test.go`: `CarriesCommitRef` (6) plus a guard that the post-link note never promises a `WI-` segment it cannot mint.
- `internal/workitem/selector/intent_test.go`: every selector form for an intent, unknown-id-is-not-found, and duplicate-id-is-ambiguous.
- `internal/commands/workitem/link_intent_test.go`: unknown selector writes no row (first), link by all three forms asserting `workitem_id` bare + `workitem_key` key form, links-lists-its-own-row, unlink-removes-it, and the unadopted-explore message.
- `internal/commands/workitem/id_test.go`: intent stdout/`--key`/`--json` contract, plus `intent` and `intent_without_frontmatter_id` rows in the existing `durableID` table.
- `internal/workitem/resolver/intent_link_test.go`: the round-trip that matters, resolving back to the intent from inside the linked worktree.
- `tests/integration/workitem_intent_links_test.go` (containerized, `//go:build integration`): full lifecycle through the real CLI, and `TestIntegration_WorktreeAdd_IntentLinksNotDangles`, the sibling of the existing unadopted-design-dir test, which reproduces the reported "worktree created, then link failed" case and asserts the worktree is created **and** linked.

The unit tests use host `t.TempDir` with plain file writes, matching the surrounding selector/link tests; nothing new shells out to git, so `just lint-no-host-fs-tests` stays satisfied. FS behavior driven through the real binary lives in the containerized suite.

## Gate results

```
go build ./...                                          clean
go vet ./... / -tags dev / -tags=integration            clean
golangci-lint --new-from-merge-base origin/main         0 issues
golangci-lint --new-from-merge-base origin/main (dev)   0 issues
just lint-no-fmt-errorf                                 clean (no regressions)
go test ./...            (stable)                       114 packages ok
go test -tags dev ./...  (dev)                           ok
just test integration                                   (see below)
```

New integration tests, run individually:

```
--- PASS: TestIntegration_IntentPrimaryLinkLifecycle (5.05s)
--- PASS: TestIntegration_WorktreeAdd_IntentLinksNotDangles (4.00s)
```

### Pre-existing gate blocker, not from this branch

`just gate` fails at `lint-no-host-fs-tests`, and it fails the same way on a clean `origin/main` tree (verified by stashing this branch's changes and re-running):

```
FAIL: NEW host-side git exec.Command in _test.go outside tests/integration/:
  ./cmd/camp/cmdutil/nothing_staged_test.go
  ./internal/git/tree_empty_test.go
```

Both files arrived in `837aff89` ("fix(commit): say nothing staged when worktree is still dirty") without being added to the justfile allowlist, and neither is touched by this branch (`git diff origin/main --` on both paths is empty). I deliberately did not add them to the allowlist here: that list is a ratchet whose stated end state is empty, and quietly widening it inside an unrelated PR is the wrong place to make that call. Every other stage of `just gate` passes.

## Tradeoffs and follow-ups

- **`id_kind` gains a value.** `camp workitem id --json` can now return `"intent"`. Additive to `workitem-id/v1alpha1`; a consumer that switches on the field sees a new case rather than a changed one.
- **`LinkMatchesWorkitem` widens some comparisons to also match `workitem_key`.** `camp workitem links` and `camp workitem unlink` previously compared `workitem_id` against `StableID` only, so they now also see legacy rows stored under the key form. That is the behavior `worktree.go` and `merged_backstop.go` already had; this makes all seven sites agree.
- **Intents still get no `WI-` commit segment.** The link resolves and supplies workitem context, but a ref needs a `.workitem` marker to live in and an intent has none. Giving intents refs means adding a `ref:` field to intent frontmatter and teaching the doctor backfill about intent files. Out of scope here; the messaging now states the actual behavior instead of promising a tag.
- **`workitem_key` goes stale on an intent stage move.** `camp intent promote` relocates the file without updating the key on existing links. Harmless today because the id is authoritative and doctor is clean, but the natural fix is for intent status transitions to rewrite `workitem_key`, the way `rename_migrate.go` already does for renames.
- **`promotedWorkitemIdentity` still returns an empty id for intent sources** (it reads `kind: workitem` frontmatter, which intent files do not have), so promoted-intent link rehoming matches by key alone. Correct today since the key is stored, and I left it alone rather than widen this diff.
