### PR TITLE
fix(jobs): capture the files git would stage, not the files on disk

### DIFF
--- a/internal/git/tree.go
+++ b/internal/git/tree.go
@@ -3,7 +3,6 @@ package git
 import (
 	"bytes"
 	"context"
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -306,40 +305,52 @@ func CaptureBlobs(ctx context.Context, repoPath string, paths []string) ([]BlobR
 	return refs, nil
 }
 
-// captureDir captures every file under a directory.
+// captureDir captures the files under a directory that git would stage.
 //
-// The walk stops at a nested repository rather than descending into it. Git
+// The list comes from git rather than a filesystem walk, because a deferred
+// capture has to produce the same commit the synchronous path would. A walk
+// sees the disk, and the disk is not the set `git add <dir>` operates on: it
+// includes ignored files, which git would refuse, and it cannot see a tracked
+// file that was deleted, which git would record as a deletion. Asking
+// ls-files for cached plus non-ignored untracked entries is that set exactly,
+// including a file that is ignored but already tracked.
+//
+// It also stops at a nested repository rather than descending into it. Git
 // records such a directory as a gitlink, so its files are not part of this
 // repository's tree at all, and capturing them would both commit another
 // project's checkout inline and produce a `<dir>/.git` entry that git rejects
 // on every attempt, leaving a job that can never drain.
 func captureDir(ctx context.Context, repoPath, dir string) ([]BlobRef, error) {
-	var paths []string
-	root := filepath.Join(repoPath, filepath.FromSlash(dir))
-	err := filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, relErr := filepath.Rel(repoPath, p)
-		if relErr != nil {
-			return relErr
-		}
-		if d.IsDir() {
-			if isRepoBoundary(p) {
-				return camperrors.Wrapf(ErrNestedRepo, "%s", filepath.ToSlash(rel))
-			}
-			return nil
-		}
-		paths = append(paths, filepath.ToSlash(rel))
-		return nil
-	})
+	if isRepoBoundary(filepath.Join(repoPath, filepath.FromSlash(dir))) {
+		return nil, camperrors.Wrapf(ErrNestedRepo, "%s", dir)
+	}
+
+	out, err := Output(ctx, repoPath,
+		"ls-files", "--cached", "--others", "--exclude-standard", "-z", "--", dir)
 	if err != nil {
-		// The boundary error already names the repository it found, which is
-		// not always the directory the walk started from.
-		if errors.Is(err, ErrNestedRepo) {
-			return nil, err
-		}
 		return nil, camperrors.Wrapf(err, "capture directory %s", dir)
+	}
+
+	var paths []string
+	seen := make(map[string]struct{})
+	for entry := range strings.SplitSeq(strings.TrimRight(out, "\x00"), "\x00") {
+		if entry == "" {
+			continue
+		}
+		// A trailing slash is git declining to look inside: below an
+		// untracked path that means an embedded repository, the same boundary
+		// the check above catches when the capture starts on one.
+		if nested, ok := strings.CutSuffix(entry, "/"); ok {
+			return nil, camperrors.Wrapf(ErrNestedRepo, "%s", nested)
+		}
+		// An unmerged path is listed once per stage. Capturing it three times
+		// would stage the same blob three times rather than fail, so dedupe
+		// instead of rejecting.
+		if _, dup := seen[entry]; dup {
+			continue
+		}
+		seen[entry] = struct{}{}
+		paths = append(paths, entry)
 	}
 	return CaptureBlobs(ctx, repoPath, paths)
 }

