### PR TITLE
fix(machine): copy approval links through remote terminals

### DIFF
--- a/cmd/camp/machine_tui_update.go
+++ b/cmd/camp/machine_tui_update.go
@@ -361,7 +361,7 @@ func (m *machineTUIModel) copyCheckURL(url string) tea.Cmd {
 		m.setError(camperrors.Wrap(err, "could not copy the link"))
 		return nil
 	}
-	m.setAdvice("copied the approval link to your clipboard")
+	m.setAdvice("copied the approval link; paste it into a browser, approve it, then press t (or r) to retry")
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.6
 require (
 	github.com/Obedience-Corp/obey-shared v0.4.6
 	github.com/alecthomas/chroma/v2 v2.23.1
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0
@@ -32,7 +33,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
-	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/internal/ui/clipboard.go
+++ b/internal/ui/clipboard.go
@@ -1,21 +1,78 @@
 package ui
 
 import (
+	"errors"
+	"io"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+
+	osc52 "github.com/aymanbagabas/go-osc52/v2"
 )
 
-// WriteClipboard copies s to the system clipboard. Overridable in tests so
-// they do not touch the real clipboard.
-var WriteClipboard = func(s string) error {
+var (
+	// clipboardOutput is the terminal Bubble Tea renders to. OSC 52 is a
+	// non-printing control sequence, so writing it here asks the operator's
+	// terminal to update its clipboard even when camp itself is across SSH.
+	clipboardOutput = io.Writer(os.Stdout)
+
+	// remoteClipboardSession is a seam for the environment check. Native
+	// clipboard commands in an SSH session target the remote machine (and
+	// xclip commonly has no display at all), not the computer in front of the
+	// operator.
+	remoteClipboardSession = func() bool {
+		return os.Getenv("SSH_CONNECTION") != "" || os.Getenv("SSH_TTY") != ""
+	}
+
+	nativeClipboardWrite = writeNativeClipboard
+)
+
+// WriteClipboard copies s to the operator's clipboard. Local sessions prefer
+// the platform clipboard command; remote sessions use OSC 52 so the request
+// travels through the terminal to the local computer. If a local clipboard
+// command is unavailable, OSC 52 is also the fallback.
+//
+// Overridable in tests so callers do not touch the real clipboard.
+var WriteClipboard = writeClipboard
+
+func writeClipboard(s string) error {
+	if remoteClipboardSession() {
+		return writeTerminalClipboard(s)
+	}
+
+	nativeErr := nativeClipboardWrite(s)
+	if nativeErr == nil {
+		return nil
+	}
+	if terminalErr := writeTerminalClipboard(s); terminalErr != nil {
+		return errors.Join(nativeErr, terminalErr)
+	}
+	return nil
+}
+
+func writeNativeClipboard(s string) error {
 	var c *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
 		c = exec.Command("pbcopy")
+	case "windows":
+		c = exec.Command("cmd", "/c", "clip")
 	default:
 		c = exec.Command("xclip", "-selection", "clipboard")
 	}
 	c.Stdin = strings.NewReader(s)
 	return c.Run()
+}
+
+func writeTerminalClipboard(s string) error {
+	sequence := osc52.New(s)
+	// GNU screen needs the sequence wrapped for its outer terminal. tmux can
+	// consume the plain sequence when set-clipboard is enabled, its normal
+	// integration path, so STY is deliberately narrower than TERM=screen-*.
+	if os.Getenv("STY") != "" {
+		sequence = sequence.Screen()
+	}
+	_, err := sequence.WriteTo(clipboardOutput)
+	return err
 }

--- a/internal/ui/clipboard_test.go
+++ b/internal/ui/clipboard_test.go
@@ -1,0 +1,100 @@
+package ui
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	osc52 "github.com/aymanbagabas/go-osc52/v2"
+)
+
+func stubClipboard(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	origOutput := clipboardOutput
+	origRemote := remoteClipboardSession
+	origNative := nativeClipboardWrite
+	t.Cleanup(func() {
+		clipboardOutput = origOutput
+		remoteClipboardSession = origRemote
+		nativeClipboardWrite = origNative
+	})
+
+	output := &bytes.Buffer{}
+	clipboardOutput = output
+	return output
+}
+
+func TestWriteClipboardRemoteUsesTerminalClipboard(t *testing.T) {
+	output := stubClipboard(t)
+	remoteClipboardSession = func() bool { return true }
+	nativeClipboardWrite = func(string) error {
+		t.Fatal("remote copy called the host clipboard command")
+		return nil
+	}
+
+	const text = "https://login.tailscale.com/a/test"
+	if err := writeClipboard(text); err != nil {
+		t.Fatalf("writeClipboard: %v", err)
+	}
+	if got, want := output.String(), osc52.New(text).String(); got != want {
+		t.Errorf("terminal sequence = %q, want %q", got, want)
+	}
+}
+
+func TestWriteClipboardLocalPrefersNativeClipboard(t *testing.T) {
+	output := stubClipboard(t)
+	remoteClipboardSession = func() bool { return false }
+	var copied string
+	nativeClipboardWrite = func(text string) error {
+		copied = text
+		return nil
+	}
+
+	if err := writeClipboard("approval-url"); err != nil {
+		t.Fatalf("writeClipboard: %v", err)
+	}
+	if copied != "approval-url" {
+		t.Errorf("native clipboard received %q", copied)
+	}
+	if output.Len() != 0 {
+		t.Errorf("terminal clipboard used after native success: %q", output.String())
+	}
+}
+
+func TestWriteClipboardFallsBackToTerminal(t *testing.T) {
+	output := stubClipboard(t)
+	remoteClipboardSession = func() bool { return false }
+	nativeClipboardWrite = func(string) error { return errors.New("no native clipboard") }
+
+	if err := writeClipboard("approval-url"); err != nil {
+		t.Fatalf("writeClipboard: %v", err)
+	}
+	if got, want := output.String(), osc52.New("approval-url").String(); got != want {
+		t.Errorf("terminal sequence = %q, want %q", got, want)
+	}
+}
+
+func TestWriteClipboardReportsNativeAndTerminalFailures(t *testing.T) {
+	stubClipboard(t)
+	remoteClipboardSession = func() bool { return false }
+	nativeClipboardWrite = func(string) error { return errors.New("native failed") }
+	clipboardOutput = errorWriter{err: errors.New("terminal failed")}
+
+	err := writeClipboard("approval-url")
+	if err == nil {
+		t.Fatal("writeClipboard unexpectedly succeeded")
+	}
+	for _, want := range []string{"native failed", "terminal failed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not contain %q", err, want)
+		}
+	}
+}
+
+type errorWriter struct{ err error }
+
+func (w errorWriter) Write([]byte) (int, error) { return 0, w.err }
+
+var _ io.Writer = errorWriter{}

