### PR TITLE
skills: add festival-intake and stop teaching scaffold-first planning

### DIFF
--- a/internal/scaffold/campaign/templates/.campaign/skills/fest-planning/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/fest-planning/SKILL.md.tmpl
@@ -5,9 +5,32 @@ description: Plan and scaffold festivals. Use when creating festival/phase/seque
 
 # Festival Planning
 
+## The Loop Is The Planning Process
+
+Create the festival, then drive `fest next`. It asks for one planning decision
+at a time and writes the structure as you answer.
+
+```bash
+fest create festival --type standard --name <name>
+fest next                     # answer what it asks
+# ...repeat until the plan is complete...
+fest validate
+```
+
+Do **not** scaffold every phase and sequence first and fill the `[REPLACE]`
+markers afterward. Scaffolding a large phase in one step writes hundreds of
+unfilled markers, drops `fest validate` from 100 to 0 with no partial-credit
+state, and creates pressure to fill them with plausible filler just to restore
+the score. The result is a green festival full of worthless tasks.
+
+The `fest create phase` / `fest create sequence` / `fest create task` commands
+below are for targeted additions to a plan that already exists, not for building
+one from scratch.
+
 ## Start Here
 
 ```bash
+fest understand planning
 fest understand methodology
 fest understand structure
 fest understand tasks
@@ -68,6 +91,8 @@ fest create phase --name "002_RESEARCH" --type research
 
 ```bash
 fest create festival
+
+# Targeted additions to an existing plan, not a way to build one
 fest create phase
 fest create sequence
 fest create task