--- a/tests/integration/capture_gitignore_test.go
+++ b/tests/integration/capture_gitignore_test.go
@@ -1,0 +1,152 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A deferred bookkeeping commit that names a directory must stage what
+// `git add <dir>` would stage, and nothing else.
+//
+// The deferred path captures content itself instead of letting git resolve the
+// paths later, which is what makes the commit mean its message. That capture
+// therefore has to reproduce git's own answer. Listing the directory off the
+// disk does not: the disk includes ignored files, and it cannot show a tracked
+// file that is no longer there.
+
+// setupIncludeCampaign builds a campaign with a workitem, so
+// `camp workitem commit --include <path>` has something to attribute a commit
+// to, and with an ignore rule to test against.
+func setupIncludeCampaign(t *testing.T, tc *TestContainer, name string) string {
+	t.Helper()
+	campPath, _ := setupDrainCampaign(t, tc, name)
+
+	const marker = `version: v1alpha6
+kind: workitem
+id: design-capture-2026-08-05
+type: design
+title: Capture
+ref: WI-cap123
+`
+	require.NoError(t, tc.WriteFile(campPath+"/workflow/design/capture/.workitem", marker))
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		printf '*.log\n' > .gitignore
+		git add .gitignore workflow/design/capture/.workitem
+		git commit -q -m "add an ignore rule and a workitem"
+	`, campPath))
+	return campPath
+}
+
+// headPaths returns every path in HEAD's tree.
+func headPaths(t *testing.T, tc *TestContainer, campPath string) []string {
+	t.Helper()
+	out := tc.GitOutput(t, campPath, "ls-tree", "-r", "--name-only", "HEAD")
+	var paths []string
+	for line := range strings.SplitSeq(out, "\n") {
+		if p := strings.TrimSpace(line); p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths
+}
+
+// An ignored file inside a captured directory must not be committed. The
+// synchronous path never staged it, so the deferred path committing it is a
+// difference the user did not ask for and would not see until it was in the
+// history.
+func TestIntegration_DeferredDirectoryCaptureSkipsIgnoredFiles(t *testing.T) {
+	tc := GetSharedContainer(t)
+	tc.EnableDeferral()
+	campPath := setupIncludeCampaign(t, tc, "capture-ignored")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p payload
+		printf 'keep me\n' > payload/keep.md
+		printf 'noisy output\n' > payload/debug.log
+	`, campPath))
+
+	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath,
+		"workitem", "commit", "--workitem", "capture", "--include", "payload", "-m", "capture payload")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "stdout:\n%s\nstderr:\n%s", stdout, stderr)
+
+	drainJobs(t, tc, campPath)
+
+	paths := headPaths(t, tc, campPath)
+	assert.Contains(t, paths, "payload/keep.md",
+		"the non-ignored file must be committed; HEAD:\n%s", strings.Join(paths, "\n"))
+	assert.NotContains(t, paths, "payload/debug.log",
+		"an ignored file must not reach the commit; HEAD:\n%s", strings.Join(paths, "\n"))
+}
+
+// A file that is ignored but already tracked still belongs in the commit.
+// Git keeps staging changes to it, because the ignore rule governs what gets
+// added, not what stays tracked, and a capture that dropped it would silently
+// discard a change the user made.
+func TestIntegration_DeferredDirectoryCaptureKeepsTrackedIgnoredFiles(t *testing.T) {
+	tc := GetSharedContainer(t)
+	tc.EnableDeferral()
+	campPath := setupIncludeCampaign(t, tc, "capture-tracked-ignored")
+
+	// Force-added, so it is tracked despite matching *.log.
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p payload
+		printf 'original\n' > payload/tracked.log
+		git add -f payload/tracked.log
+		git commit -q -m "track a file that matches the ignore rule"
+		printf 'edited\n' > payload/tracked.log
+	`, campPath))
+
+	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath,
+		"workitem", "commit", "--workitem", "capture", "--include", "payload", "-m", "capture payload")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "stdout:\n%s\nstderr:\n%s", stdout, stderr)
+
+	drainJobs(t, tc, campPath)
+
+	content := tc.GitOutput(t, campPath, "show", "HEAD:payload/tracked.log")
+	assert.Contains(t, content, "edited",
+		"a tracked file must be captured even when it matches an ignore rule; got %q", content)
+}
+
+// A tracked file deleted from inside a captured directory must be recorded as
+// the deletion it is. A disk listing cannot see it at all, so the commit
+// silently kept the old content and the user's removal did not land.
+func TestIntegration_DeferredDirectoryCaptureRecordsDeletions(t *testing.T) {
+	tc := GetSharedContainer(t)
+	tc.EnableDeferral()
+	campPath := setupIncludeCampaign(t, tc, "capture-deletions")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		mkdir -p payload
+		printf 'gone soon\n' > payload/doomed.md
+		printf 'stays\n' > payload/kept.md
+		git add payload
+		git commit -q -m "add payload files"
+		rm payload/doomed.md
+	`, campPath))
+
+	stdout, stderr, exitCode, err := tc.RunCampSplitInDir(campPath,
+		"workitem", "commit", "--workitem", "capture", "--include", "payload", "-m", "remove doomed")
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode, "stdout:\n%s\nstderr:\n%s", stdout, stderr)
+
+	drainJobs(t, tc, campPath)
+
+	paths := headPaths(t, tc, campPath)
+	assert.NotContains(t, paths, "payload/doomed.md",
+		"a deleted tracked file must not survive in the commit; HEAD:\n%s", strings.Join(paths, "\n"))
+	assert.Contains(t, paths, "payload/kept.md",
+		"the remaining file must still be committed; HEAD:\n%s", strings.Join(paths, "\n"))
+}