--- a/tests/tui/machine_tailscale_check_pty.py
+++ b/tests/tui/machine_tailscale_check_pty.py
@@ -4,10 +4,12 @@
 The VHS tape shows a reviewer what the screen looks like. This asserts what a
 recording cannot: that the approval URL is intact on ONE line (a link split
 across a wrap is one nobody can copy), that it survives the hop overlay's own
-clamp, and that o/c hand the exact URL to the platform opener and clipboard.
+clamp, and that o/c hand the exact URL to the platform opener and the local
+terminal clipboard, including when camp is running across SSH.
 
-It drives the same fixture the tape does — stub ssh, stub opener, stub
-clipboard — so nothing real is contacted and no live approval URL is produced.
+It drives the same fixture the tape does — stub ssh and opener, with a fake
+remote-session environment — so nothing real is contacted and no live approval
+URL is produced.
 
 Writes the evidence bundle files validate-evidence.py consumes:
 
@@ -17,6 +19,7 @@ Writes the evidence bundle files validate-evidence.py consumes:
 
 Usage: machine_tailscale_check_pty.py <fixture-dir> <evidence-dir>
 """
+import base64
 import fcntl
 import importlib.metadata
 import json
@@ -53,6 +56,7 @@ class Session:
         self.stream = pyte.ByteStream(self.screen)
         self.snapshots = []
         self.transcript = []
+        self.raw = bytearray()
         self.pid, self.fd = pty.fork()
         if self.pid == 0:
             os.chdir(fixture)
@@ -66,6 +70,11 @@ class Session:
                 "NO_COLOR": "1",
                 "CAMP_MACHINES_PATH": os.path.join(fixture, "machines.yaml"),
                 "CAMP_VHS_HANDOFF_LOG": os.path.join(fixture, "handoff.log"),
+                # Force the production remote-session path. A remote pbcopy or
+                # xclip targets the wrong computer; OSC 52 crosses the PTY to
+                # the operator's terminal instead.
+                "SSH_CONNECTION": "192.0.2.10 50000 192.0.2.20 22",
+                "SSH_TTY": "/dev/pts/camp-fixture",
             })
         # Both the ioctl and LINES/COLUMNS: a small default clips content and
         # sends you chasing a layout bug that does not exist.
@@ -84,6 +93,7 @@ class Session:
                 return
             if not data:
                 return
+            self.raw.extend(data)
             self.stream.feed(data)
 
     def press(self, keys, budget=KEY_BUDGET):
@@ -130,18 +140,33 @@ def whole_line_with(display, needle):
     return any(needle in line for line in display)
 
 
-def expected_handoff_tools():
-    """The opener and clipboard names camp calls on THIS platform.
+def expected_opener():
+    """The opener name camp calls on THIS platform.
 
-    Mirrors ui.browserOpenCommand and ui.WriteClipboard, which both switch on
-    runtime.GOOS: darwin gets open/pbcopy, everything else xdg-open/xclip. The
-    fixture installs all four names, so asserting the pair for the host is an
-    exact check — a camp that called the wrong tool for its platform would
-    still populate the log, and a looser "either name" assertion would pass it.
+    Mirrors ui.browserOpenCommand: darwin gets open, everything else xdg-open.
+    The fixture installs both names, so asserting the host-specific one remains
+    an exact check.
     """
     if sys.platform == "darwin":
