### PR TITLE
feat(stageguard): keep undeclared nested repos out of commits

### DIFF
--- a/cmd/camp/cmdutil/guardreport.go
+++ b/cmd/camp/cmdutil/guardreport.go
@@ -31,8 +31,9 @@ import (
 // cannot read yet is nothing to act on, while git being broken is.
 func GuardUnavailableLine(cause error) string {
 	return fmt.Sprintf(
-		"Staged without the size and bulk guard: %v\n"+
-			"  Large files were not checked. Run 'camp doctor -c bigfiles' if you want to look.",
+		"Staged without the staging guard: %v\n"+
+			"  Large files and nested repositories were not checked.\n"+
+			"  Run 'camp doctor -c bigfiles' and 'camp doctor -c orphan' if you want to look.",
 		cause)
 }
 
@@ -52,6 +53,8 @@ type GuardHandling struct {
 	ProjectExcluded []RefusedFile
 	// TrackedGrowth holds tracked files reported but always committed.
 	TrackedGrowth []stageguard.GuardViolation
+	// NestedRepos holds nested git repositories kept out of the commit.
+	NestedRepos []stageguard.GuardViolation
 }
 
 // DeclaredRoot records one artifact root camp declared, or reused.
@@ -114,7 +117,14 @@ func HandleStageOutcome(
 		_, _ = fmt.Fprintln(out, ui.Warning(GuardUnavailableLine(outcome.Unavailable)))
 	}
 
-	handling := &GuardHandling{TrackedGrowth: outcome.Reported}
+	handling := &GuardHandling{
+		TrackedGrowth: outcome.Reported,
+		// Nested repositories are recorded identically in both scopes. Unlike a
+		// large file, the answer does not depend on whether this is a campaign
+		// or a project: an undeclared gitlink breaks submodule commands the same
+		// way in either, and the remedy is the same url either would need.
+		NestedRepos: outcome.NestedRepos,
+	}
 
 	if outcome.Limits.ScopeProject {
 		for _, v := range outcome.Excluded {
@@ -282,9 +292,34 @@ func renderGuardHandling(
 	for _, p := range handling.ProjectExcluded {
 		renderProjectExclusion(out, p)
 	}
+	for _, n := range handling.NestedRepos {
+		renderNestedRepo(out, n)
+	}
 	for _, t := range handling.TrackedGrowth {
 		renderTrackedGrowth(out, t, limits)
 	}
+}
+
+// renderNestedRepo reports a nested git repository kept out of the commit.
+//
+// The consequence is stated before the remedies because it is not one users
+// can be expected to know: committing the directory looks like it worked, and
+// the damage only surfaces later, in someone else's clone, as a submodule
+// command that will not run. A line that only said "excluded" would read as
+// camp being fussy about a directory the user could see was fine.
+func renderNestedRepo(out io.Writer, v stageguard.GuardViolation) {
+	at := ""
+	if v.Head != "" {
+		at = " at " + v.Head
+	}
+	_, _ = fmt.Fprintf(out, "%s %s is its own git repository%s; it was left out of this commit\n",
+		ui.WarningIcon(), v.Path, at)
+	_, _ = fmt.Fprintf(out, "  Committing it records a submodule reference with no url behind it, which\n")
+	_, _ = fmt.Fprintf(out, "  makes 'git submodule' fail in this repo and every clone of it. Its contents\n")
+	_, _ = fmt.Fprintf(out, "  would not reach the remote either.\n")
+	_, _ = fmt.Fprintf(out, "    if it should be a submodule   git submodule add <url> %s\n", v.Path)
+	_, _ = fmt.Fprintf(out, "    if it does not belong here    echo '%s/' >> .gitignore\n", v.Path)
+	_, _ = fmt.Fprintf(out, "    if you meant it as a gitlink  --commit-nested\n")
 }
 
 // renderDeclaredRoot reports a root camp declared or reused.
@@ -447,7 +482,7 @@ func (h *GuardHandling) ExcludedAnything() bool {
 	if h == nil {
 		return false
 	}
-	if len(h.Refused) > 0 || len(h.ProjectExcluded) > 0 {
+	if len(h.Refused) > 0 || len(h.ProjectExcluded) > 0 || len(h.NestedRepos) > 0 {
 		return true
 	}
 	for _, d := range h.Declared {
@@ -482,10 +517,40 @@ func RenderGuardRefusal(out io.Writer, err error, commandName string) bool {
 	switch blocked.Kind {
 	case stageguard.Bulk:
 		renderBulkRefusal(out, blocked, commandName)
+	case stageguard.NestedRepo:
+		renderNestedRepoRefusal(out, blocked, commandName)
 	default:
 		renderLargeFileRefusal(out, blocked, commandName)
 	}
 	return true
+}
+
+// renderNestedRepoRefusal writes the report for commit.guards.nested_repos set
+// to block, where nothing was staged at all.
+func renderNestedRepoRefusal(out io.Writer, blocked *git.GuardBlockedError, commandName string) {
+	_, _ = fmt.Fprintf(out, "Error: %s not declared in .gitmodules would be committed\n\n",
+		pluralRepos(len(blocked.Violations)))
+	for _, v := range blocked.Violations {
+		head := v.Head
+		if head == "" {
+			head = "no commits"
+		}
+		_, _ = fmt.Fprintf(out, "  %s   %s\n", v.Path, head)
+	}
+	_, _ = fmt.Fprintf(out, "\nNothing was staged. commit.guards.nested_repos is set to block:\n\n")
+	for _, v := range blocked.Violations {
+		_, _ = fmt.Fprintf(out, "  make it a submodule   git submodule add <url> %s\n", v.Path)
+	}
+	_, _ = fmt.Fprintf(out, "  keep it out of git    echo '<path>/' >> .gitignore\n")
+	_, _ = fmt.Fprintf(out, "  commit it anyway      %s --commit-nested -m \"...\"\n", commandName)
+	_, _ = fmt.Fprintf(out, "  exclude and continue  camp settings set local.commit.guards.nested_repos exclude\n")
+}
+
+func pluralRepos(n int) string {
+	if n == 1 {
+		return "1 nested git repository"
+	}
+	return ui.FormatCount(n) + " nested git repositories"
 }
 
 func renderBulkRefusal(out io.Writer, blocked *git.GuardBlockedError, commandName string) {

--- a/cmd/camp/commit.go
+++ b/cmd/camp/commit.go
@@ -61,6 +61,7 @@ var (
 	commitWorkitem    string
 	commitNoEdit      bool
 	commitLarge       bool
+	commitNested      bool
 	commitJSONOut     bool
 	commitNoDrain     bool
 )
@@ -76,6 +77,7 @@ func init() {
 	commitCmd.Flags().BoolVar(&commitAutoWrite, "auto-write", false, "Run configured commit message writer")
 	commitCmd.Flags().StringVar(&commitWorkitem, "workitem", "", "explicit workitem selector for the commit tag (overrides cwd-based resolution)")
 	commitCmd.Flags().BoolVar(&commitLarge, "commit-large", false, "Commit over-threshold files instead of keeping them out of git")
+	commitCmd.Flags().BoolVar(&commitNested, "commit-nested", false, "Commit undeclared nested git repositories as gitlinks instead of keeping them out of git")
 	commitCmd.Flags().BoolVar(&commitJSONOut, "json", false, "Emit a JSON result on stdout; human output goes to stderr")
 	commitCmd.Flags().BoolVar(&commitNoDrain, "no-drain", false, "Do not wait for camp's queued commits first")
 
@@ -213,7 +215,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 		)
 		if target.IsSubmodule || commitIncludeRefs {
 			guardOutcome, stageErr = git.StageWithGuardOptions(
-				ctx, target.Path, nil, git.StageOptions{CommitLarge: commitLarge})
+				ctx, target.Path, nil, git.StageOptions{CommitLarge: commitLarge, CommitNested: commitNested})
 		} else {
 			// Campaign root: exclude submodule refs to prevent accidental
 			// ref changes from polluting content commits.
@@ -222,7 +224,7 @@ func runCommit(cmd *cobra.Command, args []string) error {
 				return pathErr
 			}
 			guardOutcome, stageErr = git.StageAllExcludingWithGuardOptions(
-				ctx, target.Path, paths, git.StageOptions{CommitLarge: commitLarge})
+				ctx, target.Path, paths, git.StageOptions{CommitLarge: commitLarge, CommitNested: commitNested})
 			if stageErr == nil {
 				// git add rejects exclude pathspecs whose target contains
 				// gitignored entries, so worktrees are unstaged after staging

--- a/cmd/camp/commit_json.go
+++ b/cmd/camp/commit_json.go
@@ -67,6 +67,14 @@ type excludedFileJSON struct {
 	//   size_guard_blocked   over the threshold under large_files: block
 	//   bulk_guard           a bulk directory refused the whole commit; Path
 	//                        is the directory and Size its total
+	//   nested_repo_blocked  a nested repository refused the whole commit
+	//                        under nested_repos: block
+	//
+	// And one that is neither a size finding nor a refusal:
+	//
+	//   nested_repo          an undeclared nested git repository; Path is the
+	//                        directory and Size is 0, since nothing was
+	//                        measured
 	Reason string `json:"reason"`
 	// ArtifactRoot is the root camp declared, set only for size_guard.
 	ArtifactRoot string `json:"artifact_root,omitempty"`
@@ -82,6 +90,12 @@ const (
 	reasonSizeGuardBlocked = "size_guard_blocked"
 	// reasonBulkGuard is a bulk directory that refused the whole commit.
 	reasonBulkGuard = "bulk_guard"
+	// reasonNestedRepo is an undeclared nested git repository excluded from
+	// the commit.
+	reasonNestedRepo = "nested_repo"
+	// reasonNestedRepoBlocked is a nested repository under nested_repos:
+	// block, where camp refused rather than excluding-and-continuing.
+	reasonNestedRepoBlocked = "nested_repo_blocked"
 )
 
 // newCommitJSONResult builds the document with every slice initialized.
@@ -119,6 +133,11 @@ func (r *commitJSONResult) applyGuardHandling(h *cmdutil.GuardHandling) {
 	for _, f := range h.ProjectExcluded {
 		r.Excluded = append(r.Excluded, excludedFileJSON{
 			Path: f.Violation.Path, Size: f.Violation.Size, Reason: f.Reason,
+		})
+	}
+	for _, v := range h.NestedRepos {
+		r.Excluded = append(r.Excluded, excludedFileJSON{
+			Path: v.Path, Size: v.Size, Reason: reasonNestedRepo,
 		})
 	}
 }
@@ -160,8 +179,11 @@ func (r *commitJSONResult) applyGuardRefusal(blocked *git.GuardBlockedError) {
 	r.Repo = blocked.RepoPath
 
 	reason := reasonSizeGuardBlocked
-	if blocked.Kind == stageguard.Bulk {
+	switch blocked.Kind {
+	case stageguard.Bulk:
 		reason = reasonBulkGuard
+	case stageguard.NestedRepo:
+		reason = reasonNestedRepoBlocked
 	}
 	for _, v := range blocked.Violations {
 		path := v.Path

--- a/cmd/camp/project/commit.go
+++ b/cmd/camp/project/commit.go
@@ -58,6 +58,7 @@ var (
 	projectCommitAutoWrite bool
 	projectCommitWorkitem  string
 	projectCommitLarge     bool
+	projectCommitNested    bool
 	projectCommitNoDrain   bool
 )
 
@@ -71,6 +72,7 @@ func init() {
 	projectCommitCmd.Flags().BoolVar(&projectCommitAutoWrite, "auto-write", false, "Run configured commit message writer")
 	projectCommitCmd.Flags().StringVar(&projectCommitWorkitem, "workitem", "", "explicit workitem selector for the commit tag (overrides cwd-based resolution)")
 	projectCommitCmd.Flags().BoolVar(&projectCommitLarge, "commit-large", false, "Commit over-threshold files instead of keeping them out of git")
+	projectCommitCmd.Flags().BoolVar(&projectCommitNested, "commit-nested", false, "Commit undeclared nested git repositories as gitlinks instead of keeping them out of git")
 	projectCommitCmd.Flags().BoolVar(&projectCommitNoDrain, "no-drain", false, "Do not wait for camp's queued commits first")
 
 	if err := projectCommitCmd.RegisterFlagCompletionFunc("project", cmdutil.CompleteProjectName); err != nil {
@@ -170,7 +172,7 @@ func runProjectCommit(cmd *cobra.Command, args []string) error {
 	// Stage if requested
 	if projectCommitAll {
 		fmt.Println(ui.Info("Staging changes..."))
-		guardOutcome, stageErr := git.StageWithGuardOptions(ctx, resolvedPath, nil, git.StageOptions{CommitLarge: projectCommitLarge})
+		guardOutcome, stageErr := git.StageWithGuardOptions(ctx, resolvedPath, nil, git.StageOptions{CommitLarge: projectCommitLarge, CommitNested: projectCommitNested})
 		if stageErr != nil {
 			return camperrors.Wrap(stageErr, "failed to stage")
 		}

--- a/cmd/camp/worktrees/commit.go
+++ b/cmd/camp/worktrees/commit.go
@@ -29,6 +29,7 @@ var (
 	wtCommitNoDrain   bool
 	wtCommitWorkitem  string
 	wtCommitLarge     bool
+	wtCommitNested    bool
 )
 
 var worktreesCommitCmd = &cobra.Command{
@@ -70,6 +71,8 @@ func init() {
 		"Run configured commit message writer")
 	worktreesCommitCmd.Flags().BoolVar(&wtCommitLarge, "commit-large", false,
 		"Commit over-threshold files instead of keeping them out of git")
+	worktreesCommitCmd.Flags().BoolVar(&wtCommitNested, "commit-nested", false,
+		"Commit undeclared nested git repositories as gitlinks instead of keeping them out of git")
 	worktreesCommitCmd.Flags().StringVar(&wtCommitWorkitem, "workitem", "",
 		"explicit workitem selector for the commit tag (overrides cwd-based resolution)")
 }
@@ -247,7 +250,7 @@ func stageWorktreeWithGuard(
 	ctx context.Context, cmd *cobra.Command, campRoot, worktreePath string,
 ) (excludedEverything bool, err error) {
 	outcome, err := git.StageWithGuardOptions(ctx, worktreePath, nil,
-		git.StageOptions{CommitLarge: wtCommitLarge})
+		git.StageOptions{CommitLarge: wtCommitLarge, CommitNested: wtCommitNested})
 	if err != nil {
 		return false, err
 	}

--- a/docs/cli-reference/camp_commit.md
+++ b/docs/cli-reference/camp_commit.md
@@ -38,6 +38,7 @@ camp commit [flags]
       --amend                 Amend the previous commit
       --auto-write            Run configured commit message writer
       --commit-large          Commit over-threshold files instead of keeping them out of git
+      --commit-nested         Commit undeclared nested git repositories as gitlinks instead of keeping them out of git
   -h, --help                  help for commit
       --include-refs          Include submodule ref changes when staging at campaign root
       --json                  Emit a JSON result on stdout; human output goes to stderr

--- a/docs/cli-reference/camp_project_commit.md
+++ b/docs/cli-reference/camp_project_commit.md
@@ -32,6 +32,7 @@ camp project commit [flags]
       --amend                 Amend the previous commit
       --auto-write            Run configured commit message writer
       --commit-large          Commit over-threshold files instead of keeping them out of git
+      --commit-nested         Commit undeclared nested git repositories as gitlinks instead of keeping them out of git
   -h, --help                  help for commit
   -m, --message stringArray   Commit message (repeatable; multiple -m are joined git-style into subject + body; required unless --auto-write)
       --no-drain              Do not wait for camp's queued commits first

--- a/internal/config/guards.go
+++ b/internal/config/guards.go
@@ -36,6 +36,11 @@ type GuardsConfig struct {
 	// no "auto" -- camp cannot infer whether a large untracked tree wants
 	// gitignore or an artifact root.
 	Bulk string `yaml:"bulk,omitempty"`
+	// NestedRepos selects the nested-repository guard mode: "exclude" (keep the
+	// nested checkout out of the commit and report), "block" (refuse), or
+	// "off". There is deliberately no "auto": excluding already is the complete
+	// fix, so there would be nothing for an auto mode to additionally do.
+	NestedRepos string `yaml:"nested_repos,omitempty"`
 	// Allow lists globs exempt from every guard, for the legitimate large file
 	// committed once.
 	Allow []string `yaml:"allow,omitempty"`
@@ -58,6 +63,7 @@ type GuardsConfig struct {
 type GuardsProjectConfig struct {
 	LargeFiles    *string `yaml:"large_files,omitempty"`
 	Bulk          *string `yaml:"bulk,omitempty"`
+	NestedRepos   *string `yaml:"nested_repos,omitempty"`
 	MaxFileSize   *string `yaml:"max_file_size,omitempty"`
 	MaxAddedFiles *int    `yaml:"max_added_files,omitempty"`
 	// Allow, when non-nil (including an explicit empty list), entirely replaces
@@ -84,6 +90,15 @@ func (g GuardsConfig) ResolveBulkMode(projectName string) string {
 		return *pc.Bulk
 	}
 	return g.Bulk
+}
+
+// ResolveNestedReposMode returns the nested-repository guard mode for
+// projectName, preferring a project override over the campaign-wide value.
+func (g GuardsConfig) ResolveNestedReposMode(projectName string) string {
+	if pc, ok := g.Projects[projectName]; ok && pc.NestedRepos != nil {
+		return *pc.NestedRepos
+	}
+	return g.NestedRepos
 }
 
 // ResolveMaxFileSize returns the per-file threshold string for projectName.

--- a/internal/git/stageguard.go
+++ b/internal/git/stageguard.go
@@ -31,6 +31,15 @@ type StageOptions struct {
 	// naming it --allow-large would read as "skip the safety check", which is
 	// backwards.
 	CommitLarge bool
+	// CommitNested forces undeclared nested repositories into the index for
+	// this invocation, recording them as gitlinks.
+	//
+	// It is separate from CommitLarge rather than folded into it because the
+	// two authorize unrelated things. A user passing --commit-large has decided
+	// a specific big file belongs in git; they have not decided to embed a
+	// foreign repository, and silently granting that would make the size flag
+	// mean more than it says.
+	CommitNested bool
 }
 
 // StageOutcome is what the guard decided about a staging operation, returned
@@ -39,6 +48,11 @@ type StageOptions struct {
 type StageOutcome struct {
 	// Excluded holds over-threshold untracked files kept out of the index.
 	Excluded []stageguard.GuardViolation
+	// NestedRepos holds undeclared nested git repositories kept out of the
+	// index. They are excluded like Excluded is, but carry a different remedy
+	// and never take part in artifact-root declaration, so they are reported
+	// separately rather than merged into it.
+	NestedRepos []stageguard.GuardViolation
 	// Reported holds tracked files whose new content crossed the threshold.
 	// They are always staged; the user is told about them instead.
 	Reported []stageguard.GuardViolation
@@ -62,10 +76,13 @@ type StageOutcome struct {
 // Empty reports whether the guard found nothing worth telling the user about.
 func (o *StageOutcome) Empty() bool {
 	return o == nil ||
-		(len(o.Excluded) == 0 && len(o.Reported) == 0 && o.Unavailable == nil)
+		(len(o.Excluded) == 0 && len(o.NestedRepos) == 0 &&
+			len(o.Reported) == 0 && o.Unavailable == nil)
 }
 
-// ExcludedPaths returns the repo-relative paths kept out of the index.
+// ExcludedPaths returns the repo-relative paths of over-threshold files kept
+// out of the index. Nested repositories are reached through NestedRepos, since
+// callers act on the two differently.
 func (o *StageOutcome) ExcludedPaths() []string {
 	if o == nil {
 		return nil
@@ -75,6 +92,26 @@ func (o *StageOutcome) ExcludedPaths() []string {
 		paths = append(paths, v.Path)
 	}
 	return paths
+}
+
+// NestedRepoPaths returns the repo-relative paths of nested repositories kept
+// out of the index.
+func (o *StageOutcome) NestedRepoPaths() []string {
+	if o == nil {
+		return nil
+	}
+	paths := make([]string, 0, len(o.NestedRepos))
+	for _, v := range o.NestedRepos {
+		paths = append(paths, v.Path)
+	}
+	return paths
+}
+
+// excludedPathspecs is every path the guard keeps out of this staging call,
+// regardless of which guard decided it. One list, so exclusion stays a single
+// git add.
+func (o *StageOutcome) excludedPathspecs() []string {
+	return append(o.ExcludedPaths(), o.NestedRepoPaths()...)
 }
 
 // GuardBlockedError reports that the guard refused a staging operation. It
@@ -100,6 +137,13 @@ func (e *GuardBlockedError) Error() string {
 			}
 		}
 		return "staging refused: bulk directory"
+	case stageguard.NestedRepo:
+		paths := make([]string, 0, len(e.Violations))
+		for _, v := range e.Violations {
+			paths = append(paths, v.Path)
+		}
+		return "staging refused: nested git repositories not declared in .gitmodules: " +
+			strings.Join(paths, ", ")
 	default:
 		paths := make([]string, 0, len(e.Violations))
 		for _, v := range e.Violations {
@@ -163,11 +207,13 @@ func runStageGuard(ctx context.Context, repoPath string, files []string, opts St
 	if !isStageEverything(files) {
 		return nil, nil, nil
 	}
-	// --commit-large is the user overruling camp's decision to exclude, which
-	// is the thing that actually needs an override once handling is automatic.
-	// It suppresses detection entirely rather than excluding-then-restoring,
-	// so the index ends up exactly as an unguarded stage would leave it.
-	if opts.CommitLarge {
+	// The override flags are the user overruling camp's decision to exclude,
+	// which is the thing that actually needs an override once handling is
+	// automatic. Each suppresses its own guard's detection rather than
+	// excluding-then-restoring, so the index ends up exactly as an unguarded
+	// stage would leave it. Only when every guard is overridden is the whole
+	// evaluation skipped.
+	if opts.CommitLarge && opts.CommitNested {
 		return nil, nil, nil
 	}
 
@@ -176,7 +222,16 @@ func runStageGuard(ctx context.Context, repoPath string, files []string, opts St
 		return &StageOutcome{Unavailable: camperrors.Wrapf(
 			err, "resolve staging guard limits for %s", repoPath)}, nil, nil
 	}
-	if limits.LargeFiles == stageguard.ModeOff && limits.Bulk == stageguard.ModeOff {
+	if opts.CommitLarge {
+		limits.LargeFiles = stageguard.ModeOff
+		limits.Bulk = stageguard.ModeOff
+	}
+	if opts.CommitNested {
+		limits.NestedRepos = stageguard.ModeOff
+	}
+	if limits.LargeFiles == stageguard.ModeOff &&
+		limits.Bulk == stageguard.ModeOff &&
+		limits.NestedRepos == stageguard.ModeOff {
 		return nil, nil, nil
 	}
 
@@ -192,6 +247,7 @@ func runStageGuard(ctx context.Context, repoPath string, files []string, opts St
 	outcome := &StageOutcome{Limits: limits}
 	var bulk []stageguard.GuardViolation
 	var overThreshold []stageguard.GuardViolation
+	var nested []stageguard.GuardViolation
 
 	for _, v := range violations {
 		switch v.Kind {
@@ -201,6 +257,8 @@ func runStageGuard(ctx context.Context, repoPath string, files []string, opts St
 			outcome.Reported = append(outcome.Reported, v)
 		case stageguard.OverThreshold:
 			overThreshold = append(overThreshold, v)
+		case stageguard.NestedRepo:
+			nested = append(nested, v)
 		}
 	}
 
@@ -216,9 +274,22 @@ func runStageGuard(ctx context.Context, repoPath string, files []string, opts St
 			Kind: stageguard.OverThreshold, Violations: overThreshold, Limits: limits, RepoPath: repoPath,
 		}
 	}
+	if len(nested) > 0 && limits.NestedRepos == stageguard.ModeBlock {
+		return nil, nil, &GuardBlockedError{
+			Kind: stageguard.NestedRepo, Violations: nested, Limits: limits, RepoPath: repoPath,
+		}
+	}
 
+	// Kept in its own field rather than folded into Excluded: everything in
+	// Excluded is a file the size guard held back, and the campaign-root path
+	// answers it by declaring an artifact root around it. A nested repository
+	// must never reach that code. Declaring an artifact root over a git
+	// repository is precisely the boundary artifacts.ResolveAutoRoot already
+	// refuses, so folding them together would turn a clear finding into a
+	// refusal about the wrong subject.
 	outcome.Excluded = overThreshold
-	return outcome, outcome.ExcludedPaths(), nil
+	outcome.NestedRepos = nested
+	return outcome, outcome.excludedPathspecs(), nil
 }
 
 // applyGuardExclusions folds guard exclusions into the pathspec, composing

--- a/internal/stageguard/check.go
+++ b/internal/stageguard/check.go
@@ -20,7 +20,7 @@ func CheckStaging(ctx context.Context, repoPath string, limits GuardLimits) ([]G
 		return nil, ctx.Err()
 	}
 
-	candidates, err := Enumerate(ctx, repoPath)
+	candidates, dirs, err := enumerate(ctx, repoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -37,6 +37,18 @@ func CheckStaging(ctx context.Context, repoPath string, limits GuardLimits) ([]G
 	violations, remaining := checkPerFile(candidates, limits)
 	if bulk, found := detectBulk(remaining, limits); found {
 		violations = append(violations, bulk)
+	}
+
+	// Nested repositories are counted separately from both guards above. They
+	// contribute no files to the bulk tally by construction, because git
+	// reported the directory instead of its contents, which is the whole reason
+	// they were invisible here before.
+	if limits.NestedRepos != ModeOff {
+		nested, err := detectNestedRepos(ctx, repoPath, dirs, limits.Allow)
+		if err != nil {
+			return nil, err
+		}
+		violations = append(violations, nested...)
 	}
 	return violations, nil
 }
@@ -262,12 +274,28 @@ func ValidateAllow(allow []string) error {
 }
 
 // SortViolations orders violations for stable reporting: bulk first because it
-// blocks, then per-file findings by descending size, then by path.
+// blocks, then nested repositories, then per-file findings by descending size,
+// then by path.
+//
+// Nested repositories precede the per-file findings rather than sorting among
+// them because they carry no size. Ordering by size would file them below every
+// large file as if they were the least of the report, when they are the finding
+// most likely to break the repository.
 func SortViolations(violations []GuardViolation) {
+	rank := func(k ViolationKind) int {
+		switch k {
+		case Bulk:
+			return 0
+		case NestedRepo:
+			return 1
+		default:
+			return 2
+		}
+	}
 	sort.SliceStable(violations, func(i, j int) bool {
 		a, b := violations[i], violations[j]
-		if (a.Kind == Bulk) != (b.Kind == Bulk) {
-			return a.Kind == Bulk
+		if ra, rb := rank(a.Kind), rank(b.Kind); ra != rb {
+			return ra < rb
 		}
 		if a.Size != b.Size {
 			return a.Size > b.Size

--- a/internal/stageguard/config.go
+++ b/internal/stageguard/config.go
@@ -85,7 +85,12 @@ func defaultLimits(scopeProject bool) GuardLimits {
 		MaxAddedFiles: DefaultMaxAddedFiles,
 		LargeFiles:    ModeAuto,
 		Bulk:          ModeBlock,
-		ScopeProject:  scopeProject,
+		// Exclude rather than block, in both scopes. Excluding a nested
+		// repository takes nothing away: its commits, branches, and remote are
+		// its own and stay reachable exactly as before. Blocking would spend a
+		// stop on a decision the user does not need to make.
+		NestedRepos:  ModeExclude,
+		ScopeProject: scopeProject,
 	}
 }
 
@@ -111,11 +116,24 @@ func applyGuardsConfig(g config.GuardsConfig, scopeProject bool, projectName str
 	}
 	if raw := g.ResolveGuardMode(projectName); raw != "" {
 		mode := Mode(raw)
-		if !mode.Valid() {
+		// Checked against this guard's own subset rather than Mode.Valid(): a
+		// mode another guard accepts is still meaningless here, and letting one
+		// through would resolve to behavior the user never asked for.
+		if mode != ModeAuto && mode != ModeBlock && mode != ModeOff {
 			return GuardLimits{}, camperrors.NewValidation("commit.guards.large_files",
 				"must be auto, block, or off, got "+strconv.Quote(raw), nil)
 		}
 		limits.LargeFiles = mode
+	}
+	if raw := g.ResolveNestedReposMode(projectName); raw != "" {
+		mode := Mode(raw)
+		// No auto: excluding is already the whole remedy, so an auto mode would
+		// name a step that does not exist.
+		if mode != ModeExclude && mode != ModeBlock && mode != ModeOff {
+			return GuardLimits{}, camperrors.NewValidation("commit.guards.nested_repos",
+				"must be exclude, block, or off, got "+strconv.Quote(raw), nil)
+		}
+		limits.NestedRepos = mode
 	}
 	if raw := g.ResolveBulkMode(projectName); raw != "" {
 		mode := Mode(raw)

--- a/internal/stageguard/enumerate.go
+++ b/internal/stageguard/enumerate.go
@@ -12,8 +12,14 @@ import (
 )
 
 // Candidate is one path a stage-everything operation would touch, with the
-// size lstat reports for it. Directories never appear: -uall expands untracked
-// directories into their individual files.
+// size lstat reports for it. Directories never appear here: -uall expands an
+// untracked directory into its individual files.
+//
+// The exception is the reason the nested-repository guard exists. Git does not
+// expand an untracked directory that is itself a git repository; it reports the
+// directory alone, because staging it would record a gitlink rather than its
+// contents. Those entries are collected separately by enumerate, since they are
+// not files and have no size to measure.
 type Candidate struct {
 	// Path is repo-relative and slash-separated.
 	Path string
@@ -33,28 +39,40 @@ type Candidate struct {
 //
 // Enumeration is stat-only. Nothing is hashed, opened, or read.
 func Enumerate(ctx context.Context, repoPath string) ([]Candidate, error) {
+	candidates, _, err := enumerate(ctx, repoPath)
+	return candidates, err
+}
+
+// enumerate returns the file candidates and, separately, the untracked
+// directories git declined to expand. Both come from one status call: running
+// it twice would double the cost of every guarded stage to learn something the
+// first call already reported.
+func enumerate(ctx context.Context, repoPath string) ([]Candidate, []string, error) {
 	if ctx.Err() != nil {
-		return nil, ctx.Err()
+		return nil, nil, ctx.Err()
 	}
 
 	out, err := statusPorcelain(ctx, repoPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	entries := parseStatusPorcelainZ(out)
 	candidates := make([]Candidate, 0, len(entries))
+	var dirs []string
 	for _, entry := range entries {
 		if ctx.Err() != nil {
-			return nil, ctx.Err()
+			return nil, nil, ctx.Err()
 		}
-		candidate, ok := classify(repoPath, entry)
-		if !ok {
-			continue
+		candidate, kind := classify(repoPath, entry)
+		switch kind {
+		case entryFile:
+			candidates = append(candidates, candidate)
+		case entryUntrackedDir:
+			dirs = append(dirs, candidate.Path)
 		}
-		candidates = append(candidates, candidate)
 	}
-	return candidates, nil
+	return candidates, dirs, nil
 }
 
 // statusPorcelain runs git status in repoPath. Ignored files are absent by
@@ -117,12 +135,26 @@ func parseStatusPorcelainZ(out []byte) []statusEntry {
 	return entries
 }
 
-// classify turns a status entry into a candidate, or reports that it is not
-// one.
-func classify(repoPath string, entry statusEntry) (Candidate, bool) {
+// entryKind sorts a status entry into what the guard does with it.
+type entryKind int
+
+const (
+	// entryIgnored is a status entry no stage-everything operation would add,
+	// or one that vanished before it could be measured.
+	entryIgnored entryKind = iota
+	// entryFile is an ordinary path with a size the per-file guards measure.
+	entryFile
+	// entryUntrackedDir is an untracked directory git did not expand. Under
+	// -uall that means git treats it as an opaque unit, which in practice means
+	// an embedded repository.
+	entryUntrackedDir
+)
+
+// classify turns a status entry into a candidate and says which kind it is.
+func classify(repoPath string, entry statusEntry) (Candidate, entryKind) {
 	untracked, ok := classifyEntry(entry)
 	if !ok {
-		return Candidate{}, false
+		return Candidate{}, entryIgnored
 	}
 	return statCandidate(repoPath, entry.Path, untracked)
 }
@@ -163,15 +195,33 @@ func classifyEntry(entry statusEntry) (untracked, ok bool) {
 // statCandidate lstats a repo-relative path. A path that vanished between the
 // status call and the stat is dropped rather than erroring: it cannot be
 // staged either, so it is not the guard's problem.
-func statCandidate(repoPath, rel string, untracked bool) (Candidate, bool) {
+//
+// Git reports an unexpanded directory with a trailing slash. It is stripped
+// here so the path matches the spelling every other layer uses: the pathspec
+// that excludes it, the .gitmodules declaration compared against it, and the
+// line the user reads.
+func statCandidate(repoPath, rel string, untracked bool) (Candidate, entryKind) {
+	rel = strings.TrimSuffix(filepath.ToSlash(rel), "/")
+	if rel == "" {
+		return Candidate{}, entryIgnored
+	}
 	abs := filepath.Join(repoPath, filepath.FromSlash(rel))
 	info, err := os.Lstat(abs)
-	if err != nil || info.IsDir() {
-		return Candidate{}, false
+	if err != nil {
+		return Candidate{}, entryIgnored
+	}
+	if info.IsDir() {
+		// Only untracked directories are candidates for the nested-repository
+		// guard. A tracked gitlink is an existing submodule reporting a changed
+		// HEAD, which is ordinary work and never the guard's business.
+		if !untracked {
+			return Candidate{}, entryIgnored
+		}
+		return Candidate{Path: rel, Untracked: true}, entryUntrackedDir
 	}
 	return Candidate{
-		Path:      filepath.ToSlash(rel),
+		Path:      rel,
 		Size:      info.Size(),
 		Untracked: untracked,
-	}, true
+	}, entryFile
 }

--- a/internal/stageguard/nested.go
+++ b/internal/stageguard/nested.go
@@ -1,0 +1,135 @@
+package stageguard
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	camperrors "github.com/Obedience-Corp/camp/internal/errors"
+)
+
+// detectNestedRepos reports which untracked directories would become orphaned
+// gitlinks if staged.
+//
+// A directory qualifies when it is a git repository and .gitmodules does not
+// declare it. Both halves matter. Without the repository test the guard would
+// fire on ordinary directories git happened not to expand; without the
+// .gitmodules test it would fire on a legitimate submodule the user is adding,
+// which is the one case where staging a gitlink is exactly right.
+//
+// The declared set is read once for the whole batch rather than per directory,
+// because the common case is zero nested repositories and the common cost
+// should be one git call that returns nothing.
+func detectNestedRepos(ctx context.Context, repoPath string, dirs []string, allow []string) ([]GuardViolation, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	if len(dirs) == 0 {
+		return nil, nil
+	}
+
+	declared, err := declaredSubmodulePaths(ctx, repoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	violations := make([]GuardViolation, 0, len(dirs))
+	for _, dir := range dirs {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if declared[dir] || MatchesAllow(dir, allow) {
+			continue
+		}
+		if !isGitRepo(filepath.Join(repoPath, filepath.FromSlash(dir))) {
+			continue
+		}
+		violations = append(violations, GuardViolation{
+			Kind: NestedRepo,
+			Path: dir,
+			Head: nestedHead(ctx, filepath.Join(repoPath, filepath.FromSlash(dir))),
+		})
+	}
+	if len(violations) == 0 {
+		return nil, nil
+	}
+	return violations, nil
+}
+
+// isGitRepo reports whether dir holds a .git entry. It accepts both a directory
+// (an ordinary clone) and a file (a worktree or submodule checkout, where .git
+// is a gitdir pointer), because git records a gitlink for either and both are
+// how the nested checkouts that motivated this guard actually arrive.
+func isGitRepo(dir string) bool {
+	_, err := os.Lstat(filepath.Join(dir, ".git"))
+	return err == nil
+}
+
+// nestedHead returns the nested repository's HEAD in short form, or "" when it
+// has none yet or cannot be read. It is reported for orientation only, so a
+// failure to read it must never fail the guard.
+func nestedHead(ctx context.Context, dir string) string {
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--short", "HEAD")
+	cmd.Env = gitEnv(os.Environ())
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// declaredSubmodulePaths returns the submodule paths .gitmodules declares, as a
+// set. A repository with no .gitmodules declares nothing, which is not an error:
+// it is the ordinary state of most repositories and the one where this guard
+// matters most.
+//
+// It shells out rather than calling internal/git.ListSubmodulePaths for the
+// same reason Enumerate runs its own git status: internal/git imports this
+// package, so importing it back would restore the cycle the leaf position
+// exists to break.
+func declaredSubmodulePaths(ctx context.Context, repoPath string) (map[string]bool, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	gitmodules := filepath.Join(repoPath, ".gitmodules")
+	if _, err := os.Lstat(gitmodules); err != nil {
+		return nil, nil
+	}
+
+	// -z terminates values with NUL, so a path containing whitespace or a
+	// newline survives intact. Parsing the file by hand would have to reproduce
+	// git's config syntax, including line continuations and quoting.
+	cmd := exec.CommandContext(ctx, "git", "config", "-f", gitmodules, "-z", "--get-regexp", `^submodule\..*\.path$`)
+	cmd.Env = gitEnv(os.Environ())
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		// Exit code 1 means no key matched: a .gitmodules with no path entries.
+		// That is a declaration of nothing, not a failure to read.
+		var exitErr *exec.ExitError
+		if camperrors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, camperrors.Wrapf(err, "read submodule paths from %s: %s",
+			gitmodules, strings.TrimSpace(stderr.String()))
+	}
+
+	declared := make(map[string]bool)
+	for _, record := range bytes.Split(bytes.TrimRight(out, "\x00"), []byte{0}) {
+		// Each record is "<key>\n<value>"; the value is the declared path.
+		_, value, found := strings.Cut(string(record), "\n")
+		if !found {
+			continue
+		}
+		if path := strings.TrimSuffix(filepath.ToSlash(strings.TrimSpace(value)), "/"); path != "" {
+			declared[path] = true
+		}
+	}
+	return declared, nil
+}

--- a/internal/stageguard/nested.go
+++ b/internal/stageguard/nested.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -127,9 +128,30 @@ func declaredSubmodulePaths(ctx context.Context, repoPath string) (map[string]bo
 		if !found {
 			continue
 		}
-		if path := strings.TrimSuffix(filepath.ToSlash(strings.TrimSpace(value)), "/"); path != "" {
-			declared[path] = true
+		if declaredPath := normalizeDeclaredPath(value); declaredPath != "" {
+			declared[declaredPath] = true
 		}
 	}
 	return declared, nil
+}
+
+// normalizeDeclaredPath renders a .gitmodules path in the single spelling git
+// status uses: slash-separated, no "./" prefix, no doubled or trailing
+// separators.
+//
+// This is not cosmetic. git config returns the value verbatim, so a hand-edited
+// ".gitmodules" saying "path = ./projects/foo" yields exactly that, while status
+// reports the same submodule as "projects/foo". Comparing the two spellings
+// directly would miss the declaration and make the guard exclude a submodule the
+// user deliberately declared, which is the one case where staging a gitlink is
+// correct. Normalizing here is cheap; a false exclusion is silent and confusing.
+//
+// A value that cleans to "." names the repository root, which is never a
+// submodule, so it declares nothing.
+func normalizeDeclaredPath(value string) string {
+	cleaned := path.Clean(filepath.ToSlash(strings.TrimSpace(value)))
+	if cleaned == "." {
+		return ""
+	}
+	return cleaned
 }

--- a/internal/stageguard/nested_test.go
+++ b/internal/stageguard/nested_test.go
@@ -116,6 +116,34 @@ func TestNestedRepoRespectsAllowGlobs(t *testing.T) {
 	}
 }
 
+// .gitmodules is hand-edited, and git config hands back whatever spelling it
+// finds there, while git status always reports the normalized one. A declared
+// submodule written "./vendor/lib" must still match the "vendor/lib" status
+// reports, or the guard excludes a submodule the user deliberately declared.
+func TestNormalizeDeclaredPathMatchesStatusSpelling(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{"already normalized", "vendor/lib", "vendor/lib"},
+		{"dot-slash prefix", "./vendor/lib", "vendor/lib"},
+		{"trailing slash", "vendor/lib/", "vendor/lib"},
+		{"doubled separator", "vendor//lib", "vendor/lib"},
+		{"surrounding space", "  vendor/lib  ", "vendor/lib"},
+		{"interior dot segment", "vendor/./lib", "vendor/lib"},
+		{"repository root declares nothing", "./", ""},
+		{"empty declares nothing", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeDeclaredPath(tt.value); got != tt.want {
+				t.Errorf("normalizeDeclaredPath(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
 // The shipped default is exclude in both scopes. A regression that left this
 // unset would resolve to the zero Mode, which is neither off nor exclude and
 // would silently change what the guard does, so it is pinned here rather than

--- a/internal/stageguard/nested_test.go
+++ b/internal/stageguard/nested_test.go
@@ -1,0 +1,187 @@
+package stageguard
+
+import (
+	"testing"
+
+	"github.com/Obedience-Corp/camp/internal/config"
+)
+
+// Mode.Valid recognizes every mode the package defines, and each guard is
+// responsible for narrowing that to its own subset. These are separate
+// concerns and this test pins the first one only.
+func TestModeValidRecognizesExclude(t *testing.T) {
+	for _, mode := range []Mode{ModeAuto, ModeExclude, ModeBlock, ModeOff} {
+		if !mode.Valid() {
+			t.Errorf("Mode(%q).Valid() = false, want true", mode)
+		}
+	}
+	for _, mode := range []Mode{"", "auto ", "EXCLUDE", "warn"} {
+		if mode.Valid() {
+			t.Errorf("Mode(%q).Valid() = true, want false", mode)
+		}
+	}
+}
+
+// A nested-repository violation blocks only under block mode. Under the
+// shipped default it is excluded and reported, which is not a block.
+func TestNestedRepoBlocksOnlyUnderBlockMode(t *testing.T) {
+	violation := GuardViolation{Kind: NestedRepo, Path: "review/app-pr136"}
+
+	tests := []struct {
+		mode Mode
+		want bool
+	}{
+		{ModeExclude, false},
+		{ModeOff, false},
+		{ModeBlock, true},
+	}
+	for _, tt := range tests {
+		got := violation.Blocks(GuardLimits{NestedRepos: tt.mode})
+		if got != tt.want {
+			t.Errorf("Blocks() under %q = %v, want %v", tt.mode, got, tt.want)
+		}
+	}
+}
+
+// A nested repository is excluded, never merely reported. ReportOnly is what
+// distinguishes tracked growth, which is always committed.
+func TestNestedRepoIsNotReportOnly(t *testing.T) {
+	if (GuardViolation{Kind: NestedRepo}).ReportOnly() {
+		t.Error("NestedRepo must be excluded, not report-only")
+	}
+}
+
+// Nested repositories sort above per-file findings despite carrying no size.
+// Ordering by size alone would file the finding most likely to break the
+// repository below every large file in the report.
+func TestSortViolationsPlacesNestedReposAboveFiles(t *testing.T) {
+	violations := []GuardViolation{
+		{Kind: OverThreshold, Path: "big.bin", Size: 900},
+		{Kind: NestedRepo, Path: "review/app-pr136"},
+		{Kind: Bulk, CommonPrefix: "vendor", Count: 1200},
+		{Kind: OverThreshold, Path: "bigger.bin", Size: 5000},
+	}
+	SortViolations(violations)
+
+	want := []ViolationKind{Bulk, NestedRepo, OverThreshold, OverThreshold}
+	for i, kind := range want {
+		if violations[i].Kind != kind {
+			t.Fatalf("position %d = %q, want %q (order: %v)", i, violations[i].Kind, kind, kinds(violations))
+		}
+	}
+	// Within the per-file group the existing descending-size rule still holds.
+	if violations[2].Path != "bigger.bin" {
+		t.Errorf("per-file findings lost their size ordering: got %q first", violations[2].Path)
+	}
+}
+
+// Multiple nested repositories keep a deterministic order, so the report does
+// not reshuffle between runs on the same working tree.
+func TestSortViolationsOrdersNestedReposByPath(t *testing.T) {
+	violations := []GuardViolation{
+		{Kind: NestedRepo, Path: "review/c"},
+		{Kind: NestedRepo, Path: "review/a"},
+		{Kind: NestedRepo, Path: "review/b"},
+	}
+	SortViolations(violations)
+
+	for i, want := range []string{"review/a", "review/b", "review/c"} {
+		if violations[i].Path != want {
+			t.Errorf("position %d = %q, want %q", i, violations[i].Path, want)
+		}
+	}
+}
+
+// The allowlist applies to nested repositories too, so a workflow that
+// deliberately keeps one checkout in place can exempt that path alone rather
+// than turning the whole guard off.
+func TestNestedRepoRespectsAllowGlobs(t *testing.T) {
+	tests := []struct {
+		name  string
+		path  string
+		allow []string
+		want  bool
+	}{
+		{"exact path", "review/app-pr136", []string{"review/app-pr136"}, true},
+		{"directory tree", "review/app-pr136", []string{"review/**"}, true},
+		{"unrelated glob", "review/app-pr136", []string{"vendor/**"}, false},
+		{"no allowlist", "review/app-pr136", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MatchesAllow(tt.path, tt.allow); got != tt.want {
+				t.Errorf("MatchesAllow(%q, %v) = %v, want %v", tt.path, tt.allow, got, tt.want)
+			}
+		})
+	}
+}
+
+// The shipped default is exclude in both scopes. A regression that left this
+// unset would resolve to the zero Mode, which is neither off nor exclude and
+// would silently change what the guard does, so it is pinned here rather than
+// only exercised end to end.
+func TestNestedReposDefaultsToExcludeInBothScopes(t *testing.T) {
+	for _, scopeProject := range []bool{false, true} {
+		limits := defaultLimits(scopeProject)
+		if limits.NestedRepos != ModeExclude {
+			t.Errorf("defaultLimits(scopeProject=%v).NestedRepos = %q, want %q",
+				scopeProject, limits.NestedRepos, ModeExclude)
+		}
+	}
+}
+
+// Each guard validates its own subset. A mode another guard accepts is a
+// configuration error here, not a value that quietly resolves to something
+// else.
+func TestNestedReposModeValidation(t *testing.T) {
+	tests := []struct {
+		mode    string
+		wantErr bool
+		want    Mode
+	}{
+		{"", false, ModeExclude}, // unset keeps the default
+		{"exclude", false, ModeExclude},
+		{"block", false, ModeBlock},
+		{"off", false, ModeOff},
+		{"auto", true, ""}, // valid for large_files, meaningless here
+		{"nonsense", true, ""},
+	}
+	for _, tt := range tests {
+		t.Run("nested_repos="+tt.mode, func(t *testing.T) {
+			limits, err := applyGuardsConfig(guardsConfigWithNested(tt.mode), false, "")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("applyGuardsConfig(%q) = nil error, want a validation error", tt.mode)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("applyGuardsConfig(%q) returned %v, want nil", tt.mode, err)
+			}
+			if limits.NestedRepos != tt.want {
+				t.Errorf("NestedRepos = %q, want %q", limits.NestedRepos, tt.want)
+			}
+		})
+	}
+}
+
+// large_files must keep rejecting exclude. Adding ModeExclude to Mode.Valid
+// would otherwise let it through to a guard that has no handling for it.
+func TestLargeFilesRejectsExcludeMode(t *testing.T) {
+	cfg := config.GuardsConfig{LargeFiles: string(ModeExclude)}
+	if _, err := applyGuardsConfig(cfg, false, ""); err == nil {
+		t.Fatal("large_files accepted \"exclude\", want a validation error")
+	}
+}
+
+func guardsConfigWithNested(mode string) config.GuardsConfig {
+	return config.GuardsConfig{NestedRepos: mode}
+}
+
+func kinds(violations []GuardViolation) []ViolationKind {
+	out := make([]ViolationKind, 0, len(violations))
+	for _, v := range violations {
+		out = append(out, v.Kind)
+	}
+	return out
+}

--- a/internal/stageguard/stageguard.go
+++ b/internal/stageguard/stageguard.go
@@ -17,16 +17,23 @@ const (
 	// ModeAuto declares an artifact root, excludes the file, and reports.
 	// Valid for the large-file guard only.
 	ModeAuto Mode = "auto"
+	// ModeExclude keeps the path out of the index and reports, declaring
+	// nothing. Valid for the nested-repository guard only, where there is
+	// nothing to declare: the nested repository already owns its own history.
+	ModeExclude Mode = "exclude"
 	// ModeBlock refuses the operation and stages nothing.
 	ModeBlock Mode = "block"
 	// ModeOff disables detection entirely.
 	ModeOff Mode = "off"
 )
 
-// Valid reports whether m is a mode this package recognizes.
+// Valid reports whether m is a mode this package recognizes. Each guard
+// accepts its own subset and validates that itself, because a mode that is
+// merely spelled correctly but meaningless for a given guard would otherwise
+// resolve to something the user did not ask for.
 func (m Mode) Valid() bool {
 	switch m {
-	case ModeAuto, ModeBlock, ModeOff:
+	case ModeAuto, ModeExclude, ModeBlock, ModeOff:
 		return true
 	}
 	return false
@@ -48,6 +55,12 @@ type GuardLimits struct {
 	LargeFiles Mode
 	// Bulk is the commit.guards.bulk mode: block or off, never auto.
 	Bulk Mode
+	// NestedRepos is the commit.guards.nested_repos mode: exclude, block, or
+	// off. It never blocks by default, because excluding costs the user
+	// nothing: the nested repository keeps its own history and remote either
+	// way, so there is no content to lose and therefore no decision to hand
+	// back.
+	NestedRepos Mode
 	// ScopeProject is true when the repository is a project rather than the
 	// campaign root. It selects which remedy the CLI offers, since camp never
 	// auto-declares an artifact root inside a project.
@@ -71,6 +84,20 @@ const (
 	// It is reported every time and excluded never: splitting one file's
 	// history between git and an artifact root is never correct.
 	TrackedGrowth ViolationKind = "tracked_growth"
+	// NestedRepo is an untracked directory that is itself a git repository and
+	// is not declared in .gitmodules. Staging it records a gitlink (mode
+	// 160000) with no url behind it, which git treats as fatal rather than
+	// skippable: every later `git submodule` call in that repository, and in
+	// every clone of it, exits non-zero. The nested repository's contents do
+	// not reach the remote either, so the commit captures nothing while
+	// breaking the repository for everyone who has it.
+	//
+	// This is the one guard where camp can know the right answer. A large file
+	// poses a question camp cannot settle (do collaborators need the bytes),
+	// but an undeclared gitlink has no legitimate reading: the user either
+	// wanted a submodule, which needs a url, or wanted the directory left
+	// alone.
+	NestedRepo ViolationKind = "nested_repo"
 )
 
 // GuardViolation is one finding. Prefix, Count, and TotalBytes are set for
@@ -88,6 +115,10 @@ type GuardViolation struct {
 	// TotalBytes is the size of a Bulk violation's files. It is reported for
 	// display and is never itself a trigger.
 	TotalBytes int64
+	// Head is the commit a NestedRepo violation's repository points at, short
+	// form, or "" when it has no commits yet. It is reported so the user can
+	// tell which checkout they are looking at without leaving the message.
+	Head string
 }
 
 // ReportOnly reports whether a violation must never cause exclusion. Tracked
@@ -104,6 +135,8 @@ func (v GuardViolation) Blocks(limits GuardLimits) bool {
 		return limits.Bulk == ModeBlock
 	case OverThreshold:
 		return limits.LargeFiles == ModeBlock
+	case NestedRepo:
+		return limits.NestedRepos == ModeBlock
 	default:
 		return false
 	}

--- a/pkg/commitkit/guard.go
+++ b/pkg/commitkit/guard.go
@@ -60,6 +60,11 @@ const (
 	// threshold. It is always reported and never excluded, because splitting
 	// one file's history between git and an artifact root is never correct.
 	TrackedGrowth = stageguard.TrackedGrowth
+	// NestedRepo is an untracked directory that is itself a git repository
+	// and is not declared in .gitmodules. It is excluded: staging it records
+	// a submodule reference with no url, which makes every later `git
+	// submodule` call in the repository and its clones fail.
+	NestedRepo = stageguard.NestedRepo
 )
 
 // StageOutcome is what the guard did during a staging operation: which files it
@@ -94,11 +99,13 @@ type Mode = stageguard.Mode
 
 // The guard modes. ModeAuto applies to the large-file guard only; the bulk
 // guard accepts ModeBlock or ModeOff, since there is no inference camp could
-// make on its behalf.
+// make on its behalf. ModeExclude applies to the nested-repository guard only,
+// where excluding is already the complete remedy and nothing is declared.
 const (
-	ModeAuto  = stageguard.ModeAuto
-	ModeBlock = stageguard.ModeBlock
-	ModeOff   = stageguard.ModeOff
+	ModeAuto    = stageguard.ModeAuto
+	ModeExclude = stageguard.ModeExclude
+	ModeBlock   = stageguard.ModeBlock
+	ModeOff     = stageguard.ModeOff
 )
 
 // CheckStaging reports what a stage-everything operation in repoPath would add

--- a/tests/integration/stage_guard_nested_test.go
+++ b/tests/integration/stage_guard_nested_test.go
@@ -1,0 +1,228 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The nested-repository guard. These tests exist because of a real failure:
+// three review worktrees were checked out inside a product repo, a blanket
+// `camp p commit` recorded them as gitlinks, and because none of them appeared
+// in .gitmodules every later `git submodule update --init --recursive` in that
+// repository exited 128. The repo built and tested fine; only its `just dev`
+// recipe, which syncs submodules first, stopped working, so the breakage read
+// as "the app will not launch" for eighteen days.
+//
+// TestIntegration_NestedRepoKeepsSubmoduleCommandsWorking is that scenario end
+// to end and is the regression the rest of this file supports.
+
+// nestedRepoAt creates a git repository with one commit at repoPath, the shape
+// a review worktree or a stray clone arrives in.
+func nestedRepoAt(t *testing.T, tc *TestContainer, repoPath string) {
+	t.Helper()
+	tc.Shell(t, fmt.Sprintf(`
+		mkdir -p %[1]s
+		cd %[1]s
+		git init -q .
+		git config user.email nested@example.com
+		git config user.name nested
+		printf 'inner content' > inner.txt
+		git add .
+		git -c user.email=nested@example.com -c user.name=nested commit -q -m "nested commit"
+	`, repoPath))
+}
+
+// indexGitlinks returns the mode-160000 index entries, which is what an
+// undeclared nested repository becomes if the guard misses it.
+func indexGitlinks(t *testing.T, tc *TestContainer, campPath string) []string {
+	t.Helper()
+	out := tc.GitOutput(t, campPath, "ls-files", "--stage")
+	var links []string
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "160000 ") {
+			continue
+		}
+		if _, path, found := strings.Cut(line, "\t"); found {
+			links = append(links, strings.TrimSpace(path))
+		}
+	}
+	return links
+}
+
+// The regression. A nested repository is kept out of the commit, everything
+// beside it still lands, and the repository's submodule commands keep working.
+//
+// The last assertion is the one that matters most: asserting only on the index
+// would pass against a guard that excluded the gitlink but left .gitmodules
+// inconsistent some other way, and it was `git submodule update` exiting
+// non-zero, not the index, that the user actually experienced.
+func TestIntegration_NestedRepoKeepsSubmoduleCommandsWorking(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-nested-basic")
+	nestedRepoAt(t, tc, campPath+"/review/app-pr136")
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "ordinary content")
+	require.NoError(t, err, "output:\n%s", output)
+
+	// Said out loud, with the remedy in the same breath.
+	assert.Contains(t, output, "review/app-pr136 is its own git repository")
+	assert.Contains(t, output, "left out of this commit")
+	assert.Contains(t, output, "git submodule add <url> review/app-pr136")
+
+	assert.Empty(t, indexGitlinks(t, tc, campPath),
+		"an undeclared gitlink reached the index")
+
+	// The rest of the commit is untouched: excluding is not refusing.
+	committed := tc.GitOutput(t, campPath, "show", "--name-only", "--format=", "HEAD")
+	assert.Contains(t, committed, "notes/one.md")
+	assert.NotContains(t, committed, "review/app-pr136")
+
+	// The actual user-visible symptom, asserted directly.
+	_, exitCode, err := tc.ExecCommand("git", "-C", campPath,
+		"submodule", "update", "--init", "--recursive")
+	require.NoError(t, err)
+	assert.Equal(t, 0, exitCode,
+		"git submodule update must still succeed after the commit")
+}
+
+// The nested repository keeps its own history. Excluding costs the user
+// nothing, which is the reason this guard excludes rather than blocking.
+func TestIntegration_NestedRepoRetainsItsOwnHistory(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-nested-history")
+	nestedRepoAt(t, tc, campPath+"/review/app-pr137")
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "ordinary content")
+	require.NoError(t, err, "output:\n%s", output)
+
+	inner := tc.GitOutput(t, campPath+"/review/app-pr137", "log", "--oneline")
+	assert.Contains(t, inner, "nested commit")
+	exists, err := tc.CheckFileExists(campPath + "/review/app-pr137/inner.txt")
+	require.NoError(t, err)
+	assert.True(t, exists, "the nested checkout must be left on disk untouched")
+}
+
+// A submodule declared in .gitmodules is exactly the case where staging a
+// gitlink is correct, so the guard must not fire on it. Without this the guard
+// would break `camp project add`, which legitimately stages a new gitlink.
+func TestIntegration_DeclaredSubmoduleIsNotFlagged(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-nested-declared")
+	nestedRepoAt(t, tc, campPath+"/vendor/lib")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		cat > .gitmodules <<'EOF'
+[submodule "vendor/lib"]
+	path = vendor/lib
+	url = git@example.com:demo/lib.git
+EOF
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "with a declared submodule")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.NotContains(t, output, "is its own git repository",
+		"a declared submodule must not trip the nested-repository guard")
+}
+
+// --commit-nested is the user overruling the guard for one commit.
+func TestIntegration_CommitNestedForcesTheGitlinkIn(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-nested-override")
+	nestedRepoAt(t, tc, campPath+"/review/app-pr138")
+
+	output, err := tc.RunCampInDir(campPath, "commit", "--commit-nested", "-m", "deliberate gitlink")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.NotContains(t, output, "is its own git repository")
+	assert.Contains(t, indexGitlinks(t, tc, campPath), "review/app-pr138")
+}
+
+// --commit-large must not quietly also authorize embedding a repository. The
+// two flags answer unrelated questions, and a user who decided a build artifact
+// belongs in git has not decided anything about nested checkouts.
+func TestIntegration_CommitLargeDoesNotAuthorizeNestedRepos(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-nested-large-is-separate")
+	nestedRepoAt(t, tc, campPath+"/review/app-pr139")
+
+	output, err := tc.RunCampInDir(campPath, "commit", "--commit-large", "-m", "large ok, nested not")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.Contains(t, output, "is its own git repository",
+		"--commit-large must leave the nested-repository guard running")
+	assert.Empty(t, indexGitlinks(t, tc, campPath))
+}
+
+// Block mode refuses the whole operation and stages nothing.
+func TestIntegration_NestedRepoBlockModeStagesNothing(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-nested-block")
+	nestedRepoAt(t, tc, campPath+"/review/app-pr140")
+	writeGuardConfig(t, tc, campPath, "    nested_repos: block")
+
+	output, _ := tc.RunCampInDir(campPath, "commit", "-m", "should refuse")
+
+	assert.Contains(t, output, "not declared in .gitmodules would be committed")
+	assert.Contains(t, output, "Nothing was staged")
+	assert.Contains(t, output, "--commit-nested")
+	assert.Empty(t, stagedPaths(t, tc, campPath), "block mode must stage nothing")
+}
+
+// Off disables the guard, which is the escape hatch for a workflow that
+// deliberately carries undeclared gitlinks.
+func TestIntegration_NestedRepoOffModeIsSilent(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-nested-off")
+	nestedRepoAt(t, tc, campPath+"/review/app-pr141")
+	writeGuardConfig(t, tc, campPath, "    nested_repos: off")
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "guard disabled")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.NotContains(t, output, "is its own git repository")
+	assert.Contains(t, indexGitlinks(t, tc, campPath), "review/app-pr141")
+}
+
+// A misspelled mode is an error rather than a silent fallback, so a typo never
+// quietly leaves the user unprotected while they believe it is set.
+func TestIntegration_NestedRepoInvalidModeIsReported(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-nested-invalid-mode")
+	writeGuardConfig(t, tc, campPath, "    nested_repos: auto")
+
+	output, _ := tc.RunCampInDir(campPath, "commit", "-m", "bad config")
+
+	assert.Contains(t, output, "commit.guards.nested_repos")
+	assert.Contains(t, output, "must be exclude, block, or off")
+}
+
+// The project scope reaches the same verdict as the campaign root. An
+// undeclared gitlink breaks submodule commands identically in either, so unlike
+// the large-file guard there is nothing here that depends on scope.
+func TestIntegration_NestedRepoGuardAppliesInsideAProject(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-nested-project")
+
+	projectPath := campPath + "/projects/api"
+	require.NoError(t, tc.CreateGitRepo(projectPath))
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		printf 'api source' > main.go
+	`, projectPath))
+	nestedRepoAt(t, tc, projectPath+"/review/pr-1")
+
+	output, err := tc.RunCampInDir(projectPath, "project", "commit", "-m", "api work")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.Contains(t, output, "review/pr-1 is its own git repository")
+	assert.Empty(t, indexGitlinks(t, tc, projectPath))
+}

--- a/tests/integration/stage_guard_nested_test.go
+++ b/tests/integration/stage_guard_nested_test.go
@@ -133,6 +133,32 @@ EOF
 		"a declared submodule must not trip the nested-repository guard")
 }
 
+// The same declaration written the way a hand edit often spells it. git config
+// returns "./vendor/lib" verbatim while status reports "vendor/lib", so an
+// exact-string comparison would miss the declaration and exclude a real
+// submodule. This is the end-to-end half of
+// TestNormalizeDeclaredPathMatchesStatusSpelling.
+func TestIntegration_DeclaredSubmoduleWithDotSlashIsNotFlagged(t *testing.T) {
+	tc := GetSharedContainer(t)
+	campPath := setupGuardCampaign(t, tc, "guard-nested-declared-dotslash")
+	nestedRepoAt(t, tc, campPath+"/vendor/lib")
+
+	tc.Shell(t, fmt.Sprintf(`
+		cd %s
+		cat > .gitmodules <<'EOF'
+[submodule "vendor/lib"]
+	path = ./vendor/lib
+	url = git@example.com:demo/lib.git
+EOF
+	`, campPath))
+
+	output, err := tc.RunCampInDir(campPath, "commit", "-m", "declared with a ./ prefix")
+	require.NoError(t, err, "output:\n%s", output)
+
+	assert.NotContains(t, output, "is its own git repository",
+		"a declared submodule must not trip the guard because of its spelling")
+}
+
 // --commit-nested is the user overruling the guard for one commit.
 func TestIntegration_CommitNestedForcesTheGitlinkIn(t *testing.T) {
 	tc := GetSharedContainer(t)


### PR DESCRIPTION
## Why

A stage-everything commit could record an untracked nested git repository as a gitlink (mode `160000`). When `.gitmodules` does not declare that path, git treats the entry as **fatal rather than skippable**: every later `git submodule` call in the repository, and in every clone of it, exits non-zero.

This is not hypothetical. Three review worktrees were checked out inside `festival-app`, a blanket `camp p commit` swept them in, and because none appeared in `.gitmodules`:

```
git submodule update --init --recursive
fatal: No url found for submodule path
'projects/worktrees/deep-review-20260711/festival-app-pr136' in .gitmodules
error: recipe `sync` failed on line 3 with exit code 128
```

That is the first step of the repo's `just dev`, so the app could not be started for eighteen days. It built and tested fine the whole time, so the breakage surfaced only as "the app will not launch." Fixed there in Obedience-Corp/festival-app#144; this is the cause.

## The blind spot

`stageguard.Enumerate` drops directory entries, on a documented assumption:

> Directories never appear: -uall expands untracked directories into their individual files.

That is not true for an embedded repository. Verified against real git:

```
$ git status --porcelain=v1 -uall
?? file.txt
?? nested/repo/          <-- the directory, never expanded

$ git add -A
warning: adding embedded git repository: nested/repo
$ git ls-files -s
100644 45b983be... 0	file.txt
160000 32d3431e... 0	nested/repo
```

Git reports the directory alone *precisely because* staging it records a gitlink rather than contents. So the single entry that becomes a gitlink was the single entry the guard discarded at `enumerate.go:169`.

## Reusing what camp already knows

`internal/git.ListOrphanedGitlinks` already compares index gitlinks against `.gitmodules`, for doctor, clone, and sync. It was never consulted at the staging chokepoint, which is the only place that can prevent the state instead of reporting it afterward. This applies the same comparison one step earlier, before the entry exists, rather than adding a parallel notion of the same thing.

## Behavior

Excluded and reported, not blocked, in both scopes:

```
⚠ review/app-pr136 is its own git repository at a210413; it was left out of this commit
  Committing it records a submodule reference with no url behind it, which
  makes 'git submodule' fail in this repo and every clone of it. Its contents
  would not reach the remote either.
    if it should be a submodule   git submodule add <url> review/app-pr136
    if it does not belong here    echo 'review/app-pr136/' >> .gitignore
    if you meant it as a gitlink  --commit-nested
```

The commit still lands; everything beside the nested repo goes in.

**Why exclude rather than block.** Unlike a large file, there is no question camp cannot settle. The nested repository keeps its own history and remote either way, so exclusion costs the user nothing, and an undeclared gitlink has no legitimate reading: the user either wanted a submodule, which needs a url, or wanted the directory left alone. Per `02-size-and-batch-guard.md`, blocking is the exception that must justify itself, and this one cannot.

**A declared submodule is exempt.** That is the one case where staging a gitlink is correct, and `camp project add` depends on it. The exemption matches on the normalized path, because `git config` returns a `.gitmodules` value verbatim while `git status` always reports the normalized one: a hand-edited `path = ./vendor/lib` would otherwise miss the lookup and get the submodule excluded.

- `commit.guards.nested_repos`: `exclude` (default), `block`, `off`, with per-project overrides and allowlist support.
- `--commit-nested` on `camp commit`, `camp project commit`, `camp worktrees commit`.
- `--json` gains `nested_repo` and `nested_repo_blocked` exclusion reasons.
- `pkg/commitkit` exports `NestedRepo` and `ModeExclude` so fest renders it too.

## Two deliberate calls

**`--commit-nested` is separate from `--commit-large`.** They authorize unrelated things. A user who decided a 30 MB binary belongs in git has not decided to embed a foreign repository, and overloading a size-named flag to also mean that would make it mean more than it says. `runStageGuard` now suppresses per guard rather than returning early, so `--commit-large` leaves this guard running. Pinned by `TestIntegration_CommitLargeDoesNotAuthorizeNestedRepos`.

**`large_files` now validates its own subset.** Adding `ModeExclude` to `Mode.Valid()` would otherwise let `large_files: exclude` through to a guard with no handling for it, resolving to behavior the user never asked for. Prior behavior is unchanged: `Valid()` already accepted exactly `auto`, `block`, `off`. Pinned by `TestLargeFilesRejectsExcludeMode`.

## Verification

`just gate-fast`: **4559/4559 tests, 0 lint issues**, both ratchets clean (`lint-no-host-fs-tests`, `lint-no-fmt-errorf`).

10 containerized integration tests in `tests/integration/stage_guard_nested_test.go`, all passing. The headline one asserts the actual user-visible symptom rather than just the index:

```go
_, exitCode, err := tc.ExecCommand("git", "-C", campPath, "submodule", "update", "--init", "--recursive")
assert.Equal(t, 0, exitCode)
```

The suite is not tautological: `TestIntegration_NestedRepoOffModeIsSilent` asserts the gitlink **is** recorded when the guard is off, which is exactly the pre-fix behavior, so both states are pinned. `TestIntegration_DeclaredSubmoduleWithDotSlashIsNotFlagged` and its unit-level counterpart were both confirmed to fail against the previous exact-string path comparison before the normalization landed.

Also verified by hand against a real campaign and the built binary: default exclude, `--commit-nested` opt-in, declared-submodule exemption, block mode staging nothing, and an invalid mode producing a validation error instead of a silent fallback.

## Note on docs

Docs regen is limited to the two per-command files. `camp-reference.md` carries unrelated pre-existing drift (it is missing `camp artifacts resolve`, which already has a per-command doc on `main`), so folding a full regen in here would mix unrelated content into this diff. Worth a separate regen commit.
