### PR TITLE
fix(tests): stop double-discounting the daemon CPU count when sizing the container pool

### DIFF
--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -132,8 +132,15 @@ func TestMain(m *testing.M) {
 // and fail in the full suite, differently each run, which reads like flaky
 // tests rather than a saturated machine.
 //
-// The halving and the bounds are unchanged. Only the number they are applied
-// to was wrong.
+// The daemon's own count is used as-is, one container per CPU. The halving
+// this function used to apply was calibrated for the host count, where it
+// approximated a VM the host was fronting; applied to the daemon's own number
+// it discounts capacity twice. On the machine above that double discount took
+// the pool from six to two — a 3x wall-clock regression on a suite whose
+// containers spend their time in short git execs, not sustained CPU — while
+// the flakiness the sizing fix cured needed only the drop from six to four.
+// The halving survives solely in the host fallback, where the count is still
+// a proxy for a machine that may be smaller.
 func poolSizeFor(daemonCPUs int) int {
 	if v := os.Getenv("CAMP_TEST_POOL_SIZE"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
@@ -141,13 +148,12 @@ func poolSizeFor(daemonCPUs int) int {
 		}
 	}
 
-	cpus := daemonCPUs
-	if cpus <= 0 {
-		// Cannot tell. Fall back to the host, which is what this did
-		// unconditionally before: no worse than the old behavior.
-		cpus = runtime.NumCPU()
+	n := daemonCPUs
+	if n <= 0 {
+		// Cannot tell. Fall back to the halved host count, which is what this
+		// did unconditionally before: no worse than the old behavior.
+		n = runtime.NumCPU() / 2
 	}
-	n := cpus / 2
 	if n < 2 {
 		n = 2
 	}

--- a/tests/integration/pool_size_test.go
+++ b/tests/integration/pool_size_test.go
@@ -21,11 +21,14 @@ func TestPoolSizeFor(t *testing.T) {
 		want       int
 	}{
 		{
-			// The case that was broken: a 4-CPU Colima VM behind a 16-CPU
-			// laptop was sized from the laptop and got six containers.
-			name:       "a four cpu daemon gets two",
+			// Both prior sizings were wrong on a 4-CPU Colima VM behind a
+			// 16-CPU laptop: sizing from the laptop gave six containers
+			// (oversubscribed, flaky), halving the daemon's own count gave
+			// two (a 3x wall-clock regression). One per daemon CPU is the
+			// point between them.
+			name:       "a four cpu daemon gets four",
 			daemonCPUs: 4,
-			want:       2,
+			want:       4,
 		},
 		{
 			name:       "a large daemon is still capped",
@@ -38,13 +41,13 @@ func TestPoolSizeFor(t *testing.T) {
 			want:       2,
 		},
 		{
-			name:       "twelve cpus lands inside the range",
+			name:       "twelve cpus lands on the cap",
 			daemonCPUs: 12,
 			want:       6,
 		},
 		{
-			name:       "ten cpus lands inside the range",
-			daemonCPUs: 10,
+			name:       "five cpus lands inside the range",
+			daemonCPUs: 5,
 			want:       5,
 		},
 	}
@@ -90,7 +93,7 @@ func TestPoolSizeForHonorsTheOverride(t *testing.T) {
 	// A meaningless override is ignored rather than obeyed into a zero-sized
 	// pool, which would deadlock every checkout.
 	t.Setenv("CAMP_TEST_POOL_SIZE", "banana")
-	if got := poolSizeFor(4); got != 2 {
-		t.Fatalf("poolSizeFor(4) with a junk override = %d, want the computed 2", got)
+	if got := poolSizeFor(4); got != 4 {
+		t.Fatalf("poolSizeFor(4) with a junk override = %d, want the computed 4", got)
 	}
 }


### PR DESCRIPTION
## The regression

af3db4b4 (Aug 3) correctly switched integration pool sizing from the host CPU count to the Docker daemon's — the host count oversized the pool (6 containers on a 4-CPU Colima VM) and produced the tests-pass-alone-fail-together flakiness that motivated the change. But it kept the `/2` halving that was calibrated for the *host* number as a proxy for a smaller VM. Applied to the daemon's own count, the discount is taken twice:

| sizing | pool on this machine (16-CPU host, 4-CPU VM) |
|---|---|
| pre-af3db4b4: host/2, cap 6 | 6 — oversubscribed, flaky |
| af3db4b4: daemon/2 | **2 — a 3x parallelism cut** |
| this PR: daemon, cap 6 | 4 — one container per VM CPU |

Every pooled test runs through `GetSharedContainer` → `t.Parallel()`, so wall-clock ≈ serial-sum / pool-size. Dropping 6→2 is what blew the 15m suite budget (surfaced during CS0005 festival gates as >23 min runs).

## The fix

One container per daemon CPU. The halving survives only in the can't-reach-the-daemon fallback, where the host count is still a proxy for a possibly-smaller VM. Floor 2, cap 6, and the `CAMP_TEST_POOL_SIZE` override are unchanged. The pinned pool-size tests are updated to the new arithmetic.

## Measured (16-CPU M-series host, 4-CPU Colima VM, resident non-test services on the same VM)

- Pool 4, quiet of other test load: **597/597 tests passed, 0 failed, 925s (15.4 min) total** including harness startup; `go test` itself stayed under its 15m `-timeout`.
- Pool 2 baseline (measured during CS0005 gates, same machine): 23+ min.
- The 6 tests that failed in an earlier contended run (`TestSkills_*`, `TestDungeonHidden_*`) pass individually AND concurrently at pool 4; that run was infra-death from VM contention (another suite's containers running simultaneously), not this change.

## Explicitly out of scope (tracked in campaign intent camp-integration-suite-exceeds-its-20260805)

- The post-suite teardown defect: runs can fail/hang *after* every test passes ("test package failed with no failing test"). It reproduced on this branch's clean run (597 pass → package fail) and on the pre-change baseline (442 pass → hang). Verbose diagnosis in progress; it predates this change and deserves its own fix.
- The resident app stack sharing the 4-CPU VM with test infra, which caps how much any pool sizing can help.