### PR TITLE
fix: stale conflict-tally assertion, and stop a collapsed run reporting as failed tests

### DIFF
--- a/internal/buildutil/tasks/integration.go
+++ b/internal/buildutil/tasks/integration.go
@@ -33,7 +33,14 @@ type IntegrationResult struct {
 	Duration    time.Duration
 	TestsPassed int
 	TestsFailed int
-	FailedTests []string // Names of failed tests
+	// TestsSkipped is counted because the integration harness turns
+	// infrastructure death into skips: once the container pool cannot be
+	// reset, every later test t.Skips rather than failing. Left uncounted, a
+	// run that collapsed after 44 of 905 tests reported "23/44 tests passed",
+	// which reads as a healthy suite with a few broken tests instead of a run
+	// that never happened.
+	TestsSkipped int
+	FailedTests  []string // Names of failed tests
 	// SuiteError is a failure of the run itself rather than of any test: a
 	// build error, a panic that took the process down, a timeout. Kept apart
 	// from FailedTests because it is not a test and must not be counted as
@@ -112,7 +119,7 @@ func Integration(verbose bool) error {
 		start := time.Now()
 
 		var pass bool
-		var testsPassed, testsFailed int
+		var testsPassed, testsFailed, testsSkipped int
 		var failedTests []string
 		var suiteError string
 		var packageFailed bool
@@ -236,6 +243,10 @@ func Integration(verbose bool) error {
 						if !strings.Contains(event.Test, "/") {
 							testsFailed++
 						}
+					case "skip":
+						if !strings.Contains(event.Test, "/") {
+							testsSkipped++
+						}
 					}
 				} else if event.Action == "fail" {
 					// A fail with no test name is the package failing as a
@@ -264,13 +275,14 @@ func Integration(verbose bool) error {
 		duration := time.Since(start)
 
 		results = append(results, IntegrationResult{
-			Suite:       name,
-			Pass:        pass,
-			Duration:    duration,
-			TestsPassed: testsPassed,
-			TestsFailed: testsFailed,
-			FailedTests: failedTests,
-			SuiteError:  suiteError,
+			Suite:        name,
+			Pass:         pass,
+			Duration:     duration,
+			TestsPassed:  testsPassed,
+			TestsFailed:  testsFailed,
+			TestsSkipped: testsSkipped,
+			FailedTests:  failedTests,
+			SuiteError:   suiteError,
 		})
 
 		if !pass {
@@ -284,12 +296,14 @@ func Integration(verbose bool) error {
 	var totalTime time.Duration
 	totalTestsPassed := 0
 	totalTestsFailed := 0
+	totalTestsSkipped := 0
 	for _, r := range results {
 		totalTime += r.Duration
 		totalTestsPassed += r.TestsPassed
 		totalTestsFailed += r.TestsFailed
+		totalTestsSkipped += r.TestsSkipped
 	}
-	totalTests := totalTestsPassed + totalTestsFailed
+	totalTests := totalTestsPassed + totalTestsFailed + totalTestsSkipped
 
 	// Display summary - show failed tests as individual rows
 	rows := [][]string{}
@@ -332,7 +346,7 @@ func Integration(verbose bool) error {
 	}
 
 	// Add totals row
-	totalStatus := fmt.Sprintf("%d/%d tests passed", totalTestsPassed, totalTests)
+	totalStatus := testTally(totalTestsPassed, totalTests, totalTestsSkipped)
 	if ui.ColourEnabled() {
 		if totalTestsFailed > 0 {
 			totalStatus = ui.Red + totalStatus + ui.Reset
@@ -360,6 +374,24 @@ func Integration(verbose bool) error {
 	}
 
 	return nil
+}
+
+// testTally renders the headline count most people read instead of the run.
+//
+// Skips are in the denominator, and called out when there are any, because
+// this harness expresses infrastructure death as skips: once the container
+// pool stops resetting, every later test t.Skips (see TestMain in
+// tests/integration). Counting only pass and fail made the denominator shrink
+// to whatever ran, so a run that collapsed after 44 of 905 tests reported
+// "23/44 tests passed" beside 21 red rows. That reads as a branch that broke
+// 21 tests. It was a run that never happened, and the 21 all pass on an idle
+// machine.
+func testTally(passed, total, skipped int) string {
+	tally := fmt.Sprintf("%d/%d tests passed", passed, total)
+	if skipped > 0 {
+		tally += fmt.Sprintf(" (%d skipped)", skipped)
+	}
+	return tally
 }
 
 // classifyRunFailure decides whether a `go test` process failure is news, and

--- a/internal/buildutil/tasks/integration_test.go
+++ b/internal/buildutil/tasks/integration_test.go
@@ -105,6 +105,58 @@ func TestClassifyRunFailure(t *testing.T) {
 	}
 }
 
+// The denominator has to be the suite, not the part of it that ran.
+//
+// The integration harness reports infrastructure death as skips, so a run that
+// dies early leaves hundreds of tests that never executed. Counting only pass
+// and fail shrank the denominator to match, and a collapsed run rendered as
+// "23/44 tests passed" — a healthy-looking suite with a few broken tests,
+// which is the opposite of what happened.
+func TestTestTally(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		passed  int
+		total   int
+		skipped int
+		want    string
+	}{
+		{
+			name:   "a clean run says nothing about skips",
+			passed: 905,
+			total:  905,
+			want:   "905/905 tests passed",
+		},
+		{
+			// The run that prompted this: 21 red rows, and every one of them
+			// passes on an idle machine.
+			name:    "a collapsed run cannot hide behind a shrunken denominator",
+			passed:  23,
+			total:   905,
+			skipped: 861,
+			want:    "23/905 tests passed (861 skipped)",
+		},
+		{
+			name:    "an ordinary skip is still reported",
+			passed:  896,
+			total:   905,
+			skipped: 8,
+			want:    "896/905 tests passed (8 skipped)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := testTally(tt.passed, tt.total, tt.skipped); got != tt.want {
+				t.Fatalf("testTally(%d, %d, %d) = %q, want %q",
+					tt.passed, tt.total, tt.skipped, got, tt.want)
+			}
+		})
+	}
+}
+
 // Whatever it reports, it is never a test name. The summary lists failed tests
 // by name so they can be rerun; a line that cannot be rerun must not look like
 // one of them.

--- a/tests/integration/artifacts_from_ssh_test.go
+++ b/tests/integration/artifacts_from_ssh_test.go
@@ -61,7 +61,7 @@ printf 'BETA-PEER-V2-LONGER' > %[1]s/beta.bin
 
 	out2, err := tc.RunCampInDir(localRoot, "sync", "--artifacts-only", "--from", loopbackMachineID)
 	require.NoError(t, err, "second artifact sync failed: %s", out2)
-	require.Contains(t, out2, "conflicts kept local", "second pull should report the kept conflict: %s", out2)
+	require.Contains(t, out2, "1 conflict kept local", "second pull should report the kept conflict: %s", out2)
 	require.Contains(t, out2, "alpha.bin (local edit preserved", "the conflicting file should be named: %s", out2)
 
 	requireFileContent(t, tc, localArtifactRoot+"/alpha.bin", "ALPHA-LOCAL-EDIT")


### PR DESCRIPTION
## What prompted this

A `just test integration` run reported 21 failed tests out of 44 in 160.50s. None of the 21 are broken.

A full run of the same suite on an idle machine, same pool config:

```
PASS=896  FAIL=1  SKIP=8
--- FAIL: TestArtifactsPullOverSSH_TransfersAndProtects (29.89s)
FAIL	github.com/Obedience-Corp/camp/tests/integration	1148.529s
```

Every one of the 21 passes. The reported run collapsed after ~5% of the suite (160s against 1148s) and the rest never executed.

## The real failure

`conflictCount()` landed in 2ae0e892 (CS0005, #550) so sync output renders "1 conflict kept local" rather than "1 conflicts kept local":

```go
func conflictCount(n int) string {
	if n == 1 {
		return "1 conflict"
	}
	return fmt.Sprintf("%d conflicts", n)
}
```

The assertion in `artifacts_from_ssh_test.go:64` dates from 685a0385, three weeks earlier, and hardcodes the plural. The fixture creates exactly one conflict, so it can never match again:

```
Error: "...(synced; 1 conflict kept local)..." does not contain "conflicts kept local"
```

Now asserts `"1 conflict kept local"`, which pins the pluralization rather than working around it.

## Why 21 healthy tests were reported as failures

`tests/integration/main_test.go` deliberately turns Docker-headroom death into skips: once the container pool stops resetting, the run arms an infrastructure banner and every later checkout calls `t.Skip`. Its own comment records a prior incident of "474 of 572 tests failing" this way on a branch where nothing was wrong.

The summary in `internal/buildutil/tasks/integration.go` switched on `run`, `pass`, and `fail` — there was no `skip` case, so skipped tests were dropped from the totals entirely. The denominator shrank to whatever ran, and a dead run rendered as "23/44 tests passed" beside 21 red rows: a healthy-looking suite with a few broken tests, which is the inverse of what happened.

Skips now count toward the total and are named when present. That same run reads:

```
23/905 tests passed (861 skipped)
```

This is the failure mode `classifyRunFailure` was already written for — the summary is the only thing most people read after a run, so its count has to mean what it says.

## Not changed

Pool sizing. Pool 4 on a 4-CPU Colima VM passed 896/905 here with no infrastructure banner, so 25e8a4a1's tuning looks right. The collapse points to contention on the VM, and the harness already names the lever (`CAMP_TEST_POOL_SIZE`).

## Verification

- `just gate` — PASSED (both profiles: builds, vet stable/dev/integration, lint stable/dev, dev + stable unit tests)
- `just test integration-run TestArtifactsPullOverSSH_TransfersAndProtects` — `ok ... 61.698s`
- `go test ./internal/buildutil/...` — ok, including the new `TestTestTally` table