### PR DESCRIPTION
> Follows #541, which merged while this was in progress. Rebased onto `main`, so this is a single commit against `main`. The unit test added to #541 in 15430c1 still passes against the rewritten `captureDir`; it is the same boundary contract, reached a different way.

## Why

A deferred bookkeeping commit captures content itself rather than letting git resolve the paths later. That is what makes the commit mean its message: an edit made between the enqueue and the run cannot land under the earlier operation's description.

The consequence is that the capture has to reproduce git's own answer, and for a directory it did not. `captureDir` listed the directory off the disk with `filepath.WalkDir`, and the disk is not the set `git add <dir>` operates on.

Two differences, both confirmed by running the tests in this PR against the unfixed code:

**Ignored files were committed.** A walk sees `payload/debug.log`; `git add payload` does not. `CommitBlobs` stages each captured blob with `git update-index --cacheinfo`, which bypasses exclude rules entirely, so the file landed in history. The synchronous path never staged it. Nothing told the user.

**Deletions were dropped.** A tracked file removed from inside a captured directory is invisible to a walk, so the capture kept the old blob and the removal did not land. `git add payload` records it as a deletion.

Reachable today through `camp workitem commit --include <dir>`, which appends the include path verbatim to the staging plan (`internal/commands/workitem/staging_paths.go:23`). Both tests fail on the current code with exactly those symptoms.

Not reachable through the most common workitem path: `camp workitem commit` without `--include` builds its plan from `git status --porcelain --untracked-files=all` (`internal/commands/workitem/staging_git.go:39`), so it passes individual files git already filtered.

## The fix

`captureDir` asks git for the file list instead of walking:

```
git ls-files --cached --others --exclude-standard -z -- <dir>
```

Cached plus non-ignored untracked is exactly the set `git add` would take, and it gets the three cases right for the same reason git does:

- an ignored, untracked file is absent
- an ignored file that is **already tracked** is present, because the ignore rule governs what gets added, not what stays tracked
- a tracked file deleted from disk is still listed, so `CaptureBlobs` records it as a deletion

Two details the listing also settles:

**Nested repositories.** Git declines to look inside one and reports it with a trailing slash (`dir/deep/nested/`) when untracked, or as a single gitlink entry (`dir/sub`) when tracked. The first is rejected directly; the second recurses into `captureDir` and hits the boundary check from #541. Verified both shapes against real git before relying on them.

**Unmerged paths** are listed once per stage, so entries are deduped rather than staged three times.

## Tests

`tests/integration/capture_gitignore_test.go`, driving `camp workitem commit --include payload` with deferral on and draining the queue:

| test | on current code |
| --- | --- |
| ignored file must not reach the commit | **fails**, `payload/debug.log` is in HEAD |
| deleted tracked file must not survive | **fails**, `payload/doomed.md` is in HEAD |
| tracked-but-ignored file must still be captured | passes |

The third is a regression guard on the fix, not a bug repro. The old walk captured everything, so it was already correct there; it would break under a naive `check-ignore` filter, which is why it is pinned.

Note for anyone re-running these: `just test integration-run` has no `-count=1`, and the integration package does not import the code under test, so a rebuilt binary does not invalidate Go's test cache. The red runs above were done with `-count=1`.

## Gate

Lint 0 issues on both profiles, the `fmt.Errorf` ratchet clean, builds and vet clean on stable, dev, and integration, and `internal/git` plus `internal/git/commit` green.

`just gate` still stops at `lint-no-host-fs-tests`, which is `main`'s pre-existing failure, not this branch's: #545 migrates the two host-FS test files that trip it.

One flake seen and chased down: a `just test unit` run reported `internal/sync` failing. It passes standalone twice, passes under `go test ./...`, and `main` at the same commit passes all 4091. Unrelated to this change, and `internal/sync` is untouched here.