-        return "open", "pbcopy"
-    return "xdg-open", "xclip"
+        return "open"
+    return "xdg-open"
+
+
+def osc52_clipboard_values(raw):
+    """Decode plain OSC 52 system-clipboard writes from a PTY byte stream."""
+    marker = b"\x1b]52;c;"
+    values = []
+    start = 0
+    while True:
+        begin = raw.find(marker, start)
+        if begin < 0:
+            return values
+        begin += len(marker)
+        end = raw.find(b"\x07", begin)
+        if end < 0:
+            return values
+        values.append(base64.b64decode(raw[begin:end]).decode("utf-8"))
+        start = end + 1
 
 
 def main():
@@ -175,6 +200,9 @@ def main():
     copied = s.snapshot("link-copied")
     if not whole_line_with(copied, "copied the approval link"):
         failures.append("c did not report copying the link")
+    clipboard_values = osc52_clipboard_values(bytes(s.raw))
+    if clipboard_values != [CHECK_URL]:
+        failures.append("OSC 52 did not copy the exact URL: %r" % clipboard_values)
 
     snapshots.extend(s.snapshots)
     transcript.extend(s.transcript)
@@ -206,11 +234,11 @@ def main():
     transcript.append("===== handoff.log =====")
     transcript.extend(handed)
 
-    opener, clipboard = expected_handoff_tools()
+    opener = expected_opener()
     if ("%s %s" % (opener, CHECK_URL)) not in handed:
         failures.append("%s was not handed the exact URL: %r" % (opener, handed))
-    if ("%s %s" % (clipboard, CHECK_URL)) not in handed:
-        failures.append("%s was not handed the exact URL: %r" % (clipboard, handed))
+    if any(line.startswith(("pbcopy ", "xclip ")) for line in handed):
+        failures.append("remote copy called a host clipboard tool: %r" % handed)
 
     # The shapes here are the evidence-bundle contract, not this script's
     # preference: validate-evidence.py requires an object with renderer,
@@ -245,7 +273,7 @@ def main():
         print("FAIL: %s" % failure, file=sys.stderr)
     if failures:
         return 1
-    print("machine-tailscale-check: %d snapshots, link intact and handed off" % len(snapshots))
+    print("machine-tailscale-check: %d snapshots, link intact and copied over OSC 52" % len(snapshots))
     return 0
 
 


### PR DESCRIPTION
## Summary

- copy Tailscale approval URLs to the operator clipboard over OSC 52 during SSH sessions
- preserve native clipboard commands for local sessions, with terminal clipboard fallback when they are unavailable
- make the success message explain the remaining approve-and-retry flow
- strengthen unit and PTY coverage so the exact URL must cross the real terminal stream

## Root cause

The earlier machine TUI fix invoked pbcopy on macOS or xclip elsewhere. In an SSH or headless session those commands either target the remote host clipboard or fail because no graphical display exists. Its PTY fixture stubbed those binaries, so it only proved that a command ran, not that the local operator clipboard received the URL.

## User impact

Pressing c on a waiting Tailscale approval link now reaches the clipboard of the computer running the terminal, including remote Camp sessions. Local sessions retain their native clipboard behavior.

## Verification

- just gate
- just tui pty-machine-tailscale-check
- go test ./internal/ui ./cmd/camp