@@ -75,6 +100,24 @@ fest create task
 fest promote
 fest validate
 ```
+
+## Task Quality (Not Checked By validate)
+
+`fest validate` scores structure, not substance. A festival of one-line tasks
+validates at 100. Task quality is on you.
+
+A task document is written for an agent that has none of the planning
+conversation's context. Tutorial-grade means:
+
+- It names the files it touches.
+- It states expected behavior, including error paths, not just the happy path.
+- It cites real `file:line` anchors you have actually opened. Never write an
+  anchor because it sounds plausible; open the file and verify it.
+- It says how to tell the task is done, in terms someone else could check.
+
+Plan the full scope. Do not trim work out of a plan to make it look achievable,
+and do not defer the hard parts to an invented later phase. Scaling down is the
+user's call, made against a complete plan.
 
 ## Link + FGO Navigation (Required for Project-Context Execution)
 
@@ -108,6 +151,9 @@ fest scaffold from-plan --plan STRUCTURE.md --name my-festival
 
 ## Common Mistakes
 
+- Scaffolding a whole phase of sequences up front, then filling `[REPLACE]`
+  markers. Drive `fest next` instead.
+- Writing thin task documents because `fest validate` still scores 100.
 - Using `fest link --project ...` (invalid).
 - Assuming an old link still works after changing project directory location.
 - Picking `implementation` type when requirements are still unclear (should be `standard` or `research` first).

--- a/internal/scaffold/campaign/templates/.campaign/skills/festival-intake/SKILL.md.tmpl
+++ b/internal/scaffold/campaign/templates/.campaign/skills/festival-intake/SKILL.md.tmpl
@@ -1,0 +1,93 @@
+---
+name: festival-intake
+description: Route work that is too large for a single chat into a structured plan. Use when the user describes a multi-step build, a migration, a rewrite, an audit, a refactor across many files, or a research question with several threads. Use when a goal would otherwise need step-by-step supervision across more than one session. Also use when the user says "plan this", "where do I start", "help me build X", "this is a big one", or hands over a spec, a ticket, or a document and asks what to do with it.
+---
+
+# Festival Intake
+
+This is the front door. Every other campaign skill assumes the user already
+knows what a festival is. This one does not, and it must fire before they do.
+
+When it fires, you owe the user the six steps below, in order. Do not skip
+straight to creating things.
+
+## Step 1: Size it out loud
+
+Say which gear this is and why, in one line, before doing anything else. The
+user learns the system has three gears by watching you pick one.
+
+| Signal | Route |
+| --- | --- |
+| One file, one session, reversible | Answer in chat. Create nothing. |
+| Linear, a handful of steps, one repo | `fest create workflow <name>` |
+| Multi-phase, multi-repo, needs review gates, or outlives a session | `fest create festival` |
+
+Most requests are the first row. Reaching for a festival on small work is a
+failure mode, not thoroughness. When it is genuinely between two rows, pick the
+smaller one and say you can promote it later.
+
+## Step 2: Show the shape, then ask
+
+Before scaffolding anything, present the proposed phases and the sequences under
+each, and get a yes.
+
+You already have everything you need to do this at that point in the
+conversation, so it costs nothing. It is the user's one chance to redirect
+before work gets written to disk, and it is what makes the rest of the run
+trustworthy.
+
+## Step 3: Plan through the loop, not by scaffolding
+
+Create the festival, then drive `fest next` and answer what it asks.
+
+Do **not** scaffold every phase and sequence up front and fill in the
+`[REPLACE]` markers afterward. That path looks faster and is the single worst
+thing you can do to a festival:
+
+- Scaffolding ten sequences at once writes hundreds of unfilled markers.
+- `fest validate` drops to 0 the moment they exist, and stays there.
+- The pressure is then to fill markers with plausible filler to restore the
+  score, which produces a green festival full of worthless tasks.
+
+`fest next` walks you through planning one decision at a time and never opens
+that window. The loop is the planning process, not just the execution process.
+
+## Step 4: Plan the full scope
+
+Plan the whole feature. Do not quietly trim scope to make the plan look
+achievable, and do not defer the hard parts to a "phase 2" you invented.
+
+If the work is genuinely too big, say so and plan it anyway. Scaling down is the
+user's decision to make against a complete plan, not yours to make by writing a
+smaller one.
+
+## Step 5: Write tutorial-grade tasks
+
+A task document is written for an agent that has none of this conversation's
+context. Assume the reader knows the codebase and nothing else.
+
+Every task should name the files it touches, state the expected behavior
+including error paths, and cite real `file:line` anchors you have actually
+opened. Do not write anchors that sound plausible; verify them.
+
+`fest validate` scores structure, not substance. A festival full of one-line
+tasks validates at 100. Nothing will catch a thin task except you.
+
+## Step 6: Execute with traceability
+
+- Commit with `fest commit` while executing a festival, never `camp commit`.
+- One worktree per repo the festival touches.
+- Mark tasks with `fest task completed` as you go, so `fest next` stays correct.
+
+## Where to go next
+
+| You are | Read |
+| --- | --- |
+| Choosing structure and types | `fest-planning` skill, `fest understand planning` |
+| Running an existing festival | `fest-execution` skill, `fest understand loop` |
+| Doing the linear version | `fest-standalone-workflows` skill |
+| Unsure where a document belongs | `campaign-structure` skill |
+| About to commit | `campaign-commit` skill |
+
+`fest understand` is the methodology in full. Read topics as you need them
+rather than all at once.

--- a/internal/scaffold/campaign/templates/AGENTS.md.tmpl
+++ b/internal/scaffold/campaign/templates/AGENTS.md.tmpl
@@ -48,9 +48,55 @@ This is the AI agent instruction file for the {{ .vars.campaign_name }} campaign
 
 ## AI Instructions
 
-<!-- Add specific instructions for AI agents -->
+These defaults apply until this campaign overrides them. Add your own below.
 
-Planning-layer rule of thumb: use `camp intent` for fast capture and small actionable work, `workflow/design/` for architecture or exploratory thinking, and festivals for structured multi-step execution. Intent state is stored under `.campaign/intents/`. Canonical guide: https://fest.build/guides/intent-design-festival/
+### Sizing work
+
+Say which gear you are in before creating anything:
+
+- One file, one session, reversible: answer in chat, create nothing.
+- Linear, a handful of steps: `fest create workflow <name>`.
+- Multi-phase, multi-repo, or outlives a session: `fest create festival`.
+
+Most requests are the first row. Reaching for a festival on small work is a
+failure mode, not thoroughness.
+
+### Planning a festival
+
+Create it, then drive `fest next` and answer what it asks. Do not scaffold every
+phase and sequence up front and fill the `[REPLACE]` markers afterward: it drops
+`fest validate` to 0 and produces plausible filler instead of a plan. The loop is
+the planning process.
+
+Plan the full scope. Scaling down is the user's call, made against a complete
+plan.
+
+### Task documents
+
+`fest validate` scores structure, not substance, so a festival of one-line tasks
+still validates at 100. Write each task for an agent with none of this
+conversation's context: name the files it touches, state error paths as well as
+the happy path, and cite `file:line` anchors you have actually opened.
+
+### Committing
+
+Never run raw `git commit` in a campaign.
+
+- Executing a festival: `fest commit -m "..."`
+- Inside `projects/*` or a worktree: `camp p commit -m "..."`
+- Campaign root files: `camp commit -m "..."`
+
+### Capturing work
+
+Use `camp intent` for fast capture and small actionable work, `workflow/design/`
+for architecture or exploratory thinking, and festivals for structured
+multi-step execution. Intent state lives under `.campaign/intents/`.
+Canonical guide: https://fest.build/guides/intent-design-festival/
+
+### Learning the methodology
+
+`fest understand` covers it in full. Read topics when you need them rather than
+all at once. Start with `fest understand planning` and `fest understand loop`.
 
 ---
 

--- a/internal/scaffold/init_test.go
+++ b/internal/scaffold/init_test.go
@@ -169,12 +169,43 @@ func TestInit(t *testing.T) {
 		".campaign/skills/campaign-commit/SKILL.md",
 		".campaign/skills/camp-projects/SKILL.md",
 		".campaign/skills/fest-execution/SKILL.md",
+		".campaign/skills/festival-intake/SKILL.md",
 	}
 	for _, relPath := range expectedSkillFiles {
 		path := filepath.Join(campaignDir, relPath)
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			t.Errorf("skill file %s was not created", relPath)
 		}
+	}
+
+	// festival-intake is the front door: its description must trigger on plain
+	// outcome language, because a new user has no festival vocabulary yet.
+	intakePath := filepath.Join(campaignDir, ".campaign", "skills", "festival-intake", "SKILL.md")
+	intakeSkill, err := os.ReadFile(intakePath)
+	if err != nil {
+		t.Fatalf("failed to read festival-intake skill: %v", err)
+	}
+	for _, phrase := range []string{"migration", "rewrite", "audit", "plan this", "where do I start"} {
+		if !strings.Contains(string(intakeSkill), phrase) {
+			t.Errorf("festival-intake description should trigger on %q", phrase)
+		}
+	}
+
+	// The planning skill must lead with the fest next loop. Teaching
+	// scaffold-first is what produces hundreds of unfilled [REPLACE] markers
+	// and a validate score of 0.
+	planningPath := filepath.Join(campaignDir, ".campaign", "skills", "fest-planning", "SKILL.md")
+	planningSkill, err := os.ReadFile(planningPath)
+	if err != nil {
+		t.Fatalf("failed to read fest-planning skill: %v", err)
+	}
+	if !strings.Contains(string(planningSkill), "The Loop Is The Planning Process") {
+		t.Error("fest-planning should lead with the fest next loop, not scaffolding")
+	}
+	loopIdx := strings.Index(string(planningSkill), "fest next")
+	createPhaseIdx := strings.Index(string(planningSkill), "fest create phase")
+	if loopIdx < 0 || createPhaseIdx < 0 || loopIdx > createPhaseIdx {
+		t.Error("fest-planning should introduce the fest next loop before fest create phase")
 	}
 	workflowSkillPath := filepath.Join(campaignDir, ".campaign", "skills", "campaign-workflows", "SKILL.md")
 	workflowSkill, err := os.ReadFile(workflowSkillPath)


### PR DESCRIPTION
## What

Ships the behavioral half of the campaign skill bundle. The installed product
shipped command reference; the rules that make a festival worth executing were
never distributed, so a cold-start agent gets the vocabulary and none of the
judgment.

### `festival-intake` (new)

The front door. Every existing skill's description gates on festival vocabulary
the user does not have yet ("Use when creating festival/phase/sequence/task
structure"), so a naive prompt like *"help me rebuild the auth system"* trips
nothing at all. The methodology is fully documented and unreachable.

This one triggers on outcome language instead: migration, rewrite, audit,
refactor, "plan this", "where do I start", "this is a big one", or handing over
a spec and asking what to do with it.

It then carries a six-step obligation:

1. Size it out loud (chat / standalone workflow / festival) so the user learns
   the system has three gears by watching you pick one.
2. Show the proposed phases and get a yes **before** scaffolding anything.
3. Plan through `fest next`, not by scaffolding.
4. Plan the full scope; scaling down is the user's call against a complete plan.
5. Write tutorial-grade tasks.
6. `fest commit` while executing, one worktree per repo.

### `fest-planning` (rewritten opening)

This is a live bug, not just an omission. The skill led with
`fest create festival` then `fest create phase` and never mentioned the loop.
That is exactly the path that produces the scaffold cliff:

- Scaffolding a large phase in one step writes hundreds of unfilled `[REPLACE]`
  markers.
- `fest validate` drops from 100 to 0 with no partial-credit state.
- Filling markers with plausible filler becomes the score-restoring move, which
  yields a green festival full of worthless tasks.

We were shipping the instruction that causes our own worst failure mode. It now
leads with the `fest next` loop and demotes `fest create phase/sequence/task` to
targeted additions to a plan that already exists.

Also adds a task-quality section: `fest validate` scores structure, not
substance, so a festival of one-line tasks validates at 100. Nothing catches a
thin task except the agent writing it.

### `AGENTS.md` template

The AI Instructions section was a single HTML comment. It now ships sizing,
planning, task-quality, and commit defaults, so the first file every harness
reads says something on a fresh install. The three genuinely campaign-specific
placeholders (Overview, Projects, Development Guidelines) are left alone.

## Testing

- `just test unit`: 4091 tests pass.
- New assertions in `internal/scaffold/init_test.go`: the intake skill is
  scaffolded, its description contains the outcome-language triggers, and
  `fest-planning` introduces the loop **before** `fest create phase` (ordering
  assertion, so a future edit cannot quietly re-invert it).
- Verified end to end against a fixture campaign outside this repo: `camp init`
  scaffolds `festival-intake`, the template renders, and `camp skills link`
  auto-projects it into `.claude/skills/` and `.agents/skills/`. No hardcoded
  skill lists needed updating (`//go:embed all:campaign` plus `os.ReadDir`).

## Gate note (pre-existing failure, not from this branch)

`just gate` fails on `lint-no-host-fs-tests`:

```
FAIL: NEW host-side git exec.Command in _test.go outside tests/integration/:
  ./cmd/camp/cmdutil/nothing_staged_test.go
  ./internal/git/tree_empty_test.go
```

Both files are on `main` and neither is touched here. The failure reproduces
with this branch's changes stashed. They need migrating to `tests/integration/`
or adding to the justfile allowlist; folding that into a skills PR would be the
wrong place for it.

`just fmt` also reformats three unrelated files (`cmd/camp/jobs.go`,
`cmd/camp/machine_tui.go`, `cmd/camp/machine_adopt_test.go`). Reverted here so
they do not ride along.

## Related

Part of WI-3d9b84. Companion PRs: fest #322 (`fest deps --ready`), and a festival
PR wiring the plugin bundles and a `workflows/` script that consumes it.
